### PR TITLE
8286441: Remove mode parameter from jdk.internal.perf.Perf.attach()

### DIFF
--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -1097,7 +1097,7 @@ static size_t sharedmem_filesize(int fd, TRAPS) {
 
 // attach to a named shared memory region.
 //
-static void mmap_attach_shared(const char* user, int vmid, PerfMemory::PerfMemoryMode mode, char** addr, size_t* sizep, TRAPS) {
+static void mmap_attach_shared(const char* user, int vmid, char** addr, size_t* sizep, TRAPS) {
 
   char* mapAddress;
   int result;
@@ -1105,30 +1105,10 @@ static void mmap_attach_shared(const char* user, int vmid, PerfMemory::PerfMemor
   size_t size = 0;
   const char* luser = NULL;
 
-  int mmap_prot;
-  int file_flags;
+  int mmap_prot = PROT_READ;
+  int file_flags = O_RDONLY | O_NOFOLLOW;
 
   ResourceMark rm;
-
-  // map the high level access mode to the appropriate permission
-  // constructs for the file and the shared memory mapping.
-  if (mode == PerfMemory::PERF_MODE_RO) {
-    mmap_prot = PROT_READ;
-    file_flags = O_RDONLY | O_NOFOLLOW;
-  }
-  else if (mode == PerfMemory::PERF_MODE_RW) {
-#ifdef LATER
-    mmap_prot = PROT_READ | PROT_WRITE;
-    file_flags = O_RDWR | O_NOFOLLOW;
-#else
-    THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-              "Unsupported access mode");
-#endif
-  }
-  else {
-    THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-              "Illegal access mode");
-  }
 
   // for linux, determine if vmid is for a containerized process
   int nspid = LINUX_ONLY(os::Linux::get_namespace_pid(vmid)) NOT_LINUX(-1);
@@ -1288,7 +1268,7 @@ void PerfMemory::delete_memory_region() {
 // the indicated process's PerfData memory region into this JVMs
 // address space.
 //
-void PerfMemory::attach(const char* user, int vmid, PerfMemoryMode mode, char** addrp, size_t* sizep, TRAPS) {
+void PerfMemory::attach(const char* user, int vmid, char** addrp, size_t* sizep, TRAPS) {
 
   if (vmid == 0 || vmid == os::current_process_id()) {
      *addrp = start();
@@ -1296,7 +1276,7 @@ void PerfMemory::attach(const char* user, int vmid, PerfMemoryMode mode, char** 
      return;
   }
 
-  mmap_attach_shared(user, vmid, mode, addrp, sizep, CHECK);
+  mmap_attach_shared(user, vmid, addrp, sizep, CHECK);
 }
 
 // detach from the PerfData memory region of another JVM

--- a/src/hotspot/os/windows/perfMemory_windows.cpp
+++ b/src/hotspot/os/windows/perfMemory_windows.cpp
@@ -1574,7 +1574,6 @@ static size_t sharedmem_filesize(const char* filename, TRAPS) {
 // into the address space of the process
 //
 static void open_file_mapping(const char* user, int vmid,
-                              PerfMemory::PerfMemoryMode mode,
                               char** addrp, size_t* sizep, TRAPS) {
 
   ResourceMark rm;
@@ -1582,27 +1581,10 @@ static void open_file_mapping(const char* user, int vmid,
   void *mapAddress = 0;
   size_t size = 0;
   HANDLE fmh;
-  DWORD ofm_access;
-  DWORD mv_access;
+  DWORD ofm_access = FILE_MAP_READ;
+  DWORD mv_access = FILE_MAP_READ;
   const char* luser = NULL;
 
-  if (mode == PerfMemory::PERF_MODE_RO) {
-    ofm_access = FILE_MAP_READ;
-    mv_access = FILE_MAP_READ;
-  }
-  else if (mode == PerfMemory::PERF_MODE_RW) {
-#ifdef LATER
-    ofm_access = FILE_MAP_READ | FILE_MAP_WRITE;
-    mv_access = FILE_MAP_READ | FILE_MAP_WRITE;
-#else
-    THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-              "Unsupported access mode");
-#endif
-  }
-  else {
-    THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-              "Illegal access mode");
-  }
 
   // if a user name wasn't specified, then find the user name for
   // the owner of the target vm.
@@ -1796,7 +1778,7 @@ void PerfMemory::delete_memory_region() {
 // the indicated process's PerfData memory region into this JVMs
 // address space.
 //
-void PerfMemory::attach(const char* user, int vmid, PerfMemoryMode mode,
+void PerfMemory::attach(const char* user, int vmid,
                         char** addrp, size_t* sizep, TRAPS) {
 
   if (vmid == 0 || vmid == os::current_process_id()) {
@@ -1805,7 +1787,7 @@ void PerfMemory::attach(const char* user, int vmid, PerfMemoryMode mode,
      return;
   }
 
-  open_file_mapping(user, vmid, mode, addrp, sizep, CHECK);
+  open_file_mapping(user, vmid, addrp, sizep, CHECK);
 }
 
 // detach from the PerfData memory region of another JVM

--- a/src/hotspot/os/windows/perfMemory_windows.cpp
+++ b/src/hotspot/os/windows/perfMemory_windows.cpp
@@ -1573,8 +1573,7 @@ static size_t sharedmem_filesize(const char* filename, TRAPS) {
 // this method opens a file mapping object and maps the object
 // into the address space of the process
 //
-static void open_file_mapping(const char* user, int vmid,
-                              char** addrp, size_t* sizep, TRAPS) {
+static void open_file_mapping(const char* user, int vmid, char** addrp, size_t* sizep, TRAPS) {
 
   ResourceMark rm;
 

--- a/src/hotspot/share/prims/perf.cpp
+++ b/src/hotspot/share/prims/perf.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ static char* jstr_to_utf(JNIEnv *env, jstring str, TRAPS) {
   return utfstr;
 }
 
-PERF_ENTRY(jobject, Perf_Attach(JNIEnv *env, jobject unused, jstring user, int vmid, int mode))
+PERF_ENTRY(jobject, Perf_Attach(JNIEnv *env, jobject unused, jstring user, int vmid))
 
   PerfWrapper("Perf_Attach");
 
@@ -80,13 +80,8 @@ PERF_ENTRY(jobject, Perf_Attach(JNIEnv *env, jobject unused, jstring user, int v
     user_utf = user == NULL ? NULL : jstr_to_utf(env, user, CHECK_NULL);
   }
 
-  if (mode != PerfMemory::PERF_MODE_RO &&
-      mode != PerfMemory::PERF_MODE_RW) {
-    THROW_0(vmSymbols::java_lang_IllegalArgumentException());
-  }
-
   // attach to the PerfData memory region for the specified VM
-  PerfMemory::attach(user_utf, vmid, (PerfMemory::PerfMemoryMode) mode,
+  PerfMemory::attach(user_utf, vmid,
                      &address, &capacity, CHECK_NULL);
 
   {
@@ -300,7 +295,7 @@ PERF_END
 
 static JNINativeMethod perfmethods[] = {
 
-  {CC "attach",              CC "(" JLS "II)" BB, FN_PTR(Perf_Attach)},
+  {CC "attach0",             CC "(" JLS "I)" BB,  FN_PTR(Perf_Attach)},
   {CC "detach",              CC "(" BB ")V",      FN_PTR(Perf_Detach)},
   {CC "createLong",          CL_ARGS,             FN_PTR(Perf_CreateLong)},
   {CC "createByteArray",     CBA_ARGS,            FN_PTR(Perf_CreateByteArray)},

--- a/src/hotspot/share/prims/perf.cpp
+++ b/src/hotspot/share/prims/perf.cpp
@@ -81,8 +81,7 @@ PERF_ENTRY(jobject, Perf_Attach(JNIEnv *env, jobject unused, jstring user, int v
   }
 
   // attach to the PerfData memory region for the specified VM
-  PerfMemory::attach(user_utf, vmid,
-                     &address, &capacity, CHECK_NULL);
+  PerfMemory::attach(user_utf, vmid, &address, &capacity, CHECK_NULL);
 
   {
     ThreadToNativeFromVM ttnfv(thread);

--- a/src/hotspot/share/runtime/perfMemory.hpp
+++ b/src/hotspot/share/runtime/perfMemory.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -128,11 +128,6 @@ class PerfMemory : AllStatic {
     static void delete_memory_region();
 
   public:
-    enum PerfMemoryMode {
-      PERF_MODE_RO = 0,
-      PERF_MODE_RW = 1
-    };
-
     static char* alloc(size_t size);
     static char* start() { return _start; }
     static char* end() { return _end; }
@@ -148,7 +143,7 @@ class PerfMemory : AllStatic {
 
     // methods for attaching to and detaching from the PerfData
     // memory segment of another JVM process on the same system.
-    static void attach(const char* user, int vmid, PerfMemoryMode mode,
+    static void attach(const char* user, int vmid,
                        char** addrp, size_t* size, TRAPS);
     static void detach(char* addr, size_t bytes);
 

--- a/src/hotspot/share/runtime/perfMemory.hpp
+++ b/src/hotspot/share/runtime/perfMemory.hpp
@@ -143,8 +143,7 @@ class PerfMemory : AllStatic {
 
     // methods for attaching to and detaching from the PerfData
     // memory segment of another JVM process on the same system.
-    static void attach(const char* user, int vmid,
-                       char** addrp, size_t* size, TRAPS);
+    static void attach(const char* user, int vmid, char** addrp, size_t* size, TRAPS);
     static void detach(char* addr, size_t bytes);
 
     static void initialize();

--- a/src/java.base/share/classes/jdk/internal/perf/Perf.java
+++ b/src/java.base/share/classes/jdk/internal/perf/Perf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,9 +55,6 @@ import jdk.internal.ref.CleanerFactory;
 public final class Perf {
 
     private static Perf instance;
-
-    private static final int PERF_MODE_RO = 0;
-    private static final int PERF_MODE_RW = 1;
 
     private Perf() { }    // prevent instantiation
 
@@ -171,50 +168,28 @@ public final class Perf {
      * for the Java virtual machine running this method, then the returned
      * <code>ByteBuffer</code> object will always be coherent and dynamically
      * changing.
-     * <p>
-     * The attach mode specifies the access permissions requested for the
-     * instrumentation buffer of the target virtual machine. The permitted
-     * access permissions are:
-     * <ul>
-     * <li>"r"  - Read only access. This Java virtual machine has only
-     * read access to the instrumentation buffer for the target Java
-     * virtual machine.
-     * <li>"rw"  - Read/Write access. This Java virtual machine has read and
-     * write access to the instrumentation buffer for the target Java virtual
-     * machine. This mode is currently not supported and is reserved for
-     * future enhancements.
-     * </ul>
      *
      * @param   lvmid            an integer that uniquely identifies the
      *                           target local Java virtual machine.
-     * @param   mode             a string indicating the attach mode.
      * @return  ByteBuffer       a direct allocated byte buffer
-     * @throws  IllegalArgumentException  The lvmid or mode was invalid.
+     * @throws  IllegalArgumentException  The lvmid was invalid.
      * @throws  IOException      An I/O error occurred while trying to acquire
      *                           the instrumentation buffer.
      * @throws  OutOfMemoryError The instrumentation buffer could not be mapped
      *                           into the virtual machine's address space.
      * @see     java.nio.ByteBuffer
      */
-    public ByteBuffer attach(int lvmid, String mode)
+    public ByteBuffer attach(int lvmid)
            throws IllegalArgumentException, IOException
     {
-        if (mode.compareTo("r") == 0) {
-            return attachImpl(null, lvmid, PERF_MODE_RO);
-        }
-        else if (mode.compareTo("rw") == 0) {
-            return attachImpl(null, lvmid, PERF_MODE_RW);
-        }
-        else {
-            throw new IllegalArgumentException("unknown mode");
-        }
+        return attachImpl(null, lvmid);
     }
 
     /**
      * Attach to the instrumentation buffer for the specified Java virtual
      * machine owned by the given user.
      * <p>
-     * This method behaves just as the <code>attach(int lvmid, String mode)
+     * This method behaves just as the <code>attach(int lvmid)
      * </code> method, except that it only searches for Java virtual machines
      * owned by the specified user.
      *
@@ -223,27 +198,18 @@ public final class Perf {
      *                           virtual machine.
      * @param   lvmid            an integer that uniquely identifies the
      *                           target local Java virtual machine.
-     * @param   mode             a string indicating the attach mode.
      * @return  ByteBuffer       a direct allocated byte buffer
-     * @throws  IllegalArgumentException  The lvmid or mode was invalid.
+     * @throws  IllegalArgumentException  The lvmid was invalid.
      * @throws  IOException      An I/O error occurred while trying to acquire
      *                           the instrumentation buffer.
      * @throws  OutOfMemoryError The instrumentation buffer could not be mapped
      *                           into the virtual machine's address space.
      * @see     java.nio.ByteBuffer
      */
-    public ByteBuffer attach(String user, int lvmid, String mode)
+    public ByteBuffer attach(String user, int lvmid)
            throws IllegalArgumentException, IOException
     {
-        if (mode.compareTo("r") == 0) {
-            return attachImpl(user, lvmid, PERF_MODE_RO);
-        }
-        else if (mode.compareTo("rw") == 0) {
-            return attachImpl(user, lvmid, PERF_MODE_RW);
-        }
-        else {
-            throw new IllegalArgumentException("unknown mode");
-        }
+        return attachImpl(user, lvmid);
     }
 
     /**
@@ -259,18 +225,17 @@ public final class Perf {
      *                           virtual machine.
      * @param   lvmid            an integer that uniquely identifies the
      *                           target local Java virtual machine.
-     * @param   mode             a string indicating the attach mode.
      * @return  ByteBuffer       a direct allocated byte buffer
-     * @throws  IllegalArgumentException  The lvmid or mode was invalid.
+     * @throws  IllegalArgumentException  The lvmid was invalid.
      * @throws  IOException      An I/O error occurred while trying to acquire
      *                           the instrumentation buffer.
      * @throws  OutOfMemoryError The instrumentation buffer could not be mapped
      *                           into the virtual machine's address space.
      */
-    private ByteBuffer attachImpl(String user, int lvmid, int mode)
+    private ByteBuffer attachImpl(String user, int lvmid)
             throws IllegalArgumentException, IOException
     {
-        final ByteBuffer b = attach(user, lvmid, mode);
+        final ByteBuffer b = attach0(user, lvmid);
 
         if (lvmid == 0) {
             // The native instrumentation buffer for this Java virtual
@@ -326,15 +291,14 @@ public final class Perf {
      *                           virtual machine.
      * @param   lvmid            an integer that uniquely identifies the
      *                           target local Java virtual machine.
-     * @param   mode             a string indicating the attach mode.
      * @return  ByteBuffer       a direct allocated byte buffer
-     * @throws  IllegalArgumentException  The lvmid or mode was invalid.
+     * @throws  IllegalArgumentException  The lvmid was invalid.
      * @throws  IOException      An I/O error occurred while trying to acquire
      *                           the instrumentation buffer.
      * @throws  OutOfMemoryError The instrumentation buffer could not be mapped
      *                           into the virtual machine's address space.
      */
-    private native ByteBuffer attach(String user, int lvmid, int mode)
+    private native ByteBuffer attach0(String user, int lvmid)
                    throws IllegalArgumentException, IOException;
 
     /**

--- a/src/java.management/share/classes/sun/management/VMManagementImpl.java
+++ b/src/java.management/share/classes/sun/management/VMManagementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -258,7 +258,7 @@ class VMManagementImpl implements VMManagement {
         @SuppressWarnings("removal")
         Perf perf =  AccessController.doPrivileged(new Perf.GetPerfAction());
         try {
-            ByteBuffer bb = perf.attach(0, "r");
+            ByteBuffer bb = perf.attach(0);
             if (bb.capacity() == 0) {
                 noPerfData = true;
                 return null;

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/HostIdentifier.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/HostIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,10 +66,7 @@ import java.net.*;
  *          (protocol) dependent. These components are ignored by the
  *          default local protocol, <em>local:</em>. For the default remote
  *          protocol, <em>rmi</em>, the Path component is interpreted as
- *          the name of the RMI remote object. The Query component may
- *          contain an access mode specifier <em>?mode=</em> specifying
- *          <em>"r"</em> or <em>"rw"</em> access (write access currently
- *          ignored). The Fragment part is ignored.
+ *          the name of the RMI remote object. The Fragment part is ignored.
  *       </p></li>
  * </ul>
  * <p>
@@ -495,26 +492,6 @@ public class HostIdentifier {
      */
     public String getFragment() {
         return uri.getFragment();
-    }
-
-    /**
-     * Return the mode indicated in this HostIdentifier.
-     *
-     * @return String - the mode string. If no mode is specified, then "r"
-     *                  is returned. otherwise, the specified mode is returned.
-     */
-    public String getMode() {
-        String query = getQuery();
-        if (query != null) {
-            String[] queryArgs = query.split("\\+");
-            for (String queryArg : queryArgs) {
-                if (queryArg.startsWith("mode=")) {
-                    int index = queryArg.indexOf('=');
-                    return queryArg.substring(index + 1);
-                }
-            }
-        }
-        return "r";
     }
 
     /**

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/VmIdentifier.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/VmIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -373,26 +373,6 @@ public class VmIdentifier {
             }
         } catch (NumberFormatException e) { }
         return result;
-    }
-
-    /**
-     * Return the mode indicated in this VmIdentifier.
-     *
-     * @return String - the mode string. If no mode is specified, then "r"
-     *                  is returned. otherwise, the specified mode is returned.
-     */
-    public String getMode() {
-        String query = getQuery();
-        if (query != null) {
-            String[] queryArgs = query.split("\\+");
-            for (String queryArg : queryArgs) {
-                if (queryArg.startsWith("mode=")) {
-                    int index = queryArg.indexOf('=');
-                    return queryArg.substring(index + 1);
-                }
-            }
-        }
-        return "r";
     }
 
     /**

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/file/PerfDataBuffer.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/file/PerfDataBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,22 +53,11 @@ public class PerfDataBuffer extends AbstractPerfDataBuffer {
      */
     public PerfDataBuffer(VmIdentifier vmid) throws MonitorException {
         File f = new File(vmid.getURI());
-        String mode = vmid.getMode();
 
         try {
-            FileChannel fc = new RandomAccessFile(f, mode).getChannel();
-            ByteBuffer bb = null;
-
-            if (mode.equals("r")) {
-                bb = fc.map(FileChannel.MapMode.READ_ONLY, 0L, (int)fc.size());
-            } else if (mode.equals("rw")) {
-                bb = fc.map(FileChannel.MapMode.READ_WRITE, 0L, (int)fc.size());
-            } else {
-                throw new IllegalArgumentException("Invalid mode: " + mode);
-            }
-
+            FileChannel fc = new RandomAccessFile(f, "r").getChannel();
+            ByteBuffer bb = fc.map(FileChannel.MapMode.READ_ONLY, 0L, (int)fc.size());
             fc.close();               // doesn't need to remain open
-
             createPerfDataBuffer(bb, 0);
         } catch (FileNotFoundException e) {
             throw new MonitorException("Could not find " + vmid.toString());

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/file/PerfDataBuffer.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/file/PerfDataBuffer.java
@@ -54,11 +54,10 @@ public class PerfDataBuffer extends AbstractPerfDataBuffer {
     public PerfDataBuffer(VmIdentifier vmid) throws MonitorException {
         File f = new File(vmid.getURI());
 
-        try {
-            FileChannel fc = new RandomAccessFile(f, "r").getChannel();
+        try (FileChannel fc = new RandomAccessFile(f, "r").getChannel()) {
             ByteBuffer bb = fc.map(FileChannel.MapMode.READ_ONLY, 0L, (int)fc.size());
-            fc.close();               // doesn't need to remain open
             createPerfDataBuffer(bb, 0);
+            // fc doesn't need to remain open
         } catch (FileNotFoundException e) {
             throw new MonitorException("Could not find " + vmid.toString());
         } catch (IOException e) {

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/PerfDataBuffer.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/PerfDataBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ public class PerfDataBuffer extends AbstractPerfDataBuffer {
     public PerfDataBuffer(VmIdentifier vmid) throws MonitorException {
         try {
             // Try 1.4.2 and later first
-            ByteBuffer bb = perf.attach(vmid.getLocalVmId(), vmid.getMode());
+            ByteBuffer bb = perf.attach(vmid.getLocalVmId());
             createPerfDataBuffer(bb, vmid.getLocalVmId());
 
         } catch (IllegalArgumentException e) {

--- a/src/jdk.jcmd/share/classes/sun/tools/jps/Jps.java
+++ b/src/jdk.jcmd/share/classes/sun/tools/jps/Jps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,7 @@ public class Jps {
                 }
 
                 MonitoredVm vm = null;
-                String vmidString = "//" + lvmid + "?mode=r";
+                String vmidString = "//" + lvmid;
 
                 String errorString = null;
 

--- a/src/jdk.jstatd/share/classes/sun/jvmstat/monitor/remote/RemoteHost.java
+++ b/src/jdk.jstatd/share/classes/sun/jvmstat/monitor/remote/RemoteHost.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,8 +53,7 @@ public interface RemoteHost extends Remote {
      * @throws RemoteException
      *
      */
-    RemoteVm attachVm(int vmid, String mode) throws RemoteException,
-                                                    MonitorException;
+    RemoteVm attachVm(int vmid) throws RemoteException, MonitorException;
 
     /**
      * Remote method to detach from a remote HotSpot Java Virtual Machine

--- a/src/jdk.jstatd/share/classes/sun/jvmstat/perfdata/monitor/protocol/rmi/MonitoredHostProvider.java
+++ b/src/jdk.jstatd/share/classes/sun/jvmstat/perfdata/monitor/protocol/rmi/MonitoredHostProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,8 +141,7 @@ public class MonitoredHostProvider extends MonitoredHost {
         VmIdentifier nvmid = null;
         try {
             nvmid = hostId.resolve(vmid);
-            RemoteVm rvm = remoteHost.attachVm(vmid.getLocalVmId(),
-                                               vmid.getMode());
+            RemoteVm rvm = remoteHost.attachVm(vmid.getLocalVmId());
             RemoteMonitoredVm rmvm = new RemoteMonitoredVm(rvm, nvmid, timer,
                                                            interval);
             rmvm.attach();

--- a/src/jdk.jstatd/share/classes/sun/tools/jstatd/RemoteHostImpl.java
+++ b/src/jdk.jstatd/share/classes/sun/tools/jstatd/RemoteHostImpl.java
@@ -67,14 +67,12 @@ public class RemoteHostImpl implements RemoteHost, HostListener {
         monitoredHost.addHostListener(this);
     }
 
-    public RemoteVm attachVm(int lvmid)
-                    throws RemoteException, MonitorException {
+    public RemoteVm attachVm(int lvmid) throws RemoteException, MonitorException {
         Integer v = lvmid;
         RemoteVm stub = null;
         StringBuilder sb = new StringBuilder();
 
-        sb.append("local://").append(lvmid).append("@localhost");
-        String vmidStr = sb.toString();
+        String vmidStr = "local://" + lvmid + "@localhost";
 
         try {
             VmIdentifier vmid = new VmIdentifier(vmidStr);

--- a/src/jdk.jstatd/share/classes/sun/tools/jstatd/RemoteHostImpl.java
+++ b/src/jdk.jstatd/share/classes/sun/tools/jstatd/RemoteHostImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,17 +67,13 @@ public class RemoteHostImpl implements RemoteHost, HostListener {
         monitoredHost.addHostListener(this);
     }
 
-    public RemoteVm attachVm(int lvmid, String mode)
+    public RemoteVm attachVm(int lvmid)
                     throws RemoteException, MonitorException {
         Integer v = lvmid;
         RemoteVm stub = null;
         StringBuilder sb = new StringBuilder();
 
         sb.append("local://").append(lvmid).append("@localhost");
-        if (mode != null) {
-            sb.append("?mode=").append(mode);
-        }
-
         String vmidStr = sb.toString();
 
         try {

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/ConnectorAddressLink.java
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/ConnectorAddressLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -143,7 +143,7 @@ public class ConnectorAddressLink {
         Perf perf = Perf.getPerf();
         ByteBuffer bb;
         try {
-            bb = perf.attach(vmid, "r");
+            bb = perf.attach(vmid);
         } catch (IllegalArgumentException iae) {
             throw new IOException(iae.getMessage());
         }
@@ -200,7 +200,7 @@ public class ConnectorAddressLink {
         Perf perf = Perf.getPerf();
         ByteBuffer bb;
         try {
-            bb = perf.attach(vmid, "r");
+            bb = perf.attach(vmid);
         } catch (IllegalArgumentException iae) {
             throw new IOException(iae.getMessage());
         }


### PR DESCRIPTION
The `mode` parameter for ` jdk.internal.perf.Perf.attach()` has never supported the value `"rw"` since the source code was imported to the openjdk repo more than 15 years ago. In fact HotSpot throws `IllegalArgumentException` when such a mode is specified.

It's unlikely such a mode will be required for future enhancements. Support for `"rw"` is removed. The "mode" parameter is also removed, since now `"r"` is the only supported mode.

I also cleaned up related code in the JDK and HotSpot.

Testing:
- Passed tiers 1 ~ 5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286441](https://bugs.openjdk.java.net/browse/JDK-8286441): Remove mode parameter from jdk.internal.perf.Perf.attach()


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to [22c22c30](https://git.openjdk.java.net/jdk/pull/8622/files/22c22c3039e991c3793887b03826f8668c40b824)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8622/head:pull/8622` \
`$ git checkout pull/8622`

Update a local copy of the PR: \
`$ git checkout pull/8622` \
`$ git pull https://git.openjdk.java.net/jdk pull/8622/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8622`

View PR using the GUI difftool: \
`$ git pr show -t 8622`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8622.diff">https://git.openjdk.java.net/jdk/pull/8622.diff</a>

</details>
