### PR TITLE
8286559: Re-examine synchronization of mark and reset methods on InflaterInputStream

### DIFF
--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -264,21 +264,22 @@ public class InflaterInputStream extends FilterInputStream {
     /**
      * Marks the current position in this input stream.
      *
-     * <p> The {@code mark} method of {@code InflaterInputStream}
+     * @implNote The {@code mark} method of {@code InflaterInputStream}
      * does nothing.
      *
      * @param   readlimit   the maximum limit of bytes that can be read before
      *                      the mark position becomes invalid.
      * @see     java.io.InputStream#reset()
      */
-    public synchronized void mark(int readlimit) {
+    @Override
+    public void mark(int readlimit) {
     }
 
     /**
      * Repositions this stream to the position at the time the
      * {@code mark} method was last called on this input stream.
      *
-     * <p> The method {@code reset} for class
+     * @implNote The method {@code reset} for class
      * {@code InflaterInputStream} does nothing except throw an
      * {@code IOException}.
      *
@@ -286,7 +287,8 @@ public class InflaterInputStream extends FilterInputStream {
      * @see     java.io.InputStream#mark(int)
      * @see     java.io.IOException
      */
-    public synchronized void reset() throws IOException {
+    @Override
+    public void reset() throws IOException {
         throw new IOException("mark/reset not supported");
     }
 }

--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -264,7 +264,7 @@ public class InflaterInputStream extends FilterInputStream {
     /**
      * Marks the current position in this input stream.
      *
-     * @implNote The {@code mark} method of {@code InflaterInputStream}
+     * @implSpec The {@code mark} method of {@code InflaterInputStream}
      * does nothing.
      *
      * @param   readlimit   the maximum limit of bytes that can be read before
@@ -279,7 +279,7 @@ public class InflaterInputStream extends FilterInputStream {
      * Repositions this stream to the position at the time the
      * {@code mark} method was last called on this input stream.
      *
-     * @implNote The method {@code reset} for class
+     * @implSpec The method {@code reset} for class
      * {@code InflaterInputStream} does nothing except throw an
      * {@code IOException}.
      *


### PR DESCRIPTION
Can I please get a review of this change that addresses https://bugs.openjdk.java.net/browse/JDK-8286559? 

The commit here removes the `synchronized` on `mark` and `reset` methods of `InflaterInputStream`. The `mark` method is a no-op method and the `reset` method only always throws a `IOException`. So `synchronized` isn't adding any value here. 

Additionally, the commit does a minor change to the javadoc of these methods to use `@implNote` to describe what the implementation does. Please let me know if the `@implNote` is unnecessary, in which case, I'll revert that part.

This change is similar to what was recently done for `FilterInputStream` https://github.com/openjdk/jdk/pull/8309 and `PushbackInputStream` https://github.com/openjdk/jdk/pull/8433

tier1, tier2 and tier3 tests were run and no related failures were noticed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issues
 * [JDK-8286559](https://bugs.openjdk.java.net/browse/JDK-8286559): Re-examine synchronization of mark and reset methods on InflaterInputStream
 * [JDK-8286579](https://bugs.openjdk.java.net/browse/JDK-8286579): Re-examine synchronization of mark and reset methods on InflaterInputStream (**CSR**)


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to [89de6078](https://git.openjdk.java.net/jdk/pull/8649/files/89de6078d4ff242de5fbe44bdea26ef43409b07f)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8649/head:pull/8649` \
`$ git checkout pull/8649`

Update a local copy of the PR: \
`$ git checkout pull/8649` \
`$ git pull https://git.openjdk.java.net/jdk pull/8649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8649`

View PR using the GUI difftool: \
`$ git pr show -t 8649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8649.diff">https://git.openjdk.java.net/jdk/pull/8649.diff</a>

</details>
