### PR TITLE
8286704: G1: Call offset_of directly in subclasses of G1CardSetContainer

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
@@ -188,12 +188,6 @@ private:
       Atomic::release_store(_num_entries_addr, _local_num_entries);
     }
   };
-
-  template<typename Derived>
-  static size_t header_size_in_bytes_internal() {
-    return offset_of(Derived, _data);
-  }
-
 public:
   G1CardSetArray(uint const card_in_region, EntryCountType num_cards);
 
@@ -206,7 +200,7 @@ public:
 
   size_t num_entries() const { return _num_entries & EntryMask; }
 
-  static size_t header_size_in_bytes() { return header_size_in_bytes_internal<G1CardSetArray>(); }
+  static size_t header_size_in_bytes();
 
   static size_t size_in_bytes(size_t num_cards) {
     return header_size_in_bytes() + sizeof(EntryDataType) * num_cards;
@@ -216,13 +210,6 @@ public:
 class G1CardSetBitMap : public G1CardSetContainer {
   size_t _num_bits_set;
   BitMap::bm_word_t _bits[1];
-
-  using ContainerPtr = G1CardSet::ContainerPtr;
-
-  template<typename Derived>
-  static size_t header_size_in_bytes_internal() {
-    return offset_of(Derived, _bits);
-  }
 
 public:
   G1CardSetBitMap(uint const card_in_region, uint const size_in_bits);
@@ -244,7 +231,7 @@ public:
     return static_cast<uint>(bm.get_next_one_offset(idx));
   }
 
-  static size_t header_size_in_bytes() { return header_size_in_bytes_internal<G1CardSetBitMap>(); }
+  static size_t header_size_in_bytes();
 
   static size_t size_in_bytes(size_t size_in_bits) { return header_size_in_bytes() + BitMap::calc_size_in_words(size_in_bits) * BytesPerWord; }
 };
@@ -257,11 +244,6 @@ public:
 private:
   ContainerPtr _buckets[2];
   // Do not add class member variables beyond this point
-
-  template<typename Derived>
-  static size_t header_size_in_bytes_internal() {
-    return offset_of(Derived, _buckets);
-  }
 
   // Iterates over the given ContainerPtr with at index in this Howl card set,
   // applying a CardOrRangeVisitor on it.
@@ -297,7 +279,7 @@ public:
     return round_up_power_of_2(num_cards);
   }
 
-  static size_t header_size_in_bytes() { return header_size_in_bytes_internal<G1CardSetHowl>(); }
+  static size_t header_size_in_bytes();
 
   static size_t size_in_bytes(size_t num_arrays) {
     return header_size_in_bytes() + sizeof(ContainerPtr) * num_arrays;

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
@@ -221,6 +221,10 @@ void G1CardSetArray::iterate(CardVisitor& found) {
   }
 }
 
+inline size_t G1CardSetArray::header_size_in_bytes() {
+  return offset_of(G1CardSetArray, _data);
+}
+
 inline G1CardSetBitMap::G1CardSetBitMap(uint card_in_region, uint size_in_bits) :
   G1CardSetContainer(), _num_bits_set(1) {
   assert(size_in_bits % (sizeof(_bits[0]) * BitsPerByte) == 0,
@@ -250,6 +254,10 @@ inline void G1CardSetBitMap::iterate(CardVisitor& found, size_t size_in_bits, ui
     found((offset | (uint)idx));
     idx = bm.get_next_one_offset(idx + 1);
   }
+}
+
+inline size_t G1CardSetBitMap::header_size_in_bytes() {
+    return offset_of(G1CardSetBitMap, _bits);
 }
 
 inline G1CardSetHowl::G1CardSetHowl(EntryCountType card_in_region, G1CardSetConfiguration* config) :
@@ -350,6 +358,10 @@ inline G1CardSetHowl::EntryCountType G1CardSetHowl::num_buckets(size_t size_in_b
   // power of two to not use more than expected memory.
   num_arrays = round_down_power_of_2(MAX2((size_t)1, MIN2(num_arrays, max_num_buckets)));
   return (EntryCountType)num_arrays;
+}
+
+inline size_t G1CardSetHowl::header_size_in_bytes() {
+  return offset_of(G1CardSetHowl, _buckets);
 }
 
 #endif // SHARE_GC_G1_G1CARDSETCONTAINERS_INLINE_HPP


### PR DESCRIPTION
Simple cleanup in subclasses of `G1CardSetContainer`.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286704](https://bugs.openjdk.java.net/browse/JDK-8286704): G1: Call offset_of directly in subclasses of G1CardSetContainer


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8698/head:pull/8698` \
`$ git checkout pull/8698`

Update a local copy of the PR: \
`$ git checkout pull/8698` \
`$ git pull https://git.openjdk.java.net/jdk pull/8698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8698`

View PR using the GUI difftool: \
`$ git pr show -t 8698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8698.diff">https://git.openjdk.java.net/jdk/pull/8698.diff</a>

</details>
