### PR TITLE
8286756: Cleanup foreign API benchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/foreign/JavaLayouts.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/JavaLayouts.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.java.lang.foreign;
+
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.VarHandle;
+
+import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+
+/**
+ * Some useful Java {@link ValueLayout} and associated {@link ValueLayout#arrayElementVarHandle(int...)} var handles.
+ */
+public class JavaLayouts {
+    static final ValueLayout.OfInt JAVA_INT_UNALIGNED = JAVA_INT.withBitAlignment(8);
+
+    static final ValueLayout.OfFloat JAVA_FLOAT_UNALIGNED = JAVA_FLOAT.withBitAlignment(8);
+
+    static final ValueLayout.OfLong JAVA_LONG_UNALIGNED = JAVA_LONG.withBitAlignment(8);
+
+    static final VarHandle VH_INT_UNALIGNED = JAVA_INT_UNALIGNED.arrayElementVarHandle();
+
+    static final VarHandle VH_INT = JAVA_INT.arrayElementVarHandle();
+
+    static final VarHandle VH_FLOAT_UNALIGNED = JAVA_FLOAT_UNALIGNED.arrayElementVarHandle();
+
+    static final VarHandle VH_FLOAT = JAVA_FLOAT.arrayElementVarHandle();
+
+    static final VarHandle VH_LONG_UNALIGNED = JAVA_LONG_UNALIGNED.arrayElementVarHandle();
+
+    static final VarHandle VH_LONG = JAVA_LONG.arrayElementVarHandle();
+}

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverConstant.java
@@ -68,7 +68,7 @@ public class LoopOverConstant extends JavaLayouts {
     }
 
     //setup native memory segment
