### PR TITLE
8286480: Remove the c1 getEventWriter() intrinsic to simplify post-Loom integration platform-porting efforts

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -6697,8 +6697,10 @@ class StubGenerator: public StubCodeGenerator {
     __ bind(null_jobject);
   }
 
-  static RuntimeStub* generate_jfr_stub(const char* name, address entrypoint) {
-
+  // For c2: c_rarg0 is junk, call to runtime to write a checkpoint.
+  // It returns a jobject handle to the event writer.
+  // The handle is dereferenced and the return value is the event writer oop.
+  static RuntimeStub* generate_jfr_write_checkpoint() {
     enum layout {
       rbp_off,
       rbpH_off,
@@ -6709,7 +6711,7 @@ class StubGenerator: public StubCodeGenerator {
 
     int insts_size = 512;
     int locs_size = 64;
-    CodeBuffer code(name, insts_size, locs_size);
+    CodeBuffer code("jfr_write_checkpoint", insts_size, locs_size);
     OopMapSet* oop_maps = new OopMapSet();
     MacroAssembler* masm = new MacroAssembler(&code);
     MacroAssembler* _masm = masm;
@@ -6719,7 +6721,7 @@ class StubGenerator: public StubCodeGenerator {
     int frame_complete = __ pc() - start;
     address the_pc = __ pc();
     jfr_prologue(the_pc, _masm, rthread);
-    __ call_VM_leaf(entrypoint, 1);
+    __ call_VM_leaf(CAST_FROM_FN_PTR(address, JfrIntrinsicSupport::write_checkpoint), 1);
     jfr_epilogue(_masm, rthread);
     __ leave();
     __ ret(lr);
@@ -6728,25 +6730,10 @@ class StubGenerator: public StubCodeGenerator {
     oop_maps->add_gc_map(the_pc - start, map);
 
     RuntimeStub* stub = // codeBlob framesize is in words (not VMRegImpl::slot_size)
-      RuntimeStub::new_runtime_stub(name, &code, frame_complete,
+      RuntimeStub::new_runtime_stub("jfr_write_checkpoint", &code, frame_complete,
                                     (framesize >> (LogBytesPerWord - LogBytesPerInt)),
                                     oop_maps, false);
     return stub;
-  }
-
-  // For c2: c_rarg0 is junk, call to runtime to write a checkpoint.
-  // It returns a jobject handle to the event writer.
-  // The handle is dereferenced and the return value is the event writer oop.
-  RuntimeStub* generate_jfr_write_checkpoint() {
-    return generate_jfr_stub("jfr_write_checkpoint",
-                              CAST_FROM_FN_PTR(address, JfrIntrinsicSupport::write_checkpoint));
-  }
-
-  // For c1: call the corresponding runtime routine, it returns a jobject handle to the event writer.
-  // The handle is dereferenced and the return value is the event writer oop.
-  RuntimeStub* generate_jfr_get_event_writer() {
-    return generate_jfr_stub("jfr_get_event_writer",
-                              CAST_FROM_FN_PTR(address, JfrIntrinsicSupport::event_writer));
   }
 
 #endif // INCLUDE_JFR
@@ -7746,8 +7733,6 @@ class StubGenerator: public StubCodeGenerator {
 
     JFR_ONLY(StubRoutines::_jfr_write_checkpoint_stub = generate_jfr_write_checkpoint();)
     JFR_ONLY(StubRoutines::_jfr_write_checkpoint = StubRoutines::_jfr_write_checkpoint_stub->entry_point();)
-    JFR_ONLY(StubRoutines::_jfr_get_event_writer_stub = generate_jfr_get_event_writer();)
-    JFR_ONLY(StubRoutines::_jfr_get_event_writer = StubRoutines::_jfr_get_event_writer_stub->entry_point();)
   }
 
   void generate_all() {

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -7616,7 +7616,10 @@ address generate_avx_ghash_processBlocks() {
     __ bind(null_jobject);
   }
 
-  static RuntimeStub* generate_jfr_stub(const char* name, address entrypoint) {
+  // For c2: c_rarg0 is junk, call to runtime to write a checkpoint.
+  // It returns a jobject handle to the event writer.
+  // The handle is dereferenced and the return value is the event writer oop.
+  RuntimeStub* generate_jfr_write_checkpoint() {
     enum layout {
       rbp_off,
       rbpH_off,
@@ -7627,7 +7630,7 @@ address generate_avx_ghash_processBlocks() {
 
     int insts_size = 512;
     int locs_size = 64;
-    CodeBuffer code(name, insts_size, locs_size);
+    CodeBuffer code("jfr_write_checkpoint", insts_size, locs_size);
     OopMapSet* oop_maps = new OopMapSet();
     MacroAssembler* masm = new MacroAssembler(&code);
     MacroAssembler* _masm = masm;
@@ -7637,7 +7640,7 @@ address generate_avx_ghash_processBlocks() {
     int frame_complete = __ pc() - start;
     address the_pc = __ pc();
     jfr_prologue(the_pc, _masm);
-    __ call_VM_leaf(entrypoint, 1);
+    __ call_VM_leaf(CAST_FROM_FN_PTR(address, JfrIntrinsicSupport::write_checkpoint), 1);
     jfr_epilogue(_masm);
     __ leave();
     __ ret(0);
@@ -7646,25 +7649,10 @@ address generate_avx_ghash_processBlocks() {
     oop_maps->add_gc_map(the_pc - start, map);
 
     RuntimeStub* stub = // codeBlob framesize is in words (not VMRegImpl::slot_size)
-      RuntimeStub::new_runtime_stub(name, &code, frame_complete,
+      RuntimeStub::new_runtime_stub("jfr_write_checkpoint", &code, frame_complete,
                                     (framesize >> (LogBytesPerWord - LogBytesPerInt)),
                                     oop_maps, false);
     return stub;
-  }
-
-  // For c2: c_rarg0 is junk, call to runtime to write a checkpoint.
-  // It returns a jobject handle to the event writer.
-  // The handle is dereferenced and the return value is the event writer oop.
-  RuntimeStub* generate_jfr_write_checkpoint() {
-    return generate_jfr_stub("jfr_write_checkpoint",
-                              CAST_FROM_FN_PTR(address, JfrIntrinsicSupport::write_checkpoint));
-  }
-
-  // For c1: call the corresponding runtime routine, it returns a jobject handle to the event writer.
-  // The handle is dereferenced and the return value is the event writer oop.
-  RuntimeStub* generate_jfr_get_event_writer() {
-    return generate_jfr_stub("jfr_get_event_writer",
-                              CAST_FROM_FN_PTR(address, JfrIntrinsicSupport::event_writer));
   }
 
 #endif // INCLUDE_JFR
@@ -7900,8 +7888,6 @@ address generate_avx_ghash_processBlocks() {
 
     JFR_ONLY(StubRoutines::_jfr_write_checkpoint_stub = generate_jfr_write_checkpoint();)
     JFR_ONLY(StubRoutines::_jfr_write_checkpoint = StubRoutines::_jfr_write_checkpoint_stub->entry_point();)
-    JFR_ONLY(StubRoutines::_jfr_get_event_writer_stub = generate_jfr_get_event_writer();)
-    JFR_ONLY(StubRoutines::_jfr_get_event_writer = StubRoutines::_jfr_get_event_writer_stub->entry_point();)
   }
 
   void generate_all() {

--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -228,7 +228,6 @@ bool Compiler::is_intrinsic_supported(const methodHandle& method) {
   case vmIntrinsics::_Continuation_doYield:
 #ifdef JFR_HAVE_INTRINSICS
   case vmIntrinsics::_counterTime:
-  case vmIntrinsics::_getEventWriter:
 #endif
   case vmIntrinsics::_getObjectSize:
     break;

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -2898,22 +2898,6 @@ void LIRGenerator::do_IfOp(IfOp* x) {
   __ cmove(lir_cond(x->cond()), t_val.result(), f_val.result(), reg, as_BasicType(x->x()->type()));
 }
 
-#ifdef JFR_HAVE_INTRINSICS
-
-void LIRGenerator::do_getEventWriter(Intrinsic* x) {
-  BasicTypeList signature(0);
-  CallingConvention* cc = frame_map()->c_calling_convention(&signature);
-  LIR_Opr reg = result_register_for(x->type());
-  address entry = StubRoutines::jfr_get_event_writer();
-  CodeEmitInfo* info = state_for(x, x->state());
-  __ call_runtime(entry, getThreadTemp(), reg, cc->args(), info);
-  LIR_Opr result = rlock_result(x);
-  __ move(reg, result);
-}
-
-#endif
-
-
 void LIRGenerator::do_RuntimeCall(address routine, Intrinsic* x) {
   assert(x->number_of_arguments() == 0, "wrong type");
   // Enforce computation of _reserved_argument_area_size which is required on some platforms.
@@ -2939,9 +2923,6 @@ void LIRGenerator::do_Intrinsic(Intrinsic* x) {
   }
 
 #ifdef JFR_HAVE_INTRINSICS
-  case vmIntrinsics::_getEventWriter:
-    do_getEventWriter(x);
-    break;
   case vmIntrinsics::_counterTime:
     do_RuntimeCall(CAST_FROM_FN_PTR(address, JfrTime::time_function()), x);
     break;

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -324,7 +324,6 @@ const char* Runtime1::name_for_address(address entry) {
   FUNCTION_CASE(entry, trace_block_entry);
 #ifdef JFR_HAVE_INTRINSICS
   FUNCTION_CASE(entry, JfrTime::time_function());
-  FUNCTION_CASE(entry, StubRoutines::jfr_get_event_writer());
 #endif
   FUNCTION_CASE(entry, StubRoutines::updateBytesCRC32());
   FUNCTION_CASE(entry, StubRoutines::updateBytesCRC32C());

--- a/src/hotspot/share/jfr/support/jfrIntrinsics.cpp
+++ b/src/hotspot/share/jfr/support/jfrIntrinsics.cpp
@@ -49,14 +49,7 @@ static void assert_epoch_identity(JavaThread* jt, u2 current_epoch) {
   const u2 vthread_epoch = epoch_raw & epoch_mask;
   assert(vthread_epoch == current_epoch, "invariant");
 }
-#endif
-
-void* JfrIntrinsicSupport::event_writer(JavaThread* jt) {
-  DEBUG_ONLY(assert_precondition(jt);)
-  // Can safepoint here.
-  ThreadInVMfromJava transition(jt);
-  return JfrJavaEventWriter::event_writer(jt);
-}
+#endif // ASSERT
 
 void* JfrIntrinsicSupport::write_checkpoint(JavaThread* jt) {
   DEBUG_ONLY(assert_precondition(jt);)

--- a/src/hotspot/share/jfr/support/jfrIntrinsics.hpp
+++ b/src/hotspot/share/jfr/support/jfrIntrinsics.hpp
@@ -36,7 +36,6 @@
 
 class JfrIntrinsicSupport : AllStatic {
  public:
-  static void* event_writer(JavaThread* jt);
   static void* write_checkpoint(JavaThread* jt);
   static void load_barrier(const Klass* klass);
   static address epoch_address();

--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -181,8 +181,6 @@ address StubRoutines::_cont_returnBarrierExc = NULL;
 
 JFR_ONLY(RuntimeStub* StubRoutines::_jfr_write_checkpoint_stub = NULL;)
 JFR_ONLY(address StubRoutines::_jfr_write_checkpoint = NULL;)
-JFR_ONLY(RuntimeStub* StubRoutines::_jfr_get_event_writer_stub = NULL;)
-JFR_ONLY(address StubRoutines::_jfr_get_event_writer = NULL;)
 
 // Initialization
 //

--- a/src/hotspot/share/runtime/stubRoutines.hpp
+++ b/src/hotspot/share/runtime/stubRoutines.hpp
@@ -259,8 +259,6 @@ class StubRoutines: AllStatic {
 
   JFR_ONLY(static RuntimeStub* _jfr_write_checkpoint_stub;)
   JFR_ONLY(static address _jfr_write_checkpoint;)
-  JFR_ONLY(static RuntimeStub* _jfr_get_event_writer_stub;)
-  JFR_ONLY(static address _jfr_get_event_writer;)
 
   // Vector Math Routines
   static address _vector_f_math[VectorSupport::NUM_VEC_SIZES][VectorSupport::NUM_SVML_OP];
@@ -439,7 +437,6 @@ class StubRoutines: AllStatic {
   static address cont_returnBarrierExc(){return _cont_returnBarrierExc; }
 
   JFR_ONLY(static address jfr_write_checkpoint() { return _jfr_write_checkpoint; })
-  JFR_ONLY(static address jfr_get_event_writer() { return _jfr_get_event_writer; })
 
   static address select_fill_function(BasicType t, bool aligned, const char* &name);
 


### PR DESCRIPTION
Greetings,

The C1 intrinsic for getEventWriter() did not materialize and is currently only bouncing a platform-specific stub to enter the VM, putting an unnecessary burden on post-Loom integration platform-porting efforts.

The platform-specific stub for C2, jfr_write_checkpoint, is still needed but is only called if a java/lang/VirtualThread is mounted. As such, it could be left unimplemented.

Testing: jdk_jfr

Thanks
Markus
