### PR TITLE
8286376: Wrong condition for using non-immediate oops on AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -4202,7 +4202,7 @@ void MacroAssembler::movoop(Register dst, jobject obj, bool immediate) {
   // ordered with respected to oop accesses.
   // Using immediate literals would necessitate ISBs.
   BarrierSet* bs = BarrierSet::barrier_set();
-  if ((bs->barrier_set_nmethod() != NULL && bs->barrier_set_assembler()->nmethod_code_patching()) || !immediate) {
+  if ((bs->barrier_set_nmethod() != NULL && !bs->barrier_set_assembler()->nmethod_code_patching()) || !immediate) {
     address dummy = address(uintptr_t(pc()) & -wordSize); // A nearby aligned address
     ldr_constant(dst, Address(dummy, rspec));
   } else


### PR DESCRIPTION
With the introduction of loom, nmethod entry barriers were added for all GCs. So far, the use of nmethod entry barriers has implied that nmethod oops are patched in the instruction stream. That is no longer the case. A condition was added to make sure we still get non-immediate oops on AArch64 for collectors that use nmethod entry barriers, and support immediate oops. However, the condition was messed up, so we instead end up doing the wrong thing. We should do the right thing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286376](https://bugs.openjdk.java.net/browse/JDK-8286376): Wrong condition for using non-immediate oops on AArch64


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8593/head:pull/8593` \
`$ git checkout pull/8593`

Update a local copy of the PR: \
`$ git checkout pull/8593` \
`$ git pull https://git.openjdk.java.net/jdk pull/8593/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8593`

View PR using the GUI difftool: \
`$ git pr show -t 8593`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8593.diff">https://git.openjdk.java.net/jdk/pull/8593.diff</a>

</details>
