### PR TITLE
8286972: Support the new loop induction variable related PopulateIndex IR node on x86

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -2274,6 +2274,80 @@ void C2_MacroAssembler::vectortest(int bt, int vlen, XMMRegister src1, XMMRegist
   }
 }
 
+void C2_MacroAssembler::vpadd(BasicType elem_bt, XMMRegister dst, XMMRegister src1, XMMRegister src2, int vlen_enc) {
+  assert(UseAVX >= 2, "required");
+  bool is_bw = ((elem_bt == T_BYTE) || (elem_bt == T_SHORT));
+  bool is_bw_supported = VM_Version::supports_avx512bw();
+  if (is_bw && !is_bw_supported) {
+    assert(vlen_enc != Assembler::AVX_512bit, "required");
+    assert((dst->encoding() < 16) && (src1->encoding() < 16) && (src2->encoding() < 16),
+           "XMM register should be 0-15");
+  }
+  switch (elem_bt) {
+    case T_BYTE: vpaddb(dst, src1, src2, vlen_enc); return;
+    case T_SHORT: vpaddw(dst, src1, src2, vlen_enc); return;
+    case T_INT: vpaddd(dst, src1, src2, vlen_enc); return;
+    case T_FLOAT: vaddps(dst, src1, src2, vlen_enc); return;
+    case T_LONG: vpaddq(dst, src1, src2, vlen_enc); return;
+    case T_DOUBLE: vaddpd(dst, src1, src2, vlen_enc); return;
+    default: assert(false, "%s", type2name(elem_bt));
+  }
+}
+
+void C2_MacroAssembler::vpbroadcast(BasicType elem_bt, XMMRegister dst, Register src, int vlen_enc) {
+  assert(UseAVX >= 2, "required");
+  bool is_bw = ((elem_bt == T_BYTE) || (elem_bt == T_SHORT));
+  bool is_vl = vlen_enc != Assembler::AVX_512bit;
+  if ((UseAVX > 2) &&
+      (!is_bw || VM_Version::supports_avx512bw()) &&
+      (!is_vl || VM_Version::supports_avx512vl())) {
+    switch (elem_bt) {
+      case T_BYTE: evpbroadcastb(dst, src, vlen_enc); return;
+      case T_SHORT: evpbroadcastw(dst, src, vlen_enc); return;
+      case T_FLOAT: case T_INT: evpbroadcastd(dst, src, vlen_enc); return;
+      case T_DOUBLE: case T_LONG: evpbroadcastq(dst, src, vlen_enc); return;
+      default: assert(false, "%s", type2name(elem_bt));
+    }
+  } else {
+    assert(vlen_enc != Assembler::AVX_512bit, "required");
+    assert((dst->encoding() < 16),"XMM register should be 0-15");
+    switch (elem_bt) {
+      case T_BYTE: movdl(dst, src); vpbroadcastb(dst, dst, vlen_enc); return;
+      case T_SHORT: movdl(dst, src); vpbroadcastw(dst, dst, vlen_enc); return;
+      case T_INT: movdl(dst, src); vpbroadcastd(dst, dst, vlen_enc); return;
+      case T_FLOAT: movdl(dst, src); vbroadcastss(dst, dst, vlen_enc); return;
+      case T_LONG: movdq(dst, src); vpbroadcastq(dst, dst, vlen_enc); return;
+      case T_DOUBLE: movdl(dst, src); vbroadcastsd(dst, dst, vlen_enc); return;
+      default: assert(false, "%s", type2name(elem_bt));
+    }
+  }
+}
+
+void C2_MacroAssembler::vconvert_b2x(BasicType to_elem_bt, XMMRegister dst, XMMRegister src, int vlen_enc) {
+  switch (to_elem_bt) {
+    case T_SHORT:
+      vpmovsxbw(dst, src, vlen_enc);
+      break;
+    case T_INT:
+      vpmovsxbd(dst, src, vlen_enc);
+      break;
+    case T_FLOAT:
+      vpmovsxbd(dst, src, vlen_enc);
+      vcvtdq2ps(dst, dst, vlen_enc);
+      break;
+    case T_LONG:
+      vpmovsxbq(dst, src, vlen_enc);
+      break;
+    case T_DOUBLE: {
+      int mid_vlen_enc = (vlen_enc == Assembler::AVX_512bit) ? Assembler::AVX_256bit : Assembler::AVX_128bit;
+      vpmovsxbd(dst, src, mid_vlen_enc);
+      vcvtdq2pd(dst, dst, vlen_enc);
+      break;
+    }
+    default: assert(false, "%s", type2name(to_elem_bt));
+  }
+}
+
 //-------------------------------------------------------------------------------------------
 
 // IndexOf for constant substrings with size >= 8 chars

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -2294,6 +2294,7 @@ void C2_MacroAssembler::vpadd(BasicType elem_bt, XMMRegister dst, XMMRegister sr
   }
 }
 
