### PR TITLE
8286623: Bundle zlib by default with JDK on macos aarch64

### DIFF
--- a/make/autoconf/lib-bundled.m4
+++ b/make/autoconf/lib-bundled.m4
@@ -166,7 +166,9 @@ AC_DEFUN_ONCE([LIB_SETUP_ZLIB],
 
   DEFAULT_ZLIB=system
   if test "x$OPENJDK_TARGET_OS" = xwindows -o "x$OPENJDK_TARGET_OS" = xaix; then
-    # On windows and aix default is bundled, on others default is system
+    # On windows and aix default is bundled
+    DEFAULT_ZLIB=bundled
+  elif test "x$OPENJDK_TARGET_OS" = xmacosx -a "x$OPENJDK_TARGET_CPU" = xaarch64; then
     DEFAULT_ZLIB=bundled
   fi
 

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -450,7 +450,7 @@ var getJibProfilesProfiles = function (input, common, data) {
             target_os: "macosx",
             target_cpu: "aarch64",
             dependencies: ["devkit", "gtest", "pandoc"],
-            configure_args: concat(common.configure_args_64bit, "--with-zlib=system",
+            configure_args: concat(common.configure_args_64bit,
                 "--with-macosx-version-max=11.00.00"),
         },
 


### PR DESCRIPTION
Can I please get a review of this change to the build system which now makes bundled zlib as the default for macos aarch64 systems? 

We have been running into various intermittent failures on macos aarch64 systems for several months now. After investigation we have been able to ascertain that the root cause of the issue lies within the zlib that's shipped on macos aarch64 systems. The complete details about that issue is available at https://bugs.openjdk.java.net/browse/JDK-8282954. 
We have filed a bug with Apple for their inputs on what we can do to fix it in that shipped library. Given the nature of that issue, we don't have a timeline on when/if the solution for that will be available. Until that time, at least, the proposal is to use bundled zlib (which doesn't reproduce those failures) by default on macos aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286623](https://bugs.openjdk.java.net/browse/JDK-8286623): Bundle zlib by default with JDK on macos aarch64


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8675/head:pull/8675` \
`$ git checkout pull/8675`

Update a local copy of the PR: \
`$ git checkout pull/8675` \
`$ git pull https://git.openjdk.java.net/jdk pull/8675/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8675`

View PR using the GUI difftool: \
`$ git pr show -t 8675`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8675.diff">https://git.openjdk.java.net/jdk/pull/8675.diff</a>

</details>
