### PR TITLE
8286122: [macos]: App bundle cannot upload to Mac App Store due to info.plist embedded in java exe

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/DeployParams.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/DeployParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -146,6 +145,7 @@ public class DeployParams {
         }
     }
 
+    @SuppressWarnings("unchecked")
     public void validate() throws PackagerException {
         boolean hasModule = (bundlerArguments.get(
                 Arguments.CLIOptions.MODULE.getId()) != null);
@@ -161,6 +161,8 @@ public class DeployParams {
                 Arguments.CLIOptions.INPUT.getId()) != null);
         boolean hasModulePath = (bundlerArguments.get(
                 Arguments.CLIOptions.MODULE_PATH.getId()) != null);
+        boolean hasMacAppStore = (bundlerArguments.get(
+                Arguments.CLIOptions.MAC_APP_STORE.getId()) != null);
         boolean runtimeInstaller = !isTargetAppImage() &&
                 !hasAppImage && !hasModule && !hasMain && hasRuntimeImage;
 
@@ -271,6 +273,45 @@ public class DeployParams {
             if (!(Files.exists(Path.of(icon)))) {
                 throw new PackagerException("ERR_IconFileNotExit",
                         Path.of(icon).toAbsolutePath().toString());
+            }
+        }
+
+
+        if (hasMacAppStore) {
+            // Validate jlink-options if mac-app-store is set
+            Object jlinkOptions = bundlerArguments.get(
+                    Arguments.CLIOptions.JLINK_OPTIONS.getId());
+            if (jlinkOptions instanceof List) {
+                List<String> options = (List<String>) jlinkOptions;
+                if (!options.contains("--strip-native-commands")) {
+                    throw new PackagerException(
+                            "ERR_MissingJLinkOptMacAppStore",
+                            "--strip-native-commands");
+                }
+            }
+
+            // Validate runtime if mac-app-store is set. Predefined runtime
+            // should not contain "bin" folder.
+            runtime = (String)bundlerArguments.get(
+                    Arguments.CLIOptions.PREDEFINED_RUNTIME_IMAGE.getId());
+            if (runtime != null) {
+                // Should exist from check above if not null
+                Path topImage = Path.of(runtime);
+
+                // On Mac topImage can be runtime root or runtime home.
+                Path runtimeHome = topImage.resolve("Contents/Home");
+                if (Files.isDirectory(runtimeHome)) {
+                    // topImage references runtime root, adjust it to pick data
+                    // from runtime home
+                    topImage = runtimeHome;
+                }
+
+                Path runtimeBin = topImage.resolve("bin");
+                if (Files.isDirectory(runtimeBin)) {
+                    throw new PackagerException(
+                            "ERR_MacAppStoreRuntimeBinExists",
+                            topImage.toAbsolutePath().toString());
+                }
             }
         }
     }

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -109,3 +109,5 @@ ERR_NoEntryPoint=Error: creating application image requires --main-jar or --modu
 ERR_InputNotDirectory=Error: Input directory specified is not a directory: {0}
 ERR_CannotReadInputDir=Error: No permission to read from input directory: {0}
 ERR_CannotParseOptions=Error: Processing @filename option: {0}
+ERR_MissingJLinkOptMacAppStore=Error: --mac-app-store argument requires a {0} option for --jlink-options argument
+ERR_MacAppStoreRuntimeBinExists=Error: Runtime image "{0}" should not contain "bin" folder. Use --strip-native-commands jlink option when generating runtime image used with --mac-app-store argument.

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources_de.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources_de.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -108,3 +108,5 @@ ERR_NoEntryPoint=Fehler: F\u00FCr das Erstellen des Anwendungsimages muss entwed
 ERR_InputNotDirectory=Fehler: Das angegebene Eingabeverzeichnis ist kein Verzeichnis: {0}
 ERR_CannotReadInputDir=Fehler: Keine Berechtigung zum Lesen aus Eingabeverzeichnis vorhanden: {0}
 ERR_CannotParseOptions=Fehler: Option @filename wird verarbeitet: {0}
+ERR_MissingJLinkOptMacAppStore=Error: --mac-app-store argument requires a {0} option for --jlink-options argument
+ERR_MacAppStoreRuntimeBinExists=Error: Runtime image "{0}" should not contain "bin" folder. Use --strip-native-commands jlink option when generating runtime image used with --mac-app-store argument.

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources_ja.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources_ja.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -108,3 +108,5 @@ ERR_NoEntryPoint=\u30A8\u30E9\u30FC: \u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\
 ERR_InputNotDirectory=\u30A8\u30E9\u30FC: \u6307\u5B9A\u3055\u308C\u305F\u5165\u529B\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u306F\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u3067\u306F\u3042\u308A\u307E\u305B\u3093: {0}
 ERR_CannotReadInputDir=\u30A8\u30E9\u30FC: \u5165\u529B\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u304B\u3089\u8AAD\u307F\u53D6\u308B\u6A29\u9650\u304C\u3042\u308A\u307E\u305B\u3093: {0}
 ERR_CannotParseOptions=\u30A8\u30E9\u30FC: @filename\u30AA\u30D7\u30B7\u30E7\u30F3\u306E\u51E6\u7406: {0}
