### PR TITLE
8286660: codestrings gtest fails on AArch64: "udf" in padding

### DIFF
--- a/test/hotspot/gtest/code/test_codestrings.cpp
+++ b/test/hotspot/gtest/code/test_codestrings.cpp
@@ -42,8 +42,9 @@ static const char* replace_addr_expr(const char* str)
     std::basic_string<char> tmp1 = std::regex_replace(str, std::regex("0x[0-9a-fA-F]+"), "<addr>");
     // Padding: aarch64
     std::basic_string<char> tmp2 = std::regex_replace(tmp1, std::regex("\\s+<addr>:\\s+\\.inst\\t<addr> ; undefined"), "");
+    std::basic_string<char> tmp3 = std::regex_replace(tmp2, std::regex("\\s+<addr>:\\s+udf\\t#[0-9]+"), "");
     // Padding: x64
-    std::basic_string<char> red  = std::regex_replace(tmp2, std::regex("\\s+<addr>:\\s+hlt[ \\t]+(?!\\n\\s+;;)"), "");
+    std::basic_string<char> red  = std::regex_replace(tmp3, std::regex("\\s+<addr>:\\s+hlt[ \\t]+(?!\\n\\s+;;)"), "");
 
     return os::strdup(red.c_str());
 }


### PR DESCRIPTION
On hsdis-enabled AArch64 machine this test fails even with [JDK-8274039](https://bugs.openjdk.java.net/browse/JDK-8274039):

```
$ CONF=linux-aarch64-server-fastdebug make run-test TEST=jtreg:gtest/GTestWrapper.java

[----------] 1 test from codestrings
[ RUN      ] codestrings.validate_vm
/home/shade/shipilev-jdk/test/hotspot/gtest/code/test_codestrings.cpp:85: Failure
Expected equality of these values:
  replace_addr_expr(out1.as_string())
    Which is: "--------------------------------------------------------------------------------\n ;; First block comment.\n  <addr>:   nop\n--------------------------------------------------------------------------------\n"
  replace_addr_expr(out2.as_string())
    Which is: "--------------------------------------------------------------------------------\n ;; First block comment.\n  <addr>:   nop\n  <addr>:   udf\t#0\n--------------------------------------------------------------------------------\n"
With diff:
@@ +2,4 @@
  ;; First block comment.
   <addr>:   nop
+  <addr>:   udf\t#0
 --------------------------------------------------------------------------------\n
```

Additional testing:
 - [x] Linux x86_64 gtests still pass
 - [x] Linux x86_32 gtests still pass
 - [x] Linux AArch64 gtests now pass