### PR TITLE
8286771: workaround implemented for JDK-8282607 is incomplete

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
@@ -162,6 +162,7 @@ public class MachCodeFramesInErrorFile {
             // code blob dumping is missing, exit successfully.
             System.out.println("Could not find \"" + preCodeBlobSectionHeader + "\" in " + hsErrPath);
             System.out.println("Looks like hs-err is truncated - exiting with success");
+            return;
         }
 
         Matcher matcher = Pattern.compile("\\[MachCode\\]\\s*\\[Verified Entry Point\\]\\s*  # \\{method\\} \\{[^}]*\\} '([^']+)' '([^']+)' in '([^']+)'", Pattern.DOTALL).matcher(hsErr);


### PR DESCRIPTION
Completes the workaround implemented in [JDK-8282607](https://bugs.openjdk.java.net/browse/JDK-8282607) so that the test actually passes when hs-err truncation is seen.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286771](https://bugs.openjdk.java.net/browse/JDK-8286771): workaround implemented for JDK-8282607 is incomplete


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8713/head:pull/8713` \
`$ git checkout pull/8713`

Update a local copy of the PR: \
`$ git checkout pull/8713` \
`$ git pull https://git.openjdk.java.net/jdk pull/8713/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8713`

View PR using the GUI difftool: \
`$ git pr show -t 8713`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8713.diff">https://git.openjdk.java.net/jdk/pull/8713.diff</a>

</details>