+ERR_MissingJLinkOptMacAppStore=Error: --mac-app-store argument requires a {0} option for --jlink-options argument
+ERR_MacAppStoreRuntimeBinExists=Error: Runtime image "{0}" should not contain "bin" folder. Use --strip-native-commands jlink option when generating runtime image used with --mac-app-store argument.

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources_zh_CN.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources_zh_CN.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -108,3 +108,5 @@ ERR_NoEntryPoint=\u9519\u8BEF\uFF1A\u521B\u5EFA\u5E94\u7528\u7A0B\u5E8F\u6620\u5
 ERR_InputNotDirectory=\u9519\u8BEF\uFF1A\u6307\u5B9A\u7684\u8F93\u5165\u76EE\u5F55\u4E0D\u662F\u76EE\u5F55\uFF1A{0}
 ERR_CannotReadInputDir=\u9519\u8BEF\uFF1A\u65E0\u6743\u4ECE\u8F93\u5165\u76EE\u5F55\u8BFB\u53D6\uFF1A{0}
 ERR_CannotParseOptions=\u9519\u8BEF\uFF1A\u6B63\u5728\u5904\u7406 @filename \u9009\u9879\uFF1A{0}
+ERR_MissingJLinkOptMacAppStore=Error: --mac-app-store argument requires a {0} option for --jlink-options argument
+ERR_MacAppStoreRuntimeBinExists=Error: Runtime image "{0}" should not contain "bin" folder. Use --strip-native-commands jlink option when generating runtime image used with --mac-app-store argument.

