### PR TITLE
8286870: Memory leak with RepeatCompilation

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2312,8 +2312,9 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
       /* Repeat compilation without installing code for profiling purposes */
       int repeat_compilation_count = directive->RepeatCompilationOption;
       while (repeat_compilation_count > 0) {
+        ResourceMark rm(thread);
         task->print_ul("NO CODE INSTALLED");
-        comp->compile_method(&ci_env, target, osr_bci, false , directive);
+        comp->compile_method(&ci_env, target, osr_bci, false, directive);
         repeat_compilation_count--;
       }
     }


### PR DESCRIPTION
While using `RepeatCompilation` in combination with replay compilation and stress options to reproduce an intermittent issue, I noticed that it does not free the compiler thread arena after each compilation, leading to a (temporary) memory leak and out of memory errors. For example, each compilation of [JDK-8280696](https://bugs.openjdk.java.net/browse/JDK-8280696) allocates an additional 1218 kB.

The fix is to simply add a `ResourceMark` in the loop.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286870](https://bugs.openjdk.java.net/browse/JDK-8286870): Memory leak with RepeatCompilation


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8744/head:pull/8744` \
`$ git checkout pull/8744`

Update a local copy of the PR: \
`$ git checkout pull/8744` \
`$ git pull https://git.openjdk.java.net/jdk pull/8744/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8744`

View PR using the GUI difftool: \
`$ git pr show -t 8744`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8744.diff">https://git.openjdk.java.net/jdk/pull/8744.diff</a>

</details>
