### PR TITLE
8286447: [Linux] AWT should start in Headless mode if headful AWT library not installed

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/PlatformGraphicsInfo.java
+++ b/src/java.desktop/unix/classes/sun/awt/PlatformGraphicsInfo.java
@@ -25,6 +25,7 @@
 
 package sun.awt;
 
+import java.io.File;
 import java.awt.GraphicsEnvironment;
 import java.awt.Toolkit;
 import java.security.AccessController;
@@ -43,17 +44,42 @@ public class PlatformGraphicsInfo {
     /**
       * Called from java.awt.GraphicsEnvironment when
       * to check if on this platform, the JDK should default to
-      * headless mode, in the case the application did specify
+      * headless mode, in the case the application did not specify
       * a value for the java.awt.headless system property.
       */
     @SuppressWarnings("removal")
     public static boolean getDefaultHeadlessProperty() {
-        return
+        boolean noDisplay =
             AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
 
                final String display = System.getenv("DISPLAY");
-               return  display == null || display.trim().isEmpty();
+               return display == null || display.trim().isEmpty();
             });
+        if (noDisplay) {
+            return true;
+        }
+        /*
+         * If we positively identify a separate headless library support being present
+         * but no corresponding headful library, then we can support headless but
+         * not headful, so report that back to the caller.
+         * This does require duplication of knowing the name of the libraries
+         * also in libawt's OnLoad() but we need to make sure that the Java
+         * code is also set up as headless from the start - it is not so easy
+         * to try headful and then unwind that and then retry as headless.
+         */
+        final String[] libDirs = System.getProperty("sun.boot.library.path", "").split(":");
+        boolean headless =
+            AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
+                for (String libDir : libDirs) {
+                    File headlessLib = new File(libDir, "libawt_headless.so");
+                    File xawtLib = new File(libDir, "libawt_xawt.so");
+                    if (headlessLib.exists() && !xawtLib.exists()) {
+                        return true;
+                    }
+                }
+                return false;
+            });
+        return headless; 
     }
 
     /**
@@ -63,7 +89,11 @@ public class PlatformGraphicsInfo {
       */
     public static String getDefaultHeadlessMessage() {
         return
-            "\nNo X11 DISPLAY variable was set,\n" +
-            "but this program performed an operation which requires it.";
+            """
+
+            No X11 DISPLAY variable was set,
+            or no headful library support was found,
+            but this program performed an operation which requires it,
+            """;
     }
 }

--- a/src/java.desktop/unix/classes/sun/awt/PlatformGraphicsInfo.java
+++ b/src/java.desktop/unix/classes/sun/awt/PlatformGraphicsInfo.java
@@ -79,7 +79,7 @@ public class PlatformGraphicsInfo {
                 }
                 return false;
             });
-        return headless; 
+        return headless;
     }
 
     /**

--- a/src/java.desktop/unix/classes/sun/awt/PlatformGraphicsInfo.java
+++ b/src/java.desktop/unix/classes/sun/awt/PlatformGraphicsInfo.java
@@ -67,9 +67,9 @@ public class PlatformGraphicsInfo {
          * code is also set up as headless from the start - it is not so easy
          * to try headful and then unwind that and then retry as headless.
          */
-        final String[] libDirs = System.getProperty("sun.boot.library.path", "").split(":");
         boolean headless =
             AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
+                String[] libDirs = System.getProperty("sun.boot.library.path", "").split(":");
                 for (String libDir : libDirs) {
                     File headlessLib = new File(libDir, "libawt_headless.so");
                     File xawtLib = new File(libDir, "libawt_xawt.so");


### PR DESCRIPTION
As per the bug report and the CSR (please review that too), this makes AWT load in headless mode
if only headless libraries are installed.

It passes all our normal testing which at least should show that this doesn't regress anything.
I had to manually remove libawt_xawt.so to verify that it will do as expected in such a case,
and it would not be easy to create a test for that.

CSR : https://bugs.openjdk.java.net/browse/JDK-8286598

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issues
 * [JDK-8286447](https://bugs.openjdk.java.net/browse/JDK-8286447): [Linux] AWT should start in Headless mode if headful AWT library not installed
 * [JDK-8286598](https://bugs.openjdk.java.net/browse/JDK-8286598): [Linux] AWT should start in Headless mode if headful AWT library not installed (**CSR**)


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**) ⚠️ Review applies to [68b9ec2a](https://git.openjdk.java.net/jdk/pull/8659/files/68b9ec2add8854f6488c950341b7db6d655e6a09)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8659/head:pull/8659` \
`$ git checkout pull/8659`

Update a local copy of the PR: \
`$ git checkout pull/8659` \
`$ git pull https://git.openjdk.java.net/jdk pull/8659/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8659`

View PR using the GUI difftool: \
`$ git pr show -t 8659`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8659.diff">https://git.openjdk.java.net/jdk/pull/8659.diff</a>

</details>
