### PR TITLE
8286893: G1: Recent card set coarsening statistics wrong

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -157,6 +157,14 @@ void G1CardSetCoarsenStats::reset() {
   }
 }
 
+void G1CardSetCoarsenStats::set(G1CardSetCoarsenStats& other) {
+  STATIC_ASSERT(ARRAY_SIZE(_coarsen_from) == ARRAY_SIZE(_coarsen_collision));
+  for (uint i = 0; i < ARRAY_SIZE(_coarsen_from); i++) {
+    _coarsen_from[i] = other._coarsen_from[i];
+    _coarsen_collision[i] = other._coarsen_collision[i];
+  }
+}
+
 void G1CardSetCoarsenStats::subtract_from(G1CardSetCoarsenStats& other) {
   STATIC_ASSERT(ARRAY_SIZE(_coarsen_from) == ARRAY_SIZE(_coarsen_collision));
   for (uint i = 0; i < ARRAY_SIZE(_coarsen_from); i++) {
@@ -893,10 +901,13 @@ G1CardSetCoarsenStats G1CardSet::coarsen_stats() {
 
 void G1CardSet::print_coarsen_stats(outputStream* out) {
   _last_coarsen_stats.subtract_from(_coarsen_stats);
+
   out->print("Coarsening (recent): ");
   _last_coarsen_stats.print_on(out);
   out->print("Coarsening (all): ");
   _coarsen_stats.print_on(out);
+
+  _last_coarsen_stats.set(_coarsen_stats);
 }
 
 size_t G1CardSet::mem_size() const {

--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -161,6 +161,8 @@ public:
 
   void reset();
 
+  void set(G1CardSetCoarsenStats& other);
+
   void subtract_from(G1CardSetCoarsenStats& other);
 
   // Record a coarsening for the given tag/category. Collision should be true if
@@ -189,7 +191,7 @@ class G1CardSet : public CHeapObj<mtGCCardSet> {
   friend class G1ReleaseCardsets;
 
   static G1CardSetCoarsenStats _coarsen_stats; // Coarsening statistics since VM start.
-  static G1CardSetCoarsenStats _last_coarsen_stats; // Coarsening statistics at last GC.
+  static G1CardSetCoarsenStats _last_coarsen_stats; // Coarsening statistics before last GC.
 public:
   // Two lower bits are used to encode the card set container types
   static const uintptr_t ContainerPtrHeaderSize = 2;


### PR DESCRIPTION
Looking at G1CardSet::print_coarsen_stats() the recent coarsening stats are calculated by:

current total coarsening - coarsening happened in previous (the one before the latest) GC cycle

but should be

current total coarsening - previous total coarsening



A sample output after the commit:
GC(71) Coarsening (recent): Inline->AoC 62300 (202) AoC->Howl 6879 (163) Howl->Full 0 (0) Inline->AoC 52757 (123) AoC->BitMap 3750 (498) BitMap->Full 0 (0)
GC(71) Coarsening (all): Inline->AoC 7032200 (8895) AoC->Howl 2167925 (13809) Howl->Full 0 (0) Inline->AoC 16892632 (11060) AoC->BitMap 300358 (32143) BitMap->Full 0 (0)
GC(72) Coarsening (recent): Inline->AoC 61664 (87) AoC->Howl 6430 (70) Howl->Full 0 (0) Inline->AoC 49677 (30) AoC->BitMap 3358 (179) BitMap->Full 0 (0)
GC(72) Coarsening (all): Inline->AoC 7093864 (8982) AoC->Howl 2174355 (13879) Howl->Full 0 (0) Inline->AoC 16942309 (11090) AoC->BitMap 303716 (32322) BitMap->Full 0 (0)
GC(74) Coarsening (recent): Inline->AoC 807201 (57) AoC->Howl 13360 (48) Howl->Full 0 (0) Inline->AoC 94560 (30) AoC->BitMap 29545 (190) BitMap->Full 0 (0)
GC(74) Coarsening (all): Inline->AoC 7901065 (9039) AoC->Howl 2187715 (13927) Howl->Full 0 (0) Inline->AoC 17036869 (11120) AoC->BitMap 333261 (32512) BitMap->Full 0 (0)
GC(75) Coarsening (recent): Inline->AoC 137571 (258) AoC->Howl 70042 (659) Howl->Full 0 (0) Inline->AoC 543734 (461) AoC->BitMap 5747 (937) BitMap->Full 0 (0)
GC(75) Coarsening (all): Inline->AoC 8038636 (9297) AoC->Howl 2257757 (14586) Howl->Full 0 (0) Inline->AoC 17580603 (11581) AoC->BitMap 339008 (33449) BitMap->Full 0 (0)



Testing: tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286893](https://bugs.openjdk.java.net/browse/JDK-8286893): G1: Recent card set coarsening statistics wrong


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8785/head:pull/8785` \
`$ git checkout pull/8785`

Update a local copy of the PR: \
`$ git checkout pull/8785` \
`$ git pull https://git.openjdk.java.net/jdk pull/8785/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8785`

View PR using the GUI difftool: \
`$ git pr show -t 8785`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8785.diff">https://git.openjdk.java.net/jdk/pull/8785.diff</a>

</details>
