### PR TITLE
8286367: riscv: riscv port is broken after JDK-8284161

### DIFF
--- a/src/hotspot/cpu/riscv/continuationHelper_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/continuationHelper_riscv.inline.hpp
@@ -93,8 +93,7 @@ inline void ContinuationHelper::InterpretedFrame::patch_sender_sp(frame& f, intp
 }
 
 inline address* ContinuationHelper::Frame::return_pc_address(const frame& f) {
-  Unimplemented();
-  return NULL;
+  return (address*)(f.real_fp() - 1);
 }
 
 inline address ContinuationHelper::Frame::real_pc(const frame& f) {

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -259,22 +259,25 @@ bool frame::safe_for_sender(JavaThread *thread) {
 void frame::patch_pc(Thread* thread, address pc) {
   assert(_cb == CodeCache::find_blob(pc), "unexpected pc");
   address* pc_addr = &(((address*) sp())[-1]);
+
   if (TracePcPatching) {
     tty->print_cr("patch_pc at address " INTPTR_FORMAT " [" INTPTR_FORMAT " -> " INTPTR_FORMAT "]",
                   p2i(pc_addr), p2i(*pc_addr), p2i(pc));
   }
+
   // Either the return address is the original one or we are going to
   // patch in the same address that's already there.
-  assert(_pc == *pc_addr || pc == *pc_addr, "must be");
+  assert(_pc == *pc_addr || pc == *pc_addr || *pc_addr == 0, "must be");
+  DEBUG_ONLY(address old_pc = _pc;)
   *pc_addr = pc;
+  _pc = pc; // must be set before call to get_deopt_original_pc
   address original_pc = CompiledMethod::get_deopt_original_pc(this);
   if (original_pc != NULL) {
-    assert(original_pc == _pc, "expected original PC to be stored before patching");
+    assert(original_pc == old_pc, "expected original PC to be stored before patching");
     _deopt_state = is_deoptimized;
-    // leave _pc as is
+    _pc = original_pc;
   } else {
     _deopt_state = not_deoptimized;
-    _pc = pc;
   }
 }
 
@@ -378,6 +381,7 @@ void frame::verify_deopt_original_pc(CompiledMethod* nm, intptr_t* unextended_sp
 
 //------------------------------------------------------------------------------
 // frame::adjust_unextended_sp
+#ifdef ASSERT
 void frame::adjust_unextended_sp() {
   // On riscv, sites calling method handle intrinsics and lambda forms are treated
   // as any other call site. Therefore, no special action is needed when we are
@@ -394,6 +398,8 @@ void frame::adjust_unextended_sp() {
     }
   }
 }
+#endif
+
 
 //------------------------------------------------------------------------------
 // frame::sender_for_interpreter_frame

--- a/src/hotspot/cpu/riscv/frame_riscv.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.hpp
@@ -166,7 +166,7 @@
   // original sp we use that convention.
 
   intptr_t*     _unextended_sp;
-  void adjust_unextended_sp();
+  void adjust_unextended_sp() NOT_DEBUG_RETURN;
 
   intptr_t* ptr_at_addr(int offset) const {
     return (intptr_t*) addr_at(offset);
@@ -189,6 +189,7 @@
   frame(intptr_t* ptr_sp, intptr_t* ptr_fp);
 
   void init(intptr_t* ptr_sp, intptr_t* ptr_fp, address pc);
+  void setup(address pc);
 
   // accessors for the instance variables
   // Note: not necessarily the real 'frame pointer' (see real_fp)

--- a/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
@@ -29,6 +29,7 @@
 
 #include "code/codeCache.hpp"
 #include "code/vmreg.inline.hpp"
+#include "runtime/sharedRuntime.hpp"
 
 // Inline functions for RISCV frames:
 
@@ -54,20 +55,31 @@ inline void frame::init(intptr_t* ptr_sp, intptr_t* ptr_fp, address pc) {
   _unextended_sp = ptr_sp;
   _fp = ptr_fp;
   _pc = pc;
+  _oop_map = NULL;
+  _on_heap = false;
+  DEBUG_ONLY(_frame_index = -1;)
+
   assert(pc != NULL, "no pc?");
   _cb = CodeCache::find_blob(pc);
+  setup(pc);
+}
+
+inline void frame::setup(address pc) {
   adjust_unextended_sp();
 
   address original_pc = CompiledMethod::get_deopt_original_pc(this);
   if (original_pc != NULL) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;
+    assert(_cb == NULL || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
+           "original PC must be in the main code section of the compiled method (or must be immediately following it)");
   } else {
-    _deopt_state = not_deoptimized;
+    if (_cb == SharedRuntime::deopt_blob()) {
+      _deopt_state = is_deoptimized;
+    } else {
+      _deopt_state = not_deoptimized;
+    }
   }
-
-  _on_heap = false;
-  DEBUG_ONLY(_frame_index = -1;)
 }
 
 inline frame::frame(intptr_t* ptr_sp, intptr_t* ptr_fp, address pc) {
@@ -83,20 +95,11 @@ inline frame::frame(intptr_t* ptr_sp, intptr_t* unextended_sp, intptr_t* ptr_fp,
   _pc = pc;
   assert(pc != NULL, "no pc?");
   _cb = CodeCache::find_blob(pc);
-  adjust_unextended_sp();
-
-  address original_pc = CompiledMethod::get_deopt_original_pc(this);
-  if (original_pc != NULL) {
-    _pc = original_pc;
-    assert(_cb->as_compiled_method()->insts_contains_inclusive(_pc),
-           "original PC must be in the main code section of the the compiled method (or must be immediately following it)");
-    _deopt_state = is_deoptimized;
-  } else {
-    _deopt_state = not_deoptimized;
-  }
-
+  _oop_map = NULL;
   _on_heap = false;
   DEBUG_ONLY(_frame_index = -1;)
+
+  setup(pc);
 }
 
 inline frame::frame(intptr_t* ptr_sp) {
@@ -293,7 +296,11 @@ inline void frame::set_saved_oop_result(RegisterMap* map, oop obj) {
 PRAGMA_DIAG_POP
 
 inline const ImmutableOopMap* frame::get_oop_map() const {
-  Unimplemented();
+  if (_cb == NULL) return NULL;
+  if (_cb->oop_maps() != NULL) {
+    const ImmutableOopMap* oop_map = OopMapSet::find_map(this);
+    return oop_map;
+  }
   return NULL;
 }
 

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -28,6 +28,7 @@
 #define CPU_RISCV_NATIVEINST_RISCV_HPP
 
 #include "asm/assembler.hpp"
+#include "runtime/continuation.hpp"
 #include "runtime/icache.hpp"
 #include "runtime/os.hpp"
 
@@ -195,7 +196,7 @@ class NativeInstruction {
   }
   static bool is_lwu_to_zr(address instr);
 
-  inline bool is_nop();
+  inline bool is_nop() const;
   inline bool is_jump_or_nop();
   bool is_safepoint_poll();
   bool is_sigill_zombie_not_entrant();
@@ -494,7 +495,7 @@ class NativeIllegalInstruction: public NativeInstruction {
   static void insert(address code_pos);
 };
 
-inline bool NativeInstruction::is_nop()         {
+inline bool NativeInstruction::is_nop() const {
   uint32_t insn = *(uint32_t*)addr_at(0);
   return insn == 0x13;
 }
@@ -571,14 +572,17 @@ public:
 
 class NativePostCallNop: public NativeInstruction {
 public:
-  bool check() const { Unimplemented(); return false; }
-  int displacement() const { Unimplemented(); return 0; }
+  bool check() const { return is_nop(); }
+  int displacement() const { return 0; }
   void patch(jint diff) { Unimplemented(); }
   void make_deopt() { Unimplemented(); }
 };
 
 inline NativePostCallNop* nativePostCallNop_at(address address) {
-  Unimplemented();
+  NativePostCallNop* nop = (NativePostCallNop*) address;
+  if (nop->check()) {
+    return nop;
+  }
   return NULL;
 }
 
@@ -590,6 +594,7 @@ public:
   void  verify() { Unimplemented(); }
 
   static bool is_deopt_at(address instr) {
+    if (!Continuations::enabled()) return false;
     Unimplemented();
     return false;
   }

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -798,6 +798,7 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call) {
 // End of helpers
 
 address TemplateInterpreterGenerator::generate_Continuation_doYield_entry(void) {
+  if (!Continuations::enabled()) return nullptr;
   Unimplemented();
   return NULL;
 }


### PR DESCRIPTION
[JDK-8284161](https://bugs.openjdk.java.net/browse/JDK-8284161) implements a preview version of virtual threads on x86_64 and aarch64, and riscv port is broken everywhere. The initial patch is required to make everything on riscv work without "--enable-preview".

Hotspot/jdk tier1 and all jtreg cases have been tested on Unmatched and Qemu respectively without new failures, except for the "-enable-preview" ones.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286367](https://bugs.openjdk.java.net/browse/JDK-8286367): riscv: riscv port is broken after JDK-8284161


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Contributors
 * Fei Yang `<fyang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8595/head:pull/8595` \
`$ git checkout pull/8595`

Update a local copy of the PR: \
`$ git checkout pull/8595` \
`$ git pull https://git.openjdk.java.net/jdk pull/8595/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8595`

View PR using the GUI difftool: \
`$ git pr show -t 8595`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8595.diff">https://git.openjdk.java.net/jdk/pull/8595.diff</a>

</details>
