### PR TITLE
8286636: MacroAssembler::post_call_nop should have InstructionMark

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3829,6 +3829,7 @@ encode %{
       }
     }
 
+    _masm.clear_inst_mark();
     __ post_call_nop();
 
     // Only non uncommon_trap calls need to reinitialize ptrue.
@@ -3845,6 +3846,7 @@ encode %{
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }
+    _masm.clear_inst_mark();
     __ post_call_nop();
     if (Compile::current()->max_vector_size() > 0) {
       __ reinitialize_ptrue();
@@ -3874,6 +3876,7 @@ encode %{
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
+      _masm.clear_inst_mark();
       __ post_call_nop();
     } else {
       Label retaddr;

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -830,6 +830,7 @@ void MacroAssembler::post_call_nop() {
   if (!Continuations::enabled()) {
     return;
   }
+  InstructionMark im(this);
   relocate(post_call_nop_Relocation::spec());
   nop();
 }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1998,6 +1998,7 @@ void MacroAssembler::post_call_nop() {
   if (!Continuations::enabled()) {
     return;
   }
+  InstructionMark im(this);
   relocate(post_call_nop_Relocation::spec());
   emit_int8((int8_t)0x0f);
   emit_int8((int8_t)0x1f);


### PR DESCRIPTION
`InstructionMark` checks the instruction boundaries, which is important for relocatable instructions. Everywhere where we do any (?) sort of relocation, we do `InstructionMark`. I found that newly added `MacroAssembler::post_call_nop` does not have it, and thus some new code in x86_32 Loom prototype fails with missing instruction mark / instruction overlapping checks. 

If we add it to `InstructionMark` in AArch64 code, then "overlapping instructions" asserts start to fire, because Loom inserted `post_call_nops` when there was an active instruction mark. x86_64 solves this by [resetting the mark before the nop](https://github.com/openjdk/jdk/blob/40f43c6b1ffc88d55dd3223f5d0259ae73cf0356/src/hotspot/cpu/x86/x86_64.ad#L2084), this patch does the same.

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1`
 - [x] Linux AArch64 fastdebug `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286636](https://bugs.openjdk.java.net/browse/JDK-8286636): MacroAssembler::post_call_nop should have InstructionMark


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8678/head:pull/8678` \
`$ git checkout pull/8678`

Update a local copy of the PR: \
`$ git checkout pull/8678` \
`$ git pull https://git.openjdk.java.net/jdk pull/8678/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8678`

View PR using the GUI difftool: \
`$ git pr show -t 8678`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8678.diff">https://git.openjdk.java.net/jdk/pull/8678.diff</a>

</details>
