### PR TITLE
8286429: jpackageapplauncher build fails intermittently in Tier[45]

### DIFF
--- a/make/common/modules/LauncherCommon.gmk
+++ b/make/common/modules/LauncherCommon.gmk
@@ -197,9 +197,11 @@ endef
 ################################################################################
 # Create man pages for jmod to pick up. There should be a one-to-one
 # relationship between executables and man pages (even if this is not always
-# the case), so piggyback man page generation on the launcher compilation.
+# the case), so piggyback man page generation on the launcher compilation. This
+# file may be included from other places as well, so only process man pages
+# when called from <module>/Launcher.gmk.
 
-ifeq ($(call isTargetOsType, unix), true)
+ifeq ($(call isTargetOsType, unix)+$(MAKEFILE_PREFIX), true+Launcher)
   # Only build manpages on unix systems.
   # We assume all our man pages should reside in section 1.
 
@@ -243,9 +245,9 @@ ifeq ($(call isTargetOsType, unix), true)
           FILTER := $(PANDOC_TROFF_MANPAGE_FILTER), \
           POST_PROCESS := $(MAN_POST_PROCESS), \
           REPLACEMENTS := \
-		@@COPYRIGHT_YEAR@@ => $(COPYRIGHT_YEAR) ; \
-		@@VERSION_SHORT@@ => $(VERSION_SHORT) ; \
-		@@VERSION_SPECIFICATION@@ => $(VERSION_SPECIFICATION), \
+              @@COPYRIGHT_YEAR@@ => $(COPYRIGHT_YEAR) ; \
+              @@VERSION_SHORT@@ => $(VERSION_SHORT) ; \
+              @@VERSION_SPECIFICATION@@ => $(VERSION_SPECIFICATION), \
           EXTRA_DEPS := $(PANDOC_TROFF_MANPAGE_FILTER) \
               $(PANDOC_TROFF_MANPAGE_FILTER_SOURCE), \
       ))


### PR DESCRIPTION
The way LauncherCommon.gmk is currently written, it's only meant to be included from "make/module/<module>/Launcher.gmk", or at least only from one single place for each module. This is because the man page generation that happens in LauncherCommon.gmk is module global. For the jdk.jpackage module, LauncherCommon.gmk is now called from two separate sub makefiles, both make/module/jdk.jpackage/Lib.gmk and make/module/jdk.jpackage/Launcher.gmk. These files are called from the top level targets jdk.jpackage-libs and jdk.jpackage-launchers respectively. These top level targets are assumed to be able to run independently of each other, which is normally fine, but now they define the same rules for the same files. This creates a race where one may be deleting files that the other one is creating, causing directories to disappear while files are being written to them. This can fail the build, but also risks silently corrupting the build.

This patch fixes this by adding a conditional around the man page generation, which helps guarantee that man pages are only processed when called from make/module/<module>/Launcher.gmk. It's a bit of a hack, but it's building on top of the existing design of piggybacking man page generation on the launchers build.

Also fixing broken whitespace further down in the file (tabs->space).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286429](https://bugs.openjdk.java.net/browse/JDK-8286429): jpackageapplauncher build fails intermittently in Tier[45]


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8618/head:pull/8618` \
`$ git checkout pull/8618`

Update a local copy of the PR: \
`$ git checkout pull/8618` \
`$ git pull https://git.openjdk.java.net/jdk pull/8618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8618`

View PR using the GUI difftool: \
`$ git pr show -t 8618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8618.diff">https://git.openjdk.java.net/jdk/pull/8618.diff</a>

</details>
