### PR TITLE
8286541: JFR: RecordingFile.write is missing "since 19"

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingFile.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingFile.java
@@ -231,6 +231,8 @@ public final class RecordingFile implements Closeable {
      * @throws SecurityException if a security manager exists and its
      *                           {@code checkWrite} method denies write access to the
      *                           file
+     *
+     * @since 19
      */
     public void write(Path destination, Predicate<RecordedEvent> filter) throws IOException {
         Objects.requireNonNull(destination, "destination");


### PR DESCRIPTION
Could I have review of a fix that add "since 19" to the RecordingFile.write(Path, Predicate) methods.

Testing: build and verify javadoc 

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286541](https://bugs.openjdk.java.net/browse/JDK-8286541): JFR: RecordingFile.write is missing "since 19"


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8643/head:pull/8643` \
`$ git checkout pull/8643`

Update a local copy of the PR: \
`$ git checkout pull/8643` \
`$ git pull https://git.openjdk.java.net/jdk pull/8643/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8643`

View PR using the GUI difftool: \
`$ git pr show -t 8643`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8643.diff">https://git.openjdk.java.net/jdk/pull/8643.diff</a>

</details>
