### PR TITLE
8286560: Remove user parameter from jdk.internal.perf.Perf.attach()

### DIFF
--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -1099,11 +1099,6 @@ static size_t sharedmem_filesize(int fd, TRAPS) {
 //
 static void mmap_attach_shared(int vmid, char** addr, size_t* sizep, TRAPS) {
 
-  char* mapAddress;
-  int result;
-  int fd;
-  size_t size = 0;
-
   int mmap_prot = PROT_READ;
   int file_flags = O_RDONLY | O_NOFOLLOW;
 
@@ -1145,7 +1140,7 @@ static void mmap_attach_shared(int vmid, char** addr, size_t* sizep, TRAPS) {
   FREE_C_HEAP_ARRAY(char, filename);
 
   // open the shared memory file for the give vmid
-  fd = open_sharedmem_file(rfilename, file_flags, THREAD);
+  int fd = open_sharedmem_file(rfilename, file_flags, THREAD);
 
   if (fd == OS_ERR) {
     return;
@@ -1156,6 +1151,7 @@ static void mmap_attach_shared(int vmid, char** addr, size_t* sizep, TRAPS) {
     return;
   }
 
+  size_t size;
   if (*sizep == 0) {
     size = sharedmem_filesize(fd, CHECK);
   } else {
@@ -1164,9 +1160,9 @@ static void mmap_attach_shared(int vmid, char** addr, size_t* sizep, TRAPS) {
 
   assert(size > 0, "unexpected size <= 0");
 
-  mapAddress = (char*)::mmap((char*)0, size, mmap_prot, MAP_SHARED, fd, 0);
+  char* mapAddress = (char*)::mmap((char*)0, size, mmap_prot, MAP_SHARED, fd, 0);
 
-  result = ::close(fd);
+  int result = ::close(fd);
   assert(result != OS_ERR, "could not close file");
 
   if (mapAddress == MAP_FAILED) {

--- a/src/hotspot/os/windows/perfMemory_windows.cpp
+++ b/src/hotspot/os/windows/perfMemory_windows.cpp
@@ -1576,10 +1576,6 @@ static size_t sharedmem_filesize(const char* filename, TRAPS) {
 static void open_file_mapping(int vmid, char** addrp, size_t* sizep, TRAPS) {
 
   ResourceMark rm;
-
-  void *mapAddress = 0;
-  size_t size = 0;
-  HANDLE fmh;
   DWORD ofm_access = FILE_MAP_READ;
   DWORD mv_access = FILE_MAP_READ;
   const char* luser = get_user_name(vmid);
@@ -1621,6 +1617,7 @@ static void open_file_mapping(int vmid, char** addrp, size_t* sizep, TRAPS) {
   FREE_C_HEAP_ARRAY(char, filename);
   FREE_C_HEAP_ARRAY(char, objectname);
 
+  size_t size;
   if (*sizep == 0) {
     size = sharedmem_filesize(rfilename, CHECK);
   } else {
@@ -1630,12 +1627,11 @@ static void open_file_mapping(int vmid, char** addrp, size_t* sizep, TRAPS) {
   assert(size > 0, "unexpected size <= 0");
 
   // Open the file mapping object with the given name
-  fmh = open_sharedmem_object(robjectname, ofm_access, CHECK);
-
+  HANDLE fmh = open_sharedmem_object(robjectname, ofm_access, CHECK);
   assert(fmh != INVALID_HANDLE_VALUE, "unexpected handle value");
 
   // map the entire file into the address space
-  mapAddress = MapViewOfFile(
+  void* mapAddress = MapViewOfFile(
                  fmh,             /* HANDLE Handle of file mapping object */
                  mv_access,       /* DWORD access flags */
                  0,               /* DWORD High word of offset */

--- a/src/hotspot/share/prims/perf.cpp
+++ b/src/hotspot/share/prims/perf.cpp
@@ -64,24 +64,15 @@ static char* jstr_to_utf(JNIEnv *env, jstring str, TRAPS) {
   return utfstr;
 }
 
-PERF_ENTRY(jobject, Perf_Attach(JNIEnv *env, jobject unused, jstring user, int vmid))
+PERF_ENTRY(jobject, Perf_Attach(JNIEnv *env, jobject unused, int vmid))
 
   PerfWrapper("Perf_Attach");
 
   char* address = 0;
   size_t capacity = 0;
-  const char* user_utf = NULL;
-
-  ResourceMark rm;
-
-  {
-    ThreadToNativeFromVM ttnfv(thread);
-
-    user_utf = user == NULL ? NULL : jstr_to_utf(env, user, CHECK_NULL);
-  }
 
   // attach to the PerfData memory region for the specified VM
-  PerfMemory::attach(user_utf, vmid, &address, &capacity, CHECK_NULL);
+  PerfMemory::attach(vmid, &address, &capacity, CHECK_NULL);
 
   {
     ThreadToNativeFromVM ttnfv(thread);
@@ -294,7 +285,7 @@ PERF_END
 
 static JNINativeMethod perfmethods[] = {
 
-  {CC "attach0",             CC "(" JLS "I)" BB,  FN_PTR(Perf_Attach)},
+  {CC "attach0",             CC "(I)" BB,         FN_PTR(Perf_Attach)},
   {CC "detach",              CC "(" BB ")V",      FN_PTR(Perf_Detach)},
   {CC "createLong",          CL_ARGS,             FN_PTR(Perf_CreateLong)},
   {CC "createByteArray",     CBA_ARGS,            FN_PTR(Perf_CreateByteArray)},

--- a/src/hotspot/share/runtime/perfMemory.hpp
+++ b/src/hotspot/share/runtime/perfMemory.hpp
@@ -143,7 +143,7 @@ class PerfMemory : AllStatic {
 
     // methods for attaching to and detaching from the PerfData
     // memory segment of another JVM process on the same system.
-    static void attach(const char* user, int vmid, char** addrp, size_t* size, TRAPS);
+    static void attach(int vmid, char** addrp, size_t* size, TRAPS);
     static void detach(char* addr, size_t bytes);
 
     static void initialize();

--- a/src/java.base/share/classes/jdk/internal/perf/Perf.java
+++ b/src/java.base/share/classes/jdk/internal/perf/Perf.java
@@ -179,8 +179,7 @@ public final class Perf {
      *                           into the virtual machine's address space.
      * @see     java.nio.ByteBuffer
      */
-    public ByteBuffer attach(int lvmid)
-           throws IllegalArgumentException, IOException
+    public ByteBuffer attach(int lvmid) throws IOException
     {
         final ByteBuffer b = attach0(lvmid);
 
@@ -242,8 +241,7 @@ public final class Perf {
      * @throws  OutOfMemoryError The instrumentation buffer could not be mapped
      *                           into the virtual machine's address space.
      */
-    private native ByteBuffer attach0(int lvmid)
-                   throws IllegalArgumentException, IOException;
+    private native ByteBuffer attach0(int lvmid) throws IOException;
 
     /**
      * Native method to perform the implementation specific detach mechanism.

--- a/src/java.base/share/classes/jdk/internal/perf/Perf.java
+++ b/src/java.base/share/classes/jdk/internal/perf/Perf.java
@@ -182,60 +182,7 @@ public final class Perf {
     public ByteBuffer attach(int lvmid)
            throws IllegalArgumentException, IOException
     {
-        return attachImpl(null, lvmid);
-    }
-
-    /**
-     * Attach to the instrumentation buffer for the specified Java virtual
-     * machine owned by the given user.
-     * <p>
-     * This method behaves just as the <code>attach(int lvmid)
-     * </code> method, except that it only searches for Java virtual machines
-     * owned by the specified user.
-     *
-     * @param   user             A <code>String</code> object containing the
-     *                           name of the user that owns the target Java
-     *                           virtual machine.
-     * @param   lvmid            an integer that uniquely identifies the
-     *                           target local Java virtual machine.
-     * @return  ByteBuffer       a direct allocated byte buffer
-     * @throws  IllegalArgumentException  The lvmid was invalid.
-     * @throws  IOException      An I/O error occurred while trying to acquire
-     *                           the instrumentation buffer.
-     * @throws  OutOfMemoryError The instrumentation buffer could not be mapped
-     *                           into the virtual machine's address space.
-     * @see     java.nio.ByteBuffer
-     */
-    public ByteBuffer attach(String user, int lvmid)
-           throws IllegalArgumentException, IOException
-    {
-        return attachImpl(user, lvmid);
-    }
-
-    /**
-     * Call the implementation specific attach method.
-     * <p>
-     * This method calls into the Java virtual machine to perform the platform
-     * specific attach method. Buffers returned from this method are
-     * internally managed as <code>PhantomRefereces</code> to provide for
-     * guaranteed, secure release of the native resources.
-     *
-     * @param   user             A <code>String</code> object containing the
-     *                           name of the user that owns the target Java
-     *                           virtual machine.
-     * @param   lvmid            an integer that uniquely identifies the
-     *                           target local Java virtual machine.
-     * @return  ByteBuffer       a direct allocated byte buffer
-     * @throws  IllegalArgumentException  The lvmid was invalid.
-     * @throws  IOException      An I/O error occurred while trying to acquire
-     *                           the instrumentation buffer.
-     * @throws  OutOfMemoryError The instrumentation buffer could not be mapped
-     *                           into the virtual machine's address space.
-     */
-    private ByteBuffer attachImpl(String user, int lvmid)
-            throws IllegalArgumentException, IOException
-    {
-        final ByteBuffer b = attach0(user, lvmid);
+        final ByteBuffer b = attach0(lvmid);
 
         if (lvmid == 0) {
             // The native instrumentation buffer for this Java virtual
@@ -286,9 +233,6 @@ public final class Perf {
      * target Java virtual machine will result in two distinct ByteBuffer
      * objects returned by this method. This may change in a future release.
      *
-     * @param   user             A <code>String</code> object containing the
-     *                           name of the user that owns the target Java
-     *                           virtual machine.
      * @param   lvmid            an integer that uniquely identifies the
      *                           target local Java virtual machine.
      * @return  ByteBuffer       a direct allocated byte buffer
@@ -298,7 +242,7 @@ public final class Perf {
      * @throws  OutOfMemoryError The instrumentation buffer could not be mapped
      *                           into the virtual machine's address space.
      */
-    private native ByteBuffer attach0(String user, int lvmid)
+    private native ByteBuffer attach0(int lvmid)
                    throws IllegalArgumentException, IOException;
 
     /**


### PR DESCRIPTION
The API `jdk.internal.perf.Perf.::attach(String user, int lvmid)` is never used. It should be removed, and all the handling of a specified user name should be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286560](https://bugs.openjdk.java.net/browse/JDK-8286560): Remove user parameter from jdk.internal.perf.Perf.attach()


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [afa66232](https://git.openjdk.java.net/jdk/pull/8669/files/afa6623224f1afb54b948326834bb6c16921784a)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [afa66232](https://git.openjdk.java.net/jdk/pull/8669/files/afa6623224f1afb54b948326834bb6c16921784a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8669/head:pull/8669` \
`$ git checkout pull/8669`

Update a local copy of the PR: \
`$ git checkout pull/8669` \
`$ git pull https://git.openjdk.java.net/jdk pull/8669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8669`

View PR using the GUI difftool: \
`$ git pr show -t 8669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8669.diff">https://git.openjdk.java.net/jdk/pull/8669.diff</a>

</details>
