### PR TITLE
8285308: Win: Japanese logical fonts are drawn with wrong size

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WFontConfiguration.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WFontConfiguration.java
@@ -264,7 +264,7 @@ public final class WFontConfiguration extends FontConfiguration {
                 }
                 case "ru" -> "RUSSIAN_CHARSET";
                 case "el" -> "GREEK_CHARSET";
-                case "iw" -> "HEBREW_CHARSET";
+                case "iw", "he" -> "HEBREW_CHARSET";
                 case "ja" -> "SHIFTJIS_CHARSET";
                 case "ko" -> "HANGEUL_CHARSET";
                 case "th" -> "THAI_CHARSET";

--- a/src/java.desktop/windows/classes/sun/awt/windows/WFontConfiguration.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WFontConfiguration.java
@@ -52,7 +52,10 @@ public final class WFontConfiguration extends FontConfiguration {
 
     @Override
     protected void initReorderMap() {
-        if (encoding.equalsIgnoreCase("windows-31j")) {
+        if (encoding.equalsIgnoreCase("windows-31j") ||
+            (encoding.equalsIgnoreCase("UTF-8") &&
+             startupLocale.getLanguage().equals("ja")))
+        {
             localeMap = new Hashtable<>();
             /* Substitute Mincho for Gothic in this one case.
              * Note the windows fontconfig files already contain the mapping:
@@ -173,6 +176,7 @@ public final class WFontConfiguration extends FontConfiguration {
             String componentFontName = fontDescriptors[i].getNativeName();
             if (componentFontName.endsWith(charset)) {
                 fontName = componentFontName;
+                break;
             }
         }
         return fontName;
@@ -180,7 +184,7 @@ public final class WFontConfiguration extends FontConfiguration {
 
     private static HashMap<String, String> subsetCharsetMap = new HashMap<>();
     private static HashMap<String, String> subsetEncodingMap = new HashMap<>();
-    private static String textInputCharset;
+    private static String textInputCharset = "DEFAULT_CHARSET";
 
     private void initTables(String defaultEncoding) {
         subsetCharsetMap.put("alphabetic", "ANSI_CHARSET");
@@ -237,8 +241,6 @@ public final class WFontConfiguration extends FontConfiguration {
             textInputCharset = "CHINESEBIG5_CHARSET";
         } else if ("windows-1251".equals(defaultEncoding)) {
             textInputCharset = "RUSSIAN_CHARSET";
-        } else if ("UTF-8".equals(defaultEncoding)) {
-            textInputCharset = "DEFAULT_CHARSET";
         } else if ("windows-1253".equals(defaultEncoding)) {
             textInputCharset = "GREEK_CHARSET";
         } else if ("windows-1255".equals(defaultEncoding)) {
@@ -249,8 +251,25 @@ public final class WFontConfiguration extends FontConfiguration {
             textInputCharset = "HANGEUL_CHARSET";
         } else if ("x-windows-874".equals(defaultEncoding)) {
             textInputCharset = "THAI_CHARSET";
-        } else {
-            textInputCharset = "DEFAULT_CHARSET";
+        } else if (defaultEncoding.startsWith("UTF-8")) {
+            String lang = startupLocale.getLanguage();
+            String country = startupLocale.getCountry();
+            textInputCharset = switch(lang) {
+                case "ar" -> "ARABIC_CHARSET";
+                case "zh" -> {
+                    yield switch(country) {
+                        case "TW", "HK" -> "CHINESEBIG5_CHARSET";
+                        default -> "GB2312_CHARSET";
+                    };
+                }
+                case "ru" -> "RUSSIAN_CHARSET";
+                case "el" -> "GREEK_CHARSET";
+                case "iw" -> "HEBREW_CHARSET";
+                case "ja" -> "SHIFTJIS_CHARSET";
+                case "ko" -> "HANGEUL_CHARSET";
+                case "th" -> "THAI_CHARSET";
+                default -> "DEFAULT_CHARSET";
+            };
         }
     }
 }


### PR DESCRIPTION
This replaces the PR from Toshio  https://git.openjdk.java.net/jdk/pull/8329
It is similar in the idea from what we converged on towards the end there but
1) I'd like to preserve all the support for the old encodings since JEP-400 explicitly supports using -Dfile.encoding=windows-31j (for example)
2) I wanted to have the look up for the font to use in the windows text control succeed on the first font it finds not the last. In practice I expect this to be a no-op but if someone did have two that match .. don't you think they mean the first one to be the primary ?
3) I needed to update the encoding match to ensure that some optional re-ordering for Japanese logical fonts works in the UTF-8.ja locale as that is now the default.

I verified this fix by changing regional settings as well as passing -Duser.language=ja -Duser.country=JP and logical fonts on lightweights (verified in Font2DTest) are as expected and the "fonttest.java" now behaves as it did in JDK 17 and earlier. Since you need to switch regional settings automating this test was not possible.

@toshiona you very likely want to take a look at it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8285308](https://bugs.openjdk.java.net/browse/JDK-8285308): Win: Japanese logical fonts are drawn with wrong size


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8662/head:pull/8662` \
`$ git checkout pull/8662`

Update a local copy of the PR: \
`$ git checkout pull/8662` \
`$ git pull https://git.openjdk.java.net/jdk pull/8662/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8662`

View PR using the GUI difftool: \
`$ git pr show -t 8662`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8662.diff">https://git.openjdk.java.net/jdk/pull/8662.diff</a>

</details>
