### PR TITLE
8286810: Use public [Double|Float].PRECISION fields in jdk.internal.math.[Double|Float]Consts

### DIFF
--- a/src/java.base/share/classes/jdk/internal/math/DoubleConsts.java
+++ b/src/java.base/share/classes/jdk/internal/math/DoubleConsts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package jdk.internal.math;
 
+import static java.lang.Double.*;
+
 /**
  * This class contains additional constants documenting limits of the
  * {@code double} type.
@@ -42,42 +44,42 @@ public class DoubleConsts {
      * The number of logical bits in the significand of a
      * {@code double} number, including the implicit bit.
      */
-    public static final int SIGNIFICAND_WIDTH   = 53;
+    public static final int SIGNIFICAND_WIDTH = PRECISION;
 
     /**
      * The exponent the smallest positive {@code double}
      * subnormal value would have if it could be normalized..
      */
-    public static final int     MIN_SUB_EXPONENT = Double.MIN_EXPONENT -
-                                                   (SIGNIFICAND_WIDTH - 1);
+    public static final int MIN_SUB_EXPONENT =
+            MIN_EXPONENT - (SIGNIFICAND_WIDTH - 1);
 
     /**
      * Bias used in representing a {@code double} exponent.
      */
-    public static final int     EXP_BIAS        = 1023;
+    public static final int EXP_BIAS =
+            (1 << (SIZE - SIGNIFICAND_WIDTH - 1)) - 1;
 
     /**
      * Bit mask to isolate the sign bit of a {@code double}.
      */
-    public static final long    SIGN_BIT_MASK   = 0x8000000000000000L;
+    public static final long SIGN_BIT_MASK = 1L << (SIZE - 1);
 
     /**
-     * Bit mask to isolate the exponent field of a
-     * {@code double}.
+     * Bit mask to isolate the exponent field of a {@code double}.
      */
-    public static final long    EXP_BIT_MASK    = 0x7FF0000000000000L;
+    public static final long EXP_BIT_MASK =
+            ((1L << (SIZE - SIGNIFICAND_WIDTH)) - 1) << (SIGNIFICAND_WIDTH - 1);
 
     /**
-     * Bit mask to isolate the significand field of a
-     * {@code double}.
+     * Bit mask to isolate the significand field of a {@code double}.
      */
-    public static final long    SIGNIF_BIT_MASK = 0x000FFFFFFFFFFFFFL;
+    public static final long SIGNIF_BIT_MASK = (1L << (SIGNIFICAND_WIDTH - 1)) - 1;
 
     /**
      * Bit mask to isolate the magnitude bits (combined exponent and
      * significand fields) of a {@code double}.
      */
-    public static final long    MAG_BIT_MASK = ~SIGN_BIT_MASK;
+    public static final long MAG_BIT_MASK = EXP_BIT_MASK | SIGNIF_BIT_MASK;
 
     static {
         // verify bit masks cover all bit positions and that the bit
@@ -87,6 +89,5 @@ public class DoubleConsts {
                 ((SIGN_BIT_MASK & SIGNIF_BIT_MASK) == 0L) &&
                 ((EXP_BIT_MASK & SIGNIF_BIT_MASK) == 0L)) &&
                 ((SIGN_BIT_MASK | MAG_BIT_MASK) == ~0L));
-
     }
 }