--- a/test/jdk/tools/jpackage/macosx/MacAppStoreJlinkOptionsTest.java
+++ b/test/jdk/tools/jpackage/macosx/MacAppStoreJlinkOptionsTest.java
@@ -45,7 +45,7 @@ import jdk.jpackage.test.Annotations.Test;
 public class MacAppStoreJLinkOptionsTest {
 
     @Test
-    public static void test() throws Exception {
+    public static void testWithStripNativeCommands() throws Exception {
         JPackageCommand cmd = JPackageCommand.helloAppImage();
         cmd.addArguments("--mac-app-store", "--jlink-options",
                 "--strip-debug --no-man-pages --no-header-files --strip-native-commands");
@@ -54,7 +54,7 @@ public class MacAppStoreJLinkOptionsTest {
     }
 
     @Test
-    public static void test2() throws Exception {
+    public static void testWithoutStripNativeCommands() throws Exception {
         JPackageCommand cmd = JPackageCommand.helloAppImage();
         cmd.addArguments("--mac-app-store", "--jlink-options",
                 "--strip-debug --no-man-pages --no-header-files");

--- a/test/jdk/tools/jpackage/macosx/MacAppStoreJlinkOptionsTest.java
+++ b/test/jdk/tools/jpackage/macosx/MacAppStoreJlinkOptionsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.jpackage.test.JPackageCommand;
+import jdk.jpackage.test.Annotations.Test;
+
+/**
+ * Tests generation of app image with --mac-app-store and --jlink-options. jpackage should able
+ * to generate app image if "--strip-native-commands" is specified for --jlink-options and should
+ * fail if it is not specified.
+ */
+
+/*
+ * @test
+ * @summary jpackage with --mac-app-store and --jlink-options
+ * @library ../helpers
+ * @library /test/lib
+ * @build jdk.jpackage.test.*
+ * @build MacAppStoreJLinkOptionsTest
+ * @modules jdk.jpackage/jdk.jpackage.internal
+ * @requires (os.family == "mac")
+ * @run main/othervm -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=MacAppStoreJLinkOptionsTest
+ */
+public class MacAppStoreJLinkOptionsTest {
+
+    @Test
+    public static void test() throws Exception {
+        JPackageCommand cmd = JPackageCommand.helloAppImage();
+        cmd.addArguments("--mac-app-store", "--jlink-options",
+                "--strip-debug --no-man-pages --no-header-files --strip-native-commands");
+
+        cmd.executeAndAssertHelloAppImageCreated();
+    }
+
+    @Test
+    public static void test2() throws Exception {
+        JPackageCommand cmd = JPackageCommand.helloAppImage();
+        cmd.addArguments("--mac-app-store", "--jlink-options",
+                "--strip-debug --no-man-pages --no-header-files");
+
+        cmd.execute(1);
+    }
+}

--- a/test/jdk/tools/jpackage/macosx/MacAppStoreRuntimeTest.java
+++ b/test/jdk/tools/jpackage/macosx/MacAppStoreRuntimeTest.java
@@ -32,6 +32,7 @@ import jdk.jpackage.test.Executor;
 import jdk.jpackage.test.TKit;
 import jdk.jpackage.test.JavaTool;
 import jdk.jpackage.test.Annotations.Test;
+import jdk.jpackage.test.Annotations.Parameter;
 
 
 /**
@@ -86,18 +87,16 @@ public class MacAppStoreRuntimeTest {
     }
 
     @Test
-    public static void test() throws Exception {
+    @Parameter("true")
+    @Parameter("false")
+    public static void test(boolean stripNativeCommands) throws Exception {
         JPackageCommand cmd = JPackageCommand.helloAppImage();
-        cmd.addArguments("--mac-app-store", "--runtime-image", getRuntimeImage(true));
+        cmd.addArguments("--mac-app-store", "--runtime-image", getRuntimeImage(stripNativeCommands));
 
-        cmd.executeAndAssertHelloAppImageCreated();
-    }
-
-    @Test
-    public static void test2() throws Exception {
-        JPackageCommand cmd = JPackageCommand.helloAppImage();
-        cmd.addArguments("--mac-app-store", "--runtime-image", getRuntimeImage(false));
-
-        cmd.execute(1);
+        if (stripNativeCommands) {
+            cmd.executeAndAssertHelloAppImageCreated();
+        } else {
+            cmd.execute(1);
+        }
     }
 }

--- a/test/jdk/tools/jpackage/macosx/MacAppStoreRuntimeTest.java
+++ b/test/jdk/tools/jpackage/macosx/MacAppStoreRuntimeTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import jdk.jpackage.test.JPackageCommand;
+import jdk.jpackage.test.Executor;
+import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.JavaTool;
+import jdk.jpackage.test.Annotations.Test;
+
+
+/**
+ * Tests generation of app image with --mac-app-store and --runtime-image. jpackage should able
+ * to generate app image if runtime image does not have "bin" folder and fail otherwise.
+ */
+
+/*
+ * @test
+ * @summary jpackage with --mac-app-store and --runtime-image
+ * @library ../helpers
+ * @library /test/lib
+ * @build jdk.jpackage.test.*
+ * @build MacAppStoreRuntimeTest
+ * @modules jdk.jpackage/jdk.jpackage.internal
+ * @requires (os.family == "mac")
+ * @run main/othervm -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=MacAppStoreRuntimeTest
+ */
+public class MacAppStoreRuntimeTest {
+
+    private static String getRuntimeImage(boolean stripNativeCommands) throws IOException {
+        final Path workDir = TKit.createTempDirectory("runtime").resolve("data");
+        final Path jlinkOutputDir = workDir.resolve("temp.runtime");
+        Files.createDirectories(jlinkOutputDir.getParent());
+
+        // List of modules required for test app.
+        final var modules = new String[] {
+            "java.base",
+            "java.desktop"
+        };
+
+        List<String> jlinkArgs = new ArrayList<>();
+        jlinkArgs.add("--output");
+        jlinkArgs.add(jlinkOutputDir.toString());
+        jlinkArgs.add("--add-modules");
+        jlinkArgs.add(String.join(",", modules));
+        jlinkArgs.add("--strip-debug");
+        jlinkArgs.add("--no-header-files");
+        jlinkArgs.add("--no-man-pages");
+        if (stripNativeCommands) {
+            jlinkArgs.add("--strip-native-commands");
+        }
+
+        new Executor()
+                .setToolProvider(JavaTool.JLINK)
+                .dumpOutput()
+                .addArguments(jlinkArgs)
+                .execute();
+
+        return jlinkOutputDir.toString();
+    }
+
+    @Test
+    public static void test() throws Exception {
+        JPackageCommand cmd = JPackageCommand.helloAppImage();
+        cmd.addArguments("--mac-app-store", "--runtime-image", getRuntimeImage(true));
+
+        cmd.executeAndAssertHelloAppImageCreated();
+    }
+
+    @Test
+    public static void test2() throws Exception {
+        JPackageCommand cmd = JPackageCommand.helloAppImage();
+        cmd.addArguments("--mac-app-store", "--runtime-image", getRuntimeImage(false));
+
+        cmd.execute(1);
+    }
+}


### PR DESCRIPTION
- It is not possible to support native JDK commands such as "java" inside Mac App Store bundles due to embedded info.plist. Workarounds suggested in JDK-8286122 does not seems to be visible.
 - With proposed fix we will enforce "--strip-native-commands" option for jlink, so native JDK commands are not included when generating Mac App Store bundles.
 - Custom runtime provided via --runtime-image should not contain native commands as well, otherwise jpackage will throw error.
 - Added two tests to validate fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286122](https://bugs.openjdk.java.net/browse/JDK-8286122): [macos]: App bundle cannot upload to Mac App Store due to info.plist embedded in java exe


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8666/head:pull/8666` \
`$ git checkout pull/8666`

Update a local copy of the PR: \
`$ git checkout pull/8666` \
`$ git pull https://git.openjdk.java.net/jdk pull/8666/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8666`

View PR using the GUI difftool: \
`$ git pr show -t 8666`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8666.diff">https://git.openjdk.java.net/jdk/pull/8666.diff</a>

</details>
