### PR TITLE
BodySubscribers.ofInputStream may fail on readAllBytes

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
@@ -502,7 +502,7 @@ public class ResponseSubscribers {
             // don't attempt to read more than what is available
             // in the current buffer.
             int read = Math.min(buffer.remaining(), len);
-            assert read > 0 && read <= buffer.remaining();
+            assert read >= 0 && read <= buffer.remaining();
 
             // buffer.get() will do the boundary check for us.
             buffer.get(bytes, off, read);


### PR DESCRIPTION
It happens only when assertions are enabled `-ea`.

`InputStream` of `BodySubscribers.ofInputStream` may fail on readAllBytes/readNBytes with `java.lang.AssertionError`.

Demo:
```
    public static void main( String[] args ) throws Exception {
        final InputStream body =
            HttpClient.newHttpClient().send( HttpRequest.newBuilder( URI.create( "https://github.com/" )).build(), HttpResponse.BodyHandlers.ofInputStream() ).body();
        try (body) {
            System.out.println( new String(body.readAllBytes(), StandardCharsets.UTF_8) );
        }
    }
```

Reason:
`HttpResponseInputStream.read` violates `InputStream.read` method spec (only in `ea` mode):

> If len is zero, then no bytes are read and 0 is returned.

But `InputStream.readNBytes` relies on this part of spec and sometimes tries to read 0 bytes from `InputStream`.

Fix:
Do not assert on read of 0 bytes.