### PR TITLE
8286200: SequenceInputStream::read(b, off, 0) returns -1 at EOF

### DIFF
--- a/src/java.base/share/classes/java/io/SequenceInputStream.java
+++ b/src/java.base/share/classes/java/io/SequenceInputStream.java
@@ -181,7 +181,8 @@ public class SequenceInputStream extends InputStream {
      * @return     the total number of bytes read into the buffer, or
      *             {@code -1} if there is no more data because the end of
      *             the last contained stream has been reached.
-     * @throws     NullPointerException if {@code b} is {@code null}.
+     * @throws     NullPointerException if the end of the last contained
+     *             stream has not been reached and {@code b} is {@code null}.
      * @throws     IndexOutOfBoundsException if the end of the last contained
      *             stream has not been reached and {@code off} is negative,
      *             {@code len} is negative, or {@code len} is

--- a/src/java.base/share/classes/java/io/SequenceInputStream.java
+++ b/src/java.base/share/classes/java/io/SequenceInputStream.java
@@ -181,8 +181,9 @@ public class SequenceInputStream extends InputStream {
      * @return     the total number of bytes read into the buffer, or
      *             {@code -1} if there is no more data because the end of
      *             the last contained stream has been reached.
-     * @throws     NullPointerException If {@code b} is {@code null}.
-     * @throws     IndexOutOfBoundsException If {@code off} is negative,
+     * @throws     NullPointerException if {@code b} is {@code null}.
+     * @throws     IndexOutOfBoundsException if the end of the last contained
+     *             stream has not been reached and {@code off} is negative,
      *             {@code len} is negative, or {@code len} is
      *             greater than {@code b.length - off}
      * @throws     IOException  if an I/O error occurs.

--- a/src/java.base/share/classes/java/io/SequenceInputStream.java
+++ b/src/java.base/share/classes/java/io/SequenceInputStream.java
@@ -162,10 +162,11 @@ public class SequenceInputStream extends InputStream {
     }
 
     /**
-     * Reads up to {@code len} bytes of data from this input stream
-     * into an array of bytes.  If {@code len} is not zero, the method
-     * blocks until at least 1 byte of input is available; otherwise, no
-     * bytes are read and {@code 0} is returned.
+     * Reads up to {@code len} bytes of data from this input stream into an
+     * array of bytes.  If the end of the last contained stream has been reached
+     * then {@code -1} is returned.  Otherwise, if {@code len} is not zero, the
+     * method blocks until at least 1 byte of input is available; if {@code len}
+     * is zero, no bytes are read and {@code 0} is returned.
      * <p>
      * The {@code read} method of {@code SequenceInputStream}
      * tries to read the data from the current substream. If it fails to


### PR DESCRIPTION
Modify the specification of `SequenceInputStream.read(byte[],int,int)` to indicate that `-1` is returned at the EOF of the last stream even if `len` is zero.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issues
 * [JDK-8286200](https://bugs.openjdk.java.net/browse/JDK-8286200): SequenceInputStream::read(b, off, 0) returns -1 at EOF
 * [JDK-8286675](https://bugs.openjdk.java.net/browse/JDK-8286675): SequenceInputStream::read(b, off, 0) returns -1 at EOF (**CSR**)


### Reviewers
 * @rgiulietti (no known github.com user name / role)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8664/head:pull/8664` \
`$ git checkout pull/8664`

Update a local copy of the PR: \
`$ git checkout pull/8664` \
`$ git pull https://git.openjdk.java.net/jdk pull/8664/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8664`

View PR using the GUI difftool: \
`$ git pr show -t 8664`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8664.diff">https://git.openjdk.java.net/jdk/pull/8664.diff</a>

</details>
