### PR TITLE
8286387: Remove unused FreeListAllocator::reduce_free_list

### DIFF
--- a/src/hotspot/share/gc/shared/freeListAllocator.cpp
+++ b/src/hotspot/share/gc/shared/freeListAllocator.cpp
@@ -195,19 +195,3 @@ bool FreeListAllocator::try_transfer_pending() {
   Atomic::release_store(&_transfer_lock, false);
   return true;
 }
-
-size_t FreeListAllocator::reduce_free_list(size_t remove_goal) {
-  try_transfer_pending();
-  size_t removed = 0;
-  for ( ; removed < remove_goal; ++removed) {
-    FreeNode* node = _free_list.pop();
-    if (node == nullptr) break;
-    node->~FreeNode();
-    _config->deallocate(node);
-  }
-  size_t new_count = Atomic::sub(&_free_count, removed);
-  log_debug(gc, freelist)
-           ("Reduced %s free list by " SIZE_FORMAT " to " SIZE_FORMAT,
-            name(), removed, new_count);
-  return removed;
-}

--- a/src/hotspot/share/gc/shared/freeListAllocator.hpp
+++ b/src/hotspot/share/gc/shared/freeListAllocator.hpp
@@ -150,12 +150,6 @@ public:
   size_t mem_size() const {
     return sizeof(*this);
   }
-
-  // Deallocate some of the available nodes in the free_list.
-  // remove_goal is the target number to remove.  Returns the number
-  // actually deallocated, which may be less than the goal if there
-  // were fewer available.
-  size_t reduce_free_list(size_t remove_goal);
 };
 
 #endif // SHARE_GC_SHARED_FREELISTALLOCATOR_HPP

--- a/src/hotspot/share/gc/shared/ptrQueue.cpp
+++ b/src/hotspot/share/gc/shared/ptrQueue.cpp
@@ -72,10 +72,6 @@ void BufferNode::Allocator::release(BufferNode* node) {
   _free_list.release(node);
 }
 
-size_t BufferNode::Allocator::reduce_free_list(size_t remove_goal) {
-  return _free_list.reduce_free_list(remove_goal);
-}
-
 PtrQueueSet::PtrQueueSet(BufferNode::Allocator* allocator) :
   _allocator(allocator)
 {}

--- a/src/hotspot/share/gc/shared/ptrQueue.hpp
+++ b/src/hotspot/share/gc/shared/ptrQueue.hpp
@@ -198,11 +198,6 @@ public:
   // If _free_list has items buffered in the pending list, transfer
   // these to make them available for re-allocation.
   bool flush_free_list() { return _free_list.try_transfer_pending(); }
-
-  // Deallocate some of the available buffers.  remove_goal is the target
-  // number to remove.  Returns the number actually deallocated, which may
-  // be less than the goal if there were fewer available.
-  size_t reduce_free_list(size_t remove_goal);
 };
 
 // A PtrQueueSet represents resources common to a set of pointer queues.

--- a/test/hotspot/gtest/gc/shared/test_ptrQueueBufferAllocator.cpp
+++ b/test/hotspot/gtest/gc/shared/test_ptrQueueBufferAllocator.cpp
@@ -85,13 +85,6 @@ TEST_VM(PtrQueueBufferAllocatorTest, test) {
   }
   ASSERT_TRUE(BufferNode::TestSupport::try_transfer_pending(&allocator));
   ASSERT_EQ(node_count, allocator.free_count());
-
-  // Destroy some nodes in the free list.
-  // We don't have a way to verify destruction, but we can at
-  // least verify we don't crash along the way.
-  size_t count = allocator.free_count();
-  ASSERT_EQ(count, allocator.reduce_free_list(count));
-  // destroy allocator.
 }
 
 // Stress test with lock-free allocator and completed buffer list.


### PR DESCRIPTION
Simple change of removing an unused API.

Test: tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286387](https://bugs.openjdk.java.net/browse/JDK-8286387): Remove unused FreeListAllocator::reduce_free_list


### Reviewers
 * @limck599 (no known github.com user name / role)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8594/head:pull/8594` \
`$ git checkout pull/8594`

Update a local copy of the PR: \
`$ git checkout pull/8594` \
`$ git pull https://git.openjdk.java.net/jdk pull/8594/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8594`

View PR using the GUI difftool: \
`$ git pr show -t 8594`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8594.diff">https://git.openjdk.java.net/jdk/pull/8594.diff</a>

</details>
