### PR TITLE
JDK-8286832: JavaDoc pages call browser history API too often

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/script.js
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/script.js
@@ -137,14 +137,14 @@ document.addEventListener("DOMContentLoaded", function(e) {
     window.addEventListener("hashchange", function(e) {
         history.replaceState(contentDiv.scrollTop, document.title);
     });
+    var timeoutId;
     contentDiv.addEventListener("scroll", function(e) {
-        var timeoutID;
-        if (!timeoutID) {
-            timeoutID = setTimeout(function() {
-                history.replaceState(contentDiv.scrollTop, document.title);
-                timeoutID = null;
-            }, 100);
+        if (timeoutId) {
+            clearTimeout(timeoutId);
         }
+        timeoutId = setTimeout(function() {
+            history.replaceState(contentDiv.scrollTop, document.title);
+        }, 100);
     });
     if (!location.hash) {
         history.replaceState(contentDiv.scrollTop, document.title);


### PR DESCRIPTION
This is a small but important fix in our browser script that ensures that the `history.replaceState()` function is not called repeatedly during scrolling. The existing code makes sure the function is called no more often then every 100 milliseconds, but that is still unnecessarily often and enough to make Firefox complain and degrade the scrolling performance on Chrome on Android. 

The new code does not call the function until after the user has stopped scrolling. This is what we want and fixes all the above mentioned problems. 

I have tested the new code thoroughly on Firefox and Chrome on Mac OS and Linux, Safari on Mac OS and  iOS as well as Chrome on Android.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286832](https://bugs.openjdk.java.net/browse/JDK-8286832): JavaDoc pages call browser history API too often


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8751/head:pull/8751` \
`$ git checkout pull/8751`

Update a local copy of the PR: \
`$ git checkout pull/8751` \
`$ git pull https://git.openjdk.java.net/jdk pull/8751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8751`

View PR using the GUI difftool: \
`$ git pr show -t 8751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8751.diff">https://git.openjdk.java.net/jdk/pull/8751.diff</a>

</details>
