### PR TITLE
JDK-8286617: Improve parameter names in javax.lang.model utility visitors

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor14.java
@@ -64,10 +64,10 @@ public abstract class AbstractElementVisitor14<R, P> extends AbstractElementVisi
      * @implSpec Visits a {@code RecordComponentElement} in a manner defined by a
      * subclass.
      *
-     * @param t  {@inheritDoc}
+     * @param e  {@inheritDoc}
      * @param p  {@inheritDoc}
      * @return   {@inheritDoc}
      */
     @Override
-    public abstract R visitRecordComponent(RecordComponentElement t, P p);
+    public abstract R visitRecordComponent(RecordComponentElement e, P p);
 }

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor9.java
@@ -64,10 +64,10 @@ public abstract class AbstractElementVisitor9<R, P> extends AbstractElementVisit
      * @implSpec Visits a {@code ModuleElement} in a manner defined by a
      * subclass.
      *
-     * @param t  {@inheritDoc}
+     * @param e  {@inheritDoc}
      * @param p  {@inheritDoc}
      * @return   {@inheritDoc}
      */
     @Override
-    public abstract R visitModule(ModuleElement t, P p);
+    public abstract R visitModule(ModuleElement e, P p);
 }

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor6.java
@@ -117,11 +117,11 @@ public class SimpleTypeVisitor6<R, P> extends AbstractTypeVisitor6<R, P> {
      * @implSpec The implementation in this class just returns {@link
      * #DEFAULT_VALUE}; subclasses will commonly override this method.
      *
-     * @param e the type to process
+     * @param t the type to process
      * @param p a visitor-specified parameter
      * @return {@code DEFAULT_VALUE} unless overridden
      */
-    protected R defaultAction(TypeMirror e, P p) {
+    protected R defaultAction(TypeMirror t, P p) {
         return DEFAULT_VALUE;
     }
 


### PR DESCRIPTION
Fix inconsistencies in parameter naming; will update copyrights years if needed before a push.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286617](https://bugs.openjdk.java.net/browse/JDK-8286617): Improve parameter names in javax.lang.model utility visitors


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [60d7655a](https://git.openjdk.java.net/jdk/pull/8671/files/60d7655a2964ae6e124730c75ad883d9740dcfb2)
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to [60d7655a](https://git.openjdk.java.net/jdk/pull/8671/files/60d7655a2964ae6e124730c75ad883d9740dcfb2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8671/head:pull/8671` \
`$ git checkout pull/8671`

Update a local copy of the PR: \
`$ git checkout pull/8671` \
`$ git pull https://git.openjdk.java.net/jdk pull/8671/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8671`

View PR using the GUI difftool: \
`$ git pr show -t 8671`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8671.diff">https://git.openjdk.java.net/jdk/pull/8671.diff</a>

</details>
