### PR TITLE
8286475: Drop --enable-preview from instanceof pattern matching related tests

### DIFF
--- a/test/langtools/tools/javac/ConditionalExpressionResolvePending.java
+++ b/test/langtools/tools/javac/ConditionalExpressionResolvePending.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/ConditionalExpressionResolvePending.java
+++ b/test/langtools/tools/javac/ConditionalExpressionResolvePending.java
@@ -35,7 +35,7 @@
  * @build toolbox.ToolBox toolbox.JavacTask
  * @build combo.ComboTestHelper
  * @compile ConditionalExpressionResolvePending.java
- * @run main/othervm --enable-preview ConditionalExpressionResolvePending
+ * @run main/othervm ConditionalExpressionResolvePending
  */
 
 import combo.ComboInstance;


### PR DESCRIPTION
There are plenty of tests failing on many architectures due to `--enable-preview` VM code introduced by Loom. This improvement eliminates some of the redundant `--enable-preview` clauses from the instanceof pattern matching tests, since instanceof pattern matching have been graduated from preview in JDK 16. 

Additional testing:
 - [x] Linux x86_64 fastdebug, affected tests still pass
 - [x] Linux x86_32 fastdebug, affected tests start to pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286475](https://bugs.openjdk.java.net/browse/JDK-8286475): Drop --enable-preview from instanceof pattern matching related tests


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8628/head:pull/8628` \
`$ git checkout pull/8628`

Update a local copy of the PR: \
`$ git checkout pull/8628` \
`$ git pull https://git.openjdk.java.net/jdk pull/8628/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8628`

View PR using the GUI difftool: \
`$ git pr show -t 8628`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8628.diff">https://git.openjdk.java.net/jdk/pull/8628.diff</a>

</details>
