### PR TITLE
8286782: Exclude vmTestbase/gc/gctests/WeakReference/weak006/weak006.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -155,6 +155,7 @@ vmTestbase/nsk/jvmti/scenarios/jni_interception/JI06/ji06t001/TestDescription.ja
 vmTestbase/nsk/jvmti/SetJNIFunctionTable/setjniftab001/TestDescription.java 8219652 aix-ppc64
 vmTestbase/nsk/jvmti/AttachOnDemand/attach002a/TestDescription.java 8277812 generic-all
 
+vmTestbase/gc/gctests/WeakReference/weak006/weak006.java 8286737 generic-all
 vmTestbase/gc/lock/jni/jnilock002/TestDescription.java 8192647 generic-all
 
 vmTestbase/jit/escape/LockCoarsening/LockCoarsening001.java 8148743 generic-all


### PR DESCRIPTION
Please review following trivial fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286782](https://bugs.openjdk.java.net/browse/JDK-8286782): Exclude vmTestbase/gc/gctests/WeakReference/weak006/weak006.java


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8716/head:pull/8716` \
`$ git checkout pull/8716`

Update a local copy of the PR: \
`$ git checkout pull/8716` \
`$ git pull https://git.openjdk.java.net/jdk pull/8716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8716`

View PR using the GUI difftool: \
`$ git pr show -t 8716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8716.diff">https://git.openjdk.java.net/jdk/pull/8716.diff</a>

</details>
