### PR TITLE
8286596: AArch64: -XX:UseBranchProtection=pac-ret crashes after JDK-8284161

### DIFF
--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -271,7 +271,7 @@ void RegisterSaver::restore_live_registers(MacroAssembler* masm) {
   __ pop_CPU_state(_save_vectors);
 #endif
   __ ldp(rfp, lr, Address(__ post(sp, 2 * wordSize)));
-
+  __ authenticate_return_address();
 }
 
 // Is vector's size (in bytes) bigger than a size saved by default?


### PR DESCRIPTION
`RegisterSaver::restore_live_registers()` used to call `__ leave()` but after the Loom integration it directly pops LR/FP from the stack.  With `-XX:UseBranchProtection=pac-ret` we need a call to `__ authenticate_return_address()` here to insert the AUTIA instruction to check and strip the PAC code from the saved LR.

Tested `java -XX:UseBranchProtection=pac-ret -version` on a machine that supports PAC, plus tier1.  Note that some additional fixes will be required to support virtual threads with PAC enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286596](https://bugs.openjdk.java.net/browse/JDK-8286596): AArch64: -XX:UseBranchProtection=pac-ret crashes after JDK-8284161


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Ningsheng Jian](https://openjdk.java.net/census#njian) (@nsjian - Committer)


### Contributors
 * Alan Hayward `<ahayward@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8682/head:pull/8682` \
`$ git checkout pull/8682`

Update a local copy of the PR: \
`$ git checkout pull/8682` \
`$ git pull https://git.openjdk.java.net/jdk pull/8682/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8682`

View PR using the GUI difftool: \
`$ git pr show -t 8682`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8682.diff">https://git.openjdk.java.net/jdk/pull/8682.diff</a>

</details>
