### PR TITLE
8286668: JFR: Cleanup

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/AnnotationElement.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/AnnotationElement.java
@@ -385,5 +385,4 @@ public final class AnnotationElement {
     boolean isInBoot() {
         return inBootClassLoader;
     }
-
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/EventFactory.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/EventFactory.java
@@ -226,5 +226,4 @@ public final class EventFactory {
     public void unregister() {
         MetadataRepository.getInstance().unregister(eventClass);
     }
-
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/ASMToolkit.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/ASMToolkit.java
@@ -33,40 +33,26 @@ import jdk.internal.org.objectweb.asm.Type;
 import jdk.internal.org.objectweb.asm.util.TraceClassVisitor;
 import jdk.jfr.ValueDescriptor;
 
-public final class ASMToolkit {
+final class ASMToolkit {
     public static final Type TYPE_STRING = Type.getType(String.class);
     private static final Type TYPE_THREAD = Type.getType(Thread.class);
     private static final Type TYPE_CLASS = Type.getType(Class.class);
 
     public static Type toType(ValueDescriptor v) {
-        String typeName = v.getTypeName();
-
-        switch (typeName) {
-        case "byte":
-            return Type.BYTE_TYPE;
-        case "short":
-            return Type.SHORT_TYPE;
-        case "int":
-            return Type.INT_TYPE;
-        case "long":
-            return Type.LONG_TYPE;
-        case "double":
-            return Type.DOUBLE_TYPE;
-        case "float":
-            return Type.FLOAT_TYPE;
-        case "char":
-            return Type.CHAR_TYPE;
-        case "boolean":
-            return Type.BOOLEAN_TYPE;
-        case "java.lang.String":
-            return TYPE_STRING;
-        case "java.lang.Thread":
-            return TYPE_THREAD;
-        case "java.lang.Class":
-            return TYPE_CLASS;
-        }
-        // Add support for SettingControl?
-       throw new Error("Not a valid type " + v.getTypeName());
+        return switch (v.getTypeName()) {
+            case "byte" -> Type.BYTE_TYPE;
+            case "short" -> Type.SHORT_TYPE;
+            case "int" ->  Type.INT_TYPE;
+            case "long" ->Type.LONG_TYPE;
+            case "double" -> Type.DOUBLE_TYPE;
+            case "float" -> Type.FLOAT_TYPE;
+            case "char" -> Type.CHAR_TYPE;
+            case "boolean" -> Type.BOOLEAN_TYPE;
+            case "java.lang.String" -> TYPE_STRING;
+            case "java.lang.Thread" -> TYPE_THREAD;
+            case "java.lang.Class" -> TYPE_CLASS;
+            default -> throw new Error("Not a valid type " + v.getTypeName());
+        };
     }
 
     /**
@@ -78,32 +64,17 @@ public final class ASMToolkit {
      * @return descriptor
      */
     public static String getDescriptor(String typeName) {
-        if ("int".equals(typeName)) {
-            return "I";
-        }
-        if ("long".equals(typeName)) {
-            return "J";
-        }
-        if ("boolean".equals(typeName)) {
-            return "Z";
-        }
-        if ("float".equals(typeName)) {
-            return "F";
-        }
-        if ("double".equals(typeName)) {
-            return "D";
-        }
-        if ("short".equals(typeName)) {
-            return "S";
-        }
-        if ("char".equals(typeName)) {
-            return "C";
-        }
-        if ("byte".equals(typeName)) {
-            return "B";
-        }
-        String internal = getInternalName(typeName);
-        return Type.getObjectType(internal).getDescriptor();
+        return switch (typeName) {
+            case "int" -> "I";
+            case "long" -> "J";
+            case "boolean" -> "Z";
+            case "float" -> "F";
+            case "double" -> "D";
+            case "short" -> "S";
+            case "char" -> "C";
+            case "byte" -> "B";
+            default -> Type.getObjectType(getInternalName(typeName)).getDescriptor();
+        };
     }
 
     /**

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/AnnotationConstruct.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/AnnotationConstruct.java
@@ -38,11 +38,11 @@ import jdk.jfr.Unsigned;
 
 public final class AnnotationConstruct {
 
-    private static final class AnnotationInvokationHandler implements InvocationHandler {
+    private static final class AnnotationInvocationHandler implements InvocationHandler {
 
         private final AnnotationElement annotationElement;
 
-        AnnotationInvokationHandler(AnnotationElement a) {
+        AnnotationInvocationHandler(AnnotationElement a) {
             this.annotationElement = a;
         }
 
@@ -91,7 +91,7 @@ public final class AnnotationConstruct {
     public final <T> T getAnnotation(Class<? extends Annotation> clazz) {
         AnnotationElement ae = getAnnotationElement(clazz);
         if (ae != null) {
-            return (T) Proxy.newProxyInstance(clazz.getClassLoader(), new Class<?>[] { clazz }, new AnnotationInvokationHandler(ae));
+            return (T) Proxy.newProxyInstance(clazz.getClassLoader(), new Class<?>[] { clazz }, new AnnotationInvocationHandler(ae));
         }
         return null;
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Control.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Control.java
@@ -36,7 +36,7 @@ import java.util.Set;
 import jdk.jfr.SettingControl;
 import jdk.jfr.internal.settings.JDKSettingControl;
 
-public final class Control {
+final class Control {
     @SuppressWarnings("removal")
     private final AccessControlContext context;
     private static final int CACHE_SIZE = 5;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventControl.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventControl.java
@@ -56,13 +56,7 @@ import jdk.jfr.internal.settings.ThrottleSetting;
 // holds SettingControl instances that need to be released
 // when a class is unloaded (to avoid memory leaks).
 public final class EventControl {
-    static final class NamedControl {
-        public final String name;
-        public final Control control;
-        NamedControl(String name, Control control) {
-            this.name = name;
-            this.control = control;
-        }
+    record NamedControl(String name, Control control) {
     }
     static final String FIELD_SETTING_PREFIX = "setting";
     private static final Type TYPE_ENABLED = TypeLibrary.createType(EnabledSetting.class);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataDescriptor.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataDescriptor.java
@@ -41,14 +41,7 @@ import jdk.jfr.internal.consumer.RecordingInput;
  */
 public final class MetadataDescriptor {
 
-    static final class Attribute {
-        final String name;
-        final String value;
-
-        private Attribute(String name, String value) {
-            this.name = name;
-            this.value = value;
-        }
+    record Attribute(String name, String value) {
     }
 
     static final class Element {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataLoader.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataLoader.java
@@ -111,7 +111,7 @@ public final class MetadataLoader {
     }
 
     // <Field>
-    private static class FieldElement {
+    private static final class FieldElement {
         private final String name;
         private final String label;
         private final String description;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataReader.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataReader.java
@@ -181,33 +181,26 @@ final class MetadataReader {
 
     private Object objectify(String typeName, String text) throws IOException {
         try {
-            switch (typeName) {
-            case "int":
-                return Integer.valueOf(text);
-            case "long":
-                return Long.valueOf(text);
-            case "double":
-                return Double.valueOf(text);
-            case "float":
-                return Float.valueOf(text);
-            case "short":
-                return Short.valueOf(text);
-            case "char":
-                if (text.length() != 1) {
-                    throw new IOException("Unexpected size of char");
+            return switch (typeName) {
+                case "int" -> Integer.valueOf(text);
+                case "long" -> Long.valueOf(text);
+                case "double" ->   Double.valueOf(text);
+                case "float" -> Float.valueOf(text);
+                case "short" -> Short.valueOf(text);
+                case "char" -> {
+                    if (text.length() != 1) {
+                        throw new IOException("Unexpected size of char");
+                    }
+                    yield text.charAt(0);
                 }
-                return text.charAt(0);
-            case "byte":
-                return Byte.valueOf(text);
-            case "boolean":
-                return Boolean.valueOf(text);
-            case "java.lang.String":
-                return text;
-            }
+                case "byte" -> Byte.valueOf(text);
+                case "boolean" -> Boolean.valueOf(text);
+                case "java.lang.String" -> text;
+                default -> throw new IOException("Unsupported type for annotation " + typeName);
+            };
         } catch (IllegalArgumentException iae) {
             throw new IOException("Could not parse text representation of " + typeName);
         }
-        throw new IOException("Unsupported type for annotation " + typeName);
     }
 
     private Type getType(String attribute, Element element) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -38,7 +38,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import jdk.jfr.AnnotationElement;
 import jdk.jfr.Event;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataWriter.java
@@ -137,8 +137,8 @@ final class MetadataWriter {
     private void buildStringPool(Element element, Set<String> pool) {
         pool.add(element.name);
         for (Attribute a : element.attributes) {
-            pool.add(a.name);
-            pool.add(a.value);
+            pool.add(a.name());
+            pool.add(a.value());
         }
         for (Element child : element.elements) {
             buildStringPool(child, pool);
@@ -149,8 +149,8 @@ final class MetadataWriter {
         writeInt(output, lookup.get(element.name));
         writeInt(output, element.attributes.size());
         for (Attribute a : element.attributes) {
-            writeInt(output, lookup.get(a.name));
-            writeInt(output, lookup.get(a.value));
+            writeInt(output, lookup.get(a.name()));
+            writeInt(output, lookup.get(a.value()));
         }
         writeInt(output, element.elements.size());
         for (Element child : element.elements) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/SettingsManager.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/SettingsManager.java
@@ -219,11 +219,11 @@ final class SettingsManager {
         }
         for (NamedControl nc: ec.getNamedControls()) {
             Set<String> values = null;
-            String settingName = nc.name;
+            String settingName = nc.name();
             if (is != null) {
                 values = is.getValues(settingName);
             }
-            Control control = nc.control;
+            Control control = nc.control();
             if (values != null) {
                 control.apply(values);
                 String after = control.getLastValue();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
@@ -59,19 +59,14 @@ public abstract class AbstractEventStream implements EventStream {
     @SuppressWarnings("removal")
     private final AccessControlContext accessControllerContext;
     private final StreamConfiguration streamConfiguration = new StreamConfiguration();
-    protected final PlatformRecording recording;
     private final List<Configuration> configurations;
-
+    private final ParserState parserState = new ParserState();
     private volatile Thread thread;
     private Dispatcher dispatcher;
-
-    protected final ParserState parserState = new ParserState();
-
     private boolean daemon = false;
 
-    AbstractEventStream(@SuppressWarnings("removal") AccessControlContext acc, PlatformRecording recording, List<Configuration> configurations) throws IOException {
+    AbstractEventStream(@SuppressWarnings("removal") AccessControlContext acc, List<Configuration> configurations) throws IOException {
         this.accessControllerContext = Objects.requireNonNull(acc);
-        this.recording = recording;
         this.configurations = configurations;
     }
 
@@ -215,12 +210,18 @@ public abstract class AbstractEventStream implements EventStream {
 
     protected abstract void process() throws IOException;
 
+    protected abstract boolean isRecording();
+
     protected final void closeParser() {
         parserState.close();
     }
 
     protected final boolean isClosed() {
         return parserState.isClosed();
+    }
+
+    protected final ParserState parserState() {
+        return parserState;
     }
 
     public final void startAsync(long startNanos) {
@@ -254,7 +255,7 @@ public abstract class AbstractEventStream implements EventStream {
             if (streamConfiguration.started) {
                 throw new IllegalStateException("Event stream can only be started once");
             }
-            if (recording != null && streamConfiguration.startTime == null) {
+            if (isRecording() && streamConfiguration.startTime == null) {
                 streamConfiguration.setStartNanos(startNanos);
             }
             streamConfiguration.setStarted(true);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkHeader.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkHeader.java
@@ -31,7 +31,6 @@ import jdk.jfr.internal.LogLevel;
 import jdk.jfr.internal.LogTag;
 import jdk.jfr.internal.Logger;
 import jdk.jfr.internal.MetadataDescriptor;
-import jdk.jfr.internal.Utils;
 
 public final class ChunkHeader {
     public static final long HEADER_SIZE = 68;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
@@ -50,30 +50,17 @@ import jdk.jfr.internal.consumer.filter.ChunkWriter;
  */
 public final class ChunkParser {
 
-    public static final class ParserConfiguration {
-        private final boolean reuse;
-        private final boolean ordered;
-        private final ParserFilter eventFilter;
-        private final ChunkWriter chunkWriter;
-
-        long filterStart;
-        long filterEnd;
-
-        public ParserConfiguration(long filterStart, long filterEnd, boolean reuse, boolean ordered, ParserFilter filter, ChunkWriter chunkWriter) {
-            this.filterStart = filterStart;
-            this.filterEnd = filterEnd;
-            this.reuse = reuse;
-            this.ordered = ordered;
-            this.eventFilter = filter;
-            this.chunkWriter = chunkWriter;
-        }
+    public record ParserConfiguration(long filterStart, long filterEnd, boolean reuse,  boolean ordered, ParserFilter filter, ChunkWriter chunkWriter) {
 
         public ParserConfiguration() {
             this(0, Long.MAX_VALUE, false, false, ParserFilter.ACCEPT_ALL, null);
         }
 
-        public boolean isOrdered() {
-            return ordered;
+        ParserConfiguration withRange(long filterStart, long filterEnd) {
+            if (filterStart == this.filterStart && filterEnd == this.filterEnd) {
+                return this;
+            }
+            return new ParserConfiguration(filterStart, filterEnd, reuse, ordered, filter, chunkWriter);
         }
     }
 
@@ -178,7 +165,7 @@ public final class ChunkParser {
                 ep.setReuse(configuration.reuse);
                 ep.setFilterStart(configuration.filterStart);
                 ep.setFilterEnd(configuration.filterEnd);
-                long threshold = configuration.eventFilter.getThreshold(name);
+                long threshold = configuration.filter().getThreshold(name);
                 if (threshold >= 0) {
                     ep.setEnabled(true);
                     ep.setThresholdNanos(threshold);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ConstantLookup.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ConstantLookup.java
@@ -28,7 +28,7 @@ package jdk.jfr.internal.consumer;
 import jdk.jfr.internal.Type;
 
 final class ConstantLookup {
-    final Type type;
+    private final Type type;
     private ConstantMap current;
     private ConstantMap previous = ConstantMap.EMPTY;
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
@@ -41,7 +41,6 @@ import jdk.jfr.internal.JVM;
 import jdk.jfr.internal.PlatformRecording;
 import jdk.jfr.internal.SecuritySupport;
 import jdk.jfr.internal.Utils;
-import jdk.jfr.internal.consumer.ChunkParser.ParserConfiguration;
 
 /**
  * Implementation of an {@code EventStream}} that operates against a directory
@@ -54,7 +53,7 @@ public final class EventDirectoryStream extends AbstractEventStream {
 
     private final RepositoryFiles repositoryFiles;
     private final FileAccess fileAccess;
-
+    private final PlatformRecording recording;
     private ChunkParser currentParser;
     private long currentChunkStartNanos;
     private RecordedEvent[] sortedCache;
@@ -70,7 +69,8 @@ public final class EventDirectoryStream extends AbstractEventStream {
             PlatformRecording recording,
             List<Configuration> configurations,
             boolean allowSubDirectories) throws IOException {
-        super(acc, recording, configurations);
+        super(acc, configurations);
+        this.recording = recording;
         if (p != null && SecuritySupport.PRIVILEGED == fileAccess) {
             throw new SecurityException("Priviliged file access not allowed with potentially malicious Path implementation");
         }
@@ -134,7 +134,7 @@ public final class EventDirectoryStream extends AbstractEventStream {
         Dispatcher lastDisp = null;
         Dispatcher disp = dispatcher();
         Path path;
-        boolean validStartTime = recording != null || disp.startTime != null;
+        boolean validStartTime = isRecording() || disp.startTime != null;
         if (validStartTime) {
             path = repositoryFiles.firstPath(disp.startNanos, true);
         } else {
@@ -146,7 +146,7 @@ public final class EventDirectoryStream extends AbstractEventStream {
         currentChunkStartNanos = repositoryFiles.getTimestamp(path);
         try (RecordingInput input = new RecordingInput(path.toFile(), fileAccess)) {
             input.setStreamed();
-            currentParser = new ChunkParser(input, disp.parserConfiguration, parserState);
+            currentParser = new ChunkParser(input, disp.parserConfiguration, parserState());
             long segmentStart = currentParser.getStartNanos() + currentParser.getChunkDuration();
             long filterStart = validStartTime ? disp.startNanos : segmentStart;
             long filterEnd = disp.endTime != null ? disp.endNanos : Long.MAX_VALUE;
@@ -156,13 +156,11 @@ public final class EventDirectoryStream extends AbstractEventStream {
                 while (!isClosed() && !currentParser.isChunkFinished()) {
                     disp = dispatcher();
                     if (disp != lastDisp) {
-                        ParserConfiguration pc = disp.parserConfiguration;
-                        pc.filterStart = filterStart;
-                        pc.filterEnd = filterEnd;
-                        currentParser.updateConfiguration(pc, true);
+                        var ranged = disp.parserConfiguration.withRange(filterStart, filterEnd);
+                        currentParser.updateConfiguration(ranged, true);
                         lastDisp = disp;
                     }
-                    if (disp.parserConfiguration.isOrdered()) {
+                    if (disp.parserConfiguration.ordered()) {
                         processOrdered(disp);
                     } else {
                         processUnordered(disp);
@@ -208,10 +206,14 @@ public final class EventDirectoryStream extends AbstractEventStream {
     }
 
     private boolean isLastChunk() {
-        if (recording == null) {
+        if (!isRecording()) {
             return false;
         }
         return recording.getFinalChunkStartNanos() >= currentParser.getStartNanos();
+    }
+
+    protected boolean isRecording() {
+        return recording != null;
     }
 
     private void processOrdered(Dispatcher c) throws IOException {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventFileStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventFileStream.java
@@ -31,7 +31,6 @@ import java.security.AccessControlContext;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Objects;
 import jdk.jfr.consumer.RecordedEvent;
 
 /**
@@ -47,7 +46,7 @@ public final class EventFileStream extends AbstractEventStream {
     private RecordedEvent[] cacheSorted;
 
     public EventFileStream(@SuppressWarnings("removal") AccessControlContext acc, Path file) throws IOException {
-        super(acc, null, Collections.emptyList());
+        super(acc, Collections.emptyList());
         this.input = new RecordingInput(file.toFile(), FileAccess.UNPRIVILEGED);
         this.input.setStreamed();
     }
@@ -74,6 +73,11 @@ public final class EventFileStream extends AbstractEventStream {
     }
 
     @Override
+    protected boolean isRecording() {
+        return false;
+    }
+
+    @Override
     protected void process() throws IOException {
         Dispatcher disp = dispatcher();
         long start = 0;
@@ -85,7 +89,7 @@ public final class EventFileStream extends AbstractEventStream {
             end = disp.endNanos;
         }
 
-        currentParser = new ChunkParser(input, disp.parserConfiguration, parserState);
+        currentParser = new ChunkParser(input, disp.parserConfiguration, parserState());
         while (!isClosed()) {
             onMetadata(currentParser);
             if (currentParser.getStartNanos() > end) {
@@ -93,10 +97,9 @@ public final class EventFileStream extends AbstractEventStream {
                 return;
             }
             disp = dispatcher();
-            disp.parserConfiguration.filterStart = start;
-            disp.parserConfiguration.filterEnd = end;
-            currentParser.updateConfiguration(disp.parserConfiguration, true);
-            if (disp.parserConfiguration.isOrdered()) {
+            var ranged  = disp.parserConfiguration.withRange(start, end);
+            currentParser.updateConfiguration(ranged, true);
+            if (disp.parserConfiguration.ordered()) {
                 processOrdered(disp);
             } else {
                 processUnordered(disp);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventParser.java
@@ -28,9 +28,7 @@ package jdk.jfr.internal.consumer;
 import static jdk.jfr.internal.EventInstrumentation.FIELD_DURATION;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Predicate;
 
 import jdk.jfr.EventType;
 import jdk.jfr.ValueDescriptor;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/FinishedStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/FinishedStream.java
@@ -63,5 +63,4 @@ public final class FinishedStream extends EventByteStream {
     public synchronized void close() throws IOException {
         inputStream.close();
     }
-
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ParserFactory.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ParserFactory.java
@@ -122,31 +122,23 @@ final class ParserFactory {
     }
 
     private Parser createPrimitiveParser(Type type, boolean event) throws IOException {
-        switch (type.getName()) {
-        case "int":
-            return new IntegerParser();
-        case "long":
-            return new LongParser();
-        case "float":
-            return new FloatParser();
-        case "double":
-            return new DoubleParser();
-        case "char":
-            return new CharacterParser();
-        case "boolean":
-            return new BooleanParser();
-        case "short":
-            return new ShortParser();
-        case "byte":
-            return new ByteParser();
-        case "java.lang.String":
-            ConstantMap pool = new ConstantMap(ObjectFactory.create(type, timeConverter), type);
-            ConstantLookup lookup = new ConstantLookup(pool, type);
-            constantLookups.put(type.getId(), lookup);
-            return new StringParser(lookup, event);
-        default:
-            throw new IOException("Unknown primitive type " + type.getName());
-        }
+        return switch (type.getName()) {
+            case "int" ->  new IntegerParser();
+            case "long" -> new LongParser();
+            case "float" ->  new FloatParser();
+            case "double" -> new DoubleParser();
+            case "char" ->  new CharacterParser();
+            case "boolean" -> new BooleanParser();
+            case "short" -> new ShortParser();
+            case "byte" ->  new ByteParser();
+            case "java.lang.String" -> {
+                ConstantMap pool = new ConstantMap(ObjectFactory.create(type, timeConverter), type);
+                ConstantLookup lookup = new ConstantLookup(pool, type);
+                constantLookups.put(type.getId(), lookup);
+                yield new StringParser(lookup, event);
+            }
+            default ->  throw new IOException("Unknown primitive type " + type.getName());
+        };
     }
 
     private Parser registerParserType(Type t, Parser parser) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/ConstructorTracerWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/ConstructorTracerWriter.java
@@ -38,7 +38,8 @@ import jdk.internal.org.objectweb.asm.Type;
 
 final class ConstructorTracerWriter extends ClassVisitor {
 
-    private ConstructorWriter useInputParameter, noUseInputParameter;
+    private final ConstructorWriter useInputParameter;
+    private final ConstructorWriter noUseInputParameter;
 
     static byte[] generateBytes(Class<?> clz, byte[] oldBytes) throws IOException {
         InputStream in = new ByteArrayInputStream(oldBytes);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/ConstructorWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/ConstructorWriter.java
@@ -34,9 +34,9 @@ import jdk.internal.org.objectweb.asm.Opcodes;
 
 final class ConstructorWriter extends MethodVisitor {
 
-    private boolean useInputParameter;
-    private String shortClassName;
-    private String fullClassName;
+    private final boolean useInputParameter;
+    private final String shortClassName;
+    private final String fullClassName;
 
     ConstructorWriter(Class<?> classToChange, boolean useInputParameter) {
         super(Opcodes.ASM7);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Filters.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Filters.java
@@ -39,7 +39,6 @@ import jdk.jfr.consumer.RecordedEvent;
  * Helper class for creating filters.
  */
 public class Filters {
-    private static final Predicate<RecordedThread> FALSE_THREAD_PREDICATE = e -> false;
 
     static Predicate<EventType> createCategoryFilter(String filterText) throws UserSyntaxException {
         List<String> filters = explodeFilter(filterText);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Main.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Main.java
@@ -25,9 +25,9 @@
 
 package jdk.jfr.internal.tool;
 
+import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
-import java.util.LinkedList;
 
 /**
  * Launcher class for the JDK_HOME\bin\jfr tool
@@ -40,7 +40,7 @@ public final class Main {
     private static final int EXIT_WRONG_ARGUMENTS = 2;
 
     public static void main(String... args) {
-        Deque<String> argList = new LinkedList<>(Arrays.asList(args));
+        Deque<String> argList = new ArrayDeque<>(Arrays.asList(args));
         if (argList.isEmpty()) {
             System.out.println(Command.title);
             System.out.println();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/StructuredWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/StructuredWriter.java
@@ -31,7 +31,7 @@ abstract class StructuredWriter {
     private final PrintWriter out;
     private final StringBuilder builder = new StringBuilder(4000);
 
-    private char[] indentionArray = new char[0];
+    private String indention = "";
     private int indent = 0;
     private int column;
     // print first event immediately so tool feels responsive
@@ -65,7 +65,7 @@ abstract class StructuredWriter {
     }
 
     public final void printIndent() {
-        builder.append(indentionArray, 0, indent);
+        builder.append(indention, 0, indent);
         column += indent;
     }
 
@@ -114,11 +114,8 @@ abstract class StructuredWriter {
     }
 
     private void updateIndent() {
-        if (indent > indentionArray.length) {
-            indentionArray = new char[indent];
-            for (int i = 0; i < indentionArray.length; i++) {
-                indentionArray[i] = ' ';
-            }
+        if (indent > indention.length()) {
+            indention = " ".repeat(2 * indent);
         }
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Summary.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Summary.java
@@ -147,19 +147,11 @@ final class Summary extends Command {
             String header = "      Count  Size (bytes) ";
             String typeHeader = " Event Type";
             minWidth = Math.max(minWidth, typeHeader.length());
-            println(typeHeader + pad(minWidth - typeHeader.length(), ' ') + header);
-            println(pad(minWidth + header.length(), '='));
+            println(typeHeader + " ".repeat(minWidth - typeHeader.length()) + header);
+            println("=".repeat(minWidth + header.length()));
             for (Statistics s : statsList) {
                 System.out.printf(" %-" + minWidth + "s%10d  %12d\n", s.name, s.count, s.size);
             }
         }
-    }
-
-    private String pad(int count, char c) {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < count; i++) {
-            sb.append(c);
-        }
-        return sb.toString();
     }
 }


### PR DESCRIPTION
Could I have a review of some cleanups (remove unused imports, use record classes, change to switch expressions, remove unnecessary empty lines etc).

Most changes are self-explanatory, but the AbstractEventStream class may need a comment. It's changed so it no longer takes a recording object in the constructor. This means the recording object can be kept in a private field in the subclass EventDirectoryStream, which seems more appropriate as the object is not needed in the base class and its other subclass EventFileStream. A isRecording() method is added to describe if a stream is tied to an ongoing recording or not. The field parserState is made private, but exposed to subclasses using the parserState() method.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286668](https://bugs.openjdk.java.net/browse/JDK-8286668): JFR: Cleanup


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8687/head:pull/8687` \
`$ git checkout pull/8687`

Update a local copy of the PR: \
`$ git checkout pull/8687` \
`$ git pull https://git.openjdk.java.net/jdk pull/8687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8687`

View PR using the GUI difftool: \
`$ git pr show -t 8687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8687.diff">https://git.openjdk.java.net/jdk/pull/8687.diff</a>

</details>
