### PR TITLE
8286467: G1: Collection set pruning adds one region too many

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSetChooser.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetChooser.cpp
@@ -274,7 +274,7 @@ public:
 
   virtual bool do_heap_region(HeapRegion* r) {
     size_t const reclaimable = r->reclaimable_bytes();
-    if (_num_pruned > _max_pruned ||
+    if (_num_pruned >= _max_pruned ||
         _cur_wasted + reclaimable > _max_wasted) {
       return true;
     }


### PR DESCRIPTION
The following if statement in the do_heap_region function of G1PruneRegionClosure:

> if (_num_pruned > _max_pruned ||
> _cur_wasted + reclaimable > _max_wasted) {
> return true;
> }

should be >=, otherwise one too many region than intended will be added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286467](https://bugs.openjdk.java.net/browse/JDK-8286467): G1: Collection set pruning adds one region too many


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8645/head:pull/8645` \
`$ git checkout pull/8645`

Update a local copy of the PR: \
`$ git checkout pull/8645` \
`$ git pull https://git.openjdk.java.net/jdk pull/8645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8645`

View PR using the GUI difftool: \
`$ git pr show -t 8645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8645.diff">https://git.openjdk.java.net/jdk/pull/8645.diff</a>

</details>
