### PR TITLE
JDK-8282278: Support for IsoFields in JapaneseDate/MinguoDate/ThaiBuddhistDate

### DIFF
--- a/src/java.base/share/classes/java/time/LocalDate.java
+++ b/src/java.base/share/classes/java/time/LocalDate.java
@@ -138,7 +138,8 @@ import java.util.stream.Stream;
  */
 @jdk.internal.ValueBased
 public final class LocalDate
-        implements Temporal, TemporalAdjuster, ChronoLocalDate, Serializable {
+        implements Temporal, TemporalAdjuster, ChronoLocalDate, Serializable,
+                   java.time.chrono.FooDate {
 
     /**
      * The minimum supported {@code LocalDate}, '-999999999-01-01'.

--- a/src/java.base/share/classes/java/time/chrono/FooChronology.java
+++ b/src/java.base/share/classes/java/time/chrono/FooChronology.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.time.chrono;
+
+import java.time.*;
+import java.time.temporal.*;
+
+/**
+ * Super interface for experimentation.
+ */
+public interface FooChronology {
+    /**
+     * Obtains adate from the era, year-of-era, month-of-year
+     * and day-of-month fields.
+     *
+     * @param era  the ISO era, not null
+     * @param yearOfEra  the ISO year-of-era
+     * @param month  the ISO month-of-year
+     * @param dayOfMonth  the ISO day-of-month
+     * @return the ISO local date, not null
+     * @throws DateTimeException if unable to create the date
+     * @throws ClassCastException if conditions
+     */
+    public FooDate date(Era era, int yearOfEra, int month, int dayOfMonth);
+
+    /**
+     * Obtains adate from the proleptic-year, month-of-year
+     * and day-of-month fields.
+     *
+     * @param prolepticYear  the ISO proleptic-year
+     * @param month  the ISO month-of-year
+     * @param dayOfMonth  the ISO day-of-month
+     * @return the ISO local date, not null
+     * @throws DateTimeException if unable to create the date
+     */
+    public FooDate date(int prolepticYear, int month, int dayOfMonth);
+
+    /**
+     * Obtains an date from another date-time object.
+     *
+     * @param temporal  the date-time object to convert, not null
+     * @return the ISO local date, not null
+     * @throws DateTimeException if unable to create the date
+     */
+    public FooDate date(TemporalAccessor temporal);
+
+    /**
+     * Obtains the current date from the system clock in the default time-zone.
+     *
+     * @return the current date using the system clock and default time-zone, not null
+     * @throws DateTimeException if unable to create the date
+     */
+    public FooDate dateNow();
+
+    /**
+     * Obtains the current date from the system clock in the specified time-zone.
+     * @return the current date using the system clock, not null
+     * @throws DateTimeException if unable to create the date
+     * @param zone the zone ID to use, not null
+     */
+    public FooDate dateNow(ZoneId zone);
+
+    /**
+     * Obtains the currentdate from the specified clock.
+     *
+     * @param clock  the clock to use, not null
+     * @return the current ISO local date, not null
+     * @throws DateTimeException if unable to create the date
+     */
+    public FooDate dateNow(Clock clock);
+
+
+    /**
+     * Obtains a date from the era, year-of-era and day-of-year fields.
+     *
+     * @param era  the era, not null
+     * @param yearOfEra  the year-of-era
+     * @param dayOfYear  the  day-of-year
+     * @return the ISO local date, not null
+     * @throws DateTimeException if unable to create the date
+     */
+    public FooDate dateYearDay(Era era, int yearOfEra, int dayOfYear);
+
+    /**
+     * Obtains a date from the proleptic-year and day-of-year fields.
+     *
+     * @param prolepticYear  the proleptic-year
+     * @param dayOfYear  the day-of-year
+     * @return the  local date, not null
+     * @throws DateTimeException if unable to create the date
+     */
+    public FooDate dateYearDay(int prolepticYear, int dayOfYear);
+
+    /**
+     * {@return the era}
+     * @param eraValue the value of the era
+     */
+    Era eraOf(int eraValue);
+
+    
+    /**
+     * {@return the eras}
+     */
+    java.util.List<Era> eras();
+
+    /**
+     * {@return the calendar type of the underlying calendar system}
+     */
+    String getCalendarType();
+
+    /**
+     * {@return the id of the chronology}
+     */
+    public String getId();
+
+    /**
+     * {@return true if this year is a leap year, false otherwise}
+     * @param prolepticYear  the proleptic year to check
+     */
+    boolean isLeapYear(long prolepticYear);
+
+    /**
+     * {@return the proleptic year}
+     * @param era the era
+     * @param yearOfEra the year of the era
+     */
+    int prolepticYear(Era era, int yearOfEra);
+
+    /**
+     * {@return the range of valid values for the specified field}
+     * @param field the field
+     */
+    ValueRange range(ChronoField field);
+
+    /**
+     * {@return the date after parsing the field values}
+     * @param fieldValues the field values
+     * @param resolverStyle the resolverStyle
+     */
+    FooDate resolveDate(java.util.Map<TemporalField,Long> fieldValues,
+                        java.time.format.ResolverStyle resolverStyle);
+}

--- a/src/java.base/share/classes/java/time/chrono/FooDate.java
+++ b/src/java.base/share/classes/java/time/chrono/FooDate.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.time.chrono;
+
+import java.time.temporal.*;
+
+/**
+ * Super interface for experimentation.
+ */
+public interface FooDate {
+    /**
+     * {@return the chronology}
+     */
+    Chronology getChronology();
+
+    /**
+     * {@return the era}
+     */
+    Era getEra();
+
+    /**
+     * {@return the length of month}
+     */
+    int lengthOfMonth();
+
+    /**
+     * {@return an object of the same type as this object with the
+     * specified period subtracted}
+     * @param amountToAdd the amount of the specified unit to
+     * subtract, may be negative
+     * @param unit the unit of the amount to subtract, not null
+     */
+    FooDate minus(long amountToAdd, TemporalUnit unit);
+
+    /**
+     * {@return an object of the same type as this object with an
+     * amount subtracted}
+     * @param amount the amount to subtract, not null
+     */
+    FooDate minus(TemporalAmount amount);
+
+    /**
+     * {@return an object of the same type as this object with the
+     * specified period added}
+     * @param amountToAdd the amount of the specified unit to
+     * add, may be negative
+     * @param unit the unit of the amount to add, not null
+     */
+    FooDate plus(long amountToAdd, TemporalUnit unit);
+
+    /**
+     * {@return an object of the same type as this object with an
+     * amount added}
+     * @param amount the amount to add, not null
+     */
+    FooDate plus(TemporalAmount amount);
+
+    /**
+     * {@return Calculates the period between this date and another
+     * date as a ChronoPeriod}
+     * @param endDate the end date, exclusive, which may be in any
+     * chronology, not null
+     */
+    ChronoPeriod until(ChronoLocalDate endDate);
+
+    /**
+     * {@return Calculates the amount of time until another date in
+     * terms of the specified unit}
+     * @param endExclusive the end date, exclusive, which is converted
+     * to a ChronoLocalDate in the same chronology, not null
+     * @param unit the unit to measure the amount in, not null
+     */
+    long until(Temporal endExclusive, TemporalUnit unit);
+
+    /**
+     * {@return an adjusted object of the same type as this object
+     * with the adjustment made}
+     * @param adjuster the adjuster to use, not null
+     */
+    FooDate with(TemporalAdjuster adjuster);
+
+    /**
+     * {@return an object of the same type as this object with the
+     * specified field altered}
+     * @param field the field to set in the result, not null
+     * @param newValue the new value of the field in the result
+     */
+    FooDate with(TemporalField field, long newValue);
+}

--- a/src/java.base/share/classes/java/time/chrono/IsoChronology.java
+++ b/src/java.base/share/classes/java/time/chrono/IsoChronology.java
@@ -123,7 +123,8 @@ import java.util.Objects;
  *
  * @since 1.8
  */
-public final class IsoChronology extends AbstractChronology implements Serializable {
+public final class IsoChronology extends AbstractChronology implements Serializable,
+    FooChronology {
 
     /**
      * Singleton instance of the ISO chronology.

--- a/src/java.base/share/classes/java/time/chrono/JapaneseChronology.java
+++ b/src/java.base/share/classes/java/time/chrono/JapaneseChronology.java
@@ -119,7 +119,8 @@ import sun.util.calendar.LocalGregorianCalendar;
  *
  * @since 1.8
  */
-public final class JapaneseChronology extends AbstractChronology implements Serializable {
+public final class JapaneseChronology extends AbstractChronology implements Serializable,
+    FooChronology {
 
     static final LocalGregorianCalendar JCAL =
         (LocalGregorianCalendar) CalendarSystem.forName("japanese");

--- a/src/java.base/share/classes/java/time/chrono/JapaneseDate.java
+++ b/src/java.base/share/classes/java/time/chrono/JapaneseDate.java
@@ -126,7 +126,7 @@ import sun.util.calendar.LocalGregorianCalendar;
 @jdk.internal.ValueBased
 public final class JapaneseDate
         extends ChronoLocalDateImpl<JapaneseDate>
-        implements ChronoLocalDate, Serializable {
+        implements ChronoLocalDate, Serializable, FooDate {
 
     /**
      * Serialization version.

--- a/src/java.base/share/classes/java/time/chrono/MinguoChronology.java
+++ b/src/java.base/share/classes/java/time/chrono/MinguoChronology.java
@@ -104,7 +104,8 @@ import java.util.Map;
  *
  * @since 1.8
  */
-public final class MinguoChronology extends AbstractChronology implements Serializable {
+public final class MinguoChronology extends AbstractChronology implements Serializable,
+    FooChronology {
 
     /**
      * Singleton instance for the Minguo chronology.

--- a/src/java.base/share/classes/java/time/chrono/MinguoDate.java
+++ b/src/java.base/share/classes/java/time/chrono/MinguoDate.java
@@ -106,7 +106,7 @@ import java.util.Objects;
 @jdk.internal.ValueBased
 public final class MinguoDate
         extends ChronoLocalDateImpl<MinguoDate>
-        implements ChronoLocalDate, Serializable {
+        implements ChronoLocalDate, Serializable, FooDate {
 
     /**
      * Serialization version.

--- a/src/java.base/share/classes/java/time/chrono/ThaiBuddhistDate.java
+++ b/src/java.base/share/classes/java/time/chrono/ThaiBuddhistDate.java
@@ -106,7 +106,7 @@ import java.util.Objects;
 @jdk.internal.ValueBased
 public final class ThaiBuddhistDate
         extends ChronoLocalDateImpl<ThaiBuddhistDate>
-        implements ChronoLocalDate, Serializable {
+        implements ChronoLocalDate, Serializable, FooDate {
 
     /**
      * Serialization version.


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Issue of type `CSR` is not allowed for integrations

### Issue
 * [JDK-8282278](https://bugs.openjdk.org/browse/JDK-8282278): Support for IsoFields in JapaneseDate/MinguoDate/ThaiBuddhistDate (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/8619/head:pull/8619` \
`$ git checkout pull/8619`

Update a local copy of the PR: \
`$ git checkout pull/8619` \
`$ git pull https://git.openjdk.org/jdk pull/8619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8619`

View PR using the GUI difftool: \
`$ git pr show -t 8619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/8619.diff">https://git.openjdk.org/jdk/pull/8619.diff</a>

</details>
