### PR TITLE
8286212: Cgroup v1 initialization causes NPE on some systems

### DIFF
--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -77,40 +77,19 @@ void CgroupV1Controller::set_subsystem_path(char *cgroup_path) {
           // If there are no matches between the root and the cgroup path,
           // the controller's mount point will be used, which is a reasonable
           // fallback.
-          int buflen;
-          strncpy(buf, _mount_point, MAXPATHLEN);
-          buf[MAXPATHLEN-1] = '\0';
-          buflen = strlen(buf);
-          if ((buflen + strlen(cgroup_path)) > (MAXPATHLEN-1)) {
-              return;
-          }
-          char tmp_root_buf[MAXPATHLEN+1];
-          char tmp_cgroup_buf[MAXPATHLEN+1];
-          strcpy(tmp_root_buf, _root);
-          strcpy(tmp_cgroup_buf, cgroup_path);
-          char* tmp_root = &tmp_root_buf[0];
-          char* tmp_cgroup = &tmp_cgroup_buf[0];
-          char* root_save = NULL;
-          char* cgroup_save = NULL;
-          char* root_token = NULL;
-          char* cg_token = NULL;
-          char* buf_ptr = buf + buflen;
-          while ((root_token = strtok_r(tmp_root, "/", &root_save)) != NULL &&
-                 (cg_token = strtok_r(tmp_cgroup, "/", &cgroup_save)) != NULL) {
-            if (root_token == NULL || cg_token == NULL) {
-              break;
+          stringStream ss;
+          ss.print_raw(_mount_point);
+          const char* root_p = _root;
+          const char* cgroup_p = cgroup_path;
+          int last_matching_slash_pos = -1;
+          for (int i = 0; *root_p == *cgroup_p && *root_p != 0; i++) {
+            if (*root_p == '/') {
+              last_matching_slash_pos = i;
             }
-            if (strcmp(root_token, cg_token) == 0) {
-              strncpy(buf_ptr, "/", 2);
-              buf_ptr++;
-              strcpy(buf_ptr, root_token);
-              buf_ptr = buf_ptr + strlen(root_token);
-            }
-            tmp_root = NULL;
-            tmp_cgroup = NULL;
+            root_p++; cgroup_p++;
           }
-          buf[MAXPATHLEN-1] = '\0';
-          _path = os::strdup(buf);
+          ss.print_raw(_root, last_matching_slash_pos);
+          _path = os::strdup(ss.base());
         }
       }
     }

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -32,6 +32,7 @@
 #include "runtime/os.hpp"
 #include "utilities/globalDefinitions.hpp"
 
