### PR TITLE
8282280: Update Xerces to Version 2.12.2

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XML11EntityScanner.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XML11EntityScanner.java
@@ -114,7 +114,7 @@ public class XML11EntityScanner
             if (fCurrentEntity.position == fCurrentEntity.count) {
                 invokeListeners(1);
                 fCurrentEntity.ch[0] = (char)c;
-                load(1, false, false);
+                load(1, true, false);
                 offset = 0;
             }
             if (c == '\r' && external && fCurrentEntity.position < fCurrentEntity.count) {
@@ -877,7 +877,7 @@ public class XML11EntityScanner
                 c = fCurrentEntity.ch[fCurrentEntity.position++];
                 // In internal entities control characters are allowed to appear unescaped.
                 if ((c == quote && !fCurrentEntity.literal)
-                    || c == '%' || !XML11Char.isXML11InternalEntityContent(c)) {
+                    || c == '%' || !XML11Char.isXML11InternalEntityContent(c) || c == '\r') {
                     fCurrentEntity.position--;
                     break;
                 }

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityScanner.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityScanner.java
@@ -1156,7 +1156,7 @@ public class XMLEntityScanner implements XMLLocator  {
             c = fCurrentEntity.ch[fCurrentEntity.position];
             if ((c == quote &&
                     (!fCurrentEntity.literal || isExternal)) ||
-                    c == '%' || !XMLChar.isContent(c)) {
+                    c == '%' || !XMLChar.isContent(c) || c == '\r' && !isExternal) {
                 break;
             }
             if (whiteSpaceInfoNeeded && c == '\t') {

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/XSSimpleTypeDecl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/XSSimpleTypeDecl.java
@@ -1168,9 +1168,11 @@ public class XSSimpleTypeDecl implements XSSimpleType, TypeInfo {
             // check 4.3.1.c1 error: fBase.length & (maxLength | minLength)
             if((fBase.fFacetsDefined & FACET_LENGTH) != 0 || (fFacetsDefined & FACET_LENGTH) != 0){
                 if ((fFacetsDefined & FACET_MINLENGTH) != 0){
-                    if (fBase.fLength < fMinLength) {
-                        // fBase.length, minLength and maxLength defined
+                    if ((fBase.fFacetsDefined & FACET_LENGTH) != 0 && fBase.fLength < fMinLength) {
                         reportError("length-minLength-maxLength.1.1", new Object[]{fTypeName, Integer.toString(fBase.fLength), Integer.toString(fMinLength)});
+                    }
+                    if ((fFacetsDefined & FACET_LENGTH) != 0 && fLength < fMinLength) {
+                        reportError("length-minLength-maxLength.1.1", new Object[]{fTypeName, Integer.toString(fLength), Integer.toString(fMinLength)});
                     }
                     if ((fBase.fFacetsDefined & FACET_MINLENGTH) == 0){
                         reportError("length-minLength-maxLength.1.2.a", new Object[]{fTypeName});
@@ -1180,9 +1182,11 @@ public class XSSimpleTypeDecl implements XSSimpleType, TypeInfo {
                     }
                 }
                 if ((fFacetsDefined & FACET_MAXLENGTH) != 0){
-                    if (fBase.fLength > fMaxLength) {
-                        // fBase.length, minLength and maxLength defined
+                    if ((fBase.fFacetsDefined & FACET_LENGTH) != 0 && fBase.fLength > fMaxLength) {
                         reportError("length-minLength-maxLength.2.1", new Object[]{fTypeName, Integer.toString(fBase.fLength), Integer.toString(fMaxLength)});
+                    }
+                    if ((fFacetsDefined & FACET_LENGTH) != 0 && fLength > fMaxLength) {
+                        reportError("length-minLength-maxLength.2.1", new Object[]{fTypeName, Integer.toString(fLength), Integer.toString(fMaxLength)});
                     }
                     if ((fBase.fFacetsDefined & FACET_MAXLENGTH) == 0){
                         reportError("length-minLength-maxLength.2.2.a", new Object[]{fTypeName});

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/msg/DOMMessages.properties
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/msg/DOMMessages.properties
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # This file stores localized messages for the Xerces
 # DOM implementation.
 #

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/msg/DatatypeMessages.properties
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/msg/DatatypeMessages.properties
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # This file stores localized messages for the Xerces JAXP Datatype API implementation.
 #
 # The messages are arranged in key and value tuples in a ListResourceBundle.

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/msg/JAXPValidationMessages.properties
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/msg/JAXPValidationMessages.properties
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # This file stores localized messages for the Xerces JAXP Validation API implementation.
 #
 # The messages are arranged in key and value tuples in a ListResourceBundle.

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/msg/SAXMessages.properties
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/msg/SAXMessages.properties
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # This file stores localized messages for the Xerces
 # SAX implementation.
 #

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/msg/XIncludeMessages.properties
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/msg/XIncludeMessages.properties
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # Messages for message reporting
 BadMessageKey = The error message corresponding to the message key can not be found.
 FormatFailed = An internal error occurred while formatting the following message:\n  

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/msg/XMLMessages.properties
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/msg/XMLMessages.properties
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # This file contains error and warning messages related to XML
 # The messages are arranged in key and value tuples in a ListResourceBundle.
 #

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/msg/XMLSchemaMessages.properties
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/msg/XMLSchemaMessages.properties
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # This file contains error and warning messages related to XML Schema
 # The messages are arranged in key and value tuples in a ListResourceBundle.
 
@@ -49,6 +66,7 @@
         cvc-complex-type.3.2.1 = cvc-complex-type.3.2.1: Element ''{0}'' does not have an attribute wildcard for attribute ''{1}''.
         cvc-complex-type.3.2.2 = cvc-complex-type.3.2.2: Attribute ''{1}'' is not allowed to appear in element ''{0}''.
         cvc-complex-type.4 = cvc-complex-type.4: Attribute ''{1}'' must appear on element ''{0}''.
+        cvc-complex-type.4_ns = cvc-complex-type.4: Attribute ''{1}'' belonging to namespace ''{2}'', must appear on element ''{0}''.
         cvc-complex-type.5.1 = cvc-complex-type.5.1: In element ''{0}'', attribute ''{1}'' is a Wild ID. But there is already a Wild ID ''{2}''. There can be only one.
         cvc-complex-type.5.2 = cvc-complex-type.5.2: In element ''{0}'', attribute ''{1}'' is a Wild ID. But there is already an attribute ''{2}'' derived from ID among the '{'attribute uses'}'.
         cvc-datatype-valid.1.2.1 = cvc-datatype-valid.1.2.1: ''{0}'' is not a valid value for ''{1}''.

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/msg/XMLSerializerMessages.properties
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/msg/XMLSerializerMessages.properties
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # This file stores error messages for the Xerces XML
 # serializer.  Many DOM Load/Save error messages also 
 # live here, since the serializer largely implements that package.

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/msg/XPointerMessages.properties
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/msg/XPointerMessages.properties
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # This file stores localized messages for the Xerces XPointer implementation.
 #
 # The messages are arranged in key and value tuples in a ListResourceBundle.

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/XMLSchemaValidator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/XMLSchemaValidator.java
@@ -3221,6 +3221,18 @@ public class XMLSchemaValidator
                     reportSchemaError(
                         "cvc-complex-type.4",
                         new Object[] { element.rawname, currDecl.fName });
+                if (!isSpecified) {
+                    if (currDecl.fTargetNamespace != null) {
+                       reportSchemaError(
+                                "cvc-complex-type.4_ns",
+                                new Object[] { element.rawname, currDecl.fName, currDecl.fTargetNamespace });
+                    }
+                    else {
+                       reportSchemaError(
+                                "cvc-complex-type.4",
+                                new Object[] { element.rawname, currDecl.fName });
+                    }
+                }
             }
             // if the attribute is not specified, then apply the value constraint
             if (!isSpecified && constType != XSConstants.VC_NONE) {

--- a/src/java.xml/share/legal/xerces.md
+++ b/src/java.xml/share/legal/xerces.md
@@ -1,4 +1,4 @@
-## Apache Xerces v2.12.1
+## Apache Xerces v2.12.2
 
 ### Apache Xerces Notice
 <pre>
@@ -8,7 +8,7 @@
     =========================================================================
     
     Apache Xerces Java
-    Copyright 1999-2020 The Apache Software Foundation
+    Copyright 1999-2022 The Apache Software Foundation
 
     This product includes software developed at
     The Apache Software Foundation (http://www.apache.org/).

--- a/test/jaxp/javax/xml/jaxp/unittest/validation/IDREFS_length006.xsd
+++ b/test/jaxp/javax/xml/jaxp/unittest/validation/IDREFS_length006.xsd
@@ -1,0 +1,25 @@
+<?xml version='1.0'?>
+<xsd:schema xmlns:xsd='http://www.w3.org/2001/XMLSchema' >
+<!-- Schema to test IDREFS datatype -->
+  <xsd:element name='test' type='fooType' />
+  <xsd:complexType name='fooType' > 
+    <xsd:sequence>
+      <xsd:element name='foo' >
+        <xsd:complexType>
+          <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+              <xsd:attribute name='attrTest'>
+                <xsd:simpleType> 
+                  <xsd:restriction base="xsd:IDREFS">
+                            <xsd:length value="5"/>
+                            <xsd:minLength value="1"/>
+                  </xsd:restriction>
+                </xsd:simpleType>
+              </xsd:attribute>
+            </xsd:extension>
+          </xsd:simpleContent>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+</xsd:schema>

--- a/test/jaxp/javax/xml/jaxp/unittest/validation/NMTOKENS_length006.xsd
+++ b/test/jaxp/javax/xml/jaxp/unittest/validation/NMTOKENS_length006.xsd
@@ -1,0 +1,25 @@
+<?xml version='1.0'?>
+<xsd:schema xmlns:xsd='http://www.w3.org/2001/XMLSchema' >
+<!-- Schema to test NMTOKENS datatype -->
+  <xsd:element name='test' type='fooType' />
+  <xsd:complexType name='fooType' > 
+    <xsd:sequence>
+      <xsd:element name='foo' >
+        <xsd:complexType>
+          <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+              <xsd:attribute name='attrTest'>
+                <xsd:simpleType> 
+                  <xsd:restriction base="xsd:NMTOKENS">
+                            <xsd:length value="5"/>
+                            <xsd:minLength value="1"/>
+                  </xsd:restriction>
+                </xsd:simpleType>
+              </xsd:attribute>
+            </xsd:extension>
+          </xsd:simpleContent>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+</xsd:schema>

--- a/test/jaxp/javax/xml/jaxp/unittest/validation/SchemaTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/validation/SchemaTest.java
@@ -66,7 +66,7 @@ public class SchemaTest {
         "</xs:schema>";
 
     /*
-     * DataProvider: valid xsd
+     * DataProvider: valid xsd strings.
      */
     @DataProvider(name = "xsd")
     Object[][] getXSDString() {
@@ -76,7 +76,7 @@ public class SchemaTest {
     }
 
     /*
-     * DataProvider: valid xsd
+     * DataProvider: valid external xsd files.
      */
     @DataProvider(name = "xsdFile")
     Object[][] getXSDFile() {

--- a/test/jaxp/javax/xml/jaxp/unittest/validation/SchemaTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/validation/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import javax.xml.XMLConstants;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.SchemaFactory;
 import org.testng.Assert;
-import org.testng.annotations.Listeners;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
@@ -39,13 +39,86 @@ import org.xml.sax.SAXParseException;
 
 /*
  * @test
- * @bug 8149915 8222991
+ * @bug 8149915 8222991 8282280 8144117
  * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
  * @run testng/othervm validation.SchemaTest
- * @summary Test Schema creation
+ * @summary Tests schemas and Schema creation.
  */
-@Listeners({jaxp.library.FilePolicy.class})
 public class SchemaTest {
+    private static final String XSD_8144117 = "<?xml version='1.0'?>\n" +
+        "<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>\n" +
+        "\n" +
+        "  <xs:simpleType name='mjtype1'>\n" +
+        "    <xs:restriction base='xs:string'>\n" +
+        "      <xs:minLength value='3'/>\n" +
+        "    </xs:restriction>\n" +
+        "  </xs:simpleType>\n" +
+        "\n" +
+        "  <xs:simpleType name='mjtype2'>\n" +
+        "    <xs:restriction base='mjtype1'>\n" +
+        "      <xs:minLength value='3'/>\n" +
+        "      <xs:length value='4'/>\n" +
+        "    </xs:restriction>\n" +
+        "  </xs:simpleType>\n" +
+        "\n" +
+        "  <xs:element name='top' type='mjtype2'/>\n" +
+        "\n" +
+        "</xs:schema>";
+
+    /*
+     * DataProvider: valid xsd
+     */
+    @DataProvider(name = "xsd")
+    Object[][] getXSDString() {
+        return new Object[][]{
+            {XSD_8144117},
+        };
+    }
+
+    /*
+     * DataProvider: valid xsd
+     */
+    @DataProvider(name = "xsdFile")
+    Object[][] getXSDFile() {
+        return new Object[][]{
+            /*
+             * Refer to the related JCK issue. The following tests match the rules
+             * specified in:
+             * XML Schema Part 2: Datatypes (https://www.w3.org/TR/xmlschema-2/)
+             * 4.3.1.4 Constraints on length Schema Components
+             * and are therefore valid.
+             */
+            {"NMTOKENS_length006.xsd"},
+            {"IDREFS_length006.xsd"},
+        };
+    }
+
+    /**
+     * @bug 8144117 fix by 8282280
+     * Verifies that the schema is valid.
+     *
+     * @param xsd the schema
+     * @throws Exception if the test fails
+     */
+    @Test(dataProvider = "xsd")
+    public void testSchema1(String xsd) throws Exception {
+        SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        factory.newSchema(new StreamSource(new StringReader(xsd)));
+    }
+
+    /**
+     * @bug 8282280
+     * Verifies that the schema is valid.
+     *
+     * @param xsd the schema file
+     * @throws Exception if the test fails
+     */
+    @Test(dataProvider = "xsdFile")
+    public void testSchema2(String xsd) throws Exception {
+        SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        factory.newSchema(new File(getClass().getResource(xsd).getFile()));
+    }
+
     /**
      * Verifies that an over-the-limit value of an enumeration is caught as a
      * warning.


### PR DESCRIPTION
Update to Xerces 2.12.2.

The update also fixes JDK-8144117. Added a test.

Tests: local XML tests passed. Tier2 passed. Two JCK tests failed with this update. See related issue report.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8282280](https://bugs.openjdk.java.net/browse/JDK-8282280): Update Xerces to Version 2.12.2


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8732/head:pull/8732` \
`$ git checkout pull/8732`

Update a local copy of the PR: \
`$ git checkout pull/8732` \
`$ git pull https://git.openjdk.java.net/jdk pull/8732/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8732`

View PR using the GUI difftool: \
`$ git pr show -t 8732`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8732.diff">https://git.openjdk.java.net/jdk/pull/8732.diff</a>

</details>
