### PR TITLE
8286943: G1: With virtualized remembered sets, maximum number of cards configured is wrong

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -50,12 +50,13 @@ static uint default_log2_card_regions_per_region() {
 }
 
 G1CardSetConfiguration::G1CardSetConfiguration() :
-  G1CardSetConfiguration(HeapRegion::LogCardsPerRegion,                             /* inline_ptr_bits_per_card */
+  G1CardSetConfiguration(HeapRegion::LogCardsPerRegion - default_log2_card_regions_per_region(),                                                                                   /* inline_ptr_bits_per_card */
                          G1RemSetArrayOfCardsEntries,                               /* max_cards_in_array */
                          (double)G1RemSetCoarsenHowlBitmapToHowlFullPercent / 100,  /* cards_in_bitmap_threshold_percent */
                          G1RemSetHowlNumBuckets,                                    /* num_buckets_in_howl */
                          (double)G1RemSetCoarsenHowlToFullPercent / 100,            /* cards_in_howl_threshold_percent */
-                         (uint)HeapRegion::CardsPerRegion,                          /* max_cards_in_cardset */
+                         (uint)HeapRegion::CardsPerRegion >> default_log2_card_regions_per_region(),
+                                                                                    /* max_cards_in_card_set */
                          default_log2_card_regions_per_region())                    /* log2_card_regions_per_region */
 {
   assert((_log2_card_regions_per_heap_region + _log2_cards_per_card_region) == (uint)HeapRegion::LogCardsPerRegion,
@@ -75,7 +76,7 @@ G1CardSetConfiguration::G1CardSetConfiguration(uint max_cards_in_array,
                                                     max_cards_in_array,
                                                     max_buckets_in_howl),
                          cards_in_howl_threshold_percent,                      /* cards_in_howl_threshold_percent */
-                         max_cards_in_card_set,                                /* max_cards_in_cardset */
+                         max_cards_in_card_set,                                /* max_cards_in_card_set */
                          log2_card_regions_per_region)
 { }
 
@@ -96,10 +97,24 @@ G1CardSetConfiguration::G1CardSetConfiguration(uint inline_ptr_bits_per_card,
   _log2_max_cards_in_howl_bitmap(log2i_exact(_max_cards_in_howl_bitmap)),
   _bitmap_hash_mask(~(~(0) << _log2_max_cards_in_howl_bitmap)),
   _log2_card_regions_per_heap_region(log2_card_regions_per_heap_region),
-  _log2_cards_per_card_region(log2i_exact(_max_cards_in_card_set) - _log2_card_regions_per_heap_region) {
+  _log2_cards_per_card_region(log2i_exact(_max_cards_in_card_set)) {
 
+  assert(_inline_ptr_bits_per_card <= G1CardSetContainer::LogCardsPerRegionLimit,
+         "inline_ptr_bits_per_card (%u) can not represent all card indexes (%u)",
+         _inline_ptr_bits_per_card, G1CardSetContainer::LogCardsPerRegionLimit);
   assert(is_power_of_2(_max_cards_in_card_set),
          "max_cards_in_card_set must be a power of 2: %u", _max_cards_in_card_set);
+  assert(_max_cards_in_card_set <= G1CardSetContainer::cards_per_region_limit(),
+         "Specified number of cards (%u) exceeds maximum representable (%u)",
+         _max_cards_in_card_set, G1CardSetContainer::cards_per_region_limit());
+  assert(_cards_in_howl_bitmap_threshold <= _max_cards_in_howl_bitmap,
+         "Threshold to coarsen Howl Bitmap to Howl Full (%u) must be "
+         "smaller than or equal to max number of cards in Howl bitmap (%u)",
+         _cards_in_howl_bitmap_threshold, _max_cards_in_howl_bitmap);
+  assert(_cards_in_howl_threshold <= _max_cards_in_card_set,
+         "Threshold to coarsen Howl to Full (%u) must be "
+         "smaller than or equal to max number of cards in card region (%u)",
+         _cards_in_howl_threshold, _max_cards_in_card_set);
 
   init_card_set_alloc_options();
   log_configuration();
@@ -129,7 +144,7 @@ void G1CardSetConfiguration::log_configuration() {
                           num_buckets_in_howl(), cards_in_howl_threshold(),
                           max_cards_in_howl_bitmap(), G1CardSetBitMap::size_in_bytes(max_cards_in_howl_bitmap()), cards_in_howl_bitmap_threshold(),
                           (uint)1 << log2_card_regions_per_heap_region(),
-                          (uint)1 << log2_cards_per_card_region());
+                          max_cards_in_region());
 }
 
 uint G1CardSetConfiguration::max_cards_in_inline_ptr() const {

--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -100,13 +100,24 @@ G1CardSetConfiguration::G1CardSetConfiguration(uint inline_ptr_bits_per_card,
   _log2_cards_per_card_region(log2i_exact(_max_cards_in_card_set)) {
 
   assert(_inline_ptr_bits_per_card <= G1CardSetContainer::LogCardsPerRegionLimit,
-         "inline_ptr_bits_per_card (%u) can not represent all card indexes (%u)",
+         "inline_ptr_bits_per_card (%u) is wasteful, can represent more than maximum possible card indexes (%u)",
          _inline_ptr_bits_per_card, G1CardSetContainer::LogCardsPerRegionLimit);
+  assert(_inline_ptr_bits_per_card >= _log2_cards_per_card_region,
+         "inline_ptr_bits_per_card (%u) must be larger than possible card indexes (%u)",
+         _inline_ptr_bits_per_card, _log2_cards_per_card_region);
+
+  assert(cards_in_bitmap_threshold_percent >= 0.0 && cards_in_bitmap_threshold_percent <= 1.0,
+         "cards_in_bitmap_threshold_percent (%1.2f) out of range", cards_in_bitmap_threshold_percent);
+
+  assert(cards_in_howl_threshold_percent >= 0.0 && cards_in_howl_threshold_percent <= 1.0,
+         "cards_in_howl_threshold_percent (%1.2f) out of range", cards_in_howl_threshold_percent);
+
   assert(is_power_of_2(_max_cards_in_card_set),
          "max_cards_in_card_set must be a power of 2: %u", _max_cards_in_card_set);
   assert(_max_cards_in_card_set <= G1CardSetContainer::cards_per_region_limit(),
          "Specified number of cards (%u) exceeds maximum representable (%u)",
          _max_cards_in_card_set, G1CardSetContainer::cards_per_region_limit());
+
   assert(_cards_in_howl_bitmap_threshold <= _max_cards_in_howl_bitmap,
          "Threshold to coarsen Howl Bitmap to Howl Full (%u) must be "
          "smaller than or equal to max number of cards in Howl bitmap (%u)",

--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -110,7 +110,7 @@ public:
   uint howl_bucket_index(uint card_idx) { return card_idx >> _log2_max_cards_in_howl_bitmap; }
 
   // Full card configuration
-  // Maximum number of cards in a non-full card set for a single region. Card sets
+  // Maximum number of cards in a non-full card set for a single card region. Card sets
   // with more entries per region are coarsened to Full.
   uint max_cards_in_region() const { return _max_cards_in_card_set; }
 

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
@@ -157,6 +157,8 @@ public:
 
   // Log of largest card index that can be stored in any G1CardSetContainer
   static uint LogCardsPerRegionLimit;
+
+  static uint cards_per_region_limit() { return 1u << LogCardsPerRegionLimit; }
 };
 
 class G1CardSetArray : public G1CardSetContainer {

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.inline.hpp
@@ -119,7 +119,7 @@ void HeapRegionRemSet::split_card(OopOrNarrowOopStar from, uint& card_region, ui
   size_t offset = pointer_delta(from, _heap_base_address, 1);
   card_region = (uint)(offset >> _split_card_shift);
   card_within_region = (uint)((offset & _split_card_mask) >> CardTable::card_shift());
-  assert(card_within_region < ((uint)1 << G1CardSetContainer::LogCardsPerRegionLimit), "must be");
+  assert(card_within_region < G1CardSetContainer::cards_per_region_limit(), "must be");
 }
 
 void HeapRegionRemSet::add_reference(OopOrNarrowOopStar from, uint tid) {


### PR DESCRIPTION
Hi all,

  can I get reviews for this change that fixes passing a wrong parameter value to card set configuration that

* prevents upgrading a Howl container to Full with virtualized remembered sets (Heap regions >= 64M) as the (default) threshold for coarsening from Howl to Full is max_cards_in_cardset * 0.9, which is always higher than the value tested against (65k, max card set container element number).
* and also unnecessarily increases the bits used for inline ptrs

I added some basic parameter verification to the main constructor which would have caught this issue.

Testing: gha, tier1-3

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286943](https://bugs.openjdk.java.net/browse/JDK-8286943): G1: With virtualized remembered sets, maximum number of cards configured is wrong


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8773/head:pull/8773` \
`$ git checkout pull/8773`

Update a local copy of the PR: \
`$ git checkout pull/8773` \
`$ git pull https://git.openjdk.java.net/jdk pull/8773/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8773`

View PR using the GUI difftool: \
`$ git pr show -t 8773`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8773.diff">https://git.openjdk.java.net/jdk/pull/8773.diff</a>

</details>
