### PR TITLE
8272791: java -XX:BlockZeroingLowLimit=1 crashes after 8270947

### DIFF
--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -105,7 +105,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
           "Use DC ZVA for block zeroing")                               \
   product(intx, BlockZeroingLowLimit, 256,                              \
           "Minimum size in bytes when block zeroing will be used")      \
-          range(1, max_jint)                                            \
+          range(wordSize, max_jint)                                     \
   product(bool, TraceTraps, false, "Trace all traps the signal handler")\
   product(int, SoftwarePrefetchHintDistance, -1,                        \
           "Use prfm hint with specified distance in compiled code."     \

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -4855,7 +4855,7 @@ address MacroAssembler::zero_words(Register ptr, Register cnt)
 // r10, r11, rscratch1, and rscratch2 are clobbered.
 address MacroAssembler::zero_words(Register base, uint64_t cnt)
 {
-  guarantee(zero_words_block_size < BlockZeroingLowLimit,
+  guarantee(wordSize <= BlockZeroingLowLimit,
             "increase BlockZeroingLowLimit");
   address result = nullptr;
   if (cnt <= (uint64_t)BlockZeroingLowLimit / BytesPerWord) {

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -4855,7 +4855,7 @@ address MacroAssembler::zero_words(Register ptr, Register cnt)
 // r10, r11, rscratch1, and rscratch2 are clobbered.
 address MacroAssembler::zero_words(Register base, uint64_t cnt)
 {
-  guarantee(wordSize <= BlockZeroingLowLimit,
+  assert(wordSize <= BlockZeroingLowLimit,
             "increase BlockZeroingLowLimit");
   address result = nullptr;
   if (cnt <= (uint64_t)BlockZeroingLowLimit / BytesPerWord) {

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -380,6 +380,12 @@ void VM_Version::initialize() {
     if (FLAG_IS_DEFAULT(BlockZeroingLowLimit)) {
       FLAG_SET_DEFAULT(BlockZeroingLowLimit, 4 * VM_Version::zva_length());
     }
+    if (!FLAG_IS_DEFAULT(BlockZeroingLowLimit)) {
+      // BlockZeroingLowLimit is a limit in bytes. It's not possible
+      // to initialize blocks smaller than wordSize, 8 bytes. As this
+      // flag is a tuning parameter, silently set the limit to 1 word.
+      BlockZeroingLowLimit = MAX2(BlockZeroingLowLimit, (intx)wordSize);
+    }
   } else if (UseBlockZeroing) {
     warning("DC ZVA is not available on this CPU");
     FLAG_SET_DEFAULT(UseBlockZeroing, false);

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -380,12 +380,6 @@ void VM_Version::initialize() {
     if (FLAG_IS_DEFAULT(BlockZeroingLowLimit)) {
       FLAG_SET_DEFAULT(BlockZeroingLowLimit, 4 * VM_Version::zva_length());
     }
-    if (!FLAG_IS_DEFAULT(BlockZeroingLowLimit)) {
-      // BlockZeroingLowLimit is a limit in bytes. It's not possible
-      // to initialize blocks smaller than wordSize, 8 bytes. As this
-      // flag is a tuning parameter, silently set the limit to 1 word.
-      BlockZeroingLowLimit = MAX2(BlockZeroingLowLimit, (intx)wordSize);
-    }
   } else if (UseBlockZeroing) {
     warning("DC ZVA is not available on this CPU");
     FLAG_SET_DEFAULT(UseBlockZeroing, false);


### PR DESCRIPTION
This is an assertion failure caused by setting `BlockZeroingLowLimit` < `wordSize`.

I believe there was some confusion when writing this code about whether `BlockZeroingLowLimit` should be in words or bytes, and it makes no sense for it to be less than a single word. If anyone ever tried to use a parameter < 8, it triggers an assertion.

This patch does two things. Firstly, it corrects a `guarantee` which erroneously used `zero_words_block_size` rather than `wordSize`. The value of both of these is 8, so it doesn't change anything in the generated code. Secondly, it clips the `BlockZeroingLowLimit` so that it doesn't trigger the assertion.

Perhaps it would be better to change the lower limit to 8 instead of this silent correction. There is no backward compatibility issue here, because any attempt to set `BlockZeroingLowLimit` < 8 in the past would have exited the VM with an error, so I don't believe a CSR is warranted if we do change the allowable range.

So, which should it be? Change the lower limit of the range of the `BlockZeroingLowLimit` system flag, or allow 1 still to be used and silently fix it? Opinions welcome.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8272791](https://bugs.openjdk.java.net/browse/JDK-8272791): java -XX:BlockZeroingLowLimit=1 crashes after 8270947


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [f6984247](https://git.openjdk.java.net/jdk/pull/8756/files/f6984247c5d61c5b5615b1402d7f07459c2c5658)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8756/head:pull/8756` \
`$ git checkout pull/8756`

Update a local copy of the PR: \
`$ git checkout pull/8756` \
`$ git pull https://git.openjdk.java.net/jdk pull/8756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8756`

View PR using the GUI difftool: \
`$ git pr show -t 8756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8756.diff">https://git.openjdk.java.net/jdk/pull/8756.diff</a>

</details>
