### PR TITLE
8286182: C2: crash with SIGFPE when executing compiled code

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -65,7 +65,8 @@ Node* PhaseIdealLoop::split_thru_phi(Node* n, Node* region, int policy) {
   // phi p of a trip-counted (integer) loop whose inputs could be zero (include zero in their type range). p could have a more precise type
   // range that does not necessarily include all values of its inputs. Since each of these inputs will be a divisor of the newly cloned nodes
   // of 'n', we need to bail out of one of these divisors could be zero (zero in its type range).
-  if ((n->Opcode() == Op_DivI || n->Opcode() == Op_ModI) && n->in(0) == NULL
+  if ((n->Opcode() == Op_DivI || n->Opcode() == Op_NoOvfDivI || n->Opcode() == Op_ModI || n->Opcode() == Op_NoOvfModI)
+      && n->in(0) == NULL
       && region->is_CountedLoop() && n->in(2) == region->as_CountedLoop()->phi()) {
     Node* phi = region->as_CountedLoop()->phi();
     for (uint i = 1; i < phi->req(); i++) {

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1689,7 +1689,9 @@ void PhaseIterGVN::remove_speculative_types()  {
 bool PhaseIterGVN::no_dependent_zero_check(Node* n) const {
   switch (n->Opcode()) {
     case Op_DivI:
-    case Op_ModI: {
+    case Op_NoOvfDivI:
+    case Op_ModI:
+    case Op_NoOvfModI: {
       // Type of divisor includes 0?
       if (type(n->in(2)) == Type::TOP) {
         // 'n' is dead. Treat as if zero check is still there to avoid any further optimizations.
@@ -1699,7 +1701,9 @@ bool PhaseIterGVN::no_dependent_zero_check(Node* n) const {
       return (type_divisor->_hi < 0 || type_divisor->_lo > 0);
     }
     case Op_DivL:
-    case Op_ModL: {
+    case Op_NoOvfDivL:
+    case Op_ModL:
+    case Op_NoOvfModL: {
       // Type of divisor includes 0?
       if (type(n->in(2)) == Type::TOP) {
         // 'n' is dead. Treat as if zero check is still there to avoid any further optimizations.


### PR DESCRIPTION
The bug is not assigned to me, but I have seen that the C2 code which checks for div by 0 is not aware of the new nodes from [JDK-8284742](https://bugs.openjdk.java.net/browse/JDK-8284742).
This fixes the VM to pass the reproducer. I'm not sure if more opcode checks are required to get added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286182](https://bugs.openjdk.java.net/browse/JDK-8286182): C2: crash with SIGFPE when executing compiled code


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8726/head:pull/8726` \
`$ git checkout pull/8726`

Update a local copy of the PR: \
`$ git checkout pull/8726` \
`$ git pull https://git.openjdk.java.net/jdk pull/8726/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8726`

View PR using the GUI difftool: \
`$ git pr show -t 8726`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8726.diff">https://git.openjdk.java.net/jdk/pull/8726.diff</a>

</details>