+
 /*
  * Set directory to subsystem specific files based
  * on the contents of the mountinfo and cgroup files.
@@ -73,7 +74,7 @@ void CgroupV1Controller::set_subsystem_path(char *cgroup_path) {
             _path = os::strdup(buf);
           }
         } else {
-          // Find the longest common substring as namespaces are hierarchical.
+          // Find the longest common prefix as namespaces are hierarchical.
           // If there are no matches between the root and the cgroup path,
           // the controller's mount point will be used, which is a reasonable
           // fallback.
@@ -81,20 +82,30 @@ void CgroupV1Controller::set_subsystem_path(char *cgroup_path) {
           ss.print_raw(_mount_point);
           const char* root_p = _root;
           const char* cgroup_p = cgroup_path;
-          int last_matching_slash_pos = -1;
-          for (int i = 0; *root_p == *cgroup_p && *root_p != 0; i++) {
-            if (*root_p == '/') {
-              last_matching_slash_pos = i;
-            }
-            root_p++; cgroup_p++;
-          }
-          ss.print_raw(_root, last_matching_slash_pos);
+          int last_slash = find_last_slash_pos(root_p, cgroup_p);
+          assert(last_slash >= 0, "not an absolute path?");
+          ss.print_raw(_root, last_slash);
           _path = os::strdup(ss.base());
         }
       }
     }
   }
 }
+
+// Return last index of '/' in s1 and s2 up to which point paths
+// are the same in s1 and s2. -1 otherwise. For example
+// returns 4 for s1 = "/cat/dog" and s2 = "/cat/cow".
+int CgroupV1Controller::find_last_slash_pos(const char* s1, const char* s2) {
+  int last_matching_slash_pos = -1;
+  for (int i = 0; *s1 == *s2 && *s1 != 0; i++) {
+    if (*s1 == '/') {
+      last_matching_slash_pos = i;
+    }
+    s1++; s2++;
+  }
+  return last_matching_slash_pos;
+}
+
 
 /* uses_mem_hierarchy
  *

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
@@ -49,6 +49,8 @@ class CgroupV1Controller: public CgroupController {
 
     virtual void set_subsystem_path(char *cgroup_path);
     char *subsystem_path() { return _path; }
+  private:
+    int find_last_slash_pos(const char* s1, const char* s2);
 };
 
 class CgroupV1MemoryController: public CgroupV1Controller {

--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
@@ -112,7 +112,13 @@ public class CgroupSubsystemFactory {
             CgroupSubsystem subsystem = CgroupV2Subsystem.getInstance(anyController);
             return subsystem != null ? new CgroupMetrics(subsystem) : null;
         } else {
-            CgroupV1Subsystem subsystem = CgroupV1Subsystem.getInstance(infos);
+            CgroupV1Subsystem subsystem = null;
+            try {
+                subsystem = CgroupV1Subsystem.getInstance(infos);
+            } catch (NullPointerException e) {
+                Logger logger = System.getLogger("jdk.internal.platform");
+                logger.log(Level.DEBUG, "Creating cgroupv1 instance threw NPE. Metrics disabled.");
+            }
             return subsystem != null ? new CgroupV1MetricsImpl(subsystem) : null;
         }
     }

--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
@@ -80,14 +80,20 @@ public class CgroupV1Subsystem implements CgroupSubsystem, CgroupV1Metrics {
             switch (info.getName()) {
             case "memory": {
                 if (info.getMountRoot() != null && info.getMountPoint() != null) {
-                    CgroupV1MemorySubSystemController controller = new CgroupV1MemorySubSystemController(info.getMountRoot(), info.getMountPoint());
-                    controller.setPath(info.getCgroupPath());
-                    boolean isHierarchial = getHierarchical(controller);
-                    controller.setHierarchical(isHierarchial);
-                    boolean isSwapEnabled = getSwapEnabled(controller);
-                    controller.setSwapEnabled(isSwapEnabled);
-                    subsystem.setMemorySubSystem(controller);
-                    anyActiveControllers = true;
+                    try {
+                        CgroupV1MemorySubSystemController controller = new CgroupV1MemorySubSystemController(info.getMountRoot(), info.getMountPoint());
+                        controller.setPath(info.getCgroupPath());
+                        boolean isHierarchial = getHierarchical(controller);
+                        controller.setHierarchical(isHierarchial);
+                        boolean isSwapEnabled = getSwapEnabled(controller);
+                        controller.setSwapEnabled(isSwapEnabled);
+                        subsystem.setMemorySubSystem(controller);
+                        anyActiveControllers = true;
+                    } catch (NullPointerException npe) {
+                        // disable the memory controller, as hierarchical or
+                        // swap enabled look-up threw NPE when trying to find interface
+                        // files
+                    }
                 }
                 break;
             }

--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1SubsystemController.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1SubsystemController.java
@@ -62,6 +62,22 @@ public class CgroupV1SubsystemController implements CgroupSubsystemController {
                             String cgroupSubstr = cgroupPath.substring(root.length());
                             path = mountPoint + cgroupSubstr;
                         }
+                    } else {
+                        StringBuilder pathBuilder = new StringBuilder();
+                        pathBuilder.append(mountPoint);
+                        // Find the longest commonly shared path
+                        String[] rTokens = root.split("/");
+                        String[] cTokens = cgroupPath.split("/");
+                        for (int i = 0; rTokens[i].equals(cTokens[i]); i++) {
+                            // "/foo".split() ==> [ "", "foo" ]. Therefore, skip empty
+                            // tokens
+                            if (rTokens[i].isEmpty() && cTokens[i].isEmpty()) {
+                                continue;
+                            }
+                            pathBuilder.append("/");
+                            pathBuilder.append(rTokens[i]);
+                        }
+                        path = pathBuilder.toString();
                     }
                 }
             }

--- a/test/hotspot/gtest/runtime/test_os_linux_cgroups.cpp
+++ b/test/hotspot/gtest/runtime/test_os_linux_cgroups.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+
+#ifdef LINUX
+
+#include "cgroupV1Subsystem_linux.hpp"
+#include "unittest.hpp"
+
+TEST(os_linux_cgroup, set_cgroup1_subsystem_path) {
+  int length = 5;
+  const char* mount_paths[] =     { "/sys/fs/cgroup/memory",
+                                    "/sys/fs/cgroup/memory", /* non-matched cg path  */
+                                    "/sys/fs/cgroup/mem",    /* root matched cg path */
+                                    "/sys/fs/cgroup/memory", /* substring match      */
+                                    "/sys/fs/cgroup/m"       /* non-matched cg path  */
+                                  };
+  const char* root_paths[] =      { "/",
+                                    "/user.slice/user-1000.slice/session-50.scope",  /* non-matched cg path  */
+                                    "/user.slice/user-1000.slice/user@1000.service", /* root matched cg path */
+                                    "/user.slice/user-1000.slice",                   /* substring match */
+                                    "/machine.slice/user-2002.slice"                 /* root match only */
+                                  };
+  const char* cgroup_paths[] =    { "/user.slice/user-1000.slice/user@1000.service",
+                                    "/user.slice/user-1000.slice/session-3.scope",   /* non-matched cg path  */
+                                    "/user.slice/user-1000.slice/user@1000.service", /* root matched cg path */
+                                    "/user.slice/user-1000.slice/user@1001.service", /* substring match */
+                                    "/user.sl/user-3000.slice/user@3001.service"     /* root match only */
+                                  };
+  const char* expected_cg_paths[] { "/sys/fs/cgroup/memory/user.slice/user-1000.slice/user@1000.service",
+                                    "/sys/fs/cgroup/memory/user.slice/user-1000.slice", /* closest substring match */
+                                    "/sys/fs/cgroup/mem",                               /* root matched cg path    */
+                                    "/sys/fs/cgroup/memory/user@1001.service",          /* substring match */
+                                    "/sys/fs/cgroup/m"                                  /* root match only */
+                                  };
+
+  for (int i = 0; i < length; i++) {
+    CgroupV1Controller* ctrl = new CgroupV1Controller((char*)root_paths[i], (char*)mount_paths[i]);
+    ctrl->set_subsystem_path((char*)cgroup_paths[i]);
+    ASSERT_STREQ(expected_cg_paths[i], ctrl->subsystem_path());
+  }
+}
+
+#endif

