### PR TITLE
8190546: File.toPath() reject directory names with trailing space

### DIFF
--- a/src/java.base/windows/classes/sun/nio/fs/WindowsPathParser.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsPathParser.java
@@ -164,14 +164,9 @@ class WindowsPathParser {
         int len = path.length();
         off = nextNonSlash(path, off, len);
         int start = off;
-        char lastC = 0;
         while (off < len) {
             char c = path.charAt(off);
             if (isSlash(c)) {
-                if (lastC == ' ')
-                    throw new InvalidPathException(path,
-                                                   "Trailing char <" + lastC + ">",
-                                                   off - 1);
                 sb.append(path, start, off);
                 off = nextNonSlash(path, off, len);
                 if (off != len)   //no slash at the end of normalized path
@@ -182,15 +177,10 @@ class WindowsPathParser {
                     throw new InvalidPathException(path,
                                                    "Illegal char <" + c + ">",
                                                    off);
-                lastC = c;
                 off++;
             }
         }
         if (start != off) {
-            if (lastC == ' ')
-                throw new InvalidPathException(path,
-                                               "Trailing char <" + lastC + ">",
-                                               off - 1);
             sb.append(path, start, off);
         }
         return sb.toString();

--- a/test/jdk/java/nio/file/Path/PathOps.java
+++ b/test/jdk/java/nio/file/Path/PathOps.java
@@ -1412,10 +1412,10 @@ public class PathOps {
             .invalid();
         test("foo\u0000\bar")
             .invalid();
-        test("C:\\foo ")                // trailing space
-             .invalid();
+        test("C:\\foo ")
+            .string("C:\\foo ");// trailing space
         test("C:\\foo \\bar")
-            .invalid();
+            .string("C:\\foo \\bar");
         //test("C:\\foo.")              // trailing dot
             //.invalid();
         //test("C:\\foo...\\bar")

--- a/test/jdk/java/nio/file/Path/TrailingSpace.java
+++ b/test/jdk/java/nio/file/Path/TrailingSpace.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 JetBrains s.r.o.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8190546
+ * @summary Verifies that a path name that ends with a space can be
+ *          successfully created and deleted.
+ */
+
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.io.IOException;
+
+public class TrailingSpace {
+    static void testResolve(String parent, String... paths) {
+        final Path p = Path.of(parent, paths);
+        System.out.println("Path successfully created: " + p);
+    }
+
+    static void testResolve(String path) {
+        final Path p = Path.of(path);
+        System.out.println("Path successfully created: " + p);
+    }
+
+    static void testDelete(String path) throws IOException {
+        final Path p = Files.createDirectories(Path.of(path));
+        Files.delete(p);
+    }
+
+    public static void main(String args[]) throws IOException {
+        testResolve("./", "ends-with-space ");
+        testResolve("ends-with-space ");
+        testResolve("1", "2", "ends-with-space ", "3");
+        testResolve("1\\2\\ends-with-space \\3");
+        testResolve("1/2/ends-with-space /3");
+        testResolve("1/2/ends-with-space \\3");
+        testResolve("ends-with-space /");
+        testResolve("ends-with-space ///");
+        testResolve("ends-with-space \\");
+        testResolve("ends-with-space \\\\\\");
+
+        testDelete("ends-with-space ");
+        testDelete("ends-with-space-1 \\");
+    }
+}


### PR DESCRIPTION
[JDK-8190546](https://bugs.openjdk.java.net/browse/JDK-8190546) is currently closed as will-not-fix with a reference to Win32 documentation [1] that kind of discourages the use of space at the very end of a file name. That documentation says the following:

> Do not end a file or directory name with a space or a period. Although the underlying file system may support such names, the Windows shell and user interface does not


Indeed, it's hard or even impossible to create such a file using the "normal" windows GUI, but you can use that GUI to _delete_ such a file. In Java, you can't do either. 

I'm proposing to lift this restriction primarily based on our user's requests and one or two use cases that seem legitimate.

Working in a cygwin terminal, you can fairly easily create a file name ending with a space. And when you turn to your Java-based IDE to delete it, you get an error from the very basic level of NIO that you can't overrule, which seems to be quite unfortunate. Another source of files legitimately ending with a space would be any Unix filesystem accessed from a Windows Java application (be that a local `\\wsl$` or a NFS mounted from a remote machine). 

If you are interested in moving forward with the issue, please review the PR. Thank you!

References
[1] https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8190546](https://bugs.openjdk.java.net/browse/JDK-8190546): File.toPath() reject directory names with trailing space ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8788/head:pull/8788` \
`$ git checkout pull/8788`

Update a local copy of the PR: \
`$ git checkout pull/8788` \
`$ git pull https://git.openjdk.java.net/jdk pull/8788/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8788`

View PR using the GUI difftool: \
`$ git pr show -t 8788`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8788.diff">https://git.openjdk.java.net/jdk/pull/8788.diff</a>

</details>
