### PR TITLE
8286788: Test java/lang/Thread/virtual/ThreadAPI.testGetStackTrace3 fails

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/ThreadAPI.java
+++ b/test/jdk/java/lang/Thread/virtual/ThreadAPI.java
@@ -23,11 +23,12 @@
 
 /**
  * @test
+ * @bug 8284161 8286788
  * @summary Test Thread API with virtual threads
+ * @enablePreview
  * @modules java.base/java.lang:+open
  * @library /test/lib
- * @compile --enable-preview -source ${jdk.version} ThreadAPI.java
- * @run testng/othervm/timeout=300 --enable-preview ThreadAPI
+ * @run testng/othervm/timeout=300 ThreadAPI
  */
 
 import java.time.Duration;
@@ -1897,11 +1898,11 @@ public class ThreadAPI {
         var thread = Thread.ofVirtual().start(() -> {
             try { sel.select(); } catch (Exception e) { }
         });
-        Thread.sleep(200);  // give time for thread to block
         try {
-            assertTrue(thread.getState() == Thread.State.RUNNABLE);
-            StackTraceElement[] stack = thread.getStackTrace();
-            assertTrue(contains(stack, "select"));
+            while (!contains(thread.getStackTrace(), "select")) {
+                assertTrue(thread.isAlive());
+                Thread.sleep(20);
+            }
         } finally {
             sel.close();
             thread.join();
@@ -1909,7 +1910,7 @@ public class ThreadAPI {
     }
 
     /**
-     * Test Thread::getStackTrace on running thread waiting in Object.wait.
+     * Test Thread::getStackTrace on thread waiting in Object.wait.
      */
     @Test
     public void testGetStackTrace4() throws Exception {


### PR DESCRIPTION
This is a test fix. ThreadAPI.testGetStackTrace3 tests Thread::getStackTrace on a thread doing a selection operation. The test is not reliable as it expects to see the "select" method in the stack trace after waiting 200ms. The test is changed to poll the stack trace so that it's no longer dependent on sleep.

The update includes a drive-by change to the test description to use `@enablePreview`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286788](https://bugs.openjdk.java.net/browse/JDK-8286788): Test java/lang/Thread/virtual/ThreadAPI.testGetStackTrace3 fails


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8743/head:pull/8743` \
`$ git checkout pull/8743`

Update a local copy of the PR: \
`$ git checkout pull/8743` \
`$ git pull https://git.openjdk.java.net/jdk pull/8743/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8743`

View PR using the GUI difftool: \
`$ git pr show -t 8743`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8743.diff">https://git.openjdk.java.net/jdk/pull/8743.diff</a>

</details>