--- a/test/jdk/jdk/internal/platform/cgroup/CgroupV1SubsystemControllerTest.java
+++ b/test/jdk/jdk/internal/platform/cgroup/CgroupV1SubsystemControllerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import jdk.internal.platform.cgroupv1.CgroupV1SubsystemController;
+
+/*
+ * @test
+ * @key cgroups
+ * @requires os.family == "linux"
+ * @modules java.base/jdk.internal.platform.cgroupv1
+ * @library /test/lib
+ * @run junit/othervm CgroupV1SubsystemControllerTest
+ */
+public class CgroupV1SubsystemControllerTest {
+
+    @Test
+    public void testCgPathEqualsRoot() {
+        String root = "/";
+        String mountPoint = "/somemount";
+        CgroupV1SubsystemController ctrl = new CgroupV1SubsystemController(root, mountPoint);
+        ctrl.setPath("/");
+        assertEquals(mountPoint, ctrl.path());
+    }
+
+    @Test
+    public void testCgPathNonEmptyRoot() {
+        String root = "/";
+        String mountPoint = "/sys/fs/cgroup/memory";
+        CgroupV1SubsystemController ctrl = new CgroupV1SubsystemController(root, mountPoint);
+        String cgroupPath = "/subpath";
+        ctrl.setPath(cgroupPath);
+        String expectedPath = mountPoint + cgroupPath;
+        assertEquals(expectedPath, ctrl.path());
+    }
+
+    @Test
+    public void testCgPathSubstring() {
+        String root = "/foo/bar/baz";
+        String mountPoint = "/sys/fs/cgroup/memory";
+        CgroupV1SubsystemController ctrl = new CgroupV1SubsystemController(root, mountPoint);
+        String cgroupPath = "/foo/bar/baz/some";
+        ctrl.setPath(cgroupPath);
+        String expectedPath = mountPoint + "/some";
+        assertEquals(expectedPath, ctrl.path());
+    }
+
+    @Test
+    public void testCgPathParentMatch() {
+        String root = "/user.slice/user-1000.slice/session-50.scope";
+        String mountPoint = "/sys/fs/cgroup/memory";
+        CgroupV1SubsystemController ctrl = new CgroupV1SubsystemController(root, mountPoint);
+        String cgroupPath = "/user.slice/user-1000.slice/session-3.scope";
+        ctrl.setPath(cgroupPath);
+        String expectedPath = mountPoint + "/user.slice/user-1000.slice";
+        assertEquals(expectedPath, ctrl.path());
+    }
+
+    @Test
+    public void testCgPathFallbackToMountPoint() {
+        String root = "/user.slice/user-1000.slice/session-50.scope";
+        String mountPoint = "/sys/fs/cgroup/memory";
+        CgroupV1SubsystemController ctrl = new CgroupV1SubsystemController(root, mountPoint);
+        String cgroupPath = "/machine.slice/machine-1032.slice/session-3.scope";
+        ctrl.setPath(cgroupPath);
+        String expectedPath = mountPoint;
+        assertEquals(expectedPath, ctrl.path());
+    }
+}

