### PR TITLE
8286401: Address possibly lossy conversions in Microbenchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/java/nio/ByteBuffers.java
+++ b/test/micro/org/openjdk/bench/java/nio/ByteBuffers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/nio/ByteBuffers.java
+++ b/test/micro/org/openjdk/bench/java/nio/ByteBuffers.java
@@ -115,8 +115,8 @@ public class ByteBuffers {
     // -- Heap_Byte_Swap_RO
 
     @Benchmark
-    public int testHeapLoopGetByteSwapRO() {
-        int r = 0;
+    public byte testHeapLoopGetByteSwapRO() {
+        byte r = 0;
         for (int i = 0; i < heapByteBufferSwapRO.capacity(); i+=1) {
             r += heapByteBufferSwapRO.get(i);
         }
@@ -133,8 +133,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetByteSwap() {
-        int r = 0;
+    public byte testHeapLoopGetByteSwap() {
+        byte r = 0;
         for (int i = 0; i < heapByteBufferSwap.capacity(); i+=1) {
             r += heapByteBufferSwap.get(i);
         }
@@ -144,8 +144,8 @@ public class ByteBuffers {
     // -- Heap_Byte__RO
 
     @Benchmark
-    public int testHeapLoopGetByteRO() {
-        int r = 0;
+    public byte testHeapLoopGetByteRO() {
+        byte r = 0;
         for (int i = 0; i < heapByteBufferRO.capacity(); i+=1) {
             r += heapByteBufferRO.get(i);
         }
@@ -162,8 +162,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetByte() {
-        int r = 0;
+    public byte testHeapLoopGetByte() {
+        byte r = 0;
         for (int i = 0; i < heapByteBuffer.capacity(); i+=1) {
             r += heapByteBuffer.get(i);
         }
@@ -173,8 +173,8 @@ public class ByteBuffers {
     // -- Direct_Byte_Swap_RO
 
     @Benchmark
-    public int testDirectLoopGetByteSwapRO() {
-        int r = 0;
+    public byte testDirectLoopGetByteSwapRO() {
+        byte r = 0;
         for (int i = 0; i < directByteBufferSwapRO.capacity(); i+=1) {
             r += directByteBufferSwapRO.get(i);
         }
@@ -191,8 +191,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetByteSwap() {
-        int r = 0;
+    public byte testDirectLoopGetByteSwap() {
+        byte r = 0;
         for (int i = 0; i < directByteBufferSwap.capacity(); i+=1) {
             r += directByteBufferSwap.get(i);
         }
@@ -202,8 +202,8 @@ public class ByteBuffers {
     // -- Direct_Byte__RO
 
     @Benchmark
-    public int testDirectLoopGetByteRO() {
-        int r = 0;
+    public byte testDirectLoopGetByteRO() {
+        byte r = 0;
         for (int i = 0; i < directByteBufferRO.capacity(); i+=1) {
             r += directByteBufferRO.get(i);
         }
@@ -220,8 +220,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetByte() {
-        int r = 0;
+    public byte testDirectLoopGetByte() {
+        byte r = 0;
         for (int i = 0; i < directByteBuffer.capacity(); i+=1) {
             r += directByteBuffer.get(i);
         }
@@ -231,8 +231,8 @@ public class ByteBuffers {
     // -- Heap_Char_Swap_RO
 
     @Benchmark
-    public int testHeapLoopGetCharSwapRO() {
-        int r = 0;
+    public char testHeapLoopGetCharSwapRO() {
+        char r = 0;
         for (int i = 0; i < heapByteBufferSwapRO.capacity(); i+=2) {
             r += heapByteBufferSwapRO.getChar(i);
         }
@@ -249,8 +249,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetCharSwap() {
-        int r = 0;
+    public char testHeapLoopGetCharSwap() {
+        char r = 0;
         for (int i = 0; i < heapByteBufferSwap.capacity(); i+=2) {
             r += heapByteBufferSwap.getChar(i);
         }
@@ -260,8 +260,8 @@ public class ByteBuffers {
     // -- Heap_Char__RO
 
     @Benchmark
-    public int testHeapLoopGetCharRO() {
-        int r = 0;
+    public char testHeapLoopGetCharRO() {
+        char r = 0;
         for (int i = 0; i < heapByteBufferRO.capacity(); i+=2) {
             r += heapByteBufferRO.getChar(i);
         }
@@ -278,8 +278,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetChar() {
-        int r = 0;
+    public char testHeapLoopGetChar() {
+        char r = 0;
         for (int i = 0; i < heapByteBuffer.capacity(); i+=2) {
             r += heapByteBuffer.getChar(i);
         }
@@ -289,8 +289,8 @@ public class ByteBuffers {
     // -- Direct_Char_Swap_RO
 
     @Benchmark
-    public int testDirectLoopGetCharSwapRO() {
-        int r = 0;
+    public char testDirectLoopGetCharSwapRO() {
+        char r = 0;
         for (int i = 0; i < directByteBufferSwapRO.capacity(); i+=2) {
             r += directByteBufferSwapRO.getChar(i);
         }
@@ -307,8 +307,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetCharSwap() {
-        int r = 0;
+    public char testDirectLoopGetCharSwap() {
+        char r = 0;
         for (int i = 0; i < directByteBufferSwap.capacity(); i+=2) {
             r += directByteBufferSwap.getChar(i);
         }
@@ -318,8 +318,8 @@ public class ByteBuffers {
     // -- Direct_Char__RO
 
     @Benchmark
-    public int testDirectLoopGetCharRO() {
-        int r = 0;
+    public char testDirectLoopGetCharRO() {
+        char r = 0;
         for (int i = 0; i < directByteBufferRO.capacity(); i+=2) {
             r += directByteBufferRO.getChar(i);
         }
@@ -336,8 +336,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetChar() {
-        int r = 0;
+    public char testDirectLoopGetChar() {
+        char r = 0;
         for (int i = 0; i < directByteBuffer.capacity(); i+=2) {
             r += directByteBuffer.getChar(i);
         }
@@ -347,8 +347,8 @@ public class ByteBuffers {
     // -- Heap_Short_Swap_RO
 
     @Benchmark
-    public int testHeapLoopGetShortSwapRO() {
-        int r = 0;
+    public short testHeapLoopGetShortSwapRO() {
+        short r = 0;
         for (int i = 0; i < heapByteBufferSwapRO.capacity(); i+=2) {
             r += heapByteBufferSwapRO.getShort(i);
         }
@@ -365,8 +365,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetShortSwap() {
-        int r = 0;
+    public short testHeapLoopGetShortSwap() {
+        short r = 0;
         for (int i = 0; i < heapByteBufferSwap.capacity(); i+=2) {
             r += heapByteBufferSwap.getShort(i);
         }
@@ -376,8 +376,8 @@ public class ByteBuffers {
     // -- Heap_Short__RO
 
     @Benchmark
-    public int testHeapLoopGetShortRO() {
-        int r = 0;
+    public short testHeapLoopGetShortRO() {
+        short r = 0;
         for (int i = 0; i < heapByteBufferRO.capacity(); i+=2) {
             r += heapByteBufferRO.getShort(i);
         }
@@ -394,8 +394,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetShort() {
-        int r = 0;
+    public short testHeapLoopGetShort() {
+        short r = 0;
         for (int i = 0; i < heapByteBuffer.capacity(); i+=2) {
             r += heapByteBuffer.getShort(i);
         }
@@ -405,8 +405,8 @@ public class ByteBuffers {
     // -- Direct_Short_Swap_RO
 
     @Benchmark
-    public int testDirectLoopGetShortSwapRO() {
-        int r = 0;
+    public short testDirectLoopGetShortSwapRO() {
+        short r = 0;
         for (int i = 0; i < directByteBufferSwapRO.capacity(); i+=2) {
             r += directByteBufferSwapRO.getShort(i);
         }
@@ -423,8 +423,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetShortSwap() {
-        int r = 0;
+    public short testDirectLoopGetShortSwap() {
+        short r = 0;
         for (int i = 0; i < directByteBufferSwap.capacity(); i+=2) {
             r += directByteBufferSwap.getShort(i);
         }
@@ -434,8 +434,8 @@ public class ByteBuffers {
     // -- Direct_Short__RO
 
     @Benchmark
-    public int testDirectLoopGetShortRO() {
-        int r = 0;
+    public short testDirectLoopGetShortRO() {
+        short r = 0;
         for (int i = 0; i < directByteBufferRO.capacity(); i+=2) {
             r += directByteBufferRO.getShort(i);
         }
@@ -452,8 +452,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetShort() {
-        int r = 0;
+    public short testDirectLoopGetShort() {
+        short r = 0;
         for (int i = 0; i < directByteBuffer.capacity(); i+=2) {
             r += directByteBuffer.getShort(i);
         }
@@ -579,8 +579,8 @@ public class ByteBuffers {
     // -- Heap_Long_Swap_RO
 
     @Benchmark
-    public int testHeapLoopGetLongSwapRO() {
-        int r = 0;
+    public long testHeapLoopGetLongSwapRO() {
+        long r = 0;
         for (int i = 0; i < heapByteBufferSwapRO.capacity(); i+=8) {
             r += heapByteBufferSwapRO.getLong(i);
         }
@@ -597,8 +597,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetLongSwap() {
-        int r = 0;
+    public long testHeapLoopGetLongSwap() {
+        long r = 0;
         for (int i = 0; i < heapByteBufferSwap.capacity(); i+=8) {
             r += heapByteBufferSwap.getLong(i);
         }
@@ -608,8 +608,8 @@ public class ByteBuffers {
     // -- Heap_Long__RO
 
     @Benchmark
-    public int testHeapLoopGetLongRO() {
-        int r = 0;
+    public long testHeapLoopGetLongRO() {
+        long r = 0;
         for (int i = 0; i < heapByteBufferRO.capacity(); i+=8) {
             r += heapByteBufferRO.getLong(i);
         }
@@ -626,8 +626,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetLong() {
-        int r = 0;
+    public long testHeapLoopGetLong() {
+        long r = 0;
         for (int i = 0; i < heapByteBuffer.capacity(); i+=8) {
             r += heapByteBuffer.getLong(i);
         }
@@ -637,8 +637,8 @@ public class ByteBuffers {
     // -- Direct_Long_Swap_RO
 
     @Benchmark
-    public int testDirectLoopGetLongSwapRO() {
-        int r = 0;
+    public long testDirectLoopGetLongSwapRO() {
+        long r = 0;
         for (int i = 0; i < directByteBufferSwapRO.capacity(); i+=8) {
             r += directByteBufferSwapRO.getLong(i);
         }
@@ -655,8 +655,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetLongSwap() {
-        int r = 0;
+    public long testDirectLoopGetLongSwap() {
+        long r = 0;
         for (int i = 0; i < directByteBufferSwap.capacity(); i+=8) {
             r += directByteBufferSwap.getLong(i);
         }
@@ -666,8 +666,8 @@ public class ByteBuffers {
     // -- Direct_Long__RO
 
     @Benchmark
-    public int testDirectLoopGetLongRO() {
-        int r = 0;
+    public long testDirectLoopGetLongRO() {
+        long r = 0;
         for (int i = 0; i < directByteBufferRO.capacity(); i+=8) {
             r += directByteBufferRO.getLong(i);
         }
@@ -684,8 +684,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetLong() {
-        int r = 0;
+    public long testDirectLoopGetLong() {
+        long r = 0;
         for (int i = 0; i < directByteBuffer.capacity(); i+=8) {
             r += directByteBuffer.getLong(i);
         }
@@ -695,8 +695,8 @@ public class ByteBuffers {
     // -- Heap_Float_Swap_RO
 
     @Benchmark
-    public int testHeapLoopGetFloatSwapRO() {
-        int r = 0;
+    public float testHeapLoopGetFloatSwapRO() {
+        float r = 0;
         for (int i = 0; i < heapByteBufferSwapRO.capacity(); i+=4) {
             r += heapByteBufferSwapRO.getFloat(i);
         }
@@ -713,8 +713,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetFloatSwap() {
-        int r = 0;
+    public float testHeapLoopGetFloatSwap() {
+        float r = 0;
         for (int i = 0; i < heapByteBufferSwap.capacity(); i+=4) {
             r += heapByteBufferSwap.getFloat(i);
         }
@@ -724,8 +724,8 @@ public class ByteBuffers {
     // -- Heap_Float__RO
 
     @Benchmark
-    public int testHeapLoopGetFloatRO() {
-        int r = 0;
+    public float testHeapLoopGetFloatRO() {
+        float r = 0;
         for (int i = 0; i < heapByteBufferRO.capacity(); i+=4) {
             r += heapByteBufferRO.getFloat(i);
         }
@@ -742,8 +742,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetFloat() {
-        int r = 0;
+    public float testHeapLoopGetFloat() {
+        float r = 0;
         for (int i = 0; i < heapByteBuffer.capacity(); i+=4) {
             r += heapByteBuffer.getFloat(i);
         }
@@ -753,8 +753,8 @@ public class ByteBuffers {
     // -- Direct_Float_Swap_RO
 
     @Benchmark
-    public int testDirectLoopGetFloatSwapRO() {
-        int r = 0;
+    public float testDirectLoopGetFloatSwapRO() {
+        float r = 0;
         for (int i = 0; i < directByteBufferSwapRO.capacity(); i+=4) {
             r += directByteBufferSwapRO.getFloat(i);
         }
@@ -771,8 +771,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetFloatSwap() {
-        int r = 0;
+    public float testDirectLoopGetFloatSwap() {
+        float r = 0;
         for (int i = 0; i < directByteBufferSwap.capacity(); i+=4) {
             r += directByteBufferSwap.getFloat(i);
         }
@@ -782,8 +782,8 @@ public class ByteBuffers {
     // -- Direct_Float__RO
 
     @Benchmark
-    public int testDirectLoopGetFloatRO() {
-        int r = 0;
+    public float testDirectLoopGetFloatRO() {
+        float r = 0;
         for (int i = 0; i < directByteBufferRO.capacity(); i+=4) {
             r += directByteBufferRO.getFloat(i);
         }
@@ -800,8 +800,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetFloat() {
-        int r = 0;
+    public float testDirectLoopGetFloat() {
+        float r = 0;
         for (int i = 0; i < directByteBuffer.capacity(); i+=4) {
             r += directByteBuffer.getFloat(i);
         }
@@ -811,8 +811,8 @@ public class ByteBuffers {
     // -- Heap_Double_Swap_RO
 
     @Benchmark
-    public int testHeapLoopGetDoubleSwapRO() {
-        int r = 0;
+    public double testHeapLoopGetDoubleSwapRO() {
+        double r = 0;
         for (int i = 0; i < heapByteBufferSwapRO.capacity(); i+=8) {
             r += heapByteBufferSwapRO.getDouble(i);
         }
@@ -829,8 +829,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetDoubleSwap() {
-        int r = 0;
+    public double testHeapLoopGetDoubleSwap() {
+        double r = 0;
         for (int i = 0; i < heapByteBufferSwap.capacity(); i+=8) {
             r += heapByteBufferSwap.getDouble(i);
         }
@@ -840,8 +840,8 @@ public class ByteBuffers {
     // -- Heap_Double__RO
 
     @Benchmark
-    public int testHeapLoopGetDoubleRO() {
-        int r = 0;
+    public double testHeapLoopGetDoubleRO() {
+        double r = 0;
         for (int i = 0; i < heapByteBufferRO.capacity(); i+=8) {
             r += heapByteBufferRO.getDouble(i);
         }
@@ -858,8 +858,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetDouble() {
-        int r = 0;
+    public double testHeapLoopGetDouble() {
+        double r = 0;
         for (int i = 0; i < heapByteBuffer.capacity(); i+=8) {
             r += heapByteBuffer.getDouble(i);
         }
@@ -869,8 +869,8 @@ public class ByteBuffers {
     // -- Direct_Double_Swap_RO
 
     @Benchmark
-    public int testDirectLoopGetDoubleSwapRO() {
-        int r = 0;
+    public double testDirectLoopGetDoubleSwapRO() {
+        double r = 0;
         for (int i = 0; i < directByteBufferSwapRO.capacity(); i+=8) {
             r += directByteBufferSwapRO.getDouble(i);
         }
@@ -887,8 +887,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetDoubleSwap() {
-        int r = 0;
+    public double testDirectLoopGetDoubleSwap() {
+        double r = 0;
         for (int i = 0; i < directByteBufferSwap.capacity(); i+=8) {
             r += directByteBufferSwap.getDouble(i);
         }
@@ -898,8 +898,8 @@ public class ByteBuffers {
     // -- Direct_Double__RO
 
     @Benchmark
-    public int testDirectLoopGetDoubleRO() {
-        int r = 0;
+    public double testDirectLoopGetDoubleRO() {
+        double r = 0;
         for (int i = 0; i < directByteBufferRO.capacity(); i+=8) {
             r += directByteBufferRO.getDouble(i);
         }
@@ -916,8 +916,8 @@ public class ByteBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetDouble() {
-        int r = 0;
+    public double testDirectLoopGetDouble() {
+        double r = 0;
         for (int i = 0; i < directByteBuffer.capacity(); i+=8) {
             r += directByteBuffer.getDouble(i);
         }

--- a/test/micro/org/openjdk/bench/java/nio/CharBuffers.java
+++ b/test/micro/org/openjdk/bench/java/nio/CharBuffers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/nio/CharBuffers.java
+++ b/test/micro/org/openjdk/bench/java/nio/CharBuffers.java
@@ -101,8 +101,8 @@ public class CharBuffers {
 
     // ---------------- HELPER METHODS
 
-    private int innerLoopGetChar(CharBuffer buf) {
-        int r = 0;
+    private char innerLoopGetChar(CharBuffer buf) {
+        char r = 0;
         for (int i = 0; i < buf.capacity(); i++) {
             r += buf.get(i);
         }
@@ -135,7 +135,7 @@ public class CharBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetChar() {
+    public char testHeapLoopGetChar() {
         return innerLoopGetChar(heapCharBuffer);
     }
 
@@ -148,7 +148,7 @@ public class CharBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetCharViewSwapRO() {
+    public char testHeapLoopGetCharViewSwapRO() {
         return innerLoopGetChar(heapByteBufferAsCharBufferViewSwapRO);
     }
 
@@ -172,7 +172,7 @@ public class CharBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetCharViewSwap() {
+    public char testHeapLoopGetCharViewSwap() {
         return innerLoopGetChar(heapByteBufferAsCharBufferViewSwap);
     }
 
@@ -185,7 +185,7 @@ public class CharBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetCharViewRO() {
+    public char testHeapLoopGetCharViewRO() {
         return innerLoopGetChar(heapByteBufferAsCharBufferViewRO);
     }
 
@@ -209,7 +209,7 @@ public class CharBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetCharView() {
+    public char testHeapLoopGetCharView() {
         return innerLoopGetChar(heapByteBufferAsCharBufferView);
     }
 
@@ -222,7 +222,7 @@ public class CharBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetCharViewSwapRO() {
+    public char testDirectLoopGetCharViewSwapRO() {
         return innerLoopGetChar(directByteBufferAsCharBufferViewSwapRO);
     }
 
@@ -246,7 +246,7 @@ public class CharBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetCharViewSwap() {
+    public char testDirectLoopGetCharViewSwap() {
         return innerLoopGetChar(directByteBufferAsCharBufferViewSwap);
     }
 
@@ -259,7 +259,7 @@ public class CharBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetCharViewRO() {
+    public char testDirectLoopGetCharViewRO() {
         return innerLoopGetChar(directByteBufferAsCharBufferViewRO);
     }
 
@@ -283,7 +283,7 @@ public class CharBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetCharView() {
+    public char testDirectLoopGetCharView() {
         return innerLoopGetChar(directByteBufferAsCharBufferView);
     }
 }

--- a/test/micro/org/openjdk/bench/java/nio/DoubleBuffers.java
+++ b/test/micro/org/openjdk/bench/java/nio/DoubleBuffers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/nio/DoubleBuffers.java
+++ b/test/micro/org/openjdk/bench/java/nio/DoubleBuffers.java
@@ -101,8 +101,8 @@ public class DoubleBuffers {
 
     // ---------------- HELPER METHODS
 
-    private int innerLoopGetDouble(DoubleBuffer buf) {
-        int r = 0;
+    private double innerLoopGetDouble(DoubleBuffer buf) {
+        double r = 0;
         for (int i = 0; i < buf.capacity(); i++) {
             r += buf.get(i);
         }
@@ -135,7 +135,7 @@ public class DoubleBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetDouble() {
+    public double testHeapLoopGetDouble() {
         return innerLoopGetDouble(heapDoubleBuffer);
     }
 
@@ -148,7 +148,7 @@ public class DoubleBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetDoubleViewSwapRO() {
+    public double testHeapLoopGetDoubleViewSwapRO() {
         return innerLoopGetDouble(heapByteBufferAsDoubleBufferViewSwapRO);
     }
 
@@ -172,7 +172,7 @@ public class DoubleBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetDoubleViewSwap() {
+    public double testHeapLoopGetDoubleViewSwap() {
         return innerLoopGetDouble(heapByteBufferAsDoubleBufferViewSwap);
     }
 
@@ -185,7 +185,7 @@ public class DoubleBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetDoubleViewRO() {
+    public double testHeapLoopGetDoubleViewRO() {
         return innerLoopGetDouble(heapByteBufferAsDoubleBufferViewRO);
     }
 
@@ -209,7 +209,7 @@ public class DoubleBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetDoubleView() {
+    public double testHeapLoopGetDoubleView() {
         return innerLoopGetDouble(heapByteBufferAsDoubleBufferView);
     }
 
@@ -222,7 +222,7 @@ public class DoubleBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetDoubleViewSwapRO() {
+    public double testDirectLoopGetDoubleViewSwapRO() {
         return innerLoopGetDouble(directByteBufferAsDoubleBufferViewSwapRO);
     }
 
@@ -246,7 +246,7 @@ public class DoubleBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetDoubleViewSwap() {
+    public double testDirectLoopGetDoubleViewSwap() {
         return innerLoopGetDouble(directByteBufferAsDoubleBufferViewSwap);
     }
 
@@ -259,7 +259,7 @@ public class DoubleBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetDoubleViewRO() {
+    public double testDirectLoopGetDoubleViewRO() {
         return innerLoopGetDouble(directByteBufferAsDoubleBufferViewRO);
     }
 
@@ -283,7 +283,7 @@ public class DoubleBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetDoubleView() {
+    public double testDirectLoopGetDoubleView() {
         return innerLoopGetDouble(directByteBufferAsDoubleBufferView);
     }
 }

--- a/test/micro/org/openjdk/bench/java/nio/FloatBuffers.java
+++ b/test/micro/org/openjdk/bench/java/nio/FloatBuffers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/nio/FloatBuffers.java
+++ b/test/micro/org/openjdk/bench/java/nio/FloatBuffers.java
@@ -101,8 +101,8 @@ public class FloatBuffers {
 
     // ---------------- HELPER METHODS
 
-    private int innerLoopGetFloat(FloatBuffer buf) {
-        int r = 0;
+    private float innerLoopGetFloat(FloatBuffer buf) {
+        float r = 0;
         for (int i = 0; i < buf.capacity(); i++) {
             r += buf.get(i);
         }
@@ -135,7 +135,7 @@ public class FloatBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetFloat() {
+    public float testHeapLoopGetFloat() {
         return innerLoopGetFloat(heapFloatBuffer);
     }
 
@@ -148,7 +148,7 @@ public class FloatBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetFloatViewSwapRO() {
+    public float testHeapLoopGetFloatViewSwapRO() {
         return innerLoopGetFloat(heapByteBufferAsFloatBufferViewSwapRO);
     }
 
@@ -172,7 +172,7 @@ public class FloatBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetFloatViewSwap() {
+    public float testHeapLoopGetFloatViewSwap() {
         return innerLoopGetFloat(heapByteBufferAsFloatBufferViewSwap);
     }
 
@@ -185,7 +185,7 @@ public class FloatBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetFloatViewRO() {
+    public float testHeapLoopGetFloatViewRO() {
         return innerLoopGetFloat(heapByteBufferAsFloatBufferViewRO);
     }
 
@@ -209,7 +209,7 @@ public class FloatBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetFloatView() {
+    public float testHeapLoopGetFloatView() {
         return innerLoopGetFloat(heapByteBufferAsFloatBufferView);
     }
 
@@ -222,7 +222,7 @@ public class FloatBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetFloatViewSwapRO() {
+    public float testDirectLoopGetFloatViewSwapRO() {
         return innerLoopGetFloat(directByteBufferAsFloatBufferViewSwapRO);
     }
 
@@ -246,7 +246,7 @@ public class FloatBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetFloatViewSwap() {
+    public float testDirectLoopGetFloatViewSwap() {
         return innerLoopGetFloat(directByteBufferAsFloatBufferViewSwap);
     }
 
@@ -259,7 +259,7 @@ public class FloatBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetFloatViewRO() {
+    public float testDirectLoopGetFloatViewRO() {
         return innerLoopGetFloat(directByteBufferAsFloatBufferViewRO);
     }
 
@@ -283,7 +283,7 @@ public class FloatBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetFloatView() {
+    public float testDirectLoopGetFloatView() {
         return innerLoopGetFloat(directByteBufferAsFloatBufferView);
     }
 }

--- a/test/micro/org/openjdk/bench/java/nio/IntBuffers.java
+++ b/test/micro/org/openjdk/bench/java/nio/IntBuffers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/nio/LongBuffers.java
+++ b/test/micro/org/openjdk/bench/java/nio/LongBuffers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/nio/LongBuffers.java
+++ b/test/micro/org/openjdk/bench/java/nio/LongBuffers.java
@@ -101,8 +101,8 @@ public class LongBuffers {
 
     // ---------------- HELPER METHODS
 
-    private int innerLoopGetLong(LongBuffer buf) {
-        int r = 0;
+    private long innerLoopGetLong(LongBuffer buf) {
+        long r = 0;
         for (int i = 0; i < buf.capacity(); i++) {
             r += buf.get(i);
         }
@@ -135,7 +135,7 @@ public class LongBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetLong() {
+    public long testHeapLoopGetLong() {
         return innerLoopGetLong(heapLongBuffer);
     }
 
@@ -148,7 +148,7 @@ public class LongBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetLongViewSwapRO() {
+    public long testHeapLoopGetLongViewSwapRO() {
         return innerLoopGetLong(heapByteBufferAsLongBufferViewSwapRO);
     }
 
@@ -172,7 +172,7 @@ public class LongBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetLongViewSwap() {
+    public long testHeapLoopGetLongViewSwap() {
         return innerLoopGetLong(heapByteBufferAsLongBufferViewSwap);
     }
 
@@ -185,7 +185,7 @@ public class LongBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetLongViewRO() {
+    public long testHeapLoopGetLongViewRO() {
         return innerLoopGetLong(heapByteBufferAsLongBufferViewRO);
     }
 
@@ -209,7 +209,7 @@ public class LongBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetLongView() {
+    public long testHeapLoopGetLongView() {
         return innerLoopGetLong(heapByteBufferAsLongBufferView);
     }
 
@@ -222,7 +222,7 @@ public class LongBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetLongViewSwapRO() {
+    public long testDirectLoopGetLongViewSwapRO() {
         return innerLoopGetLong(directByteBufferAsLongBufferViewSwapRO);
     }
 
@@ -246,7 +246,7 @@ public class LongBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetLongViewSwap() {
+    public long testDirectLoopGetLongViewSwap() {
         return innerLoopGetLong(directByteBufferAsLongBufferViewSwap);
     }
 
@@ -259,7 +259,7 @@ public class LongBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetLongViewRO() {
+    public long testDirectLoopGetLongViewRO() {
         return innerLoopGetLong(directByteBufferAsLongBufferViewRO);
     }
 
@@ -283,7 +283,7 @@ public class LongBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetLongView() {
+    public long testDirectLoopGetLongView() {
         return innerLoopGetLong(directByteBufferAsLongBufferView);
     }
 }

--- a/test/micro/org/openjdk/bench/java/nio/ShortBuffers.java
+++ b/test/micro/org/openjdk/bench/java/nio/ShortBuffers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/nio/ShortBuffers.java
+++ b/test/micro/org/openjdk/bench/java/nio/ShortBuffers.java
@@ -101,8 +101,8 @@ public class ShortBuffers {
 
     // ---------------- HELPER METHODS
 
-    private int innerLoopGetShort(ShortBuffer buf) {
-        int r = 0;
+    private short innerLoopGetShort(ShortBuffer buf) {
+        short r = 0;
         for (int i = 0; i < buf.capacity(); i++) {
             r += buf.get(i);
         }
@@ -135,7 +135,7 @@ public class ShortBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetShort() {
+    public short testHeapLoopGetShort() {
         return innerLoopGetShort(heapShortBuffer);
     }
 
@@ -148,7 +148,7 @@ public class ShortBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetShortViewSwapRO() {
+    public short testHeapLoopGetShortViewSwapRO() {
         return innerLoopGetShort(heapByteBufferAsShortBufferViewSwapRO);
     }
 
@@ -172,7 +172,7 @@ public class ShortBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetShortViewSwap() {
+    public short testHeapLoopGetShortViewSwap() {
         return innerLoopGetShort(heapByteBufferAsShortBufferViewSwap);
     }
 
@@ -185,7 +185,7 @@ public class ShortBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetShortViewRO() {
+    public short testHeapLoopGetShortViewRO() {
         return innerLoopGetShort(heapByteBufferAsShortBufferViewRO);
     }
 
@@ -209,7 +209,7 @@ public class ShortBuffers {
     }
 
     @Benchmark
-    public int testHeapLoopGetShortView() {
+    public short testHeapLoopGetShortView() {
         return innerLoopGetShort(heapByteBufferAsShortBufferView);
     }
 
@@ -222,7 +222,7 @@ public class ShortBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetShortViewSwapRO() {
+    public short testDirectLoopGetShortViewSwapRO() {
         return innerLoopGetShort(directByteBufferAsShortBufferViewSwapRO);
     }
 
@@ -246,7 +246,7 @@ public class ShortBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetShortViewSwap() {
+    public short testDirectLoopGetShortViewSwap() {
         return innerLoopGetShort(directByteBufferAsShortBufferViewSwap);
     }
 
@@ -259,7 +259,7 @@ public class ShortBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetShortViewRO() {
+    public short testDirectLoopGetShortViewRO() {
         return innerLoopGetShort(directByteBufferAsShortBufferViewRO);
     }
 
@@ -283,7 +283,7 @@ public class ShortBuffers {
     }
 
     @Benchmark
-    public int testDirectLoopGetShortView() {
+    public short testDirectLoopGetShortView() {
         return innerLoopGetShort(directByteBufferAsShortBufferView);
     }
 }

--- a/test/micro/org/openjdk/bench/java/nio/X-Buffers-bin.java.template
+++ b/test/micro/org/openjdk/bench/java/nio/X-Buffers-bin.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/nio/X-Buffers-bin.java.template
+++ b/test/micro/org/openjdk/bench/java/nio/X-Buffers-bin.java.template
@@ -53,7 +53,7 @@ class XXX {
 #end[RO]
 
     @Benchmark
-    public int test$Ms$LoopGet$Type${#if[view]?View}$SWAP$$RO$() {
+    public $type$ test$Ms$LoopGet$Type${#if[view]?View}$SWAP$$RO$() {
         return innerLoopGet$Type$($ms${#if[view]?ByteBufferAs}$Type$Buffer{#if[view]?View}$SWAP$$RO$);
     }
 #end[byte]

--- a/test/micro/org/openjdk/bench/java/nio/X-Buffers.java.template
+++ b/test/micro/org/openjdk/bench/java/nio/X-Buffers.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/nio/X-Buffers.java.template
+++ b/test/micro/org/openjdk/bench/java/nio/X-Buffers.java.template
@@ -133,8 +133,8 @@ public class $Type$Buffers {
 #if[!byte]
     // ---------------- HELPER METHODS
 
-    private int innerLoopGet$Type$($Type$Buffer buf) {
-        int r = 0;
+    private $type$ innerLoopGet$Type$($Type$Buffer buf) {
+        $type$ r = 0;
         for (int i = 0; i < buf.capacity(); i++) {
             r += buf.get(i);
         }

--- a/test/micro/org/openjdk/bench/java/nio/X-ByteBuffers-bin.java.template
+++ b/test/micro/org/openjdk/bench/java/nio/X-ByteBuffers-bin.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/nio/X-ByteBuffers-bin.java.template
+++ b/test/micro/org/openjdk/bench/java/nio/X-ByteBuffers-bin.java.template
@@ -40,8 +40,8 @@ class XXX {
 #end[RO]
 
     @Benchmark
-    public int test$Ms$LoopGet$Type$$SWAP$$RO$() {
-        int r = 0;
+    public $type$ test$Ms$LoopGet$Type$$SWAP$$RO$() {
+        $type$ r = 0;
         for (int i = 0; i < $ms$ByteBuffer$SWAP$$RO$.capacity(); i+=$CarrierBW$) {
             r += $ms$ByteBuffer$SWAP$$RO$.get{#if[!byte]?$Type$}(i);
         }

--- a/test/micro/org/openjdk/bench/javax/crypto/full/CipherBench.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/CipherBench.java
@@ -69,7 +69,7 @@ public abstract class CipherBench extends CryptoBase {
         }
 
         // toggle some bits in the IV to get around IV reuse defenses
-        iv[0] ^= 0xFF;
+        iv[0] ^= (byte)0xFF;
         AlgorithmParameterSpec paramSpec = makeParameterSpec();
 
         c.init(mode, ks, paramSpec);

--- a/test/micro/org/openjdk/bench/vm/compiler/PointerBenchmarkFlat.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/PointerBenchmarkFlat.java
@@ -1,5 +1,5 @@
 /*
-  * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+  * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
   * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
   *
   * This code is free software; you can redistribute it and/or modify it
@@ -145,19 +145,19 @@ public class PointerBenchmarkFlat {
     }
 
     @Benchmark
-    public int test() {
-        int sum = 0;
+    public long test() {
+        long sum = 0;
         for (int i = 0 ; i < ELEM_SIZE ; i++) {
-            sum += (int)ptr_ptr.get(i).address().toRawLongValue();
+            sum += ptr_ptr.get(i).address().toRawLongValue();
         }
         return sum;
     }
 
     @Benchmark
-    public int testFlat() {
-        int sum = 0;
+    public long testFlat() {
+        long sum = 0;
         for (int i = 0 ; i < ELEM_SIZE ; i++) {
-            sum += (int)ptr_ptr_flat.get(i).address().toRawLongValue();
+            sum += ptr_ptr_flat.get(i).address().toRawLongValue();
         }
         return sum;
     }

--- a/test/micro/org/openjdk/bench/vm/compiler/PointerBenchmarkFlat.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/PointerBenchmarkFlat.java
@@ -148,7 +148,7 @@ public class PointerBenchmarkFlat {
     public int test() {
         int sum = 0;
         for (int i = 0 ; i < ELEM_SIZE ; i++) {
-            sum += ptr_ptr.get(i).address().toRawLongValue();
+            sum += (int)ptr_ptr.get(i).address().toRawLongValue();
         }
         return sum;
     }
@@ -157,7 +157,7 @@ public class PointerBenchmarkFlat {
     public int testFlat() {
         int sum = 0;
         for (int i = 0 ; i < ELEM_SIZE ; i++) {
-            sum += ptr_ptr_flat.get(i).address().toRawLongValue();
+            sum += (int)ptr_ptr_flat.get(i).address().toRawLongValue();
         }
         return sum;
     }

--- a/test/micro/org/openjdk/bench/vm/compiler/Straighten.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/Straighten.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,8 +120,8 @@ public class Straighten {
 
     /** Tests how well serial constant long compares are straightened. */
     @Benchmark
-    public int testStraighten1long() throws Exception {
-        int dummy = 0;
+    public long testStraighten1long() throws Exception {
+        long dummy = 0;
         long[] arr = longArr;
         for (long l : arr) {
             dummy += innerCandidate1long(l);
@@ -182,8 +182,8 @@ public class Straighten {
 
     /** Tests how well constant long definitions are straightened. */
     @Benchmark
-    public int testStraighten2long() throws Exception {
-        int dummy = 0;
+    public long testStraighten2long() throws Exception {
+        long dummy = 0;
         long[] arr = longArr;
         for (long l : arr) {
             dummy += innerCandidate2long(l);
@@ -236,8 +236,8 @@ public class Straighten {
 
     /** Tests how well variable long compares are straightened. */
     @Benchmark
-    public int testStraighten3long() throws Exception {
-        int dummy = 0;
+    public long testStraighten3long() throws Exception {
+        long dummy = 0;
         long[] arr = longArr;
         for (int i = 0; i < arr.length - 1; i++) {
             dummy += innerCandidate3long(arr[i], arr[i + 1]);


### PR DESCRIPTION
#8599 would add a new warning. This address the conversions in the microbenchmark component by means of making the types precise or adding explicit casts. There's quite a few changes in the ByteBuffers benchmarks, but the real change is in the template as these are generated.

I've run through a subset of the affected benchmarks and verified that the results are either neutral or improve somewhat (seem to be the case in a few of the ByteBuffer micros).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286401](https://bugs.openjdk.java.net/browse/JDK-8286401): Address possibly lossy conversions in Microbenchmarks


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Eric Caspole](https://openjdk.java.net/census#ecaspole) (@ericcaspole - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8654/head:pull/8654` \
`$ git checkout pull/8654`

Update a local copy of the PR: \
`$ git checkout pull/8654` \
`$ git pull https://git.openjdk.java.net/jdk pull/8654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8654`

View PR using the GUI difftool: \
`$ git pr show -t 8654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8654.diff">https://git.openjdk.java.net/jdk/pull/8654.diff</a>

</details>
