### PR TITLE
8286438: Add jhsdb jstack processing without --mixed in efh

### DIFF
--- a/test/failure_handler/src/share/conf/common.properties
+++ b/test/failure_handler/src/share/conf/common.properties
@@ -35,7 +35,7 @@ onTimeout=\
         jcmd.vm.symboltable jcmd.vm.uptime jcmd.vm.dynlibs \
         jcmd.vm.system_properties \
   jcmd.gc.heap_info jcmd.gc.class_histogram jcmd.gc.finalizer_info jcmd.thread.dump_to_file \
-  jstack jhsdb.jstack.live
+  jstack jhsdb.jstack.live.default jhsdb.jstack.live.mixed
 
 jinfo.app=jinfo
 
@@ -64,12 +64,14 @@ jstack.args=-e -l %p
 jstack.params.repeat=6
 
 jhsdb.app=jhsdb
-jhsdb.jstack.live.args=jstack --mixed --pid %p
-jhsdb.jstack.live.params.repeat=6
+jhsdb.jstack.live.default.args=jstack --pid %p
+jhsdb.jstack.live.default.params.repeat=6
+jhsdb.jstack.live.mixed.args=jstack --mixed --pid %p
+jhsdb.jstack.live.mixed.params.repeat=6
 
-cores=jhsdb.jstack.core jhsdb.jstack.core.mixed
+cores=jhsdb.jstack.core.default jhsdb.jstack.core.mixed
 # Assume that java standard laucher has been used
-jhsdb.jstack.core.args=jstack --core %p --exe %java
+jhsdb.jstack.core.default.args=jstack --core %p --exe %java
 jhsdb.jstack.core.mixed.args=jstack --mixed --core %p --exe %java
 
 ################################################################################


### PR DESCRIPTION
The default is required only to set the same depth level in the tree on HTML page for default and mixed mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286438](https://bugs.openjdk.java.net/browse/JDK-8286438): Add jhsdb jstack processing without --mixed in efh


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8610/head:pull/8610` \
`$ git checkout pull/8610`

Update a local copy of the PR: \
`$ git checkout pull/8610` \
`$ git pull https://git.openjdk.java.net/jdk pull/8610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8610`

View PR using the GUI difftool: \
`$ git pr show -t 8610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8610.diff">https://git.openjdk.java.net/jdk/pull/8610.diff</a>

</details>
