### PR TITLE
8286873: Improve websocket test execution time

### DIFF
--- a/test/jdk/java/net/httpclient/websocket/BlowupOutputQueue.java
+++ b/test/jdk/java/net/httpclient/websocket/BlowupOutputQueue.java
@@ -124,14 +124,15 @@ public class BlowupOutputQueue extends PendingOperations {
             webSocket.request(N);
             allButCloseReceived.await();
             webSocket.request(1); // Receive the last message: Close
+            List<MockListener.Invocation> invocations = listener.invocations();
+            cfClose = webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok");
+
+            assertFalse(invocations.contains(new MockListener.OnError(webSocket, IOException.class)));
+            assertFalse(cfText.isDone());
+            assertFalse(cfPing.isDone());
+            assertFalse(cfClose.isDone());
             return null;
         }, () -> cfText.isDone());
-        List<MockListener.Invocation> invocations = listener.invocations();
-        cfClose = webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok");
-
-        assertFalse(invocations.contains(new MockListener.OnError(webSocket, IOException.class)));
-        assertFalse(cfText.isDone());
-        assertFalse(cfPing.isDone());
-        assertFalse(cfClose.isDone());
+        webSocket.abort();
     }
 }

--- a/test/jdk/java/net/httpclient/websocket/BlowupOutputQueue.java
+++ b/test/jdk/java/net/httpclient/websocket/BlowupOutputQueue.java
@@ -111,7 +111,7 @@ public class BlowupOutputQueue extends PendingOperations {
                 System.out.printf("begin cycle #%s at %s%n", i, start);
                 cfText = webSocket.sendText(data, true);
                 try {
-                    cfText.get(maxWaitSec, TimeUnit.SECONDS);
+                    cfText.get(waitSec, TimeUnit.SECONDS);
                     data.clear();
                 } catch (TimeoutException e) {
                     break;

--- a/test/jdk/java/net/httpclient/websocket/BlowupOutputQueue.java
+++ b/test/jdk/java/net/httpclient/websocket/BlowupOutputQueue.java
@@ -133,6 +133,5 @@ public class BlowupOutputQueue extends PendingOperations {
             assertFalse(cfClose.isDone());
             return null;
         }, () -> cfText.isDone());
-        webSocket.abort();
     }
 }

