### PR TITLE
8286956: Loom: Define test groups for development/porting use

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -108,6 +108,22 @@ hotspot_vector_2 = \
 hotspot_compiler_arraycopy = \
   compiler/arraycopy/stress
 
+tier1_loom = \
+  :tier1_loom_runtime \
+  :tier1_loom_serviceability
+
+tier1_loom_runtime = \
+  runtime/vthread \
+  runtime/jni/IsVirtualThread
+
+tier1_loom_serviceability = \
+  serviceability/jvmti/vthread \
+  serviceability/jvmti/events \
+  serviceability/dcmd/thread
+
+hotspot_loom = \
+  :tier1_loom
+
 tier1_common = \
   sanity/BasicVMTest.java \
   gtest/GTestWrapper.java \

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -265,6 +265,18 @@ jdk_launcher = \
     tools/launcher \
     sun/tools
 
+jdk_loom = \
+    com/sun/management/HotSpotDiagnosticMXBean/ \
+    java/lang/Thread \
+    java/lang/ThreadGroup \
+    java/lang/management/ThreadMXBean \
+    java/util/concurrent \
+    java/net/vthread \
+    java/nio/channels/vthread \
+    jdk/internal/misc/ThreadFlock \
+    jdk/internal/vm/Continuation \
+    jdk/jfr/threading
+
 #
 # Tool (and tool API) tests are split into core and svc groups
 #


### PR DESCRIPTION
It would be beneficial to bring over the Loom-specific test groups from the loom repo to aid development/porting work.

https://github.com/openjdk/loom/blob/fibers/test/jdk/TEST.groups#L97-L108
https://github.com/openjdk/loom/blob/6f42923b3342e41d95b262733205283068802b40/test/hotspot/jtreg/TEST.groups#L111-L125

I had to drop `jdk/incubator/concurrent` from JDK definition, because there are no tests in that folder and tests break.

Additional testing:
 - [x] Linux x86_64 fastdebug `hotspot_loom jdk_loom`
 - [x] Linux AArch64 fastdebug `hotspot_loom jdk_loom`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286956](https://bugs.openjdk.java.net/browse/JDK-8286956): Loom: Define test groups for development/porting use


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8765/head:pull/8765` \
`$ git checkout pull/8765`

Update a local copy of the PR: \
`$ git checkout pull/8765` \
`$ git pull https://git.openjdk.java.net/jdk pull/8765/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8765`

View PR using the GUI difftool: \
`$ git pr show -t 8765`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8765.diff">https://git.openjdk.java.net/jdk/pull/8765.diff</a>

</details>
