### PR TITLE
8272094: compiler/codecache/TestStressCodeBuffers.java crashes with "failed to allocate space for trampoline"

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -15423,7 +15423,11 @@ instruct clearArray_imm_reg(immL cnt, iRegP_R10 base, iRegL_R11 temp, Universe d
   format %{ "ClearArray $cnt, $base" %}
 
   ins_encode %{
-    __ zero_words($base$$Register, (uint64_t)$cnt$$constant);
+    address tpc = __ zero_words($base$$Register, (uint64_t)$cnt$$constant);
+    if (tpc == NULL) {
+      ciEnv::current()->record_failure("CodeCache is full");
+      return;
+    }
   %}
 
   ins_pipe(pipe_class_memory);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -4853,10 +4853,11 @@ address MacroAssembler::zero_words(Register ptr, Register cnt)
 // cnt:          Immediate count in HeapWords.
 //
 // r10, r11, rscratch1, and rscratch2 are clobbered.
-void MacroAssembler::zero_words(Register base, uint64_t cnt)
+address MacroAssembler::zero_words(Register base, uint64_t cnt)
 {
   guarantee(zero_words_block_size < BlockZeroingLowLimit,
             "increase BlockZeroingLowLimit");
+  address result;
   if (cnt <= (uint64_t)BlockZeroingLowLimit / BytesPerWord) {
 #ifndef PRODUCT
     {
@@ -4890,10 +4891,12 @@ void MacroAssembler::zero_words(Register base, uint64_t cnt)
       stp(zr, zr, Address(base, i * wordSize));
     }
     BLOCK_COMMENT("} zero_words");
+    result = pc();
   } else {
     mov(r10, base); mov(r11, cnt);
-    zero_words(r10, r11);
+    result = zero_words(r10, r11);
   }
+  return result;
 }
 
 // Zero blocks of memory by using DC ZVA.

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -4857,7 +4857,7 @@ address MacroAssembler::zero_words(Register base, uint64_t cnt)
 {
   guarantee(zero_words_block_size < BlockZeroingLowLimit,
             "increase BlockZeroingLowLimit");
-  address result;
+  address result = nullptr;
   if (cnt <= (uint64_t)BlockZeroingLowLimit / BytesPerWord) {
 #ifndef PRODUCT
     {

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -4820,7 +4820,6 @@ address MacroAssembler::zero_words(Register ptr, Register cnt)
       address tpc = trampoline_call(zero_blocks);
       if (tpc == NULL) {
         DEBUG_ONLY(reset_labels(around));
-        assert(false, "failed to allocate space for trampoline");
         return NULL;
       }
     } else {

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1291,7 +1291,7 @@ public:
                      int elem_size);
 
   void fill_words(Register base, Register cnt, Register value);
-  void zero_words(Register base, uint64_t cnt);
+  address zero_words(Register base, uint64_t cnt);
   address zero_words(Register ptr, Register cnt);
   void zero_dcache_blocks(Register base, Register cnt);
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -68,7 +68,6 @@ compiler/rtm/print/TestPrintPreciseRTMLockingStatistics.java 8183263 generic-x64
 compiler/c2/Test8004741.java 8235801 generic-all
 
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all
-compiler/codecache/TestStressCodeBuffers.java 8272094 generic-aarch64
 
 
 #############################################################################


### PR DESCRIPTION
This problem is, I believe, caused by an assertion left in the source code after development.
The fix is simply to remove the assertion.

It's not at all easy to reproduce this bug, being a very intermittent failure, but in the end I reproduced it by making `-XX:+StressCodeBuffers` much more stressful, like so:
```

diff --git a/src/hotspot/share/asm/codeBuffer.cpp b/src/hotspot/share/asm/codeBuffer.cpp
index ddd946d7542..c74ba21cf63 100644
--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -837,7 +837,8 @@ void CodeBuffer::expand(CodeSection* which_cs, csize_t amount) {
   if (StressCodeBuffers && blob() != NULL) {
     static int expand_count = 0;
     if (expand_count >= 0)  expand_count += 1;
-    if (expand_count > 100 && is_power_of_2(expand_count)) {
+    if (expand_count > 100 && // is_power_of_2(expand_count)
+        expand_count % 40 == 0) {
       tty->print_cr("StressCodeBuffers: have expanded %d times", expand_count);
       // simulate an occasional allocation failure:
       free_blob();

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8272094](https://bugs.openjdk.java.net/browse/JDK-8272094): compiler/codecache/TestStressCodeBuffers.java crashes with "failed to allocate space for trampoline"


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [c06acfac](https://git.openjdk.java.net/jdk/pull/8730/files/c06acfaced3272ef9f5c240d79948f3bca3d2877)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8730/head:pull/8730` \
`$ git checkout pull/8730`

Update a local copy of the PR: \
`$ git checkout pull/8730` \
`$ git pull https://git.openjdk.java.net/jdk pull/8730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8730`

View PR using the GUI difftool: \
`$ git pr show -t 8730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8730.diff">https://git.openjdk.java.net/jdk/pull/8730.diff</a>

</details>
