### PR TITLE
8286015 JFR: Remove jfr.save.generated.asm

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventInstrumentation.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventInstrumentation.java
@@ -325,9 +325,7 @@ public final class EventInstrumentation {
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
         classNode.accept(cw);
         cw.visitEnd();
-        byte[] result = cw.toByteArray();
-        Utils.writeGeneratedASM(classNode.name, result);
-        return result;
+        return cw.toByteArray();
     }
 
     public byte[] buildUninstrumented() {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
@@ -79,8 +79,6 @@ public final class Utils {
     public static final String ACCESS_FLIGHT_RECORDER = "accessFlightRecorder";
     private static final String LEGACY_EVENT_NAME_PREFIX = "com.oracle.jdk.";
 
-    private static Boolean SAVE_GENERATED;
-
     private static final Duration MICRO_SECOND = Duration.ofNanos(1_000);
     private static final Duration SECOND = Duration.ofSeconds(1);
     private static final Duration MINUTE = Duration.ofMinutes(1);
@@ -511,31 +509,6 @@ public final class Utils {
         }
         if (eventClass == Event.class || eventClass == jdk.internal.event.Event.class || !jdk.internal.event.Event.class.isAssignableFrom(eventClass)) {
             throw new IllegalArgumentException("Must be a subclass to " + Event.class.getName());
-        }
-    }
-
-    public static void writeGeneratedASM(String className, byte[] bytes) {
-        if (SAVE_GENERATED == null) {
-            // We can't calculate value statically because it will force
-            // initialization of SecuritySupport, which cause
-            // UnsatisfiedLinkedError on JDK 8 or non-Oracle JDKs
-            SAVE_GENERATED = SecuritySupport.getBooleanProperty("jfr.save.generated.asm");
-        }
-        if (SAVE_GENERATED) {
-            className = className.substring(className.lastIndexOf("/") + 1, className.length());
-            try {
-                try (FileOutputStream fos = new FileOutputStream(className + ".class")) {
-                    fos.write(bytes);
-                }
-
-                try (FileWriter fw = new FileWriter(className + ".asm"); PrintWriter pw = new PrintWriter(fw)) {
-                    ClassReader cr = new ClassReader(bytes);
-                    CheckClassAdapter.verify(cr, true, pw);
-                }
-                Logger.log(LogTag.JFR_SYSTEM_BYTECODE, LogLevel.INFO, "Instrumented code saved to " + className + ".class and .asm");
-            } catch (IOException e) {
-                Logger.log(LogTag.JFR_SYSTEM_BYTECODE, LogLevel.INFO, "Could not save instrumented code, for " + className + ".class and .asm");
-            }
         }
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/JIClassInstrumentation.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/JIClassInstrumentation.java
@@ -37,7 +37,6 @@ import jdk.internal.org.objectweb.asm.ClassWriter;
 import jdk.internal.org.objectweb.asm.Opcodes;
 import jdk.internal.org.objectweb.asm.tree.ClassNode;
 import jdk.jfr.internal.SecuritySupport;
-import jdk.jfr.internal.Utils;
 
 /**
  * This class will perform byte code instrumentation given an "instrumentor" class.
@@ -72,7 +71,6 @@ final class JIClassInstrumentation {
         this.targetClassReader = new ClassReader(old_target_bytes);
         this.instrClassReader = new ClassReader(getOriginalClassBytes(instrumentor));
         this.newBytes = makeBytecode();
-        Utils.writeGeneratedASM(target.getName(), newBytes);
     }
 
     private static byte[] getOriginalClassBytes(Class<?> clazz) throws IOException {


### PR DESCRIPTION
Could I have a review of a fix that removes the jfr.save.generated.asm property.

It was a developer property that could be set to write generated JFR .class files to disk. The mechanism doesn't work due to a bug, but nobody has noticed it for years. For debugging JFR bytecode generation, it's much more convenient to use  -Xlog:jfr+system+bytecode=trace to print ASM to standard output. 

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286015](https://bugs.openjdk.java.net/browse/JDK-8286015): JFR: Remove jfr.save.generated.asm


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8637/head:pull/8637` \
`$ git checkout pull/8637`

Update a local copy of the PR: \
`$ git checkout pull/8637` \
`$ git pull https://git.openjdk.java.net/jdk pull/8637/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8637`

View PR using the GUI difftool: \
`$ git pr show -t 8637`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8637.diff">https://git.openjdk.java.net/jdk/pull/8637.diff</a>

</details>
