### PR TITLE
8286540: Build failure caused by missing DefaultPollerProvider implementation on AIX

### DIFF
--- a/src/java.base/aix/classes/sun/nio/ch/DefaultPollerProvider.java
+++ b/src/java.base/aix/classes/sun/nio/ch/DefaultPollerProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package sun.nio.ch;
+
+import java.io.IOException;
+
+/**
+ * Default PollerProvider for AIX.
+ */
+class DefaultPollerProvider extends PollerProvider {
+    DefaultPollerProvider() { }
+
+    @Override
+    Poller readPoller() throws IOException {
+        return new PollsetPoller(true);
+    }
+
+    @Override
+    Poller writePoller() throws IOException {
+        return new PollsetPoller(false);
+    }
+}

--- a/src/java.base/aix/classes/sun/nio/ch/PollsetPoller.java
+++ b/src/java.base/aix/classes/sun/nio/ch/PollsetPoller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/aix/classes/sun/nio/ch/PollsetPoller.java
+++ b/src/java.base/aix/classes/sun/nio/ch/PollsetPoller.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 
 class PollsetPoller extends Poller {
 
-    PollsetPoller (boolean read) throws IOException {
+    PollsetPoller(boolean read) throws IOException {
         super(read);
     }
 

--- a/src/java.base/aix/classes/sun/nio/ch/PollsetPoller.java
+++ b/src/java.base/aix/classes/sun/nio/ch/PollsetPoller.java
@@ -39,25 +39,25 @@ class PollsetPoller extends Poller {
     @Override
     int fdVal() {
         // Stub
-        throw new RuntimeException("Unimplemented on AIX");
+        throw new UnsupportedOperationException("Unimplemented on AIX");
     }
 
     @Override
     void implRegister(int fdVal) throws IOException {
         // Stub
-        throw new RuntimeException("Unimplemented on AIX");
+        throw new UnsupportedOperationException("Unimplemented on AIX");
     }
 
     @Override
     void implDeregister(int fdVal) {
         // Stub
-        throw new RuntimeException("Unimplemented on AIX");
+        throw new UnsupportedOperationException("Unimplemented on AIX");
     }
 
     @Override
     int poll(int timeout) throws IOException {
         // Stub
-        throw new RuntimeException("Unimplemented on AIX");
+        throw new UnsupportedOperationException("Unimplemented on AIX");
     }
 }
 

--- a/src/java.base/aix/classes/sun/nio/ch/PollsetPoller.java
+++ b/src/java.base/aix/classes/sun/nio/ch/PollsetPoller.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package sun.nio.ch;
+
+import java.io.IOException;
+
+/**
+ * Poller implementation based on the AIX Pollset library.
+ */
+
+class PollsetPoller extends Poller {
+
+    PollsetPoller (boolean read) throws IOException {
+        super(read);
+    }
+
+    @Override
+    int fdVal() {
+        // Stub
+        throw new RuntimeException("Unimplemented on AIX");
+    }
+
+    @Override
+    void implRegister(int fdVal) throws IOException {
+        // Stub
+        throw new RuntimeException("Unimplemented on AIX");
+    }
+
+    @Override
+    void implDeregister(int fdVal) {
+        // Stub
+        throw new RuntimeException("Unimplemented on AIX");
+    }
+
+    @Override
+    int poll(int timeout) throws IOException {
+        // Stub
+        throw new RuntimeException("Unimplemented on AIX");
+    }
+}
+


### PR DESCRIPTION
This change provides a stub implementation of DefaultPollerProvider on AIX. This is a temporary measure to ensure AIX can still be built while work on a full implementation is under way.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286540](https://bugs.openjdk.java.net/browse/JDK-8286540): Build failure caused by missing DefaultPollerProvider implementation on AIX


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8658/head:pull/8658` \
`$ git checkout pull/8658`

Update a local copy of the PR: \
`$ git checkout pull/8658` \
`$ git pull https://git.openjdk.java.net/jdk pull/8658/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8658`

View PR using the GUI difftool: \
`$ git pr show -t 8658`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8658.diff">https://git.openjdk.java.net/jdk/pull/8658.diff</a>

</details>
