### PR TITLE
8286638: C2: CmpU needs to do more precise over/underflow analysis

### DIFF
--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -827,11 +827,10 @@ const Type* CmpUNode::Value(PhaseGVN* phase) const {
         int w = MAX2(r0->_widen, r1->_widen); // _widen does not matter here
         const TypeInt* tr1 = TypeInt::make(lo_tr1, hi_tr1, w);
         const TypeInt* tr2 = TypeInt::make(lo_tr2, hi_tr2, w);
-        const Type* cmp1 = sub(tr1, t2);
-        const Type* cmp2 = sub(tr2, t2);
-        if (cmp1 == cmp2) {
-          return cmp1; // Hit!
-        }
+        const TypeInt* cmp1 = sub(tr1, t2)->is_int();
+        const TypeInt* cmp2 = sub(tr2, t2)->is_int();
+        // compute union, so that cmp handles all possible results from the two cases
+        return cmp1->meet(cmp2);
       }
     }
   }

--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckCmpUUnderflow.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckCmpUUnderflow.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8283466
+ * @summary Dominator failure because ConvL2I node becomes TOP, kills data-flow, but range-check does not collapse
+ *          due to insufficient overflow/underflow handling in CmpUNode::Value.
+ *
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -Xcomp -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,compiler.rangechecks.TestRangeCheckCmpUUnderflow::*
+ *                   -XX:StressSeed=858221963
+ *                   compiler.rangechecks.TestRangeCheckCmpUUnderflow
+ *
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -Xcomp -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,compiler.rangechecks.TestRangeCheckCmpUUnderflow::*
+ *                   -XX:RepeatCompilation=300
+ *                   compiler.rangechecks.TestRangeCheckCmpUUnderflow
+*/
+
+package compiler.rangechecks;
+
+public class TestRangeCheckCmpUUnderflow {
+    volatile int a;
+    int b[];
+    float c[];
+    void e() {
+        int g, f, i;
+        for (g = 2;; g++) {
+            for (i = g; i < 1; i++) {
+                f = a;
+                c[i - 1] -= b[i];
+            }
+	}
+    }
+    public static void main(String[] args) {
+        try {
+            TestRangeCheckCmpUUnderflow j = new TestRangeCheckCmpUUnderflow();
+            j.e();
+        } catch (Exception ex) {}
+    }
+}

--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckCmpUUnderflow.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckCmpUUnderflow.java
@@ -29,11 +29,6 @@
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -Xcomp -XX:-TieredCompilation
  *                   -XX:CompileCommand=compileonly,compiler.rangechecks.TestRangeCheckCmpUUnderflow::*
- *                   -XX:StressSeed=858221963
- *                   compiler.rangechecks.TestRangeCheckCmpUUnderflow
- *
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -Xcomp -XX:-TieredCompilation
- *                   -XX:CompileCommand=compileonly,compiler.rangechecks.TestRangeCheckCmpUUnderflow::*
  *                   -XX:RepeatCompilation=300
  *                   compiler.rangechecks.TestRangeCheckCmpUUnderflow
 */

--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckCmpUUnderflow.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckCmpUUnderflow.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8283466
+ * @bug 8286638
  * @summary Dominator failure because ConvL2I node becomes TOP, kills data-flow, but range-check does not collapse
  *          due to insufficient overflow/underflow handling in CmpUNode::Value.
  *

--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckCmpUUnderflow.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckCmpUUnderflow.java
@@ -51,7 +51,7 @@ public class TestRangeCheckCmpUUnderflow {
                 f = a;
                 c[i - 1] -= b[i];
             }
-	}
+        }
     }
     public static void main(String[] args) {
         try {


### PR DESCRIPTION
`CmpUNode::Value` already does an under/overflow analysis, in case we have an `AddI` or `SubI` above it.
Instead of assuming the types are now the full `#int` range, we separately analyze the normal and the over/underflowed range.

We get the two ranges `tr1` and `tr2`, which we now both compare with the right input `t2`, via `sub`.
If both `cmp1` and `cmp2` are equal, for example both are `[ge]`, and below we have a Bool node that checks for `[lt]`, we know that this can never be true.

However, I now encountered a case where `cmp1` was `[gt]` and `cmp2` was `[ge]`. Unfortunately, they are not the same, so we just discarded our analysis, and since it is an overflow case just cannot say anything. But we could actually know that both will never be `[lt]`.

Thus, **I propose** to take the `meet` (the union of all possible results of `cmp1` and `cmp2`. In this example, the meet would be `[ge]`.

**Why is this important?**
I got a bug, where a ConvI2L node was able to determine the range was impossible, ripping out the data-flow. But the range-check did not manage to do the same analysis, because of an underflow. This leads to some mangled code further down.

**Detailed analysis of that case:**

type `i: [minint...0]`
access to `c[i-1]`

**Range-check:**
`int index = AddI(i, -1)`
-> type index: [minint-1 ... -1] -> underflow
We detect that this AddI may have 2 ranges:
`tr1: int:<=-1`
`tr2: int:max `(underflow: minint-1)

We then check how these ranges compare to in2:
`t2: int:>=0`

For this we compute:
`const Type* cmp1 = sub(tr1, t2);` -> TypeInt::CC_GT = [1]
`const Type* cmp2 = sub(tr2, t2);` -> TypeInt::CC_GE = [0...1]

But then, we only do something with this result if `cmp1 == cmp2`.
We never detect that the `Bool [lt] `could never be true.


**Data-flow:**
`long index = ConvI2L( AddI(i, -1) )`
-> type of` ConvI2L: [0...maxint-1]`
-> why do we know this? Because this is before an array access. We assume range-check guarantees index in range `[0...c.size()-1]`, and `c.size()<=maxint`.
Then there is a push_thru_add, and we get:
`long index = AddL( ConvI2L(i), -1)`
-> type of new `ConvI2L: [1...maxint-1]` - because we correct the lo by 1 for the add. Somehow we do not adjust hi, in my opinion it should now be maxint, to correct by 1.
Consequence: if hi is maxint or maxint-1, there is no overflow.
Then, we statically detect that:
type `i: [minint...0]`
type` ConvI2L: [1...maxint-1]`
-> filter results in `TOP` -> data-flow is eliminated sucessfully.


Added **regression test** that matches this example above.
Larger test suite passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286638](https://bugs.openjdk.java.net/browse/JDK-8286638): C2: CmpU needs to do more precise over/underflow analysis


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8679/head:pull/8679` \
`$ git checkout pull/8679`

Update a local copy of the PR: \
`$ git checkout pull/8679` \
`$ git pull https://git.openjdk.java.net/jdk pull/8679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8679`

View PR using the GUI difftool: \
`$ git pr show -t 8679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8679.diff">https://git.openjdk.java.net/jdk/pull/8679.diff</a>

</details>
