### PR TITLE
8286647: JFR: Build failure when C1 or C2 is disabled after JDK-8282420

### DIFF
--- a/src/hotspot/share/jfr/instrumentation/jfrResolution.cpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrResolution.cpp
@@ -23,7 +23,6 @@
  */
 
 #include "precompiled.hpp"
-#include "c1/c1_GraphBuilder.hpp"
 #include "ci/ciKlass.hpp"
 #include "ci/ciMethod.hpp"
 #include "classfile/vmSymbols.hpp"
@@ -31,9 +30,16 @@
 #include "jfr/instrumentation/jfrResolution.hpp"
 #include "jfr/recorder/checkpoint/types/traceid/jfrTraceIdMacros.hpp"
 #include "oops/method.inline.hpp"
-#include "opto/parse.hpp"
 #include "runtime/thread.hpp"
 #include "runtime/vframe.inline.hpp"
+
+#ifdef COMPILER1
+#include "c1/c1_GraphBuilder.hpp"
+#endif
+
+#ifdef COMPILER2
+#include "opto/parse.hpp"
+#endif
 
 static const char* const link_error_msg = "illegal access linking method 'jdk.jfr.internal.event.EventWriterFactory.getEventWriter(long)'";
 
@@ -88,16 +94,20 @@ static inline bool is_compiler_linking_event_writer(const ciKlass * holder, cons
   return target->name()->get_symbol() == event_writer_method_name;
 }
 
+#ifdef COMPILER1
 // C1
 void JfrResolution::on_c1_resolution(const GraphBuilder * builder, const ciKlass * holder, const ciMethod * target) {
   if (is_compiler_linking_event_writer(holder, target) && !IS_METHOD_BLESSED(builder->method()->get_Method())) {
     builder->bailout(link_error_msg);
   }
 }
+#endif
 
+#ifdef COMPILER2
 // C2
 void JfrResolution::on_c2_resolution(const Parse * parse, const ciKlass * holder, const ciMethod * target) {
   if (is_compiler_linking_event_writer(holder, target) && !IS_METHOD_BLESSED(parse->method()->get_Method())) {
     parse->C->record_failure(link_error_msg);
   }
 }
+#endif

--- a/src/hotspot/share/jfr/jfr.cpp
+++ b/src/hotspot/share/jfr/jfr.cpp
@@ -104,13 +104,17 @@ void Jfr::on_resolution(const CallInfo& info, TRAPS) {
   JfrResolution::on_runtime_resolution(info, THREAD);
 }
 
+#ifdef COMPILER1
 void Jfr::on_resolution(const GraphBuilder* builder, const ciKlass* holder, const ciMethod* target) {
   JfrResolution::on_c1_resolution(builder, holder, target);
 }
+#endif
 
+#ifdef COMPILER2
 void Jfr::on_resolution(const Parse* parse, const ciKlass* holder, const ciMethod* target) {
   JfrResolution::on_c2_resolution(parse, holder, target);
 }
+#endif
 
 void Jfr::on_vm_shutdown(bool exception_handler) {
   if (JfrRecorder::is_recording()) {

--- a/src/hotspot/share/jfr/jfr.hpp
+++ b/src/hotspot/share/jfr/jfr.hpp
@@ -34,18 +34,12 @@
 class CallInfo;
 class ciKlass;
 class ciMethod;
+class GraphBuilder;
 class JavaThread;
 class Klass;
 class outputStream;
-class Thread;
-
-#ifdef COMPILER1
-class GraphBuilder;
-#endif
-
-#ifdef COMPILER2
 class Parse;
-#endif
+class Thread;
 
 extern "C" void JNICALL jfr_register_natives(JNIEnv*, jclass);
 
@@ -67,12 +61,8 @@ class Jfr : AllStatic {
   static void on_thread_start(Thread* thread);
   static void on_thread_exit(Thread* thread);
   static void on_resolution(const CallInfo& info, TRAPS);
-#ifdef COMPILER2
   static void on_resolution(const Parse* parse, const ciKlass* holder, const ciMethod* target);
-#endif
-#ifdef COMPILER1
   static void on_resolution(const GraphBuilder* builder, const ciKlass* holder, const ciMethod* target);
-#endif
   static void on_java_thread_start(JavaThread* starter, JavaThread* startee);
   static void on_set_current_thread(JavaThread* jt, oop thread);
   static void on_vm_shutdown(bool exception_handler = false);

--- a/src/hotspot/share/jfr/jfr.hpp
+++ b/src/hotspot/share/jfr/jfr.hpp
@@ -34,12 +34,18 @@
 class CallInfo;
 class ciKlass;
 class ciMethod;
-class GraphBuilder;
 class JavaThread;
 class Klass;
 class outputStream;
-class Parse;
 class Thread;
+
+#ifdef COMPILER1
+class GraphBuilder;
+#endif
+
+#ifdef COMPILER2
+class Parse;
+#endif
 
 extern "C" void JNICALL jfr_register_natives(JNIEnv*, jclass);
 
@@ -61,8 +67,12 @@ class Jfr : AllStatic {
   static void on_thread_start(Thread* thread);
   static void on_thread_exit(Thread* thread);
   static void on_resolution(const CallInfo& info, TRAPS);
+#ifdef COMPILER2
   static void on_resolution(const Parse* parse, const ciKlass* holder, const ciMethod* target);
+#endif
+#ifdef COMPILER1
   static void on_resolution(const GraphBuilder* builder, const ciKlass* holder, const ciMethod* target);
+#endif
   static void on_java_thread_start(JavaThread* starter, JavaThread* startee);
   static void on_set_current_thread(JavaThread* jt, oop thread);
   static void on_vm_shutdown(bool exception_handler = false);


### PR DESCRIPTION
Hi all,

JDK fails to build when c1 or c2 is disabled after JDK-8282420.
The reason is that c1/c2 code is used without `#ifdef` guards.
The fix just adds some `#ifdef`.

Testing:
 - build   on Linux/x64
 - jdk/jfr on Linux/x64

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286647](https://bugs.openjdk.java.net/browse/JDK-8286647): JFR: Build failure when C1 or C2 is disabled after JDK-8282420


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8680/head:pull/8680` \
`$ git checkout pull/8680`

Update a local copy of the PR: \
`$ git checkout pull/8680` \
`$ git pull https://git.openjdk.java.net/jdk pull/8680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8680`

View PR using the GUI difftool: \
`$ git pr show -t 8680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8680.diff">https://git.openjdk.java.net/jdk/pull/8680.diff</a>

</details>
