### PR TITLE
8286573: Remove the unnecessary method Attr#attribTopLevel and its usage

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5155,27 +5155,11 @@ public class Attr extends JCTree.Visitor {
             case MODULEDEF:
                 attribModule(env.tree.pos(), ((JCModuleDecl)env.tree).sym);
                 break;
-            case TOPLEVEL:
-                attribTopLevel(env);
-                break;
             case PACKAGEDEF:
                 attribPackage(env.tree.pos(), ((JCPackageDecl) env.tree).packge);
                 break;
             default:
                 attribClass(env.tree.pos(), env.enclClass.sym);
-        }
-    }
-
-    /**
-     * Attribute a top level tree. These trees are encountered when the
-     * package declaration has annotations.
-     */
-    public void attribTopLevel(Env<AttrContext> env) {
-        JCCompilationUnit toplevel = env.toplevel;
-        try {
-            annotate.flush();
-        } catch (CompletionFailure ex) {
-            chk.completionError(toplevel.pos(), ex);
         }
     }
 


### PR DESCRIPTION
Hi all,

The original patch [1] added the method `Attr#attribTopLevel` to validate the annotations of the package. Then the annotation validation was moved to the annotation pipeline [2] and the TopLevel tree node was refactored (added JCPackageDecl) [3]. So now the `Attr#attribTopLevel` is replaced by method `attribPackage` and actually is not used by any code. It is good to remove it.

And there are only 3 places (shown below) that add the `Env` instance to the `Todo` list which the `Attr` uses as input. They add the `Env` of module, package, class seperately to the todo list . So the `Attr` doesn't need to handle the situation about TopLevel JCCompilationUnit.

1. Enter::visitTopLevel  `todo.append(packageEnv)`
2. Enter::visitModuleDef `todo.append(moduleEnv)`
3. ImportsPhase::runPhase `todo.append(env)`

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

[1]https://github.com/openjdk/jdk/commit/13d31713dc6ac7134d81abeb11a659df2104d71f
[2]https://github.com/openjdk/jdk/commit/da21af58f4811285f7050691d51fe32600c0e5f8
[3]https://github.com/openjdk/jdk/commit/9783b65028eba41796c3e05ebb545b1a722f56b0

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286573](https://bugs.openjdk.java.net/browse/JDK-8286573): Remove the unnecessary method Attr#attribTopLevel and its usage


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8648/head:pull/8648` \
`$ git checkout pull/8648`

Update a local copy of the PR: \
`$ git checkout pull/8648` \
`$ git pull https://git.openjdk.java.net/jdk pull/8648/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8648`

View PR using the GUI difftool: \
`$ git pr show -t 8648`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8648.diff">https://git.openjdk.java.net/jdk/pull/8648.diff</a>

</details>
