### PR TITLE
8286423: Destroy password protection in the example code in KeyStore

### DIFF
--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -145,21 +145,24 @@ import sun.security.util.Debug;
  * <pre>
  *    KeyStore.ProtectionParameter protParam =
  *        new KeyStore.PasswordProtection(password);
+ *    try {
+ *        // get my private key
+ *        KeyStore.PrivateKeyEntry pkEntry = (KeyStore.PrivateKeyEntry)
+ *            ks.getEntry("privateKeyAlias", protParam);
+ *        PrivateKey myPrivateKey = pkEntry.getPrivateKey();
  *
- *    // get my private key
- *    KeyStore.PrivateKeyEntry pkEntry = (KeyStore.PrivateKeyEntry)
- *        ks.getEntry("privateKeyAlias", protParam);
- *    PrivateKey myPrivateKey = pkEntry.getPrivateKey();
+ *        // save my secret key
+ *        javax.crypto.SecretKey mySecretKey;
+ *        KeyStore.SecretKeyEntry skEntry =
+ *            new KeyStore.SecretKeyEntry(mySecretKey);
+ *        ks.setEntry("secretKeyAlias", skEntry, protParam);
  *
- *    // save my secret key
- *    javax.crypto.SecretKey mySecretKey;
- *    KeyStore.SecretKeyEntry skEntry =
- *        new KeyStore.SecretKeyEntry(mySecretKey);
- *    ks.setEntry("secretKeyAlias", skEntry, protParam);
- *
- *    // store away the keystore
- *    try (FileOutputStream fos = new FileOutputStream("newKeyStoreName")) {
- *        ks.store(fos, password);
+ *        // store away the keystore
+ *        try (FileOutputStream fos = new FileOutputStream("newKeyStoreName")) {
+ *            ks.store(fos, password);
+ *        }
+ *    } finally {
+ *        protParam.destroy();
  *    }
  * </pre>
  *

--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -143,7 +143,7 @@ import sun.security.util.Debug;
  * to read existing entries from the keystore, or to write new entries
  * into the keystore:
  * <pre>
- *    KeyStore.ProtectionParameter protParam =
+ *    KeyStore.PasswordProtection protParam =
  *        new KeyStore.PasswordProtection(password);
  *    try {
  *        // get my private key

--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -145,7 +145,7 @@ import sun.security.util.Debug;
  * <pre>
  *    KeyStore.PasswordProtection protParam =
  *        new KeyStore.PasswordProtection(password);
- *    try {
+ *    try (FileOutputStream fos = new FileOutputStream("newKeyStoreName")) {
  *        // get my private key
  *        KeyStore.PrivateKeyEntry pkEntry = (KeyStore.PrivateKeyEntry)
  *            ks.getEntry("privateKeyAlias", protParam);
@@ -158,9 +158,7 @@ import sun.security.util.Debug;
  *        ks.setEntry("secretKeyAlias", skEntry, protParam);
  *
  *        // store away the keystore
- *        try (FileOutputStream fos = new FileOutputStream("newKeyStoreName")) {
- *            ks.store(fos, password);
- *        }
+ *        ks.store(fos, password);
  *    } finally {
  *        protParam.destroy();
  *    }


### PR DESCRIPTION
Hi,

May I have this simple example update in the KeyStore specification?

Password protection should be destroyed in the example code in KeyStore specification. Otherwise, applications may just copy and past the code, and forget to clean up password protection.

It's a trivial update, and may not worthy of a CSR.  But please let me know if you would like to have a CSR filed.

Thanks,
Xuelei

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286423](https://bugs.openjdk.java.net/browse/JDK-8286423): Destroy password protection in the example code in KeyStore


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8623/head:pull/8623` \
`$ git checkout pull/8623`

Update a local copy of the PR: \
`$ git checkout pull/8623` \
`$ git pull https://git.openjdk.java.net/jdk pull/8623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8623`

View PR using the GUI difftool: \
`$ git pr show -t 8623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8623.diff">https://git.openjdk.java.net/jdk/pull/8623.diff</a>

</details>
