### PR TITLE
8286339: compiler/c2/irTests/TestEnumFinalFold.java fails if Enum/String methods are not inlined

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -66,7 +66,6 @@ compiler/rtm/locking/TestUseRTMXendForLockBusy.java 8183263 generic-x64
 compiler/rtm/print/TestPrintPreciseRTMLockingStatistics.java 8183263 generic-x64
 
 compiler/c2/Test8004741.java 8235801 generic-all
-compiler/c2/irTests/TestEnumFinalFold.java 8286339 generic-all
 
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all
 compiler/codecache/TestStressCodeBuffers.java 8272094 generic-aarch64

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestEnumFinalFold.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestEnumFinalFold.java
@@ -37,7 +37,12 @@ import compiler.lib.ir_framework.*;
 public class TestEnumFinalFold {
 
     public static void main(String[] args) {
-        TestFramework.run();
+        TestFramework.runWithFlags(
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:CompileCommand=inline,java.lang.Enum::name",
+            "-XX:CompileCommand=inline,java.lang.Enum::ordinal",
+            "-XX:CompileCommand=inline,java.lang.String::length"
+        );
     }
 
     private enum MyEnum {


### PR DESCRIPTION
As shown in the bug, the test relies on test methods in `Enum` and `String` to be inlined for constant folding to happen. In some testing modes, this does not happen. The fix is to force inlining for methods that test uses. It is kinda odd to ask force inlining of system class methods, but it does not seem problematic.

Additional testing:
 - [x] Test now passes in unusual test modes reported
 - [x] Test still passes in default test modes on x86_32 and x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286339](https://bugs.openjdk.java.net/browse/JDK-8286339): compiler/c2/irTests/TestEnumFinalFold.java fails if Enum/String methods are not inlined


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8625/head:pull/8625` \
`$ git checkout pull/8625`

Update a local copy of the PR: \
`$ git checkout pull/8625` \
`$ git pull https://git.openjdk.java.net/jdk pull/8625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8625`

View PR using the GUI difftool: \
`$ git pr show -t 8625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8625.diff">https://git.openjdk.java.net/jdk/pull/8625.diff</a>

</details>
