### PR TITLE
8286393: Address possibly lossy conversions in java.rmi

### DIFF
--- a/src/java.rmi/share/classes/sun/rmi/log/LogInputStream.java
+++ b/src/java.rmi/share/classes/sun/rmi/log/LogInputStream.java
@@ -103,7 +103,7 @@ class LogInputStream extends InputStream {
             return 0;
         n = (length < n) ? length : n;
         n = in.skip(n);
-        length -= n;
+        length -= (int) n;
         return n;
     }
 

--- a/src/java.smartcardio/share/classes/sun/security/smartcardio/ChannelImpl.java
+++ b/src/java.smartcardio/share/classes/sun/security/smartcardio/ChannelImpl.java
@@ -255,14 +255,14 @@ final class ChannelImpl extends CardChannel {
         if (channel <= 3) {
             // mask of bits 7, 1, 0 (channel number)
             // 0xbc == 1011 1100
-            com[0] &= 0xbc;
-            com[0] |= channel;
+            com[0] &= (byte) 0xbc;
+            com[0] |= (byte) channel;
         } else if (channel <= 19) {
             // mask of bits 7, 3, 2, 1, 0 (channel number)
             // 0xbc == 1011 0000
-            com[0] &= 0xb0;
-            com[0] |= 0x40;
-            com[0] |= (channel - 4);
+            com[0] &= (byte) 0xb0;
+            com[0] |= (byte) 0x40;
+            com[0] |= (byte) (channel - 4);
         } else {
             throw new RuntimeException("Unsupported channel number: " + channel);
         }


### PR DESCRIPTION
Updates to modules java.rmi and java.smartcardio to remove warnings about lossy-conversions introduced by PR#8599.

Explicit casts are inserted where implicit casts occur.

8286393: Address possibly lossy conversions in java.rmi
8286388: Address possibly lossy conversions in java.smartcardio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issues
 * [JDK-8286393](https://bugs.openjdk.java.net/browse/JDK-8286393): Address possibly lossy conversions in java.rmi
 * [JDK-8286388](https://bugs.openjdk.java.net/browse/JDK-8286388): Address possibly lossy conversions in java.smartcardio


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8683/head:pull/8683` \
`$ git checkout pull/8683`

Update a local copy of the PR: \
`$ git checkout pull/8683` \
`$ git pull https://git.openjdk.java.net/jdk pull/8683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8683`

View PR using the GUI difftool: \
`$ git pr show -t 8683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8683.diff">https://git.openjdk.java.net/jdk/pull/8683.diff</a>

</details>
