### PR TITLE
8284115: [IR Framework] Compilation is not found due to rare safepoint while dumping PrintIdeal/PrintOptoAssembly

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/AbstractLine.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/AbstractLine.java
@@ -25,6 +25,8 @@ package compiler.lib.ir_framework.driver.irmatching.parser;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Base class of a read line from the hotspot_pid* file.
@@ -32,9 +34,11 @@ import java.io.IOException;
 abstract class AbstractLine {
     private final BufferedReader reader;
     protected String line;
+    private final Pattern compileIdPatternForTestClass;
 
-    public AbstractLine(BufferedReader reader) {
+    public AbstractLine(BufferedReader reader, Pattern compileIdPatternForTestClass) {
         this.reader = reader;
+        this.compileIdPatternForTestClass = compileIdPatternForTestClass;
     }
 
     public String getLine() {
@@ -47,5 +51,38 @@ abstract class AbstractLine {
     public boolean readLine() throws IOException {
         line = reader.readLine();
         return line != null;
+    }
+
+    /**
+     * Is this line a start of a method in the test class? We only care about test class entries. There might be non-class
+     * entries as well if the user specified additional compile commands. Ignore these.
+     */
+    public boolean isTestClassCompilation() {
+        if (isCompilation()) {
+            Matcher matcher = compileIdPatternForTestClass.matcher(line);
+            return matcher.find();
+        }
+        return false;
+    }
+
+    /**
+     * Is this header a C2 non-OSR compilation header entry?
+     */
+    public boolean isCompilation() {
+        return line.startsWith("<task_queued") && notOSRCompilation() && notC2Compilation();
+    }
+
+    /**
+     * OSR compilations have compile_kind set.
+     */
+    protected boolean notOSRCompilation() {
+        return !line.contains("compile_kind='");
+    }
+
+    /**
+     * Non-C2 compilations have level set.
+     */
+    private boolean notC2Compilation() {
+        return !line.contains("level='");
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/Block.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/Block.java
@@ -23,39 +23,21 @@
 
 package compiler.lib.ir_framework.driver.irmatching.parser;
 
-import java.io.BufferedReader;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.List;
 
 /**
- * Class representing a normal line read from the hotspot_pid* file.
+ * Class representing a PrintIdeal or PrintOptoAssembly output block read from the hotspot_pid* file.
  */
-class Line extends AbstractLine {
-    public Line(BufferedReader reader, Pattern compileIdPatternForTestClass) {
-        super(reader, compileIdPatternForTestClass);
+record Block(String output, List<String> testClassCompilations) {
+    public String getOutput() {
+        return output;
     }
 
-    /**
-     * Is this line a start of a PrintIdeal or PrintOptoAssembly output block?
-     */
-    public boolean isBlockStart() {
-        return isPrintIdealStart() || isPrintOptoAssemblyStart();
+    public boolean containsTestClassCompilations() {
+        return !testClassCompilations.isEmpty();
     }
 
-    /**
-     * Is this line a start of a PrintIdeal output block?
-     */
-    public boolean isPrintIdealStart() {
-        // Ignore OSR compilations which have compile_kind set.
-        return line.startsWith("<ideal") && notOSRCompilation();
-    }
-
-    /**
-     * Is this line a start of a PrintOptoAssembly output block?
-     */
-    private boolean isPrintOptoAssemblyStart() {
-        // Ignore OSR compilations which have compile_kind set.
-        return line.startsWith("<opto_assembly") && notOSRCompilation();
+    public List<String> getTestClassCompilations() {
+        return testClassCompilations;
     }
 }
-

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/BlockLine.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/BlockLine.java
@@ -24,14 +24,15 @@
 package compiler.lib.ir_framework.driver.irmatching.parser;
 
 import java.io.BufferedReader;
+import java.util.regex.Pattern;
 
 /**
  * Class representing a block line inside a PrintIdeal or PrintOptoAssembly output block read from the hotspot_pid* file.
  */
 class BlockLine extends AbstractLine {
 
-    public BlockLine(BufferedReader reader) {
-        super(reader);
+    public BlockLine(BufferedReader reader, Pattern compileIdPatternForTestClass) {
+        super(reader, compileIdPatternForTestClass);
     }
 
     /**

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/BlockOutputReader.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/BlockOutputReader.java
@@ -25,27 +25,36 @@ package compiler.lib.ir_framework.driver.irmatching.parser;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Class to read all lines of a PrintIdeal or PrintOptoAssembly block.
  */
 class BlockOutputReader {
-    private final BufferedReader reader;
+    private final BlockLine line;
 
-    public BlockOutputReader(BufferedReader reader) {
-        this.reader = reader;
+    public BlockOutputReader(BufferedReader reader, Pattern compileIdPatternForTestClass) {
+        this.line = new BlockLine(reader, compileIdPatternForTestClass);
     }
 
     /**
      * Read all lines belonging to a PrintIdeal or PrintOptoAssembly output block.
      */
-    public String readBlock() throws IOException {
-        BlockLine line = new BlockLine(reader);
+    public Block readBlock() throws IOException {
         StringBuilder builder = new StringBuilder();
+        List<String> testClassCompilations = new ArrayList<>();
         while (line.readLine() && !line.isBlockEnd()) {
+            if (line.isTestClassCompilation()) {
+                // Could have safepointed while writing the block (see IRMatcher.SAFEPOINT_WHILE_PRINTING_MESSAGE)
+                // and enqueuing the next test class method for compilation during the interruption. Record this
+                // method to ensure that we read the PrintIdeal/PrintOptoAssembly blocks for that method later.
+                testClassCompilations.add(line.getLine());
+            }
             builder.append(escapeXML(line.getLine())).append(System.lineSeparator());
         }
-        return builder.toString();
+        return new Block(builder.toString(), testClassCompilations);
     }
 
     /**

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/HotSpotPidFileParser.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/HotSpotPidFileParser.java
@@ -56,6 +56,7 @@ class HotSpotPidFileParser {
     public void setCompilationsMap(Map<String, IRMethod> compilationsMap) {
         this.compilationsMap = compilationsMap;
     }
+
     /**
      * Parse the hotspot_pid*.log file from the test VM. Read the PrintIdeal and PrintOptoAssembly outputs for all
      * methods of the test class that need to be IR matched (found in compilations map).
@@ -75,16 +76,26 @@ class HotSpotPidFileParser {
         Map<Integer, IRMethod> compileIdMap = new HashMap<>();
         try (var reader = Files.newBufferedReader(Paths.get(hotspotPidFileName))) {
             Line line = new Line(reader, compileIdPatternForTestClass);
-            BlockOutputReader blockOutputReader = new BlockOutputReader(reader);
+            BlockOutputReader blockOutputReader = new BlockOutputReader(reader, compileIdPatternForTestClass);
             while (line.readLine()) {
                 if (line.isTestClassCompilation()) {
                     parseTestMethodCompileId(compileIdMap, line.getLine());
                 } else if (isTestMethodBlockStart(line, compileIdMap)) {
-                    String blockOutput = blockOutputReader.readBlock();
-                    setIRMethodOutput(blockOutput, line, compileIdMap);
+                    processMethodBlock(compileIdMap, line, blockOutputReader);
                 }
             }
         }
+    }
+
+    private void processMethodBlock(Map<Integer, IRMethod> compileIdMap, Line line, BlockOutputReader blockOutputReader)
+            throws IOException {
+        Block block = blockOutputReader.readBlock();
+        if (block.containsTestClassCompilations()) {
+            // Register all test method compilations that could have been emitted during a rare safepoint while
+            // dumping the PrintIdeal/PrintOptoAssembly output.
+            block.getTestClassCompilations().forEach(l -> parseTestMethodCompileId(compileIdMap, l));
+        }
+        setIRMethodOutput(block.getOutput(), line, compileIdMap);
     }
 
     private void parseTestMethodCompileId(Map<Integer, IRMethod> compileIdMap, String line) {
@@ -101,6 +112,9 @@ class HotSpotPidFileParser {
         return matcher.group(2);
     }
 
+    /**
+     * Is this a @Test method?
+     */
     private boolean isTestAnnotatedMethod(String testMethodName) {
         return compilationsMap.containsKey(testMethodName);
     }
@@ -108,8 +122,6 @@ class HotSpotPidFileParser {
     private IRMethod getIrMethod(String testMethodName) {
         return compilationsMap.get(testMethodName);
     }
-
-
 
     private int getCompileId(String line) {
         Matcher matcher = COMPILE_ID_PATTERN.matcher(line);
@@ -119,6 +131,9 @@ class HotSpotPidFileParser {
         return Integer.parseInt(matcher.group(1));
     }
 
+    /**
+     * Is this line the start of a PrintIdeal/PrintOptoAssembly output block of a @Test method?
+     */
     private boolean isTestMethodBlockStart(Line line, Map<Integer, IRMethod> compileIdMap) {
       return line.isBlockStart() && isTestClassMethodBlock(line, compileIdMap);
     }


### PR DESCRIPTION
This is yet another manifestation of the safepointing problem while printing a `PrintIdeal/PrintOptoAssembly` block.

In this case here, a safepoint is done and the `<!-- safepoint while printing -->` message is emitted while dumping a `PrintIdeal` block of `retainDenominator()` inside the `hotspot_pid` file. During this interruption, another test class method is enqueued for compilation which is logged to the `hotspot_pid` file before the printing of the `PrintIdeal` block resumes:

```
# PrintIdeal output of retainDenominator()
 3 Start === 3 0 [[ 3 5 6 7 8 9 13 11 ]] #{0:control, 1:abIO, 2:memory, 3:rawptr:BotPTR, 4:return_address, 5:compiler/c2/irTests/DivLNodeIdealizationTests:NotNull *, 6:long, 7:half, 8:long, 9:half}
 36 CallStaticJava === 34 6 7 8 9 ( 35 1 1 1 1 1 26 1 27 1 ) [[ 37 ]] # Static uncommon_trap(reason=&apos;div0_check&apos; action=&apos;maybe_recompile&apos; debug_id=&apos;0&apos;) void ( int ) C=0.000100 DivLNodeIdealizationTests::retainDenominator @ bci:4 (line 130) !jvms: DivLNodeIdealizationTests::retainDenominator<!-- safepoint while printing -->

# Safepoint interruption
<writer thread='40451'/>

# Enqueuing of another test class method identityThird()
<task_queued compile_id='205' method='compiler.c2.irTests.DivLNodeIdealizationTests identityThird (JJ)J' bytes='6' count='6000' iicount='6000' blocking='1' stamp='1.046' comment='whitebox' hot_count='6000'/>
<writer thread='23811'/>
 @ bci:4 (line 130)

# Continue to dump PrintIdeal of retainDenominator()
 41 DivL === 33 26 13 [[ 42 ]] !jvms: DivLNodeIdealizationTests::retainDenominator @ bci:4 (line 130)
 9 Parm === 3 [[ 42 36 ]] ReturnAdr !jvms: DivLNodeIdealizationTests::retainDenominator @ bci:-1 (line 130)
```

The `HotSpotPidFileParser` looks for these enqueue messages containing the method name in order to find and correctly map the corresponding `PrintIdeal` and `PrintOptoAssembly` outputs. However, the `HotSpotPidFileParser` does not expect such an enqueuing message to be found inside a `PrintIdeal/PrintOptoAssembly` block and thus ignores it. As a result, we later do not parse the `PrintIdeal` and `PrintOptoAssembly` output of the enqueued method during the safepoint and fail with the assertion that we did not find any compilation output for the method.

In the example above, the assertion says that we did not find the compilation output of `identityThird()` whose enqueue message was ignored inside the `PrintIdeal` block of `retainDominator()`.

The proposed fix is to make `HotSpotPidFileParser` aware of the possibility of a safepoint while reading the `PrintIdeal` or `PrintOptoAssembly` output and therefore add a check if there was a method enqueued for compilation while reading inside `BlockOutputReader::readBlock()`.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8284115](https://bugs.openjdk.java.net/browse/JDK-8284115): [IR Framework] Compilation is not found due to rare safepoint while dumping PrintIdeal/PrintOptoAssembly


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8692/head:pull/8692` \
`$ git checkout pull/8692`

Update a local copy of the PR: \
`$ git checkout pull/8692` \
`$ git pull https://git.openjdk.java.net/jdk pull/8692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8692`

View PR using the GUI difftool: \
`$ git pr show -t 8692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8692.diff">https://git.openjdk.java.net/jdk/pull/8692.diff</a>

</details>
