### PR TITLE
8286057: Make javac error on a generic enum friendlier

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -4033,6 +4033,10 @@ public class JavacParser implements Parser {
 
         Name name = typeName();
 
+        if(typeParametersOpt().size() > 0) {
+            log.error(DiagnosticFlag.SYNTAX, S.prevToken().endPos, Errors.EnumCantBeGeneric);
+        }
+
         List<JCExpression> implementing = List.nil();
         if (token.kind == IMPLEMENTS) {
             nextToken();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -4033,8 +4033,13 @@ public class JavacParser implements Parser {
 
         Name name = typeName();
 
-        if(typeParametersOpt().size() > 0) {
-            log.error(DiagnosticFlag.SYNTAX, S.prevToken().endPos, Errors.EnumCantBeGeneric);
+        int typeNamePos = token.pos;
+        List<JCTypeParameter> typarams = typeParametersOpt(true);
+        if (typarams == null || !typarams.isEmpty()) {
+            int errorPosition = typarams == null
+                    ? typeNamePos
+                    : typarams.head.pos;
+            log.error(DiagnosticFlag.SYNTAX, errorPosition, Errors.EnumCantBeGeneric);
         }
 
         List<JCExpression> implementing = List.nil();
@@ -4539,9 +4544,21 @@ public class JavacParser implements Parser {
      *  }
      */
     protected List<JCTypeParameter> typeParametersOpt() {
+        return typeParametersOpt(false);
+    }
+    /** Parses a potentially empty type parameter list if needed with `allowEmpty`.
+     *  The caller is free to choose the desirable error message in this (erroneous) case.
+     */
+    protected List<JCTypeParameter> typeParametersOpt(boolean parseEmpty) {
         if (token.kind == LT) {
             ListBuffer<JCTypeParameter> typarams = new ListBuffer<>();
             nextToken();
+
+            if (parseEmpty && token.kind == GT) {
+                accept(GT);
+                return null;
+            }
+
             typarams.append(typeParameter());
             while (token.kind == COMMA) {
                 nextToken();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -550,6 +550,9 @@ compiler.err.enum.types.not.extensible=\
 compiler.err.enum.no.finalize=\
     enums cannot have finalize methods
 
+compiler.err.enum.cant.be.generic=\
+    enums cannot be generic
+
 # 0: file name, 1: string
 compiler.err.error.reading.file=\
     error reading {0}; {1}

--- a/test/langtools/tools/javac/T8286057.java
+++ b/test/langtools/tools/javac/T8286057.java
@@ -1,0 +1,13 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8286057
+ * @summary Make javac error on a generic enum friendlier
+ *
+ * @compile/fail/ref=T8286057.out -XDrawDiagnostics T8286057.java
+ */
+
+class EnumsCantBeGeneric {
+  public enum E1<> {}
+  public enum E2<T> {}
+  public enum E3<T, T> {}
+}

--- a/test/langtools/tools/javac/T8286057.out
+++ b/test/langtools/tools/javac/T8286057.out
@@ -1,0 +1,4 @@
+T8286057.java:10:17: compiler.err.enum.cant.be.generic
+T8286057.java:11:18: compiler.err.enum.cant.be.generic
+T8286057.java:12:18: compiler.err.enum.cant.be.generic
+3 errors

--- a/test/langtools/tools/javac/diags/examples/EnumsCantBeGeneric.java
+++ b/test/langtools/tools/javac/diags/examples/EnumsCantBeGeneric.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.err.enum.cant.be.generic
+
+class EnumsCantBeGeneric {
+    public enum E<T> {}
+}


### PR DESCRIPTION
Improves the error message for generic enumerations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286057](https://bugs.openjdk.java.net/browse/JDK-8286057): Make javac error on a generic enum friendlier


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8677/head:pull/8677` \
`$ git checkout pull/8677`

Update a local copy of the PR: \
`$ git checkout pull/8677` \
`$ git pull https://git.openjdk.java.net/jdk pull/8677/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8677`

View PR using the GUI difftool: \
`$ git pr show -t 8677`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8677.diff">https://git.openjdk.java.net/jdk/pull/8677.diff</a>

</details>
