### PR TITLE
8286556: Remove EagerInitialization develop option

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1453,7 +1453,6 @@ void SystemDictionary::define_instance_class(InstanceKlass* k, Handle class_load
     // Grabs and releases SystemDictionary_lock
     update_dictionary(name_hash, k, class_loader);
   }
-  k->eager_initialize(THREAD);
 
   // notify jvmti
   if (JvmtiExport::should_post_class_load()) {

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -711,25 +711,6 @@ klassItable InstanceKlass::itable() const {
   return klassItable(const_cast<InstanceKlass*>(this));
 }
 
-void InstanceKlass::eager_initialize(Thread *thread) {
-  if (!EagerInitialization) return;
-
-  if (this->is_not_initialized()) {
-    // abort if the the class has a class initializer
-    if (this->class_initializer() != NULL) return;
-
-    // abort if it is java.lang.Object (initialization is handled in genesis)
-    Klass* super_klass = super();
-    if (super_klass == NULL) return;
-
-    // abort if the super class should be initialized
-    if (!InstanceKlass::cast(super_klass)->is_initialized()) return;
-
-    // call body to expose the this pointer
-    eager_initialize_impl();
-  }
-}
-
 // JVMTI spec thinks there are signers and protection domain in the
 // instanceKlass.  These accessors pretend these fields are there.
 // The hprof specification also thinks these fields are in InstanceKlass.
@@ -762,38 +743,6 @@ void InstanceKlass::fence_and_clear_init_lock() {
   OrderAccess::storestore();
   java_lang_Class::clear_init_lock(java_mirror());
   assert(!is_not_initialized(), "class must be initialized now");
-}
-
-void InstanceKlass::eager_initialize_impl() {
-  EXCEPTION_MARK;
-  HandleMark hm(THREAD);
-  Handle h_init_lock(THREAD, init_lock());
-  ObjectLocker ol(h_init_lock, THREAD);
-
-  // abort if someone beat us to the initialization
-  if (!is_not_initialized()) return;  // note: not equivalent to is_initialized()
-
-  ClassState old_state = init_state();
-  link_class_impl(THREAD);
-  if (HAS_PENDING_EXCEPTION) {
-    CLEAR_PENDING_EXCEPTION;
-    // Abort if linking the class throws an exception.
-
-    // Use a test to avoid redundantly resetting the state if there's
-    // no change.  Set_init_state() asserts that state changes make
-    // progress, whereas here we might just be spinning in place.
-    if (old_state != _init_state)
-      set_init_state(old_state);
-  } else {
-    // linking successful, mark class as initialized
-    set_init_state(fully_initialized);
-    fence_and_clear_init_lock();
-    // trace
-    if (log_is_enabled(Info, class, init)) {
-      ResourceMark rm(THREAD);
-      log_info(class, init)("[Initialized %s without side effects]", external_name());
-    }
-  }
 }
 
 

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -574,9 +574,6 @@ public:
   void link_methods(TRAPS);
   Method* class_initializer() const;
 
-  // set the class to initialized if no static initializer is present
-  void eager_initialize(Thread *thread);
-
   // reference type
   ReferenceType reference_type() const     { return (ReferenceType)_reference_type; }
   void set_reference_type(ReferenceType t) {
@@ -1179,7 +1176,6 @@ private:
   bool verify_code                               (TRAPS);
   void initialize_impl                           (TRAPS);
   void initialize_super_interfaces               (TRAPS);
-  void eager_initialize_impl                     ();
 
   void add_initialization_error(JavaThread* current, Handle exception);
   oop get_initialization_error(JavaThread* current);

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -973,9 +973,6 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, UsePopCountInstruction, false,                              \
           "Use population count instruction")                               \
                                                                             \
-  develop(bool, EagerInitialization, false,                                 \
-          "Eagerly initialize classes if possible")                         \
-                                                                            \
   product(bool, LogTouchedMethods, false, DIAGNOSTIC,                       \
           "Log methods which have been ever touched in runtime")            \
                                                                             \

--- a/test/hotspot/jtreg/runtime/logging/ClassInitializationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassInitializationTest.java
@@ -53,19 +53,7 @@ public class ClassInitializationTest {
         out.shouldContain("Verification for BadMap50 failed");
         out.shouldContain("Fail over class verification to old verifier for: BadMap50");
 
-        // (2)
-        if (Platform.isDebugBuild()) {
-            pb = ProcessTools.createJavaProcessBuilder("-Xlog:class+init=info",
-                                                       "-Xverify:all",
-                                                       "-XX:+EagerInitialization",
-                                                       "-Xmx128m",
-                                                       InnerClass.class.getName());
-            out = new OutputAnalyzer(pb.start());
-            out.shouldContain("[Initialized").shouldContain("without side effects]");
-            out.shouldHaveExitValue(0);
-        }
-
-        // (3) class+init should turn off.
+        // (2) class+init should turn off.
         pb = ProcessTools.createJavaProcessBuilder("-Xlog:class+init=off",
                                                    "-Xverify:all",
                                                    "-Xmx128m",


### PR DESCRIPTION
This is a long unused option which interferes with code I'm trying to replace, so removing it.
Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286556](https://bugs.openjdk.java.net/browse/JDK-8286556): Remove EagerInitialization develop option


### Reviewers
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8653/head:pull/8653` \
`$ git checkout pull/8653`

Update a local copy of the PR: \
`$ git checkout pull/8653` \
`$ git pull https://git.openjdk.java.net/jdk pull/8653/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8653`

View PR using the GUI difftool: \
`$ git pr show -t 8653`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8653.diff">https://git.openjdk.java.net/jdk/pull/8653.diff</a>

</details>
