### PR TITLE
8286474: Drop --enable-preview from Sealed Classes related tests

### DIFF
--- a/test/jdk/java/lang/reflect/sealed_classes/SealedClassesReflectionTest.java
+++ b/test/jdk/java/lang/reflect/sealed_classes/SealedClassesReflectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8227046
  * @summary reflection test for sealed classes
- * @compile -source ${jdk.version} SealedClassesReflectionTest.java
+ * @compile SealedClassesReflectionTest.java
  * @run testng/othervm SealedClassesReflectionTest
  */
 

--- a/test/jdk/java/lang/reflect/sealed_classes/SealedClassesReflectionTest.java
+++ b/test/jdk/java/lang/reflect/sealed_classes/SealedClassesReflectionTest.java
@@ -25,8 +25,8 @@
  * @test
  * @bug 8227046
  * @summary reflection test for sealed classes
- * @compile --enable-preview -source ${jdk.version} SealedClassesReflectionTest.java
- * @run testng/othervm --enable-preview SealedClassesReflectionTest
+ * @compile -source ${jdk.version} SealedClassesReflectionTest.java
+ * @run testng/othervm SealedClassesReflectionTest
  */
 
 import java.lang.annotation.*;

--- a/test/jdk/java/lang/reflect/sealed_classes/TestSecurityManagerChecks.java
+++ b/test/jdk/java/lang/reflect/sealed_classes/TestSecurityManagerChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/reflect/sealed_classes/TestSecurityManagerChecks.java
+++ b/test/jdk/java/lang/reflect/sealed_classes/TestSecurityManagerChecks.java
@@ -28,8 +28,8 @@
  * @library /test/lib
  * @modules java.compiler
  * @build jdk.test.lib.compiler.CompilerUtils jdk.test.lib.compiler.ModuleInfoMaker TestSecurityManagerChecks
- * @run main/othervm -Djava.security.manager=allow --enable-preview TestSecurityManagerChecks named
- * @run main/othervm -Djava.security.manager=allow --enable-preview TestSecurityManagerChecks unnamed
+ * @run main/othervm -Djava.security.manager=allow TestSecurityManagerChecks named
+ * @run main/othervm -Djava.security.manager=allow TestSecurityManagerChecks unnamed
  */
 
 import java.io.IOException;


### PR DESCRIPTION
There are plenty of tests failing on many architectures due to `--enable-preview` VM code introduced by Loom. This improvement eliminates some of the redundant `--enable-preview` clauses from the Sealed Classes tests, since Sealed Classes have been graduated from preview in JDK 17.

Additional testing:
 - [x] Linux x86_64 fastdebug, affected tests still pass
 - [x] Linux x86_32 fastdebug, affected tests start to pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286474](https://bugs.openjdk.java.net/browse/JDK-8286474): Drop --enable-preview from Sealed Classes related tests


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - Committer)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8627/head:pull/8627` \
`$ git checkout pull/8627`

Update a local copy of the PR: \
`$ git checkout pull/8627` \
`$ git pull https://git.openjdk.java.net/jdk pull/8627/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8627`

View PR using the GUI difftool: \
`$ git pr show -t 8627`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8627.diff">https://git.openjdk.java.net/jdk/pull/8627.diff</a>

</details>
