### PR TITLE
8263075: C2: simplify anti-dependence check in PhaseCFG::implicit_null_check()

### DIFF
--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -331,7 +331,7 @@ void PhaseCFG::implicit_null_check(Block* block, Node *proj, Node *val, int allo
        // mach use (faulting) trying to hoist
        // n might be blocker to hoisting
        // This assert ensures that the following code should be run
-       assert(mb != block, "mb should be distinct from block"); 
+       assert(mb != block, "mb should be distinct from block");
        uint k;
        uint num_nodes = mb->number_of_nodes();
        for (k = 1; k < num_nodes; k++) {

--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -337,12 +337,14 @@ void PhaseCFG::implicit_null_check(Block* block, Node *proj, Node *val, int allo
        for (k = 1; k < num_nodes; k++) {
          Node *n = mb->get_node(k);
          if (n->needs_anti_dependence_check() &&
-             n->in(LoadNode::Memory) == mach->in(StoreNode::Memory))
+             n->in(LoadNode::Memory) == mach->in(StoreNode::Memory)) {
            break;              // Found anti-dependent load
+         }
        }
-       if (k < num_nodes)
+       if (k < num_nodes) {
          continue;             // Found anti-dependent load
-
+       }
+       
        // Make sure control does not do a merge (would have to check allpaths)
        if (mb->num_preds() != 2) continue;
 

--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -326,25 +326,28 @@ void PhaseCFG::implicit_null_check(Block* block, Node *proj, Node *val, int allo
     Block *mb = get_block_for_node(mach);
     // Hoisting stores requires more checks for the anti-dependence case.
     // Give up hoisting if we have to move the store past any load.
-    if( was_store ) {
-      Block *b = mb;            // Start searching here for a local load
-      // mach use (faulting) trying to hoist
-      // n might be blocker to hoisting
-      while( b != block ) {
-        uint k;
-        for( k = 1; k < b->number_of_nodes(); k++ ) {
-          Node *n = b->get_node(k);
-          if( n->needs_anti_dependence_check() &&
-              n->in(LoadNode::Memory) == mach->in(StoreNode::Memory) )
-            break;              // Found anti-dependent load
-        }
-        if( k < b->number_of_nodes() )
-          break;                // Found anti-dependent load
-        // Make sure control does not do a merge (would have to check allpaths)
-        if( b->num_preds() != 2 ) break;
-        b = get_block_for_node(b->pred(1)); // Move up to predecessor block
-      }
-      if( b != block ) continue;
+    if (was_store) {
+       // Start searching here for a local load
+       // mach use (faulting) trying to hoist
+       // n might be blocker to hoisting
+       // This assert ensures that the following code should be run
+       assert(mb != block, "mb should be distinct from block"); 
+       uint k;
+       uint num_nodes = mb->number_of_nodes();
+       for (k = 1; k < num_nodes; k++) {
+         Node *n = mb->get_node(k);
+         if (n->needs_anti_dependence_check() &&
+             n->in(LoadNode::Memory) == mach->in(StoreNode::Memory))
+           break;              // Found anti-dependent load
+       }
+       if (k < num_nodes)
+         continue;             // Found anti-dependent load
+
+       // Make sure control does not do a merge (would have to check allpaths)
+       if (mb->num_preds() != 2) continue;
+
+       // This assert ensures that the above code should only be run once
+       assert(get_block_for_node(mb->pred(1)) == block, "Unexpected predecessor block");
     }
 
     // Make sure this memory op is not already being used for a NullCheck

--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -344,7 +344,7 @@ void PhaseCFG::implicit_null_check(Block* block, Node *proj, Node *val, int allo
        if (k < num_nodes) {
          continue;             // Found anti-dependent load
        }
-       
+
        // Make sure control does not do a merge (would have to check allpaths)
        if (mb->num_preds() != 2) continue;
 

--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -331,9 +331,9 @@ void PhaseCFG::implicit_null_check(Block* block, Node *proj, Node *val, int allo
        if (mb->num_preds() != 2) {
          continue;
        }
-       //mach is a store, hence block is the immediate dominator of mb.
-       //Due to the null-check shape of block (where its successors cannot re-join),
-       //block must be the direct predecessor of mb.
+       // mach is a store, hence block is the immediate dominator of mb.
+       // Due to the null-check shape of block (where its successors cannot re-join),
+       // block must be the direct predecessor of mb.
        assert(get_block_for_node(mb->pred(1)) == block, "Unexpected predecessor block");
        uint k;
        uint num_nodes = mb->number_of_nodes();

--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -330,10 +330,10 @@ void PhaseCFG::implicit_null_check(Block* block, Node *proj, Node *val, int allo
        // Make sure control does not do a merge (would have to check allpaths)
        if (mb->num_preds() != 2) {
          continue;
-       } 
-       //mach is a store, hence block is the immediate dominator of mb. 
-       //Due to the null-check shape of block (where its successors cannot re-join), 
-       //block must be the direct predecessor of mb.       
+       }
+       //mach is a store, hence block is the immediate dominator of mb.
+       //Due to the null-check shape of block (where its successors cannot re-join),
+       //block must be the direct predecessor of mb.
        assert(get_block_for_node(mb->pred(1)) == block, "Unexpected predecessor block");
        uint k;
        uint num_nodes = mb->number_of_nodes();


### PR DESCRIPTION
The reporter for this issue (https://bugs.openjdk.java.net/browse/JDK-8263075) indicated that there's an assumption that we can rely on that the while loop in question will run exactly one time. Based on this, I've done the following:

- Asserted the condition that makes sure the code runs at least once
- Asserted the condition that makes sure the code runs only once
- Removed the `while` loop
- Changed a couple of `break` statements into `continue` statements. They no longer need to break out of the `while` loop, now that it's gone. However, they were early exits from the `while` loop that ended up resulting in `continue` statements for the larger enclosing loop. Thus we can just call `continue` directly.
- Removed the local variable `b`, as we no longer need to traverse the node hierarchy. We can use `mb` directly.

Passes jdk, langtools, and hotspot Tier 1 tests on Linux (x64 and ARM64) and macOS (x64 and ARM64). Most Tier 1 tests pass on Windows (x64 and ARM64), but there are a handful of failures unrelated to this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8263075](https://bugs.openjdk.java.net/browse/JDK-8263075): C2: simplify anti-dependence check in PhaseCFG::implicit_null_check()


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [c055174a](https://git.openjdk.java.net/jdk/pull/8684/files/c055174a1daa445c966f1b12e3094907e8b4d6d1)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [c055174a](https://git.openjdk.java.net/jdk/pull/8684/files/c055174a1daa445c966f1b12e3094907e8b4d6d1)
 * [Roberto Castañeda Lozano](https://openjdk.java.net/census#rcastanedalo) (@robcasloz - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8684/head:pull/8684` \
`$ git checkout pull/8684`

Update a local copy of the PR: \
`$ git checkout pull/8684` \
`$ git pull https://git.openjdk.java.net/jdk pull/8684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8684`

View PR using the GUI difftool: \
`$ git pr show -t 8684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8684.diff">https://git.openjdk.java.net/jdk/pull/8684.diff</a>

</details>
