### PR TITLE
8274113: (fc) Tune FileChannel.transferFrom()

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -536,9 +536,9 @@ public class FileChannelImpl
     }
 
     // Assume at first that the underlying kernel supports sendfile();
-    // set this to false if we find out later that it doesn't
+    // set this to true if we find out later that it doesn't
     //
-    private static volatile boolean transferToSupported = true;
+    private static volatile boolean transferToNotSupported = false;
 
     // Assume that the underlying kernel sendfile() will work if the target
     // fd is a pipe; set this to false if we find out later that it doesn't
@@ -582,7 +582,7 @@ public class FileChannelImpl
             }
             if (n == IOStatus.UNSUPPORTED) {
                 // Don't bother trying again
-                transferToSupported = false;
+                transferToNotSupported = true;
                 return IOStatus.UNSUPPORTED;
             }
             return IOStatus.normalize(n);
@@ -596,7 +596,7 @@ public class FileChannelImpl
                                     WritableByteChannel target)
         throws IOException
     {
-        if (!transferToSupported)
+        if (transferToNotSupported)
             return IOStatus.UNSUPPORTED;
 
         FileDescriptor targetFD = null;
@@ -778,9 +778,9 @@ public class FileChannelImpl
     }
 
     // Assume at first that the underlying kernel supports copy_file_range();
-    // set this to false if we find out later that it doesn't
+    // set this to true if we find out later that it doesn't
     //
-    private static volatile boolean transferFromSupported = true;
+    private static volatile boolean transferFromNotSupported = false;
 
     private long transferFromDirectlyInternal(FileDescriptor srcFD,
                                               long position, long count)
@@ -803,7 +803,7 @@ public class FileChannelImpl
             } while ((n == IOStatus.INTERRUPTED) && isOpen());
             if (n == IOStatus.UNSUPPORTED) {
                 // Don't bother trying again
-                transferFromSupported = false;
+                transferFromNotSupported = true;
                 return IOStatus.UNSUPPORTED;
             }
             return IOStatus.normalize(n);
