### PR TITLE
8286689: (se) Adjusting to select timeout after EINTR messed up after JDK-8286378

### DIFF
--- a/src/java.base/linux/classes/sun/nio/ch/EPollSelectorImpl.java
+++ b/src/java.base/linux/classes/sun/nio/ch/EPollSelectorImpl.java
@@ -125,7 +125,7 @@ class EPollSelectorImpl extends SelectorImpl {
                 if (numEntries == IOStatus.INTERRUPTED && timedPoll) {
                     // timed poll interrupted so need to adjust timeout
                     long adjust = System.nanoTime() - startTime;
-                    to =- (int) TimeUnit.NANOSECONDS.toMillis(adjust);
+                    to -= (int) TimeUnit.NANOSECONDS.toMillis(adjust);
                     if (to <= 0) {
                         // timeout expired so no retry
                         numEntries = 0;

--- a/src/java.base/macosx/classes/sun/nio/ch/KQueueSelectorImpl.java
+++ b/src/java.base/macosx/classes/sun/nio/ch/KQueueSelectorImpl.java
@@ -129,7 +129,7 @@ class KQueueSelectorImpl extends SelectorImpl {
                 if (numEntries == IOStatus.INTERRUPTED && timedPoll) {
                     // timed poll interrupted so need to adjust timeout
                     long adjust = System.nanoTime() - startTime;
-                    to -= TimeUnit.MILLISECONDS.convert(adjust, TimeUnit.NANOSECONDS);
+                    to -= TimeUnit.NANOSECONDS.toMillis(adjust);
                     if (to <= 0) {
                         // timeout expired so no retry
                         numEntries = 0;

--- a/src/java.base/unix/classes/sun/nio/ch/PollSelectorImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/PollSelectorImpl.java
@@ -120,7 +120,7 @@ class PollSelectorImpl extends SelectorImpl {
                 if (numPolled == IOStatus.INTERRUPTED && timedPoll) {
                     // timed poll interrupted so need to adjust timeout
                     long adjust = System.nanoTime() - startTime;
-                    to =- (int) TimeUnit.NANOSECONDS.toMillis(adjust);
+                    to -= (int) TimeUnit.NANOSECONDS.toMillis(adjust);
                     if (to <= 0) {
                         // timeout expired so no retry
                         numPolled = 0;


### PR DESCRIPTION
Can I please get a review which fixes a recent unintentional change that went in as part of https://github.com/openjdk/jdk/pull/8642? The issue was caught here https://github.com/openjdk/jdk/pull/8642/files#r871994710 after the change was integrated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286689](https://bugs.openjdk.java.net/browse/JDK-8286689): (se) Adjusting to select timeout after EINTR messed up after JDK-8286378


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to [560b531f](https://git.openjdk.java.net/jdk/pull/8693/files/560b531fad4dbe197ae4a563d600f6c29eb486a2)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8693/head:pull/8693` \
`$ git checkout pull/8693`

Update a local copy of the PR: \
`$ git checkout pull/8693` \
`$ git pull https://git.openjdk.java.net/jdk pull/8693/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8693`

View PR using the GUI difftool: \
`$ git pr show -t 8693`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8693.diff">https://git.openjdk.java.net/jdk/pull/8693.diff</a>

</details>
