### PR TITLE
8286671: (fc) Modify sun.nio.ch.FileChannelImpl.map0() to accept a FileDescriptor parameter

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -1239,7 +1239,7 @@ public class FileChannelImpl
                 mapSize = size + pagePosition;
                 try {
                     // If map0 did not throw an exception, the address is valid
-                    addr = map0(prot, mapPosition, mapSize, isSync);
+                    addr = map0(fd, prot, mapPosition, mapSize, isSync);
                 } catch (OutOfMemoryError x) {
                     // An OutOfMemoryError may indicate that we've exhausted
                     // memory so force gc and re-attempt map
@@ -1250,7 +1250,7 @@ public class FileChannelImpl
                         Thread.currentThread().interrupt();
                     }
                     try {
-                        addr = map0(prot, mapPosition, mapSize, isSync);
+                        addr = map0(fd, prot, mapPosition, mapSize, isSync);
                     } catch (OutOfMemoryError y) {
                         // After a second OOME, fail
                         throw new IOException("Map failed", y);
@@ -1500,7 +1500,8 @@ public class FileChannelImpl
     // -- Native methods --
 
     // Creates a new mapping
-    private native long map0(int prot, long position, long length, boolean isSync)
+    private native long map0(FileDescriptor fd, int prot, long position,
+                             long length, boolean isSync)
         throws IOException;
 
     // Removes an existing mapping

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -1515,12 +1515,12 @@ public class FileChannelImpl
     // Retrieves the maximum size of a transfer
     private static native int maxDirectTransferSize0();
 
-    // Caches fieldIDs
-    private static native long initIDs();
+    // Retrieves allocation granularity
+    private static native long allocationGranularity0();
 
     static {
         IOUtil.load();
-        allocationGranularity = initIDs();
+        allocationGranularity = allocationGranularity0();
         MAX_DIRECT_TRANSFER_SIZE = maxDirectTransferSize0();
     }
 }

--- a/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
+++ b/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
@@ -50,13 +50,10 @@
 #include "java_lang_Integer.h"
 #include <assert.h>
 
-static jfieldID chan_fd;        /* jobject 'fd' in sun.nio.ch.FileChannelImpl */
-
 JNIEXPORT jlong JNICALL
 Java_sun_nio_ch_FileChannelImpl_initIDs(JNIEnv *env, jclass clazz)
 {
     jlong pageSize = sysconf(_SC_PAGESIZE);
-    chan_fd = (*env)->GetFieldID(env, clazz, "fd", "Ljava/io/FileDescriptor;");
     return pageSize;
 }
 
@@ -73,11 +70,10 @@ handle(JNIEnv *env, jlong rv, char *msg)
 
 
 JNIEXPORT jlong JNICALL
-Java_sun_nio_ch_FileChannelImpl_map0(JNIEnv *env, jobject this,
+Java_sun_nio_ch_FileChannelImpl_map0(JNIEnv *env, jobject this, jobject fdo,
                                      jint prot, jlong off, jlong len, jboolean map_sync)
 {
     void *mapAddress = 0;
-    jobject fdo = (*env)->GetObjectField(env, this, chan_fd);
     jint fd = fdval(env, fdo);
     int protections = 0;
     int flags = 0;

--- a/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
+++ b/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
@@ -51,7 +51,7 @@
 #include <assert.h>
 
 JNIEXPORT jlong JNICALL
-Java_sun_nio_ch_FileChannelImpl_initIDs(JNIEnv *env, jclass clazz)
+Java_sun_nio_ch_FileChannelImpl_allocationGranularity0(JNIEnv *env, jclass clazz)
 {
     jlong pageSize = sysconf(_SC_PAGESIZE);
     return pageSize;

--- a/src/java.base/windows/native/libnio/ch/FileChannelImpl.c
+++ b/src/java.base/windows/native/libnio/ch/FileChannelImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,11 +37,10 @@
 #pragma comment(lib, "Mswsock.lib")
 
 /**************************************************************
- * static method to store field ID's in initializers
- * and retrieve the allocation granularity
+ * static method to retrieve the allocation granularity
  */
 JNIEXPORT jlong JNICALL
-Java_sun_nio_ch_FileChannelImpl_initIDs(JNIEnv *env, jclass clazz)
+Java_sun_nio_ch_FileChannelImpl_allocationGranularity0(JNIEnv *env, jclass clazz)
 {
     SYSTEM_INFO si;
     jint align;

--- a/src/java.base/windows/native/libnio/ch/FileChannelImpl.c
+++ b/src/java.base/windows/native/libnio/ch/FileChannelImpl.c
@@ -36,8 +36,6 @@
 #include <Mswsock.h>
 #pragma comment(lib, "Mswsock.lib")
 
-static jfieldID chan_fd; /* id for jobject 'fd' in java.io.FileChannel */
-
 /**************************************************************
  * static method to store field ID's in initializers
  * and retrieve the allocation granularity
@@ -49,7 +47,6 @@ Java_sun_nio_ch_FileChannelImpl_initIDs(JNIEnv *env, jclass clazz)
     jint align;
     GetSystemInfo(&si);
     align = si.dwAllocationGranularity;
-    chan_fd = (*env)->GetFieldID(env, clazz, "fd", "Ljava/io/FileDescriptor;");
     return align;
 }
 
@@ -59,7 +56,7 @@ Java_sun_nio_ch_FileChannelImpl_initIDs(JNIEnv *env, jclass clazz)
  */
 
 JNIEXPORT jlong JNICALL
-Java_sun_nio_ch_FileChannelImpl_map0(JNIEnv *env, jobject this,
+Java_sun_nio_ch_FileChannelImpl_map0(JNIEnv *env, jobject this, jobject fdo,
                                      jint prot, jlong off, jlong len, jboolean map_sync)
 {
     void *mapAddress = 0;
@@ -68,7 +65,6 @@ Java_sun_nio_ch_FileChannelImpl_map0(JNIEnv *env, jobject this,
     jlong maxSize = off + len;
     jint lowLen = (jint)(maxSize);
     jint highLen = (jint)(maxSize >> 32);
-    jobject fdo = (*env)->GetObjectField(env, this, chan_fd);
     HANDLE fileHandle = (HANDLE)(handleval(env, fdo));
     HANDLE mapping;
     DWORD mapAccess = FILE_MAP_READ;


### PR DESCRIPTION
Add a `FileDescriptor` as the first parameter of `map0()` and remove from the corresponding native code the use of `fd_chan`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286671](https://bugs.openjdk.java.net/browse/JDK-8286671): (fc) Modify sun.nio.ch.FileChannelImpl.map0() to accept a FileDescriptor parameter


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [1b022d82](https://git.openjdk.java.net/jdk/pull/8689/files/1b022d82c97fe9d5e4daa33e3f513df25757f614)
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - Committer) ⚠️ Review applies to [1b022d82](https://git.openjdk.java.net/jdk/pull/8689/files/1b022d82c97fe9d5e4daa33e3f513df25757f614)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8689/head:pull/8689` \
`$ git checkout pull/8689`

Update a local copy of the PR: \
`$ git checkout pull/8689` \
`$ git pull https://git.openjdk.java.net/jdk pull/8689/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8689`

View PR using the GUI difftool: \
`$ git pr show -t 8689`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8689.diff">https://git.openjdk.java.net/jdk/pull/8689.diff</a>

</details>
