### PR TITLE
8286390: Address possibly lossy conversions in jdk.incubator.foreign moved to java.base

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
@@ -212,7 +212,7 @@ public class ProgrammableInvoker {
 
         for (int i = 0; i < highLevelType.parameterCount(); i++) {
             List<Binding> bindings = callingSequence.argumentBindings(i);
-            argInsertPos += Math.toIntExact(bindings.stream().filter(Binding.VMStore.class::isInstance).count()) + 1;
+            argInsertPos += ((int) bindings.stream().filter(Binding.VMStore.class::isInstance).count()) + 1;
             // We interpret the bindings in reverse since we have to construct a MethodHandle from the bottom up
             for (int j = bindings.size() - 1; j >= 0; j--) {
                 Binding binding = bindings.get(j);

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
@@ -212,7 +212,7 @@ public class ProgrammableInvoker {
 
         for (int i = 0; i < highLevelType.parameterCount(); i++) {
             List<Binding> bindings = callingSequence.argumentBindings(i);
-            argInsertPos += bindings.stream().filter(Binding.VMStore.class::isInstance).count() + 1;
+            argInsertPos += Math.toIntExact(bindings.stream().filter(Binding.VMStore.class::isInstance).count()) + 1;
             // We interpret the bindings in reverse since we have to construct a MethodHandle from the bottom up
             for (int j = bindings.size() - 1; j >= 0; j--) {
                 Binding binding = bindings.get(j);


### PR DESCRIPTION
Address possible lossy conversion warning in `ProgrammableInvoker`.

Testing: `run-test-jdk_foreign`, testing with patch from https://github.com/openjdk/jdk/pull/8599 to see if the warning is gone.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286390](https://bugs.openjdk.java.net/browse/JDK-8286390): Address possibly lossy conversions in jdk.incubator.foreign moved to java.base


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8697/head:pull/8697` \
`$ git checkout pull/8697`

Update a local copy of the PR: \
`$ git checkout pull/8697` \
`$ git pull https://git.openjdk.java.net/jdk pull/8697/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8697`

View PR using the GUI difftool: \
`$ git pr show -t 8697`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8697.diff">https://git.openjdk.java.net/jdk/pull/8697.diff</a>

</details>
