### PR TITLE
8287044: Loom: Incorrect StackChunk::pc accessors

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -1168,8 +1168,8 @@ class jdk_internal_vm_StackChunk: AllStatic {
   static inline int sp(oop chunk);
   static inline void set_sp(oop chunk, int value);
   static inline void set_sp(HeapWord* chunk, int value); // used while allocating
-  static inline intptr_t pc(oop chunk);
-  static inline void set_pc(oop chunk, intptr_t value);
+  static inline address pc(oop chunk);
+  static inline void set_pc(oop chunk, address value);
   static inline int argsize(oop chunk);
   static inline void set_argsize(oop chunk, int value);
   static inline uint8_t flags(oop chunk);

--- a/src/hotspot/share/classfile/javaClasses.inline.hpp
+++ b/src/hotspot/share/classfile/javaClasses.inline.hpp
@@ -326,12 +326,12 @@ inline void jdk_internal_vm_StackChunk::set_sp(HeapWord* chunk, int value) {
   *(int*)(((char*)chunk) + _sp_offset) = (int)value;
 }
 
-inline intptr_t jdk_internal_vm_StackChunk::pc(oop chunk) {
-  return chunk->long_field(_pc_offset);
+inline address jdk_internal_vm_StackChunk::pc(oop chunk) {
+  return chunk->address_field(_pc_offset);
 }
 
-inline void jdk_internal_vm_StackChunk::set_pc(oop chunk, intptr_t value) {
-  chunk->long_field_put(_pc_offset, value);
+inline void jdk_internal_vm_StackChunk::set_pc(oop chunk, address value) {
+  chunk->address_field_put(_pc_offset, value);
 }
 
 inline int jdk_internal_vm_StackChunk::argsize(oop chunk) {

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -57,8 +57,8 @@ inline int stackChunkOopDesc::stack_size() const        { return jdk_internal_vm
 inline int stackChunkOopDesc::sp() const                { return jdk_internal_vm_StackChunk::sp(as_oop()); }
 inline void stackChunkOopDesc::set_sp(int value)        { jdk_internal_vm_StackChunk::set_sp(this, value); }
 
-inline address stackChunkOopDesc::pc() const            { return (address)jdk_internal_vm_StackChunk::pc(as_oop()); }
-inline void stackChunkOopDesc::set_pc(address value)    { jdk_internal_vm_StackChunk::set_pc(this, (intptr_t)value); }
+inline address stackChunkOopDesc::pc() const            { return jdk_internal_vm_StackChunk::pc(as_oop()); }
+inline void stackChunkOopDesc::set_pc(address value)    { jdk_internal_vm_StackChunk::set_pc(this, value); }
 
 inline int stackChunkOopDesc::argsize() const           { return jdk_internal_vm_StackChunk::argsize(as_oop()); }
 inline void stackChunkOopDesc::set_argsize(int value)   { jdk_internal_vm_StackChunk::set_argsize(as_oop(), value); }


### PR DESCRIPTION
The injected field is defined as:

```
  macro(jdk_internal_vm_StackChunk, pc, intptr_signature, false) \
```

...yet it is read and written as "long", which silently overwrites adjacent fields in `StackChunk` on 32-bit platforms. This is a blocker for any 32-bit support. There are plenty of other `intptr` injected fields in other classes (e.g. `Class::array_klass`), and they are properly accessed by "address" accessors. 

Additional testing:
 - [x] Linux x86_64 fastdebug, prospective `jdk_loom hotspot_loom`
 - [x] Linux AArch64 fastdebug, prospective `jdk_loom hotspot_loom`
 - [x] Linux x86_32 fastdebug experimental port is not broken here anymore

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287044](https://bugs.openjdk.java.net/browse/JDK-8287044): Loom: Incorrect StackChunk::pc accessors


### Reviewers
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - Author)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8792/head:pull/8792` \
`$ git checkout pull/8792`

Update a local copy of the PR: \
`$ git checkout pull/8792` \
`$ git pull https://git.openjdk.java.net/jdk pull/8792/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8792`

View PR using the GUI difftool: \
`$ git pr show -t 8792`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8792.diff">https://git.openjdk.java.net/jdk/pull/8792.diff</a>

</details>
