### PR TITLE
8286849: Use @Stable for generic repositories

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -79,6 +79,7 @@ import jdk.internal.reflect.Reflection;
 import jdk.internal.reflect.ReflectionFactory;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
+import jdk.internal.vm.annotation.Stable;
 import sun.invoke.util.Wrapper;
 import sun.reflect.generics.factory.CoreReflectionFactory;
 import sun.reflect.generics.factory.GenericsFactory;
@@ -3292,7 +3293,8 @@ public final class Class<T> implements java.io.Serializable,
     private native String getGenericSignature0();
 
     // Generic info repository; lazily initialized
-    private transient volatile ClassRepository genericInfo;
+    @Stable
+    private transient ClassRepository genericInfo;
 
     // accessor for factory
     private GenericsFactory getFactory() {

--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -73,6 +73,7 @@ public final class Constructor<T> extends Executable {
     // Generics and annotations support
     private final transient String    signature;
     // generic info repository; lazily initialized
+    @Stable
     private transient ConstructorRepository genericInfo;
     private final byte[]              annotations;
     private final byte[]              parameterAnnotations;
@@ -87,12 +88,14 @@ public final class Constructor<T> extends Executable {
     // Accessor for generic info repository
     @Override
     ConstructorRepository getGenericInfo() {
+        var genericInfo = this.genericInfo;
         // lazily initialize repository if necessary
         if (genericInfo == null) {
             // create and cache generic info repository
             genericInfo =
                 ConstructorRepository.make(getSignature(),
                                            getFactory());
+            this.genericInfo = genericInfo;
         }
         return genericInfo; //return cached repository
     }

--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,6 +76,7 @@ class Field extends AccessibleObject implements Member {
     // Generics and annotations support
     private final transient String    signature;
     // generic info repository; lazily initialized
+    @Stable
     private transient FieldRepository genericInfo;
     private final byte[]              annotations;
     // Cached field accessor created without override
@@ -105,11 +106,13 @@ class Field extends AccessibleObject implements Member {
 
     // Accessor for generic info repository
     private FieldRepository getGenericInfo() {
+        var genericInfo = this.genericInfo;
         // lazily initialize repository if necessary
         if (genericInfo == null) {
             // create and cache generic info repository
             genericInfo = FieldRepository.make(getGenericSignature(),
                                                getFactory());
+            this.genericInfo = genericInfo;
         }
         return genericInfo; //return cached repository
     }

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -82,6 +82,7 @@ public final class Method extends Executable {
     // Generics and annotations support
     private final transient String    signature;
     // generic info repository; lazily initialized
+    @Stable
     private transient MethodRepository genericInfo;
     private final byte[]              annotations;
     private final byte[]              parameterAnnotations;
@@ -108,11 +109,13 @@ public final class Method extends Executable {
     // Accessor for generic info repository
     @Override
     MethodRepository getGenericInfo() {
+        var genericInfo = this.genericInfo;
         // lazily initialize repository if necessary
         if (genericInfo == null) {
             // create and cache generic info repository
             genericInfo = MethodRepository.make(getGenericSignature(),
                                                 getFactory());
+            this.genericInfo = genericInfo;
         }
         return genericInfo; //return cached repository
     }

--- a/src/java.base/share/classes/java/lang/reflect/RecordComponent.java
+++ b/src/java.base/share/classes/java/lang/reflect/RecordComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package java.lang.reflect;
 
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.vm.annotation.Stable;
 import sun.reflect.annotation.AnnotationParser;
 import sun.reflect.annotation.TypeAnnotation;
 import sun.reflect.annotation.TypeAnnotationParser;
@@ -54,6 +55,7 @@ public final class RecordComponent implements AnnotatedElement {
     private Method accessor;
     private String signature;
     // generic info repository; lazily initialized
+    @Stable
     private transient FieldRepository genericInfo;
     private byte[] annotations;
     private byte[] typeAnnotations;
@@ -127,10 +129,12 @@ public final class RecordComponent implements AnnotatedElement {
 
     // Accessor for generic info repository
     private FieldRepository getGenericInfo() {
+        var genericInfo = this.genericInfo;
         // lazily initialize repository if necessary
         if (genericInfo == null) {
             // create and cache generic info repository
             genericInfo = FieldRepository.make(getGenericSignature(), getFactory());
+            this.genericInfo = genericInfo;
         }
         return genericInfo; //return cached repository
     }

--- a/src/java.base/share/classes/sun/reflect/generics/repository/ClassRepository.java
+++ b/src/java.base/share/classes/sun/reflect/generics/repository/ClassRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package sun.reflect.generics.repository;
 
 import java.lang.reflect.Type;
+import jdk.internal.vm.annotation.Stable;
 import sun.reflect.generics.factory.GenericsFactory;
 import sun.reflect.generics.tree.ClassSignature;
 import sun.reflect.generics.tree.TypeTree;
@@ -43,10 +44,12 @@ public class ClassRepository extends GenericDeclRepository<ClassSignature> {
     public static final ClassRepository NONE = ClassRepository.make("Ljava/lang/Object;", null);
 
     /** The generic superclass info.  Lazily initialized. */
-    private volatile Type superclass;
+    @Stable
+    private Type superclass;
 
     /** The generic superinterface info.  Lazily initialized. */
-    private volatile Type[] superInterfaces;
+    @Stable
+    private Type[] superInterfaces;
 
     // private, to enforce use of static factory
     private ClassRepository(String rawSig, GenericsFactory f) {

--- a/src/java.base/share/classes/sun/reflect/generics/repository/ConstructorRepository.java
+++ b/src/java.base/share/classes/sun/reflect/generics/repository/ConstructorRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package sun.reflect.generics.repository;
 
 import java.lang.reflect.Type;
+import jdk.internal.vm.annotation.Stable;
 import sun.reflect.generics.factory.GenericsFactory;
 import sun.reflect.generics.parser.SignatureParser;
 import sun.reflect.generics.tree.FieldTypeSignature;
@@ -44,10 +45,12 @@ public class ConstructorRepository
     extends GenericDeclRepository<MethodTypeSignature> {
 
     /** The generic parameter types.  Lazily initialized. */
-    private volatile Type[] parameterTypes;
+    @Stable
+    private Type[] parameterTypes;
 
     /** The generic exception types.  Lazily initialized. */
-    private volatile Type[] exceptionTypes;
+    @Stable
+    private Type[] exceptionTypes;
 
     // protected, to enforce use of static factory yet allow subclassing
     protected ConstructorRepository(String rawSig, GenericsFactory f) {

--- a/src/java.base/share/classes/sun/reflect/generics/repository/FieldRepository.java
+++ b/src/java.base/share/classes/sun/reflect/generics/repository/FieldRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package sun.reflect.generics.repository;
 
 
 import java.lang.reflect.Type;
+import jdk.internal.vm.annotation.Stable;
 import sun.reflect.generics.factory.GenericsFactory;
 import sun.reflect.generics.tree.TypeSignature;
 import sun.reflect.generics.parser.SignatureParser;
@@ -42,7 +43,8 @@ import sun.reflect.generics.visitor.Reifier;
 public class FieldRepository extends AbstractRepository<TypeSignature> {
 
     /** The generic type info.  Lazily initialized. */
-    private volatile Type genericType;
+    @Stable
+    private Type genericType;
 
     // protected, to enforce use of static factory yet allow subclassing
     protected FieldRepository(String rawSig, GenericsFactory f) {

--- a/src/java.base/share/classes/sun/reflect/generics/repository/GenericDeclRepository.java
+++ b/src/java.base/share/classes/sun/reflect/generics/repository/GenericDeclRepository.java
@@ -26,6 +26,7 @@
 package sun.reflect.generics.repository;
 
 import java.lang.reflect.TypeVariable;
+import jdk.internal.vm.annotation.Stable;
 import sun.reflect.generics.factory.GenericsFactory;
 import sun.reflect.generics.tree.FormalTypeParameter;
 import sun.reflect.generics.tree.Signature;
@@ -45,7 +46,8 @@ public abstract class GenericDeclRepository<S extends Signature>
     public static final TypeVariable<?>[] EMPTY_TYPE_VARS = new TypeVariable<?>[0];
 
     /** The formal type parameters.  Lazily initialized. */
-    private volatile TypeVariable<?>[] typeParameters;
+    @Stable
+    private TypeVariable<?>[] typeParameters;
 
     protected GenericDeclRepository(String rawSig, GenericsFactory f) {
         super(rawSig, f);

--- a/src/java.base/share/classes/sun/reflect/generics/repository/MethodRepository.java
+++ b/src/java.base/share/classes/sun/reflect/generics/repository/MethodRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package sun.reflect.generics.repository;
 
 
 import java.lang.reflect.Type;
+import jdk.internal.vm.annotation.Stable;
 import sun.reflect.generics.factory.GenericsFactory;
 import sun.reflect.generics.visitor.Reifier;
 
@@ -40,7 +41,8 @@ import sun.reflect.generics.visitor.Reifier;
 public class MethodRepository extends ConstructorRepository {
 
     /** The generic return type info.  Lazily initialized. */
-    private volatile Type returnType;
+    @Stable
+    private Type returnType;
 
  // private, to enforce use of static factory
     private MethodRepository(String rawSig, GenericsFactory f) {

--- a/src/java.base/share/classes/sun/reflect/generics/scope/AbstractScope.java
+++ b/src/java.base/share/classes/sun/reflect/generics/scope/AbstractScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package sun.reflect.generics.scope;
 
 import java.lang.reflect.GenericDeclaration;
 import java.lang.reflect.TypeVariable;
+import jdk.internal.vm.annotation.Stable;
 
 
 /**
@@ -43,7 +44,8 @@ public abstract class AbstractScope<D extends GenericDeclaration>
     private final D recvr; // the declaration whose scope this instance represents
 
     /** The enclosing scope of this scope.  Lazily initialized. */
-    private volatile Scope enclosingScope;
+    @Stable
+    private Scope enclosingScope;
 
     /**
      * Constructor. Takes a reflective object whose scope the newly


### PR DESCRIPTION
Generic repositories, the implementation detail for generic information in core reflection, can be updated to use the `@Stable` annotation to replace their `volatile` access. Their existing accessor code is already safe, reading the cache fields only once.

In addition, fixed potentially non-thread-safe `genericInfo` access in `Method`, `Field`, and `RecordComponent`.