### PR TITLE
8286688: JFR: Active Setting events should have the same timestamp

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/events/ActiveSettingEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/ActiveSettingEvent.java
@@ -37,6 +37,11 @@ import jdk.jfr.internal.Type;
 @StackTrace(false)
 public final class ActiveSettingEvent extends AbstractJDKEvent {
 
+    public static final ActiveSettingEvent EVENT = new ActiveSettingEvent();
+
+    // The order of these fields must be the same as the parameters in
+    // commit(... , long, String, String)
+
     @Label("Event Id")
     public long id;
 
@@ -45,4 +50,8 @@ public final class ActiveSettingEvent extends AbstractJDKEvent {
 
     @Label("Setting Value")
     public String value;
+
+    public static void commit(long startTime, long duration, long id, String name, String value) {
+        // Generated
+    }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventControl.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventControl.java
@@ -279,7 +279,7 @@ public final class EventControl {
         }
     }
 
-    void writeActiveSettingEvent() {
+    void writeActiveSettingEvent(long timestamp) {
         if (!type.isRegistered()) {
             return;
         }
@@ -289,11 +289,9 @@ public final class EventControl {
                 if (value == null) {
                     value = nc.control.getDefaultValue();
                 }
-                ActiveSettingEvent event = new ActiveSettingEvent();
-                event.id = type.getId();
-                event.name = nc.name;
-                event.value = value;
-                event.commit();
+                if (ActiveSettingEvent.EVENT.isEnabled()) {
+                    ActiveSettingEvent.commit(timestamp, 0L, type.getId(), nc.name(), value);
+                }
             }
         }
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -158,7 +158,7 @@ public final class MetadataRepository {
         configuration.getPlatformEventType().setRegistered(true);
         typeLibrary.addType(configuration.getPlatformEventType());
         if (jvm.isRecording()) {
-            settingsManager.setEventControl(configuration.getEventControl(), true);
+            settingsManager.setEventControl(configuration.getEventControl(), true, JVM.counterTime());
             settingsManager.updateRetransform(Collections.singletonList((eventClass)));
        }
        setStaleMetadata();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -483,8 +483,9 @@ public final class PlatformRecorder {
             }
         }
         if (activeSettingEvent.isEnabled()) {
+            long timestamp = JVM.counterTime();
             for (EventControl ec : MetadataRepository.getInstance().getEventControls()) {
-                ec.writeActiveSettingEvent();
+                ec.writeActiveSettingEvent(timestamp);
             }
         }
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/SettingsManager.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/SettingsManager.java
@@ -142,8 +142,9 @@ final class SettingsManager {
             if (Logger.shouldLog(LogTag.JFR_SETTING, LogLevel.INFO)) {
                 eventControls.sort(Comparator.comparing(x -> x.getEventType().getName()));
             }
+            long timestamp = JVM.counterTime();
             for (EventControl ec : eventControls) {
-                setEventControl(ec, writeSettingEvents);
+                setEventControl(ec, writeSettingEvents, timestamp);
             }
         }
         if (JVM.getJVM().getAllowedToDoEventRetransforms()) {
@@ -211,7 +212,7 @@ final class SettingsManager {
       return internals.values();
     }
 
-    void setEventControl(EventControl ec, boolean writeSettingEvents) {
+    void setEventControl(EventControl ec, boolean writeSettingEvents, long timestamp) {
         InternalSetting is = getInternalSetting(ec);
         boolean shouldLog = Logger.shouldLog(LogTag.JFR_SETTING, LogLevel.INFO);
         if (shouldLog) {
@@ -251,7 +252,7 @@ final class SettingsManager {
             }
         }
         if (writeSettingEvents) {
-            ec.writeActiveSettingEvent();
+            ec.writeActiveSettingEvent(timestamp);
         }
         if (shouldLog) {
             Logger.log(LogTag.JFR_SETTING, LogLevel.INFO, "}");


### PR DESCRIPTION
Could I have a review of a change that ensures that all Active Setting events emitted together get the same timestamp.

Testing: jdk/jdk/jfr + 100 times TestActiveSettingEvent.java

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286688](https://bugs.openjdk.java.net/browse/JDK-8286688): JFR: Active Setting events should have the same timestamp


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8738/head:pull/8738` \
`$ git checkout pull/8738`

Update a local copy of the PR: \
`$ git checkout pull/8738` \
`$ git pull https://git.openjdk.java.net/jdk pull/8738/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8738`

View PR using the GUI difftool: \
`$ git pr show -t 8738`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8738.diff">https://git.openjdk.java.net/jdk/pull/8738.diff</a>

</details>
