### PR TITLE
JDK-8286887: Remove logging from search.js

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
@@ -334,7 +334,6 @@ $.widget("custom.catcomplete", $.ui.autocomplete, {
                 offset = item.offset().top - this.activeMenu.offset().top - borderTop - paddingTop;
                 scroll = this.activeMenu.scrollTop();
                 elementHeight = this.activeMenu.height() - 26;
-                console.log(item)
                 itemHeight = item.outerHeight();
 
                 if ( offset < 0 ) {


### PR DESCRIPTION
This is a trivial change to remove a logging statement in search.js that sneaked in with JDK-8248863.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286887](https://bugs.openjdk.java.net/browse/JDK-8286887): Remove logging from search.js


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8752/head:pull/8752` \
`$ git checkout pull/8752`

Update a local copy of the PR: \
`$ git checkout pull/8752` \
`$ git pull https://git.openjdk.java.net/jdk pull/8752/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8752`

View PR using the GUI difftool: \
`$ git pr show -t 8752`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8752.diff">https://git.openjdk.java.net/jdk/pull/8752.diff</a>

</details>
