### PR TITLE
8286266: [macos] Voice over moving JTable column to be the first column JVM crashes

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TableAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TableAccessibility.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, JetBrains s.r.o.. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@
 @interface TableAccessibility : CommonComponentAccessibility <NSAccessibilityTable>
 {
     NSMutableDictionary<NSNumber*, id> *rowCache;
+    BOOL cacheValid;
 }
 
 - (BOOL)isAccessibleChildSelectedFromIndex:(int)index;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TableAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TableAccessibility.m
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, JetBrains s.r.o.. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -130,6 +130,15 @@ static jmethodID sjm_getAccessibleName = NULL;
     if (rowCache == nil) {
         int rowCount = [self accessibilityRowCount];
         rowCache = [[NSMutableDictionary<NSNumber*, id> dictionaryWithCapacity:rowCount] retain];
+        cacheValid = YES;
+    }
+
+    if (!cacheValid) {
+        for (NSNumber *key in [rowCache allKeys]) {
+            [[rowCache objectForKey:key] release];
+            [rowCache removeObjectForKey:key];
+        }
+        cacheValid = YES;
     }
 
     id row = [rowCache objectForKey:[NSNumber numberWithUnsignedInteger:index]];
@@ -223,11 +232,7 @@ static jmethodID sjm_getAccessibleName = NULL;
 }
 
 - (void)clearCache {
-    for (NSNumber *key in [rowCache allKeys]) {
-        [[rowCache objectForKey:key] release];
-    }
-    [rowCache release];
-    rowCache = nil;
+    cacheValid = NO;
 }
 
 @end


### PR DESCRIPTION
Moving cache invalidation from the clearCache method to a createRowWithIndex method
eliminating race condition that causes crash. Now clearCache just notifies that cache
is invalid and should be regenerated next time it is being accessed.
