### PR TITLE
8286744: failure_handler: dmesg command on macos fails to collect data due to permission issues

### DIFF
--- a/test/failure_handler/src/share/conf/mac.properties
+++ b/test/failure_handler/src/share/conf/mac.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/failure_handler/src/share/conf/mac.properties
+++ b/test/failure_handler/src/share/conf/mac.properties
@@ -103,7 +103,9 @@ ulimit.app=bash
 ulimit.args=-c\0ulimit -a
 ulimit.args.delimiter=\0
 
-system.dmesg.app=dmesg
+system.dmesg.app=sudo
+system.dmesg.args=dmesg
+
 system.sysctl.app=sysctl
 system.sysctl.args=-a
 


### PR DESCRIPTION
Can I please get a review of this change which proposes to fix the failure handler command `dmesg` on macOS?

As noted in the JBS issue, the command currently fails with permission error. The commit in this PR uses `sudo` as suggested in the man pages of that command.

Tested locally on macOS by running:

```
cd test/failure_handler
make clean
make test
```
Then checked the generated environment.html files for the dmesg command output. Looks fine after this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286744](https://bugs.openjdk.java.net/browse/JDK-8286744): failure_handler: dmesg command on macos fails to collect data due to permission issues


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to [db538083](https://git.openjdk.java.net/jdk/pull/8703/files/db538083dfae44f1446032cd8c25ffcfc0964955)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8703/head:pull/8703` \
`$ git checkout pull/8703`

Update a local copy of the PR: \
`$ git checkout pull/8703` \
`$ git pull https://git.openjdk.java.net/jdk pull/8703/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8703`

View PR using the GUI difftool: \
`$ git pr show -t 8703`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8703.diff">https://git.openjdk.java.net/jdk/pull/8703.diff</a>

</details>
