### PR TITLE
JDK-8286459: compile error with VS2017 in continuationFreezeThaw.cpp

### DIFF
--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -2460,10 +2460,10 @@ private:
   static void resolve() {
     typedef Config<use_compressed ? oop_kind::NARROW : oop_kind::WIDE, BarrierSetT> SelectedConfigT;
 
-    freeze_entry = (address)freeze<SelectedConfigT>;
+    freeze_entry = (address)(void*)freeze<SelectedConfigT>;
 
     // If we wanted, we could templatize by kind and have three different thaw entries
-    thaw_entry   = (address)thaw<SelectedConfigT>;
+    thaw_entry   = (address)(void*)thaw<SelectedConfigT>;
   }
 };
 


### PR DESCRIPTION
After recent changes (loom?) we run into this compile error when using VS2017 :

d:\build\jdk\src\hotspot\share\runtime\continuationFreezeThaw.cpp(2463): error C2440: 'type cast': cannot convert from 'int (__cdecl *)(JavaThread *,intptr_t *)' to 'address'
d:\build\jdk\src\hotspot\share\runtime\continuationFreezeThaw.cpp(2463): note: Context does not allow for disambiguation of overloaded function
d:\build\jdk\src\hotspot\share\runtime\continuationFreezeThaw.cpp(2451): note: see reference to function template instantiation 'void ConfigResolve::resolve<true,BarrierSet::GetType<BarrierSet::CardTableBarrierSet>::type>(void)' being compiled
d:\build\jdk\src\hotspot\share\runtime\continuationFreezeThaw.cpp(2436): note: see reference to function template instantiation 'void ConfigResolve::resolve_gc<true>(void)' being compiled
d:\build\jdk\src\hotspot\share\runtime\continuationFreezeThaw.cpp(2466): error C2440: 'type cast': cannot convert from 'intptr_t *(__cdecl *)(JavaThread *,int)' to 'address'
d:\build\jdk\src\hotspot\share\runtime\continuationFreezeThaw.cpp(2466): note: Context does not allow for disambiguation of overloaded function

An additional cast can be added to make the issue go away.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286459](https://bugs.openjdk.java.net/browse/JDK-8286459): compile error with VS2017 in continuationFreezeThaw.cpp


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8632/head:pull/8632` \
`$ git checkout pull/8632`

Update a local copy of the PR: \
`$ git checkout pull/8632` \
`$ git pull https://git.openjdk.java.net/jdk pull/8632/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8632`

View PR using the GUI difftool: \
`$ git pr show -t 8632`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8632.diff">https://git.openjdk.java.net/jdk/pull/8632.diff</a>

</details>
