### PR TITLE
8286654: Add an optional description accessor on ToolProvider interface

### DIFF
--- a/src/java.base/share/classes/java/util/spi/ToolProvider.java
+++ b/src/java.base/share/classes/java/util/spi/ToolProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,30 @@ public interface ToolProvider {
      * @return the name of this tool provider
      */
     String name();
+
+    /**
+     * {@return a short description of the tool, or an empty
+     * {@code Optional} if no description is available}
+     *
+     * @apiNote It is recommended that the description fits into a single
+     * line in order to allow creating concise overviews like the following:
+     * <pre>{@code
+     * jar
+     *   Create, manipulate, and extract an archive of classes and resources.
+     * javac
+     *   Read Java declarations and compile them into class files.
+     * jlink
+     *   Assemble a set of modules (...) into a custom runtime image.
+     * }
+     * </pre>
+     *
+     * @implSpec This implementation returns an empty {@code Optional}.
+     *
+     * @since 19
+     */
+    default Optional<String> description() {
+        return Optional.empty();
+    }
 
     /**
      * Runs an instance of the tool, returning zero for a successful run.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavacToolProvider.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavacToolProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package com.sun.tools.javac.main;
 
 import java.io.PrintWriter;
+import java.util.Optional;
 import java.util.spi.ToolProvider;
 
 /**
@@ -39,6 +40,10 @@ import java.util.spi.ToolProvider;
 public class JavacToolProvider implements ToolProvider {
     public String name() {
         return "javac";
+    }
+
+    public Optional<String> description() {
+        return Optional.of("Read Java declarations and compile them into class files");
     }
 
     public int run(PrintWriter out, PrintWriter err, String... args) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavacToolProvider.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavacToolProvider.java
@@ -29,6 +29,8 @@ import java.io.PrintWriter;
 import java.util.Optional;
 import java.util.spi.ToolProvider;
 
+import com.sun.tools.javac.util.JavacMessages;
+
 /**
  * An implementation of the {@link java.util.spi.ToolProvider ToolProvider} SPI,
  * providing access to JDK Java compiler, javac.
@@ -43,7 +45,8 @@ public class JavacToolProvider implements ToolProvider {
     }
 
     public Optional<String> description() {
-        return Optional.of("Read Java declarations and compile them into class files");
+        JavacMessages messages = new JavacMessages(Main.javacBundleName);
+        return Optional.of(messages.getLocalizedString("javac.description"));
     }
 
     public int run(PrintWriter out, PrintWriter err, String... args) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,10 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
+
+## tool
+
+javac.description=read Java class and interface definitions and compile them into bytecode and class files
 
 ## standard options
 

--- a/src/jdk.jartool/share/classes/sun/tools/jar/JarToolProvider.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/JarToolProvider.java
@@ -35,7 +35,7 @@ public class JarToolProvider implements ToolProvider {
     }
 
     public Optional<String> description() {
-        return Optional.of("Create, manipulate, and extract an archive of classes and resources");
+        return Optional.of(Main.getMsg("jar.description"));
     }
 
     public int run(PrintWriter out, PrintWriter err, String... args) {

--- a/src/jdk.jartool/share/classes/sun/tools/jar/JarToolProvider.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/JarToolProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,11 +26,16 @@
 package sun.tools.jar;
 
 import java.io.PrintWriter;
+import java.util.Optional;
 import java.util.spi.ToolProvider;
 
 public class JarToolProvider implements ToolProvider {
     public String name() {
         return "jar";
+    }
+
+    public Optional<String> description() {
+        return Optional.of("Create, manipulate, and extract an archive of classes and resources");
     }
 
     public int run(PrintWriter out, PrintWriter err, String... args) {

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,10 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
+
+## tool
+
+jar.description=create an archive for classes and resources, and manipulate or restore individual classes or resources from an archive
 
 error.multiple.main.operations=\
      You may not specify more than one '-cuxtid' options

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocToolProvider.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocToolProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package jdk.javadoc.internal.tool;
 
 import java.io.PrintWriter;
+import java.util.Optional;
 import java.util.spi.ToolProvider;
 
 /**
@@ -41,6 +42,11 @@ public class JavadocToolProvider implements ToolProvider {
     @Override
     public String name() {
         return "javadoc";
+    }
+
+    // @Override - commented out due to interim builds of javadoc with JDKs < 19.
+    public Optional<String> description() {
+        return Optional.of("Generate HTML pages of API documentation from Java source files");
     }
 
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocToolProvider.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocToolProvider.java
@@ -25,8 +25,11 @@
 
 package jdk.javadoc.internal.tool;
 
+import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.JavacMessages;
 import java.io.PrintWriter;
 import java.util.Optional;
+import java.util.ResourceBundle;
 import java.util.spi.ToolProvider;
 
 /**
@@ -46,7 +49,9 @@ public class JavadocToolProvider implements ToolProvider {
 
     // @Override - commented out due to interim builds of javadoc with JDKs < 19.
     public Optional<String> description() {
-        return Optional.of("Generate HTML pages of API documentation from Java source files");
+        JavacMessages messages = JavacMessages.instance(new Context());
+        messages.add(locale -> ResourceBundle.getBundle("jdk.javadoc.internal.tool.resources.javadoc", locale));
+        return Optional.of(messages.getLocalizedString("javadoc.description"));
     }
 
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/resources/javadoc.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/resources/javadoc.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,8 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
+
+javadoc.description=generate HTML pages of API documentation from Java source files
 
 main.errors={0} errors
 main.error={0} error

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/Main.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package com.sun.tools.javap;
 
 import java.io.PrintWriter;
+import java.util.Optional;
 import java.util.spi.ToolProvider;
 
 /**
@@ -63,6 +64,10 @@ public class Main {
     public static class JavapToolProvider implements ToolProvider {
         public String name() {
             return "javap";
+        }
+
+        public Optional<String> description() {
+            return Optional.of("Disassemble one or more Java class files");
         }
 
         public int run(PrintWriter out, PrintWriter err, String... args) {

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/Main.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/Main.java
@@ -67,7 +67,8 @@ public class Main {
         }
 
         public Optional<String> description() {
-            return Optional.of("Disassemble one or more Java class files");
+            JavapTask t = new JavapTask();
+            return Optional.of(t.getMessage("javap.description"));
         }
 
         public int run(PrintWriter out, PrintWriter err, String... args) {

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/resources/javap.properties
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/resources/javap.properties
@@ -23,6 +23,8 @@
 # questions.
 #
 
+javap.description=disassemble one or more class files
+
 err.prefix=Error:
 
 err.bad.constant.pool=error while reading constant pool for {0}: {1}

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/Main.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/Main.java
@@ -71,7 +71,7 @@ public class Main {
         }
 
         public Optional<String> description() {
-            return Optional.of("Analyze dependencies of Java classes");
+            return Optional.of(JdepsTask.getMessage("jdeps.description"));
         }
 
         public int run(PrintWriter out, PrintWriter err, String... args) {

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/Main.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package com.sun.tools.jdeps;
 
 import java.io.*;
+import java.util.Optional;
 import java.util.spi.ToolProvider;
 
 /**
@@ -67,6 +68,10 @@ public class Main {
     public static class JDepsToolProvider implements ToolProvider {
         public String name() {
             return "jdeps";
+        }
+
+        public Optional<String> description() {
+            return Optional.of("Analyze dependencies of Java classes");
         }
 
         public int run(PrintWriter out, PrintWriter err, String... args) {

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/resources/jdeps.properties
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/resources/jdeps.properties
@@ -23,6 +23,8 @@
 # questions.
 #
 
+jdeps.description=launch the Java class dependency analyzer
+
 main.usage.summary=\
 Usage: {0} <options> <path ...>]\n\
 use --help for a list of possible options

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Main.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package jdk.tools.jlink.internal;
 
 import java.io.*;
+import java.util.Optional;
 import java.util.spi.ToolProvider;
 
 public class Main {
@@ -59,6 +60,11 @@ public class Main {
         @Override
         public String name() {
             return "jlink";
+        }
+
+        @Override
+        public Optional<String> description() {
+            return Optional.of("Assemble a set of modules into a custom runtime image");
         }
 
         @Override

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Main.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Main.java
@@ -64,7 +64,8 @@ public class Main {
 
         @Override
         public Optional<String> description() {
-            return Optional.of("Assemble a set of modules into a custom runtime image");
+            TaskHelper taskHelper = new TaskHelper(TaskHelper.JLINK_BUNDLE);
+            return Optional.of(taskHelper.getMessage("jlink.desciption"));
         }
 
         @Override

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/jlink.properties
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/jlink.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,8 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
+
+jlink.description=assemble and optimize a set of modules and their dependencies into a custom runtime image
 
 main.usage.summary=\
 Usage: {0} <options> --module-path <modulepath> --add-modules <module>[,<module>...]\n\

--- a/src/jdk.jlink/share/classes/jdk/tools/jmod/JmodTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jmod/JmodTask.java
@@ -1601,7 +1601,7 @@ public class JmodTask {
         return System.getProperty("java.version");
     }
 
-    private static String getMessage(String key, Object... args) {
+    static String getMessage(String key, Object... args) {
         try {
             return MessageFormat.format(ResourceBundleHelper.bundle.getString(key), args);
         } catch (MissingResourceException e) {

--- a/src/jdk.jlink/share/classes/jdk/tools/jmod/Main.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jmod/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package jdk.tools.jmod;
 
 import java.io.*;
+import java.util.Optional;
 import java.util.spi.ToolProvider;
 
 public class Main {
@@ -53,6 +54,11 @@ public class Main {
         @Override
         public String name() {
             return "jmod";
+        }
+
+        @Override
+        public Optional<String> description() {
+            return Optional.of("Create JMOD files and list the content of existing JMOD files");
         }
 
         @Override

--- a/src/jdk.jlink/share/classes/jdk/tools/jmod/Main.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jmod/Main.java
@@ -58,7 +58,7 @@ public class Main {
 
         @Override
         public Optional<String> description() {
-            return Optional.of("Create JMOD files and list the content of existing JMOD files");
+            return Optional.of(JmodTask.getMessage("jmod.description"));
         }
 
         @Override

--- a/src/jdk.jlink/share/classes/jdk/tools/jmod/resources/jmod.properties
+++ b/src/jdk.jlink/share/classes/jdk/tools/jmod/resources/jmod.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,8 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
+
+jmod.description=create JMOD files and list the content of existing JMOD files
 
 main.usage.summary=\
 Usage: {0} (create|extract|list|describe|hash) <OPTIONS> <jmod-file>\n\
@@ -115,5 +117,3 @@ warn.invalid.arg=Invalid classname or pathname not exist: {0}
 warn.no.module.hashes=No hashes recorded: no module specified for hashing depends on {0}
 warn.ignore.entry=ignoring entry {0}, in section {1}
 warn.ignore.duplicate.entry=ignoring duplicate entry {0}, in section {1}
-
-

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/JPackageToolProvider.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/JPackageToolProvider.java
@@ -42,7 +42,7 @@ public class JPackageToolProvider implements ToolProvider {
     }
 
     public Optional<String> description() {
-        return Optional.of("Package a self-contained Java application");
+        return Optional.of(jdk.jpackage.main.Main.I18N.getString("jpackage.description"));
     }
 
     public synchronized int run(

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/JPackageToolProvider.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/JPackageToolProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package jdk.jpackage.internal;
 
 import java.io.PrintWriter;
+import java.util.Optional;
 import java.util.spi.ToolProvider;
 
 /**
@@ -38,6 +39,10 @@ public class JPackageToolProvider implements ToolProvider {
 
     public String name() {
         return "jpackage";
+    }
+
+    public Optional<String> description() {
+        return Optional.of("Package a self-contained Java application");
     }
 
     public synchronized int run(

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources.properties
@@ -24,6 +24,8 @@
 #
 #
 
+jpackage.description=package a self-contained Java application
+
 param.copyright.default=Copyright (C) {0,date,YYYY}
 param.description.default=None
 param.vendor.default=Unknown

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/main/Main.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/main/Main.java
@@ -36,7 +36,7 @@ import java.text.MessageFormat;
 
 public class Main {
 
-    private static final ResourceBundle I18N = ResourceBundle.getBundle(
+    public static final ResourceBundle I18N = ResourceBundle.getBundle(
             "jdk.jpackage.internal.resources.MainResources");
 
     /**


### PR DESCRIPTION
This PR adds an optional description accessor on `ToolProvider` interface.

This PR also adds short description for each of the listed tool:
- `jar`
- `javac`
- `javadoc`
- `javap` and `jdeps`
- `jlink` and `jmod`
- `jpackage`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issues
 * [JDK-8286654](https://bugs.openjdk.java.net/browse/JDK-8286654): Add an optional description accessor on ToolProvider interface
 * [JDK-8286659](https://bugs.openjdk.java.net/browse/JDK-8286659): Add an optional description accessor on ToolProvider interface (**CSR**)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8772/head:pull/8772` \
`$ git checkout pull/8772`

Update a local copy of the PR: \
`$ git checkout pull/8772` \
`$ git pull https://git.openjdk.java.net/jdk pull/8772/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8772`

View PR using the GUI difftool: \
`$ git pr show -t 8772`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8772.diff">https://git.openjdk.java.net/jdk/pull/8772.diff</a>

</details>
