### PR TITLE
8278262: JFR: TestPrintXML can't handle missing timestamps

### DIFF
--- a/test/jdk/jdk/jfr/tool/TestPrintXML.java
+++ b/test/jdk/jdk/jfr/tool/TestPrintXML.java
@@ -138,9 +138,13 @@ public class TestPrintXML {
                 Object xmlValue = xmlMap.get(name);
                 Object expectedValue = re.getValue(name);
                 if (v.getAnnotation(Timestamp.class) != null) {
-                    // Make instant of OffsetDateTime
-                    xmlValue = OffsetDateTime.parse("" + xmlValue).toInstant().toString();
-                    expectedValue = re.getInstant(name);
+                    if (expectedValue.equals(Long.MIN_VALUE)) { // Missing
+                        expectedValue = OffsetDateTime.MIN;
+                    } else {
+                        // Make instant of OffsetDateTime
+                        xmlValue = OffsetDateTime.parse("" + xmlValue).toInstant().toString();
+                        expectedValue = re.getInstant(name);
+                    }
                 }
                 if (v.getAnnotation(Timespan.class) != null) {
                     expectedValue = re.getDuration(name);


### PR DESCRIPTION
Could I have review of a test fix. The timestamp, i.e. field "until" in the Thread Park event, is converted to an Instant value before comparing it to the XML value. This doesn't work when the value is missing (Long.MIN_VALUE). 

Testing: running jdk/jdk/jfr/tool/TestPrintXML.java 300 times without failure. 

Thanks
Erik