### PR TITLE
8286925: Move JSON parser used in JFR tests to test library

### DIFF
--- a/test/jdk/jdk/jfr/tool/TestPrintJSON.java
+++ b/test/jdk/jdk/jfr/tool/TestPrintJSON.java
@@ -35,7 +35,8 @@ import jdk.jfr.ValueDescriptor;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordedObject;
 import jdk.jfr.consumer.RecordingFile;
-import jdk.jfr.tool.JSONValue.JSONArray;
+import jdk.test.lib.json.JSONValue;
+import jdk.test.lib.json.JSONValue.JSONArray;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.process.OutputAnalyzer;
 

--- a/test/lib/jdk/test/lib/json/JSONValue.java
+++ b/test/lib/jdk/test/lib/json/JSONValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,7 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package jdk.jfr.tool;
+package jdk.test.lib.json;
 
 import java.util.ArrayList;
 import java.util.HashMap;


### PR DESCRIPTION
Could I have a review of a change that moves the JSON parser used in JFR tests to the test library so it can be used by other tests.

Testing: test/jdk/jdk/jfr/tool

Thanks
Erik Gahlin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286925](https://bugs.openjdk.java.net/browse/JDK-8286925): Move JSON parser used in JFR tests to test library


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8763/head:pull/8763` \
`$ git checkout pull/8763`

Update a local copy of the PR: \
`$ git checkout pull/8763` \
`$ git pull https://git.openjdk.java.net/jdk pull/8763/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8763`

View PR using the GUI difftool: \
`$ git pr show -t 8763`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8763.diff">https://git.openjdk.java.net/jdk/pull/8763.diff</a>

</details>