--- a/test/jdk/jdk/internal/platform/cgroup/TestCgroupSubsystemFactory.java
+++ b/test/jdk/jdk/internal/platform/cgroup/TestCgroupSubsystemFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Red Hat Inc.
+ * Copyright (c) 2020, 2022, Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,7 @@ import jdk.internal.platform.CgroupSubsystemFactory;
 import jdk.internal.platform.CgroupSubsystemFactory.CgroupTypeResult;
 import jdk.internal.platform.CgroupV1MetricsImpl;
 import jdk.internal.platform.cgroupv1.CgroupV1Subsystem;
+import jdk.internal.platform.cgroupv1.CgroupV1SubsystemController;
 import jdk.internal.platform.Metrics;
 import jdk.test.lib.Utils;
 import jdk.test.lib.util.FileUtils;
@@ -72,8 +73,10 @@ public class TestCgroupSubsystemFactory {
     private Path cgroupv1MntInfoDoubleCpusets;
     private Path cgroupv1MntInfoDoubleCpusets2;
     private Path cgroupv1MntInfoColonsHierarchy;
+    private Path cgroupv1MntInfoPrefix;
     private Path cgroupv1SelfCgroup;
     private Path cgroupv1SelfColons;
+    private Path cgroupv1SelfPrefix;
     private Path cgroupv2SelfCgroup;
     private Path cgroupv1SelfCgroupJoinCtrl;
     private Path cgroupv1CgroupsOnlyCPUCtrl;
@@ -166,6 +169,7 @@ public class TestCgroupSubsystemFactory {
             "42 30 0:38 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:14 - cgroup none rw,seclabel,cpuset\n" +
             "43 30 0:39 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:15 - cgroup none rw,seclabel,blkio\n" +
             "44 30 0:40 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:16 - cgroup none rw,seclabel,freezer\n";
+    private String mntInfoPrefix = "941 931 0:36 /user.slice/user-1000.slice/session-50.scope /sys/fs/cgroup/memory ro,nosuid,nodev,noexec,relatime - cgroup cgroup rw,seclabel,memory\n";
     private String cgroupsNonZeroHierarchy =
             "#subsys_name hierarchy   num_cgroups enabled\n" +
             "cpuset  9   1   1\n" +
@@ -217,6 +221,7 @@ public class TestCgroupSubsystemFactory {
             "2:cpu,cpuacct:/\n" +
             "1:name=systemd:/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-3c00b338-5b65-439f-8e97-135e183d135d.scope\n" +
             "0::/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-3c00b338-5b65-439f-8e97-135e183d135d.scope\n";
+    private  String cgroupv1SelfPrefixContent = "9:memory:/user.slice/user-1000.slice/session-3.scope\n";
     private String cgroupv2SelfCgroupContent = "0::/user.slice/user-1000.slice/session-2.scope";
 
     @Before
@@ -257,11 +262,17 @@ public class TestCgroupSubsystemFactory {
             cgroupv1MntInfoColonsHierarchy = Paths.get(existingDirectory.toString(), "mountinfo_colons");
             Files.writeString(cgroupv1MntInfoColonsHierarchy, mntInfoColons);
 
+            cgroupv1MntInfoPrefix = Paths.get(existingDirectory.toString(), "mountinfo-prefix");
+            Files.writeString(cgroupv1MntInfoPrefix, mntInfoPrefix);
+
             cgroupv1SelfCgroup = Paths.get(existingDirectory.toString(), "self_cgroup_cgv1");
             Files.writeString(cgroupv1SelfCgroup, cgroupv1SelfCgroupContent);
 
             cgroupv1SelfColons = Paths.get(existingDirectory.toString(), "self_colons_cgv1");
             Files.writeString(cgroupv1SelfColons, cgroupv1SelfColonsContent);
+
+            cgroupv1SelfPrefix = Paths.get(existingDirectory.toString(), "self_prefix_cgv1");
+            Files.writeString(cgroupv1SelfPrefix, cgroupv1SelfPrefixContent);
 
             cgroupv2SelfCgroup = Paths.get(existingDirectory.toString(), "self_cgroup_cgv2");
             Files.writeString(cgroupv2SelfCgroup, cgroupv2SelfCgroupContent);
@@ -391,6 +402,27 @@ public class TestCgroupSubsystemFactory {
         CgroupInfo memoryInfo = res.getInfos().get("memory");
         assertEquals(memoryInfo.getCgroupPath(), "/system.slice/containerd.service/kubepods-burstable-podf65e797d_d5f9_4604_9773_94f4bb9946a0.slice:cri-containerd:86ac6260f9f8a9c1276748250f330ae9c2fcefe5ae809364ad1e45f3edf7e08a");
         assertEquals(memoryInfo.getMountRoot(), memoryInfo.getCgroupPath());
+    }
+
+    @Test
+    public void testMountPrefixCgroupsV1() throws IOException {
+        String cgroups = cgroupv1CgInfoNonZeroHierarchy.toString();
+        String mountInfo = cgroupv1MntInfoPrefix.toString();
+        String selfCgroup = cgroupv1SelfPrefix.toString();
+        Optional<CgroupTypeResult> result = CgroupSubsystemFactory.determineType(mountInfo, cgroups, selfCgroup);
+
+        assertTrue("Expected non-empty cgroup result", result.isPresent());
+        CgroupTypeResult res = result.get();
+        CgroupInfo memoryInfo = res.getInfos().get("memory");
+        assertEquals(memoryInfo.getCgroupPath(), "/user.slice/user-1000.slice/session-3.scope");
+        String expectedMountPoint = "/sys/fs/cgroup/memory";
+        assertEquals(expectedMountPoint, memoryInfo.getMountPoint());
+        CgroupV1SubsystemController cgroupv1MemoryController = new CgroupV1SubsystemController(memoryInfo.getMountRoot(), memoryInfo.getMountPoint());
+        cgroupv1MemoryController.setPath(memoryInfo.getCgroupPath());
+        String actualPath = cgroupv1MemoryController.path();
+        assertNotNull("Controller path should not have been null", actualPath);
+        String expectedPath = expectedMountPoint + "/user.slice/user-1000.slice";
+        assertEquals("Should have found the longest common path", expectedPath, actualPath);
     }
 
     @Test


### PR DESCRIPTION
Please review this change to the cgroup v1 subsystem which makes it more resilient on some of the stranger systems. Unfortunately, I wasn't able to re-create a similar system as the reporter. The idea of using the longest substring match for the cgroupv1 file paths was based on the fact that on systemd systems processes run in separate scopes and the maven forked test runner might exhibit this property. For that it makes sense to use the common ancestor path. Nothing changes in the common cases where the `cgroup_path` matches `_root` and when the `_root` is `/` (container the former, host system the latter).

In addition, the code paths which are susceptible to throw NPE have been hardened to catch those situations. Should it happen in the future it makes more sense (to me) to not have accurate container detection in favor of continuing to keep running.

Finally, with the added unit-tests a bug was uncovered on the "substring" match case of cgroup paths in hotspot. `p` returned from `strstr` can never point to `_root` as it's used as the "needle" to find in "haystack" `cgroup_path` (not the other way round).

Testing:
- [x] Added unit tests
- [x] GHA
- [x] Container tests on cgroups v1 Linux. Continue to pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286212](https://bugs.openjdk.java.net/browse/JDK-8286212): Cgroup v1 initialization causes NPE on some systems


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8629/head:pull/8629` \
`$ git checkout pull/8629`

Update a local copy of the PR: \
`$ git checkout pull/8629` \
`$ git pull https://git.openjdk.java.net/jdk pull/8629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8629`

View PR using the GUI difftool: \
`$ git pr show -t 8629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8629.diff">https://git.openjdk.java.net/jdk/pull/8629.diff</a>

</details>
