### PR TITLE
8286433: Cache certificates decoded from TLS session tickets

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
@@ -24,7 +24,7 @@
  */
 package sun.security.ssl;
 
-import sun.security.x509.X509CertImpl;
+import sun.security.provider.X509Factory;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -459,7 +459,7 @@ final class SSLSessionImpl extends ExtendedSSLSession {
                 b = new byte[buf.getInt()];
                 buf.get(b);
                 try {
-                    this.peerCerts[j] = new X509CertImpl(b);
+                    this.peerCerts[j] = X509Factory.cachedGetX509Cert(b);
                 } catch (Exception e) {
                     throw new IOException(e);
                 }
@@ -480,7 +480,7 @@ final class SSLSessionImpl extends ExtendedSSLSession {
                     b = new byte[buf.getInt()];
                     buf.get(b);
                     try {
-                        this.localCerts[i] = new X509CertImpl(b);
+                        this.localCerts[i] = X509Factory.cachedGetX509Cert(b);
                     } catch (Exception e) {
                         throw new IOException(e);
                     }


### PR DESCRIPTION
When a TLS server resumes a session from a stateless session ticket, it populates the `SSLSessionImpl`'s `localCerts` and `peerCerts` fields with certificates deserialized from the session ticket. These certificates are often the same across a large number of tickets.

This patch implements a certificate cache lookup for these certificates. This enables us to avoid deserializing the same certificates repeatedly, and saves memory by reusing the same certificate objects.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286433](https://bugs.openjdk.java.net/browse/JDK-8286433): Cache certificates decoded from TLS session tickets


### Reviewers
 * [Sean Coffey](https://openjdk.java.net/census#coffeys) (@coffeys - **Reviewer**)
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8608/head:pull/8608` \
`$ git checkout pull/8608`

Update a local copy of the PR: \
`$ git checkout pull/8608` \
`$ git pull https://git.openjdk.java.net/jdk pull/8608/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8608`

View PR using the GUI difftool: \
`$ git pr show -t 8608`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8608.diff">https://git.openjdk.java.net/jdk/pull/8608.diff</a>

</details>
