### PR TITLE
8286808: Loom: Simplify generate_cont_thaw by passing thaw_kind directly

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -6552,8 +6552,9 @@ class StubGenerator: public StubCodeGenerator {
     return stub;
   }
 
-  address generate_cont_thaw(bool return_barrier, bool exception) {
-    assert(return_barrier || !exception, "must be");
+  address generate_cont_thaw(Continuation::thaw_kind kind) {
+    bool return_barrier = Continuation::is_thaw_return_barrier(kind);
+    bool return_barrier_exception = Continuation::is_thaw_return_barrier_exception(kind);
 
     address start = __ pc();
 
@@ -6569,7 +6570,7 @@ class StubGenerator: public StubCodeGenerator {
       __ stp(rscratch1, r0, Address(__ pre(sp, -2 * wordSize)));
     }
 
-    __ movw(c_rarg1, (return_barrier ? 1 : 0) + (exception ? 1 : 0));
+    __ movw(c_rarg1, (return_barrier ? 1 : 0);
     __ call_VM_leaf(CAST_FROM_FN_PTR(address, Continuation::prepare_thaw), rthread, c_rarg1);
     __ mov(rscratch2, r0); // r0 contains the size of the frames to thaw, 0 if overflow or no more frames
 
@@ -6600,9 +6601,7 @@ class StubGenerator: public StubCodeGenerator {
     }
 
     // If we want, we can templatize thaw by kind, and have three different entries
-    if (exception)           __ movw(c_rarg1, (uint32_t)Continuation::thaw_exception);
-    else if (return_barrier) __ movw(c_rarg1, (uint32_t)Continuation::thaw_return_barrier);
-    else                     __ movw(c_rarg1, (uint32_t)Continuation::thaw_top);
+    __ movw(c_rarg1, (uint32_t)kind);
 
     __ call_VM_leaf(Continuation::thaw_entry(), rthread, c_rarg1);
     __ mov(rscratch2, r0); // r0 is the sp of the yielding frame
@@ -6619,7 +6618,7 @@ class StubGenerator: public StubCodeGenerator {
     __ sub(sp, rscratch2, 2*wordSize); // now pointing to rfp spill
     __ mov(rfp, sp);
 
-    if (exception) {
+    if (return_barrier_exception) {
       __ ldr(c_rarg1, Address(rfp, wordSize)); // return address
       __ verify_oop(r0);
       __ mov(r19, r0); // save return value contaning the exception oop in callee-saved R19
@@ -6652,7 +6651,7 @@ class StubGenerator: public StubCodeGenerator {
 
     StubCodeMark mark(this, "StubRoutines", "Cont thaw");
     address start = __ pc();
-    generate_cont_thaw(false, false);
+    generate_cont_thaw(Continuation::thaw_top);
     return start;
   }
 
@@ -6663,7 +6662,7 @@ class StubGenerator: public StubCodeGenerator {
     StubCodeMark mark(this, "StubRoutines", "cont return barrier");
     address start = __ pc();
 
-    generate_cont_thaw(true, false);
+    generate_cont_thaw(Continuation::thaw_return_barrier);
 
     return start;
   }
@@ -6674,7 +6673,7 @@ class StubGenerator: public StubCodeGenerator {
     StubCodeMark mark(this, "StubRoutines", "cont return barrier exception handler");
     address start = __ pc();
 
-    generate_cont_thaw(true, true);
+    generate_cont_thaw(Continuation::thaw_return_barrier_exception);
 
     return start;
   }

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -6570,7 +6570,7 @@ class StubGenerator: public StubCodeGenerator {
       __ stp(rscratch1, r0, Address(__ pre(sp, -2 * wordSize)));
     }
 
-    __ movw(c_rarg1, (return_barrier ? 1 : 0);
+    __ movw(c_rarg1, (return_barrier ? 1 : 0));
     __ call_VM_leaf(CAST_FROM_FN_PTR(address, Continuation::prepare_thaw), rthread, c_rarg1);
     __ mov(rscratch2, r0); // r0 contains the size of the frames to thaw, 0 if overflow or no more frames
 

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -4507,12 +4507,6 @@ class StubGenerator: public StubCodeGenerator {
     return nullptr;
   }
 
-  address generate_cont_thaw(bool return_barrier, bool exception) {
-    if (!Continuations::enabled()) return nullptr;
-    Unimplemented();
-    return nullptr;
-  }
-
   address generate_cont_thaw() {
     if (!Continuations::enabled()) return nullptr;
     Unimplemented();

--- a/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
@@ -3872,12 +3872,6 @@ class StubGenerator: public StubCodeGenerator {
     return nullptr;
   }
 
-  address generate_cont_thaw(bool return_barrier, bool exception) {
-    if (!Continuations::enabled()) return nullptr;
-    Unimplemented();
-    return nullptr;
-  }
-
   address generate_cont_thaw() {
     if (!Continuations::enabled()) return nullptr;
     Unimplemented();

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -7490,8 +7490,9 @@ address generate_avx_ghash_processBlocks() {
     return stub;
   }
 
-  address generate_cont_thaw(bool return_barrier, bool exception) {
-    assert(return_barrier || !exception, "must be");
+  address generate_cont_thaw(Continuation::thaw_kind kind) {
+    bool return_barrier = Continuation::is_thaw_return_barrier(kind);
+    bool return_barrier_exception = Continuation::is_thaw_return_barrier_exception(kind);
 
     address start = __ pc();
 
@@ -7508,7 +7509,7 @@ address generate_avx_ghash_processBlocks() {
       __ push(rax); __ push_d(xmm0); // preserve possible return value from a method returning to the return barrier
     }
 
-    __ movl(c_rarg1, (return_barrier ? 1 : 0) + (exception ? 1 : 0));
+    __ movl(c_rarg1, (return_barrier ? 1 : 0));
     __ call_VM_leaf(CAST_FROM_FN_PTR(address, Continuation::prepare_thaw), r15_thread, c_rarg1);
     __ movptr(rbx, rax); // rax contains the size of the frames to thaw, 0 if overflow or no more frames
 
@@ -7531,9 +7532,7 @@ address generate_avx_ghash_processBlocks() {
     }
 
     // If we want, we can templatize thaw by kind, and have three different entries
-    if (exception)           __ movl(c_rarg1, (int32_t)Continuation::thaw_exception);
-    else if (return_barrier) __ movl(c_rarg1, (int32_t)Continuation::thaw_return_barrier);
-    else                     __ movl(c_rarg1, (int32_t)Continuation::thaw_top);
+    __ movl(c_rarg1, (int32_t) kind);
 
     __ call_VM_leaf(Continuation::thaw_entry(), r15_thread, c_rarg1);
     __ movptr(rbx, rax); // rax is the sp of the yielding frame
@@ -7547,7 +7546,7 @@ address generate_avx_ghash_processBlocks() {
     __ movptr(rsp, rbx); // we're now on the yield frame (which is in an address above us b/c rsp has been pushed down)
     __ subptr(rsp, 2*wordSize); // now pointing to rbp spill
 
-    if (exception) {
+    if (return_barrier_exception) {
       __ movptr(c_rarg1, Address(rsp, wordSize)); // return address
       __ push(rax); // save return value contaning the exception oop
       __ call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::exception_handler_for_return_address), r15_thread, c_rarg1);
@@ -7570,7 +7569,7 @@ address generate_avx_ghash_processBlocks() {
 
     StubCodeMark mark(this, "StubRoutines", "Cont thaw");
     address start = __ pc();
-    generate_cont_thaw(false, false);
+    generate_cont_thaw(Continuation::thaw_top);
     return start;
   }
 
@@ -7581,7 +7580,7 @@ address generate_avx_ghash_processBlocks() {
     StubCodeMark mark(this, "StubRoutines", "cont return barrier");
     address start = __ pc();
 
-    generate_cont_thaw(true, false);
+    generate_cont_thaw(Continuation::thaw_return_barrier);
 
     return start;
   }
@@ -7592,7 +7591,7 @@ address generate_avx_ghash_processBlocks() {
     StubCodeMark mark(this, "StubRoutines", "cont return barrier exception handler");
     address start = __ pc();
 
-    generate_cont_thaw(true, true);
+    generate_cont_thaw(Continuation::thaw_return_barrier_exception);
 
     return start;
   }

--- a/src/hotspot/share/runtime/continuation.hpp
+++ b/src/hotspot/share/runtime/continuation.hpp
@@ -62,8 +62,18 @@ public:
   enum thaw_kind {
     thaw_top = 0,
     thaw_return_barrier = 1,
-    thaw_exception = 2,
+    thaw_return_barrier_exception = 2,
   };
+
+  static bool is_thaw_return_barrier(thaw_kind kind) {
+    return kind != thaw_top;
+  }
+
+  static bool is_thaw_return_barrier_exception(thaw_kind kind) {
+    bool r = (kind == thaw_return_barrier_exception);
+    assert(!r || is_thaw_return_barrier(kind), "must be");
+    return r;
+  }
 
   static void init();
 


### PR DESCRIPTION
I was staring at this code for x86_32 port, and it seems `exception` implies `return_barrier`. This mostly irks me because we are passing `2` to `Continuation::prepare_thaw` and implicitly coercing it to `bool` during the call. We can instead call with `1` when `return_barrier`.

Further cleanup makes the change more obvious; we can pass `thaw_kind` directly to `generate_cont_thaw`, and thus simplify the code. Unused x86_32 and PPC64 stubs are just deleted without refactoring the args; this is supposed to produce a cleaner merge problem for current porting work.

Additional testing:
 - [x] `java/lang/Thread/virtual` on Linux x86_64 fastdebug
 - [x] `java/lang/Thread/virtual` on Linux AArch64 fastdebug
 - [x] Build Linux x86_32
 - [x] Build Linux PPC64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286808](https://bugs.openjdk.java.net/browse/JDK-8286808): Loom: Simplify generate_cont_thaw by passing thaw_kind directly


### Reviewers
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - Author)
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8725/head:pull/8725` \
`$ git checkout pull/8725`

Update a local copy of the PR: \
`$ git checkout pull/8725` \
`$ git pull https://git.openjdk.java.net/jdk pull/8725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8725`

View PR using the GUI difftool: \
`$ git pr show -t 8725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8725.diff">https://git.openjdk.java.net/jdk/pull/8725.diff</a>

</details>
