### PR TITLE
JDK-8284037: Snippet-files subdirectory not automatically detected when in unnamed package

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SnippetTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SnippetTaglet.java
@@ -38,7 +38,6 @@ import javax.lang.model.element.PackageElement;
 import javax.tools.Diagnostic;
 import javax.tools.DocumentationTool.Location;
 import javax.tools.FileObject;
-import javax.tools.JavaFileManager;
 
 import com.sun.source.doctree.AttributeTree;
 import com.sun.source.doctree.DocTree;
@@ -215,14 +214,14 @@ public class SnippetTaglet extends BaseTaglet {
             // we didn't create JavaFileManager, so we won't close it; even if an error occurs
             var fileManager = writer.configuration().getFileManager();
 
-            // first, look in local snippet-files subdirectory
-            Utils utils = writer.configuration().utils;
-            PackageElement pkg = getPackageElement(holder, utils);
-            JavaFileManager.Location l = utils.getLocationForPackage(pkg);
-            String relativeName = "snippet-files/" + v;
-            String packageName = packageName(pkg, utils);
             try {
-                fileObject = fileManager.getFileForInput(l, packageName, relativeName);
+                // first, look in local snippet-files subdirectory
+                var utils = writer.configuration().utils;
+                var pkg = getPackageElement(holder, utils);
+                var pkgLocn = utils.getLocationForPackage(pkg);
+                var pkgName = pkg.getQualifiedName().toString(); // note: empty string for unnamed package
+                var relativeName = "snippet-files/" + v;
+                fileObject = fileManager.getFileForInput(pkgLocn, pkgName, relativeName);
 
                 // if not found in local snippet-files directory, look on snippet path
                 if (fileObject == null && fileManager.hasLocation(Location.SNIPPET_PATH)) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SnippetTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SnippetTaglet.java
@@ -218,10 +218,10 @@ public class SnippetTaglet extends BaseTaglet {
                 // first, look in local snippet-files subdirectory
                 var utils = writer.configuration().utils;
                 var pkg = getPackageElement(holder, utils);
-                var pkgLocn = utils.getLocationForPackage(pkg);
+                var pkgLocation = utils.getLocationForPackage(pkg);
                 var pkgName = pkg.getQualifiedName().toString(); // note: empty string for unnamed package
                 var relativeName = "snippet-files/" + v;
-                fileObject = fileManager.getFileForInput(pkgLocn, pkgName, relativeName);
+                fileObject = fileManager.getFileForInput(pkgLocation, pkgName, relativeName);
 
                 // if not found in local snippet-files directory, look on snippet path
                 if (fileObject == null && fileManager.hasLocation(Location.SNIPPET_PATH)) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SnippetTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SnippetTaglet.java
@@ -408,10 +408,6 @@ public class SnippetTaglet extends BaseTaglet {
         return writer.invalidTagOutput(resources.getText("doclet.tag.invalid", "snippet"), details);
     }
 
-    private String packageName(PackageElement pkg, Utils utils) {
-        return utils.getPackageName(pkg);
-    }
-
     private static PackageElement getPackageElement(Element e, Utils utils) {
         if (e instanceof DocletElement de) {
             return de.getPackageElement();

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetUnnamedPackage.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetUnnamedPackage.java
@@ -90,7 +90,7 @@ public class TestSnippetUnnamedPackage extends SnippetTester {
                         <div class="snippet-container"><button class="snippet-copy" onclick="copySnippet(this)"><span data-copied="Copied!">Copy</span><img src="copy.svg" alt="Copy"></button>
                         <pre class="snippet"><code class="language-java">public class S { }</code></pre>
                         </div>
-                                                 
+
                          After.""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetUnnamedPackage.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetUnnamedPackage.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8284037
+ * @summary Snippet-files subdirectory not automatically detected when in unnamed package
+ * @library /tools/lib ../../lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.javadoc/jdk.javadoc.internal.tool
+ * @build javadoc.tester.* toolbox.ToolBox toolbox.ModuleBuilder builder.ClassBuilder
+ * @run main TestSnippetUnnamedPackage
+ */
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestSnippetUnnamedPackage extends SnippetTester {
+
+    public static void main(String... args) throws Exception {
+        new TestSnippetUnnamedPackage().runTests();
+    }
+
+    @Test
+    public void testNoSourcePath(Path base) throws IOException {
+        test(base, false);
+    }
+
+    @Test
+    public void testSourcePath(Path base) throws IOException {
+        test(base, true);
+    }
+
+    void test(Path base, boolean useSourcePath) throws IOException {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                        /**
+                         * Comment.
+                         * Before.
+                         * {@snippet class=S}
+                         * After.
+                         */
+                        public class C {
+                          private C() { }
+                        }
+                        """);
+        tb.writeFile(src.resolve("snippet-files").resolve("S.java"),
+        "public class S { }");
+
+        var args = new ArrayList<String>();
+        args.addAll(List.of("-d", base.resolve("out").toString()));
+        if (useSourcePath) {
+            args.addAll(List.of("--source-path", src.toString()));
+        }
+        args.add(src.resolve("C.java").toString());
+
+        javadoc(args.toArray(String[]::new));
+        checkExit(useSourcePath ? Exit.OK : Exit.ERROR);
+        checkOutput(Output.OUT, !useSourcePath,
+                "C.java:4: error: file not found on source path or snippet path: S.java");
+
+        checkOutput("C.html", useSourcePath,
+                """
+                        Before.
+                        \s
+                        <div class="snippet-container"><button class="snippet-copy" onclick="copySnippet(this)"><span data-copied="Copied!">Copy</span><img src="copy.svg" alt="Copy"></button>
+                        <pre class="snippet"><code class="language-java">public class S { }</code></pre>
+                        </div>
+                                                 
+                         After.""");
+    }
+}


### PR DESCRIPTION
Please review a small fix to address use of snippets in source code in the unnamed package.

The core of the fix is to replace `packageName(pkg, utils)` (which returns `"<Unnamed>"` for the unnamed package) with plain old `pkg.getQualifiedName().toString()` (which returns an empty string for the unnamed package.)

There's some minor localized cleanup and rearrangement as well.

The test verifies behavior without and then with a source path, since that is the likely path of discovery by a user playing with the unnamed package.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284037](https://bugs.openjdk.java.net/browse/JDK-8284037): Snippet-files subdirectory not automatically detected when in unnamed package


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8708/head:pull/8708` \
`$ git checkout pull/8708`

Update a local copy of the PR: \
`$ git checkout pull/8708` \
`$ git pull https://git.openjdk.java.net/jdk pull/8708/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8708`

View PR using the GUI difftool: \
`$ git pr show -t 8708`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8708.diff">https://git.openjdk.java.net/jdk/pull/8708.diff</a>

</details>
