### PR TITLE
8286601: Mac Aarch: Excessive warnings to be ignored for build jdk

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -180,6 +180,7 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
 
     clang)
       DISABLE_WARNING_PREFIX="-Wno-"
+      BUILD_CC_DISABLE_WARNING_PREFIX="-Wno-"
       CFLAGS_WARNINGS_ARE_ERRORS="-Werror"
 
       # Additional warnings that are not activated by -Wall and -Wextra


### PR DESCRIPTION
These warnings are ignored while building the build+full jdks with gcc,
but only ignored while building the full JDK if using clang. This
produces tons of warnings we normally ignore, e.g. unused parameter.

I suggest that if we're ignoring this type of error while using gcc,
we should also ignore them while using clang.

Signed-off-by: Adam Farley <adfarley@redhat.com>