### PR TITLE
8283001: windows-x86-cmp-baseline fails in some jvmti native libs

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/events/Breakpoint/breakpoint01/libbreakpoint01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/Breakpoint/breakpoint01/libbreakpoint01.cpp
@@ -205,7 +205,8 @@ VMDeath(jvmtiEnv *jvmti, JNIEnv *jni) {
   callbacksEnabled = NSK_FALSE;
 }
 
-JNIEXPORT jint JNICALL Java_breakpoint01_check(JNIEnv *jni, jobject obj) {
+JNIEXPORT jint JNICALL
+Java_breakpoint01_check(JNIEnv *jni, jobject obj) {
   for (int i = 0; i < METH_NUM; i++) {
     if (bpEvents[i] != 1) {
       result = STATUS_FAILED;
@@ -222,7 +223,8 @@ JNIEXPORT jint JNICALL Java_breakpoint01_check(JNIEnv *jni, jobject obj) {
   return result;
 }
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiCapabilities caps;
   jvmtiError err;
   jint res;

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FramePop/framepop02/libframepop02.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FramePop/framepop02/libframepop02.cpp
@@ -232,7 +232,8 @@ void JNICALL FramePop(jvmtiEnv *jvmti, JNIEnv *jni,
   }
 }
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiCapabilities caps;
   jvmtiError err;
 

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/GetAllThreadsNullTest/libGetAllThreadsNullTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/GetAllThreadsNullTest/libGetAllThreadsNullTest.cpp
@@ -30,7 +30,8 @@ extern "C" {
 
 static jvmtiEnv *jvmti_env = NULL;
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jint res = jvm->GetEnv((void **) &jvmti_env, JVMTI_VERSION_1_1);
   if (res != JNI_OK || jvmti_env == NULL) {
     LOG("Wrong test_passed of a valid call to GetEnv!\n");

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/contmon03/libcontmon03.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/contmon03/libcontmon03.cpp
@@ -35,7 +35,8 @@ extern "C" {
 static jvmtiEnv *jvmti = NULL;
 static jint result = PASSED;
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jint res;
   jvmtiError err;
   jvmtiCapabilities caps;

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/framecnt02/libframecnt02.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/framecnt02/libframecnt02.cpp
@@ -35,7 +35,8 @@ extern "C" {
 static jvmtiEnv *jvmti = NULL;
 static jint result = PASSED;
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jint res;
 
   res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/framecnt03/libframecnt03.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/framecnt03/libframecnt03.cpp
@@ -35,7 +35,8 @@ extern "C" {
 static jvmtiEnv *jvmti = NULL;
 static jint result = PASSED;
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jint res;
 
   res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/frameloc03/libframeloc03.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/frameloc03/libframeloc03.cpp
@@ -38,7 +38,8 @@ static jint result = PASSED;
 static jboolean printdump = JNI_FALSE;
 
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiError err;
   jint res;
 

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/getstacktr02/libgetstacktr02.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/getstacktr02/libgetstacktr02.cpp
@@ -36,7 +36,8 @@ static jvmtiEnv *jvmti = NULL;
 static jint result = PASSED;
 static jboolean printdump = JNI_FALSE;
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jint res;
 
   if (options != NULL && strcmp(options, "printdump") == 0) {

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/getstacktr09/libgetstacktr09.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/getstacktr09/libgetstacktr09.cpp
@@ -36,7 +36,8 @@ static jvmtiEnv *jvmti = NULL;
 static jint result = PASSED;
 static jboolean printdump = JNI_FALSE;
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jint res;
 
   if (options != NULL && strcmp(options, "printdump") == 0) {

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/thrinfo02/libthrinfo02.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/thrinfo02/libthrinfo02.cpp
@@ -36,7 +36,8 @@ static jvmtiEnv *jvmti = NULL;
 static jint result = PASSED;
 static jboolean printdump = JNI_FALSE;
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jint res;
 
   if (options != NULL && strcmp(options, "printdump") == 0) {

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/thrstat04/libthrstat04.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/thrstat04/libthrstat04.cpp
@@ -36,7 +36,8 @@ static jvmtiEnv *jvmti = NULL;
 static jint result = PASSED;
 static jboolean printdump = JNI_FALSE;
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jint res;
 
   if (options != NULL && strcmp(options, "printdump") == 0) {

--- a/test/hotspot/jtreg/serviceability/jvmti/stress/ThreadLocalStorage/SetGetThreadLocalStorageStressTest/libSetGetThreadLocalStorageStress.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/stress/ThreadLocalStorage/SetGetThreadLocalStorageStressTest/libSetGetThreadLocalStorageStress.cpp
@@ -203,7 +203,8 @@ VirtualThreadEnd(jvmtiEnv *jvmti, JNIEnv *jni, jthread vthread) {
 
 /* ============================================================================= */
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiEnv * jvmti = NULL;
 
   jvmtiEventCallbacks callbacks;
@@ -266,4 +267,3 @@ jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   }
   return JNI_OK;
 }
-

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetAllThreads/allthr01/liballthr01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetAllThreads/allthr01/liballthr01.cpp
@@ -70,7 +70,8 @@ sys_thread(jvmtiEnv *jvmti, JNIEnv *jni, void *p) {
   rml2.wait();
 }
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiCapabilities caps;
   jvmtiError err;
   jint res;

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetCurrentContendedMonitor/contmon01/libcontmon01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetCurrentContendedMonitor/contmon01/libcontmon01.cpp
@@ -31,7 +31,8 @@ extern "C" {
 
 static jvmtiEnv *jvmti = NULL;
 
-jint  Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
 
   jint res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
   if (res != JNI_OK || jvmti == NULL) {
@@ -67,4 +68,3 @@ Java_contmon01_checkMonitor(JNIEnv *jni, jclass cls, jint point, jthread thread,
 }
 
 }
-

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetCurrentContendedMonitor/contmon02/libcontmon02.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetCurrentContendedMonitor/contmon02/libcontmon02.cpp
@@ -30,7 +30,8 @@ extern "C" {
 
 static jvmtiEnv *jvmti;
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
 
   jint res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
   if (res != JNI_OK || jvmti == NULL) {

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameCount/framecnt01/libframecnt01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameCount/framecnt01/libframecnt01.cpp
@@ -29,7 +29,8 @@ extern "C" {
 
 static jvmtiEnv *jvmti_env = NULL;
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiCapabilities caps;
   jint res;
 

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameLocation/frameloc01/libframeloc01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameLocation/frameloc01/libframeloc01.cpp
@@ -81,7 +81,8 @@ ExceptionCatch(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thr,
   }
 }
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiCapabilities caps;
   jvmtiEventCallbacks callbacks;
   jvmtiError err;

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameLocation/frameloc02/libframeloc02.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameLocation/frameloc02/libframeloc02.cpp
@@ -44,7 +44,8 @@ static frame_info fi =
     {"Lframeloc02;", "check",
         "(Ljava/lang/Thread;)I", -1};
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jint res = jvm->GetEnv((void **) &jvmti_env, JVMTI_VERSION_1_1);
   if (res != JNI_OK || jvmti_env == NULL) {
     LOG("Wrong result of a valid call to GetEnv!\n");

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/GetStackTraceCurrentThreadTest/libGetStackTraceCurrentThreadTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/GetStackTraceCurrentThreadTest/libGetStackTraceCurrentThreadTest.cpp
@@ -47,7 +47,8 @@ static frame_info expected_platform_frames[] = {
     {"Ljava/lang/Thread;", "run", "()V"}
 };
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jint res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
   if (res != JNI_OK || jvmti == NULL) {
     printf("Wrong result of a valid call to GetEnv!\n");

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr03/libgetstacktr03.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr03/libgetstacktr03.cpp
@@ -50,7 +50,8 @@ static frame_info expected_virtual_frames[] = {
     {"Ljdk/internal/vm/Continuation;", "enter", "(Ljdk/internal/vm/Continuation;Z)V"}
 };
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiError err;
   jint res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
   if (res != JNI_OK || jvmti == NULL) {

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr04/libgetstacktr04.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr04/libgetstacktr04.cpp
@@ -74,7 +74,8 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *jni,
   }
 }
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiError err;
   jint res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
   if (res != JNI_OK || jvmti == NULL) {

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr05/libgetstacktr05.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr05/libgetstacktr05.cpp
@@ -97,7 +97,8 @@ SingleStep(jvmtiEnv *jvmti_env, JNIEnv *jni, jthread thread, jmethodID method, j
   }
 }
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiError err;
   jint res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
   if (res != JNI_OK || jvmti == NULL) {

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr06/libgetstacktr06.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr06/libgetstacktr06.cpp
@@ -86,7 +86,8 @@ void JNICALL SingleStep(jvmtiEnv *jvmti_env, JNIEnv *jni, jthread thread, jmetho
   }
 }
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiError err;
   jint res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
   if (res != JNI_OK || jvmti == NULL) {

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr07/libgetstacktr07.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr07/libgetstacktr07.cpp
@@ -99,7 +99,8 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *jni, jthread thread, jmetho
   }
 }
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiError err;
   jint res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
   if (res != JNI_OK || jvmti == NULL) {

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr08/libgetstacktr08.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr08/libgetstacktr08.cpp
@@ -134,7 +134,8 @@ void JNICALL SingleStep(jvmtiEnv *jvmti_env, JNIEnv *jni,
   }
 }
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiError err;
   jint res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
   if (res != JNI_OK || jvmti == NULL) {

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadInfo/thrinfo01/libthrinfo01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadInfo/thrinfo01/libthrinfo01.cpp
@@ -43,7 +43,8 @@ static info expected_info_array[] = {
     {"vthread", JNI_FALSE,JVMTI_THREAD_NORM_PRIORITY, JNI_TRUE}
 };
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jint res;
   jvmtiCapabilities caps;
 

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadState/thrstat01/libthrstat01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadState/thrstat01/libthrstat01.cpp
@@ -64,7 +64,8 @@ ThreadStart(jvmtiEnv *jvmti_env, JNIEnv *jni, jthread thread) {
   }
 }
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jint res;
   jvmtiError err;
 

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadState/thrstat02/libthrstat02.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadState/thrstat02/libthrstat02.cpp
@@ -69,7 +69,8 @@ ThreadStart(jvmtiEnv *jvmti_env, JNIEnv *jni, jthread thread) {
   }
 }
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiCapabilities caps;
   jvmtiEventCallbacks callbacks;
   jint res;

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadState/thrstat03/libthrstat03.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadState/thrstat03/libthrstat03.cpp
@@ -43,7 +43,8 @@ Java_thrstat03_init(JNIEnv *env, jclass cls, jint waitTime) {
   wait_time = waitTime * 60000;
 }
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jint res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
   if (res != JNI_OK || jvmti == NULL) {
     LOG("Wrong result of a valid call to GetEnv!\n");

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadState/thrstat05/libthrstat05.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadState/thrstat05/libthrstat05.cpp
@@ -71,7 +71,8 @@ static int g_wait_time = 1000;
 jrawMonitorID wait_lock; /* Monitor is used just for sleeping */
 
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jint res = jvm->GetEnv((void **) &jvmti_env, JVMTI_VERSION_1_1);
   if (res != JNI_OK || !jvmti_env) {
     LOG("Agent_OnLoad: Error: GetEnv returned error or NULL\n");

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThread/resumethrd01/libresumethrd01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThread/resumethrd01/libresumethrd01.cpp
@@ -98,7 +98,8 @@ agentProc(jvmtiEnv *jvmti, JNIEnv *jni, void *arg) {
     return;
 }
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiEnv *jvmti = NULL;
 
   timeout = 60 * 1000;

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThread/resumethrd02/libresumethrd02.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThread/resumethrd02/libresumethrd02.cpp
@@ -134,7 +134,8 @@ callbackThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
 /* ============================================================================= */
 
 /** Agent library initialization. */
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiEnv* jvmti = NULL;
 
   timeout =  60 * 1000;

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThreadList/resumethrdlst01/libresumethrdlst01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThreadList/resumethrdlst01/libresumethrdlst01.cpp
@@ -192,7 +192,8 @@ static int find_threads_by_name(jvmtiEnv* jvmti, JNIEnv* jni,
   return NSK_TRUE;
 }
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiEnv* jvmti = NULL;
 
   timeout =  60 * 1000;

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThreadList/resumethrdlst02/libresumethrdlst02.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThreadList/resumethrdlst02/libresumethrdlst02.cpp
@@ -232,7 +232,8 @@ callbackThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
   LOG("  ... received THREAD_END event for unknown thread: %p\n", (void*)thread);
 }
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiEnv* jvmti = NULL;
 
   timeout =  60 * 1000;

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThread/suspendthrd01/libsuspendthrd01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThread/suspendthrd01/libsuspendthrd01.cpp
@@ -95,7 +95,8 @@ agentProc(jvmtiEnv *jvmti, JNIEnv *jni, void *arg) {
 
 /* ============================================================================= */
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiEnv *jvmti = NULL;
 
   timeout = 60 * 1000;

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThread/suspendthrd02/libsuspendthrd02.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThread/suspendthrd02/libsuspendthrd02.cpp
@@ -130,7 +130,8 @@ callbackThreadEnd(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread) {
   }
 }
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiEnv *jvmti = NULL;
 
   timeout = 60 * 1000;

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThread/suspendthrd03/libsuspendthrd03.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThread/suspendthrd03/libsuspendthrd03.cpp
@@ -143,7 +143,8 @@ agentProc(jvmtiEnv *jvmti, JNIEnv *jni, void *arg) {
   /* Second part of original agentProc test block ends here. */
 }
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiEnv *jvmti = NULL;
 
   timeout = 60 * 1000;

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThreadList/suspendthrdlst01/libsuspendthrdlst01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThreadList/suspendthrdlst01/libsuspendthrdlst01.cpp
@@ -192,7 +192,8 @@ static int find_threads_by_name(jvmtiEnv *jvmti, JNIEnv *jni, const char *name, 
   return NSK_TRUE;
 }
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiEnv *jvmti = NULL;
 
   timeout = 60 * 1000;

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThreadList/suspendthrdlst02/libsuspendthrdlst02.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThreadList/suspendthrdlst02/libsuspendthrdlst02.cpp
@@ -222,7 +222,8 @@ callbackThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
   LOG("  ... received THREAD_END event for unknown thread: %p\n", (void*)thread);
 }
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiEnv* jvmti = NULL;
 
   timeout =  60 * 1000;

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SelfSuspendDisablerTest/libSelfSuspendDisablerTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SelfSuspendDisablerTest/libSelfSuspendDisablerTest.cpp
@@ -61,7 +61,8 @@ Java_SelfSuspendDisablerTest_resumeAllVirtualThreads(JNIEnv* jni, jclass cls) {
 }
 
 
-jint Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiError err;
 
   LOG("Agent init started\n");

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/libWaitNotifySuspendedVThread.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/libWaitNotifySuspendedVThread.cpp
@@ -126,7 +126,7 @@ Breakpoint(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread,
 
 /* ============================================================================= */
 
-jint
+JNIEXPORT jint JNICALL
 Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiEnv * jvmti = NULL;
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8283001](https://bugs.openjdk.java.net/browse/JDK-8283001): windows-x86-cmp-baseline fails in some jvmti native libs


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8641/head:pull/8641` \
`$ git checkout pull/8641`

Update a local copy of the PR: \
`$ git checkout pull/8641` \
`$ git pull https://git.openjdk.java.net/jdk pull/8641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8641`

View PR using the GUI difftool: \
`$ git pr show -t 8641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8641.diff">https://git.openjdk.java.net/jdk/pull/8641.diff</a>

</details>
