### PR TITLE
8283651: nsk/jvmti/SuspendThread/suspendthrd003 may leak native memory

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/agent_tools.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/agent_tools.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -450,6 +450,12 @@ jthread nsk_jvmti_threadByName(const char name[]) {
 
         if (info.name != NULL && strcmp(name, info.name) == 0) {
             foundThread = threads[i];
+        }
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)info.name))) {
+            nsk_jvmti_setFailStatus();
+            return NULL;
+        }
+        if (foundThread != NULL) {
             break;
         }
     }


### PR DESCRIPTION
A trivial fix to nsk_jvmti_threadByName() to solve a native memory leak.

This fix has been stress tested with my StressWrapper60M_NMT_detail_suspendthrd003.java
test and I did NMT detailed monitoring for the whole 60M run. Total committed memory has
gone down from 1.17GB to 300MB. Prior to my last rebase, it was down to 239MB.

I ran the fix thru Mach5 Tier[1-7] with no failures. I just rebased the fix to the latest jdk/jdk
and Mach5 Tier[1-3] have passed with no failures. Tier[45] are still running.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8283651](https://bugs.openjdk.java.net/browse/JDK-8283651): nsk/jvmti/SuspendThread/suspendthrd003 may leak native memory


### Reviewers
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8609/head:pull/8609` \
`$ git checkout pull/8609`

Update a local copy of the PR: \
`$ git checkout pull/8609` \
`$ git pull https://git.openjdk.java.net/jdk pull/8609/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8609`

View PR using the GUI difftool: \
`$ git pr show -t 8609`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8609.diff">https://git.openjdk.java.net/jdk/pull/8609.diff</a>

</details>
