### PR TITLE
8284213: Replace usages of 'a the' in xml

### DIFF
--- a/src/java.xml/share/classes/com/sun/java_cup/internal/runtime/lr_parser.java
+++ b/src/java.xml/share/classes/com/sun/java_cup/internal/runtime/lr_parser.java
@@ -910,7 +910,7 @@ public abstract class lr_parser {
    *  the stored Symbols without error, then the recovery is considered a
    *  success.  Once a successful recovery point is determined, we do an
    *  actual parse over the stored input -- modifying the real parse
-   *  configuration and executing all actions.  Finally, we return the the
+   *  configuration and executing all actions.  Finally, we return the
    *  normal parser to continue with the overall parse.
    *
    * @param debug should we produce debugging messages as we parse.

--- a/src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java
+++ b/src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java
@@ -298,7 +298,7 @@ public abstract class DocumentBuilder {
     }
     */
 
-    /** <p>Get a reference to the the {@link Schema} being used by
+    /** <p>Get a reference to the {@link Schema} being used by
      * the XML processor.</p>
      *
      * <p>If no schema is being used, <code>null</code> is returned.</p>

--- a/src/java.xml/share/classes/javax/xml/parsers/SAXParser.java
+++ b/src/java.xml/share/classes/javax/xml/parsers/SAXParser.java
@@ -507,7 +507,7 @@ public abstract class SAXParser {
     }
     */
 
-    /** <p>Get a reference to the the {@link Schema} being used by
+    /** <p>Get a reference to the {@link Schema} being used by
      * the XML processor.</p>
      *
      * <p>If no schema is being used, <code>null</code> is returned.</p>

--- a/src/java.xml/share/classes/javax/xml/stream/XMLStreamReader.java
+++ b/src/java.xml/share/classes/javax/xml/stream/XMLStreamReader.java
@@ -537,7 +537,7 @@ public interface XMLStreamReader extends XMLStreamConstants {
   public char[] getTextCharacters();
 
   /**
-   * Gets the the text associated with a CHARACTERS, SPACE or CDATA event.
+   * Gets the text associated with a CHARACTERS, SPACE or CDATA event.
    * Text starting a "sourceStart" is copied into "target" starting at "targetStart".
    * Up to "length" characters are copied.  The number of characters actually copied is returned.
    *

--- a/src/java.xml/share/classes/javax/xml/transform/TransformerException.java
+++ b/src/java.xml/share/classes/javax/xml/transform/TransformerException.java
@@ -278,7 +278,7 @@ public class TransformerException extends Exception {
     }
 
     /**
-     * Print the the trace of methods from where the error
+     * Print the trace of methods from where the error
      * originated.  This will trace all nested exception
      * objects, as well as this object.
      */
@@ -288,7 +288,7 @@ public class TransformerException extends Exception {
     }
 
     /**
-     * Print the the trace of methods from where the error
+     * Print the trace of methods from where the error
      * originated.  This will trace all nested exception
      * objects, as well as this object.
      * @param s The stream where the dump will be sent to.
@@ -299,7 +299,7 @@ public class TransformerException extends Exception {
     }
 
     /**
-     * Print the the trace of methods from where the error
+     * Print the trace of methods from where the error
      * originated.  This will trace all nested exception
      * objects, as well as this object.
      * @param s The writer where the dump will be sent to.

--- a/src/java.xml/share/classes/jdk/xml/internal/JdkXmlUtils.java
+++ b/src/java.xml/share/classes/jdk/xml/internal/JdkXmlUtils.java
@@ -110,7 +110,7 @@ public class JdkXmlUtils {
     }
 
     /**
-     * Sets the XMLReader instance with the specified property if the the
+     * Sets the XMLReader instance with the specified property if the
      * property is supported, ignores error if not, issues a warning if so
      * requested.
      *

--- a/test/jaxp/javax/xml/jaxp/functional/javax/xml/transform/ptests/TfClearParamTest.java
+++ b/test/jaxp/javax/xml/jaxp/functional/javax/xml/transform/ptests/TfClearParamTest.java
@@ -89,7 +89,7 @@ public class TfClearParamTest {
     }
 
     /**
-     * Obtains transformer's parameter with the a name that wasn't set before.
+     * Obtains transformer's parameter with a name that wasn't set before.
      * Null is expected.
      * @throws TransformerConfigurationException If for some reason the
      *         TransformerHandler can not be created.
@@ -134,7 +134,7 @@ public class TfClearParamTest {
 
     /**
      * Obtains transformer's parameter whose initiated with a stream source with
-     * the a name that set before. Value should be same as set one.
+     * the name that set before. Value should be same as set one.
      * @throws TransformerConfigurationException If for some reason the
      *         TransformerHandler can not be created.
      */
@@ -149,7 +149,7 @@ public class TfClearParamTest {
 
     /**
      * Obtains transformer's parameter whose initiated with a stream source with
-     * the a name that wasn't set before. Null is expected.
+     * a name that wasn't set before. Null is expected.
      * @throws TransformerConfigurationException If for some reason the
      *         TransformerHandler can not be created.
      */
@@ -164,7 +164,7 @@ public class TfClearParamTest {
 
     /**
      * Obtains transformer's parameter whose initiated with a sax source with
-     * the a name that set before. Value should be same as set one.
+     * the name that set before. Value should be same as set one.
      * @throws Exception If any errors occur.
      */
     @Test
@@ -181,7 +181,7 @@ public class TfClearParamTest {
 
     /**
      * Obtains transformer's parameter whose initiated with a sax source with
-     * the a name that wasn't set before. Null is expected.
+     * a name that wasn't set before. Null is expected.
      * @throws Exception If any errors occur.
      */
     @Test
@@ -199,7 +199,7 @@ public class TfClearParamTest {
 
     /**
      * Obtains transformer's parameter whose initiated with a dom source with
-     * the a name that set before. Value should be same as set one.
+     * the name that set before. Value should be same as set one.
      * @throws Exception If any errors occur.
      */
     @Test
@@ -220,7 +220,7 @@ public class TfClearParamTest {
 
     /**
      * Obtains transformer's parameter whose initiated with a dom source with
-     * the a name that wasn't set before. Null is expected.
+     * a name that wasn't set before. Null is expected.
      * @throws Exception If any errors occur.
      */
     @Test

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/IsValidatingTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/IsValidatingTest.java
@@ -55,7 +55,7 @@ public class IsValidatingTest {
      * Test StAX with IS_VALIDATING = false and a non-existent DTD.
      * Test should pass.
      *
-     * Try to parse an XML file that references a a non-existent DTD.
+     * Try to parse an XML file that references a non-existent DTD.
      * Desired behavior:
      *     If IS_VALIDATING == false, then continue processing.
      *

--- a/test/jdk/java/beans/XMLEncoder/Test4631471.java
+++ b/test/jdk/java/beans/XMLEncoder/Test4631471.java
@@ -58,7 +58,7 @@ public abstract class Test4631471 extends AbstractTest {
         }.test(false);
 
         // create a new model from the root node
-        // this simulates the the MetaData ctor:
+        // this simulates the MetaData ctor:
         // registerConstructor("javax.swing.tree.DefaultTreeModel", new String[]{"root"});
         new Test4631471() {
             protected Object getObject() {


### PR DESCRIPTION
Replaces usages of articles that follow each other in all combinations: a/the, an?/an?, the/the…

I tried to avoid changing external libraries, there are quite a few such typos.
Let me know if I should revert any files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8284213](https://bugs.openjdk.java.net/browse/JDK-8284213): Replace usages of 'a the' in xml


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Dmitry Markov](https://openjdk.java.net/census#dmarkov) (@dmarkov20 - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8769/head:pull/8769` \
`$ git checkout pull/8769`

Update a local copy of the PR: \
`$ git checkout pull/8769` \
`$ git pull https://git.openjdk.java.net/jdk pull/8769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8769`

View PR using the GUI difftool: \
`$ git pr show -t 8769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8769.diff">https://git.openjdk.java.net/jdk/pull/8769.diff</a>

</details>
