### PR TITLE
8286773: cleanup @returns in sun.security classes

### DIFF
--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -4070,7 +4070,7 @@ public final class Main {
      *                 It must have the same public key as certToVerify
      *                 but cannot be the same cert.
      * @param certToVerify the starting certificate to build the chain
-     * @returns the established chain, might be null if user decides not
+     * @return the established chain, might be null if user decides not
      */
     private Certificate[] establishCertChain(Certificate userCert,
                                              Certificate certToVerify)

--- a/src/java.base/share/classes/sun/security/util/DerValue.java
+++ b/src/java.base/share/classes/sun/security/util/DerValue.java
@@ -299,7 +299,7 @@ public class DerValue {
      *
      * @param tag the tag
      * @param out the DerOutputStream
-     * @returns a new DerValue using out as its content
+     * @return a new DerValue using out as its content
      */
     public static DerValue wrap(byte tag, DerOutputStream out) {
         return new DerValue(tag, out.buf(), 0, out.size(), false);
@@ -311,7 +311,7 @@ public class DerValue {
      * Attention: no cloning is made.
      *
      * @param buf the byte array containing the DER-encoded datum
-     * @returns a new DerValue
+     * @return a new DerValue
      */
     public static DerValue wrap(byte[] buf)
             throws IOException {
@@ -326,7 +326,7 @@ public class DerValue {
      * @param buf the byte array containing the DER-encoded datum
      * @param offset where the encoded datum starts inside {@code buf}
      * @param len length of bytes to parse inside {@code buf}
-     * @returns a new DerValue
+     * @return a new DerValue
      */
     public static DerValue wrap(byte[] buf, int offset, int len)
             throws IOException {


### PR DESCRIPTION
The below sun.security classes should use `@return` rather than `@returns`.
sun/security/tools/keytool/Main.java
sun/security/util/DerValue.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286773](https://bugs.openjdk.java.net/browse/JDK-8286773): cleanup @returns in sun.security classes


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8714/head:pull/8714` \
`$ git checkout pull/8714`

Update a local copy of the PR: \
`$ git checkout pull/8714` \
`$ git pull https://git.openjdk.java.net/jdk pull/8714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8714`

View PR using the GUI difftool: \
`$ git pr show -t 8714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8714.diff">https://git.openjdk.java.net/jdk/pull/8714.diff</a>

</details>
