### PR TITLE
8286571: java source launcher from a minimal jdk image containing jdk.compiler fails with --enable-preview option

### DIFF
--- a/src/jdk.compiler/share/classes/module-info.java
+++ b/src/jdk.compiler/share/classes/module-info.java
@@ -78,6 +78,7 @@
  */
 module jdk.compiler {
     requires transitive java.compiler;
+    requires jdk.zipfs;
 
     exports com.sun.source.doctree;
     exports com.sun.source.tree;

--- a/test/jdk/tools/launcher/SourceMode.java
+++ b/test/jdk/tools/launcher/SourceMode.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8192920 8204588 8210275
+ * @bug 8192920 8204588 8210275 8286571
  * @summary Test source mode
  * @modules jdk.compiler jdk.jlink
  * @run main SourceMode
@@ -32,6 +32,7 @@
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -102,6 +103,33 @@ public class SourceMode extends TestHelper {
         if (!tr.isOK())
             error(tr, "Bad exit code: " + tr.exitValue);
         if (!tr.contains("[1, 2, 3]"))
+            error(tr, "Expected output not found");
+        show(tr);
+    }
+
+    // java --source N --enable-preview Simple.java hello
+    // on minimal jdk image containing jdk.compiler
+    @Test
+    void test8286571() throws IOException {
+        starting("test8286571");
+        var pw = new PrintWriter(System.out);
+        int rc = ToolProvider.findFirst("jlink").orElseThrow().run(
+                pw, pw,
+                "--add-modules",
+                "jdk.compiler",
+                "--output",
+                "comp_only");
+        if (rc != 0)
+            throw new AssertionError("Jlink failed: rc = " + rc);
+        Path file = getSimpleFile("Simple.java", false);
+        TestResult tr = doExec(
+                Path.of("comp_only", "bin", isWindows ? "java.exe" : "java").toString(),
+                "--source", thisVersion,
+                "--enable-preview",
+                file.toString(), "hello");
+        if (!tr.isOK())
+            error(tr, "Bad exit code: " + tr.exitValue);
+        if (!tr.contains("[hello]"))
             error(tr, "Expected output not found");
         show(tr);
     }

--- a/test/langtools/tools/javac/file/LimitedImage.java
+++ b/test/langtools/tools/javac/file/LimitedImage.java
@@ -34,14 +34,11 @@
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.List;
 
 import toolbox.JavacTask;
 import toolbox.JarTask;
 import toolbox.Task.Expect;
 import toolbox.Task.Mode;
-import toolbox.Task.OutputKind;
 import toolbox.ToolBox;
 
 public class LimitedImage {
@@ -68,73 +65,39 @@ public class LimitedImage {
 
         new JarTask(tb, testJar).run();
 
-        List<String> actualOutput;
-        List<String> expectedOutput = Arrays.asList(
-                "- compiler.err.no.zipfs.for.archive: " + testJar.toString()
-        );
-
         //check proper diagnostics when zip/jar FS not present:
         System.err.println("Test " + testJar + " on classpath");
-        actualOutput = new JavacTask(tb, Mode.CMDLINE)
+        new JavacTask(tb, Mode.CMDLINE)
                 .classpath(testJar)
                 .options("-XDrawDiagnostics")
                 .files(testSource)
                 .outdir(".")
-                .run(Expect.FAIL)
-                .writeAll()
-                .getOutputLines(OutputKind.DIRECT);
-
-        if (!expectedOutput.equals(actualOutput)) {
-            throw new AssertionError("Unexpected output");
-        }
+                .run(Expect.SUCCESS);
 
         System.err.println("Test " + testJar + " on sourcepath");
-        actualOutput = new JavacTask(tb, Mode.CMDLINE)
+        new JavacTask(tb, Mode.CMDLINE)
                 .sourcepath(testJar)
                 .options("-XDrawDiagnostics")
                 .files(testSource)
                 .outdir(".")
-                .run(Expect.FAIL)
-                .writeAll()
-                .getOutputLines(OutputKind.DIRECT);
-
-        if (!expectedOutput.equals(actualOutput)) {
-            throw new AssertionError("Unexpected output");
-        }
+                .run(Expect.SUCCESS);
 
         System.err.println("Test " + testJar + " on modulepath");
-        actualOutput = new JavacTask(tb, Mode.CMDLINE)
+        new JavacTask(tb, Mode.CMDLINE)
                 .options("-XDrawDiagnostics",
                          "--module-path", testJar.toString())
                 .files(testSource)
                 .outdir(".")
-                .run(Expect.FAIL)
-                .writeAll()
-                .getOutputLines(OutputKind.DIRECT);
-
-        if (!expectedOutput.equals(actualOutput)) {
-            throw new AssertionError("Unexpected output");
-        }
-
-        expectedOutput = Arrays.asList(
-                "- compiler.err.no.zipfs.for.archive: " + testJar.toString(),
-                "1 error"
-        );
+                .run(Expect.SUCCESS);
 
         System.err.println("Test directory containing " + testJar + " on modulepath");
-        actualOutput = new JavacTask(tb, Mode.CMDLINE)
+        new JavacTask(tb, Mode.CMDLINE)
                 .classpath()
                 .options("-XDrawDiagnostics",
                          "--module-path", testJar.getParent().toString())
                 .files(testSource)
                 .outdir(".")
-                .run(Expect.FAIL)
-                .writeAll()
-                .getOutputLines(OutputKind.DIRECT);
-
-        if (!expectedOutput.equals(actualOutput)) {
-            throw new AssertionError("Unexpected output");
-        }
+                .run(Expect.SUCCESS);
     }
 
 }

--- a/test/langtools/tools/javac/file/LimitedImage.java
+++ b/test/langtools/tools/javac/file/LimitedImage.java
@@ -24,7 +24,7 @@
 /**
  * @test
  * @bug 8153391
- * @summary Verify javac behaves properly in absence of zip/jar FileSystemProvider
+ * @summary Verify javac behaves properly in JDK image limited to jdk.compiler module
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main


### PR DESCRIPTION
### Problem description
Minimal jdk image created by jlink with the only jdk.compiler module and its dependencies
fails to run java source launcher correctly (for example when --source N is specified).
Failing source launcher is only one the expressions of internal jdk.compiler malfunction, another example is failure to run javac with --release option.

### Root cause
Module jdk.compiler requires zip filesystem (jdk.zipfs module) to parse ct.sym file and so to provide full functionality.
Module jdk.zipfs is not included in the minimal JDK image, because module jdk.compiler does not declare it as "requires" in its module info.

### Alternative patch
The problem can be alternatively resolved by complex code checks in jdk.compiler to provide user with valid error message, however that solution would be just a workaround for jdk.compiler dual functionality (with or without presence of jdk.zipfs module). Compiler functionality without access to ct.sym through jdk.zipfs is very limited. 

### Proposed fix
This patch fixes the problem by explicit declaration of jdk.compiler dependency on jdk.zipfs.
Plus added specific test case.

Please review the patch or raise objections against declaration of jdk.compiler dependent on jdk.zipfs.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286571](https://bugs.openjdk.org/browse/JDK-8286571): java source launcher from a minimal jdk image containing jdk.compiler fails with --enable-preview option


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8747/head:pull/8747` \
`$ git checkout pull/8747`

Update a local copy of the PR: \
`$ git checkout pull/8747` \
`$ git pull https://git.openjdk.java.net/jdk pull/8747/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8747`

View PR using the GUI difftool: \
`$ git pr show -t 8747`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8747.diff">https://git.openjdk.java.net/jdk/pull/8747.diff</a>

</details>