+#ifdef _LP64
 void C2_MacroAssembler::vpbroadcast(BasicType elem_bt, XMMRegister dst, Register src, int vlen_enc) {
   assert(UseAVX >= 2, "required");
   bool is_bw = ((elem_bt == T_BYTE) || (elem_bt == T_SHORT));
@@ -2317,11 +2318,12 @@ void C2_MacroAssembler::vpbroadcast(BasicType elem_bt, XMMRegister dst, Register
       case T_INT: movdl(dst, src); vpbroadcastd(dst, dst, vlen_enc); return;
       case T_FLOAT: movdl(dst, src); vbroadcastss(dst, dst, vlen_enc); return;
       case T_LONG: movdq(dst, src); vpbroadcastq(dst, dst, vlen_enc); return;
-      case T_DOUBLE: movdl(dst, src); vbroadcastsd(dst, dst, vlen_enc); return;
+      case T_DOUBLE: movdq(dst, src); vbroadcastsd(dst, dst, vlen_enc); return;
       default: assert(false, "%s", type2name(elem_bt));
     }
   }
 }
+#endif
 
 void C2_MacroAssembler::vconvert_b2x(BasicType to_elem_bt, XMMRegister dst, XMMRegister src, int vlen_enc) {
   switch (to_elem_bt) {

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -2276,6 +2276,7 @@ void C2_MacroAssembler::vectortest(int bt, int vlen, XMMRegister src1, XMMRegist
 
 void C2_MacroAssembler::vpadd(BasicType elem_bt, XMMRegister dst, XMMRegister src1, XMMRegister src2, int vlen_enc) {
   assert(UseAVX >= 2, "required");
+#ifdef ASSERT
   bool is_bw = ((elem_bt == T_BYTE) || (elem_bt == T_SHORT));
   bool is_bw_supported = VM_Version::supports_avx512bw();
   if (is_bw && !is_bw_supported) {
@@ -2283,6 +2284,7 @@ void C2_MacroAssembler::vpadd(BasicType elem_bt, XMMRegister dst, XMMRegister sr
     assert((dst->encoding() < 16) && (src1->encoding() < 16) && (src2->encoding() < 16),
            "XMM register should be 0-15");
   }
+#endif // ASSERT
   switch (elem_bt) {
     case T_BYTE: vpaddb(dst, src1, src2, vlen_enc); return;
     case T_SHORT: vpaddw(dst, src1, src2, vlen_enc); return;

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -132,6 +132,11 @@ public:
   void vectortest(int bt, int vlen, XMMRegister src1, XMMRegister src2,
                   XMMRegister vtmp1 = xnoreg, XMMRegister vtmp2 = xnoreg, KRegister mask = knoreg);
 
+ // Covert B2X
+ void vconvert_b2x(BasicType to_elem_bt, XMMRegister dst, XMMRegister src, int vlen_enc);
+ void vpbroadcast(BasicType elem_bt, XMMRegister dst, Register src, int vlen_enc);
+ void vpadd(BasicType elem_bt, XMMRegister dst, XMMRegister src1, XMMRegister src2, int vlen_enc);
+
   // blend
   void evpcmp(BasicType typ, KRegister kdmask, KRegister ksmask, XMMRegister src1, AddressLiteral adr, int comparison, int vector_len, Register scratch = rscratch1);
   void evpcmp(BasicType typ, KRegister kdmask, KRegister ksmask, XMMRegister src1, XMMRegister src2, int comparison, int vector_len);

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -134,7 +134,9 @@ public:
 
  // Covert B2X
  void vconvert_b2x(BasicType to_elem_bt, XMMRegister dst, XMMRegister src, int vlen_enc);
+#ifdef _LP64
  void vpbroadcast(BasicType elem_bt, XMMRegister dst, Register src, int vlen_enc);
+#endif
  void vpadd(BasicType elem_bt, XMMRegister dst, XMMRegister src1, XMMRegister src2, int vlen_enc);
 
   // blend

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -8266,12 +8266,12 @@ instruct VectorPopulateIndex(vec dst, rRegI src1, immI_1 src2, vec vtmp, rRegP s
   effect(TEMP dst, TEMP vtmp, TEMP scratch);
   format %{ "vector_populate_index $dst $src1 $src2\t! using $vtmp and $scratch as TEMP" %}
   ins_encode %{
-     int vlen_in_bytes = Matcher::vector_length_in_bytes(this);
+     assert($src2$$constant == 1, "required");
+     int vlen = Matcher::vector_length(this);
      int vlen_enc = vector_length_encoding(this);
      BasicType elem_bt = Matcher::vector_element_basic_type(this);
-     assert($src2$$constant == 1, "required");
      __ vpbroadcast(elem_bt, $vtmp$$XMMRegister, $src1$$Register, vlen_enc);
-     __ load_iota_indices($dst$$XMMRegister, $scratch$$Register, vlen_in_bytes/type2aelembytes(elem_bt));
+     __ load_iota_indices($dst$$XMMRegister, $scratch$$Register, vlen);
      if (elem_bt != T_BYTE) {
        __ vconvert_b2x(elem_bt, $dst$$XMMRegister, $dst$$XMMRegister, vlen_enc);
      }
@@ -8285,12 +8285,12 @@ instruct VectorPopulateLIndex(vec dst, rRegL src1, immI_1 src2, vec vtmp, rRegP 
   effect(TEMP dst, TEMP vtmp, TEMP scratch);
   format %{ "vector_populate_index $dst $src1 $src2\t! using $vtmp and $scratch as TEMP" %}
   ins_encode %{
-     int vlen_in_bytes = Matcher::vector_length_in_bytes(this);
+     assert($src2$$constant == 1, "required");
+     int vlen = Matcher::vector_length(this);
      int vlen_enc = vector_length_encoding(this);
      BasicType elem_bt = Matcher::vector_element_basic_type(this);
-     assert($src2$$constant == 1, "required");
      __ vpbroadcast(elem_bt, $vtmp$$XMMRegister, $src1$$Register, vlen_enc);
-     __ load_iota_indices($dst$$XMMRegister, $scratch$$Register, vlen_in_bytes/type2aelembytes(elem_bt));
+     __ load_iota_indices($dst$$XMMRegister, $scratch$$Register, vlen);
      if (elem_bt != T_BYTE) {
        __ vconvert_b2x(elem_bt, $dst$$XMMRegister, $dst$$XMMRegister, vlen_enc);
      }

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1469,6 +1469,10 @@ const bool Matcher::match_rule_supported(int opcode) {
       }
       break;
     case Op_PopulateIndex:
+      if (!is_LP64) {
+        return false;
+      }
+      // fallthrough
     case Op_RoundVF:
       if (UseAVX < 2) { // enabled for AVX2 only
         return false;
@@ -1814,8 +1818,6 @@ const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType 
       break;
     case Op_PopulateIndex:
       if (size_in_bits > 256 && !VM_Version::supports_avx512bw())
-        return false;
-      if (!is_LP64 && (bt == T_LONG))
         return false;
     case Op_VectorCastB2X:
     case Op_VectorCastS2X:
@@ -8257,6 +8259,7 @@ instruct loadIotaIndices(vec dst, immI_0 src, rRegP scratch) %{
   ins_pipe( pipe_slow );
 %}
 
+#ifdef _LP64
 instruct VectorPopulateIndex(vec dst, rRegI src1, immI_1 src2, vec vtmp, rRegP scratch) %{
   match(Set dst (PopulateIndex src1 src2));
   effect(TEMP dst, TEMP vtmp, TEMP scratch);
@@ -8276,7 +8279,6 @@ instruct VectorPopulateIndex(vec dst, rRegI src1, immI_1 src2, vec vtmp, rRegP s
   ins_pipe( pipe_slow );
 %}
 
-#ifdef _LP64
 instruct VectorPopulateLIndex(vec dst, rRegL src1, immI_1 src2, vec vtmp, rRegP scratch) %{
   match(Set dst (PopulateIndex src1 src2));
   effect(TEMP dst, TEMP vtmp, TEMP scratch);

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1469,10 +1469,10 @@ const bool Matcher::match_rule_supported(int opcode) {
       }
       break;
     case Op_PopulateIndex:
-      if (!is_LP64) {
+      if (!is_LP64 || (UseAVX < 2)) {
         return false;
       }
-      // fallthrough
+      break;
     case Op_RoundVF:
       if (UseAVX < 2) { // enabled for AVX2 only
         return false;
@@ -1817,8 +1817,9 @@ const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType 
       }
       break;
     case Op_PopulateIndex:
-      if (size_in_bits > 256 && !VM_Version::supports_avx512bw())
+      if (size_in_bits > 256 && !VM_Version::supports_avx512bw()) {
         return false;
+      }
     case Op_VectorCastB2X:
     case Op_VectorCastS2X:
     case Op_VectorCastI2X:

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1468,6 +1468,7 @@ const bool Matcher::match_rule_supported(int opcode) {
         return false;
       }
       break;
+    case Op_PopulateIndex:
     case Op_RoundVF:
       if (UseAVX < 2) { // enabled for AVX2 only
         return false;
@@ -1811,6 +1812,11 @@ const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType 
         return false; // Implementation limitation
       }
       break;
+    case Op_PopulateIndex:
+      if (size_in_bits > 256 && !VM_Version::supports_avx512bw())
+        return false;
+      if (!is_LP64 && (bt == T_LONG))
+        return false;
     case Op_VectorCastB2X:
     case Op_VectorCastS2X:
     case Op_VectorCastI2X:
@@ -6918,28 +6924,7 @@ instruct vcastBtoX(vec dst, vec src) %{
 
     BasicType to_elem_bt = Matcher::vector_element_basic_type(this);
     int vlen_enc = vector_length_encoding(this);
-    switch (to_elem_bt) {
-      case T_SHORT:
-        __ vpmovsxbw($dst$$XMMRegister, $src$$XMMRegister, vlen_enc);
-        break;
-      case T_INT:
-        __ vpmovsxbd($dst$$XMMRegister, $src$$XMMRegister, vlen_enc);
-        break;
-      case T_FLOAT:
-        __ vpmovsxbd($dst$$XMMRegister, $src$$XMMRegister, vlen_enc);
-        __ vcvtdq2ps($dst$$XMMRegister, $dst$$XMMRegister, vlen_enc);
-        break;
-      case T_LONG:
-        __ vpmovsxbq($dst$$XMMRegister, $src$$XMMRegister, vlen_enc);
-        break;
-      case T_DOUBLE: {
-        int mid_vlen_enc = (vlen_enc == Assembler::AVX_512bit) ? Assembler::AVX_256bit : Assembler::AVX_128bit;
-        __ vpmovsxbd($dst$$XMMRegister, $src$$XMMRegister, mid_vlen_enc);
-        __ vcvtdq2pd($dst$$XMMRegister, $dst$$XMMRegister, vlen_enc);
-        break;
-      }
-      default: assert(false, "%s", type2name(to_elem_bt));
-    }
+    __ vconvert_b2x(to_elem_bt, $dst$$XMMRegister, $src$$XMMRegister, vlen_enc);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -8272,6 +8257,45 @@ instruct loadIotaIndices(vec dst, immI_0 src, rRegP scratch) %{
   ins_pipe( pipe_slow );
 %}
 
+instruct VectorPopulateIndex(vec dst, rRegI src1, immI_1 src2, vec vtmp, rRegP scratch) %{
+  match(Set dst (PopulateIndex src1 src2));
+  effect(TEMP dst, TEMP vtmp, TEMP scratch);
+  format %{ "vector_populate_index $dst $src1 $src2\t! using $vtmp and $scratch as TEMP" %}
+  ins_encode %{
+     int vlen_in_bytes = Matcher::vector_length_in_bytes(this);
+     int vlen_enc = vector_length_encoding(this);
+     BasicType elem_bt = Matcher::vector_element_basic_type(this);
+     assert($src2$$constant == 1, "required");
+     __ vpbroadcast(elem_bt, $vtmp$$XMMRegister, $src1$$Register, vlen_enc);
+     __ load_iota_indices($dst$$XMMRegister, $scratch$$Register, vlen_in_bytes/type2aelembytes(elem_bt));
+     if (elem_bt != T_BYTE) {
+       __ vconvert_b2x(elem_bt, $dst$$XMMRegister, $dst$$XMMRegister, vlen_enc);
+     }
+     __ vpadd(elem_bt, $dst$$XMMRegister, $dst$$XMMRegister, $vtmp$$XMMRegister, vlen_enc);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+#ifdef _LP64
+instruct VectorPopulateLIndex(vec dst, rRegL src1, immI_1 src2, vec vtmp, rRegP scratch) %{
+  match(Set dst (PopulateIndex src1 src2));
+  effect(TEMP dst, TEMP vtmp, TEMP scratch);
+  format %{ "vector_populate_index $dst $src1 $src2\t! using $vtmp and $scratch as TEMP" %}
+  ins_encode %{
+     int vlen_in_bytes = Matcher::vector_length_in_bytes(this);
+     int vlen_enc = vector_length_encoding(this);
+     BasicType elem_bt = Matcher::vector_element_basic_type(this);
+     assert($src2$$constant == 1, "required");
+     __ vpbroadcast(elem_bt, $vtmp$$XMMRegister, $src1$$Register, vlen_enc);
+     __ load_iota_indices($dst$$XMMRegister, $scratch$$Register, vlen_in_bytes/type2aelembytes(elem_bt));
+     if (elem_bt != T_BYTE) {
+       __ vconvert_b2x(elem_bt, $dst$$XMMRegister, $dst$$XMMRegister, vlen_enc);
+     }
+     __ vpadd(elem_bt, $dst$$XMMRegister, $dst$$XMMRegister, $vtmp$$XMMRegister, vlen_enc);
+  %}
+  ins_pipe( pipe_slow );
+%}
+#endif
 //-------------------------------- Rearrange ----------------------------------
 
 // LoadShuffle/Rearrange for Byte

--- a/test/hotspot/jtreg/compiler/vectorization/TestPopulateIndex.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestPopulateIndex.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+* @test
+* @summary Test vectorization of loop induction variable usage in the loop
+* @requires vm.compiler2.enabled
+* @requires vm.cpu.features ~= ".*avx2.*"
+* @requires os.arch=="amd64" | os.arch=="x86_64"
+* @library /test/lib /
+* @run driver compiler.vectorization.TestPopulateIndex
+*/
+
+package compiler.vectorization;
+import compiler.lib.ir_framework.*;
+import java.util.Random;
+
+public class TestPopulateIndex {
+    private static final int count = 65536;
+
+    private int[] idx;
+    private int[] src;
+    private int[] dst;
+    private float[] f;
+
+    public static void main(String args[]) {
+        TestFramework.run(TestPopulateIndex.class);
+    }
+
+    public TestPopulateIndex() {
+        idx = new int[count];
+        src = new int[count];
+        dst = new int[count];
+        f = new float[count];
+        Random ran = new Random(0);
+        for (int i = 0; i < count; i++) {
+            src[i] = ran.nextInt();
+        }
+    }
+
+    @Test
+    @Warmup(10000)
+    @IR(counts = {"PopulateIndex", ">= 1"})
+    public void indexArrayFill() {
+        for (int i = 0; i < count; i++) {
+            idx[i] = i;
+        }
+        checkResultIndexArrayFill();
+    }
+
+    public void checkResultIndexArrayFill() {
+        for (int i = 0; i < count; ++i) {
+            int expected = i;
+            if (idx[i] != expected) {
+                throw new RuntimeException("Invalid result: idx[" + i + "] = " + idx[i] + " != " + expected);
+            }
+        }
+    }
+
+    @Test
+    @Warmup(10000)
+    @IR(counts = {"PopulateIndex", ">= 1"})
+    public void exprWithIndex1() {
+        for (int i = 0; i < count; i++) {
+            dst[i] = src[i] * (i & 7);
+        }
+        checkResultExprWithIndex1();
+    }
+
+    public void checkResultExprWithIndex1() {
+        for (int i = 0; i < count; ++i) {
+            int expected = src[i] * (i & 7);
+            if (dst[i] != expected) {
+                throw new RuntimeException("Invalid result: dst[" + i + "] = " + dst[i] + " != " + expected);
+            }
+        }
+    }
+
+    @Test
+    @Warmup(10000)
+    @IR(counts = {"PopulateIndex", ">= 1"})
+    public void exprWithIndex2() {
+        for (int i = 0; i < count; i++) {
+            f[i] = i * i + 100;
+        }
+        checkResultExprWithIndex2();
+    }
+
+    public void checkResultExprWithIndex2() {
+        for (int i = 0; i < count; ++i) {
+            float expected = i * i  + 100;
+            if (f[i] != expected) {
+                throw new RuntimeException("Invalid result: f[" + i + "] = " + f[i] + " != " + expected);
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/vectorization/TestPopulateIndex.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestPopulateIndex.java
@@ -59,7 +59,6 @@ public class TestPopulateIndex {
     }
 
     @Test
-    @Warmup(10000)
     @IR(counts = {"PopulateIndex", ">= 1"})
     public void indexArrayFill() {
         for (int i = 0; i < count; i++) {
@@ -78,7 +77,6 @@ public class TestPopulateIndex {
     }
 
     @Test
-    @Warmup(10000)
     @IR(counts = {"PopulateIndex", ">= 1"})
     public void exprWithIndex1() {
         for (int i = 0; i < count; i++) {
@@ -97,7 +95,6 @@ public class TestPopulateIndex {
     }
 
     @Test
-    @Warmup(10000)
     @IR(counts = {"PopulateIndex", ">= 1"})
     public void exprWithIndex2() {
         for (int i = 0; i < count; i++) {

--- a/test/hotspot/jtreg/compiler/vectorization/TestPopulateIndex.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestPopulateIndex.java
@@ -25,8 +25,8 @@
 * @test
 * @summary Test vectorization of loop induction variable usage in the loop
 * @requires vm.compiler2.enabled
-* @requires vm.cpu.features ~= ".*avx2.*"
-* @requires os.arch=="amd64" | os.arch=="x86_64"
+* @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") |
+*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*sve.*")
 * @library /test/lib /
 * @run driver compiler.vectorization.TestPopulateIndex
 */

--- a/test/hotspot/jtreg/compiler/vectorization/TestPopulateIndex.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestPopulateIndex.java
@@ -23,6 +23,7 @@
 
 /**
 * @test
+* @bug 8286972
 * @summary Test vectorization of loop induction variable usage in the loop
 * @requires vm.compiler2.enabled
 * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") |
@@ -36,7 +37,7 @@ import compiler.lib.ir_framework.*;
 import java.util.Random;
 
 public class TestPopulateIndex {
-    private static final int count = 65536;
+    private static final int count = 10000;
 
     private int[] idx;
     private int[] src;
@@ -68,7 +69,7 @@ public class TestPopulateIndex {
     }
 
     public void checkResultIndexArrayFill() {
-        for (int i = 0; i < count; ++i) {
+        for (int i = 0; i < count; i++) {
             int expected = i;
             if (idx[i] != expected) {
                 throw new RuntimeException("Invalid result: idx[" + i + "] = " + idx[i] + " != " + expected);
@@ -86,7 +87,7 @@ public class TestPopulateIndex {
     }
 
     public void checkResultExprWithIndex1() {
-        for (int i = 0; i < count; ++i) {
+        for (int i = 0; i < count; i++) {
             int expected = src[i] * (i & 7);
             if (dst[i] != expected) {
                 throw new RuntimeException("Invalid result: dst[" + i + "] = " + dst[i] + " != " + expected);
@@ -104,7 +105,7 @@ public class TestPopulateIndex {
     }
 
     public void checkResultExprWithIndex2() {
-        for (int i = 0; i < count; ++i) {
+        for (int i = 0; i < count; i++) {
             float expected = i * i  + 100;
             if (f[i] != expected) {
                 throw new RuntimeException("Invalid result: f[" + i + "] = " + f[i] + " != " + expected);


### PR DESCRIPTION
This PR adds x86 backend support for the new loop induction variable related PopulateIndex IR node. 
This IR node was added as part of [JDK-8280510](https://bugs.openjdk.java.net/browse/JDK-8280510).

The performance numbers are as follows:
Before:
Benchmark                   (count)   Mode  Cnt       Score       Error  Units
IndexVector.exprWithIndex1    65536  thrpt    3   64556.552 ±  1126.396  ops/s
IndexVector.exprWithIndex2    65536  thrpt    3   22117.050 ± 11452.098  ops/s
IndexVector.indexArrayFill    65536  thrpt    3  117776.383 ±  1120.957  ops/s

After:
Benchmark                   (count)   Mode  Cnt       Score       Error  Units
IndexVector.exprWithIndex1    65536  thrpt    3  203180.290 ±  2147.807  ops/s
IndexVector.exprWithIndex2    65536  thrpt    3  274132.756 ±  6853.393  ops/s
IndexVector.indexArrayFill    65536  thrpt    3  374165.202 ± 46930.779  ops/s

Please review.

Best Regards,
Sandhya

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286972](https://bugs.openjdk.java.net/browse/JDK-8286972): Support the new loop induction variable related PopulateIndex IR node on x86


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [727daec0](https://git.openjdk.java.net/jdk/pull/8778/files/727daec095e9779724fc5924dbf41d8c8de7c98f)
 * [Jatin Bhateja](https://openjdk.java.net/census#jbhateja) (@jatin-bhateja - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8778/head:pull/8778` \
`$ git checkout pull/8778`

Update a local copy of the PR: \
`$ git checkout pull/8778` \
`$ git pull https://git.openjdk.java.net/jdk pull/8778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8778`

View PR using the GUI difftool: \
`$ git pr show -t 8778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8778.diff">https://git.openjdk.java.net/jdk/pull/8778.diff</a>

</details>
