### PR TITLE
8286969: Add a new test library API to execute kinit in SecurityTools.java

### DIFF
--- a/test/lib/jdk/test/lib/SecurityTools.java
+++ b/test/lib/jdk/test/lib/SecurityTools.java
@@ -226,6 +226,18 @@ public class SecurityTools {
     }
 
     /**
+     * Runs kinit.
+     *
+     * @param args arguments to kinit in a single string. The string is
+     *             converted to be List with makeList.
+     * @return an {@link OutputAnalyzer} object
+     * @throws Exception if there is an error
+     */
+    public static OutputAnalyzer kinit(String args) throws Exception {
+        return execute(getProcessBuilder("kinit", makeList(args)));
+    }
+
+    /**
      * Runs jar.
      *
      * @param args arguments to jar in a single string. The string is


### PR DESCRIPTION
A new API to execute kinit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286969](https://bugs.openjdk.java.net/browse/JDK-8286969): Add a new test library API to execute kinit in SecurityTools.java


### Reviewers
 * [Rajan Halade](https://openjdk.java.net/census#rhalade) (@rhalade - **Reviewer**)
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8775/head:pull/8775` \
`$ git checkout pull/8775`

Update a local copy of the PR: \
`$ git checkout pull/8775` \
`$ git pull https://git.openjdk.java.net/jdk pull/8775/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8775`

View PR using the GUI difftool: \
`$ git pr show -t 8775`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8775.diff">https://git.openjdk.java.net/jdk/pull/8775.diff</a>

</details>