--- a/src/java.base/share/classes/jdk/internal/math/DoubleConsts.java
+++ b/src/java.base/share/classes/jdk/internal/math/DoubleConsts.java
@@ -53,13 +53,13 @@ public class DoubleConsts {
      * subnormal value would have if it could be normalized..
      */
     public static final int MIN_SUB_EXPONENT =
-            MIN_EXPONENT - (SIGNIFICAND_WIDTH - 1);
+            MIN_EXPONENT - (SIGNIFICAND_WIDTH - 1); // -1074
 
     /**
      * Bias used in representing a {@code double} exponent.
      */
     public static final int EXP_BIAS =
-            (1 << (SIZE - SIGNIFICAND_WIDTH - 1)) - 1;
+            (1 << (SIZE - SIGNIFICAND_WIDTH - 1)) - 1; // 1023
 
     /**
      * Bit mask to isolate the sign bit of a {@code double}.

--- a/src/java.base/share/classes/jdk/internal/math/DoubleConsts.java
+++ b/src/java.base/share/classes/jdk/internal/math/DoubleConsts.java
@@ -25,7 +25,9 @@
 
 package jdk.internal.math;
 
-import static java.lang.Double.*;
+import static java.lang.Double.MIN_EXPONENT;
+import static java.lang.Double.PRECISION;
+import static java.lang.Double.SIZE;
 
 /**
  * This class contains additional constants documenting limits of the

--- a/src/java.base/share/classes/jdk/internal/math/FloatConsts.java
+++ b/src/java.base/share/classes/jdk/internal/math/FloatConsts.java
@@ -25,7 +25,9 @@
 
 package jdk.internal.math;
 
-import static java.lang.Float.*;
+import static java.lang.Float.MIN_EXPONENT;
+import static java.lang.Float.PRECISION;
+import static java.lang.Float.SIZE;
 
 /**
  * This class contains additional constants documenting limits of the

--- a/src/java.base/share/classes/jdk/internal/math/FloatConsts.java
+++ b/src/java.base/share/classes/jdk/internal/math/FloatConsts.java
@@ -53,13 +53,13 @@ public class FloatConsts {
      * subnormal value would have if it could be normalized.
      */
     public static final int MIN_SUB_EXPONENT =
-            MIN_EXPONENT - (SIGNIFICAND_WIDTH - 1);
+            MIN_EXPONENT - (SIGNIFICAND_WIDTH - 1); // -149
 
     /**
      * Bias used in representing a {@code float} exponent.
      */
     public static final int EXP_BIAS =
-            (1 << (SIZE - SIGNIFICAND_WIDTH - 1)) - 1;
+            (1 << (SIZE - SIGNIFICAND_WIDTH - 1)) - 1; // 127
 
     /**
      * Bit mask to isolate the sign bit of a {@code float}.

--- a/src/java.base/share/classes/jdk/internal/math/FloatConsts.java
+++ b/src/java.base/share/classes/jdk/internal/math/FloatConsts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package jdk.internal.math;
 
+import static java.lang.Float.*;
+
 /**
  * This class contains additional constants documenting limits of the
  * {@code float} type.
@@ -42,42 +44,42 @@ public class FloatConsts {
      * The number of logical bits in the significand of a
      * {@code float} number, including the implicit bit.
      */
-    public static final int SIGNIFICAND_WIDTH   = 24;
+    public static final int SIGNIFICAND_WIDTH = PRECISION;
 
     /**
-     * The exponent the smallest positive {@code float} subnormal
-     * value would have if it could be normalized.
+     * The exponent the smallest positive {@code float}
+     * subnormal value would have if it could be normalized.
      */
-    public static final int     MIN_SUB_EXPONENT = Float.MIN_EXPONENT -
-                                                   (SIGNIFICAND_WIDTH - 1);
+    public static final int MIN_SUB_EXPONENT =
+            MIN_EXPONENT - (SIGNIFICAND_WIDTH - 1);
 
     /**
      * Bias used in representing a {@code float} exponent.
      */
-    public static final int     EXP_BIAS        = 127;
+    public static final int EXP_BIAS =
+            (1 << (SIZE - SIGNIFICAND_WIDTH - 1)) - 1;
 
     /**
      * Bit mask to isolate the sign bit of a {@code float}.
      */
-    public static final int     SIGN_BIT_MASK   = 0x80000000;
+    public static final int SIGN_BIT_MASK = 1 << (SIZE - 1);
 
     /**
-     * Bit mask to isolate the exponent field of a
-     * {@code float}.
+     * Bit mask to isolate the exponent field of a {@code float}.
      */
-    public static final int     EXP_BIT_MASK    = 0x7F800000;
+    public static final int EXP_BIT_MASK =
+            ((1 << (SIZE - SIGNIFICAND_WIDTH)) - 1) << (SIGNIFICAND_WIDTH - 1);
 
     /**
-     * Bit mask to isolate the significand field of a
-     * {@code float}.
+     * Bit mask to isolate the significand field of a {@code float}.
      */
-    public static final int     SIGNIF_BIT_MASK = 0x007FFFFF;
+    public static final int SIGNIF_BIT_MASK = (1 << (SIGNIFICAND_WIDTH - 1)) - 1;
 
     /**
      * Bit mask to isolate the magnitude bits (combined exponent and
      * significand fields) of a {@code float}.
      */
-    public static final int     MAG_BIT_MASK = ~SIGN_BIT_MASK;
+    public static final int MAG_BIT_MASK = EXP_BIT_MASK | SIGNIF_BIT_MASK;
 
     static {
         // verify bit masks cover all bit positions and that the bit


### PR DESCRIPTION
Please review these simple changes in jdk.internal.math.[Double|Float]Consts

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286810](https://bugs.openjdk.java.net/browse/JDK-8286810): Use public [Double|Float].PRECISION fields in jdk.internal.math.[Double|Float]Consts


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to [3c6be86c](https://git.openjdk.java.net/jdk/pull/8729/files/3c6be86c7d2f08580eb1cdfdbe83578d3f1cc3ae)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to [3c6be86c](https://git.openjdk.java.net/jdk/pull/8729/files/3c6be86c7d2f08580eb1cdfdbe83578d3f1cc3ae)
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to [3c6be86c](https://git.openjdk.java.net/jdk/pull/8729/files/3c6be86c7d2f08580eb1cdfdbe83578d3f1cc3ae)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8729/head:pull/8729` \
`$ git checkout pull/8729`

Update a local copy of the PR: \
`$ git checkout pull/8729` \
`$ git pull https://git.openjdk.java.net/jdk pull/8729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8729`

View PR using the GUI difftool: \
`$ git pr show -t 8729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8729.diff">https://git.openjdk.java.net/jdk/pull/8729.diff</a>

</details>
