### PR TITLE
8283520: JFR: Memory leak in dcmd_arena

### DIFF
--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
@@ -261,7 +261,7 @@ static char* dcmd_arena_allocate(size_t size) {
   return (char*)dcmd_arena->Amalloc(size);
 }
 
-static const char* get_as_dcmd_arena_string(oop string, JavaThread* jt) {
+static const char* get_as_dcmd_arena_string(oop string) {
   char* str = NULL;
   const typeArrayOop value = java_lang_String::value(string);
   if (value != NULL) {
@@ -282,7 +282,7 @@ static const char* read_string_field(oop argument, const char* field_name, TRAPS
   args.set_receiver(argument);
   JfrJavaSupport::get_field(&args, THREAD);
   const oop string_oop = result.get_oop();
-  return string_oop != NULL ? get_as_dcmd_arena_string(string_oop, (JavaThread*)THREAD) : NULL;
+  return string_oop != NULL ? get_as_dcmd_arena_string(string_oop) : NULL;
 }
 
 static bool read_boolean_field(oop argument, const char* field_name, TRAPS) {

--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
@@ -30,6 +30,7 @@
 #include "jfr/jni/jfrJavaSupport.hpp"
 #include "jfr/recorder/jfrRecorder.hpp"
 #include "jfr/recorder/service/jfrOptionSet.hpp"
+#include "jfr/support/jfrThreadLocal.hpp"
 #include "logging/log.hpp"
 #include "logging/logConfiguration.hpp"
 #include "logging/logMessage.hpp"
@@ -247,9 +248,9 @@ static void initialize_dummy_descriptors(GrowableArray<DCmdArgumentInfo*>* array
 // we keep them in a thread local arena. The arena is reset between invocations.
 static THREAD_LOCAL Arena* dcmd_arena = NULL;
 
-static void prepare_dcmd_string_arena() {
-  if (dcmd_arena == NULL) {
-    dcmd_arena = new (mtTracing) Arena(mtTracing);
+static void prepare_dcmd_string_arena(JavaThread* jt) {
+  if (dcmd_arena == nullptr) {
+    dcmd_arena = JfrThreadLocal::dcmd_arena(jt);
   } else {
     dcmd_arena->destruct_contents(); // will grow on next allocation
   }
@@ -260,7 +261,7 @@ static char* dcmd_arena_allocate(size_t size) {
   return (char*)dcmd_arena->Amalloc(size);
 }
 
-static const char* get_as_dcmd_arena_string(oop string, JavaThread* t) {
+static const char* get_as_dcmd_arena_string(oop string, JavaThread* jt) {
   char* str = NULL;
   const typeArrayOop value = java_lang_String::value(string);
   if (value != NULL) {
@@ -330,7 +331,7 @@ GrowableArray<DCmdArgumentInfo*>* JfrDCmd::argument_info_array() const {
   assert(arguments->is_array(), "must be array");
   const int num_arguments = arguments->length();
   assert(num_arguments == _num_arguments, "invariant");
-  prepare_dcmd_string_arena();
+  prepare_dcmd_string_arena(thread);
   for (int i = 0; i < num_arguments; ++i) {
     DCmdArgumentInfo* const dai = create_info(arguments->obj_at(i), thread);
     assert(dai != NULL, "invariant");

--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
@@ -249,11 +249,9 @@ static void initialize_dummy_descriptors(GrowableArray<DCmdArgumentInfo*>* array
 static THREAD_LOCAL Arena* dcmd_arena = NULL;
 
 static void prepare_dcmd_string_arena(JavaThread* jt) {
-  if (dcmd_arena == nullptr) {
-    dcmd_arena = JfrThreadLocal::dcmd_arena(jt);
-  } else {
-    dcmd_arena->destruct_contents(); // will grow on next allocation
-  }
+  dcmd_arena = JfrThreadLocal::dcmd_arena(jt);
+  assert(dcmd_arena != nullptr, "invariant");
+  dcmd_arena->destruct_contents(); // will grow on next allocation
 }
 
 static char* dcmd_arena_allocate(size_t size) {

--- a/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
@@ -39,6 +39,7 @@
 #include "jfr/writers/jfrJavaEventWriter.hpp"
 #include "logging/log.hpp"
 #include "memory/allocation.inline.hpp"
+#include "memory/arena.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/os.hpp"
 #include "runtime/threadIdentifier.hpp"
@@ -55,6 +56,7 @@ JfrThreadLocal::JfrThreadLocal() :
   _checkpoint_buffer_epoch_0(NULL),
   _checkpoint_buffer_epoch_1(NULL),
   _stackframes(NULL),
+  _dcmd_arena(nullptr),
   _thread(),
   _vthread_id(0),
   _jvm_thread_id(0),
@@ -173,6 +175,10 @@ void JfrThreadLocal::release(Thread* t) {
   if (_checkpoint_buffer_epoch_1 != NULL) {
     _checkpoint_buffer_epoch_1->set_retired();
     _checkpoint_buffer_epoch_1 = NULL;
+  }
+  if (_dcmd_arena != nullptr) {
+    delete _dcmd_arena;
+    _dcmd_arena = nullptr;
   }
 }
 
@@ -461,4 +467,16 @@ void JfrThreadLocal::on_set_current_thread(JavaThread* jt, oop thread) {
     Atomic::store(&tl->_vthread_epoch, static_cast<u2>(epoch_raw & epoch_mask));
   }
   Atomic::release_store(&tl->_vthread, true);
+}
+
+Arena* JfrThreadLocal::dcmd_arena(JavaThread* jt) {
+  assert(jt != nullptr, "invariant");
+  JfrThreadLocal* tl = jt->jfr_thread_local();
+  Arena* arena = tl->_dcmd_arena;
+  if (arena != nullptr) {
+    return arena;
+  }
+  arena = new (mtTracing) Arena(mtTracing);
+  tl->_dcmd_arena = arena;
+  return arena;
 }

--- a/src/hotspot/share/jfr/support/jfrThreadLocal.hpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.hpp
@@ -28,6 +28,7 @@
 #include "jfr/utilities/jfrBlob.hpp"
 #include "jfr/utilities/jfrTypes.hpp"
 
+class Arena;
 class JavaThread;
 class JfrBuffer;
 class JfrStackFrame;
@@ -48,6 +49,7 @@ class JfrThreadLocal {
   JfrBuffer* _checkpoint_buffer_epoch_0;
   JfrBuffer* _checkpoint_buffer_epoch_1;
   mutable JfrStackFrame* _stackframes;
+  Arena* _dcmd_arena;
   JfrBlobHandle _thread;
   mutable traceid _vthread_id;
   mutable traceid _jvm_thread_id;
@@ -242,6 +244,8 @@ class JfrThreadLocal {
   bool is_included() const;
   static bool is_excluded(const Thread* thread);
   static bool is_included(const Thread* thread);
+
+  static Arena* dcmd_arena(JavaThread* jt);
 
   bool has_thread_blob() const;
   void set_thread_blob(const JfrBlobHandle& handle);


### PR DESCRIPTION
Greetings,

This changeset will address the memory leak in the dcmd_arena.

Testing: jdk_jfr

Thanks to @shipilev for reporting this issue.

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8283520](https://bugs.openjdk.java.net/browse/JDK-8283520): JFR: Memory leak in dcmd_arena


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8727/head:pull/8727` \
`$ git checkout pull/8727`

Update a local copy of the PR: \
`$ git checkout pull/8727` \
`$ git pull https://git.openjdk.java.net/jdk pull/8727/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8727`

View PR using the GUI difftool: \
`$ git pr show -t 8727`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8727.diff">https://git.openjdk.java.net/jdk/pull/8727.diff</a>

</details>