-    
+
     static final MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE, MemorySession.openImplicit());
 
     static {

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverConstant.java
@@ -22,7 +22,6 @@
  */
 package org.openjdk.bench.java.lang.foreign;
 
-import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySession;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -38,12 +37,10 @@ import org.openjdk.jmh.annotations.Warmup;
 import sun.misc.Unsafe;
 
 import java.lang.foreign.MemorySegment;
-import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.TimeUnit;
 
-import static java.lang.foreign.MemoryLayout.PathElement.sequenceElement;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -52,7 +49,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(value = 3, jvmArgsAppend = "--enable-preview")
-public class LoopOverConstant {
+public class LoopOverConstant extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;
 
@@ -71,13 +68,12 @@ public class LoopOverConstant {
     }
 
     //setup native memory segment
-
+    
     static final MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE, MemorySession.openImplicit());
-    static final VarHandle VH_int = JAVA_INT.arrayElementVarHandle();
 
     static {
         for (int i = 0; i < ELEM_SIZE; i++) {
-            VH_int.set(segment, (long) i, i);
+            VH_INT.set(segment, (long) i, i);
         }
     }
 
@@ -100,7 +96,7 @@ public class LoopOverConstant {
     @Benchmark
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public int segment_get() {
-        return (int)VH_int.get(segment, 0L);
+        return (int)VH_INT.get(segment, 0L);
     }
 
     @Benchmark
@@ -122,7 +118,7 @@ public class LoopOverConstant {
     public int segment_loop() {
         int res = 0;
         for (int i = 0; i < ELEM_SIZE; i++) {
-            res += (int) VH_int.get(segment, (long)i);
+            res += (int) VH_INT.get(segment, (long)i);
         }
         return res;
     }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNew.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNew.java
@@ -38,12 +38,10 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import sun.misc.Unsafe;
 
-import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.TimeUnit;
 
-import static java.lang.foreign.MemoryLayout.PathElement.sequenceElement;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -52,7 +50,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(value = 3, jvmArgsAppend = "--enable-preview")
-public class LoopOverNew {
+public class LoopOverNew extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;
 
@@ -60,9 +58,6 @@ public class LoopOverNew {
     static final int CARRIER_SIZE = (int)JAVA_INT.byteSize();
     static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
     static final MemoryLayout ALLOC_LAYOUT = MemoryLayout.sequenceLayout(ELEM_SIZE, JAVA_INT);
-
-    static final VarHandle VH_int = JAVA_INT.arrayElementVarHandle();
-
     final MemorySession session = MemorySession.openConfined();
     final SegmentAllocator recyclingAlloc = SegmentAllocator.prefixAllocator(MemorySegment.allocateNative(ALLOC_LAYOUT, session));
 
@@ -85,7 +80,7 @@ public class LoopOverNew {
         try (MemorySession session = MemorySession.openConfined()) {
             MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE, 4, session);
             for (int i = 0; i < ELEM_SIZE; i++) {
-                VH_int.set(segment, (long) i, i);
+                VH_INT.set(segment, (long) i, i);
             }
         }
     }
@@ -95,7 +90,7 @@ public class LoopOverNew {
         try (MemorySession session = MemorySession.openShared()) {
             MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE, 4, session);
             for (int i = 0; i < ELEM_SIZE; i++) {
-                VH_int.set(segment, (long) i, i);
+                VH_INT.set(segment, (long) i, i);
             }
         }
     }
@@ -104,7 +99,7 @@ public class LoopOverNew {
     public void segment_loop_recycle() {
         MemorySegment segment = recyclingAlloc.allocate(ALLOC_SIZE, 4);
         for (int i = 0; i < ELEM_SIZE; i++) {
-            VH_int.set(segment, (long) i, i);
+            VH_INT.set(segment, (long) i, i);
         }
     }
 
@@ -140,7 +135,7 @@ public class LoopOverNew {
         if (gcCount++ == 0) System.gc(); // GC when we overflow
         MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE, 4, MemorySession.openImplicit());
         for (int i = 0; i < ELEM_SIZE; i++) {
-            VH_int.set(segment, (long) i, i);
+            VH_INT.set(segment, (long) i, i);
         }
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNewHeap.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNewHeap.java
@@ -22,7 +22,6 @@
  */
 package org.openjdk.bench.java.lang.foreign;
 
-import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -38,11 +37,9 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import sun.misc.Unsafe;
 
-import java.lang.invoke.VarHandle;
 import java.nio.IntBuffer;
 import java.util.concurrent.TimeUnit;
 
-import static java.lang.foreign.MemoryLayout.PathElement.sequenceElement;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -51,14 +48,12 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(value = 3, jvmArgsAppend = "--enable-preview")
-public class LoopOverNewHeap {
+public class LoopOverNewHeap extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;
 
     static final int ELEM_SIZE = 1_000_000;
     static final int CARRIER_SIZE = (int)JAVA_INT.byteSize();
-
-    static final VarHandle VH_int = JAVA_INT.arrayElementVarHandle();
 
     @Param(value = {"false", "true"})
     boolean polluteProfile;
@@ -88,7 +83,7 @@ public class LoopOverNewHeap {
     public void segment_loop() {
         MemorySegment segment = MemorySegment.ofArray(new int[ELEM_SIZE]);
         for (int i = 0; i < ELEM_SIZE; i++) {
-            VH_int.set(segment, (long) i, i);
+            VH_INT.set(segment, (long) i, i);
         }
     }
 
@@ -97,7 +92,7 @@ public class LoopOverNewHeap {
     public void segment_loop_dontinline() {
         MemorySegment segment = MemorySegment.ofArray(new int[ELEM_SIZE]);
         for (int i = 0; i < ELEM_SIZE; i++) {
-            VH_int.set(segment, (long) i, i);
+            VH_INT.set(segment, (long) i, i);
         }
     }
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstant.java
@@ -22,8 +22,6 @@
  */
 package org.openjdk.bench.java.lang.foreign;
 
-import java.lang.foreign.MemoryAddress;
-import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -38,13 +36,10 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import sun.misc.Unsafe;
 
-import java.lang.foreign.ValueLayout;
-import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.TimeUnit;
 
-import static java.lang.foreign.MemoryLayout.PathElement.sequenceElement;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -53,19 +48,13 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(value = 3, jvmArgsAppend = { "--enable-preview", "--enable-native-access=ALL-UNNAMED" })
-public class LoopOverNonConstant {
+public class LoopOverNonConstant extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;
 
     static final int ELEM_SIZE = 1_000_000;
     static final int CARRIER_SIZE = (int)JAVA_INT.byteSize();
     static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
-
-    static final VarHandle VH_int = JAVA_INT.arrayElementVarHandle();
-
-    static final ValueLayout.OfInt JAVA_INT_ALIGNED = JAVA_INT.withBitAlignment(32);
-    static final VarHandle VH_int_aligned = JAVA_INT_ALIGNED.arrayElementVarHandle();
-
     MemorySegment segment;
     long unsafe_addr;
 
@@ -79,7 +68,7 @@ public class LoopOverNonConstant {
         }
         segment = MemorySegment.allocateNative(ALLOC_SIZE, MemorySession.openConfined());
         for (int i = 0; i < ELEM_SIZE; i++) {
-            VH_int.set(segment, (long) i, i);
+            VH_INT.set(segment, (long) i, i);
         }
         byteBuffer = ByteBuffer.allocateDirect(ALLOC_SIZE).order(ByteOrder.nativeOrder());
         for (int i = 0; i < ELEM_SIZE; i++) {
@@ -103,7 +92,7 @@ public class LoopOverNonConstant {
     @Benchmark
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public int segment_get() {
-        return (int) VH_int.get(segment, 0L);
+        return (int) VH_INT.get(segment, 0L);
     }
 
     @Benchmark
@@ -125,16 +114,16 @@ public class LoopOverNonConstant {
     public int segment_loop() {
         int sum = 0;
         for (int i = 0; i < ELEM_SIZE; i++) {
-            sum += (int) VH_int.get(segment, (long) i);
+            sum += (int) VH_INT.get(segment, (long) i);
         }
         return sum;
     }
 
     @Benchmark
-    public int segment_loop_aligned() {
+    public int segment_loop_unaligned() {
         int sum = 0;
         for (int i = 0; i < ELEM_SIZE; i++) {
-            sum += (int) VH_int_aligned.get(segment, (long) i);
+            sum += (int) VH_INT_UNALIGNED.get(segment, (long) i);
         }
         return sum;
     }
@@ -160,10 +149,10 @@ public class LoopOverNonConstant {
     }
 
     @Benchmark
-    public int segment_loop_instance_aligned() {
+    public int segment_loop_instance_unaligned() {
         int res = 0;
         for (int i = 0; i < ELEM_SIZE; i ++) {
-            res += segment.get(JAVA_INT_ALIGNED, i * CARRIER_SIZE);
+            res += segment.get(JAVA_INT_UNALIGNED, i * CARRIER_SIZE);
         }
         return res;
     }
@@ -191,7 +180,7 @@ public class LoopOverNonConstant {
         int sum = 0;
         MemorySegment base = segment.asSlice(0, segment.byteSize());
         for (int i = 0; i < ELEM_SIZE; i++) {
-            sum += (int) VH_int.get(base, (long) i);
+            sum += (int) VH_INT.get(base, (long) i);
         }
         return sum;
     }
@@ -201,7 +190,7 @@ public class LoopOverNonConstant {
         int sum = 0;
         MemorySegment base = segment.asReadOnly();
         for (int i = 0; i < ELEM_SIZE; i++) {
-            sum += (int) VH_int.get(base, (long) i);
+            sum += (int) VH_INT.get(base, (long) i);
         }
         return sum;
     }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantFP.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantFP.java
@@ -40,7 +40,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.TimeUnit;
 
-import static java.lang.foreign.MemoryLayout.PathElement.sequenceElement;
 import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantHeap.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantHeap.java
@@ -24,7 +24,6 @@ package org.openjdk.bench.java.lang.foreign;
 
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
-import java.lang.foreign.ValueLayout;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -38,7 +37,6 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import sun.misc.Unsafe;
 
-import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.TimeUnit;
@@ -54,7 +52,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(value = 3, jvmArgsAppend = "--enable-preview")
-public class LoopOverNonConstantHeap {
+public class LoopOverNonConstantHeap extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;
 
@@ -62,11 +60,6 @@ public class LoopOverNonConstantHeap {
     static final int CARRIER_SIZE = (int)JAVA_INT.byteSize();
     static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
     static final int UNSAFE_BYTE_BASE = unsafe.arrayBaseOffset(byte[].class);
-
-    static final VarHandle VH_INT = JAVA_INT.arrayElementVarHandle();
-
-    static final ValueLayout.OfInt JAVA_INT_UNALIGNED = JAVA_INT.withBitAlignment(8);
-    static final VarHandle VH_INT_UNALIGNED = JAVA_INT_UNALIGNED.arrayElementVarHandle();
     static final int UNSAFE_INT_BASE = unsafe.arrayBaseOffset(int[].class);
 
     MemorySegment segment, alignedSegment;
@@ -136,7 +129,7 @@ public class LoopOverNonConstantHeap {
     }
 
     @Benchmark
-    public int segment_loop() {
+    public int segment_loop_unaligned() {
         int sum = 0;
         for (int i = 0; i < ELEM_SIZE; i++) {
             sum += (int) VH_INT_UNALIGNED.get(segment, (long) i);
@@ -145,7 +138,7 @@ public class LoopOverNonConstantHeap {
     }
 
     @Benchmark
-    public int segment_loop_aligned() {
+    public int segment_loop() {
         int sum = 0;
         for (int i = 0; i < ELEM_SIZE; i++) {
             sum += (int) VH_INT.get(alignedSegment, (long) i);
@@ -154,7 +147,7 @@ public class LoopOverNonConstantHeap {
     }
 
     @Benchmark
-    public int segment_loop_instance() {
+    public int segment_loop_instance_unaligned() {
         int res = 0;
         for (int i = 0; i < ELEM_SIZE; i ++) {
             res += segment.get(JAVA_INT_UNALIGNED, i * CARRIER_SIZE);
@@ -163,7 +156,7 @@ public class LoopOverNonConstantHeap {
     }
 
     @Benchmark
-    public int segment_loop_instance_aligned() {
+    public int segment_loop_instance() {
         int res = 0;
         for (int i = 0; i < ELEM_SIZE; i ++) {
             res += alignedSegment.get(JAVA_INT, i * CARRIER_SIZE);
@@ -174,9 +167,9 @@ public class LoopOverNonConstantHeap {
     @Benchmark
     public int segment_loop_slice() {
         int sum = 0;
-        MemorySegment base = segment.asSlice(0, segment.byteSize());
+        MemorySegment base = alignedSegment.asSlice(0, alignedSegment.byteSize());
         for (int i = 0; i < ELEM_SIZE; i++) {
-            sum += (int) VH_INT_UNALIGNED.get(base, (long) i);
+            sum += (int) VH_INT.get(base, (long) i);
         }
         return sum;
     }
@@ -184,9 +177,9 @@ public class LoopOverNonConstantHeap {
     @Benchmark
     public int segment_loop_readonly() {
         int sum = 0;
-        MemorySegment base = segment.asReadOnly();
+        MemorySegment base = alignedSegment.asReadOnly();
         for (int i = 0; i < ELEM_SIZE; i++) {
-            sum += (int) VH_INT_UNALIGNED.get(base, (long) i);
+            sum += (int) VH_INT.get(base, (long) i);
         }
         return sum;
     }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantMapped.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantMapped.java
@@ -22,7 +22,6 @@
  */
 package org.openjdk.bench.java.lang.foreign;
 
-import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -39,7 +38,6 @@ import sun.misc.Unsafe;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.MappedByteBuffer;
@@ -49,7 +47,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.concurrent.TimeUnit;
 
-import static java.lang.foreign.MemoryLayout.PathElement.sequenceElement;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -58,7 +55,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(value = 3, jvmArgsAppend = "--enable-preview")
-public class LoopOverNonConstantMapped {
+public class LoopOverNonConstantMapped extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;
 
@@ -80,7 +77,6 @@ public class LoopOverNonConstantMapped {
         }
     }
 
-    static final VarHandle VH_int = JAVA_INT.arrayElementVarHandle();
     FileChannel fileChannel;
     MemorySegment segment;
     long unsafe_addr;
@@ -117,7 +113,7 @@ public class LoopOverNonConstantMapped {
     @Benchmark
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public int segment_get() {
-        return (int) VH_int.get(segment, 0L);
+        return (int) VH_INT.get(segment, 0L);
     }
 
     @Benchmark
@@ -139,7 +135,7 @@ public class LoopOverNonConstantMapped {
     public int segment_loop() {
         int sum = 0;
         for (int i = 0; i < ELEM_SIZE; i++) {
-            sum += (int) VH_int.get(segment, (long) i);
+            sum += (int) VH_INT.get(segment, (long) i);
         }
         return sum;
     }
@@ -167,7 +163,7 @@ public class LoopOverNonConstantMapped {
         int sum = 0;
         MemorySegment base = segment.asSlice(0, segment.byteSize());
         for (int i = 0; i < ELEM_SIZE; i++) {
-            sum += (int) VH_int.get(base, (long) i);
+            sum += (int) VH_INT.get(base, (long) i);
         }
         return sum;
     }
@@ -177,7 +173,7 @@ public class LoopOverNonConstantMapped {
         int sum = 0;
         MemorySegment base = segment.asReadOnly();
         for (int i = 0; i < ELEM_SIZE; i++) {
-            sum += (int) VH_int.get(base, (long) i);
+            sum += (int) VH_INT.get(base, (long) i);
         }
         return sum;
     }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantShared.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantShared.java
@@ -22,7 +22,6 @@
  */
 package org.openjdk.bench.java.lang.foreign;
 
-import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -37,12 +36,10 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import sun.misc.Unsafe;
 
-import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.TimeUnit;
 
-import static java.lang.foreign.MemoryLayout.PathElement.sequenceElement;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -51,15 +48,13 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(value = 3, jvmArgsAppend = "--enable-preview")
-public class LoopOverNonConstantShared {
+public class LoopOverNonConstantShared extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;
 
     static final int ELEM_SIZE = 1_000_000;
     static final int CARRIER_SIZE = (int)JAVA_INT.byteSize();
     static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
-
-    static final VarHandle VH_int = JAVA_INT.arrayElementVarHandle();
     MemorySegment segment;
     long unsafe_addr;
 
@@ -73,7 +68,7 @@ public class LoopOverNonConstantShared {
         }
         segment = MemorySegment.allocateNative(ALLOC_SIZE, CARRIER_SIZE, MemorySession.openConfined());
         for (int i = 0; i < ELEM_SIZE; i++) {
-            VH_int.set(segment, (long) i, i);
+            VH_INT.set(segment, (long) i, i);
         }
         byteBuffer = ByteBuffer.allocateDirect(ALLOC_SIZE).order(ByteOrder.nativeOrder());
         for (int i = 0; i < ELEM_SIZE; i++) {
@@ -97,7 +92,7 @@ public class LoopOverNonConstantShared {
     @Benchmark
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public int segment_get() {
-        return (int) VH_int.get(segment, 0L);
+        return (int) VH_INT.get(segment, 0L);
     }
 
     @Benchmark
@@ -137,7 +132,7 @@ public class LoopOverNonConstantShared {
     public int segment_loop() {
         int sum = 0;
         for (int i = 0; i < ELEM_SIZE; i++) {
-            sum += (int) VH_int.get(segment, (long) i);
+            sum += (int) VH_INT.get(segment, (long) i);
         }
         return sum;
     }
@@ -147,7 +142,7 @@ public class LoopOverNonConstantShared {
         int sum = 0;
         MemorySegment base = segment.asSlice(0, segment.byteSize());
         for (int i = 0; i < ELEM_SIZE; i++) {
-            sum += (int) VH_int.get(base, (long) i);
+            sum += (int) VH_INT.get(base, (long) i);
         }
         return sum;
     }
@@ -157,7 +152,7 @@ public class LoopOverNonConstantShared {
         int sum = 0;
         MemorySegment base = segment.asReadOnly();
         for (int i = 0; i < ELEM_SIZE; i++) {
-            sum += (int) VH_int.get(base, (long) i);
+            sum += (int) VH_INT.get(base, (long) i);
         }
         return sum;
     }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverPollutedSegments.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverPollutedSegments.java
@@ -22,7 +22,6 @@
  */
 package org.openjdk.bench.java.lang.foreign;
 
-import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -37,11 +36,8 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import sun.misc.Unsafe;
 
-import java.lang.foreign.ValueLayout;
-import java.lang.invoke.VarHandle;
 import java.util.concurrent.TimeUnit;
 
-import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -50,7 +46,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(value = 3, jvmArgsAppend = "--enable-preview")
-public class LoopOverPollutedSegments {
+public class LoopOverPollutedSegments extends JavaLayouts {
 
     static final int ELEM_SIZE = 1_000_000;
     static final int CARRIER_SIZE = (int) JAVA_INT.byteSize();
@@ -63,11 +59,6 @@ public class LoopOverPollutedSegments {
     MemorySegment nativeSegment, nativeSharedSegment, heapSegmentBytes, heapSegmentFloats;
     byte[] arr;
     long addr;
-
-    static final ValueLayout.OfInt JAVA_INT_UNALIGNED = JAVA_INT.withBitAlignment(8);
-    static final ValueLayout.OfFloat JAVA_FLOAT_UNALIGNED = JAVA_FLOAT.withBitAlignment(8);
-    static final VarHandle intHandleUnaligned = JAVA_INT_UNALIGNED.arrayElementVarHandle();
-
 
     @Setup
     public void setup() {
@@ -88,13 +79,13 @@ public class LoopOverPollutedSegments {
                 nativeSegment.setAtIndex(JAVA_FLOAT_UNALIGNED, i, i);
                 nativeSharedSegment.setAtIndex(JAVA_INT_UNALIGNED, i, i);
                 nativeSharedSegment.setAtIndex(JAVA_FLOAT_UNALIGNED, i, i);
-                intHandleUnaligned.set(nativeSegment, (long)i, i);
+                VH_INT_UNALIGNED.set(nativeSegment, (long)i, i);
                 heapSegmentBytes.setAtIndex(JAVA_INT_UNALIGNED, i, i);
                 heapSegmentBytes.setAtIndex(JAVA_FLOAT_UNALIGNED, i, i);
-                intHandleUnaligned.set(heapSegmentBytes, (long)i, i);
+                VH_INT_UNALIGNED.set(heapSegmentBytes, (long)i, i);
                 heapSegmentFloats.setAtIndex(JAVA_INT_UNALIGNED, i, i);
                 heapSegmentFloats.setAtIndex(JAVA_FLOAT_UNALIGNED, i, i);
-                intHandleUnaligned.set(heapSegmentFloats, (long)i, i);
+                VH_INT_UNALIGNED.set(heapSegmentFloats, (long)i, i);
             }
         }
     }
@@ -112,8 +103,8 @@ public class LoopOverPollutedSegments {
     public int native_segment_VH() {
         int sum = 0;
         for (int k = 0; k < ELEM_SIZE; k++) {
-            intHandleUnaligned.set(nativeSegment, (long)k, k + 1);
-            int v = (int) intHandleUnaligned.get(nativeSegment, (long)k);
+            VH_INT_UNALIGNED.set(nativeSegment, (long)k, k + 1);
+            int v = (int) VH_INT_UNALIGNED.get(nativeSegment, (long)k);
             sum += v;
         }
         return sum;
@@ -134,8 +125,8 @@ public class LoopOverPollutedSegments {
     public int heap_segment_ints_VH() {
         int sum = 0;
         for (int k = 0; k < ELEM_SIZE; k++) {
-            intHandleUnaligned.set(heapSegmentBytes, (long)k, k + 1);
-            int v = (int) intHandleUnaligned.get(heapSegmentBytes, (long)k);
+            VH_INT_UNALIGNED.set(heapSegmentBytes, (long)k, k + 1);
+            int v = (int) VH_INT_UNALIGNED.get(heapSegmentBytes, (long)k);
             sum += v;
         }
         return sum;
@@ -156,8 +147,8 @@ public class LoopOverPollutedSegments {
     public int heap_segment_floats_VH() {
         int sum = 0;
         for (int k = 0; k < ELEM_SIZE; k++) {
-            intHandleUnaligned.set(heapSegmentFloats, (long)k, k + 1);
-            int v = (int)intHandleUnaligned.get(heapSegmentFloats, (long)k);
+            VH_INT_UNALIGNED.set(heapSegmentFloats, (long)k, k + 1);
+            int v = (int)VH_INT_UNALIGNED.get(heapSegmentFloats, (long)k);
             sum += v;
         }
         return sum;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ParallelSum.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ParallelSum.java
@@ -40,7 +40,6 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.foreign.MemorySegment;
-import java.lang.invoke.VarHandle;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -51,22 +50,18 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
-import static java.lang.foreign.MemoryLayout.PathElement.sequenceElement;
-import static java.lang.foreign.ValueLayout.JAVA_INT;
-
 @BenchmarkMode(Mode.AverageTime)
 @Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(value = 3, jvmArgsAppend = "--enable-preview")
-public class ParallelSum {
+public class ParallelSum extends JavaLayouts {
 
     final static int CARRIER_SIZE = 4;
     final static int ALLOC_SIZE = CARRIER_SIZE * 1024 * 1024 * 256;
     final static int ELEM_SIZE = ALLOC_SIZE / CARRIER_SIZE;
-    static final VarHandle VH_int = JAVA_INT.arrayElementVarHandle();
-
+    
     final static MemoryLayout ELEM_LAYOUT = ValueLayout.JAVA_INT;
     final static int BULK_FACTOR = 512;
     final static SequenceLayout ELEM_LAYOUT_BULK = MemoryLayout.sequenceLayout(BULK_FACTOR, ELEM_LAYOUT);
@@ -84,7 +79,7 @@ public class ParallelSum {
         }
         segment = MemorySegment.allocateNative(ALLOC_SIZE, CARRIER_SIZE, MemorySession.openShared());
         for (int i = 0; i < ELEM_SIZE; i++) {
-            VH_int.set(segment, (long) i, i);
+            VH_INT.set(segment, (long) i, i);
         }
     }
 
@@ -98,7 +93,7 @@ public class ParallelSum {
     public int segment_serial() {
         int res = 0;
         for (int i = 0; i < ELEM_SIZE; i++) {
-            res += (int)VH_int.get(segment, (long) i);
+            res += (int)VH_INT.get(segment, (long) i);
         }
         return res;
     }
@@ -133,12 +128,12 @@ public class ParallelSum {
     }
 
     final static ToIntFunction<MemorySegment> SEGMENT_TO_INT = slice ->
-            (int) VH_int.get(slice, 0L);
+            (int) VH_INT.get(slice, 0L);
 
     final static ToIntFunction<MemorySegment> SEGMENT_TO_INT_BULK = slice -> {
         int res = 0;
         for (int i = 0; i < BULK_FACTOR ; i++) {
-            res += (int)VH_int.get(slice, (long) i);
+            res += (int)VH_INT.get(slice, (long) i);
         }
         return res;
     };
@@ -172,11 +167,11 @@ public class ParallelSum {
     }
 
     final static Predicate<MemorySegment> FIND_SINGLE = slice ->
-            (int)VH_int.get(slice, 0L) == (ELEM_SIZE - 1);
+            (int)VH_INT.get(slice, 0L) == (ELEM_SIZE - 1);
 
     final static Predicate<MemorySegment> FIND_BULK = slice -> {
         for (int i = 0; i < BULK_FACTOR ; i++) {
-            if ((int)VH_int.get(slice, (long)i) == (ELEM_SIZE - 1)) {
+            if ((int)VH_INT.get(slice, (long)i) == (ELEM_SIZE - 1)) {
                 return true;
             }
         }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ParallelSum.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ParallelSum.java
@@ -61,7 +61,7 @@ public class ParallelSum extends JavaLayouts {
     final static int CARRIER_SIZE = 4;
     final static int ALLOC_SIZE = CARRIER_SIZE * 1024 * 1024 * 256;
     final static int ELEM_SIZE = ALLOC_SIZE / CARRIER_SIZE;
-    
+
     final static MemoryLayout ELEM_LAYOUT = ValueLayout.JAVA_INT;
     final static int BULK_FACTOR = 512;
     final static SequenceLayout ELEM_LAYOUT_BULK = MemoryLayout.sequenceLayout(BULK_FACTOR, ELEM_LAYOUT);

--- a/test/micro/org/openjdk/bench/java/lang/foreign/TestAdaptVarHandles.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/TestAdaptVarHandles.java
@@ -24,9 +24,8 @@
 
 package org.openjdk.bench.java.lang.foreign;
 
-import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.ValueLayout;
+
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -49,7 +48,7 @@ import java.util.concurrent.TimeUnit;
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(value = 3, jvmArgsAppend = "--enable-preview")
-public class TestAdaptVarHandles {
+public class TestAdaptVarHandles extends JavaLayouts {
 
     static class IntBox {
 
@@ -80,17 +79,15 @@ public class TestAdaptVarHandles {
         }
     }
 
-    static final VarHandle VH_int = MethodHandles.arrayElementVarHandle(int[].class);
+    static final VarHandle VH_ARR_INT = MethodHandles.arrayElementVarHandle(int[].class);
 
-    static final VarHandle VH_box_int = MethodHandles.filterValue(VH_int, INTBOX_TO_INT, INT_TO_INTBOX);
+    static final VarHandle VH_BOX_ARR_INT = MethodHandles.filterValue(VH_ARR_INT, INTBOX_TO_INT, INT_TO_INTBOX);
 
-    static final VarHandle VH_addr_int = ValueLayout.JAVA_INT.arrayElementVarHandle();
+    static final VarHandle VH_BOX_INT = MethodHandles.filterValue(VH_INT, INTBOX_TO_INT, INT_TO_INTBOX);
 
-    static final VarHandle VH_addr_box_int = MethodHandles.filterValue(VH_addr_int, INTBOX_TO_INT, INT_TO_INTBOX);
+    static final MethodHandle MH_INT = VH_ARR_INT.toMethodHandle(VarHandle.AccessMode.GET);
 
-    static final MethodHandle MH_int = VH_int.toMethodHandle(VarHandle.AccessMode.GET);
-
-    static final MethodHandle MH_box_int = MethodHandles.filterReturnValue(MH_int, INT_TO_INTBOX);
+    static final MethodHandle MH_BOX_INT = MethodHandles.filterReturnValue(MH_INT, INT_TO_INTBOX);
 
     int[] base = new int[ELEM_SIZE];
     MemorySegment segment = MemorySegment.ofArray(base);
@@ -106,7 +103,7 @@ public class TestAdaptVarHandles {
     public int vh_loop() throws Throwable {
         int sum = 0;
         for (int i = 0; i < ELEM_SIZE; i++) {
-            sum += (int)VH_int.get(base, i);
+            sum += (int) VH_ARR_INT.get(base, i);
         }
         return sum;
     }
@@ -115,7 +112,7 @@ public class TestAdaptVarHandles {
     public int vh_box_loop() throws Throwable {
         int sum = 0;
         for (int i = 0; i < ELEM_SIZE; i++) {
-            sum += ((IntBox)VH_box_int.get(base, i)).intValue();
+            sum += ((IntBox) VH_BOX_ARR_INT.get(base, i)).intValue();
         }
         return sum;
     }
@@ -124,7 +121,7 @@ public class TestAdaptVarHandles {
     public int mh_loop() throws Throwable {
         int sum = 0;
         for (int i = 0; i < ELEM_SIZE; i++) {
-            sum += (int)MH_int.invokeExact(base, i);
+            sum += (int) MH_INT.invokeExact(base, i);
         }
         return sum;
     }
@@ -133,7 +130,7 @@ public class TestAdaptVarHandles {
     public int mh_box_loop() throws Throwable {
         int sum = 0;
         for (int i = 0; i < ELEM_SIZE; i++) {
-            sum += ((IntBox)MH_box_int.invokeExact(base, i)).intValue();
+            sum += ((IntBox) MH_BOX_INT.invokeExact(base, i)).intValue();
         }
         return sum;
     }
@@ -142,7 +139,7 @@ public class TestAdaptVarHandles {
     public int segment_loop() throws Throwable {
         int sum = 0;
         for (int i = 0; i < ELEM_SIZE; i++) {
-            sum += (int)VH_addr_int.get(segment, (long)i);
+            sum += (int)VH_INT.get(segment, (long)i);
         }
         return sum;
     }
@@ -151,7 +148,7 @@ public class TestAdaptVarHandles {
     public int segment_box_loop() throws Throwable {
         int sum = 0;
         for (int i = 0; i < ELEM_SIZE; i++) {
-            sum += ((IntBox)VH_addr_box_int.get(segment, (long)i)).intValue();
+            sum += ((IntBox)VH_BOX_INT.get(segment, (long)i)).intValue();
         }
         return sum;
     }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/UnrolledAccess.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/UnrolledAccess.java
@@ -31,8 +31,6 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import sun.misc.Unsafe;
 import java.util.concurrent.TimeUnit;
 
-import java.lang.invoke.VarHandle;
-
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -41,19 +39,11 @@ import static java.lang.foreign.ValueLayout.JAVA_LONG;
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @Fork(value = 3, jvmArgsAppend = { "--enable-preview", "--enable-native-access=ALL-UNNAMED" })
-public class UnrolledAccess {
+public class UnrolledAccess extends JavaLayouts {
 
     static final Unsafe U = Utils.unsafe;
 
     final static int SIZE = 1024;
-
-    static final ValueLayout.OfLong JAVA_LONG_UNALIGNED = JAVA_LONG.withBitAlignment(8);
-
-    static final VarHandle LONG_HANDLE = MemoryLayout.sequenceLayout(SIZE, JAVA_LONG)
-            .varHandle(MemoryLayout.PathElement.sequenceElement());
-
-    static final VarHandle LONG_HANDLE_UNALIGNED = MemoryLayout.sequenceLayout(SIZE, JAVA_LONG_UNALIGNED)
-            .varHandle(MemoryLayout.PathElement.sequenceElement());
 
     @State(Scope.Benchmark)
     public static class Data {
@@ -94,10 +84,10 @@ public class UnrolledAccess {
         final MemorySegment os = state.outputSegment;
 
         for(int i = 0; i < SIZE; i+=4) {
-            LONG_HANDLE.set(os, (long) (i),   (long) LONG_HANDLE.get(is, (long) (i))   + (long) LONG_HANDLE.get(os, (long) (i)));
-            LONG_HANDLE.set(os, (long) (i+1), (long) LONG_HANDLE.get(is, (long) (i+1)) + (long) LONG_HANDLE.get(os, (long) (i+1)));
-            LONG_HANDLE.set(os, (long) (i+2), (long) LONG_HANDLE.get(is, (long) (i+2)) + (long) LONG_HANDLE.get(os, (long) (i+2)));
-            LONG_HANDLE.set(os, (long) (i+3), (long) LONG_HANDLE.get(is, (long) (i+3)) + (long) LONG_HANDLE.get(os, (long) (i+3)));
+            VH_LONG.set(os, (long) (i),   (long) VH_LONG.get(is, (long) (i))   + (long) VH_LONG.get(os, (long) (i)));
+            VH_LONG.set(os, (long) (i+1), (long) VH_LONG.get(is, (long) (i+1)) + (long) VH_LONG.get(os, (long) (i+1)));
+            VH_LONG.set(os, (long) (i+2), (long) VH_LONG.get(is, (long) (i+2)) + (long) VH_LONG.get(os, (long) (i+2)));
+            VH_LONG.set(os, (long) (i+3), (long) VH_LONG.get(is, (long) (i+3)) + (long) VH_LONG.get(os, (long) (i+3)));
         }
     }
 
@@ -120,10 +110,10 @@ public class UnrolledAccess {
         final MemorySegment os = state.outputSegment;
 
         for(int i = 0; i < SIZE; i+=4) {
-            LONG_HANDLE_UNALIGNED.set(os, (long) (i),   (long) LONG_HANDLE_UNALIGNED.get(is, (long) (i))   + (long) LONG_HANDLE_UNALIGNED.get(os, (long) (i)));
-            LONG_HANDLE_UNALIGNED.set(os, (long) (i+1), (long) LONG_HANDLE_UNALIGNED.get(is, (long) (i+1)) + (long) LONG_HANDLE_UNALIGNED.get(os, (long) (i+1)));
-            LONG_HANDLE_UNALIGNED.set(os, (long) (i+2), (long) LONG_HANDLE_UNALIGNED.get(is, (long) (i+2)) + (long) LONG_HANDLE_UNALIGNED.get(os, (long) (i+2)));
-            LONG_HANDLE_UNALIGNED.set(os, (long) (i+3), (long) LONG_HANDLE_UNALIGNED.get(is, (long) (i+3)) + (long) LONG_HANDLE_UNALIGNED.get(os, (long) (i+3)));
+            VH_LONG_UNALIGNED.set(os, (long) (i),   (long) VH_LONG_UNALIGNED.get(is, (long) (i))   + (long) VH_LONG_UNALIGNED.get(os, (long) (i)));
+            VH_LONG_UNALIGNED.set(os, (long) (i+1), (long) VH_LONG_UNALIGNED.get(is, (long) (i+1)) + (long) VH_LONG_UNALIGNED.get(os, (long) (i+1)));
+            VH_LONG_UNALIGNED.set(os, (long) (i+2), (long) VH_LONG_UNALIGNED.get(is, (long) (i+2)) + (long) VH_LONG_UNALIGNED.get(os, (long) (i+2)));
+            VH_LONG_UNALIGNED.set(os, (long) (i+3), (long) VH_LONG_UNALIGNED.get(is, (long) (i+3)) + (long) VH_LONG_UNALIGNED.get(os, (long) (i+3)));
         }
     }
 


### PR DESCRIPTION
This simple patch regularizes some of the foreign API benchmarks. Some of the changes are:

* use of capital names for var handle and layout constants
* move shared layout and var handle constants in a new superclass, `JavaLayouts`
* regularize aligned vs. unaligned benchmarks, especially in `LoopOverNonConstantHeap`. Since the API now aligns layouts by default, where the benchmark name doesn't say anything we assume aligned layout; for benchmarks that test specifically the use of unaligned layouts, we use the `_unaligned` prefix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286756](https://bugs.openjdk.java.net/browse/JDK-8286756): Cleanup foreign API benchmarks


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8705/head:pull/8705` \
`$ git checkout pull/8705`

Update a local copy of the PR: \
`$ git checkout pull/8705` \
`$ git pull https://git.openjdk.java.net/jdk pull/8705/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8705`

View PR using the GUI difftool: \
`$ git pr show -t 8705`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8705.diff">https://git.openjdk.java.net/jdk/pull/8705.diff</a>

</details>
