### PR TITLE
8286422: Add OIDs for RC2 and Blowfish

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
+++ b/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
@@ -407,6 +407,8 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
                         byte[] keyBytes = in.getOctetString();
                         if (keyAlgo.equals(KnownOIDs.OIW_DES_CBC.stdName())) {
                             keyAlgo = "DES";
+                        } else if (keyAlgo.equals(KnownOIDs.RC2$CBC$PKCS5Padding.stdName())) {
+                            keyAlgo = "RC2";
                         }
                         SecretKeySpec secretKeySpec =
                                 new SecretKeySpec(keyBytes, keyAlgo);

--- a/src/java.base/share/classes/sun/security/util/KnownOIDs.java
+++ b/src/java.base/share/classes/sun/security/util/KnownOIDs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -268,7 +268,7 @@ public enum KnownOIDs {
     HmacSHA512$256("1.2.840.113549.2.13", "HmacSHA512/256"),
 
     // encryptionAlgs 1.2.840.113549.3.*
-    RC2$CBC$PKCS5Padding("1.2.840.113549.3.2", "RC2/CBC/PKCS5Padding"),
+    RC2$CBC$PKCS5Padding("1.2.840.113549.3.2", "RC2/CBC/PKCS5Padding", "RC2"),
     ARCFOUR("1.2.840.113549.3.4", "ARCFOUR", "RC4"),
     DESede$CBC$NoPadding("1.2.840.113549.3.7", "DESede/CBC/NoPadding"),
     RC5$CBC$PKCS5Padding("1.2.840.113549.3.9", "RC5/CBC/PKCS5Padding"),
@@ -427,7 +427,9 @@ public enum KnownOIDs {
     SkipIPAddress("1.3.6.1.4.1.42.2.11.2.1"),
     JAVASOFT_JDKKeyProtector("1.3.6.1.4.1.42.2.17.1.1"),
     JAVASOFT_JCEKeyProtector("1.3.6.1.4.1.42.2.19.1"),
-    MICROSOFT_ExportApproved("1.3.6.1.4.1.311.10.3.3");
+    MICROSOFT_ExportApproved("1.3.6.1.4.1.311.10.3.3"),
+
+    Blowfish("1.3.6.1.4.1.3029.1.1.2");
 
     private String stdName;
     private String oid;

--- a/test/jdk/sun/security/pkcs12/SecretKeyAlgorithms.java
+++ b/test/jdk/sun/security/pkcs12/SecretKeyAlgorithms.java
@@ -23,9 +23,9 @@
 
 /*
  * @test
- * @bug 8286024
+ * @bug 8286024 8286422
  * @library /test/lib
- * @summary PKCS12 keystore shows "DES/CBC" as the algorithm of a DES SecretKeyEntry
+ * @summary PKCS12 keystore should show correct SecretKey algorithm names
  */
 
 import jdk.test.lib.Asserts;
@@ -33,17 +33,30 @@ import jdk.test.lib.Asserts;
 import javax.crypto.KeyGenerator;
 import java.security.Key;
 import java.security.KeyStore;
+import java.util.Collections;
+import java.util.Map;
 
-public class DESName {
+public class SecretKeyAlgorithms {
     public static void main(String[] args) throws Exception {
         char[] pass = "changeit".toCharArray();
         KeyStore ks = KeyStore.getInstance("PKCS12");
         ks.load(null, null);
-        KeyGenerator g = KeyGenerator.getInstance("DES");
-        Key k = g.generateKey();
-        Asserts.assertEQ(k.getAlgorithm(), "DES");
-        ks.setKeyEntry("d", k, pass, null);
-        k = ks.getKey("d", pass);
-        Asserts.assertEQ(k.getAlgorithm(), "DES");
+        var names = Map.of(
+                "des", "DES",
+                "desede", "DESede",
+                "aes", "AES",
+                "blowfish", "Blowfish",
+                "rc2", "RC2",
+                "arcfour", "ARCFOUR");
+        for (var alg : names.entrySet()) {
+            KeyGenerator g = KeyGenerator.getInstance(alg.getKey());
+            Key k = g.generateKey();
+            Asserts.assertEQ(k.getAlgorithm(), alg.getValue());
+            ks.setKeyEntry(alg.getKey(), k, pass, null);
+        }
+        for (var alias : Collections.list(ks.aliases())) {
+            var k = ks.getKey(alias, pass);
+            Asserts.assertEQ(k.getAlgorithm(), names.get(alias));
+        }
     }
 }


### PR DESCRIPTION
Add missing OIDs for 2 secret key algorithms. These will be used when storing secret keys in a PKCS12 keystore. Like DES and DESede, the OIDs were originally defined for CBC mode cipher algorithms, they are reused here for key algorithms.

OpenSSL uses the same OIDs for cipher algorithms.
```
1 3 6 1 4 1 3029 1 2	: BF-CBC		: bf-cbc
rsadsi 3 2		: RC2-CBC		: rc2-cbc
```

Similar to DES, RC2 is only added as an alias so it needs to be specially treated when getting a secret key entry from a PKCS12 keystore.

No attempt is made to define these OIDs as aliases to existing cipher algorithms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286422](https://bugs.openjdk.java.net/browse/JDK-8286422): Add OIDs for RC2 and Blowfish


### Reviewers
 * [Hai-May Chao](https://openjdk.java.net/census#hchao) (@haimaychao - Committer)
 * [Anthony Scarpino](https://openjdk.java.net/census#ascarpino) (@ascarpino - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8668/head:pull/8668` \
`$ git checkout pull/8668`

Update a local copy of the PR: \
`$ git checkout pull/8668` \
`$ git pull https://git.openjdk.java.net/jdk pull/8668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8668`

View PR using the GUI difftool: \
`$ git pr show -t 8668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8668.diff">https://git.openjdk.java.net/jdk/pull/8668.diff</a>

</details>
