### PR TITLE
8286628: Remove unused BufferNode::Allocator::flush_free_list

### DIFF
--- a/src/hotspot/share/gc/shared/ptrQueue.hpp
+++ b/src/hotspot/share/gc/shared/ptrQueue.hpp
@@ -194,10 +194,6 @@ public:
   size_t free_count() const;
   BufferNode* allocate();
   void release(BufferNode* node);
-
-  // If _free_list has items buffered in the pending list, transfer
-  // these to make them available for re-allocation.
-  bool flush_free_list() { return _free_list.try_transfer_pending(); }
 };
 
 // A PtrQueueSet represents resources common to a set of pointer queues.

--- a/test/hotspot/gtest/gc/shared/test_ptrQueueBufferAllocator.cpp
+++ b/test/hotspot/gtest/gc/shared/test_ptrQueueBufferAllocator.cpp
@@ -38,7 +38,7 @@
 class BufferNode::TestSupport : AllStatic {
 public:
   static bool try_transfer_pending(Allocator* allocator) {
-    return allocator->flush_free_list();
+    return allocator->_free_list.try_transfer_pending();
   }
 
   class CompletedList;


### PR DESCRIPTION
Simple change of removing an unused API.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286628](https://bugs.openjdk.java.net/browse/JDK-8286628): Remove unused BufferNode::Allocator::flush_free_list


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8676/head:pull/8676` \
`$ git checkout pull/8676`

Update a local copy of the PR: \
`$ git checkout pull/8676` \
`$ git pull https://git.openjdk.java.net/jdk pull/8676/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8676`

View PR using the GUI difftool: \
`$ git pr show -t 8676`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8676.diff">https://git.openjdk.java.net/jdk/pull/8676.diff</a>

</details>
