### PR TITLE
8286735: (fc) FileChannel#map should document behavior when using custom file systems

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -959,7 +959,8 @@ public abstract class FileChannel
      *         If the preconditions on the parameters do not hold
      *
      * @throws UnsupportedOperationException
-     *         If an unsupported map mode is specified
+     *         If an unsupported map mode is specified, or if the implementation
+     *         does not support memory-mapped files
      *
      * @throws IOException
      *         If some other I/O error occurs
@@ -996,6 +997,10 @@ public abstract class FileChannel
      *           channel, the initialization state of the contents of the block
      *           of mapped memory associated with the returned mapped memory
      *           segment is unspecified and should not be relied upon.
+     *
+     * @implSpec The {@code map(MapMode, long, long, MemorySession)} method of
+     *           {@code FileChannel} always throws an
+     *           {@code UnsupportedOperationException}.
      *
      * @param mode
      *        The file mapping mode, see
@@ -1042,7 +1047,8 @@ public abstract class FileChannel
      *         If some other I/O error occurs.
      *
      * @throws UnsupportedOperationException
-     *         If an unsupported map mode is specified.
+     *         If an unsupported map mode is specified, or if the implementation
+     *         does not support memory-mapped files
      *
      * @since 19
      */


### PR DESCRIPTION
Clarify when the `map()` methods of `java.nio.channels.FileChannel` throw an `UnsupportedOperationException`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286735](https://bugs.openjdk.java.net/browse/JDK-8286735): (fc) FileChannel#map should document behavior when using custom file systems


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8739/head:pull/8739` \
`$ git checkout pull/8739`

Update a local copy of the PR: \
`$ git checkout pull/8739` \
`$ git pull https://git.openjdk.java.net/jdk pull/8739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8739`

View PR using the GUI difftool: \
`$ git pr show -t 8739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8739.diff">https://git.openjdk.java.net/jdk/pull/8739.diff</a>

</details>
