### PR TITLE
8284191: Replace usages of 'a the' in hotspot and java.base

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -420,7 +420,7 @@ void frame::verify_deopt_original_pc(CompiledMethod* nm, intptr_t* unextended_sp
 
   address original_pc = nm->get_original_pc(&fr);
   assert(nm->insts_contains_inclusive(original_pc),
-         "original PC must be in the main code section of the the compiled method (or must be immediately following it)");
+         "original PC must be in the main code section of the compiled method (or must be immediately following it)");
 }
 #endif
 

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -77,7 +77,7 @@ inline void frame::setup(address pc) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;
     assert(_cb == NULL || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
-           "original PC must be in the main code section of the the compiled method (or must be immediately following it)");
+           "original PC must be in the main code section of the compiled method (or must be immediately following it)");
   } else {
     if (_cb == SharedRuntime::deopt_blob()) {
       _deopt_state = is_deoptimized;

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -1978,7 +1978,7 @@ void SharedRuntime::generate_deopt_blob() {
 
   // -------------
   // This code enters when returning to a de-optimized nmethod.  A return
-  // address has been pushed on the the stack, and return values are in
+  // address has been pushed on the stack, and return values are in
   // registers.
   // If we are doing a normal deopt then we were called from the patched
   // nmethod from the point we returned to the nmethod. So the return
@@ -2729,7 +2729,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const cha
   __ str(r0, Address(sp, reg_save.rscratch1_offset_in_bytes()));
   reg_save.restore_live_registers(masm);
 
-  // We are back the the original state on entry and ready to go.
+  // We are back to the original state on entry and ready to go.
 
   __ br(rscratch1);
 
@@ -2892,4 +2892,3 @@ void OptoRuntime::generate_exception_blob() {
 }
 
 #endif // COMPILER2
-

--- a/src/hotspot/cpu/arm/frame_arm.cpp
+++ b/src/hotspot/cpu/arm/frame_arm.cpp
@@ -338,7 +338,7 @@ void frame::verify_deopt_original_pc(CompiledMethod* nm, intptr_t* unextended_sp
 
   address original_pc = nm->get_original_pc(&fr);
   assert(nm->insts_contains_inclusive(original_pc),
-         "original PC must be in the main code section of the the compiled method (or must be immediately following it)");
+         "original PC must be in the main code section of the compiled method (or must be immediately following it)");
   assert(nm->is_method_handle_return(original_pc) == is_method_handle_return, "must be");
 }
 #endif

--- a/src/hotspot/cpu/arm/frame_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.inline.hpp
@@ -85,7 +85,7 @@ inline frame::frame(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, address
   if (original_pc != NULL) {
     _pc = original_pc;
     assert(_cb->as_compiled_method()->insts_contains_inclusive(_pc),
-           "original PC must be in the main code section of the the compiled method (or must be immediately following it)");
+           "original PC must be in the main code section of the compiled method (or must be immediately following it)");
     _deopt_state = is_deoptimized;
   } else {
     _deopt_state = not_deoptimized;

--- a/src/hotspot/cpu/arm/stubGenerator_arm.cpp
+++ b/src/hotspot/cpu/arm/stubGenerator_arm.cpp
@@ -1788,7 +1788,7 @@ class StubGenerator: public StubCodeGenerator {
   //     'count' must not be less then the returned value
   //     'to' must be aligned by bytes_per_count but must not be aligned by wordSize
   //     shifts 'to' by the number of written bytes (so that it becomes the bound of memory to be written)
-  //     decreases 'count' by the the number of elements written
+  //     decreases 'count' by the number of elements written
   //     Rval's MSBs or LSBs remain to be written further by generate_{forward,backward}_shifted_copy_loop
   int align_dst(Register to, Register count, Register Rval, Register tmp,
                                         int to_remainder, int bytes_per_count, bool forward) {

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -3613,7 +3613,7 @@ class StubGenerator: public StubCodeGenerator {
 #define BLK_OFFSETOF(x) (offsetof(constant_block, x))
 
 // In little-endian mode, the lxv instruction loads the element at EA into
-// element 15 of the the vector register, EA+1 goes into element 14, and so
+// element 15 of the vector register, EA+1 goes into element 14, and so
 // on.
 //
 // To make a look-up table easier to read, ARRAY_TO_LXV_ORDER reverses the

--- a/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
@@ -1584,7 +1584,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
                   return_pc /* return pc */);
   __ merge_frames(/*top_frame_sp*/ R21_sender_SP, noreg, R11_scratch1, R12_scratch2);
 
-  // Load the PC of the the exception handler into LR.
+  // Load the PC of the exception handler into LR.
   __ mtlr(R3_RET);
 
   // Load exception into R3_ARG1 and clear pending exception in thread.

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -375,7 +375,7 @@ void frame::verify_deopt_original_pc(CompiledMethod* nm, intptr_t* unextended_sp
   assert_cond(nm != NULL);
   address original_pc = nm->get_original_pc(&fr);
   assert(nm->insts_contains_inclusive(original_pc),
-         "original PC must be in the main code section of the the compiled method (or must be immediately following it)");
+         "original PC must be in the main code section of the compiled method (or must be immediately following it)");
 }
 #endif
 

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -822,7 +822,7 @@ static void object_move(MacroAssembler* masm,
     __ bind(notZero1);
   } else {
 
-    // Oop is in an a register we must store it to the space we reserve
+    // Oop is in a register we must store it to the space we reserve
     // on the stack for oop_handles and pass a handle if oop is non-NULL
 
     const Register rOop = src.first()->as_Register();

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1898,7 +1898,7 @@ void SharedRuntime::generate_deopt_blob() {
 
   // -------------
   // This code enters when returning to a de-optimized nmethod.  A return
-  // address has been pushed on the the stack, and return values are in
+  // address has been pushed on the stack, and return values are in
   // registers.
   // If we are doing a normal deopt then we were called from the patched
   // nmethod from the point we returned to the nmethod. So the return
@@ -2591,7 +2591,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const cha
   __ sd(x10, Address(sp, reg_saver.reg_offset_in_bytes(t0)));
   reg_saver.restore_live_registers(masm);
 
-  // We are back the the original state on entry and ready to go.
+  // We are back to the original state on entry and ready to go.
 
   __ jr(t0);
 

--- a/src/hotspot/cpu/s390/c1_CodeStubs_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_CodeStubs_s390.cpp
@@ -373,7 +373,7 @@ void PatchingStub::emit_code(LIR_Assembler* ce) {
 
   // Now emit the patch record telling the runtime how to find the
   // pieces of the patch. We only need 3 bytes but to help the disassembler
-  // we make the data look like a the following add instruction:
+  // we make the data look like the following add instruction:
   //   A R1, D2(X2, B2)
   // which requires 4 bytes.
   int sizeof_patch_record = 4;

--- a/src/hotspot/cpu/s390/c1_CodeStubs_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_CodeStubs_s390.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2016, 2018 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -3001,7 +3001,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const cha
   // get the returned method
   __ get_vm_result_2(Z_method);
 
-  // We are back the the original state on entry and ready to go.
+  // We are back to the original state on entry and ready to go.
   __ z_br(Z_R1_scratch);
 
   // Pending exception after the safepoint

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -414,7 +414,7 @@ void frame::verify_deopt_original_pc(CompiledMethod* nm, intptr_t* unextended_sp
 
   address original_pc = nm->get_original_pc(&fr);
   assert(nm->insts_contains_inclusive(original_pc),
-         "original PC must be in the main code section of the the compiled method (or must be immediately following it) original_pc: " INTPTR_FORMAT " unextended_sp: " INTPTR_FORMAT " name: %s", p2i(original_pc), p2i(unextended_sp), nm->name());
+         "original PC must be in the main code section of the compiled method (or must be immediately following it) original_pc: " INTPTR_FORMAT " unextended_sp: " INTPTR_FORMAT " name: %s", p2i(original_pc), p2i(unextended_sp), nm->name());
 }
 #endif
 

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -72,7 +72,7 @@ inline void frame::setup(address pc) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;
     assert(_cb == NULL || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
-           "original PC must be in the main code section of the the compiled method (or must be immediately following it)");
+           "original PC must be in the main code section of the compiled method (or must be immediately following it)");
   } else {
     if (_cb == SharedRuntime::deopt_blob()) {
       _deopt_state = is_deoptimized;

--- a/src/hotspot/cpu/x86/globals_x86.hpp
+++ b/src/hotspot/cpu/x86/globals_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/globals_x86.hpp
+++ b/src/hotspot/cpu/x86/globals_x86.hpp
@@ -40,7 +40,7 @@ define_pd_global(uintx, CodeCacheSegmentSize,    64 COMPILER1_AND_COMPILER2_PRES
 // assign a different value for C2 without touching a number of files. Use
 // #ifdef to minimize the change as it's late in Mantis. -- FIXME.
 // c1 doesn't have this problem because the fix to 4858033 assures us
-// the the vep is aligned at CodeEntryAlignment whereas c2 only aligns
+// the vep is aligned at CodeEntryAlignment whereas c2 only aligns
 // the uep and the vep doesn't get real alignment but just slops on by
 // only assured that the entry instruction meets the 5 byte size requirement.
 #if COMPILER2_OR_JVMCI

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1077,7 +1077,7 @@ void MacroAssembler::object_move(OopMap* map,
     cmovptr(Assembler::equal, rHandle, Address(rbp, reg2offset_in(src.first())));
   } else {
 
-    // Oop is in an a register we must store it to the space we reserve
+    // Oop is in a register we must store it to the space we reserve
     // on the stack for oop_handles and pass a handle if oop is non-NULL
 
     const Register rOop = src.first()->as_Register();

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -2107,7 +2107,7 @@ void SharedRuntime::generate_deopt_blob() {
 
   // -------------
   // This code enters when returning to a de-optimized nmethod.  A return
-  // address has been pushed on the the stack, and return values are in
+  // address has been pushed on the stack, and return values are in
   // registers.
   // If we are doing a normal deopt then we were called from the patched
   // nmethod from the point we returned to the nmethod. So the return
@@ -2835,7 +2835,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const cha
 
   RegisterSaver::restore_live_registers(masm);
 
-  // We are back the the original state on entry and ready to go.
+  // We are back to the original state on entry and ready to go.
 
   __ jmp(rax);
 

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -1653,7 +1653,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   }
 
   // Change state to native (we save the return address in the thread, since it might not
-  // be pushed on the stack when we do a a stack traversal). It is enough that the pc()
+  // be pushed on the stack when we do a stack traversal). It is enough that the pc()
   // points into the right code segment. It does not have to be the correct return pc.
   // We use the same pc/oopMap repeatedly when we call out
 

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -1108,7 +1108,7 @@ static void object_move(MacroAssembler* masm,
       *receiver_offset = (offset_in_older_frame + framesize_in_slots) * VMRegImpl::stack_slot_size;
     }
   } else {
-    // Oop is in an a register we must store it to the space we reserve
+    // Oop is in a register we must store it to the space we reserve
     // on the stack for oop_handles
     const Register rOop = src.first()->as_Register();
     const Register rHandle = rax;

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -1813,7 +1813,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   }
 
   // Change state to native (we save the return address in the thread, since it might not
-  // be pushed on the stack when we do a a stack traversal). It is enough that the pc()
+  // be pushed on the stack when we do a stack traversal). It is enough that the pc()
   // points into the right code segment. It does not have to be the correct return pc.
   // We use the same pc/oopMap repeatedly when we call out
 

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -2251,7 +2251,7 @@ void SharedRuntime::generate_deopt_blob() {
 
   // -------------
   // This code enters when returning to a de-optimized nmethod.  A return
-  // address has been pushed on the the stack, and return values are in
+  // address has been pushed on the stack, and return values are in
   // registers.
   // If we are doing a normal deopt then we were called from the patched
   // nmethod from the point we returned to the nmethod. So the return
@@ -3001,7 +3001,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const cha
 
   RegisterSaver::restore_live_registers(masm);
 
-  // We are back the the original state on entry and ready to go.
+  // We are back to the original state on entry and ready to go.
 
   __ jmp(rax);
 

--- a/src/hotspot/os/posix/jvm_posix.cpp
+++ b/src/hotspot/os/posix/jvm_posix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/os/posix/jvm_posix.cpp
+++ b/src/hotspot/os/posix/jvm_posix.cpp
@@ -67,7 +67,7 @@ JVM_ENTRY_NO_ENV(void*, JVM_RegisterSignal(jint sig, void* handler))
 
     /* The following signals are used for Shutdown Hooks support. However, if
        ReduceSignalUsage (-Xrs) is set, Shutdown Hooks must be invoked via
-       System.exit(), Java is not allowed to use these signals, and the the
+       System.exit(), Java is not allowed to use these signals, and the
        user is allowed to set his own _native_ handler for these signals and
        invoke System.exit() as needed. Terminator.setup() is avoiding
        registration of these signals when -Xrs is present.
@@ -114,4 +114,3 @@ JVM_ENTRY_NO_ENV(jboolean, JVM_RaiseSignal(jint sig))
   os::signal_raise(sig);
   return JNI_TRUE;
 JVM_END
-

--- a/src/hotspot/os/windows/jvm_windows.cpp
+++ b/src/hotspot/os/windows/jvm_windows.cpp
@@ -56,7 +56,7 @@ JVM_ENTRY_NO_ENV(void*, JVM_RegisterSignal(jint sig, void* handler))
 
     /* The following signals are used for Shutdown Hooks support. However, if
        ReduceSignalUsage (-Xrs) is set, Shutdown Hooks must be invoked via
-       System.exit(), Java is not allowed to use these signals, and the the
+       System.exit(), Java is not allowed to use these signals, and the
        user is allowed to set his own _native_ handler for these signals and
        invoke System.exit() as needed. Terminator.setup() is avoiding
        registration of these signals when -Xrs is present. */
@@ -87,5 +87,3 @@ JVM_ENTRY_NO_ENV(jboolean, JVM_RaiseSignal(jint sig))
   os::signal_raise(sig);
   return JNI_TRUE;
 JVM_END
-
-

--- a/src/hotspot/os/windows/jvm_windows.cpp
+++ b/src/hotspot/os/windows/jvm_windows.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/os/windows/perfMemory_windows.cpp
+++ b/src/hotspot/os/windows/perfMemory_windows.cpp
@@ -667,7 +667,7 @@ static void cleanup_sharedmem_resources(const char* dirname) {
     // indicates that it is still running, the file file resources
     // are not removed. If the process id is invalid, or if we don't
     // have permissions to check the process status, or if the process
-    // id is valid and the process has terminated, the the file resources
+    // id is valid and the process has terminated, the file resources
     // are assumed to be stale and are removed.
     //
     if (pid == os::current_process_id() || !is_alive(pid)) {
@@ -1663,7 +1663,7 @@ static void open_file_mapping(int vmid, char** addrp, size_t* sizep, TRAPS) {
                           INTPTR_FORMAT, size, vmid, mapAddress);
 }
 
-// this method unmaps the the mapped view of the the
+// this method unmaps the mapped view of the
 // file mapping object.
 //
 static void remove_file_mapping(char* addr) {

--- a/src/hotspot/os_cpu/aix_ppc/atomic_aix_ppc.hpp
+++ b/src/hotspot/os_cpu/aix_ppc/atomic_aix_ppc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2019 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/os_cpu/aix_ppc/atomic_aix_ppc.hpp
+++ b/src/hotspot/os_cpu/aix_ppc/atomic_aix_ppc.hpp
@@ -242,7 +242,7 @@ inline T Atomic::PlatformCmpxchg<1>::operator()(T volatile* dest,
   STATIC_ASSERT(1 == sizeof(T));
 
   // Note that cmpxchg guarantees a two-way memory barrier across
-  // the cmpxchg, so it's really a a 'fence_cmpxchg_fence' if not
+  // the cmpxchg, so it's really a 'fence_cmpxchg_fence' if not
   // specified otherwise (see atomic.hpp).
 
   // Using 32 bit internally.
@@ -312,7 +312,7 @@ inline T Atomic::PlatformCmpxchg<4>::operator()(T volatile* dest,
   STATIC_ASSERT(4 == sizeof(T));
 
   // Note that cmpxchg guarantees a two-way memory barrier across
-  // the cmpxchg, so it's really a a 'fence_cmpxchg_fence' if not
+  // the cmpxchg, so it's really a 'fence_cmpxchg_fence' if not
   // specified otherwise (see atomic.hpp).
 
   T old_value;
@@ -362,7 +362,7 @@ inline T Atomic::PlatformCmpxchg<8>::operator()(T volatile* dest,
   STATIC_ASSERT(8 == sizeof(T));
 
   // Note that cmpxchg guarantees a two-way memory barrier across
-  // the cmpxchg, so it's really a a 'fence_cmpxchg_fence' if not
+  // the cmpxchg, so it's really a 'fence_cmpxchg_fence' if not
   // specified otherwise (see atomic.hpp).
 
   T old_value;

--- a/src/hotspot/os_cpu/linux_ppc/atomic_linux_ppc.hpp
+++ b/src/hotspot/os_cpu/linux_ppc/atomic_linux_ppc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2019 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/os_cpu/linux_ppc/atomic_linux_ppc.hpp
+++ b/src/hotspot/os_cpu/linux_ppc/atomic_linux_ppc.hpp
@@ -242,7 +242,7 @@ inline T Atomic::PlatformCmpxchg<1>::operator()(T volatile* dest,
   STATIC_ASSERT(1 == sizeof(T));
 
   // Note that cmpxchg guarantees a two-way memory barrier across
-  // the cmpxchg, so it's really a a 'fence_cmpxchg_fence' if not
+  // the cmpxchg, so it's really a 'fence_cmpxchg_fence' if not
   // specified otherwise (see atomic.hpp).
 
   // Using 32 bit internally.
@@ -312,7 +312,7 @@ inline T Atomic::PlatformCmpxchg<4>::operator()(T volatile* dest,
   STATIC_ASSERT(4 == sizeof(T));
 
   // Note that cmpxchg guarantees a two-way memory barrier across
-  // the cmpxchg, so it's really a a 'fence_cmpxchg_fence' if not
+  // the cmpxchg, so it's really a 'fence_cmpxchg_fence' if not
   // specified otherwise (see atomic.hpp).
 
   T old_value;
@@ -362,7 +362,7 @@ inline T Atomic::PlatformCmpxchg<8>::operator()(T volatile* dest,
   STATIC_ASSERT(8 == sizeof(T));
 
   // Note that cmpxchg guarantees a two-way memory barrier across
-  // the cmpxchg, so it's really a a 'fence_cmpxchg_fence' if not
+  // the cmpxchg, so it's really a 'fence_cmpxchg_fence' if not
   // specified otherwise (see atomic.hpp).
 
   T old_value;

--- a/src/hotspot/share/asm/assembler.hpp
+++ b/src/hotspot/share/asm/assembler.hpp
@@ -120,7 +120,7 @@ class Label {
 #endif // PRODUCT
 
   /**
-   * Returns the position of the the Label in the code buffer
+   * Returns the position of the Label in the code buffer
    * The position is a 'locator', which encodes both offset and section.
    */
   int loc() const {

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -3139,7 +3139,7 @@ BlockBegin* GraphBuilder::setup_start_block(int osr_bci, BlockBegin* std_entry, 
   // necessary if std_entry is also a backward branch target because
   // then phi functions may be necessary in the header block.  It's
   // also necessary when profiling so that there's a single block that
-  // can increment the the counters.
+  // can increment the counters.
   // In addition, with range check elimination, we may need a valid block
   // that dominates all the rest to insert range predicates.
   BlockBegin* new_header_block;
@@ -3326,7 +3326,7 @@ GraphBuilder::GraphBuilder(Compilation* compilation, IRScope* scope)
       // Compiles where the root method is an intrinsic need a special
       // compilation environment because the bytecodes for the method
       // shouldn't be parsed during the compilation, only the special
-      // Intrinsic node should be emitted.  If this isn't done the the
+      // Intrinsic node should be emitted.  If this isn't done the
       // code for the inlined version will be different than the root
       // compiled version which could lead to monotonicity problems on
       // intel.
@@ -3844,7 +3844,7 @@ void GraphBuilder::fill_sync_handler(Value lock, BlockBegin* sync_handler, bool 
     }
   }
 
-  // perform the throw as if at the the call site
+  // perform the throw as if at the call site
   apush(exception);
   throw_op(bci);
 

--- a/src/hotspot/share/c1/c1_LinearScan.hpp
+++ b/src/hotspot/share/c1/c1_LinearScan.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/c1/c1_LinearScan.hpp
+++ b/src/hotspot/share/c1/c1_LinearScan.hpp
@@ -690,7 +690,7 @@ class IntervalWalker : public CompilationResourceObj {
   void walk_to(IntervalState state, int from);
 
   // activate_current() is called when an unhandled interval becomes active (in current(), current_kind()).
-  // Return false if current() should not be moved the the active interval list.
+  // Return false if current() should not be moved the active interval list.
   // It is safe to append current to any interval list but the unhandled list.
   virtual bool activate_current() { return true; }
 

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1911,7 +1911,7 @@ bool FileMapInfo::relocate_pointers_in_core_regions(intx addr_delta) {
     address patch_end  = (address)mapped_end();
 
     // the current value of the pointers to be patched must be within this
-    // range (i.e., must be between the requested base address, and the of the current archive).
+    // range (i.e., must be between the requested base address and the address of the current archive).
     // Note: top archive may point to objects in the base archive, but not the other way around.
     address valid_old_base = (address)header()->requested_base_address();
     address valid_old_end  = valid_old_base + mapping_end_offset();

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1906,12 +1906,12 @@ bool FileMapInfo::relocate_pointers_in_core_regions(intx addr_delta) {
 
     BitMapView ptrmap((BitMap::bm_word_t*)bitmap_base, ptrmap_size_in_bits);
 
-    // Patch all pointers in the the mapped region that are marked by ptrmap.
+    // Patch all pointers in the mapped region that are marked by ptrmap.
     address patch_base = (address)mapped_base();
     address patch_end  = (address)mapped_end();
 
     // the current value of the pointers to be patched must be within this
-    // range (i.e., must be between the requesed base address, and the of the current archive).
+    // range (i.e., must be between the requested base address, and the of the current archive).
     // Note: top archive may point to objects in the base archive, but not the other way around.
     address valid_old_base = (address)header()->requested_base_address();
     address valid_old_end  = valid_old_base + mapping_end_offset();

--- a/src/hotspot/share/classfile/javaAssertions.cpp
+++ b/src/hotspot/share/classfile/javaAssertions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/classfile/javaAssertions.cpp
+++ b/src/hotspot/share/classfile/javaAssertions.cpp
@@ -58,7 +58,7 @@ int JavaAssertions::OptionList::count(OptionList* p) {
 void JavaAssertions::addOption(const char* name, bool enable) {
   assert(name != 0, "must have a name");
 
-  // Copy the name.  The storage needs to exist for the the lifetime of the vm;
+  // Copy the name.  The storage needs to exist for the lifetime of the vm;
   // it is never freed, so will be leaked (along with other option strings -
   // e.g., bootclasspath) if a process creates/destroys multiple VMs.
   int len = (int)strlen(name);

--- a/src/hotspot/share/classfile/stackMapTable.hpp
+++ b/src/hotspot/share/classfile/stackMapTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/classfile/stackMapTable.hpp
+++ b/src/hotspot/share/classfile/stackMapTable.hpp
@@ -125,7 +125,7 @@ class StackMapReader : StackObj {
       int32_t size, int32_t max_size, TRAPS) {
     if (size < 0 || size > max_size) {
       // Since this error could be caused someone rewriting the method
-      // but not knowing to update the stackmap data, we call the the
+      // but not knowing to update the stackmap data, we call the
       // verifier's error method, which may not throw an exception and
       // failover to the old verifier instead.
       _verifier->class_format_error(

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -3230,7 +3230,7 @@ const char* nmethod::reloc_string_for(u_char* begin, u_char* end) {
   return have_one ? "other" : NULL;
 }
 
-// Return a the last scope in (begin..end]
+// Return the last scope in (begin..end]
 ScopeDesc* nmethod::scope_desc_in(address begin, address end) {
   PcDesc* p = pc_desc_near(begin+1);
   if (p != NULL && p->real_pc(this) <= end) {

--- a/src/hotspot/share/compiler/disassembler.cpp
+++ b/src/hotspot/share/compiler/disassembler.cpp
@@ -212,7 +212,7 @@ class decode_env {
   decode_env(address start, address end, outputStream* output
              NOT_PRODUCT(COMMA const AsmRemarks* remarks = NULL COMMA ptrdiff_t disp = 0));
 
-  // Add 'original_start' argument which is the the original address
+  // Add 'original_start' argument which is the original address
   // the instructions were located at (if this is not equal to 'start').
   address decode_instructions(address start, address end, address original_start = NULL);
 
@@ -695,7 +695,7 @@ static int printf_to_env(void* env_pv, const char* format, ...) {
   return (int)(cnt1 - cnt0);
 }
 
-// The 'original_start' argument holds the the original address where
+// The 'original_start' argument holds the original address where
 // the instructions were located in the originating system. If zero (NULL)
 // is passed in, there is no original address.
 address decode_env::decode_instructions(address start, address end, address original_start /* = 0*/) {

--- a/src/hotspot/share/gc/g1/g1AllocRegion.hpp
+++ b/src/hotspot/share/gc/g1/g1AllocRegion.hpp
@@ -92,7 +92,7 @@ protected:
   // The memory node index this allocation region belongs to.
   uint _node_index;
 
-  // Reset the alloc region to point a the dummy region.
+  // Reset the alloc region to point the dummy region.
   void reset_alloc_region();
 
   // Perform a non-MT-safe allocation out of the given region.

--- a/src/hotspot/share/gc/g1/g1BatchedTask.hpp
+++ b/src/hotspot/share/gc/g1/g1BatchedTask.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1BatchedTask.hpp
+++ b/src/hotspot/share/gc/g1/g1BatchedTask.hpp
@@ -68,7 +68,7 @@ public:
   // Called by G1BatchedTask to determine total number of workers.
   virtual double worker_cost() const = 0;
 
-  // Called by G1BatchedTask to provide information about the the maximum
+  // Called by G1BatchedTask to provide information about the maximum
   // number of workers for all subtasks after it has been determined.
   virtual void set_max_workers(uint max_workers) { }
 

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -133,7 +133,7 @@ void G1BlockOffsetTablePart::set_remainder_to_point_to_start_incl(size_t start_c
   size_t start_card_for_region = start_card;
   u_char offset = max_jubyte;
   for (uint i = 0; i < BOTConstants::N_powers; i++) {
-    // -1 so that the the card with the actual offset is counted.  Another -1
+    // -1 so that the card with the actual offset is counted.  Another -1
     // so that the reach ends in this region and not at the start
     // of the next.
     size_t reach = start_card - 1 + (BOTConstants::power_to_cards_back(i+1) - 1);

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3398,7 +3398,7 @@ void G1CollectedHeap::update_used_after_gc(bool evacuation_failed) {
 
     assert(_archive_allocator == nullptr, "must be, should not contribute to used");
   } else {
-    // The "used" of the the collection set have already been subtracted
+    // The "used" of the collection set have already been subtracted
     // when they were freed.  Add in the bytes used.
     increase_used(_bytes_used_during_gc);
   }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1554,7 +1554,7 @@ class G1CMDrainMarkingStackClosure : public VoidClosure {
       //
       // G1CMTask::do_marking_step() is called in a loop, which we'll exit
       // if there's nothing more to do (i.e. we've completely drained the
-      // entries that were pushed as a a result of applying the 'keep alive'
+      // entries that were pushed as a result of applying the 'keep alive'
       // closure to the entries on the discovered ref lists) or we overflow
       // the global marking stack.
       //

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -167,7 +167,7 @@ class G1FreeHumongousRegionClosure : public HeapRegionClosure {
   //
   // Other implementation considerations:
   // - never consider object arrays at this time because they would pose
-  // considerable effort for cleaning up the the remembered sets. This is
+  // considerable effort for cleaning up the remembered sets. This is
   // required because stale remembered sets might reference locations that
   // are currently allocated into.
   bool is_reclaimable(uint region_idx) const {

--- a/src/hotspot/share/gc/g1/g1YoungGenSizer.hpp
+++ b/src/hotspot/share/gc/g1/g1YoungGenSizer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1YoungGenSizer.hpp
+++ b/src/hotspot/share/gc/g1/g1YoungGenSizer.hpp
@@ -36,7 +36,7 @@
 // internally work with a number of regions instead. So, some rounding
 // will occur.
 //
-// If nothing related to the the young gen size is set on the command
+// If nothing related to the young gen size is set on the command
 // line we should allow the young gen to be between G1NewSizePercent
 // and G1MaxNewSizePercent of the heap size. This means that every time
 // the heap size changes, the limits for the young gen size will be

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -728,7 +728,7 @@ void MutableNUMASpace::initialize(MemRegion mr,
 }
 
 // Set the top of the whole space.
-// Mark the the holes in chunks below the top() as invalid.
+// Mark the holes in chunks below the top() as invalid.
 void MutableNUMASpace::set_top(HeapWord* value) {
   bool found_top = false;
   for (int i = 0; i < lgrp_spaces()->length();) {

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.inline.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.inline.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.inline.hpp
@@ -44,7 +44,7 @@ inline void ParallelScavengeHeap::invoke_scavenge() {
 }
 
 inline bool ParallelScavengeHeap::is_in_young(const oop p) const {
-  // Assumes the the old gen address range is lower than that of the young gen.
+  // Assumes the old gen address range is lower than that of the young gen.
   bool result = cast_from_oop<HeapWord*>(p) >= young_gen()->reserved().start();
   assert(result == young_gen()->is_in_reserved(p),
          "incorrect test - result=%d, p=" PTR_FORMAT, result, p2i((void*)p));

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -1116,7 +1116,7 @@ class PSParallelCompact : AllStatic {
                                                  idx_t bit);
 
   // Summary phase utility routine to fill dead space (if any) at the dense
-  // prefix boundary.  Should only be called if the the dense prefix is
+  // prefix boundary.  Should only be called if the dense prefix is
   // non-empty.
   static void fill_dense_prefix_end(SpaceId id);
 

--- a/src/hotspot/share/gc/shared/adaptiveSizePolicy.hpp
+++ b/src/hotspot/share/gc/shared/adaptiveSizePolicy.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/adaptiveSizePolicy.hpp
+++ b/src/hotspot/share/gc/shared/adaptiveSizePolicy.hpp
@@ -153,7 +153,7 @@ class AdaptiveSizePolicy : public CHeapObj<mtGC> {
   //   increase the tenuring threshold because of the total major GC cost
   //   is greater than the total minor GC cost
   bool _increment_tenuring_threshold_for_gc_cost;
-  //   decrease the tenuring threshold because of the the total minor GC
+  //   decrease the tenuring threshold because of the total minor GC
   //   cost is greater than the total major GC cost
   bool _decrement_tenuring_threshold_for_gc_cost;
   //   decrease due to survivor size limit

--- a/src/hotspot/share/gc/shared/blockOffsetTable.cpp
+++ b/src/hotspot/share/gc/shared/blockOffsetTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/blockOffsetTable.cpp
+++ b/src/hotspot/share/gc/shared/blockOffsetTable.cpp
@@ -193,7 +193,7 @@ BlockOffsetArray::set_remainder_to_point_to_start_incl(size_t start_card, size_t
   size_t start_card_for_region = start_card;
   u_char offset = max_jubyte;
   for (uint i = 0; i < BOTConstants::N_powers; i++) {
-    // -1 so that the the card with the actual offset is counted.  Another -1
+    // -1 so that the card with the actual offset is counted.  Another -1
     // so that the reach ends in this region and not at the start
     // of the next.
     size_t reach = start_card - 1 + (BOTConstants::power_to_cards_back(i+1) - 1);

--- a/src/hotspot/share/gc/shared/genCollectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.hpp
@@ -204,7 +204,7 @@ public:
 
   // Returns true if the reference is to an object in the reserved space
   // for the young generation.
-  // Assumes the the young gen address range is less than that of the old gen.
+  // Assumes the young gen address range is less than that of the old gen.
   bool is_in_young(oop p) const;
 
   virtual bool requires_barriers(stackChunkOop obj) const;

--- a/src/hotspot/share/gc/shared/generation.cpp
+++ b/src/hotspot/share/gc/shared/generation.cpp
@@ -50,7 +50,7 @@ Generation::Generation(ReservedSpace rs, size_t initial_size) :
     vm_exit_during_initialization("Could not reserve enough space for "
                     "object heap");
   }
-  // Mangle all of the the initial generation.
+  // Mangle all of the initial generation.
   if (ZapUnusedHeapArea) {
     MemRegion mangle_region((HeapWord*)_virtual_space.low(),
       (HeapWord*)_virtual_space.high());

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -446,7 +446,7 @@ class ContiguousSpace: public CompactibleSpace {
   // In debug mode mangle (write it with a particular bit
   // pattern) the unused part of a space.
 
-  // Used to save the an address in a space for later use during mangling.
+  // Used to save the address in a space for later use during mangling.
   void set_top_for_allocations(HeapWord* v) PRODUCT_RETURN;
   // Used to save the space's current top for later use during mangling.
   void set_top_for_allocations() PRODUCT_RETURN;

--- a/src/hotspot/share/gc/shared/spaceDecorator.hpp
+++ b/src/hotspot/share/gc/shared/spaceDecorator.hpp
@@ -98,7 +98,7 @@ class SpaceMangler: public CHeapObj<mtGC> {
   // Return true if q matches the mangled pattern.
   static bool is_mangled(HeapWord* q) PRODUCT_RETURN0;
 
-  // Used to save the an address in a space for later use during mangling.
+  // Used to save the address in a space for later use during mangling.
   void set_top_for_allocations(HeapWord* v);
 
   // Overwrites the unused portion of this space.

--- a/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.hpp
@@ -37,7 +37,7 @@
  * load-reference-barrier (i.e. it cannot copy the object to to-space), it does not
  * necessarily follow we can return immediately from the LRB (and store to from-space).
  *
- * In very basic case, on such failure we may wait until the the evacuation is over,
+ * In very basic case, on such failure we may wait until the evacuation is over,
  * and then resolve the forwarded copy, and to the store there. This is possible
  * because other threads might still have space in their GCLABs, and successfully
  * evacuate the object.

--- a/src/hotspot/share/interpreter/bytecodeUtils.cpp
+++ b/src/hotspot/share/interpreter/bytecodeUtils.cpp
@@ -183,7 +183,7 @@ class ExceptionMessageBuilder : public StackObj {
 
   static const int _max_cause_detail = 5;
 
-  // Merges the stack the the given bci with the given stack. If there
+  // Merges the stack the given bci with the given stack. If there
   // is no stack at the bci, we just put the given stack there. This
   // method doesn't takes ownership of the stack.
   void merge(int bci, SimulatedOperandStack* stack);
@@ -1149,7 +1149,7 @@ int ExceptionMessageBuilder::get_NPE_null_slot(int bci) {
         int name_index = cp->name_ref_index_at(name_and_type_index);
         Symbol* name = cp->symbol_at(name_index);
 
-        // Assume the the call of a constructor can never cause a NullPointerException
+        // Assume the call of a constructor can never cause a NullPointerException
         // (which is true in Java). This is mainly used to avoid generating wrong
         // messages for NullPointerExceptions created explicitly by new in Java code.
         if (name != vmSymbols::object_initializer_name()) {

--- a/src/hotspot/share/interpreter/bytecodeUtils.cpp
+++ b/src/hotspot/share/interpreter/bytecodeUtils.cpp
@@ -183,7 +183,7 @@ class ExceptionMessageBuilder : public StackObj {
 
   static const int _max_cause_detail = 5;
 
-  // Merges the stack the given bci with the given stack. If there
+  // Merges the stack at the given bci with the given stack. If there
   // is no stack at the bci, we just put the given stack there. This
   // method doesn't takes ownership of the stack.
   void merge(int bci, SimulatedOperandStack* stack);

--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -3176,7 +3176,7 @@ run:
     // If we notify it again JVMDI will be all confused about how many frames
     // are still on the stack (4340444).
     //
-    // NOTE Further! It turns out the the JVMTI spec in fact expects to see
+    // NOTE Further! It turns out the JVMTI spec in fact expects to see
     // method_exit events whenever we leave an activation unless it was done
     // for popframe. This is nothing like jvmdi. However we are passing the
     // tests at the moment (apparently because they are jvmdi based) so rather

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdKlassQueue.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdKlassQueue.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdKlassQueue.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdKlassQueue.hpp
@@ -57,7 +57,7 @@ class JfrEpochQueueKlassPolicy : public JfrCHeapObj {
   void store_element(const Klass* klass, BufferPtr buffer);
   // Element size is a function of the traceid value.
   size_t element_size(const Klass* klass);
-  // Storage associated with the the queue is distributed and cached in thread locals.
+  // Storage associated with the queue is distributed and cached in thread locals.
   BufferPtr thread_local_storage(Thread* thread) const;
   void set_thread_local_storage(BufferPtr buffer, Thread* thread);
   // Klasses are validated for liveness before being forwarded to the user provided callback.

--- a/src/hotspot/share/jfr/recorder/storage/jfrVirtualMemory.cpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrVirtualMemory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/recorder/storage/jfrVirtualMemory.cpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrVirtualMemory.cpp
@@ -298,7 +298,7 @@ bool JfrVirtualMemoryManager::expand_by(size_t block_size_request_words, size_t 
   assert(is_aligned(reservation_size_request_words * BytesPerWord, os::vm_page_size()), "invariant");
   assert(is_aligned(reservation_size_request_words * BytesPerWord, os::vm_allocation_granularity()), "invariant");
   assert(block_size_request_words <= reservation_size_request_words, "invariant");
-  // Attempt to commit more memory from the the current virtual space reservation.
+  // Attempt to commit more memory from the current virtual space reservation.
   if (expand_segment_by(current(), block_size_request_words)) {
     return true;
   }

--- a/src/hotspot/share/memory/heap.cpp
+++ b/src/hotspot/share/memory/heap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/memory/heap.cpp
+++ b/src/hotspot/share/memory/heap.cpp
@@ -113,7 +113,7 @@ void CodeHeap::mark_segmap_as_used(size_t beg, size_t end, bool is_FreeBlock_joi
     //      are appended to the right.
     //  3 - Take full advantage of the segmap being almost correct with
     //      the two blocks combined. Lets assume the left block consists
-    //      of m segments. The the segmap looks like
+    //      of m segments. The segmap looks like
     //        ... (m-2) (m-1) (m) 0  1  2  3 ...
     //      By substituting the '0' by '1', we create a valid, but
     //      suboptimal, segmap range covering the two blocks combined.

--- a/src/hotspot/share/memory/heap.cpp
+++ b/src/hotspot/share/memory/heap.cpp
@@ -375,7 +375,7 @@ void CodeHeap::deallocate(void* p) {
 }
 
 /**
- * The segment map is used to quickly find the the start (header) of a
+ * The segment map is used to quickly find the start (header) of a
  * code block (e.g. nmethod) when only a pointer to a location inside the
  * code block is known. This works as follows:
  *  - The storage reserved for the code heap is divided into 'segments'.

--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -1755,7 +1755,7 @@ bool Trace::backedge(CFGEdge *e) {
 
     // Backbranch to the top of a trace
     // Scroll forward through the trace from the targ_block. If we find
-    // a loop head before another loop top, use the the loop head alignment.
+    // a loop head before another loop top, use the loop head alignment.
     for (Block *b = targ_block; b != NULL; b = next(b)) {
       if (b->has_loop_alignment()) {
         break;

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -3532,7 +3532,7 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
 
   //  Phase 3:  Process MergeMem nodes from mergemem_worklist.
   //            Walk each memory slice moving the first node encountered of each
-  //            instance type to the the input corresponding to its alias index.
+  //            instance type to the input corresponding to its alias index.
   uint length = mergemem_worklist.length();
   for( uint next = 0; next < length; ++next ) {
     MergeMemNode* nmm = mergemem_worklist.at(next);

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3623,7 +3623,7 @@ Node* GraphKit::set_output_for_allocation(AllocateNode* alloc,
 // the type to a constant.
 // The optional arguments are for specialized use by intrinsics:
 //  - If 'extra_slow_test' if not null is an extra condition for the slow-path.
-//  - If 'return_size_val', report the the total object size to the caller.
+//  - If 'return_size_val', report the total object size to the caller.
 //  - deoptimize_on_exception controls how Java exceptions are handled (rethrow vs deoptimize)
 Node* GraphKit::new_instance(Node* klass_node,
                              Node* extra_slow_test,

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -3791,7 +3791,7 @@ bool PhaseIdealLoop::do_intrinsify_fill() {
 }
 
 
-// Examine an inner loop looking for a a single store of an invariant
+// Examine an inner loop looking for a single store of an invariant
 // value in a unit stride loop,
 bool PhaseIdealLoop::match_fill_loop(IdealLoopTree* lpt, Node*& store, Node*& store_value,
                                      Node*& shift, Node*& con) {

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1760,7 +1760,7 @@ private:
 // By default the reserved copy (clone) of the loop is created as dead code - it is
 // dominated in the outer loop by this node chain:
 //   intcon(1)->If->IfFalse->reserved_copy.
-// The original loop is dominated by the the same node chain but IfTrue projection:
+// The original loop is dominated by the same node chain but IfTrue projection:
 //   intcon(0)->If->IfTrue->original_loop.
 //
 // In this implementation of CountedLoopReserveKit the ctor includes create_reserve()

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -860,7 +860,7 @@ void PhaseOutput::FillLocArray( int idx, MachSafePointNode* sfpt, Node *local,
       array->append(new ConstantIntValue((jint)0));
       array->append(new_loc_value( C->regalloc(), regnum, Location::lng ));
     } else if ( t->base() == Type::RawPtr ) {
-      // jsr/ret return address which must be restored into a the full
+      // jsr/ret return address which must be restored into the full
       // width 64-bit stack slot.
       array->append(new_loc_value( C->regalloc(), regnum, Location::lng ));
     }

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1507,7 +1507,7 @@ void PhaseIterGVN::add_users_to_worklist0( Node *n ) {
 }
 
 // Return counted loop Phi if as a counted loop exit condition, cmp
-// compares the the induction variable with n
+// compares the induction variable with n
 static PhiNode* countedloop_phi_from_cmp(CmpNode* cmp, Node* n) {
   for (DUIterator_Fast imax, i = cmp->fast_outs(imax); i < imax; i++) {
     Node* bol = cmp->fast_out(i);

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -9519,7 +9519,7 @@ myInit() {
         As a result, all future JNI calls are directed to the specified functions.
         Use <functionlink id="GetJNIFunctionTable"></functionlink> to get the
         function table to pass to this function.
-        For this function to take effect the the updated table entries must be
+        For this function to take effect the updated table entries must be
         used by the JNI clients.
         Since the table is defined <code>const</code> some compilers may optimize
         away the access to the table, thus preventing this function from taking

--- a/src/hotspot/share/prims/jvmtiCodeBlobEvents.cpp
+++ b/src/hotspot/share/prims/jvmtiCodeBlobEvents.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/prims/jvmtiCodeBlobEvents.cpp
+++ b/src/hotspot/share/prims/jvmtiCodeBlobEvents.cpp
@@ -157,7 +157,7 @@ void CodeBlobCollector::do_vtable_stub(VtableStub* vs) {
 //
 // The created list is growable array of JvmtiCodeBlobDesc - each one describes
 // a CodeBlob. Note that the list is static - this is because CodeBlob::blobs_do
-// requires a a C or static function so we can't use an instance function. This
+// requires a C or static function so we can't use an instance function. This
 // isn't a problem as the iteration is serial anyway as we need the CodeCache_lock
 // to iterate over the code cache.
 //

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -529,7 +529,7 @@ UNSAFE_ENTRY(jobject, Unsafe_StaticFieldBase0(JNIEnv *env, jobject unsafe, jobje
   assert(field != NULL, "field must not be NULL");
 
   // Note:  In this VM implementation, a field address is always a short
-  // offset from the base of a a klass metaobject.  Thus, the full dynamic
+  // offset from the base of a klass metaobject.  Thus, the full dynamic
   // range of the return type is never used.  However, some implementations
   // might put the static field inside an array shared by many classes,
   // or even at a fixed address, in which case the address could be quite

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -228,7 +228,7 @@ class frame {
   // returns the sender, but skips conversion frames
   frame real_sender(RegisterMap* map) const;
 
-  // returns the the sending Java frame, skipping any intermediate C frames
+  // returns the sending Java frame, skipping any intermediate C frames
   // NB: receiver must not be first frame
   frame java_sender() const;
 

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -1486,7 +1486,7 @@ void ObjectMonitor::wait(jlong millis, bool interruptible, TRAPS) {
   // Enter the waiting queue, which is a circular doubly linked list in this case
   // but it could be a priority queue or any data structure.
   // _WaitSetLock protects the wait queue.  Normally the wait queue is accessed only
-  // by the the owner of the monitor *except* in the case where park()
+  // by the owner of the monitor *except* in the case where park()
   // returns because of a timeout of interrupt.  Contention is exceptionally rare
   // so we use a simple spin-lock instead of a heavier-weight blocking lock.
 

--- a/src/hotspot/share/runtime/perfData.hpp
+++ b/src/hotspot/share/runtime/perfData.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/perfData.hpp
+++ b/src/hotspot/share/runtime/perfData.hpp
@@ -907,7 +907,7 @@ class PerfTraceTime : public StackObj {
 };
 
 /* The PerfTraceTimedEvent class is responsible for counting the
- * occurrence of some event and measuring the the elapsed time of
+ * occurrence of some event and measuring the elapsed time of
  * the event in two separate PerfCounter instances.
  *
  * Example:

--- a/src/hotspot/share/runtime/perfData.hpp
+++ b/src/hotspot/share/runtime/perfData.hpp
@@ -78,7 +78,7 @@ enum CounterNS {
  * by accessor methods to make algorithmic decisions as they are potentially
  * extracted from a shared memory region. Although any shared memory region
  * created is with appropriate access restrictions, allowing read-write access
- * only to the principal that created the JVM, it is believed that a the
+ * only to the principal that created the JVM, it is believed that the
  * shared memory region facilitates an easier attack path than attacks
  * launched through mechanisms such as /proc. For this reason, it is
  * recommended that data returned by PerfData accessor methods be used

--- a/src/hotspot/share/runtime/sweeper.cpp
+++ b/src/hotspot/share/runtime/sweeper.cpp
@@ -598,7 +598,7 @@ void NMethodSweeper::possibly_flush(nmethod* nm) {
           } else if (MethodCounters::is_nmethod_age_unset(age)) {
             // No counters were used before. Set the counters to the detection
             // limit value. If the method is going to be used again it will be compiled
-            // with counters that we're going to use for analysis the the next time.
+            // with counters that we're going to use for analysis the next time.
             mc->reset_nmethod_age();
           } else {
             // Method was totally idle for 10 sweeps

--- a/src/hotspot/share/runtime/vframe.hpp
+++ b/src/hotspot/share/runtime/vframe.hpp
@@ -248,7 +248,7 @@ class entryVFrame: public externalVFrame {
 };
 
 
-// A MonitorInfo is a ResourceObject that describes a the pair:
+// A MonitorInfo is a ResourceObject that describes the pair:
 // 1) the owner of the monitor
 // 2) the monitor lock
 class MonitorInfo : public ResourceObj {

--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -36,7 +36,7 @@ class VM_EmptyOperation : public VM_Operation {
 public:
   virtual void doit() final {}
   virtual bool skip_thread_oop_barriers() const final {
-    // Neither the doit function nor the the safepoint
+    // Neither the doit function nor the safepoint
     // cleanup tasks read oops in the Java threads.
     return true;
   }

--- a/src/hotspot/share/utilities/bitMap.cpp
+++ b/src/hotspot/share/utilities/bitMap.cpp
@@ -343,7 +343,7 @@ void BitMap::at_put(idx_t offset, bool value) {
 // if no other thread is executing an action to
 // change the requested bit to a state other than
 // the one that this thread is trying to set it to,
-// then the the bit is in the expected state
+// then the bit is in the expected state
 // at exit from this method. However, rather than
 // make such a strong assertion here, based on
 // assuming such constrained use (which though true

--- a/src/hotspot/share/utilities/bitMap.hpp
+++ b/src/hotspot/share/utilities/bitMap.hpp
@@ -354,7 +354,7 @@ class BitMap {
 #endif
 };
 
-// A concrete implementation of the the "abstract" BitMap class.
+// A concrete implementation of the "abstract" BitMap class.
 //
 // The BitMapView is used when the backing storage is managed externally.
 class BitMapView : public BitMap {

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -742,7 +742,7 @@ public final class ModuleLayer {
     }
 
     /**
-     * Creates a LayerInstantiationException with the a message formatted from
+     * Creates a LayerInstantiationException with the message formatted from
      * the given format string and arguments.
      */
     private static LayerInstantiationException fail(String fmt, Object ... args) {

--- a/src/java.base/share/classes/java/lang/VirtualMachineError.java
+++ b/src/java.base/share/classes/java/lang/VirtualMachineError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/VirtualMachineError.java
+++ b/src/java.base/share/classes/java/lang/VirtualMachineError.java
@@ -73,7 +73,7 @@ public abstract class VirtualMachineError extends Error {
     }
 
     /**
-     * Constructs an a {@code VirtualMachineError} with the specified
+     * Constructs a {@code VirtualMachineError} with the specified
      * cause and a detail message of {@code (cause==null ? null :
      * cause.toString())} (which typically contains the class and
      * detail message of {@code cause}).

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -2319,7 +2319,7 @@ public final class Locale implements Cloneable, Serializable {
 
     /**
      * Format a list using given pattern strings.
-     * If either of the patterns is null, then a the list is
+     * If either of the patterns is null, then the list is
      * formatted by concatenation with the delimiter ','.
      * @param stringList the list of strings to be formatted.
      * and formatting them into a list.

--- a/src/java.base/share/classes/jdk/internal/org/objectweb/asm/RecordComponentWriter.java
+++ b/src/java.base/share/classes/jdk/internal/org/objectweb/asm/RecordComponentWriter.java
@@ -69,7 +69,7 @@ final class RecordComponentWriter extends RecordComponentVisitor {
     /** The name_index field of the Record attribute. */
     private final int nameIndex;
 
-    /** The descriptor_index field of the the Record attribute. */
+    /** The descriptor_index field of the Record attribute. */
     private final int descriptorIndex;
 
     /**

--- a/src/java.base/share/classes/jdk/internal/org/objectweb/asm/util/CheckMethodAdapter.java
+++ b/src/java.base/share/classes/jdk/internal/org/objectweb/asm/util/CheckMethodAdapter.java
@@ -1378,7 +1378,7 @@ public class CheckMethodAdapter extends MethodVisitor {
     }
 
     /**
-      * Checks that a the given substring is a valid type descriptor.
+      * Checks that the given substring is a valid type descriptor.
       *
       * @param version the class version.
       * @param descriptor the string to be checked.

--- a/src/java.base/share/classes/jdk/internal/org/objectweb/asm/util/Printer.java
+++ b/src/java.base/share/classes/jdk/internal/org/objectweb/asm/util/Printer.java
@@ -1298,7 +1298,7 @@ public abstract class Printer {
     }
 
     /**
-      * Prints a the given class to the given output.
+      * Prints the given class to the given output.
       *
       * <p>Command line arguments: [-nodebug] &lt;binary class name or class file name &gt;
       *

--- a/src/java.base/share/classes/jdk/internal/util/Preconditions.java
+++ b/src/java.base/share/classes/jdk/internal/util/Preconditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/util/Preconditions.java
+++ b/src/java.base/share/classes/jdk/internal/util/Preconditions.java
@@ -79,7 +79,7 @@ public class Preconditions {
      *        to the name of one of the range check methods, checkIndex,
      *        checkFromToIndex, checkFromIndexSize
      * @param args the out-of-bounds arguments that failed the range check.
-     *        If the checkKind corresponds a the name of a range check method
+     *        If the checkKind corresponds to the name of a range check method
      *        then the bounds arguments are those that can be passed in order
      *        to the method.
      * @param oobef the exception formatter that when applied with a checkKind

--- a/src/java.base/share/classes/sun/security/provider/SHA.java
+++ b/src/java.base/share/classes/sun/security/provider/SHA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/provider/SHA.java
+++ b/src/java.base/share/classes/sun/security/provider/SHA.java
@@ -121,7 +121,7 @@ public final class SHA extends DigestBase {
     private static final int round4_kt = 0xca62c1d6;
 
     /**
-     * Compute a the hash for the current block.
+     * Compute the hash for the current block.
      *
      * This is in the same vein as Peter Gutmann's algorithm listed in
      * the back of Applied Cryptography, Compact implementation of

--- a/src/java.base/share/classes/sun/security/util/DerOutputStream.java
+++ b/src/java.base/share/classes/sun/security/util/DerOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/util/DerOutputStream.java
+++ b/src/java.base/share/classes/sun/security/util/DerOutputStream.java
@@ -381,7 +381,7 @@ extends ByteArrayOutputStream implements DerEncoder {
     private static ByteArrayTagOrder tagOrder = new ByteArrayTagOrder();
 
     /**
-     * Marshals a the contents of a set on the output stream with the
+     * Marshals the contents of a set on the output stream with the
      * encodings of its sorted in increasing order.
      *
      * @param order the order to use when sorting encodings of components.

--- a/src/java.base/share/classes/sun/security/util/ECKeySizeParameterSpec.java
+++ b/src/java.base/share/classes/sun/security/util/ECKeySizeParameterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/util/ECKeySizeParameterSpec.java
+++ b/src/java.base/share/classes/sun/security/util/ECKeySizeParameterSpec.java
@@ -31,7 +31,7 @@ import sun.security.util.ObjectIdentifier;
 /**
  * This immutable class is used when randomly generating a key pair and the
  * consumer only specifies the length of the key and therefore a curve for that
- * key size must be picked from a the list of supported curves using this spec.
+ * key size must be picked from the list of supported curves using this spec.
  *
  * @see AlgorithmParameterSpec
  * @see ECGenParameterSpec

--- a/src/java.base/windows/native/libnio/ch/wepoll.c
+++ b/src/java.base/windows/native/libnio/ch/wepoll.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/native/libnio/ch/wepoll.c
+++ b/src/java.base/windows/native/libnio/ch/wepoll.c
@@ -1906,7 +1906,7 @@ int sock_feed_event(port_state_t* port_state,
   if (epoll_events == 0)
     return 0;
 
-  /* If the the socket has the EPOLLONESHOT flag set, unmonitor all events,
+  /* If the socket has the EPOLLONESHOT flag set, unmonitor all events,
    * even EPOLLERR and EPOLLHUP. But always keep looking for closed sockets. */
   if (sock_state->user_events & EPOLLONESHOT)
     sock_state->user_events = 0;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
@@ -78,7 +78,7 @@ public class ResponseSubscribers {
      * might be called and might block before the last bit is
      * received (for instance, if a mapping subscriber is used with
      * a mapper function that maps an InputStream to a GZIPInputStream,
-     * as the the constructor of GZIPInputStream calls read()).
+     * as the constructor of GZIPInputStream calls read()).
      * @param <T> The response type.
      */
     public interface TrustedSubscriber<T> extends BodySubscriber<T> {

--- a/src/java.se/share/data/jdwp/jdwp.spec
+++ b/src/java.se/share/data/jdwp/jdwp.spec
@@ -2648,7 +2648,7 @@ JDWP "Java(tm) Debug Wire Protocol"
         "signature without access to the local variable table information.) "
         "<p>"
         "If the thread is a virtual thread then this command can be used to set "
-        "the value of local variables in the the top-most frame when the thread is "
+        "the value of local variables in the top-most frame when the thread is "
         "suspended at a breakpoint or single step event. The target VM may support "
         "setting local variables in other cases."
         (Out

--- a/src/java.security.sasl/share/classes/com/sun/security/sasl/digest/DigestMD5Client.java
+++ b/src/java.security.sasl/share/classes/com/sun/security/sasl/digest/DigestMD5Client.java
@@ -261,8 +261,8 @@ final class DigestMD5Client extends DigestMD5Base implements SaslClient {
     * Check directive values that are multi-valued and ensure that mandatory
     * directives not missing from the digest-challenge.
     *
-    * @throws SaslException if a sasl is a the mechanism cannot
-    * correctly handle a callbacks or if a violation in the
+    * @throws SaslException if a sasl mechanism cannot
+    * correctly handle callbacks or if a violation in the
     * digest challenge format is detected.
     */
     private void processChallenge(byte[][] challengeVal, List<byte[]> realmChoices)

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
@@ -228,8 +228,8 @@ public class PKCS11Exception extends Exception {
     }
 
     /**
-     * Returns true if the error code matches the the specified enum value.
-     * @return true if the error code matches the the specified enum value.
+     * Returns true if the error code matches the specified enum value.
+     * @return true if the error code matches the specified enum value.
      * @preconditions
      * @postconditions
      */

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
@@ -205,7 +205,7 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
         // Check the order of the point.
         //
         // Compute nQ (using elliptic curve arithmetic), and verify that
-        // nQ is the the identity element.
+        // nQ is the identity element.
         ImmutableIntegerModuloP xElem = ops.getField().getElement(x);
         ImmutableIntegerModuloP yElem = ops.getField().getElement(y);
         AffinePoint affP = new AffinePoint(xElem, yElem);

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
@@ -454,7 +454,7 @@ static bool read_interp_segments(struct ps_prochandle* ph) {
   return true;
 }
 
-// process segments of a a.out
+// process segments of an a.out
 // returns base address of executable.
 static uintptr_t read_exec_segments(struct ps_prochandle* ph, ELF_EHDR* exec_ehdr) {
   int i = 0;

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
@@ -1035,7 +1035,7 @@ static bool read_interp_segments(struct ps_prochandle* ph) {
    return true;
 }
 
-// process segments of a a.out
+// process segments of an a.out
 static bool read_exec_segments(struct ps_prochandle* ph, ELF_EHDR* exec_ehdr) {
    int i = 0;
    ELF_PHDR* phbuf = NULL;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/NMethod.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/NMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/NMethod.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/NMethod.java
@@ -387,7 +387,7 @@ public class NMethod extends CompiledMethod {
   // pc_desc_near returns the first PCDesc at or after the givne pc.
   PCDesc pc_desc_near(long pc) { return find_pc_desc(pc, true); }
 
-  // Return a the last scope in (begin..end]
+  // Return the last scope in (begin..end]
   public ScopeDesc scope_desc_in(long begin, long end) {
     PCDesc p = pc_desc_near(begin+1);
     if (p != null && VM.getAddressValue(p.getRealPC(this)) <= end) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/SharedObject.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/SharedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/SharedObject.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/SharedObject.java
@@ -28,7 +28,7 @@ import sun.jvm.hotspot.debugger.*;
 import sun.jvm.hotspot.debugger.cdbg.*;
 import sun.jvm.hotspot.debugger.posix.*;
 
-/** A Object can represent either a .so or an a.out file. */
+/** An Object can represent either a .so or an a.out file. */
 
 class SharedObject extends DSO {
   SharedObject(BsdDebugger dbg, String filename, long size, Address relocation) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/SharedObject.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/SharedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/SharedObject.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/SharedObject.java
@@ -28,7 +28,7 @@ import sun.jvm.hotspot.debugger.*;
 import sun.jvm.hotspot.debugger.cdbg.*;
 import sun.jvm.hotspot.debugger.posix.*;
 
-/** A Object can represent either a .so or an a.out file. */
+/** An Object can represent either a .so or an a.out file. */
 
 class SharedObject extends DSO {
   SharedObject(LinuxDebugger dbg, String filename, long size, Address relocation) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/proc/SharedObject.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/proc/SharedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/proc/SharedObject.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/proc/SharedObject.java
@@ -28,7 +28,7 @@ import sun.jvm.hotspot.debugger.*;
 import sun.jvm.hotspot.debugger.cdbg.*;
 import sun.jvm.hotspot.debugger.posix.*;
 
-/** A Object can represent either a .so or an a.out file. */
+/** An Object can represent either a .so or an a.out file. */
 
 class SharedObject extends DSO {
   SharedObject(ProcDebugger dbg, String filename, long size, Address relocation) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/win32/coff/DebugVC50SymbolIterator.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/win32/coff/DebugVC50SymbolIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/win32/coff/DebugVC50SymbolIterator.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/win32/coff/DebugVC50SymbolIterator.java
@@ -374,7 +374,7 @@ public interface DebugVC50SymbolIterator
   /** Segment portion of the procedure address. */
   public short getLGProcSegment();
 
-  /** Value defined by bitwise or of the the PROCFLAGS enumeration in
+  /** Value defined by bitwise or of the PROCFLAGS enumeration in
       {@link
       sun.jvm.hotspot.debugger.win32.coff.DebugVC50SymbolEnums}. */
   public byte getLGProcFlags();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/treetable/TreeTableModel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/treetable/TreeTableModel.java
@@ -61,7 +61,7 @@ public interface TreeTableModel extends TreeModel
     public Object getValueAt(Object node, int column);
 
     /**
-     * Indicates whether the the value for node <code>node</code>,
+     * Indicates whether the value for node <code>node</code>,
      * at column number <code>column</code> is editable.
      */
     public boolean isCellEditable(Object node, int column);

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpContext.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpContext.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpContext.java
@@ -95,7 +95,7 @@ public abstract class HttpContext {
     /**
      * Returns this context's {@link List} of {@linkplain Filter filters}. This
      * is the actual list used by the server when dispatching requests so
-     * modifications to this list immediately affect the the handling of exchanges.
+     * modifications to this list immediately affect the handling of exchanges.
      *
      * @return a {@link List} containing the filters of this context
      */
@@ -103,7 +103,7 @@ public abstract class HttpContext {
 
     /**
      * Sets the {@link Authenticator} for this {@code HttpContext}. Once an authenticator
-     * is establised on a context, all client requests must be authenticated,
+     * is established on a context, all client requests must be authenticated,
      * and the given object will be invoked to validate each request. Each call
      * to this method replaces any previous value set.
      *

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/MonitoredVm.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/MonitoredVm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/MonitoredVm.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/MonitoredVm.java
@@ -123,7 +123,7 @@ public interface MonitoredVm {
      *
      * Polling implementations may choose to poll asynchronously. This
      * method allows an asynchronous task to communicate any polling related
-     * exceptions with the application. When an a non-null exception is reported
+     * exceptions with the application. When a non-null exception is reported
      * through this interface, the MonitoredVm instance is considered to
      * be in the <em>errored</em> state.
      *

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/PerfIntegerMonitor.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/PerfIntegerMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/PerfIntegerMonitor.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/PerfIntegerMonitor.java
@@ -73,7 +73,7 @@ public class PerfIntegerMonitor extends AbstractMonitor
     /**
      * Return the current value of the IntegerInstrument as an int.
      *
-     * @return int - a the current value of the IntegerInstrument.
+     * @return int - the current value of the IntegerInstrument.
      */
     public int intValue() {
         return ib.get(0);

--- a/src/jdk.jdi/share/classes/com/sun/jdi/ClassType.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ClassType.java
@@ -345,7 +345,7 @@ public interface ClassType extends ReferenceType {
                                           InvocationException;
 
     /**
-     * Returns a the single non-abstract {@link Method} visible from
+     * Returns the single non-abstract {@link Method} visible from
      * this class that has the given name and signature.
      * See {@link ReferenceType#methodsByName(java.lang.String, java.lang.String)}
      * for information on signature format.

--- a/src/jdk.jdi/share/classes/com/sun/jdi/ClassType.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ClassType.java
@@ -345,7 +345,7 @@ public interface ClassType extends ReferenceType {
                                           InvocationException;
 
     /**
-     * Returns the single non-abstract {@link Method} visible from
+     * Returns a single non-abstract {@link Method} visible from
      * this class that has the given name and signature.
      * See {@link ReferenceType#methodsByName(java.lang.String, java.lang.String)}
      * for information on signature format.

--- a/src/jdk.jdi/share/classes/com/sun/jdi/VMMismatchException.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/VMMismatchException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdi/share/classes/com/sun/jdi/VMMismatchException.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/VMMismatchException.java
@@ -27,7 +27,7 @@ package com.sun.jdi;
 
 /**
  * Thrown to indicate that the requested operation cannot be
- * completed because the a mirror from one target VM is being
+ * completed because the mirror from one target VM is being
  * combined with a mirror from another target VM.
  *
  * @author Gordon Hirsch

--- a/src/jdk.sctp/share/classes/com/sun/nio/sctp/ShutdownNotification.java
+++ b/src/jdk.sctp/share/classes/com/sun/nio/sctp/ShutdownNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.sctp/share/classes/com/sun/nio/sctp/ShutdownNotification.java
+++ b/src/jdk.sctp/share/classes/com/sun/nio/sctp/ShutdownNotification.java
@@ -25,7 +25,7 @@
 package com.sun.nio.sctp;
 
 /**
- * Notification emitted when a peers shutdowns the association.
+ * Notification emitted when a peer shuts down an association.
  *
  * <P> When a peer sends a <i>SHUTDOWN</i>, the SCTP stack delivers this
  * notification to inform the application that it should cease sending data.

--- a/src/jdk.sctp/share/classes/com/sun/nio/sctp/ShutdownNotification.java
+++ b/src/jdk.sctp/share/classes/com/sun/nio/sctp/ShutdownNotification.java
@@ -25,7 +25,7 @@
 package com.sun.nio.sctp;
 
 /**
- * Notification emitted when a peers shutdowns an the association.
+ * Notification emitted when a peers shutdowns the association.
  *
  * <P> When a peer sends a <i>SHUTDOWN</i>, the SCTP stack delivers this
  * notification to inform the application that it should cease sending data.

--- a/test/hotspot/gtest/gc/g1/test_g1BatchedGangTask.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1BatchedGangTask.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/gc/g1/test_g1BatchedGangTask.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1BatchedGangTask.cpp
@@ -96,7 +96,7 @@ public:
     return 1.0;
   }
 
-  // Called by G1BatchedTask to provide information about the the maximum
+  // Called by G1BatchedTask to provide information about the maximum
   // number of workers for all subtasks after it has been determined.
   void set_max_workers(uint max_workers) override {
     assert(max_workers >= 1, "must be");

--- a/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/JcmdCommand.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/JcmdCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/JcmdCommand.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/JcmdCommand.java
@@ -49,7 +49,7 @@ public class JcmdCommand extends CompileCommand {
 
 
     /**
-     * Enchances parent's class method with the the JCMDtype printing:
+     * Enchances parent's class method with the JCMDtype printing:
      * {@code ... JCMDType: <jcmd_type>}
      */
     protected String formatFields() {

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/Test.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/Test.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/Test.java
@@ -32,7 +32,7 @@ import java.lang.annotation.RetentionPolicy;
  * Let {@code m} be a test method specifying the {@code @Test} annotation. If {@code m} is neither part of a
  * <b>checked test</b> (an additional method specifying {@link Check @Check} with {@code @Check(test = "m")}) nor part
  * of a <b>custom run test</b> (an additional method specifying {@link Run @Run} with {@code @Run(test = "m")}),
- * then {@code m} is a so-called <b>base test</b> and the the framework invokes {@code m} in the following way:
+ * then {@code m} is a so-called <b>base test</b> and the framework invokes {@code m} in the following way:
  * <ol>
  *     <li><p>The framework warms {@code m} up by invoking it for a predefined number of iterations (default: 2000)
  *     or any number specified by an additional {@link Warmup @Warmup} annotation at {@code m} or by using

--- a/test/hotspot/jtreg/compiler/oracle/CheckCompileCommandOption.java
+++ b/test/hotspot/jtreg/compiler/oracle/CheckCompileCommandOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/oracle/CheckCompileCommandOption.java
+++ b/test/hotspot/jtreg/compiler/oracle/CheckCompileCommandOption.java
@@ -51,7 +51,7 @@ public class CheckCompileCommandOption {
     // Type (1) is used to enable a boolean option for a method.
     //
     // Type (2) is used to support options with a value. Values can
-    // have the the following types: intx, uintx, bool, ccstr,
+    // have the following types: intx, uintx, bool, ccstr,
     // ccstrlist, and double.
 
     private static final String[][] FILE_ARGUMENTS = {

--- a/test/hotspot/jtreg/compiler/unsafe/TestLoopUnswitching.java
+++ b/test/hotspot/jtreg/compiler/unsafe/TestLoopUnswitching.java
@@ -81,7 +81,7 @@ public class TestLoopUnswitching {
                 res += UNSAFE.getInt(a, F_OFFSET);
             }
             if (flag2) {
-                // Opaque4 node here is out of the loop but Bool is in the the loop
+                // Opaque4 node here is out of the loop but Bool is in the loop
                 res += UNSAFE.getInt(a, F_OFFSET);
                 break;
             }

--- a/test/hotspot/jtreg/gc/stress/TestStressRSetCoarsening.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressRSetCoarsening.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/gc/stress/TestStressRSetCoarsening.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressRSetCoarsening.java
@@ -240,7 +240,7 @@ public class TestStressRSetCoarsening {
         final int HOWL_TO_FULL_THRESHOLD = (cardsPerRegion * coarsenHowlToFullPercent) / 100;
 
         // regToRegRefCounts - array of reference counts from region to region
-        // at the the end of iteration.
+        // at the end of iteration.
         // The number of test iterations is array length - 1.
         // If c[i] > c[i-1] then during the iteration i more references will
         // be created.

--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
@@ -149,7 +149,7 @@ class TestStringDeduplicationTools {
 
     private static void forceDeduplication(int ageThreshold, String gcType) {
         // Force deduplication to happen by either causing a FullGC or a YoungGC.
-        // We do several collections to also provoke a situation where the the
+        // We do several collections to also provoke a situation where the
         // deduplication thread needs to yield while processing the queue. This
         // also tests that the references in the deduplication queue are adjusted
         // accordingly.

--- a/test/hotspot/jtreg/runtime/Thread/TooSmallStackSize.java
+++ b/test/hotspot/jtreg/runtime/Thread/TooSmallStackSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/Thread/TooSmallStackSize.java
+++ b/test/hotspot/jtreg/runtime/Thread/TooSmallStackSize.java
@@ -186,7 +186,7 @@ public class TooSmallStackSize {
         String min_stack_allowed = checkStack("-XX:ThreadStackSize=", ThreadStackSizeString, "64");
 
         /*
-         * Try again with a the minimum stack size that was given in the error message
+         * Try again with the minimum stack size that was given in the error message
          */
         checkMinStackAllowed("-XX:ThreadStackSize=", ThreadStackSizeString, min_stack_allowed);
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestEpsilonGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestEpsilonGCWithCDS.java
@@ -29,7 +29,7 @@
  * @requires vm.gc.G1
  *
  * @comment don't run this test if any -XX::+Use???GC options are specified, since they will
- *          interfere with the the test.
+ *          interfere with the test.
  * @requires vm.gc == null
  *
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestEpsilonGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestEpsilonGCWithCDS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
@@ -29,7 +29,7 @@
  * @requires vm.gc.G1
  *
  * @comment don't run this test if any -XX::+Use???GC options are specified, since they will
- *          interfere with the the test.
+ *          interfere with the test.
  * @requires vm.gc == null
  *
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestSerialGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestSerialGCWithCDS.java
@@ -29,7 +29,7 @@
  * @requires vm.gc.G1
  *
  * @comment don't run this test if any -XX::+Use???GC options are specified, since they will
- *          interfere with the the test.
+ *          interfere with the test.
  * @requires vm.gc == null
  *
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestSerialGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestSerialGCWithCDS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPrintAs.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPrintAs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPrintAs.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPrintAs.java
@@ -48,7 +48,7 @@ public class ClhsdbPrintAs {
             theApp = LingeredApp.startApp();
             System.out.println("Started LingeredApp with pid " + theApp.getPid());
 
-            // Run the 'jstack -v' command to get the address of a the Method*
+            // Run the 'jstack -v' command to get the address of the Method*
             // representing LingeredApp.steadyState
             List<String> cmds = List.of("jstack -v");
             Map<String, List<String>> expStrMap;

--- a/test/hotspot/jtreg/vmTestbase/gc/memory/Churn/Churn.README
+++ b/test/hotspot/jtreg/vmTestbase/gc/memory/Churn/Churn.README
@@ -67,9 +67,9 @@ of a test harness.
 The total amount of needed memory is approximately
 numberOfThreads * (sizeOfArray * sizeOfArray) * (multiplier / 2) bytes
 
-The default is about 10 Megs needed, not couting garbage collection
+The default is about 10 Megs needed, not counting garbage collection
 overhead.  Garbage collection doubles the memory requirements for
-programs that run out of heap space, so the the true default size
+programs that run out of heap space, so the true default size
 is 20 Megs.
 
 

--- a/test/hotspot/jtreg/vmTestbase/gc/memory/Churn/Churn.README
+++ b/test/hotspot/jtreg/vmTestbase/gc/memory/Churn/Churn.README
@@ -1,4 +1,4 @@
-Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/jit/wide/wide01/wide01.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/wide/wide01/wide01.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/jit/wide/wide01/wide01.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/wide/wide01/wide01.java
@@ -38,7 +38,7 @@ import nsk.share.TestFailure;
 
 /*
      Check for intermediate results that are too wide.
-     The wide.java test will fail if the the result of the
+     The wide.java test will fail if the result of the
      expression (f0+f24) is maintained in greater-than-double precision
      or if the result of the expression (d0+d53) is maintained in
      greater-than-double precision.

--- a/test/hotspot/jtreg/vmTestbase/jit/wide/wide02/wide02.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/wide/wide02/wide02.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/jit/wide/wide02/wide02.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/wide/wide02/wide02.java
@@ -38,7 +38,7 @@ import nsk.share.TestFailure;
 
 /*
      Check for intermediate results that are too wide.
-     The too-wide.java test will fail if the the result of the
+     The too-wide.java test will fail if the result of the
      expression (f0+f24) is maintained in greater-than-float precision
      or if the result of the expression (d0+d53) is maintained in
      greater-than-double precision.

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
@@ -31,7 +31,7 @@
  * DECSRIPTION
  *  This is a test for jdb 'resume all' and 'resume <thread id>' commands.
  *  The debuggee starts 5 'MyThreads' that are all suspended on the lock
- *  that the main thread holds. The the test driver issues the following
+ *  that the main thread holds. The test driver issues the following
  *  commands for check:
  *    - 'suspend all' : "All threads suspended" message is expected in
  *      jdb output stream;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended001/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended001/TestDescription.java
@@ -35,7 +35,7 @@
  *     com.sun.jdi.ThreadReference.isSuspended()
  *     complies with its spec:
  *     public boolean isSuspended()
- *     Determines whether the thread has been suspended by the the debugger.
+ *     Determines whether the thread has been suspended by the debugger.
  *     Returns: true if the thread is currently suspended; false otherwise.
  *     Throws: ObjectCollectedException -
  *             if this object has been garbage collected.
@@ -75,4 +75,3 @@
  *      -transport.address=dynamic
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
  */
-

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended002/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended002/TestDescription.java
@@ -36,7 +36,7 @@
  *     com.sun.jdi.ThreadReference.isSuspended()
  *     complies with its spec:
  *     public boolean isSuspended()
- *     Determines whether the thread has been suspended by the the debugger.
+ *     Determines whether the thread has been suspended by the debugger.
  *     Returns: true if the thread is currently suspended; false otherwise.
  *     Throws: ObjectCollectedException -
  *             if this object has been garbage collected.
@@ -74,4 +74,3 @@
  *      -transport.address=dynamic
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
  */
-

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended003/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended003/TestDescription.java
@@ -35,7 +35,7 @@
  *     com.sun.jdi.ThreadReference.isSuspended()
  *     complies with its spec:
  *     public boolean isSuspended()
- *     Determines whether the thread has been suspended by the the debugger.
+ *     Determines whether the thread has been suspended by the debugger.
  *     Returns: true if the thread is currently suspended; false otherwise.
  *     Throws: ObjectCollectedException -
  *             if this object has been garbage collected.
@@ -76,4 +76,3 @@
  *      -transport.address=dynamic
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
  */
-

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended004/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended004/TestDescription.java
@@ -35,7 +35,7 @@
  *     com.sun.jdi.ThreadReference.isSuspended()
  *     complies with its spec:
  *     public boolean isSuspended()
- *     Determines whether the thread has been suspended by the the debugger.
+ *     Determines whether the thread has been suspended by the debugger.
  *     Returns: true if the thread is currently suspended; false otherwise.
  *     Throws: ObjectCollectedException -
  *             if this object has been garbage collected.
@@ -76,4 +76,3 @@
  *      -transport.address=dynamic
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
  */
-

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/redefineClasses/redefineclasses024.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/redefineClasses/redefineclasses024.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/redefineClasses/redefineclasses024.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/redefineClasses/redefineclasses024.java
@@ -39,7 +39,7 @@ import java.io.*;
  * The test against the method <code>com.sun.jdi.VirtualMachine.redefineClasses()</code>
  * and checks up the following assertion:                                       <br>
  *   "If <code>canUnrestrictedlyRedefineClasses()</code> is <code>false</code> attempting
- *    to change a a class hierarchy will throw <code>UnsupportedOperationException</code>
+ *    to change a class hierarchy will throw <code>UnsupportedOperationException</code>
  *    exception."
  *
  * The test consists of the following files:                                <br>

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ObjectFree/objfree001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ObjectFree/objfree001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ObjectFree/objfree001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ObjectFree/objfree001.java
@@ -30,7 +30,7 @@ import nsk.share.jvmti.*;
 
 /**
  * This test exercises the JVMTI event <code>ObjectFree</code>.
- * <br>It verifies that the the JVMTI raw monitor, memory management,
+ * <br>It verifies that the JVMTI raw monitor, memory management,
  * and environment local storage functions can be used during processing
  * this event.<p>
  * The test works as follows. The special class <code>objfree001u</code>

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ObjectFree/objfree001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ObjectFree/objfree001/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ObjectFree/objfree001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ObjectFree/objfree001/TestDescription.java
@@ -31,7 +31,7 @@
  * VM Testbase readme:
  * DESCRIPTION
  *     This test exercises the JVMTI event ObjectFree.
- *     It verifies that the the JVMTI raw monitor, memory management,
+ *     It verifies that the JVMTI raw monitor, memory management,
  *     and environment local storage functions can be used during
  *     processing this event.
  *     The test works as follows. The special class 'objfree001u' is
@@ -60,4 +60,3 @@
  *      nsk.jvmti.ObjectFree.objfree001
  *      ./bin 5 ./bin
  */
-

--- a/test/hotspot/jtreg/vmTestbase/vm/gc/concurrent/Concurrent.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/gc/concurrent/Concurrent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/vm/gc/concurrent/Concurrent.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/gc/concurrent/Concurrent.java
@@ -144,7 +144,7 @@ class Forest {
         }
     }
 
-    // Swap subtrees in 2 trees, the the path is used
+    // Swap subtrees in 2 trees, the path is used
     // as sequence of 1-0 to select subtree (left-reight sequence)
     static void swapSubtrees(Tree t1, Tree t2, int depth, int path) {
         TreeNode tn1 = t1.getRoot();

--- a/test/hotspot/jtreg/vmTestbase/vm/share/options/test/ExampleWithNonprimitiveOptions.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/share/options/test/ExampleWithNonprimitiveOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/vm/share/options/test/ExampleWithNonprimitiveOptions.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/share/options/test/ExampleWithNonprimitiveOptions.java
@@ -31,7 +31,7 @@ import vm.share.options.Option;
 import vm.share.options.OptionSupport;
 
 /**
- * This example uses @Option annotation with an a factory attribute,
+ * This example uses @Option annotation with a factory attribute,
  * to populate a field of a non-simple type.
  */
 public class ExampleWithNonprimitiveOptions

--- a/test/jdk/com/sun/crypto/provider/Cipher/ChaCha20/OutputSizeTest.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/ChaCha20/OutputSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/crypto/provider/Cipher/ChaCha20/OutputSizeTest.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/ChaCha20/OutputSizeTest.java
@@ -112,7 +112,7 @@ public class OutputSizeTest {
         testOutLen(cc20, 5, 0);
         testOutLen(cc20, 16, 0);
         testOutLen(cc20, 5120, 5104);
-        // Perform an update, then test with a the length of a final chunk
+        // Perform an update, then test with the length of a final chunk
         // of data.
         cc20.update(input);
         testOutLen(cc20, 1024, 6128);
@@ -178,4 +178,3 @@ public class OutputSizeTest {
         return buf;
     }
 }
-

--- a/test/jdk/com/sun/jdi/OomDebugTest.java
+++ b/test/jdk/com/sun/jdi/OomDebugTest.java
@@ -296,7 +296,7 @@ public class OomDebugTest extends TestScaffold {
     private void handleFailure(InvocationException e) {
         // There is no good way to see the OOME diagnostic message in the target since the
         // TestScaffold might throw an exception while trying to print the stack trace. I.e
-        // it might get a a VMDisconnectedException before the stack trace printing finishes.
+        // it might get a VMDisconnectedException before the stack trace printing finishes.
         System.err.println("FAILURE: InvocationException thrown. Trying to determine cause...");
         defaultHandleOOMFailure(e);
     }

--- a/test/jdk/com/sun/jdi/VarargsTest.java
+++ b/test/jdk/com/sun/jdi/VarargsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/jdi/VarargsTest.java
+++ b/test/jdk/com/sun/jdi/VarargsTest.java
@@ -328,7 +328,7 @@ public class VarargsTest extends TestScaffold {
                  * Since the number of args passed is > than
                  * the number of params, JDI assumes they are var args
                  * and tries to put the array containing the "a" and
-                 * "be" elements into a the first element of an array
+                 * "b" elements into the first element of an array
                  * of Strings.  This fails because you can't store
                  * an array into a String
                  */

--- a/test/jdk/java/io/Serializable/serialFilter/SerialFilterTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/SerialFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/io/Serializable/serialFilter/SerialFilterTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/SerialFilterTest.java
@@ -710,7 +710,7 @@ public class SerialFilterTest implements Serializable {
     }
 
     /**
-     * Generate an an object that will be serialized to some number of bytes.
+     * Generate an object that will be serialized to some number of bytes.
      * Or 1 greater if allowed is false.
      * It returns a two element Object array holding a byte array sized
      * to achieve the desired total size.

--- a/test/jdk/java/lang/SecurityManager/CheckSecurityProvider.java
+++ b/test/jdk/java/lang/SecurityManager/CheckSecurityProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/SecurityManager/CheckSecurityProvider.java
+++ b/test/jdk/java/lang/SecurityManager/CheckSecurityProvider.java
@@ -51,7 +51,7 @@ public class CheckSecurityProvider {
         String os = System.getProperty("os.name");
         /*
          * This array should be updated whenever new security providers
-         * are added to the the java.security file.
+         * are added to the java.security file.
          * NOTE: it should be in the same order as the java.security file
          */
 

--- a/test/jdk/java/lang/StackWalker/ReflectionFrames.java
+++ b/test/jdk/java/lang/StackWalker/ReflectionFrames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/StackWalker/ReflectionFrames.java
+++ b/test/jdk/java/lang/StackWalker/ReflectionFrames.java
@@ -421,7 +421,7 @@ public class ReflectionFrames {
      * This test invokes StackInspector.class.newInstance() from
      * the caller StackInspector.Caller.create method. Because
      * Class.newInstance() is not considered as a
-     * reflection frame, the the caller returned by
+     * reflection frame, the caller returned by
      * getCallerClass() should appear to be java.lang.Class
      * and not StackInspector.Caller.
      * It also checks the expected frames collected

--- a/test/jdk/java/lang/System/Logger/default/DefaultLoggerTest.java
+++ b/test/jdk/java/lang/System/Logger/default/DefaultLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/System/Logger/default/DefaultLoggerTest.java
+++ b/test/jdk/java/lang/System/Logger/default/DefaultLoggerTest.java
@@ -54,7 +54,7 @@ import java.util.stream.Stream;
  * @test
  * @bug     8140364 8145686
  * @summary Tests default loggers returned by System.getLogger, and in
- *          particular the implementation of the the System.Logger method
+ *          particular the implementation of the System.Logger method
  *          performed by the default binding.
  * @modules java.logging
  * @build DefaultLoggerTest AccessSystemLogger

--- a/test/jdk/java/lang/instrument/NoTransformerAddedTest.java
+++ b/test/jdk/java/lang/instrument/NoTransformerAddedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/instrument/NoTransformerAddedTest.java
+++ b/test/jdk/java/lang/instrument/NoTransformerAddedTest.java
@@ -59,7 +59,7 @@ NoTransformerAddedTest
     }
 
     /**
-     * Add no transformers to the the manager and check it
+     * Add no transformers to the manager and check it
      */
     public void
     testNoTransformersAdded()

--- a/test/jdk/java/lang/instrument/NullTransformerAddTest.java
+++ b/test/jdk/java/lang/instrument/NullTransformerAddTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/instrument/NullTransformerAddTest.java
+++ b/test/jdk/java/lang/instrument/NullTransformerAddTest.java
@@ -60,7 +60,7 @@ NullTransformerAddTest
 
 
     /**
-     * Add null transformers to the the manager and check it
+     * Add null transformers to the manager and check it
      */
     public void
     testNullTransformerAdd()

--- a/test/jdk/java/lang/instrument/NullTransformerRemoveTest.java
+++ b/test/jdk/java/lang/instrument/NullTransformerRemoveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/instrument/NullTransformerRemoveTest.java
+++ b/test/jdk/java/lang/instrument/NullTransformerRemoveTest.java
@@ -57,7 +57,7 @@ NullTransformerRemoveTest
 
 
     /**
-     * Remove null transformers from the the manager and check
+     * Remove null transformers from the manager and check
      * that it throws NullPointerException
      */
     public void

--- a/test/jdk/java/lang/invoke/AccessControlTest.java
+++ b/test/jdk/java/lang/invoke/AccessControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/invoke/AccessControlTest.java
+++ b/test/jdk/java/lang/invoke/AccessControlTest.java
@@ -190,7 +190,7 @@ public class AccessControlTest {
          * [A9] If the new lookup class is in the same module as the old lookup class,
          * the new previous lookup class is the old previous lookup class.
          * [A10] If the new lookup class is in a different module from the old lookup class,
-         * the new previous lookup class is the the old lookup class.
+         * the new previous lookup class is the old lookup class.
          *
          * Other than the above cases, the new lookup will have the same
          * access capabilities as the original. [A11]

--- a/test/jdk/java/net/InetAddress/ptr/Lookup.java
+++ b/test/jdk/java/net/InetAddress/ptr/Lookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/InetAddress/ptr/Lookup.java
+++ b/test/jdk/java/net/InetAddress/ptr/Lookup.java
@@ -102,7 +102,7 @@ public class Lookup {
         addr = strs[0];
         ipv4Name = strs[1];
 
-        // check that the a reverse lookup of the IPv4 address
+        // check that the reverse lookup of the IPv4 address
         // will succeed with the IPv4 only stack
         tmp = reverseWithIPv4Prefer(addr);
         System.out.println("IPv4 reverse lookup results: [" + tmp + "]");

--- a/test/jdk/java/net/InterfaceAddress/Equals.java
+++ b/test/jdk/java/net/InterfaceAddress/Equals.java
@@ -77,7 +77,7 @@ public class Equals
     }
 
     /**
-     * Returns an InterfaceAddress instance with its fields set the the values
+     * Returns an InterfaceAddress instance with its fields set the values
      * specificed.
      */
     static InterfaceAddress createInterfaceAddress(

--- a/test/jdk/java/net/InterfaceAddress/Equals.java
+++ b/test/jdk/java/net/InterfaceAddress/Equals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/InterfaceAddress/Equals.java
+++ b/test/jdk/java/net/InterfaceAddress/Equals.java
@@ -77,7 +77,7 @@ public class Equals
     }
 
     /**
-     * Returns an InterfaceAddress instance with its fields set the values
+     * Returns an InterfaceAddress instance with its fields set to the values
      * specificed.
      */
     static InterfaceAddress createInterfaceAddress(

--- a/test/jdk/java/net/Socket/SoTimeout.java
+++ b/test/jdk/java/net/Socket/SoTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/Socket/SoTimeout.java
+++ b/test/jdk/java/net/Socket/SoTimeout.java
@@ -64,7 +64,7 @@ public class SoTimeout implements Runnable {
         long waited = System.currentTimeMillis() - timeWritten;
 
         // this sequence should complete fairly quickly and if it
-        // takes something resembling the the SoTimeout value then
+        // takes something resembling the SoTimeout value then
         // we are probably incorrectly blocking and not waking up
         if (waited > 2000) {
             throw new Exception("shouldn't take " + waited + " to complete");

--- a/test/jdk/java/net/Socks/SocksSocketImplTest.java
+++ b/test/jdk/java/net/Socks/SocksSocketImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/Socks/SocksSocketImplTest.java
+++ b/test/jdk/java/net/Socks/SocksSocketImplTest.java
@@ -88,7 +88,7 @@ public class SocksSocketImplTest {
 
     /**
      * A {@link ProxySelector} which strips the "scheme" part of the {@link URI}
-     * before delegating the selection to the the {@link DefaultProxySelector}.
+     * before delegating the selection to the {@link DefaultProxySelector}.
      * This is to ensure that the {@code DefaultProxySelector} throws an {@link IllegalArgumentException}
      * during selection of the proxy
      */

--- a/test/jdk/java/net/URLConnection/contentHandler/COM/foo/content/text/plain.java
+++ b/test/jdk/java/net/URLConnection/contentHandler/COM/foo/content/text/plain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/URLConnection/contentHandler/COM/foo/content/text/plain.java
+++ b/test/jdk/java/net/URLConnection/contentHandler/COM/foo/content/text/plain.java
@@ -25,7 +25,7 @@
 /**
  * Plain text file handler
  *
- * This class provides an example of a a replacement content handler for
+ * This class provides an example of a replacement content handler for
  * the text/plain content type.  It reads the content of the URL, and prepends
  * an additional message at the beginning.
  *

--- a/test/jdk/java/net/httpclient/MessageHeadersTest.java
+++ b/test/jdk/java/net/httpclient/MessageHeadersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/httpclient/MessageHeadersTest.java
+++ b/test/jdk/java/net/httpclient/MessageHeadersTest.java
@@ -118,7 +118,7 @@ public class MessageHeadersTest {
             }
             // In that case we expect MessageHeader to read the CR but
             // leave the LF in the buffer. We therefore need to consume
-            // the the LF in order to get an empty (all consumed) buffer.
+            // the LF in order to get an empty (all consumed) buffer.
             // This is what ResponseHeaders does.
             byte c = buffer.get();
             if (c != '\n' || bbis.lastRead != '\r') {

--- a/test/jdk/java/net/httpclient/reactivestreams-tck/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/test/jdk/java/net/httpclient/reactivestreams-tck/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/httpclient/reactivestreams-tck/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/test/jdk/java/net/httpclient/reactivestreams-tck/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -61,7 +61,7 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
 
   /**
    * Test class must specify the expected time it takes for the publisher to
-   * shut itself down when the the last downstream {@code Subscription} is cancelled.
+   * shut itself down when the last downstream {@code Subscription} is cancelled.
    *
    * The processor will be required to be able to buffer {@code TestEnvironment.TEST_BUFFER_SIZE} elements.
    */
@@ -72,7 +72,7 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
 
   /**
    * Test class must specify the expected time it takes for the publisher to
-   * shut itself down when the the last downstream {@code Subscription} is cancelled.
+   * shut itself down when the last downstream {@code Subscription} is cancelled.
    *
    * The processor will be required to be able to buffer {@code TestEnvironment.TEST_BUFFER_SIZE} elements.
    *
@@ -85,7 +85,7 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
 
   /**
    * Test class must specify the expected time it takes for the publisher to
-   * shut itself down when the the last downstream {@code Subscription} is cancelled.
+   * shut itself down when the last downstream {@code Subscription} is cancelled.
    *
    * @param publisherReferenceGCTimeoutMillis used to determine after how much time a reference to a Subscriber should be already dropped by the Publisher.
    * @param processorBufferSize            number of elements the processor is required to be able to buffer.

--- a/test/jdk/java/net/httpclient/reactivestreams-tck/org/reactivestreams/tck/SubscriberWhiteboxVerification.java
+++ b/test/jdk/java/net/httpclient/reactivestreams-tck/org/reactivestreams/tck/SubscriberWhiteboxVerification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/httpclient/reactivestreams-tck/org/reactivestreams/tck/SubscriberWhiteboxVerification.java
+++ b/test/jdk/java/net/httpclient/reactivestreams-tck/org/reactivestreams/tck/SubscriberWhiteboxVerification.java
@@ -814,7 +814,7 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
      * requested that many elements.
      * <p>
      * This does not necessarily have to correlate 1:1 with a {@code Subscription.request(elements)} call, but the sum
-     * of the elements requested by your {@code Subscriber} must eventually be at least the the sum of the elements
+     * of the elements requested by your {@code Subscriber} must eventually be at least the sum of the elements
      * triggered to be requested by all the invocations of this method.
      * <p>
      * Additionally, subscribers are permitted to delay requesting elements until previous requests for elements have

--- a/test/jdk/java/net/httpclient/websocket/BlowupOutputQueue.java
+++ b/test/jdk/java/net/httpclient/websocket/BlowupOutputQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/httpclient/websocket/BlowupOutputQueue.java
+++ b/test/jdk/java/net/httpclient/websocket/BlowupOutputQueue.java
@@ -60,7 +60,7 @@ public class BlowupOutputQueue extends PendingOperations {
      * At this stage, there are at least 2 messages are in queue. Now, start
      * receiving. Received Ping messages will cause automatic Pong replies. When
      * all done, there will be at least 3 messages in the queue. (As at least
-     * the a single Ping has to be replied). Then send a Close message. Now
+     * a single Ping has to be replied). Then send a Close message. Now
      * there are at least 4 messages in the queue. Finally, receive the last
      * message which is a Close message. This will cause an automatic reply with
      * a Close message from the client side. All in all there should be at least

--- a/test/jdk/java/nio/channels/SocketChannel/ConnectState.java
+++ b/test/jdk/java/nio/channels/SocketChannel/ConnectState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/channels/SocketChannel/ConnectState.java
+++ b/test/jdk/java/nio/channels/SocketChannel/ConnectState.java
@@ -113,7 +113,7 @@ public class ConnectState {
         // For instance on Solaris, when using a server colocated on the
         // machine we cannot guarantee that we will get a
         // ConnectionPendingException when connecting twice on the same
-        // non-blocking socket. We may instead get a an
+        // non-blocking socket. We may instead get an
         // AlreadyConnectedException, which is also valid: it simply means
         // that the first connection has been immediately accepted.
         Test(String name, Collection<Class<?>> exceptions, int state)

--- a/test/jdk/java/security/SecureRandom/SerializedSeedTest.java
+++ b/test/jdk/java/security/SecureRandom/SerializedSeedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/security/SecureRandom/SerializedSeedTest.java
+++ b/test/jdk/java/security/SecureRandom/SerializedSeedTest.java
@@ -25,8 +25,8 @@
  * @test
  * @bug 8141039
  * @library /test/lib
- * @summary When random number is generated through the a SecureRandom instance
- *          as well from it's serialized instance in the same time then the
+ * @summary When random number is generated through a SecureRandom instance
+ *          as well from its serialized instance in the same time then the
  *          generated random numbers should be different when one or both are
  *          reseeded.
  * @run main/othervm -Djava.security.egd=file:/dev/urandom SerializedSeedTest

--- a/test/jdk/java/security/Signature/ResetAfterException.java
+++ b/test/jdk/java/security/Signature/ResetAfterException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/security/Signature/ResetAfterException.java
+++ b/test/jdk/java/security/Signature/ResetAfterException.java
@@ -114,7 +114,7 @@ public class ResetAfterException {
                 // expected exception; ignore
                 System.out.println("Expected Ex for short output buffer: " + e);
             }
-            // Signature object should reset after an a failed verification
+            // Signature object should reset after a failed verification
             sig.update(data);
             try {
                 // verify with valid signature bytes again

--- a/test/jdk/jdk/internal/math/FloatingDecimal/OldFloatingDecimalForTest.java
+++ b/test/jdk/jdk/internal/math/FloatingDecimal/OldFloatingDecimalForTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/internal/math/FloatingDecimal/OldFloatingDecimalForTest.java
+++ b/test/jdk/jdk/internal/math/FloatingDecimal/OldFloatingDecimalForTest.java
@@ -2358,7 +2358,7 @@ public class OldFloatingDecimalForTest{
                      * half-way case for a rounding to float.  If the
                      * double value is a half-way case, the double
                      * significand may have to be modified to round
-                     * the the right float value (see the stickyRound
+                     * the right float value (see the stickyRound
                      * method).  If the rounding to double has lost
                      * what would be float sticky bit information, the
                      * double significand must be incremented.  If the

--- a/test/jdk/jdk/internal/misc/Unsafe/CopyCommon.java
+++ b/test/jdk/jdk/internal/misc/Unsafe/CopyCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/internal/misc/Unsafe/CopyCommon.java
+++ b/test/jdk/jdk/internal/misc/Unsafe/CopyCommon.java
@@ -381,7 +381,7 @@ public class CopyCommon {
             }
         }
 
-        // Verify the the front padding is unchanged
+        // Verify the front padding is unchanged
         verifyUnswappedData(dst, 0, 0, dstOffset);
 
         if (swap) {

--- a/test/jdk/jdk/nio/zipfs/TestLocOffsetFromZip64EF.java
+++ b/test/jdk/jdk/nio/zipfs/TestLocOffsetFromZip64EF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/nio/zipfs/TestLocOffsetFromZip64EF.java
+++ b/test/jdk/jdk/nio/zipfs/TestLocOffsetFromZip64EF.java
@@ -81,7 +81,7 @@ public class TestLocOffsetFromZip64EF {
     }
 
     /**
-     * Create a Zip file that will result in an Zip64 Extra (EXT) header
+     * Create a Zip file that will result in a Zip64 Extra (EXT) header
      * being added to the CEN entry in order to find the LOC offset for
      * SMALL_FILE_NAME.
      */

--- a/test/jdk/jdk/nio/zipfs/TestLocOffsetFromZip64EF.java
+++ b/test/jdk/jdk/nio/zipfs/TestLocOffsetFromZip64EF.java
@@ -81,7 +81,7 @@ public class TestLocOffsetFromZip64EF {
     }
 
     /**
-     * Create a Zip file that will result in the an Zip64 Extra (EXT) header
+     * Create a Zip file that will result in an Zip64 Extra (EXT) header
      * being added to the CEN entry in order to find the LOC offset for
      * SMALL_FILE_NAME.
      */

--- a/test/jdk/jdk/nio/zipfs/testng/util/ZipFsBaseTest.java
+++ b/test/jdk/jdk/nio/zipfs/testng/util/ZipFsBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/nio/zipfs/testng/util/ZipFsBaseTest.java
+++ b/test/jdk/jdk/nio/zipfs/testng/util/ZipFsBaseTest.java
@@ -231,7 +231,7 @@ public class ZipFsBaseTest {
      * @throws IOException If an error occurs
      */
     protected static void rmdir(Path dir) throws IOException {
-        // Nothing to do if the the file does not exist
+        // Nothing to do if the file does not exist
         if (!Files.exists(dir)) {
             return;
         }

--- a/test/jdk/sun/net/www/protocol/jar/MultiReleaseJarURLConnection.java
+++ b/test/jdk/sun/net/www/protocol/jar/MultiReleaseJarURLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/net/www/protocol/jar/MultiReleaseJarURLConnection.java
+++ b/test/jdk/sun/net/www/protocol/jar/MultiReleaseJarURLConnection.java
@@ -209,7 +209,7 @@ public class MultiReleaseJarURLConnection {
             String fragment = vclsUrl.getRef();
             Assert.assertNull(fragment);
 
-            // and verify that the the url is a reified pointer to the runtime entry
+            // and verify that the url is a reified pointer to the runtime entry
             String rep = vclsUrl.toString();
             //System.out.println("    getResource(\"/version/Version.class\") returned: " + rep);
             if (style.equals("http")) {

--- a/test/jdk/sun/security/krb5/auto/HttpNegotiateServer.java
+++ b/test/jdk/sun/security/krb5/auto/HttpNegotiateServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/security/krb5/auto/HttpNegotiateServer.java
+++ b/test/jdk/sun/security/krb5/auto/HttpNegotiateServer.java
@@ -386,15 +386,15 @@ public class HttpNegotiateServer {
         };
 
         System.err.println("\n\nExpecting to succeed when executing " +
-                "with the the logged in subject.");
+                "with the logged in subject.");
 
         try {
             Subject.callAs(subject, test_action);
             System.err.println("\n\nConnection succeed when executing " +
-                    "with the the logged in subject.");
+                    "with the logged in subject.");
         } catch (CompletionException e) {
             System.err.println("\n\nFailure unexpected when executing " +
-                    "with the the logged in subject.");
+                    "with the logged in subject.");
             e.printStackTrace();
             throw new RuntimeException("Failed to login as subject");
         }

--- a/test/jdk/sun/security/tools/jarsigner/OldSig.java
+++ b/test/jdk/sun/security/tools/jarsigner/OldSig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/security/tools/jarsigner/OldSig.java
+++ b/test/jdk/sun/security/tools/jarsigner/OldSig.java
@@ -29,7 +29,7 @@
  */
 /*
  * See also PreserveRawManifestEntryAndDigest.java for tests with arbitrarily
- * formatted individual sections in addition the the main attributes tested
+ * formatted individual sections in addition the main attributes tested
  * here.
  */
 

--- a/test/jdk/sun/security/tools/jarsigner/OldSig.java
+++ b/test/jdk/sun/security/tools/jarsigner/OldSig.java
@@ -29,7 +29,7 @@
  */
 /*
  * See also PreserveRawManifestEntryAndDigest.java for tests with arbitrarily
- * formatted individual sections in addition the main attributes tested
+ * formatted individual sections in addition to the main attributes tested
  * here.
  */
 

--- a/test/jdk/tools/launcher/TooSmallStackSize.java
+++ b/test/jdk/tools/launcher/TooSmallStackSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/tools/launcher/TooSmallStackSize.java
+++ b/test/jdk/tools/launcher/TooSmallStackSize.java
@@ -162,7 +162,7 @@ public class TooSmallStackSize extends TestHelper {
         String min_stack_allowed = checkStack("64k");
 
         /*
-         * Try again with a the minimum stack size that was given in the error message
+         * Try again with the minimum stack size that was given in the error message
          */
         checkMinStackAllowed(min_stack_allowed);
 

--- a/test/langtools/tools/javac/api/T6838467.java
+++ b/test/langtools/tools/javac/api/T6838467.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/api/T6838467.java
+++ b/test/langtools/tools/javac/api/T6838467.java
@@ -133,7 +133,7 @@ public class T6838467 {
 
             // If the directories or zip files match, we expect "n" matches in
             // the "n-squared" comparisons to come, where "n" is the number of
-            // entries in the the directories or zip files.
+            // entries in the directories or zip files.
             // If the directories or zip files don't themselves match,
             // we obviously don't expect any of their contents to match either.
             int expectEqualCount = (f1.getCanonicalFile().equals(f2.getCanonicalFile()) ? paths.length : 0);
@@ -254,4 +254,3 @@ public class T6838467 {
     int errors;
     Set<String> foundClasses = new HashSet<>();
 }
-

--- a/test/langtools/tools/javac/sealed/BinaryCompatibilityTests.java
+++ b/test/langtools/tools/javac/sealed/BinaryCompatibilityTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/sealed/BinaryCompatibilityTests.java
+++ b/test/langtools/tools/javac/sealed/BinaryCompatibilityTests.java
@@ -381,7 +381,7 @@ public class BinaryCompatibilityTests extends TestRunner {
         );
     }
 
-    /* 1- compiles the the superclass source code along with the first version of the subclass source code
+    /* 1- compiles the superclass source code along with the first version of the subclass source code
      * 2- executes the super class just to make sure that it works
      * 3- compiles the second version of the subclass along with the class file of the superclass
      * 4- executes the super class and makes sure that it executes successfully

--- a/test/langtools/tools/lib/toolbox/JavacTask.java
+++ b/test/langtools/tools/lib/toolbox/JavacTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/lib/toolbox/JavacTask.java
+++ b/test/langtools/tools/lib/toolbox/JavacTask.java
@@ -258,7 +258,7 @@ public class JavacTask extends AbstractTask<JavacTask> {
     }
 
     /**
-     * Sets the the annotation processors to be used.
+     * Sets the annotation processors to be used.
      */
     public JavacTask processors(Processor... procs) {
         this.procs = List.of(procs);

--- a/test/lib/jdk/test/lib/cds/CDSOptions.java
+++ b/test/lib/jdk/test/lib/cds/CDSOptions.java
@@ -111,7 +111,7 @@ public class CDSOptions {
     //  - The dumping will be done with the default G1GC so we can generate
     //    the archived heap.
     //  - The runtime execution will be done with the EpsilonGC, to test its
-    //    ability to load the the archived heap.
+    //    ability to load the archived heap.
     //
     // jtreg -vmoptions:-Dtest.cds.runtime.options=-XX:+UnlockExperimentalVMOptions,-XX:+UseEpsilonGC \
     //       test/hotspot/jtreg/runtime/cds

--- a/test/lib/jdk/test/lib/jfr/Events.java
+++ b/test/lib/jdk/test/lib/jfr/Events.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib/jdk/test/lib/jfr/Events.java
+++ b/test/lib/jdk/test/lib/jfr/Events.java
@@ -269,7 +269,7 @@ public class Events {
      * Creates a list of events from a recording.
      *
      * @param recording recording, not {@code null}
-     * @return an a list, not null
+     * @return a list, not null
      * @throws IOException if an event set could not be created due to I/O
      *         errors.
      */


### PR DESCRIPTION
Replaces usages of articles that follow each other in all combinations: a/the, an?/an?, the/the…

Also, I fixed a couple of spelling mistakes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8284191](https://bugs.openjdk.java.net/browse/JDK-8284191): Replace usages of 'a the' in hotspot and java.base


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to [c7e73658](https://git.openjdk.java.net/jdk/pull/8768/files/c7e73658a97496c8a95eb3a4e04a67c61be798e0)
 * [Bradford Wetmore](https://openjdk.java.net/census#wetmore) (@bradfordwetmore - **Reviewer**) ⚠️ Review applies to [c7e73658](https://git.openjdk.java.net/jdk/pull/8768/files/c7e73658a97496c8a95eb3a4e04a67c61be798e0)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [c7e73658](https://git.openjdk.java.net/jdk/pull/8768/files/c7e73658a97496c8a95eb3a4e04a67c61be798e0)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [c7e73658](https://git.openjdk.java.net/jdk/pull/8768/files/c7e73658a97496c8a95eb3a4e04a67c61be798e0)
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to [c7e73658](https://git.openjdk.java.net/jdk/pull/8768/files/c7e73658a97496c8a95eb3a4e04a67c61be798e0)
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to [c7e73658](https://git.openjdk.java.net/jdk/pull/8768/files/c7e73658a97496c8a95eb3a4e04a67c61be798e0)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8768/head:pull/8768` \
`$ git checkout pull/8768`

Update a local copy of the PR: \
`$ git checkout pull/8768` \
`$ git pull https://git.openjdk.java.net/jdk pull/8768/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8768`

View PR using the GUI difftool: \
`$ git pr show -t 8768`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8768.diff">https://git.openjdk.java.net/jdk/pull/8768.diff</a>

</details>
