### PR TITLE
8286452: The array length of testSmallConstArray should be small and const

### DIFF
--- a/test/micro/org/openjdk/bench/vm/gc/Alloc.java
+++ b/test/micro/org/openjdk/bench/vm/gc/Alloc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/vm/gc/Alloc.java
+++ b/test/micro/org/openjdk/bench/vm/gc/Alloc.java
@@ -38,13 +38,14 @@ import java.util.concurrent.TimeUnit;
 public class Alloc {
 
     public static final int LENGTH = 400;
-    public static final int ARR_LEN = 100;
-    public int largeLen = 100;
-    public int smalllen = 6;
+    public static final int largeConstLen = 100;
+    public static final int smallConstLen = 6;
+    public int largeVariableLen = 100;
+    public int smallVariableLen = 6;
 
     @Benchmark
     public void testLargeConstArray(Blackhole bh) throws Exception {
-        int localArrlen = ARR_LEN;
+        int localArrlen = largeConstLen;
         for (int i = 0; i < LENGTH; i++) {
             Object[] tmp = new Object[localArrlen];
             bh.consume(tmp);
@@ -53,7 +54,7 @@ public class Alloc {
 
     @Benchmark
     public void testLargeVariableArray(Blackhole bh) throws Exception {
-        int localArrlen = largeLen;
+        int localArrlen = largeVariableLen;
         for (int i = 0; i < LENGTH; i++) {
             Object[] tmp = new Object[localArrlen];
             bh.consume(tmp);
@@ -62,7 +63,7 @@ public class Alloc {
 
     @Benchmark
     public void testSmallConstArray(Blackhole bh) throws Exception {
-        int localArrlen = largeLen;
+        int localArrlen = smallConstLen;
         for (int i = 0; i < LENGTH; i++) {
             Object[] tmp = new Object[localArrlen];
             bh.consume(tmp);
@@ -82,7 +83,7 @@ public class Alloc {
 
     @Benchmark
     public void testSmallVariableArray(Blackhole bh) throws Exception {
-        int localArrlen = smalllen;
+        int localArrlen = smallVariableLen;
         for (int i = 0; i < LENGTH; i++) {
             Object[] tmp = new Object[localArrlen];
             bh.consume(tmp);


### PR DESCRIPTION
testLargeVariableArray and testSmallConstArray are the same, the localArrlen of testSmallConstArray should be small and const.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286452](https://bugs.openjdk.java.net/browse/JDK-8286452): The array length of testSmallConstArray should be small and const


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8621/head:pull/8621` \
`$ git checkout pull/8621`

Update a local copy of the PR: \
`$ git checkout pull/8621` \
`$ git pull https://git.openjdk.java.net/jdk pull/8621/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8621`

View PR using the GUI difftool: \
`$ git pr show -t 8621`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8621.diff">https://git.openjdk.java.net/jdk/pull/8621.diff</a>

</details>
