### PR TITLE
8284690: [macos] VoiceOver : Getting java.lang.IllegalArgumentException: Invalid location on Editable JComboBox

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TableAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TableAccessibility.h
@@ -29,6 +29,7 @@
 @interface TableAccessibility : CommonComponentAccessibility <NSAccessibilityTable>
 {
     NSMutableDictionary<NSNumber*, id> *rowCache;
+    BOOL cacheValid;
 }
 
 - (BOOL)isAccessibleChildSelectedFromIndex:(int)index;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TableAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TableAccessibility.m
@@ -130,6 +130,15 @@ static jmethodID sjm_getAccessibleName = NULL;
     if (rowCache == nil) {
         int rowCount = [self accessibilityRowCount];
         rowCache = [[NSMutableDictionary<NSNumber*, id> dictionaryWithCapacity:rowCount] retain];
+        cacheValid = YES;
+    }
+
+    if (!cacheValid) {
+        for (NSNumber *key in [rowCache allKeys]) {
+            [[rowCache objectForKey:key] release];
+            [rowCache removeObjectForKey:key];
+        }
+        cacheValid = YES;
     }
 
     id row = [rowCache objectForKey:[NSNumber numberWithUnsignedInteger:index]];
@@ -223,11 +232,7 @@ static jmethodID sjm_getAccessibleName = NULL;
 }
 
 - (void)clearCache {
-    for (NSNumber *key in [rowCache allKeys]) {
-        [[rowCache objectForKey:key] release];
-    }
-    [rowCache release];
-    rowCache = nil;
+    cacheValid = NO;
 }
 
 @end


### PR DESCRIPTION
Moving cache invalidation from the clearCache method to a createRowWithIndex method
eliminating race condition that causes crash. Now clearCache just notifies that cache
is invalid and should be regenerated next time it is being accessed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8284690](https://bugs.openjdk.java.net/browse/JDK-8284690): [macos] VoiceOver : Getting java.lang.IllegalArgumentException: Invalid location on Editable JComboBox


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8635/head:pull/8635` \
`$ git checkout pull/8635`

Update a local copy of the PR: \
`$ git checkout pull/8635` \
`$ git pull https://git.openjdk.java.net/jdk pull/8635/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8635`

View PR using the GUI difftool: \
`$ git pr show -t 8635`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8635.diff">https://git.openjdk.java.net/jdk/pull/8635.diff</a>

</details>
