### PR TITLE
8286823: Default to UseAVX=2 on all Skylake/Cascade Lake CPUs

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -895,8 +895,9 @@ void VM_Version::get_processor_features() {
     }
   }
   if (FLAG_IS_DEFAULT(UseAVX)) {
-    // Don't use AVX-512 on older Skylakes unless explicitly requested.
-    if (use_avx_limit > 2 && is_intel_skylake() && _stepping < 5) {
+    // Don't use AVX-512 on Skylake (or the related Cascade Lake) CPUs unless explicitly
+    // requested - these instructions can cause performance issues on these processors.
+    if (use_avx_limit > 2 && is_intel_skylake()) {
       FLAG_SET_DEFAULT(UseAVX, 2);
     } else {
       FLAG_SET_DEFAULT(UseAVX, use_avx_limit);


### PR DESCRIPTION
The current code already does this for 'older' Skylake processors,
namely those with _stepping < 5. My testing indicates this is a
problem for later processors in this family too, so I have removed the
max stepping condition.

The original exclusion was added in https://bugs.openjdk.java.net/browse/JDK-8221092.

A general description of the overall issue is given at
https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#Downclocking.

According to https://en.wikichip.org/wiki/intel/microarchitectures/cascade_lake#CPUID,
stepping values 5..7 indicate Cascade Lake. I have tested on a CPU with stepping=7,
and I see CPU frequency reduction from 3.1GHz down to 2.7GHz (~23%) when using
-XX:UseAVX=3, along with a corresponding performance reduction.

I first saw this issue in a real production workload, where the main AVX3 instructions
being executed were those generated for various flavours of disjoint_arraycopy.

I can reproduce a similar effect using SPECjvm2008's xml.transform benchmark.

```
java --add-opens=java.xml/com.sun.org.apache.xerces.internal.parsers=ALL-UNNAMED \
--add-opens=java.xml/com.sun.org.apache.xerces.internal.util=ALL-UNNAMED \
-jar SPECjvm2008.jar -ikv -ict xml.transform
```

Before the change, or with -XX:UseAVX=3:

```
Valid run!
Score on xml.transform: 776.00 ops/m
```

After the change, or with -XX:UseAVX=2:

```
Valid run!
Score on xml.transform: 894.07 ops/m
```

So, a 15% improvement in this benchmark. It's possible some benchmarks will be negatively
affected by this change, but I contend that this is still the right move given the stark
difference in this benchmark combined with the fact that use of AVX3 instructions can
affect *all* processes/code on the host due to the downclocking, and the fact that this
effect is very hard to root-cause, for example CPU profiles look very similar before and
after since all code is equally slowed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286823](https://bugs.openjdk.java.net/browse/JDK-8286823): Default to UseAVX=2 on all Skylake/Cascade Lake CPUs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8731/head:pull/8731` \
`$ git checkout pull/8731`

Update a local copy of the PR: \
`$ git checkout pull/8731` \
`$ git pull https://git.openjdk.java.net/jdk pull/8731/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8731`

View PR using the GUI difftool: \
`$ git pr show -t 8731`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8731.diff">https://git.openjdk.java.net/jdk/pull/8731.diff</a>

</details>
