### PR TITLE
8286551: JDK-8286460 causes tests to fail to compile in Tier2

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/CDSMHTest_generate.sh
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/CDSMHTest_generate.sh
@@ -31,7 +31,7 @@ do
     fname="$i$name_suffix"
     cat << EOF > $fname
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,6 +79,7 @@ do
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Path;
 import jdk.test.lib.Platform;
 
 public class $i extends DynamicArchiveTestBase {

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesAsCollectorTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesAsCollectorTest.java
@@ -47,6 +47,7 @@
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Path;
 import jdk.test.lib.Platform;
 
 public class MethodHandlesAsCollectorTest extends DynamicArchiveTestBase {

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesCastFailureTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesCastFailureTest.java
@@ -47,6 +47,7 @@
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Path;
 import jdk.test.lib.Platform;
 
 public class MethodHandlesCastFailureTest extends DynamicArchiveTestBase {

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesGeneralTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesGeneralTest.java
@@ -47,6 +47,7 @@
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Path;
 import jdk.test.lib.Platform;
 
 public class MethodHandlesGeneralTest extends DynamicArchiveTestBase {

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesInvokersTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesInvokersTest.java
@@ -47,6 +47,7 @@
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Path;
 import jdk.test.lib.Platform;
 
 public class MethodHandlesInvokersTest extends DynamicArchiveTestBase {

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesPermuteArgumentsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesPermuteArgumentsTest.java
@@ -47,6 +47,7 @@
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Path;
 import jdk.test.lib.Platform;
 
 public class MethodHandlesPermuteArgumentsTest extends DynamicArchiveTestBase {

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesSpreadArgumentsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesSpreadArgumentsTest.java
@@ -47,6 +47,7 @@
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Path;
 import jdk.test.lib.Platform;
 
 public class MethodHandlesSpreadArgumentsTest extends DynamicArchiveTestBase {

--- a/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/CDSMHTest_generate.sh
+++ b/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/CDSMHTest_generate.sh
@@ -31,7 +31,7 @@ do
     fname="$i$name_suffix"
     cat << EOF > $fname
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,6 +78,7 @@ do
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;

--- a/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesAsCollectorTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesAsCollectorTest.java
@@ -46,6 +46,7 @@
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;

--- a/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesCastFailureTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesCastFailureTest.java
@@ -46,6 +46,7 @@
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;

--- a/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesGeneralTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesGeneralTest.java
@@ -46,6 +46,7 @@
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;

--- a/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesInvokersTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesInvokersTest.java
@@ -46,6 +46,7 @@
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;

--- a/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesPermuteArgumentsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesPermuteArgumentsTest.java
@@ -46,6 +46,7 @@
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;

--- a/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesSpreadArgumentsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesSpreadArgumentsTest.java
@@ -46,6 +46,7 @@
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;


### PR DESCRIPTION
The tests fail compilation due to a missing import statement.

Simple fix to add the following import statement to the tests:

`import java.nio.file.Path`

Ran the tests successfully locally on linux-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286551](https://bugs.openjdk.java.net/browse/JDK-8286551): JDK-8286460 causes tests to fail to compile in Tier2


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8639/head:pull/8639` \
`$ git checkout pull/8639`

Update a local copy of the PR: \
`$ git checkout pull/8639` \
`$ git pull https://git.openjdk.java.net/jdk pull/8639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8639`

View PR using the GUI difftool: \
`$ git pr show -t 8639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8639.diff">https://git.openjdk.java.net/jdk/pull/8639.diff</a>

</details>
