### PR TITLE
8286734: (fc) FileChannelImpl#map() cleanup after merge of Foreign Function & Memory API

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -1014,6 +1014,10 @@ public class FileChannelImpl
             unmap();
         }
 
+        public long capacity() {
+            return cap;
+        }
+
         public void unmap() {
             if (address == 0)
                 return;
@@ -1126,15 +1130,15 @@ public class FileChannelImpl
             else
                 return Util.newMappedByteBuffer(0, 0, dummy, null, isSync);
         } else if ((!writable) || (prot == MAP_RO)) {
-            return Util.newMappedByteBufferR((int)unmapper.cap,
-                    unmapper.address + unmapper.pagePosition,
-                    unmapper.fd,
-                    unmapper, isSync);
+            return Util.newMappedByteBufferR((int)unmapper.capacity(),
+                    unmapper.address(),
+                    unmapper.fileDescriptor(),
+                    unmapper, unmapper.isSync());
         } else {
-            return Util.newMappedByteBuffer((int)unmapper.cap,
-                    unmapper.address + unmapper.pagePosition,
-                    unmapper.fd,
-                    unmapper, isSync);
+            return Util.newMappedByteBuffer((int)unmapper.capacity(),
+                    unmapper.address(),
+                    unmapper.fileDescriptor(),
+                    unmapper, unmapper.isSync());
         }
     }
 


### PR DESCRIPTION
Make `map()` methods more consistent.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286734](https://bugs.openjdk.java.net/browse/JDK-8286734): (fc) FileChannelImpl#map() cleanup after merge of Foreign Function & Memory API


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8741/head:pull/8741` \
`$ git checkout pull/8741`

Update a local copy of the PR: \
`$ git checkout pull/8741` \
`$ git pull https://git.openjdk.java.net/jdk pull/8741/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8741`

View PR using the GUI difftool: \
`$ git pr show -t 8741`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8741.diff">https://git.openjdk.java.net/jdk/pull/8741.diff</a>

</details>
