### PR TITLE
8287013: StringConcatFactory: remove short and byte mixers/prependers

### DIFF
--- a/src/java.base/share/classes/java/lang/StringConcatHelper.java
+++ b/src/java.base/share/classes/java/lang/StringConcatHelper.java
@@ -75,30 +75,8 @@ final class StringConcatHelper {
      * @param value       value to mix in
      * @return            new length and coder
      */
-    static long mix(long lengthCoder, byte value) {
-        return mix(lengthCoder, (int)value);
-    }
-
-    /**
-     * Mix value length and coder into current length and coder.
-     * @param lengthCoder String length with coder packed into higher bits
-     *                    the upper word.
-     * @param value       value to mix in
-     * @return            new length and coder
-     */
     static long mix(long lengthCoder, char value) {
         return checkOverflow(lengthCoder + 1) | (StringLatin1.canEncode(value) ? 0 : UTF16);
-    }
-
-    /**
-     * Mix value length and coder into current length and coder.
-     * @param lengthCoder String length with coder packed into higher bits
-     *                    the upper word.
-     * @param value       value to mix in
-     * @return            new length and coder
-     */
-    static long mix(long lengthCoder, short value) {
-        return mix(lengthCoder, (int)value);
     }
 
     /**
@@ -199,23 +177,6 @@ final class StringConcatHelper {
     }
 
     /**
-     * Prepends constant and the stringly representation of value into buffer,
-     * given the coder and final index. Index is measured in chars, not in bytes!
-     *
-     * @param indexCoder final char index in the buffer, along with coder packed
-     *                   into higher bits.
-     * @param buf        buffer to append to
-     * @param value      boolean value to encode
-     * @param prefix     a constant to prepend before value
-     * @return           updated index (coder value retained)
-     */
-    static long prepend(long indexCoder, byte[] buf, byte value, String prefix) {
-        indexCoder = prepend(indexCoder, buf, (int)value);
-        if (prefix != null) indexCoder = prepend(indexCoder, buf, prefix);
-        return indexCoder;
-    }
-
-    /**
      * Prepends the stringly representation of char value into buffer,
      * given the coder and final index. Index is measured in chars, not in bytes!
      *
@@ -247,23 +208,6 @@ final class StringConcatHelper {
      */
     static long prepend(long indexCoder, byte[] buf, char value, String prefix) {
         indexCoder = prepend(indexCoder, buf, value);
-        if (prefix != null) indexCoder = prepend(indexCoder, buf, prefix);
-        return indexCoder;
-    }
-
-    /**
-     * Prepends constant and the stringly representation of value into buffer,
-     * given the coder and final index. Index is measured in chars, not in bytes!
-     *
-     * @param indexCoder final char index in the buffer, along with coder packed
-     *                   into higher bits.
-     * @param buf        buffer to append to
-     * @param value      boolean value to encode
-     * @param prefix     a constant to prepend before value
-     * @return           updated index (coder value retained)
-     */
-    static long prepend(long indexCoder, byte[] buf, short value, String prefix) {
-        indexCoder = prepend(indexCoder, buf, (int)value);
         if (prefix != null) indexCoder = prepend(indexCoder, buf, prefix);
         return indexCoder;
     }


### PR DESCRIPTION
The current short and byte mixers and prependers simply delegate to the int variants. At the LambdaForm level the values has already been implicitly cast to int, so removing this indirection and directly adapting to call the int-based variants is possible.

This is a cleanup with minimal effect on bootstrap overhead and peak performance, since all the LF logic only deals with basic types (where byte and short and other subword primitives has been widened to ints anyhow).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287013](https://bugs.openjdk.java.net/browse/JDK-8287013): StringConcatFactory: remove short and byte mixers/prependers


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8786/head:pull/8786` \
`$ git checkout pull/8786`

Update a local copy of the PR: \
`$ git checkout pull/8786` \
`$ git pull https://git.openjdk.java.net/jdk pull/8786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8786`

View PR using the GUI difftool: \
`$ git pr show -t 8786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8786.diff">https://git.openjdk.java.net/jdk/pull/8786.diff</a>

</details>
