### PR TITLE
Experiment: add a simple mechanism for deferring the preparation of LambdaForms

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
@@ -113,6 +113,7 @@ abstract non-sealed class BoundMethodHandle extends MethodHandle {
         if (!tooComplex()) {
             return this;
         }
+        this.prepare();
         return makeReinvoker(this);
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -479,7 +479,29 @@ public abstract sealed class MethodHandle implements Constable
         this.type = Objects.requireNonNull(type);
         this.form = Objects.requireNonNull(form).uncustomize();
 
-        this.form.prepare();  // TO DO:  Try to delay this step until just before invocation.
+        if (DEFERRED_PREPARE.get() == 0) {
+            this.form.prepare();  // TO DO:  Try to delay this step until just before invocation.
+        }
+    }
+
+    /* package-private */ static void deferPreparation() {
+        DEFERRED_PREPARE.set(DEFERRED_PREPARE.get() + 1);
+    }
+    /* package-private */ static void reEnablePreparation() {
+        assert (DEFERRED_PREPARE.get() > 0);
+        DEFERRED_PREPARE.set(DEFERRED_PREPARE.get() - 1);
+    }
+
+    private static final ThreadLocal<Integer> DEFERRED_PREPARE = new ThreadLocal<>() {
+        @Override
+        protected Integer initialValue() {
+            return 0;
+        }
+    };
+
+    /*non-public*/
+    void prepare() {
+        this.form.prepare();
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
@@ -506,12 +506,16 @@ public final class StringConcatFactory {
             }
         }
 
+        MethodHandle newString = newString();
+        // This disables automatic preparation of MethodHandles (and the bytecode compilation of their LambdaForms)
+        // until MethodHandle.enablePreparation is called
+        MethodHandle.deferPreparation();
         // Start building the combinator tree. The tree "starts" with (<parameters>)String, and "finishes"
         // with the (byte[], long)String shape to invoke newString in StringConcatHelper. The combinators are
         // assembled bottom-up, which makes the code arguably hard to read.
 
         // Drop all remaining parameter types, leave only helper arguments:
-        MethodHandle mh = MethodHandles.dropArguments(newString(), 2, ptypes);
+        MethodHandle mh = MethodHandles.dropArguments(newString, 2, ptypes);
 
         long initialLengthCoder = INITIAL_CODER;
 
@@ -538,9 +542,11 @@ public final class StringConcatFactory {
                 constant = el;
             } else {
                 // Add prepender, along with any prefix constant
+                MethodHandle prepend = prepender(constant, ptypes[pos]);
+                prepend.prepare();
                 mh = MethodHandles.filterArgumentsWithCombiner(
                         mh, 1,
-                        prepender(constant, ptypes[pos]),
+                        prepend,
                         1, 0, // indexCoder, storage
                         2 + pos  // selected argument
                 );
@@ -564,6 +570,7 @@ public final class StringConcatFactory {
         } else {
             newArrayCombinator = newArray();
         }
+        newArrayCombinator.prepare();
         mh = MethodHandles.foldArgumentsWithCombiner(mh, 0, newArrayCombinator,
                 1 // index
         );
@@ -594,6 +601,7 @@ public final class StringConcatFactory {
             if (el == null) {
                     if (pos >= 0) {
                         // Compute new "index" in-place using old value plus the appropriate argument.
+                        mix.prepare();
                         mh = MethodHandles.filterArgumentsWithCombiner(mh, 0, mix,
                                 0, // old-index
                                 1 + pos // selected argument
@@ -608,7 +616,9 @@ public final class StringConcatFactory {
         // Insert the initialLengthCoder value into the final mixer, then
         // fold that into the base method handle
         if (pos >= 0) {
+            mix.prepare();
             mix = MethodHandles.insertArguments(mix, 0, initialLengthCoder);
+            mix.prepare();
             mh = MethodHandles.foldArgumentsWithCombiner(mh, 0, mix,
                     1 + pos // selected argument
             );
@@ -623,7 +633,8 @@ public final class StringConcatFactory {
         if (filters != null) {
             mh = MethodHandles.filterArguments(mh, 0, filters);
         }
-
+        mh.prepare();
+        MethodHandle.reEnablePreparation();
         return mh;
     }
 
@@ -653,8 +664,9 @@ public final class StringConcatFactory {
     private static final Function<Class<?>, MethodHandle> NULL_PREPEND = new Function<>() {
         @Override
         public MethodHandle apply(Class<?> c) {
-            return MethodHandles.insertArguments(
-                    PREPENDERS.computeIfAbsent(c, PREPEND), 3, (String)null);
+            MethodHandle prepend = PREPENDERS.computeIfAbsent(c, PREPEND);
+            prepend.prepare();
+            return MethodHandles.insertArguments(prepend, 3, (String)null);
         }
     };
 


### PR DESCRIPTION
One of the drags on startup/footprint from complex MH usage is the fact that we currently compile most LambdaForms to bytecode eagerly. When building up complex expression trees most LFs generated will not ever be invoked directly, since they'll be further edited to produce the final form. 

This experiment adds a crude mechanism to defer automatic preparation of LFs when creating a MH (along with the necessary weaponry to force preparation of such MHs that need it). On a bug I'm looking at [JDK-8278540](https://bugs.openjdk.java.net/browse/JDK-8278540) this reduces first time execution overhead of the StringConcatFactory bootstrap by 25%. Generalizing this to allow `form.prepare()` to be completely lazy might enable further gains. 

For `StringConcatFactory` in particular we might see even larger overhead reduction by reducing the number of rebinds by chunking some of the processing. I'll do some prototyping of that in parallel with exploring how late-preparation can be achieved more generally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8734/head:pull/8734` \
`$ git checkout pull/8734`

Update a local copy of the PR: \
`$ git checkout pull/8734` \
`$ git pull https://git.openjdk.java.net/jdk pull/8734/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8734`

View PR using the GUI difftool: \
`$ git pr show -t 8734`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8734.diff">https://git.openjdk.java.net/jdk/pull/8734.diff</a>

</details>
