### PR TITLE
8282607: runtime/ErrorHandling/MachCodeFramesInErrorFile.java failed with "RuntimeException: 0 < 2"

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
@@ -154,6 +154,16 @@ public class MachCodeFramesInErrorFile {
             return;
         }
 
+        String preCodeBlobSectionHeader = "Stack slot to memory mapping:";
+        if (!hsErr.contains(preCodeBlobSectionHeader) &&
+            System.getProperty("os.arch").equals("aarch64") &&
+            System.getProperty("os.name").toLowerCase().startsWith("mac")) {
+            // JDK-8282607: hs_err can be truncated. If the section preceding
+            // code blob dumping is missing, exit successfully.
+            System.out.println("Could not find \"" + preCodeBlobSectionHeader + "\" in " + hsErrPath);
+            System.out.println("Looks like hs-err is truncated - exiting with success");
+        }
+
         Matcher matcher = Pattern.compile("\\[MachCode\\]\\s*\\[Verified Entry Point\\]\\s*  # \\{method\\} \\{[^}]*\\} '([^']+)' '([^']+)' in '([^']+)'", Pattern.DOTALL).matcher(hsErr);
         List<String> machCodeHeaders = matcher.results().map(mr -> String.format("'%s' '%s' in '%s'", mr.group(1), mr.group(2), mr.group(3))).collect(Collectors.toList());
         int minExpectedMachCodeSections = Math.max(1, compiledJavaFrames);


### PR DESCRIPTION
I've looked through the failures reported in https://bugs.openjdk.java.net/browse/JDK-8282607 and in all cases, the problem is that hs_err is truncated while printing the register to memory mapping and always while printing x14. Here are a few examples:

```
Register to memory mapping:

 x0=0x000000000000000a is an unknown value
 x1=0x000000000000000a is an unknown value
 x2=0x0 is NULL
 x3=0x000000000000000a is an unknown value
 x4=0x000000013e009080 points into unknown readable memory: 0xabababababababab | ab ab ab ab ab ab ab ab
 x5=0x0000000000000005 is an unknown value
 x6=0x0 is NULL
 x7=0x0 is NULL
 x8=0x0 is NULL
 x9=0x0000000000000001 is an unknown value
x10=0x2010000030300000 is an unknown value
x11=0x0000000000000002 is an unknown value
x12={method} {0x0000000800467b20} 'getLong' '(Ljava/lang/Object;J)J' in 'jdk/internal/misc/Unsafe'
x13=0x0000000080000000 is an unknown value
x14=
```
and:
```
Register to memory mapping:

 x0=0x000000000000000a is an unknown value
 x1=0x000000000000000a is an unknown value
 x2=0x0 is NULL
 x3=0x000000000000000a is an unknown value
 x4=0x000000012002ebc0 is pointing into metadata
 x5=0x0000000000000012 is an unknown value
 x6=0x0 is NULL
 x7=0x0000000136808210 is a thread
 x8=0x0 is NULL
 x9=0x0000000000000001 is an unknown value
x10=0x2010000030300000 is an unknown value
x11=0x0000010000000102 is an unknown value
x12={method} {0x00000008004b0ed0} 'getLong' '(Ljava/lang/Object;J)J' in 'jdk/internal/misc/Unsafe'
x13=0x0000000080000000 is an unknown value
x14=
```

To avoid the MachCodeFramesInErrorFile test failing as a result of the intermittent truncation, the test has been modified to pass if the section preceding the code blob dumping is not seen.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8282607](https://bugs.openjdk.java.net/browse/JDK-8282607): runtime/ErrorHandling/MachCodeFramesInErrorFile.java failed with "RuntimeException: 0 < 2"


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8650/head:pull/8650` \
`$ git checkout pull/8650`

Update a local copy of the PR: \
`$ git checkout pull/8650` \
`$ git pull https://git.openjdk.java.net/jdk pull/8650/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8650`

View PR using the GUI difftool: \
`$ git pr show -t 8650`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8650.diff">https://git.openjdk.java.net/jdk/pull/8650.diff</a>

</details>
