### PR TITLE
8286090: Add RC2/RC4 to jdk.security.legacyAlgorithms

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -654,7 +654,7 @@ jdk.certpath.disabledAlgorithms=MD2, MD5, SHA1 jdkCA & usage TLSServer, \
 
 jdk.security.legacyAlgorithms=SHA1, \
     RSA keySize < 2048, DSA keySize < 2048, \
-    DES, DESede, MD5
+    DES, DESede, MD5, RC2, ARCFOUR
 
 #
 # Algorithm restrictions for signed JAR files

--- a/test/jdk/sun/security/tools/keytool/WeakSecretKeyTest.java
+++ b/test/jdk/sun/security/tools/keytool/WeakSecretKeyTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8255552
+ * @bug 8255552 8286090
  * @summary Test keytool commands associated with secret key entries which use weak algorithms
  * @library /test/lib
  */
@@ -58,11 +58,25 @@ public class WeakSecretKeyTest {
                 .shouldHaveExitValue(0);
 
         SecurityTools.keytool("-keystore ks.p12 -storepass changeit " +
+                "-genseckey -keyalg RC2 -alias rc2key -keysize 128")
+                .shouldContain("Warning")
+                .shouldMatch("The generated secret key uses the RC2 algorithm.*considered a security risk")
+                .shouldHaveExitValue(0);
+
+        SecurityTools.keytool("-keystore ks.p12 -storepass changeit " +
+                "-genseckey -keyalg RC4 -alias rc4key -keysize 1024")
+                .shouldContain("Warning")
+                .shouldMatch("The generated secret key uses the ARCFOUR algorithm.*considered a security risk")
+                .shouldHaveExitValue(0);
+
+        SecurityTools.keytool("-keystore ks.p12 -storepass changeit " +
                 "-list -v")
                 .shouldContain("Warning")
                 .shouldMatch("<des3key> uses the DESede algorithm.*considered a security risk")
                 .shouldMatch("<deskey> uses the DES algorithm.*considered a security risk")
                 .shouldNotMatch("<aeskey> uses the AES algorithm.*considered a security risk")
+                .shouldMatch("<rc2key> uses the RC2 algorithm.*considered a security risk")
+                .shouldMatch("<rc4key> uses the ARCFOUR algorithm.*considered a security risk")
                 .shouldHaveExitValue(0);
 
         SecurityTools.setResponse("changeit", "changeit");
@@ -71,6 +85,8 @@ public class WeakSecretKeyTest {
                 .shouldContain("Warning")
                 .shouldMatch("<des3key> uses the DESede algorithm.*considered a security risk")
                 .shouldMatch("<deskey> uses the DES algorithm.*considered a security risk")
+                .shouldMatch("<rc2key> uses the RC2 algorithm.*considered a security risk")
+                .shouldMatch("<rc4key> uses the ARCFOUR algorithm.*considered a security risk")
                 .shouldHaveExitValue(0);
 
         SecurityTools.keytool("-keystore ks.new -storepass changeit " +
@@ -78,6 +94,8 @@ public class WeakSecretKeyTest {
                 .shouldContain("Warning")
                 .shouldMatch("<des3key> uses the DESede algorithm.*considered a security risk")
                 .shouldMatch("<deskey> uses the DES algorithm.*considered a security risk")
+                .shouldMatch("<rc2key> uses the RC2 algorithm.*considered a security risk")
+                .shouldMatch("<rc4key> uses the ARCFOUR algorithm.*considered a security risk")
                 .shouldHaveExitValue(0);
 
         Files.writeString(Files.createFile(Paths.get(JAVA_SECURITY_FILE)),


### PR DESCRIPTION
Please review the small change to add RC2 and ARCFOUR to jdk.security.legacyAlgorithms. So it enables keytool -genseckey, -list, and -importkeystore commands to warn users when RC2 or ARCFOUR algorithm is used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issues
 * [JDK-8286090](https://bugs.openjdk.java.net/browse/JDK-8286090): Add RC2/RC4 to jdk.security.legacyAlgorithms
 * [JDK-8286764](https://bugs.openjdk.java.net/browse/JDK-8286764): Add RC2/RC4 to jdk.security.legacyAlgorithms (**CSR**)


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8712/head:pull/8712` \
`$ git checkout pull/8712`

Update a local copy of the PR: \
`$ git checkout pull/8712` \
`$ git pull https://git.openjdk.java.net/jdk pull/8712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8712`

View PR using the GUI difftool: \
`$ git pr show -t 8712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8712.diff">https://git.openjdk.java.net/jdk/pull/8712.diff</a>

</details>