@@ -819,7 +819,7 @@ public class FileChannelImpl
     {
         if (!src.readable)
             throw new NonReadableChannelException();
-        if (!transferFromSupported)
+        if (transferFromNotSupported)
             return IOStatus.UNSUPPORTED;
         FileDescriptor srcFD = src.fd;
         if (srcFD == null)

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -538,7 +538,7 @@ public class FileChannelImpl
     // Assume at first that the underlying kernel supports sendfile();
     // set this to true if we find out later that it doesn't
     //
-    private static volatile boolean transferToNotSupported = false;
+    private static volatile boolean transferToNotSupported;
 
     // Assume that the underlying kernel sendfile() will work if the target
     // fd is a pipe; set this to false if we find out later that it doesn't
@@ -780,7 +780,7 @@ public class FileChannelImpl
     // Assume at first that the underlying kernel supports copy_file_range();
     // set this to true if we find out later that it doesn't
     //
-    private static volatile boolean transferFromNotSupported = false;
+    private static volatile boolean transferFromNotSupported;
 
     private long transferFromDirectlyInternal(FileDescriptor srcFD,
                                               long position, long count)

--- a/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
+++ b/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
@@ -31,6 +31,7 @@
 
 #if defined(__linux__)
 #include <sys/sendfile.h>
+#include <dlfcn.h>
 #elif defined(_AIX)
 #include <string.h>
 #include <sys/socket.h>
@@ -52,11 +53,21 @@
 
 static jfieldID chan_fd;        /* jobject 'fd' in sun.nio.ch.FileChannelImpl */
 
+#if defined(__linux__)
+typedef ssize_t copy_file_range_func(int, loff_t*, int, loff_t*, size_t,
+                                     unsigned int);
+static copy_file_range_func* my_copy_file_range_func = NULL;
+#endif
+
 JNIEXPORT jlong JNICALL
 Java_sun_nio_ch_FileChannelImpl_initIDs(JNIEnv *env, jclass clazz)
 {
     jlong pageSize = sysconf(_SC_PAGESIZE);
     chan_fd = (*env)->GetFieldID(env, clazz, "fd", "Ljava/io/FileDescriptor;");
+#if defined(__linux__)
+    my_copy_file_range_func =
+        (copy_file_range_func*) dlsym(RTLD_DEFAULT, "copy_file_range");
+#endif
     return pageSize;
 }
 
@@ -251,6 +262,38 @@ Java_sun_nio_ch_FileChannelImpl_transferTo0(JNIEnv *env, jobject this,
     return IOS_UNSUPPORTED_CASE;
 #endif
 }
+
+JNIEXPORT jlong JNICALL
+Java_sun_nio_ch_FileChannelImpl_transferFrom0(JNIEnv *env, jobject this,
+                                              jobject srcFDO, jobject dstFDO,
+                                              jlong position, jlong count)
+{
+#if defined(__linux__)
+    if (my_copy_file_range_func == NULL)
+        return IOS_UNSUPPORTED;
+
+    jint srcFD = fdval(env, srcFDO);
+    jint dstFD = fdval(env, dstFDO);
+
+    off64_t offset = (off64_t)position;
+    jlong n = my_copy_file_range_func(srcFD, NULL, dstFD, &offset, count, 0);
+    if (n < 0) {
+        if (errno == EAGAIN)
+            return IOS_UNAVAILABLE;
+        if ((errno == EINVAL || errno == EXDEV) && ((ssize_t)count >= 0))
+            return IOS_UNSUPPORTED_CASE;
+        if (errno == EINTR) {
+            return IOS_INTERRUPTED;
+        }
+        JNU_ThrowIOExceptionWithLastError(env, "Transfer failed");
+        return IOS_THROWN;
+    }
+    return n;
+#else
+    return IOS_UNSUPPORTED;
+#endif
+}
+
 
 JNIEXPORT jint JNICALL
 Java_sun_nio_ch_FileChannelImpl_maxDirectTransferSize0(JNIEnv* env, jobject this)

--- a/src/java.base/windows/native/libnio/ch/FileChannelImpl.c
+++ b/src/java.base/windows/native/libnio/ch/FileChannelImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -193,6 +193,13 @@ Java_sun_nio_ch_FileChannelImpl_transferTo0(JNIEnv *env, jobject this,
     return chunkSize;
 }
 
+JNIEXPORT jlong JNICALL
+Java_sun_nio_ch_FileChannelImpl_transferFrom0(JNIEnv *env, jobject this,
+                                              jobject srcFDO, jobject dstFDO,
+                                              jlong position, jlong count)
+{
+    return IOS_UNSUPPORTED;
+}
 
 JNIEXPORT jint JNICALL
 Java_sun_nio_ch_FileChannelImpl_maxDirectTransferSize0(JNIEnv* env, jobject this)

--- a/test/jdk/java/nio/channels/FileChannel/Transfers.java
+++ b/test/jdk/java/nio/channels/FileChannel/Transfers.java
@@ -23,7 +23,7 @@
 
 /* @test
  * @summary Comprehensive test for FileChannel.transfer{From,To}
- * @bug 4708120
+ * @bug 4708120 8274113
  * @author Mark Reinhold
  * @run main/timeout=300 Transfers
  */
@@ -468,10 +468,16 @@ public class Transfers {
         int pos = (int)seed & 0xfff;
         fc.position(pos);
 
-        int n = (int)fc.transferFrom(src.channel(), off, len);
-        if (n != len)
-            throw new Failure("Incorrect transfer length: " + n
-                              + " (expected " + len + ")");
+        long position = off;
+        long count = len;
+        while (count > 0) {
+            int n = (int)fc.transferFrom(src.channel(), position, count);
+            if (n < 0 || n > count)
+                throw new Failure("Incorrect transfer length n = : " + n
+                                  + " (expected 0 <= n <= " + len + ")");
+            position += n;
+            count -= n;
+        }
 
         // Check that source didn't change, and was read correctly
         src.verify();


### PR DESCRIPTION
This request proposes to change `FileChannel.transferFrom()` to add a fast path on Linux and a threshold for mapped transfers on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8274113](https://bugs.openjdk.java.net/browse/JDK-8274113): (fc) Tune FileChannel.transferFrom()


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8644/head:pull/8644` \
`$ git checkout pull/8644`

Update a local copy of the PR: \
`$ git checkout pull/8644` \
`$ git pull https://git.openjdk.java.net/jdk pull/8644/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8644`

View PR using the GUI difftool: \
`$ git pr show -t 8644`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8644.diff">https://git.openjdk.java.net/jdk/pull/8644.diff</a>

</details>
