### PR TITLE
8286435: JDK-8284316 caused validate-source to fail in Tier1

### DIFF
--- a/test/jdk/javax/accessibility/manual/SwingSetTest.java
+++ b/test/jdk/javax/accessibility/manual/SwingSetTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
  */
 

--- a/test/jdk/javax/accessibility/manual/TestJProgressBarAccessibility.java
+++ b/test/jdk/javax/accessibility/manual/TestJProgressBarAccessibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/accessibility/manual/lib/ManualTestFrame.java
+++ b/test/jdk/javax/accessibility/manual/lib/ManualTestFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
A trivial to solve JDK-8284316 caused validate-source to fail in Tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286435](https://bugs.openjdk.java.net/browse/JDK-8286435): JDK-8284316 caused validate-source to fail in Tier1


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8607/head:pull/8607` \
`$ git checkout pull/8607`

Update a local copy of the PR: \
`$ git checkout pull/8607` \
`$ git pull https://git.openjdk.java.net/jdk pull/8607/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8607`

View PR using the GUI difftool: \
`$ git pr show -t 8607`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8607.diff">https://git.openjdk.java.net/jdk/pull/8607.diff</a>

</details>
