### PR TITLE
8287008: Improve tests for thread dumps in JSON format

### DIFF
--- a/src/java.base/share/classes/jdk/internal/vm/ThreadDumper.java
+++ b/src/java.base/share/classes/jdk/internal/vm/ThreadDumper.java
@@ -188,7 +188,7 @@ public class ThreadDumper {
 
         String now = Instant.now().toString();
         String runtimeVersion = Runtime.version().toString();
-        out.format("    \"processId\": %d,%n", processId());
+        out.format("    \"processId\": \"%d\",%n", processId());
         out.format("    \"time\": \"%s\",%n", escape(now));
         out.format("    \"runtimeVersion\": \"%s\",%n", escape(runtimeVersion));
 
@@ -226,7 +226,7 @@ public class ThreadDumper {
         if (owner == null) {
             out.format("        \"owner\": null,%n");
         } else {
-            out.format("        \"owner\": %d,%n", owner.threadId());
+            out.format("        \"owner\": \"%d\",%n", owner.threadId());
         }
 
         long threadCount = 0;
@@ -241,7 +241,7 @@ public class ThreadDumper {
 
         // thread count
         threadCount = Long.max(threadCount, container.threadCount());
-        out.format("        \"threadCount\": %d%n", threadCount);
+        out.format("        \"threadCount\": \"%d\"%n", threadCount);
 
         if (more) {
             out.println("      },");
@@ -255,7 +255,7 @@ public class ThreadDumper {
      */
     private static void dumpThreadToJson(Thread thread, PrintStream out, boolean more) {
         out.println("         {");
-        out.format("           \"tid\": %d,%n", thread.threadId());
+        out.format("           \"tid\": \"%d\",%n", thread.threadId());
         out.format("           \"name\": \"%s\",%n", escape(thread.getName()));
         out.format("           \"stack\": [%n");
         int i = 0;

--- a/test/hotspot/jtreg/serviceability/dcmd/thread/ThreadDumpToFileTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/thread/ThreadDumpToFileTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8284161 8287008
  * @summary Basic test for jcmd Thread.dump_to_file
  * @library /test/lib
  * @run testng/othervm ThreadDumpToFileTest
@@ -34,6 +35,8 @@ import java.nio.file.Path;
 import java.util.stream.Stream;
 import jdk.test.lib.dcmd.PidJcmdExecutor;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.threaddump.ThreadDump;
+
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
@@ -65,13 +68,14 @@ public class ThreadDumpToFileTest {
         Path file = genThreadDumpPath(".json");
         threadDump(file, "-format=json").shouldMatch("Created");
 
-        // test that the threadDump object is present
-        assertTrue(find(file, "threadDump"), "`threadDump` not found in " + file);
+        // parse the JSON text
+        String jsonText = Files.readString(file);
+        ThreadDump threadDump = ThreadDump.parse(jsonText);
 
         // test that thread dump contains the id of the current thread
-        long tid = Thread.currentThread().threadId();
-        String expected = "\"tid\": " + tid;
-        assertTrue(find(file, expected), expected + " not found in " + file);
+        var rootContainer = threadDump.rootThreadContainer();
+        var tid = Thread.currentThread().threadId();
+        rootContainer.findThread(tid).orElseThrow();
     }
 
     /**

--- a/test/hotspot/jtreg/serviceability/dcmd/thread/ThreadDumpToFileTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/thread/ThreadDumpToFileTest.java
@@ -72,7 +72,10 @@ public class ThreadDumpToFileTest {
         String jsonText = Files.readString(file);
         ThreadDump threadDump = ThreadDump.parse(jsonText);
 
-        // test that thread dump contains the id of the current thread
+        // test that the process id is this process
+        assertTrue(threadDump.processId() == ProcessHandle.current().pid());
+
+        // test that the current thread is in the root thread container
         var rootContainer = threadDump.rootThreadContainer();
         var tid = Thread.currentThread().threadId();
         rootContainer.findThread(tid).orElseThrow();

--- a/test/jdk/com/sun/management/HotSpotDiagnosticMXBean/DumpThreads.java
+++ b/test/jdk/com/sun/management/HotSpotDiagnosticMXBean/DumpThreads.java
@@ -131,7 +131,8 @@ public class DumpThreads {
                     rootContainer.findThread(currentThread.threadId()).orElseThrow();
                 }
 
-                // find the thread container for the executor
+                // find the thread container for the executor. The name of this executor
+                // is its String representaiton in this case.
                 String name = executor.toString();
                 var container = threadDump.findThreadContainer(name).orElseThrow();
                 assertFalse(container.owner().isPresent());

--- a/test/lib/jdk/test/lib/threaddump/ThreadDump.java
+++ b/test/lib/jdk/test/lib/threaddump/ThreadDump.java
@@ -82,7 +82,7 @@ import jdk.test.lib.json.JSONValue;
  *         "owner": null,
  *         "threads": [...],
  *         "threadCount": "1"
- *       }
+ *       },
  *       {
  *         "container": "java.util.concurrent.ThreadPoolExecutor@20322d26\/jdk.internal.vm.SharedThreadContainer@184f6be2",
  *         "parent": "<root>",

--- a/test/lib/jdk/test/lib/threaddump/ThreadDump.java
+++ b/test/lib/jdk/test/lib/threaddump/ThreadDump.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.threaddump;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+import jdk.test.lib.json.JSONValue;
+
+/**
+ * Represents a thread dump that is obtained by parsing JSON text.
+ */
+public final class ThreadDump {
+    private final String processId;
+    private final String time;
+    private final String runtimeVersion;
+    private ThreadContainer rootThreadContainer;
+
+    /**
+     * Represents an element in the threadDump/threadContainers array.
+     */
+    public static class ThreadContainer {
+        private final String name;
+        private long ownerTid;
+        private ThreadContainer parent;
+        private Set<ThreadInfo> threads;
+        private final Set<ThreadContainer> children = new HashSet<>();
+
+        ThreadContainer(String name) {
+            this.name = name;
+        }
+
+        /**
+         * Returns the thread container name.
+         */
+        public String name() {
+            return name;
+        }
+
+        /**
+         * Return the thread identifier of the owner thread or {@code null} if not owned.
+         */
+        public long ownerTid() {
+            return ownerTid;
+        }
+
+        /**
+         * Returns the parent thread container or {@code null} if this is the root.
+         */
+        public ThreadContainer parent() {
+            return parent;
+        }
+
+        /**
+         * Returns a stream of the children thread containers.
+         */
+        public Stream<ThreadContainer> children() {
+            return children.stream();
+        }
+
+        /**
+         * Returns a stream of {@code ThreadInfo} objects for the threads in this container.
+         */
+        public Stream<ThreadInfo> threads() {
+            return threads.stream();
+        }
+
+        /**
+         * Finds the thread in this container with the given thread identifier.
+         */
+        public Optional<ThreadInfo> findThread(long tid) {
+            return threads()
+                    .filter(ti -> ti.tid() == tid)
+                    .findAny();
+        }
+
+
+        /**
+         * Helper method to recursively find a container with the given name.
+         */
+        ThreadContainer findThreadContainer(String name) {
+            if (name().equals(name))
+                return this;
+            if (name().startsWith(name + "/"))
+                return this;
+            return children()
+                    .map(c -> c.findThreadContainer(name))
+                    .filter(c -> c != null)
+                    .findAny()
+                    .orElse(null);
+        }
+
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof ThreadContainer other) {
+                return name.equals(other.name);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    /**
+     * Represents an element in the threadDump/threadContainers/threads array.
+     */
+    public static final class ThreadInfo {
+        private final long tid;
+        private final String name;
+        private final List<String> stack;
+
+        ThreadInfo(long tid, String name, List<String> stack) {
+            this.tid = tid;
+            this.name = name;
+            this.stack = stack;
+        }
+
+        /**
+         * Returns the thread identifier.
+         */
+        public long tid() {
+            return tid;
+        }
+
+        /**
+         * Returns the thread name.
+         */
+        public String name() {
+            return name;
+        }
+
+        /**
+         * Returns the thread stack.
+         */
+        public Stream<String> stack() {
+            return stack.stream();
+        }
+
+        @Override
+        public int hashCode() {
+            return Long.hashCode(tid);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof ThreadInfo other) {
+                return this.tid == other.tid;
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder("#");
+            sb.append(tid);
+            if (name.length() > 0) {
+                sb.append(",");
+                sb.append(name);
+            }
+            return sb.toString();
+        }
+    }
+
+    /**
+     * Parses the given JSON text as a thread dump.
+     */
+    private ThreadDump(String json) {
+        JSONValue threadDumpObj = JSONValue.parse(json).get("threadDump");
+
+        // maps container name to ThreadContainer
+        Map<String, ThreadContainer> map = new HashMap<>();
+
+        // threadContainers array
+        JSONValue threadContainersObj = threadDumpObj.get("threadContainers");
+        for (JSONValue containerObj : threadContainersObj.asArray()) {
+            String name = containerObj.get("container").asString();
+            String parentName = containerObj.get("parent").asString();
+            String owner = containerObj.get("owner").asString();
+            JSONValue.JSONArray threadsObj = containerObj.get("threads").asArray();
+
+            // threads array
+            Set<ThreadInfo> threadInfos = new HashSet<>();
+            for (JSONValue threadObj : threadsObj) {
+                long tid = Long.parseLong(threadObj.get("tid").asString());
+                String threadName = threadObj.get("name").asString();
+                JSONValue.JSONArray stackObj = threadObj.get("stack").asArray();
+                List<String> stack = new ArrayList<>();
+                for (JSONValue steObject : stackObj) {
+                    stack.add(steObject.asString());
+                }
+                threadInfos.add(new ThreadInfo(tid, threadName, stack));
+            }
+
+            // add to map if not already encountered
+            var container = map.computeIfAbsent(name, k -> new ThreadContainer(name));
+            if (owner != null)
+                container.ownerTid = Long.parseLong(owner);
+            container.threads = threadInfos;
+
+            if (parentName == null) {
+                rootThreadContainer = container;
+            } else {
+                // add parent to map if not already encountered and add to set of children
+                var parent = map.computeIfAbsent(parentName,k -> new ThreadContainer(parentName));
+                container.parent = parent;
+                parent.children.add(container);
+            }
+        }
+
+        this.processId = threadDumpObj.get("processId").asString();
+        this.time = threadDumpObj.get("time").asString();
+        this.runtimeVersion = threadDumpObj.get("runtimeVersion").asString();
+    }
+
+    /**
+     * Returns the value of threadDump/processId.
+     */
+    public String processId() {
+        return processId;
+    }
+
+    /**
+     * Returns the value of threadDump/time.
+     */
+    public String time() {
+        return time;
+    }
+
+    /**
+     * Returns the value of threadDump/runtimeVersion.
+     */
+    public String runtimeVersion() {
+        return runtimeVersion;
+    }
+
+    /**
+     * Returns the root container in the threadDump/threadContainers array.
+     */
+    public ThreadContainer rootThreadContainer() {
+        return rootThreadContainer;
+    }
+
+    /**
+     * Finds a container in the threadDump/threadContainers array with the given name.
+     */
+    public Optional<ThreadContainer> findThreadContainer(String name) {
+        ThreadContainer container = rootThreadContainer.findThreadContainer(name);
+        return Optional.ofNullable(container);
+    }
+
+    /**
+     * Parses JSON text as a thread dump.
+     * @throws RuntimeException if an error occurs
+     */
+    public static ThreadDump parse(String json) {
+        return new ThreadDump(json);
+    }
+}

--- a/test/lib/jdk/test/lib/threaddump/ThreadDump.java
+++ b/test/lib/jdk/test/lib/threaddump/ThreadDump.java
@@ -79,7 +79,7 @@ import jdk.test.lib.json.JSONValue;
  *         "container": "ForkJoinPool.commonPool",
  *         "parent": "<root>",
  *         "owner": null,
- *         "threads:": [...],
+ *         "threads": [...],
  *         "threadCount": 1
  *       }
  *     ]


### PR DESCRIPTION
This change is mostly test infrastructure and improvements to the testing of thread dumps in JSON format. It also tweaks the thread dump format so that the process identifier and thread identifiers are a type string rather than number.

The tests for thread dumps added by JEP 425 are changed to use the test infrastructure library. The tests for JEP 428 will also make use of this test infrastructure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287008](https://bugs.openjdk.java.net/browse/JDK-8287008): Improve tests for thread dumps in JSON format


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8784/head:pull/8784` \
`$ git checkout pull/8784`

Update a local copy of the PR: \
`$ git checkout pull/8784` \
`$ git pull https://git.openjdk.java.net/jdk pull/8784/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8784`

View PR using the GUI difftool: \
`$ git pr show -t 8784`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8784.diff">https://git.openjdk.java.net/jdk/pull/8784.diff</a>

</details>
