### PR TITLE
8286814: Shenandoah: RedefineRunningMethods.java test failed with Loom

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2310,10 +2310,13 @@ void ShenandoahHeap::flush_liveness_cache(uint worker_id) {
 bool ShenandoahHeap::requires_barriers(stackChunkOop obj) const {
   if (is_idle()) return false;
 
+  // Objects allocated after marking start are implicitly alive, don't need any barriers during
+  // marking phase.
   if (is_concurrent_mark_in_progress() && marking_context()->allocated_after_mark_start(obj)) {
     return false;
   }
-
+  // Objects allocated after evacuation start are guaranteed in to-space, don't need any barriers
+  // during evacuation/update references phases.
   if (has_forwarded_objects() &&
       cast_from_oop<HeapWord*>(obj) >= heap_region_containing(obj)->get_update_watermark()) {
     return false;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2308,10 +2308,16 @@ void ShenandoahHeap::flush_liveness_cache(uint worker_id) {
 }
 
 bool ShenandoahHeap::requires_barriers(stackChunkOop obj) const {
-  ShenandoahHeapRegion* region = heap_region_containing(obj);
-  bool allocated_after_mark_start = marking_context()->allocated_after_mark_start(obj);
-  bool requires_concmark_barriers = is_concurrent_mark_in_progress() && !allocated_after_mark_start;
-  bool requires_loadref_barriers = has_forwarded_objects() && cast_from_oop<HeapWord*>(obj) < heap_region_containing(obj)->get_update_watermark();
-  bool requires_deep_loadref_barriers = allocated_after_mark_start && has_forwarded_objects();
-  return requires_concmark_barriers || requires_loadref_barriers || requires_deep_loadref_barriers;
+  if (is_idle()) return false;
+
+  if (is_concurrent_mark_in_progress() && marking_context()->allocated_after_mark_start(obj)) {
+    return false;
+  }
+
+  if (has_forwarded_objects() &&
+      cast_from_oop<HeapWord*>(obj) >= heap_region_containing(obj)->get_update_watermark()) {
+    return false;
+  }
+
+  return true;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2315,6 +2315,7 @@ bool ShenandoahHeap::requires_barriers(stackChunkOop obj) const {
   if (is_concurrent_mark_in_progress() && marking_context()->allocated_after_mark_start(obj)) {
     return false;
   }
+
   // Objects allocated after evacuation start are guaranteed in to-space, don't need any barriers
   // during evacuation/update references phases.
   if (has_forwarded_objects() &&

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -1285,8 +1285,8 @@ stackChunkOop Freeze<ConfigT>::allocate_chunk(size_t stack_size) {
   if (fast_oop != nullptr) {
     assert(!chunk->requires_barriers(), "Unfamiliar GC requires barriers on TLAB allocation");
   } else {
-    assert(!UseZGC || !chunk->requires_barriers(), "Allocated ZGC object requires barriers");
-    _barriers = !UseZGC && chunk->requires_barriers();
+    assert(!UseZGC || !UseShenandoahGC || !chunk->requires_barriers(), "Allocated ZGC/ShenandoahGC object requires barriers");
+    _barriers = !UseZGC && !UseShenandoahGC && chunk->requires_barriers();
 
     if (_barriers) {
       log_develop_trace(continuations)("allocation requires barriers");


### PR DESCRIPTION
Please review this patch that fixed failed tests.

To determine if a barrier is needed for newly allocated `stackChunkOop`, it needs to consider current GC phases, as TAMS and update watermark are specific to corresponding GC phase.

Test:

- [x] tier1 with `--enable-preview -XX:+UseShenandoahGC` on Linux x86_64 
- [x] tier2 with `--enable-preview -XX:+UseShenandoahGC` on Linux x86_64
- [ ] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286814](https://bugs.openjdk.java.net/browse/JDK-8286814): Shenandoah: RedefineRunningMethods.java test failed with Loom


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [c565201f](https://git.openjdk.java.net/jdk/pull/8757/files/c565201f5291ecb8bbc561cc04e06ce2ed9c95dc)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8757/head:pull/8757` \
`$ git checkout pull/8757`

Update a local copy of the PR: \
`$ git checkout pull/8757` \
`$ git pull https://git.openjdk.java.net/jdk pull/8757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8757`

View PR using the GUI difftool: \
`$ git pr show -t 8757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8757.diff">https://git.openjdk.java.net/jdk/pull/8757.diff</a>

</details>