--- a/test/jdk/java/net/httpclient/websocket/BlowupOutputQueue.java
+++ b/test/jdk/java/net/httpclient/websocket/BlowupOutputQueue.java
@@ -111,7 +111,7 @@ public class BlowupOutputQueue extends PendingOperations {
                 System.out.printf("begin cycle #%s at %s%n", i, start);
                 cfText = webSocket.sendText(data, true);
                 try {
-                    cfText.get(MAX_WAIT_SEC, TimeUnit.SECONDS);
+                    cfText.get(maxWaitSec, TimeUnit.SECONDS);
                     data.clear();
                 } catch (TimeoutException e) {
                     break;

--- a/test/jdk/java/net/httpclient/websocket/BlowupOutputQueue.java
+++ b/test/jdk/java/net/httpclient/websocket/BlowupOutputQueue.java
@@ -57,10 +57,10 @@ public class BlowupOutputQueue extends PendingOperations {
      * utilized and then make sure there won't be any errors caused by that.
      *
      * First, fill the queue with Text messages. Once done, send a Ping message.
-     * At this stage, there are at least 2 messages are in queue. Now, start
+     * At this stage, there are at least 2 messages in queue. Now, start
      * receiving. Received Ping messages will cause automatic Pong replies. When
      * all done, there will be at least 3 messages in the queue. (As at least
-     * the a single Ping has to be replied). Then send a Close message. Now
+     * a single Ping has to be replied). Then send a Close message. Now
      * there are at least 4 messages in the queue. Finally, receive the last
      * message which is a Close message. This will cause an automatic reply with
      * a Close message from the client side. All in all there should be at least

--- a/test/jdk/java/net/httpclient/websocket/PendingBinaryPingClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingBinaryPingClose.java
@@ -60,7 +60,7 @@ public class PendingBinaryPingClose extends PendingOperations {
                 System.out.printf("begin cycle #%s at %s%n", i, start);
                 cfBinary = webSocket.sendBinary(data, last);
                 try {
-                    cfBinary.get(MAX_WAIT_SEC, TimeUnit.SECONDS);
+                    cfBinary.get(maxWaitSec, TimeUnit.SECONDS);
                     data.clear();
                 } catch (TimeoutException e) {
                     break;

--- a/test/jdk/java/net/httpclient/websocket/PendingBinaryPingClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingBinaryPingClose.java
@@ -60,7 +60,7 @@ public class PendingBinaryPingClose extends PendingOperations {
                 System.out.printf("begin cycle #%s at %s%n", i, start);
                 cfBinary = webSocket.sendBinary(data, last);
                 try {
-                    cfBinary.get(maxWaitSec, TimeUnit.SECONDS);
+                    cfBinary.get(waitSec, TimeUnit.SECONDS);
                     data.clear();
                 } catch (TimeoutException e) {
                     break;

--- a/test/jdk/java/net/httpclient/websocket/PendingBinaryPingClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingBinaryPingClose.java
@@ -74,11 +74,11 @@ public class PendingBinaryPingClose extends PendingOperations {
             assertFails(ISE, webSocket.sendBinary(ByteBuffer.allocate(0), true));
             assertFails(ISE, webSocket.sendBinary(ByteBuffer.allocate(0), false));
             cfPing = webSocket.sendPing(ByteBuffer.allocate(125));
-            assertHangs(cfPing);
             assertFails(ISE, webSocket.sendPing(ByteBuffer.allocate(125)));
             assertFails(ISE, webSocket.sendPong(ByteBuffer.allocate(125)));
             cfClose = webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok");
-            assertHangs(cfClose);
+            assertHangs(cfPing);
+            assertNotDone(cfClose);
             assertNotDone(cfBinary);
             return null;
         }, () -> cfBinary.isDone());

--- a/test/jdk/java/net/httpclient/websocket/PendingBinaryPingClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingBinaryPingClose.java
@@ -80,11 +80,11 @@ public class PendingBinaryPingClose extends PendingOperations {
             assertHangs(cfPing);
             assertNotDone(cfClose);
             assertNotDone(cfBinary);
+            webSocket.abort();
+            assertFails(IOE, cfBinary);
+            assertFails(IOE, cfPing);
+            assertFails(IOE, cfClose);
             return null;
         }, () -> cfBinary.isDone());
-        webSocket.abort();
-        assertFails(IOE, cfBinary);
-        assertFails(IOE, cfPing);
-        assertFails(IOE, cfClose);
     }
 }

--- a/test/jdk/java/net/httpclient/websocket/PendingBinaryPingClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingBinaryPingClose.java
@@ -77,8 +77,7 @@ public class PendingBinaryPingClose extends PendingOperations {
             assertFails(ISE, webSocket.sendPing(ByteBuffer.allocate(125)));
             assertFails(ISE, webSocket.sendPong(ByteBuffer.allocate(125)));
             cfClose = webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok");
-            assertHangs(cfPing);
-            assertNotDone(cfClose);
+            assertAllHang(cfPing, cfClose);
             assertNotDone(cfBinary);
             webSocket.abort();
             assertFails(IOE, cfBinary);

--- a/test/jdk/java/net/httpclient/websocket/PendingBinaryPongClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingBinaryPongClose.java
@@ -62,7 +62,7 @@ public class PendingBinaryPongClose extends PendingOperations {
                 System.out.printf("begin cycle #%s at %s%n", i, start);
                 cfBinary = webSocket.sendBinary(data, last);
                 try {
-                    cfBinary.get(MAX_WAIT_SEC, TimeUnit.SECONDS);
+                    cfBinary.get(maxWaitSec, TimeUnit.SECONDS);
                     data.clear();
                 } catch (TimeoutException e) {
                     break;

--- a/test/jdk/java/net/httpclient/websocket/PendingBinaryPongClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingBinaryPongClose.java
@@ -76,11 +76,11 @@ public class PendingBinaryPongClose extends PendingOperations {
             assertFails(ISE, webSocket.sendBinary(ByteBuffer.allocate(0), true));
             assertFails(ISE, webSocket.sendBinary(ByteBuffer.allocate(0), false));
             cfPong = webSocket.sendPong(ByteBuffer.allocate(125));
-            assertHangs(cfPong);
             assertFails(ISE, webSocket.sendPing(ByteBuffer.allocate(125)));
             assertFails(ISE, webSocket.sendPong(ByteBuffer.allocate(125)));
             cfClose = webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok");
-            assertHangs(cfClose);
+            assertHangs(cfPong);
+            assertNotDone(cfClose);
             assertNotDone(cfBinary);
             return null;
         }, () -> cfBinary.isDone());

--- a/test/jdk/java/net/httpclient/websocket/PendingBinaryPongClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingBinaryPongClose.java
@@ -80,11 +80,11 @@ public class PendingBinaryPongClose extends PendingOperations {
             assertHangs(cfPong);
             assertNotDone(cfClose);
             assertNotDone(cfBinary);
+            webSocket.abort();
+            assertFails(IOE, cfBinary);
+            assertFails(IOE, cfPong);
+            assertFails(IOE, cfClose);
             return null;
         }, () -> cfBinary.isDone());
-        webSocket.abort();
-        assertFails(IOE, cfBinary);
-        assertFails(IOE, cfPong);
-        assertFails(IOE, cfClose);
     }
 }

--- a/test/jdk/java/net/httpclient/websocket/PendingBinaryPongClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingBinaryPongClose.java
@@ -38,8 +38,6 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import static java.net.http.HttpClient.Builder.NO_PROXY;
-import static java.net.http.HttpClient.newBuilder;
 
 public class PendingBinaryPongClose extends PendingOperations {
 
@@ -62,7 +60,7 @@ public class PendingBinaryPongClose extends PendingOperations {
                 System.out.printf("begin cycle #%s at %s%n", i, start);
                 cfBinary = webSocket.sendBinary(data, last);
                 try {
-                    cfBinary.get(maxWaitSec, TimeUnit.SECONDS);
+                    cfBinary.get(waitSec, TimeUnit.SECONDS);
                     data.clear();
                 } catch (TimeoutException e) {
                     break;

--- a/test/jdk/java/net/httpclient/websocket/PendingBinaryPongClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingBinaryPongClose.java
@@ -77,8 +77,7 @@ public class PendingBinaryPongClose extends PendingOperations {
             assertFails(ISE, webSocket.sendPing(ByteBuffer.allocate(125)));
             assertFails(ISE, webSocket.sendPong(ByteBuffer.allocate(125)));
             cfClose = webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok");
-            assertHangs(cfPong);
-            assertNotDone(cfClose);
+            assertAllHang(cfPong, cfClose);
             assertNotDone(cfBinary);
             webSocket.abort();
             assertFails(IOE, cfBinary);

--- a/test/jdk/java/net/httpclient/websocket/PendingOperations.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingOperations.java
@@ -44,7 +44,8 @@ public class PendingOperations {
     // receive buffer must be full.
     // At the time of writing, using anything <= 5s on Mac will make the
     // tests fail intermittently.
-    long maxWaitSec;
+    static final long MAX_WAIT_SEC = 10; // seconds.
+    long waitSec;
 
     DummyWebSocketServer server;
     WebSocket webSocket;
@@ -100,9 +101,9 @@ public class PendingOperations {
         do {
             iterations++;
             if (iterations == 1) {
-                maxWaitSec = 1;
+                waitSec = initialWaitSec();
             } else {
-                maxWaitSec = 10;
+                waitSec = MAX_WAIT_SEC;
             }
             System.out.println("--- iteration " + iterations + " ---");
             try {
@@ -129,5 +130,9 @@ public class PendingOperations {
                 Thread.sleep(100);
             }
         } while (iterations <= ITERATIONS);
+    }
+
+    long initialWaitSec() {
+        return 1;
     }
 }

--- a/test/jdk/java/net/httpclient/websocket/PendingOperations.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingOperations.java
@@ -41,10 +41,10 @@ public class PendingOperations {
     static final Class<IllegalStateException> ISE = IllegalStateException.class;
     static final Class<IOException> IOE = IOException.class;
     // Time after which we deem that the local send buffer and remote
-    // receive buffer must be full. This has been heuristically determined.
+    // receive buffer must be full.
     // At the time of writing, using anything <= 5s on Mac will make the
     // tests fail intermittently.
-    static final long MAX_WAIT_SEC = 10; // seconds.
+    long maxWaitSec;
 
     DummyWebSocketServer server;
     WebSocket webSocket;
@@ -99,6 +99,11 @@ public class PendingOperations {
         int iterations = 0;
         do {
             iterations++;
+            if (iterations == 1) {
+                maxWaitSec = 1;
+            } else {
+                maxWaitSec = 10;
+            }
             System.out.println("--- iteration " + iterations + " ---");
             try {
                 callable.call();

--- a/test/jdk/java/net/httpclient/websocket/PendingOperations.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingOperations.java
@@ -65,6 +65,12 @@ public class PendingOperations {
     }
 
     /* shortcut */
+    static void assertAllHang(CompletableFuture<?> cf1,
+                              CompletableFuture<?> cf2) {
+        assertHangs(CompletableFuture.anyOf(cf1, cf2));
+    }
+
+    /* shortcut */
     static void assertHangs(CompletionStage<?> stage) {
         Support.assertHangs(stage);
     }

--- a/test/jdk/java/net/httpclient/websocket/PendingPingBinaryClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPingBinaryClose.java
@@ -78,12 +78,12 @@ public class PendingPingBinaryClose extends PendingOperations {
             assertHangs(cfBinary);
             assertNotDone(cfClose);
             assertNotDone(cfPing);
+            webSocket.abort();
+            assertFails(IOE, cfPing);
+            assertFails(IOE, cfBinary);
+            assertFails(IOE, cfClose);
             return null;
         }, () -> cfPing.isDone());
-        webSocket.abort();
-        assertFails(IOE, cfPing);
-        assertFails(IOE, cfBinary);
-        assertFails(IOE, cfClose);
     }
 
     @Override

--- a/test/jdk/java/net/httpclient/websocket/PendingPingBinaryClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPingBinaryClose.java
@@ -74,9 +74,9 @@ public class PendingPingBinaryClose extends PendingOperations {
             assertFails(ISE, webSocket.sendPing(ByteBuffer.allocate(125)));
             assertFails(ISE, webSocket.sendPong(ByteBuffer.allocate(125)));
             cfBinary = webSocket.sendBinary(ByteBuffer.allocate(4), last);
-            assertHangs(cfBinary);
             cfClose = webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok");
-            assertHangs(cfClose);
+            assertHangs(cfBinary);
+            assertNotDone(cfClose);
             assertNotDone(cfPing);
             return null;
         }, () -> cfPing.isDone());

--- a/test/jdk/java/net/httpclient/websocket/PendingPingBinaryClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPingBinaryClose.java
@@ -62,7 +62,7 @@ public class PendingPingBinaryClose extends PendingOperations {
                 System.out.printf("begin cycle #%s at %s%n", i, start);
                 cfPing = webSocket.sendPing(data);
                 try {
-                    cfPing.get(maxWaitSec, TimeUnit.SECONDS);
+                    cfPing.get(waitSec, TimeUnit.SECONDS);
                     data.clear();
                 } catch (TimeoutException e) {
                     break;
@@ -84,5 +84,10 @@ public class PendingPingBinaryClose extends PendingOperations {
         assertFails(IOE, cfPing);
         assertFails(IOE, cfBinary);
         assertFails(IOE, cfClose);
+    }
+
+    @Override
+    long initialWaitSec() {
+        return isWindows() ? 3 : 1;
     }
 }

--- a/test/jdk/java/net/httpclient/websocket/PendingPingBinaryClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPingBinaryClose.java
@@ -62,7 +62,7 @@ public class PendingPingBinaryClose extends PendingOperations {
                 System.out.printf("begin cycle #%s at %s%n", i, start);
                 cfPing = webSocket.sendPing(data);
                 try {
-                    cfPing.get(MAX_WAIT_SEC, TimeUnit.SECONDS);
+                    cfPing.get(maxWaitSec, TimeUnit.SECONDS);
                     data.clear();
                 } catch (TimeoutException e) {
                     break;

--- a/test/jdk/java/net/httpclient/websocket/PendingPingBinaryClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPingBinaryClose.java
@@ -88,6 +88,7 @@ public class PendingPingBinaryClose extends PendingOperations {
 
     @Override
     long initialWaitSec() {
+        // Some Windows machines increase buffer size after 1-2 seconds
         return isWindows() ? 3 : 1;
     }
 }

--- a/test/jdk/java/net/httpclient/websocket/PendingPingBinaryClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPingBinaryClose.java
@@ -75,8 +75,7 @@ public class PendingPingBinaryClose extends PendingOperations {
             assertFails(ISE, webSocket.sendPong(ByteBuffer.allocate(125)));
             cfBinary = webSocket.sendBinary(ByteBuffer.allocate(4), last);
             cfClose = webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok");
-            assertHangs(cfBinary);
-            assertNotDone(cfClose);
+            assertAllHang(cfBinary, cfClose);
             assertNotDone(cfPing);
             webSocket.abort();
             assertFails(IOE, cfPing);

--- a/test/jdk/java/net/httpclient/websocket/PendingPingTextClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPingTextClose.java
@@ -65,7 +65,7 @@ public class PendingPingTextClose extends PendingOperations {
                     if (debug) System.out.printf("begin cycle #%s at %s%n", i, start);
                     cfPing = webSocket.sendPing(data);
                     try {
-                        cfPing.get(MAX_WAIT_SEC, TimeUnit.SECONDS);
+                        cfPing.get(maxWaitSec, TimeUnit.SECONDS);
                         data.clear();
                     } catch (TimeoutException e) {
                         done = true;
@@ -73,7 +73,7 @@ public class PendingPingTextClose extends PendingOperations {
                         break;
                     } finally {
                         long stop = System.currentTimeMillis();
-                        if (debug || done || (stop - start) > (MAX_WAIT_SEC * 1000L)/2L)
+                        if (debug || done || (stop - start) > (maxWaitSec * 1000L)/2L)
                             System.out.printf("end cycle #%s at %s (%s ms)%n", i, stop, stop - start);
                     }
                 }

--- a/test/jdk/java/net/httpclient/websocket/PendingPingTextClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPingTextClose.java
@@ -79,12 +79,12 @@ public class PendingPingTextClose extends PendingOperations {
                 }
                 assertFails(ISE, webSocket.sendPing(ByteBuffer.allocate(125)));
                 assertFails(ISE, webSocket.sendPong(ByteBuffer.allocate(125)));
-                System.out.println("asserting that sendText hangs");
                 cfText = webSocket.sendText("hello", last);
+                cfClose = webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok");
+                System.out.println("asserting that sendText hangs");
                 assertHangs(cfText);
                 System.out.println("asserting that sendClose hangs");
-                cfClose = webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok");
-                assertHangs(cfClose);
+                assertNotDone(cfClose);
                 System.out.println("asserting that cfPing is not completed");
                 assertNotDone(cfPing);
                 System.out.println("finishing");

--- a/test/jdk/java/net/httpclient/websocket/PendingPingTextClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPingTextClose.java
@@ -103,6 +103,7 @@ public class PendingPingTextClose extends PendingOperations {
 
     @Override
     long initialWaitSec() {
+        // Some Windows machines increase buffer size after 1-2 seconds
         return isWindows() ? 3 : 1;
     }
 }

--- a/test/jdk/java/net/httpclient/websocket/PendingPingTextClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPingTextClose.java
@@ -88,12 +88,12 @@ public class PendingPingTextClose extends PendingOperations {
                 System.out.println("asserting that cfPing is not completed");
                 assertNotDone(cfPing);
                 System.out.println("finishing");
+                webSocket.abort();
+                assertFails(IOE, cfPing);
+                assertFails(IOE, cfText);
+                assertFails(IOE, cfClose);
                 return null;
             }, () -> cfPing.isDone()); // can't use method ref: cfPing not initialized
-            webSocket.abort();
-            assertFails(IOE, cfPing);
-            assertFails(IOE, cfText);
-            assertFails(IOE, cfClose);
         } catch (Throwable t) {
             System.err.printf("pendingPingTextClose(%s) failed: %s%n", last, t);
             t.printStackTrace();

--- a/test/jdk/java/net/httpclient/websocket/PendingPingTextClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPingTextClose.java
@@ -65,7 +65,7 @@ public class PendingPingTextClose extends PendingOperations {
                     if (debug) System.out.printf("begin cycle #%s at %s%n", i, start);
                     cfPing = webSocket.sendPing(data);
                     try {
-                        cfPing.get(maxWaitSec, TimeUnit.SECONDS);
+                        cfPing.get(waitSec, TimeUnit.SECONDS);
                         data.clear();
                     } catch (TimeoutException e) {
                         done = true;
@@ -73,7 +73,7 @@ public class PendingPingTextClose extends PendingOperations {
                         break;
                     } finally {
                         long stop = System.currentTimeMillis();
-                        if (debug || done || (stop - start) > (maxWaitSec * 1000L)/2L)
+                        if (debug || done || (stop - start) > (waitSec * 1000L)/2L)
                             System.out.printf("end cycle #%s at %s (%s ms)%n", i, stop, stop - start);
                     }
                 }
@@ -99,5 +99,10 @@ public class PendingPingTextClose extends PendingOperations {
             t.printStackTrace();
             throw t;
         }
+    }
+
+    @Override
+    long initialWaitSec() {
+        return isWindows() ? 3 : 1;
     }
 }

--- a/test/jdk/java/net/httpclient/websocket/PendingPingTextClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPingTextClose.java
@@ -81,10 +81,8 @@ public class PendingPingTextClose extends PendingOperations {
                 assertFails(ISE, webSocket.sendPong(ByteBuffer.allocate(125)));
                 cfText = webSocket.sendText("hello", last);
                 cfClose = webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok");
-                System.out.println("asserting that sendText hangs");
-                assertHangs(cfText);
-                System.out.println("asserting that sendClose hangs");
-                assertNotDone(cfClose);
+                System.out.println("asserting that sendText and sendClose hang");
+                assertAllHang(cfText, cfClose);
                 System.out.println("asserting that cfPing is not completed");
                 assertNotDone(cfPing);
                 System.out.println("finishing");

--- a/test/jdk/java/net/httpclient/websocket/PendingPongBinaryClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPongBinaryClose.java
@@ -88,6 +88,7 @@ public class PendingPongBinaryClose extends PendingOperations {
 
     @Override
     long initialWaitSec() {
+        // Some Windows machines increase buffer size after 1-2 seconds
         return isWindows() ? 3 : 1;
     }
 }

--- a/test/jdk/java/net/httpclient/websocket/PendingPongBinaryClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPongBinaryClose.java
@@ -74,9 +74,9 @@ public class PendingPongBinaryClose extends PendingOperations {
             assertFails(ISE, webSocket.sendPing(ByteBuffer.allocate(125)));
             assertFails(ISE, webSocket.sendPong(ByteBuffer.allocate(125)));
             cfBinary = webSocket.sendBinary(ByteBuffer.allocate(4), last);
-            assertHangs(cfBinary);
             cfClose = webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok");
-            assertHangs(cfClose);
+            assertHangs(cfBinary);
+            assertNotDone(cfClose);
             assertNotDone(cfPong);
             return null;
         }, () -> cfPong.isDone());

--- a/test/jdk/java/net/httpclient/websocket/PendingPongBinaryClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPongBinaryClose.java
@@ -62,7 +62,7 @@ public class PendingPongBinaryClose extends PendingOperations {
                 System.out.printf("begin cycle #%s at %s%n", i, start);
                 cfPong = webSocket.sendPong(data);
                 try {
-                    cfPong.get(maxWaitSec, TimeUnit.SECONDS);
+                    cfPong.get(waitSec, TimeUnit.SECONDS);
                     data.clear();
                 } catch (TimeoutException e) {
                     break;
@@ -84,5 +84,10 @@ public class PendingPongBinaryClose extends PendingOperations {
         assertFails(IOE, cfPong);
         assertFails(IOE, cfBinary);
         assertFails(IOE, cfClose);
+    }
+
+    @Override
+    long initialWaitSec() {
+        return isWindows() ? 3 : 1;
     }
 }

--- a/test/jdk/java/net/httpclient/websocket/PendingPongBinaryClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPongBinaryClose.java
@@ -78,12 +78,12 @@ public class PendingPongBinaryClose extends PendingOperations {
             assertHangs(cfBinary);
             assertNotDone(cfClose);
             assertNotDone(cfPong);
+            webSocket.abort();
+            assertFails(IOE, cfPong);
+            assertFails(IOE, cfBinary);
+            assertFails(IOE, cfClose);
             return null;
         }, () -> cfPong.isDone());
-        webSocket.abort();
-        assertFails(IOE, cfPong);
-        assertFails(IOE, cfBinary);
-        assertFails(IOE, cfClose);
     }
 
     @Override

--- a/test/jdk/java/net/httpclient/websocket/PendingPongBinaryClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPongBinaryClose.java
@@ -62,7 +62,7 @@ public class PendingPongBinaryClose extends PendingOperations {
                 System.out.printf("begin cycle #%s at %s%n", i, start);
                 cfPong = webSocket.sendPong(data);
                 try {
-                    cfPong.get(MAX_WAIT_SEC, TimeUnit.SECONDS);
+                    cfPong.get(maxWaitSec, TimeUnit.SECONDS);
                     data.clear();
                 } catch (TimeoutException e) {
                     break;

--- a/test/jdk/java/net/httpclient/websocket/PendingPongBinaryClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPongBinaryClose.java
@@ -75,8 +75,7 @@ public class PendingPongBinaryClose extends PendingOperations {
             assertFails(ISE, webSocket.sendPong(ByteBuffer.allocate(125)));
             cfBinary = webSocket.sendBinary(ByteBuffer.allocate(4), last);
             cfClose = webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok");
-            assertHangs(cfBinary);
-            assertNotDone(cfClose);
+            assertAllHang(cfBinary, cfClose);
             assertNotDone(cfPong);
             webSocket.abort();
             assertFails(IOE, cfPong);

--- a/test/jdk/java/net/httpclient/websocket/PendingPongTextClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPongTextClose.java
@@ -62,7 +62,7 @@ public class PendingPongTextClose extends PendingOperations {
                 System.out.printf("begin cycle #%s at %s%n", i, start);
                 cfPong = webSocket.sendPong(data);
                 try {
-                    cfPong.get(MAX_WAIT_SEC, TimeUnit.SECONDS);
+                    cfPong.get(maxWaitSec, TimeUnit.SECONDS);
                     data.clear();
                 } catch (TimeoutException e) {
                     break;

--- a/test/jdk/java/net/httpclient/websocket/PendingPongTextClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPongTextClose.java
@@ -78,12 +78,12 @@ public class PendingPongTextClose extends PendingOperations {
             assertHangs(cfText);
             assertNotDone(cfClose);
             assertNotDone(cfPong);
+            webSocket.abort();
+            assertFails(IOE, cfPong);
+            assertFails(IOE, cfText);
+            assertFails(IOE, cfClose);
             return null;
         }, () -> cfPong.isDone());
-        webSocket.abort();
-        assertFails(IOE, cfPong);
-        assertFails(IOE, cfText);
-        assertFails(IOE, cfClose);
     }
 
     @Override

--- a/test/jdk/java/net/httpclient/websocket/PendingPongTextClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPongTextClose.java
@@ -88,6 +88,7 @@ public class PendingPongTextClose extends PendingOperations {
 
     @Override
     long initialWaitSec() {
+        // Some Windows machines increase buffer size after 1-2 seconds
         return isWindows() ? 3 : 1;
     }
 }

--- a/test/jdk/java/net/httpclient/websocket/PendingPongTextClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPongTextClose.java
@@ -62,7 +62,7 @@ public class PendingPongTextClose extends PendingOperations {
                 System.out.printf("begin cycle #%s at %s%n", i, start);
                 cfPong = webSocket.sendPong(data);
                 try {
-                    cfPong.get(maxWaitSec, TimeUnit.SECONDS);
+                    cfPong.get(waitSec, TimeUnit.SECONDS);
                     data.clear();
                 } catch (TimeoutException e) {
                     break;
@@ -84,5 +84,10 @@ public class PendingPongTextClose extends PendingOperations {
         assertFails(IOE, cfPong);
         assertFails(IOE, cfText);
         assertFails(IOE, cfClose);
+    }
+
+    @Override
+    long initialWaitSec() {
+        return isWindows() ? 3 : 1;
     }
 }

--- a/test/jdk/java/net/httpclient/websocket/PendingPongTextClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPongTextClose.java
@@ -74,9 +74,9 @@ public class PendingPongTextClose extends PendingOperations {
             assertFails(ISE, webSocket.sendPing(ByteBuffer.allocate(125)));
             assertFails(ISE, webSocket.sendPong(ByteBuffer.allocate(125)));
             cfText = webSocket.sendText("hello", last);
-            assertHangs(cfText);
             cfClose = webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok");
-            assertHangs(cfClose);
+            assertHangs(cfText);
+            assertNotDone(cfClose);
             assertNotDone(cfPong);
             return null;
         }, () -> cfPong.isDone());

--- a/test/jdk/java/net/httpclient/websocket/PendingPongTextClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPongTextClose.java
@@ -75,8 +75,7 @@ public class PendingPongTextClose extends PendingOperations {
             assertFails(ISE, webSocket.sendPong(ByteBuffer.allocate(125)));
             cfText = webSocket.sendText("hello", last);
             cfClose = webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok");
-            assertHangs(cfText);
-            assertNotDone(cfClose);
+            assertAllHang(cfText, cfClose);
             assertNotDone(cfPong);
             webSocket.abort();
             assertFails(IOE, cfPong);

--- a/test/jdk/java/net/httpclient/websocket/PendingTextPingClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingTextPingClose.java
@@ -82,11 +82,11 @@ public class PendingTextPingClose extends PendingOperations {
             assertHangs(cfPing);
             assertNotDone(cfClose);
             assertNotDone(cfText);
+            webSocket.abort();
+            assertFails(IOE, cfText);
+            assertFails(IOE, cfPing);
+            assertFails(IOE, cfClose);
             return null;
         }, () -> cfText.isDone());
-        webSocket.abort();
-        assertFails(IOE, cfText);
-        assertFails(IOE, cfPing);
-        assertFails(IOE, cfClose);
     }
 }

--- a/test/jdk/java/net/httpclient/websocket/PendingTextPingClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingTextPingClose.java
@@ -62,7 +62,7 @@ public class PendingTextPingClose extends PendingOperations {
                 cfText = webSocket.sendText(data, last);
                 try {
                     if (!cfText.isDone()) System.gc();
-                    cfText.get(maxWaitSec, TimeUnit.SECONDS);
+                    cfText.get(waitSec, TimeUnit.SECONDS);
                     data.clear();
                 } catch (TimeoutException e) {
                     break;

--- a/test/jdk/java/net/httpclient/websocket/PendingTextPingClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingTextPingClose.java
@@ -76,11 +76,11 @@ public class PendingTextPingClose extends PendingOperations {
             assertFails(ISE, webSocket.sendBinary(ByteBuffer.allocate(0), true));
             assertFails(ISE, webSocket.sendBinary(ByteBuffer.allocate(0), false));
             cfPing = webSocket.sendPing(ByteBuffer.allocate(125));
-            assertHangs(cfPing);
             assertFails(ISE, webSocket.sendPing(ByteBuffer.allocate(125)));
             assertFails(ISE, webSocket.sendPong(ByteBuffer.allocate(125)));
             cfClose = webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok");
-            assertHangs(cfClose);
+            assertHangs(cfPing);
+            assertNotDone(cfClose);
             assertNotDone(cfText);
             return null;
         }, () -> cfText.isDone());

--- a/test/jdk/java/net/httpclient/websocket/PendingTextPingClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingTextPingClose.java
@@ -62,7 +62,7 @@ public class PendingTextPingClose extends PendingOperations {
                 cfText = webSocket.sendText(data, last);
                 try {
                     if (!cfText.isDone()) System.gc();
-                    cfText.get(MAX_WAIT_SEC, TimeUnit.SECONDS);
+                    cfText.get(maxWaitSec, TimeUnit.SECONDS);
                     data.clear();
                 } catch (TimeoutException e) {
                     break;

--- a/test/jdk/java/net/httpclient/websocket/PendingTextPingClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingTextPingClose.java
@@ -79,8 +79,7 @@ public class PendingTextPingClose extends PendingOperations {
             assertFails(ISE, webSocket.sendPing(ByteBuffer.allocate(125)));
             assertFails(ISE, webSocket.sendPong(ByteBuffer.allocate(125)));
             cfClose = webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok");
-            assertHangs(cfPing);
-            assertNotDone(cfClose);
+            assertAllHang(cfPing, cfClose);
             assertNotDone(cfText);
             webSocket.abort();
             assertFails(IOE, cfText);

--- a/test/jdk/java/net/httpclient/websocket/PendingTextPongClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingTextPongClose.java
@@ -75,11 +75,11 @@ public class PendingTextPongClose extends PendingOperations {
             assertFails(ISE, webSocket.sendBinary(ByteBuffer.allocate(0), true));
             assertFails(ISE, webSocket.sendBinary(ByteBuffer.allocate(0), false));
             cfPong = webSocket.sendPong(ByteBuffer.allocate(125));
-            assertHangs(cfPong);
             assertFails(ISE, webSocket.sendPing(ByteBuffer.allocate(125)));
             assertFails(ISE, webSocket.sendPong(ByteBuffer.allocate(125)));
             cfClose = webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok");
-            assertHangs(cfClose);
+            assertHangs(cfPong);
+            assertNotDone(cfClose);
             assertNotDone(cfText);
             return null;
         }, () -> cfText.isDone());

--- a/test/jdk/java/net/httpclient/websocket/PendingTextPongClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingTextPongClose.java
@@ -61,7 +61,7 @@ public class PendingTextPongClose extends PendingOperations {
                 System.out.printf("begin cycle #%s at %s%n", i, start);
                 cfText = webSocket.sendText(data, last);
                 try {
-                    cfText.get(MAX_WAIT_SEC, TimeUnit.SECONDS);
+                    cfText.get(maxWaitSec, TimeUnit.SECONDS);
                     data.clear();
                 } catch (TimeoutException e) {
                     break;

--- a/test/jdk/java/net/httpclient/websocket/PendingTextPongClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingTextPongClose.java
@@ -81,11 +81,11 @@ public class PendingTextPongClose extends PendingOperations {
             assertHangs(cfPong);
             assertNotDone(cfClose);
             assertNotDone(cfText);
+            webSocket.abort();
+            assertFails(IOE, cfText);
+            assertFails(IOE, cfPong);
+            assertFails(IOE, cfClose);
             return null;
         }, () -> cfText.isDone());
-        webSocket.abort();
-        assertFails(IOE, cfText);
-        assertFails(IOE, cfPong);
-        assertFails(IOE, cfClose);
     }
 }

--- a/test/jdk/java/net/httpclient/websocket/PendingTextPongClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingTextPongClose.java
@@ -61,7 +61,7 @@ public class PendingTextPongClose extends PendingOperations {
                 System.out.printf("begin cycle #%s at %s%n", i, start);
                 cfText = webSocket.sendText(data, last);
                 try {
-                    cfText.get(maxWaitSec, TimeUnit.SECONDS);
+                    cfText.get(waitSec, TimeUnit.SECONDS);
                     data.clear();
                 } catch (TimeoutException e) {
                     break;

--- a/test/jdk/java/net/httpclient/websocket/PendingTextPongClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingTextPongClose.java
@@ -78,8 +78,7 @@ public class PendingTextPongClose extends PendingOperations {
             assertFails(ISE, webSocket.sendPing(ByteBuffer.allocate(125)));
             assertFails(ISE, webSocket.sendPong(ByteBuffer.allocate(125)));
             cfClose = webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok");
-            assertHangs(cfPong);
-            assertNotDone(cfClose);
+            assertAllHang(cfPong, cfClose);
             assertNotDone(cfText);
             webSocket.abort();
             assertFails(IOE, cfText);


### PR DESCRIPTION
This PR improves the execution time of jdk_net tests (and, by extension, tier2) by about 3 minutes.

Tests located under `jdk/java/net/httpclient/websocket` are never run in parallel. Each of the 8 modified `Pending***` tests originally required 40 seconds to complete. After the proposed changes, they usually complete in 15 seconds.

This PR modifies the tests to initially run with 1 second timeout. If the test fails with 1 second timeout, it is retried with timeout increased to 10 seconds (the original value).

The modified tests were executed at least 10 times on each of: Windows, Linux (both x64 and aarch64), MacOS (both x64 and aarch64). No failures were observed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286873](https://bugs.openjdk.java.net/browse/JDK-8286873): Improve websocket test execution time


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to [52b735bf](https://git.openjdk.java.net/jdk/pull/8746/files/52b735bf7eebb9e8a5b2ecb6ee09059dddf4c207)
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8746/head:pull/8746` \
`$ git checkout pull/8746`

Update a local copy of the PR: \
`$ git checkout pull/8746` \
`$ git pull https://git.openjdk.java.net/jdk pull/8746/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8746`

View PR using the GUI difftool: \
`$ git pr show -t 8746`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8746.diff">https://git.openjdk.java.net/jdk/pull/8746.diff</a>

</details>
