### PR TITLE
8286386: Address possibly lossy conversions in java.net.http

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/BufferingSubscriber.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/BufferingSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ public class BufferingSubscriber<T> implements TrustedSubscriber<T>
     /** The internal buffers holding the buffered data. */
     private ArrayList<ByteBuffer> internalBuffers;
     /** The actual accumulated remaining bytes in internalBuffers. */
-    private int accumulatedBytes;
+    private long accumulatedBytes;
 
     /** Holds the Throwable from upstream's onError. */
     private volatile Throwable throwable;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/hpack/QuickHuffman.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/hpack/QuickHuffman.java
@@ -68,7 +68,9 @@ public final class QuickHuffman {
         // is code on 5 bits which means casting to int here is safe: the
         // returned value is expected to be in the range (5..30) and will
         // never be negative.
-        return (int) (codes[c] & 0x00000000ffffffffL);
+        int len = (int) (codes[c] & 0x00000000ffffffffL);
+        assert len >= 0;
+        return len;
     }
 
     private static final int EOS_LENGTH = 30;
@@ -737,7 +739,6 @@ public final class QuickHuffman {
                         throw new IllegalArgumentException("char=" + ((int) c));
                     }
                     int len = codeLengthOf(c);
-                    assert len >= 0;
                     if (bufferLen + len <= 64) {
                         buffer |= (codeValueOf(c) >>> bufferLen); // append
                         bufferLen += len;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/hpack/QuickHuffman.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/hpack/QuickHuffman.java
@@ -63,8 +63,8 @@ public final class QuickHuffman {
         return codes[c] & 0xffffffff00000000L;
     }
 
-    private static long codeLengthOf(char c) {
-        return codes[c] & 0x00000000ffffffffL;
+    private static int codeLengthOf(char c) {
+        return (int) (codes[c] & 0x00000000ffffffffL);
     }
 
     private static final int EOS_LENGTH = 30;
@@ -732,10 +732,11 @@ public final class QuickHuffman {
                     if (c > 255) {
                         throw new IllegalArgumentException("char=" + ((int) c));
                     }
-                    long len = codeLengthOf(c);
+                    int len = codeLengthOf(c);
+                    assert len >= 0;
                     if (bufferLen + len <= 64) {
                         buffer |= (codeValueOf(c) >>> bufferLen); // append
-                        bufferLen += (int) len;
+                        bufferLen += len;
                         pos++;
                     } else {
                         break;
@@ -779,7 +780,7 @@ public final class QuickHuffman {
             int len = 0;
             for (int i = start; i < end; i++) {
                 char c = value.charAt(i);
-                len += (int) codeLengthOf(c);
+                len += codeLengthOf(c);
             }
             return bytesForBits(len);
         }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/hpack/QuickHuffman.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/hpack/QuickHuffman.java
@@ -64,6 +64,10 @@ public final class QuickHuffman {
     }
 
     private static int codeLengthOf(char c) {
+        // codes are up to 30 bits long - and their length
+        // is code on 5 bits which means casting to int here is safe: the
+        // returned value is expected to be in the range (5..30) and will
+        // never be negative.
         return (int) (codes[c] & 0x00000000ffffffffL);
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/hpack/QuickHuffman.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/hpack/QuickHuffman.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -735,7 +735,7 @@ public final class QuickHuffman {
                     long len = codeLengthOf(c);
                     if (bufferLen + len <= 64) {
                         buffer |= (codeValueOf(c) >>> bufferLen); // append
-                        bufferLen += len;
+                        bufferLen += (int) len;
                         pos++;
                     } else {
                         break;
@@ -779,7 +779,7 @@ public final class QuickHuffman {
             int len = 0;
             for (int i = start; i < end; i++) {
                 char c = value.charAt(i);
-                len += codeLengthOf(c);
+                len += (int) codeLengthOf(c);
             }
             return bytesForBits(len);
         }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/hpack/QuickHuffman.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/hpack/QuickHuffman.java
@@ -65,7 +65,7 @@ public final class QuickHuffman {
 
     private static int codeLengthOf(char c) {
         // codes are up to 30 bits long - and their length
-        // is code on 5 bits which means casting to int here is safe: the
+        // is coded on 5 bits which means casting to int here is safe: the
         // returned value is expected to be in the range (5..30) and will
         // never be negative.
         int len = (int) (codes[c] & 0x00000000ffffffffL);

--- a/src/java.net.http/share/classes/jdk/internal/net/http/websocket/Frame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/websocket/Frame.java
@@ -217,7 +217,7 @@ final class Frame {
             } else {
                 // Explicit cast required:
                 // The negation "~" sets the high order bits
-                // so the value is more than 16 bits and the
+                // so the value becomes more than 16 bits and the
                 // compiler will emit a warning if not cast
                 firstChar &= (char) ~0b10000000_00000000;
             }
@@ -283,9 +283,7 @@ final class Frame {
         }
 
         HeaderWriter noMask() {
-            // The negation "~" sets the high order bits
-            // so the value is more than 16 bits and the
-            // compiler will emit a warning if not cast
+            // Explicit cast required: see fin() above
             firstChar &= (char) ~0b00000000_10000000;
             mask = false;
             return this;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/websocket/Frame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/websocket/Frame.java
@@ -39,11 +39,8 @@ final class Frame {
 
     static final int MAX_HEADER_SIZE_BYTES = 2 + 8 + 4;
     static final int MAX_CONTROL_FRAME_PAYLOAD_LENGTH = 125;
-    static final char FIN_BIT_MASK = 0b10000000_00000000;
-    static final char RSV1_BIT_MASK = 0b01000000_00000000;
-    static final char RSV2_BIT_MASK = 0b00100000_00000000;
-    static final char RSV3_BIT_MASK = 0b00010000_00000000;
-    static final char MASK_BIT_MASK = 0b00000000_10000000;
+    static final char FIN_BIT = 0b10000000_00000000;
+    static final char RSV1_BIT = 0b01000000_00000000;
 
     enum Opcode {
 
@@ -218,36 +215,48 @@ final class Frame {
 
         HeaderWriter fin(boolean value) {
             if (value) {
-                firstChar |= FIN_BIT_MASK;
+                firstChar |=  0b10000000_00000000;
             } else {
-                firstChar &= ~FIN_BIT_MASK;
+                // The negation "~" sets the high order bits
+                // so the value is more than 16 bits and the
+                // compiler will emit a warning if not cast
+                firstChar &= (char) ~0b10000000_00000000;
             }
             return this;
         }
 
         HeaderWriter rsv1(boolean value) {
             if (value) {
-                firstChar |= RSV1_BIT_MASK;
+                firstChar |=  0b01000000_00000000;
             } else {
-                firstChar &= ~RSV1_BIT_MASK;
+                // The negation "~" sets the high order bits
+                // so the value is more than 16 bits and the
+                // compiler will emit a warning if not cast
+                firstChar &= (char) ~0b01000000_00000000;
             }
             return this;
         }
 
         HeaderWriter rsv2(boolean value) {
             if (value) {
-                firstChar |= RSV2_BIT_MASK;
+                firstChar |=  0b00100000_00000000;
             } else {
-                firstChar &= ~RSV2_BIT_MASK;
+                // The negation "~" sets the high order bits
+                // so the value is more than 16 bits and the
+                // compiler will emit a warning if not cast
+                firstChar &= (char) ~0b00100000_00000000;
             }
             return this;
         }
 
         HeaderWriter rsv3(boolean value) {
             if (value) {
-                firstChar |= RSV3_BIT_MASK;
+                firstChar |=  0b00010000_00000000;
             } else {
-                firstChar &= ~RSV3_BIT_MASK;
+                // The negation "~" sets the high order bits
+                // so the value is more than 16 bits and the
+                // compiler will emit a warning if not cast
+                firstChar &= (char) ~0b00010000_00000000;
             }
             return this;
         }
@@ -281,7 +290,10 @@ final class Frame {
         }
 
         HeaderWriter noMask() {
-            firstChar &= ~MASK_BIT_MASK;
+            // The negation "~" sets the high order bits
+            // so the value is more than 16 bits and the
+            // compiler will emit a warning if not cast
+            firstChar &= (char) ~0b00000000_10000000;
             mask = false;
             return this;
         }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/websocket/Frame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/websocket/Frame.java
@@ -215,6 +215,7 @@ final class Frame {
             if (value) {
                 firstChar |=  0b10000000_00000000;
             } else {
+                // Explicit cast required:
                 // The negation "~" sets the high order bits
                 // so the value is more than 16 bits and the
                 // compiler will emit a warning if not cast
@@ -227,9 +228,7 @@ final class Frame {
             if (value) {
                 firstChar |=  0b01000000_00000000;
             } else {
-                // The negation "~" sets the high order bits
-                // so the value is more than 16 bits and the
-                // compiler will emit a warning if not cast
+                // Explicit cast required - see fin() above
                 firstChar &= (char) ~0b01000000_00000000;
             }
             return this;
@@ -239,9 +238,7 @@ final class Frame {
             if (value) {
                 firstChar |=  0b00100000_00000000;
             } else {
-                // The negation "~" sets the high order bits
-                // so the value is more than 16 bits and the
-                // compiler will emit a warning if not cast
+                // Explicit cast required - see fin() above
                 firstChar &= (char) ~0b00100000_00000000;
             }
             return this;
@@ -251,9 +248,7 @@ final class Frame {
             if (value) {
                 firstChar |=  0b00010000_00000000;
             } else {
-                // The negation "~" sets the high order bits
-                // so the value is more than 16 bits and the
-                // compiler will emit a warning if not cast
+                // Explicit cast required - see fin() above
                 firstChar &= (char) ~0b00010000_00000000;
             }
             return this;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/websocket/Frame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/websocket/Frame.java
@@ -39,6 +39,11 @@ final class Frame {
 
     static final int MAX_HEADER_SIZE_BYTES = 2 + 8 + 4;
     static final int MAX_CONTROL_FRAME_PAYLOAD_LENGTH = 125;
+    static final char FIN_BIT  = 0b10000000_00000000;
+    static final char RSV1_BIT = 0b01000000_00000000;
+    static final char RSV2_BIT = 0b00100000_00000000;
+    static final char RSV3_BIT = 0b00010000_00000000;
+    static final char MASK_BIT = 0b00000000_10000000;
 
     enum Opcode {
 
@@ -213,48 +218,36 @@ final class Frame {
 
         HeaderWriter fin(boolean value) {
             if (value) {
-                firstChar |=  0b10000000_00000000;
+                firstChar |=  FIN_BIT;
             } else {
-                // The negation "~" sets the high order bits
-                // so the value is more than 16 bits and the
-                // compiler will emit a warning if not cast
-                firstChar &= (char) ~0b10000000_00000000;
+                firstChar &= ~FIN_BIT;
             }
             return this;
         }
 
         HeaderWriter rsv1(boolean value) {
             if (value) {
-                firstChar |=  0b01000000_00000000;
+                firstChar |=  RSV1_BIT;
             } else {
-                // The negation "~" sets the high order bits
-                // so the value is more than 16 bits and the
-                // compiler will emit a warning if not cast
-                firstChar &= (char) ~0b01000000_00000000;
+                firstChar &= ~RSV1_BIT;
             }
             return this;
         }
 
         HeaderWriter rsv2(boolean value) {
             if (value) {
-                firstChar |=  0b00100000_00000000;
+                firstChar |=  RSV2_BIT;
             } else {
-                // The negation "~" sets the high order bits
-                // so the value is more than 16 bits and the
-                // compiler will emit a warning if not cast
-                firstChar &= (char) ~0b00100000_00000000;
+                firstChar &= ~RSV2_BIT;
             }
             return this;
         }
 
         HeaderWriter rsv3(boolean value) {
             if (value) {
-                firstChar |=  0b00010000_00000000;
+                firstChar |=  RSV3_BIT;
             } else {
-                // The negation "~" sets the high order bits
-                // so the value is more than 16 bits and the
-                // compiler will emit a warning if not cast
-                firstChar &= (char) ~0b00010000_00000000;
+                firstChar &= ~RSV3_BIT;
             }
             return this;
         }
@@ -288,10 +281,7 @@ final class Frame {
         }
 
         HeaderWriter noMask() {
-            // The negation "~" sets the high order bits
-            // so the value is more than 16 bits and the
-            // compiler will emit a warning if not cast
-            firstChar &= (char) ~0b00000000_10000000;
+            firstChar &= ~MASK_BIT;
             mask = false;
             return this;
         }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/websocket/Frame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/websocket/Frame.java
@@ -39,11 +39,11 @@ final class Frame {
 
     static final int MAX_HEADER_SIZE_BYTES = 2 + 8 + 4;
     static final int MAX_CONTROL_FRAME_PAYLOAD_LENGTH = 125;
-    static final char FIN_BIT  = 0b10000000_00000000;
-    static final char RSV1_BIT = 0b01000000_00000000;
-    static final char RSV2_BIT = 0b00100000_00000000;
-    static final char RSV3_BIT = 0b00010000_00000000;
-    static final char MASK_BIT = 0b00000000_10000000;
+    static final char FIN_BIT_MASK = 0b10000000_00000000;
+    static final char RSV1_BIT_MASK = 0b01000000_00000000;
+    static final char RSV2_BIT_MASK = 0b00100000_00000000;
+    static final char RSV3_BIT_MASK = 0b00010000_00000000;
+    static final char MASK_BIT_MASK = 0b00000000_10000000;
 
     enum Opcode {
 
@@ -218,36 +218,36 @@ final class Frame {
 
         HeaderWriter fin(boolean value) {
             if (value) {
-                firstChar |=  FIN_BIT;
+                firstChar |= FIN_BIT_MASK;
             } else {
-                firstChar &= ~FIN_BIT;
+                firstChar &= ~FIN_BIT_MASK;
             }
             return this;
         }
 
         HeaderWriter rsv1(boolean value) {
             if (value) {
-                firstChar |=  RSV1_BIT;
+                firstChar |= RSV1_BIT_MASK;
             } else {
-                firstChar &= ~RSV1_BIT;
+                firstChar &= ~RSV1_BIT_MASK;
             }
             return this;
         }
 
         HeaderWriter rsv2(boolean value) {
             if (value) {
-                firstChar |=  RSV2_BIT;
+                firstChar |= RSV2_BIT_MASK;
             } else {
-                firstChar &= ~RSV2_BIT;
+                firstChar &= ~RSV2_BIT_MASK;
             }
             return this;
         }
 
         HeaderWriter rsv3(boolean value) {
             if (value) {
-                firstChar |=  RSV3_BIT;
+                firstChar |= RSV3_BIT_MASK;
             } else {
-                firstChar &= ~RSV3_BIT;
+                firstChar &= ~RSV3_BIT_MASK;
             }
             return this;
         }
@@ -281,7 +281,7 @@ final class Frame {
         }
 
         HeaderWriter noMask() {
-            firstChar &= ~MASK_BIT;
+            firstChar &= ~MASK_BIT_MASK;
             mask = false;
             return this;
         }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/websocket/Frame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/websocket/Frame.java
@@ -39,8 +39,6 @@ final class Frame {
 
     static final int MAX_HEADER_SIZE_BYTES = 2 + 8 + 4;
     static final int MAX_CONTROL_FRAME_PAYLOAD_LENGTH = 125;
-    static final char FIN_BIT = 0b10000000_00000000;
-    static final char RSV1_BIT = 0b01000000_00000000;
 
     enum Opcode {
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/websocket/Frame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/websocket/Frame.java
@@ -215,7 +215,7 @@ final class Frame {
             if (value) {
                 firstChar |=  0b10000000_00000000;
             } else {
-                // the negation. "~" sets the high order bits
+                // The negation "~" sets the high order bits
                 // so the value is more than 16 bits and the
                 // compiler will emit a warning if not cast
                 firstChar &= (char) ~0b10000000_00000000;
@@ -227,7 +227,7 @@ final class Frame {
             if (value) {
                 firstChar |=  0b01000000_00000000;
             } else {
-                // the negation. "~" sets the high order bits
+                // The negation "~" sets the high order bits
                 // so the value is more than 16 bits and the
                 // compiler will emit a warning if not cast
                 firstChar &= (char) ~0b01000000_00000000;
@@ -239,7 +239,7 @@ final class Frame {
             if (value) {
                 firstChar |=  0b00100000_00000000;
             } else {
-                // the negation. "~" sets the high order bits
+                // The negation "~" sets the high order bits
                 // so the value is more than 16 bits and the
                 // compiler will emit a warning if not cast
                 firstChar &= (char) ~0b00100000_00000000;
@@ -251,7 +251,7 @@ final class Frame {
             if (value) {
                 firstChar |=  0b00010000_00000000;
             } else {
-                // the negation. "~" sets the high order bits
+                // The negation "~" sets the high order bits
                 // so the value is more than 16 bits and the
                 // compiler will emit a warning if not cast
                 firstChar &= (char) ~0b00010000_00000000;
@@ -288,7 +288,7 @@ final class Frame {
         }
 
         HeaderWriter noMask() {
-            // the negation. "~" sets the high order bits
+            // The negation "~" sets the high order bits
             // so the value is more than 16 bits and the
             // compiler will emit a warning if not cast
             firstChar &= (char) ~0b00000000_10000000;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/websocket/Frame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/websocket/Frame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -215,7 +215,10 @@ final class Frame {
             if (value) {
                 firstChar |=  0b10000000_00000000;
             } else {
-                firstChar &= ~0b10000000_00000000;
+                // the negation. "~" sets the high order bits
+                // so the value is more than 16 bits and the
+                // compiler will emit a warning if not cast
+                firstChar &= (char) ~0b10000000_00000000;
             }
             return this;
         }
@@ -224,7 +227,10 @@ final class Frame {
             if (value) {
                 firstChar |=  0b01000000_00000000;
             } else {
-                firstChar &= ~0b01000000_00000000;
+                // the negation. "~" sets the high order bits
+                // so the value is more than 16 bits and the
+                // compiler will emit a warning if not cast
+                firstChar &= (char) ~0b01000000_00000000;
             }
             return this;
         }
@@ -233,7 +239,10 @@ final class Frame {
             if (value) {
                 firstChar |=  0b00100000_00000000;
             } else {
-                firstChar &= ~0b00100000_00000000;
+                // the negation. "~" sets the high order bits
+                // so the value is more than 16 bits and the
+                // compiler will emit a warning if not cast
+                firstChar &= (char) ~0b00100000_00000000;
             }
             return this;
         }
@@ -242,7 +251,10 @@ final class Frame {
             if (value) {
                 firstChar |=  0b00010000_00000000;
             } else {
-                firstChar &= ~0b00010000_00000000;
+                // the negation. "~" sets the high order bits
+                // so the value is more than 16 bits and the
+                // compiler will emit a warning if not cast
+                firstChar &= (char) ~0b00010000_00000000;
             }
             return this;
         }
@@ -259,7 +271,7 @@ final class Frame {
             payloadLen = value;
             firstChar &= 0b11111111_10000000; // Clear previous payload length leftovers
             if (payloadLen < 126) {
-                firstChar |= payloadLen;
+                firstChar |= (char) payloadLen;
             } else if (payloadLen < 65536) {
                 firstChar |= 126;
             } else {
@@ -276,7 +288,10 @@ final class Frame {
         }
 
         HeaderWriter noMask() {
-            firstChar &= ~0b00000000_10000000;
+            // the negation. "~" sets the high order bits
+            // so the value is more than 16 bits and the
+            // compiler will emit a warning if not cast
+            firstChar &= (char) ~0b00000000_10000000;
             mask = false;
             return this;
         }


### PR DESCRIPTION
In relation to [JDK-8244681](https://bugs.openjdk.java.net/browse/JDK-8244681), please find here a patch that addresses possibly lossy conversions in java.net.http

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286386](https://bugs.openjdk.java.net/browse/JDK-8286386): Address possibly lossy conversions in java.net.http


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to [1f0902ed](https://git.openjdk.java.net/jdk/pull/8656/files/1f0902ed73a84fb47ddac35beabc06a75bacb723)
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**) ⚠️ Review applies to [deb22998](https://git.openjdk.java.net/jdk/pull/8656/files/deb229988c5335de7ca551e146dbf4c084d891c6)
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8656/head:pull/8656` \
`$ git checkout pull/8656`

Update a local copy of the PR: \
`$ git checkout pull/8656` \
`$ git pull https://git.openjdk.java.net/jdk pull/8656/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8656`

View PR using the GUI difftool: \
`$ git pr show -t 8656`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8656.diff">https://git.openjdk.java.net/jdk/pull/8656.diff</a>

</details>
