### PR TITLE
8286391: Address possibly lossy conversions in jdk.compiler

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -825,7 +825,7 @@ public class ClassWriter extends ClassFile {
         databuf.appendChar(poolWriter.innerClasses.size());
         for (ClassSymbol inner : poolWriter.innerClasses) {
             inner.markAbstractIfNeeded(types);
-            char flags = (char) adjustFlags(inner.flags_field);
+            int flags = adjustFlags(inner.flags_field);
             if ((flags & INTERFACE) != 0) flags |= ABSTRACT; // Interfaces are always ABSTRACT
             flags &= ~STRICTFP; //inner classes should not have the strictfp flag set.
             if (dumpInnerClassModifiers) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Code.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Code.java
@@ -2015,7 +2015,7 @@ public class Code {
             if (localVar != null) {
                 for (LocalVar.Range range: localVar.aliveRanges) {
                     if (range.closed() && range.start_pc + range.length >= oldCP) {
-                        range.length += delta;
+                        range.length += (char)delta;
                     }
                 }
             }


### PR DESCRIPTION
This is a part of addressing of all possibly lossy conversions in compound assignments across JDK sources.
Two cases have been found in jdk.compiler and they are addressed by this patch.
One case in ClassWriter is resolved by changing local variable from char to int type to avoid multiple implicit and explicit conversions.
Second case in Code is resolved by making the implicit conversion from int to char explicit.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286391](https://bugs.openjdk.java.net/browse/JDK-8286391): Address possibly lossy conversions in jdk.compiler


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8652/head:pull/8652` \
`$ git checkout pull/8652`

Update a local copy of the PR: \
`$ git checkout pull/8652` \
`$ git pull https://git.openjdk.java.net/jdk pull/8652/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8652`

View PR using the GUI difftool: \
`$ git pr show -t 8652`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8652.diff">https://git.openjdk.java.net/jdk/pull/8652.diff</a>

</details>
