### PR TITLE
8286442: ProblemList compiler/c2/irTests/TestSkeletonPredicates.java in -Xcomp mode

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -35,6 +35,8 @@ vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t002/TestDescription.java 82456
 
 serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
 
+compiler/c2/irTests/TestSkeletonPredicates.java 8286361 generic-all
+
 #############################################################################
 
 # Loom


### PR DESCRIPTION
A trivial fix to ProblemList compiler/c2/irTests/TestSkeletonPredicates.java in -Xcomp mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286442](https://bugs.openjdk.java.net/browse/JDK-8286442): ProblemList compiler/c2/irTests/TestSkeletonPredicates.java in -Xcomp mode


### Reviewers
 * [Christian Tornqvist](https://openjdk.java.net/census#ctornqvi) (@ctornqvi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8612/head:pull/8612` \
`$ git checkout pull/8612`

Update a local copy of the PR: \
`$ git checkout pull/8612` \
`$ git pull https://git.openjdk.java.net/jdk pull/8612/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8612`

View PR using the GUI difftool: \
`$ git pr show -t 8612`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8612.diff">https://git.openjdk.java.net/jdk/pull/8612.diff</a>

</details>
