### PR TITLE
8286681: ShenandoahControlThread::request_gc misses the case of GCCause::_codecache_GC_threshold

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013, 2021, Red Hat, Inc. All rights reserved.
+ * Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -478,6 +479,7 @@ void ShenandoahControlThread::request_gc(GCCause::Cause cause) {
   assert(GCCause::is_user_requested_gc(cause) ||
          GCCause::is_serviceability_requested_gc(cause) ||
          cause == GCCause::_metadata_GC_clear_soft_refs ||
+         cause == GCCause::_codecache_GC_threshold ||
          cause == GCCause::_full_gc_alot ||
          cause == GCCause::_wb_full_gc ||
          cause == GCCause::_wb_breakpoint ||

--- a/test/jdk/java/foreign/TestIntrinsics.java
+++ b/test/jdk/java/foreign/TestIntrinsics.java
@@ -32,21 +32,6 @@
  *   TestIntrinsics
  */
 
-/*
- * @test
- * @bug 8286681
- * @summary ShenandoahControlThread::request_gc misses the case of GCCause::_codecache_GC_threshold
- * @enablePreview
- * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
- * @requires vm.gc.Shenandoah
- * @run testng/othervm
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   --enable-native-access=ALL-UNNAMED
- *   -Xbatch
- *   -XX:+UseShenandoahGC
- *   TestIntrinsics
- */
-
 import java.lang.foreign.Addressable;
 import java.lang.foreign.Linker;
 import java.lang.foreign.FunctionDescriptor;

--- a/test/jdk/java/foreign/TestIntrinsics.java
+++ b/test/jdk/java/foreign/TestIntrinsics.java
@@ -32,6 +32,21 @@
  *   TestIntrinsics
  */
 
+/*
+ * @test
+ * @bug 8286681
+ * @summary ShenandoahControlThread::request_gc misses the case of GCCause::_codecache_GC_threshold
+ * @enablePreview
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @requires vm.gc.Shenandoah
+ * @run testng/othervm
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Xbatch
+ *   -XX:+UseShenandoahGC
+ *   TestIntrinsics
+ */
+
 import java.lang.foreign.Addressable;
 import java.lang.foreign.Linker;
 import java.lang.foreign.FunctionDescriptor;


### PR DESCRIPTION
Hi all,

Some tests fail with Shenandoah GC after JDK-8282191.
The reason is that the assert in `ShenandoahControlThread::request_gc` misses the case of `GCCause::_codecache_GC_threshold`.
It would be better to fix it.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286681](https://bugs.openjdk.java.net/browse/JDK-8286681): ShenandoahControlThread::request_gc misses the case of GCCause::_codecache_GC_threshold


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**) ⚠️ Review applies to [8f094d32](https://git.openjdk.java.net/jdk/pull/8691/files/8f094d32b2a0f0fdb99ff72eed6f7125e0c5768e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8691/head:pull/8691` \
`$ git checkout pull/8691`

Update a local copy of the PR: \
`$ git checkout pull/8691` \
`$ git pull https://git.openjdk.java.net/jdk pull/8691/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8691`

View PR using the GUI difftool: \
`$ git pr show -t 8691`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8691.diff">https://git.openjdk.java.net/jdk/pull/8691.diff</a>

</details>
