### PR TITLE
8286944: Loom: Common ContinuationEntry cookie handling

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -8080,7 +8080,7 @@ OopMap* continuation_enter_setup(MacroAssembler* masm, int& stack_slots) {
 //          c_rarg3 -- isVirtualThread
 void fill_continuation_entry(MacroAssembler* masm) {
 #ifdef ASSERT
-  __ movw(rscratch1, 0x1234);
+  __ movw(rscratch1, ContinuationEntry::cookie_value());
   __ strw(rscratch1, Address(sp, ContinuationEntry::cookie_offset()));
 #endif
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -8199,7 +8199,7 @@ OopMap* continuation_enter_setup(MacroAssembler* masm, int& stack_slots) {
 //          c_rarg3 -- isVirtualThread
 // kills rax
 void fill_continuation_entry(MacroAssembler* masm) {
-  DEBUG_ONLY(__ movl(Address(rsp, ContinuationEntry::cookie_offset()), 0x1234);)
+  DEBUG_ONLY(__ movl(Address(rsp, ContinuationEntry::cookie_offset()), ContinuationEntry::cookie_value());)
 
   __ movptr(Address(rsp, ContinuationEntry::cont_offset()), c_rarg1);
   __ movl  (Address(rsp, ContinuationEntry::flags_offset()), c_rarg3);

--- a/src/hotspot/share/runtime/continuationEntry.hpp
+++ b/src/hotspot/share/runtime/continuationEntry.hpp
@@ -37,11 +37,18 @@ class JavaThread;
 
 // Metadata stored in the continuation entry frame
 class ContinuationEntry {
-public:
 #ifdef ASSERT
+private:
+  static const int COOKIE_VALUE = 0x1234;
   int cookie;
+
+public:
+  static int cookie_value() { return COOKIE_VALUE; }
   static ByteSize cookie_offset() { return byte_offset_of(ContinuationEntry, cookie); }
-  void verify_cookie() { assert(this->cookie == 0x1234, ""); }
+
+  void verify_cookie() {
+    assert(cookie == COOKIE_VALUE, "Bad cookie: %#x, expected: %#x", cookie, COOKIE_VALUE);
+  }
 #endif
 
 public:


### PR DESCRIPTION
Platform-specific code injects the cookie to the head of ContinuationEntry. The value for this cookie is hard-coded in platform-specific code, which is fragile. It would be better to common the cookie handling a bit to ease porting. In fact, I have spent an hour trying to debug a thing where I mistyped a cookie value in x86_32 code, hence my interest.

Additional testing:
 - [x] Linux x86_64 fastdebug, `java/lang/Thread/virtual`
 - [x] Linux AArch64 fastdebug, `java/lang/Thread/virtual`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286944](https://bugs.openjdk.java.net/browse/JDK-8286944): Loom: Common ContinuationEntry cookie handling


### Reviewers
 * [Rickard Bäckman](https://openjdk.java.net/census#rbackman) (@rickard - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8762/head:pull/8762` \
`$ git checkout pull/8762`

Update a local copy of the PR: \
`$ git checkout pull/8762` \
`$ git pull https://git.openjdk.java.net/jdk pull/8762/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8762`

View PR using the GUI difftool: \
`$ git pr show -t 8762`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8762.diff">https://git.openjdk.java.net/jdk/pull/8762.diff</a>

</details>
