### PR TITLE
8284404: Too aggressive sweeping with Loom

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 #include "code/codeCache.hpp"
 #include "runtime/arguments.hpp"
+#include "runtime/continuation.hpp"
 #include "runtime/flags/jvmFlag.hpp"
 #include "runtime/flags/jvmFlagAccess.hpp"
 #include "runtime/flags/jvmFlagConstraintsCompiler.hpp"
@@ -587,7 +588,9 @@ void CompilerConfig::ergo_initialize() {
 #endif
 
   if (FLAG_IS_DEFAULT(SweeperThreshold)) {
-    if ((SweeperThreshold * ReservedCodeCacheSize / 100) > (1.2 * M)) {
+    if (Continuations::enabled()) {
+      FLAG_SET_ERGO(SweeperThreshold, SweeperThreshold * 10.0);
+    } else if ((SweeperThreshold * ReservedCodeCacheSize / 100) > (1.2 * M)) {
       // Cap default SweeperThreshold value to an equivalent of 1.2 Mb
       FLAG_SET_ERGO(SweeperThreshold, (1.2 * M * 100) / ReservedCodeCacheSize);
     }

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -589,6 +589,10 @@ void CompilerConfig::ergo_initialize() {
 
   if (FLAG_IS_DEFAULT(SweeperThreshold)) {
     if (Continuations::enabled()) {
+      // When continuations are enabled, the sweeper needs to trigger GC to
+      // be able to sweep nmethods. Therefore, it's in general a good idea
+      // to be significantly less aggressive with sweeping, in order not to
+      // trigger excessive GC work.
       FLAG_SET_ERGO(SweeperThreshold, SweeperThreshold * 10.0);
     } else if ((SweeperThreshold * ReservedCodeCacheSize / 100) > (1.2 * M)) {
       // Cap default SweeperThreshold value to an equivalent of 1.2 Mb


### PR DESCRIPTION
The normal sweeping heuristics trigger sweeping whenever 0.5% of the reserved code cache could have died. Normally that is fine, but with loom such sweeping requires a full GC cycle, as stacks can now be in the Java heap as well. In that context, 0.5% does seem to be a bit too trigger happy. So this patch adjusts that default when using loom to 10x higher.
If you run something like jython which spins up a lot of code, it unsurprisingly triggers a lot less GCs due to code cache pressure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284404](https://bugs.openjdk.org/browse/JDK-8284404): Too aggressive sweeping with Loom


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [461f8a30](https://git.openjdk.org/jdk/pull/8673/files/461f8a3002ce2718698a43d5bca13fdfbd9d9879)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/8673/head:pull/8673` \
`$ git checkout pull/8673`

Update a local copy of the PR: \
`$ git checkout pull/8673` \
`$ git pull https://git.openjdk.org/jdk pull/8673/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8673`

View PR using the GUI difftool: \
`$ git pr show -t 8673`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/8673.diff">https://git.openjdk.org/jdk/pull/8673.diff</a>

</details>
