### PR TITLE
8286287: Reading file as UTF-16 causes Error which "shouldn't happen"

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -658,8 +658,6 @@ public final class String
 
             // decode using CharsetDecoder
             int en = scale(length, cd.maxCharsPerByte());
-            cd.onMalformedInput(CodingErrorAction.REPLACE)
-                    .onUnmappableCharacter(CodingErrorAction.REPLACE);
             char[] ca = new char[en];
             if (charset.getClass().getClassLoader0() != null &&
                     System.getSecurityManager() != null) {
@@ -1207,6 +1205,8 @@ public final class String
     private static int decodeWithDecoder(CharsetDecoder cd, char[] dst, byte[] src, int offset, int length) {
         ByteBuffer bb = ByteBuffer.wrap(src, offset, length);
         CharBuffer cb = CharBuffer.wrap(dst, 0, dst.length);
+        cd.onMalformedInput(CodingErrorAction.REPLACE)
+            .onUnmappableCharacter(CodingErrorAction.REPLACE);
         try {
             CoderResult cr = cd.decode(bb, cb, true);
             if (!cr.isUnderflow())

--- a/test/jdk/java/lang/StringCoding/Enormous.java
+++ b/test/jdk/java/lang/StringCoding/Enormous.java
@@ -23,7 +23,7 @@
 
 /* @test
  * @bug 4949631
- * @summary Check for ability to decode arrays of odd sizes > 16MB
+ * @summary Check for ability to recode arrays of odd sizes > 16MB
  * @run main/othervm -Xms100m -Xmx200m Enormous
  */
 


### PR DESCRIPTION
`String.decodeWithDecoder()` method requires the `CharsetDecoder` parameter replaces on malformed/unmappable characters with replacements. However, there was a code path that lacked to set the `CodingErrorAction.REPLACE` on the decoder. Unrelated, one typo in a test was also fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286287](https://bugs.openjdk.java.net/browse/JDK-8286287): Reading file as UTF-16 causes Error which "shouldn't happen"


### Reviewers
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - Committer) ⚠️ Review applies to [0fa7cd38](https://git.openjdk.java.net/jdk/pull/8640/files/0fa7cd388f4428f7ea7ded8cbafed51973b2cfcf)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to [0fa7cd38](https://git.openjdk.java.net/jdk/pull/8640/files/0fa7cd388f4428f7ea7ded8cbafed51973b2cfcf)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8640/head:pull/8640` \
`$ git checkout pull/8640`

Update a local copy of the PR: \
`$ git checkout pull/8640` \
`$ git pull https://git.openjdk.java.net/jdk pull/8640/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8640`

View PR using the GUI difftool: \
`$ git pr show -t 8640`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8640.diff">https://git.openjdk.java.net/jdk/pull/8640.diff</a>

</details>
