### PR TITLE
8281682: Redundant .ico files in Windows app-image cause unnecessary bloat

### DIFF
--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WindowsAppImageBuilder.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WindowsAppImageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,8 +117,9 @@ public class WindowsAppImageBuilder extends AbstractAppImageBuilder {
                 mainParams);
         Path iconTarget = null;
         if (iconResource != null) {
-            iconTarget = appLayout.destktopIntegrationDirectory().resolve(
-                    APP_NAME.fetchFrom(params) + ".ico");
+            Path iconDir = StandardBundlerParam.TEMP_ROOT.fetchFrom(params).resolve(
+                    "icons");
+            iconTarget = iconDir.resolve(APP_NAME.fetchFrom(params) + ".ico");
             if (null == iconResource.saveToFile(iconTarget)) {
                 iconTarget = null;
             }

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixAppImageFragmentBuilder.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixAppImageFragmentBuilder.java
@@ -485,17 +485,11 @@ class WixAppImageFragmentBuilder extends WixFragmentBuilder {
 
         Path shortcutPath = folder.getPath(this).resolve(launcherBasename);
         return addComponent(xml, shortcutPath, Component.Shortcut, unused -> {
-            final Path icoFile = IOUtils.addSuffix(
-                    installedAppImage.destktopIntegrationDirectory().resolve(
-                            launcherBasename), ".ico");
-
             xml.writeAttribute("Name", launcherBasename);
             xml.writeAttribute("WorkingDirectory", INSTALLDIR.toString());
             xml.writeAttribute("Advertise", "no");
-            xml.writeAttribute("IconIndex", "0");
             xml.writeAttribute("Target", String.format("[#%s]",
                     Component.File.idOf(launcherPath)));
-            xml.writeAttribute("Icon", Id.Icon.of(icoFile));
         });
     }
 

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Functional.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Functional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -149,9 +149,10 @@ public class Functional {
     }
 
     @SuppressWarnings("unchecked")
-    public static void rethrowUnchecked(Throwable throwable) throws ExceptionBox {
+    public static RuntimeException rethrowUnchecked(Throwable throwable) throws
+            ExceptionBox {
         if (throwable instanceof RuntimeException) {
-            throw (RuntimeException)throwable;
+            throw (RuntimeException) throwable;
         }
 
         if (throwable instanceof InvocationTargetException) {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Functional.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Functional.java
@@ -152,7 +152,7 @@ public class Functional {
     public static RuntimeException rethrowUnchecked(Throwable throwable) throws
             ExceptionBox {
         if (throwable instanceof RuntimeException) {
-            throw (RuntimeException) throwable;
+            throw (RuntimeException)throwable;
         }
 
         if (throwable instanceof InvocationTargetException) {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LauncherIconVerifier.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LauncherIconVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,12 @@
 package jdk.jpackage.test;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
 
 public final class LauncherIconVerifier {
     public LauncherIconVerifier() {
@@ -60,7 +64,11 @@ public final class LauncherIconVerifier {
         Path iconPath = cmd.appLayout().destktopIntegrationDirectory().resolve(
                 curLauncherName + TKit.ICON_SUFFIX);
 
-        if (expectedDefault) {
+        if (TKit.isWindows()) {
+            TKit.assertPathExists(iconPath, false);
+            WinIconVerifier.instance.verifyLauncherIcon(cmd, launcherName,
+                    expectedIcon, expectedDefault);
+        } else if (expectedDefault) {
             TKit.assertPathExists(iconPath, true);
         } else if (expectedIcon == null) {
             TKit.assertPathExists(iconPath, false);
@@ -71,6 +79,141 @@ public final class LauncherIconVerifier {
                     "Check icon file [%s] of %s launcher is a copy of source icon file [%s]",
                     iconPath, label, expectedIcon));
         }
+    }
+
+    private static class WinIconVerifierException extends RuntimeException {
+
+        public WinIconVerifierException(String msg) {
+            super(msg);
+        }
+    }
+
+    private static class WinIconVerifier {
+
+        WinIconVerifier() {
+            try {
+                executableRebranderClass = Class.forName(
+                        "jdk.jpackage.internal.ExecutableRebrander");
+
+                lockResource = executableRebranderClass.getDeclaredMethod(
+                        "lockResource", String.class);
+                lockResource.setAccessible(true);
+
+                unlockResource = executableRebranderClass.getDeclaredMethod(
+                        "unlockResource", long.class);
+                unlockResource.setAccessible(true);
+
+                iconSwap = executableRebranderClass.getDeclaredMethod("iconSwap",
+                        long.class, String.class);
+                iconSwap.setAccessible(true);
+            } catch (ClassNotFoundException | NoSuchMethodException
+                    | SecurityException ex) {
+                throw Functional.rethrowUnchecked(ex);
+            }
+        }
+
+        private void verifyLauncherIcon(JPackageCommand cmd, String launcherName,
+                Path expectedIcon, boolean expectedDefault) {
+            TKit.withTempDirectory("icons", tmpDir -> {
+                Path launcher = cmd.appLauncherPath(launcherName);
+                Path iconWorkDir = tmpDir.resolve(launcher.getFileName());
+                Path iconContainer = iconWorkDir.resolve("container.exe");
+                Files.createDirectories(iconContainer.getParent());
+                Files.copy(getDefaultAppLauncher(expectedIcon == null
+                        && !expectedDefault), iconContainer);
+                if (expectedIcon != null) {
+                    setIcon(expectedIcon, iconContainer);
+                }
+
+                Path extractedExpectedIcon = extractIconFromExecutable(
+                        iconWorkDir, iconContainer, "expected");
+                Path extractedActualIcon = extractIconFromExecutable(iconWorkDir,
+                        launcher, "actual");
+                TKit.assertTrue(-1 == Files.mismatch(extractedExpectedIcon,
+                        extractedActualIcon),
+                        String.format(
+                                "Check icon file [%s] of %s launcher is a copy of source icon file [%s]",
+                                extractedActualIcon,
+                                Optional.ofNullable(launcherName).orElse("main"),
+                                extractedExpectedIcon));
+            });
+        }
+
+        private Path extractIconFromExecutable(Path outputDir, Path executable,
+                String label) {
+            Path psScript = outputDir.resolve(label + ".ps1");
+            Path extractedIcon = outputDir.resolve(label + ".bmp");
+            TKit.createTextFile(psScript, List.of(
+                    "[System.Reflection.Assembly]::LoadWithPartialName('System.Drawing')",
+                    String.format(
+                            "[System.Drawing.Icon]::ExtractAssociatedIcon(\"%s\").ToBitmap().Save(\"%s\", [System.Drawing.Imaging.ImageFormat]::Bmp)",
+                            executable.toAbsolutePath().normalize(),
+                            extractedIcon.toAbsolutePath().normalize()),
+                    "exit 0"));
+
+            Executor.of("powershell", "-NoLogo", "-NoProfile", "-File",
+                    psScript.toAbsolutePath().normalize().toString()).execute();
+
+            return extractedIcon;
+        }
+
+        private Path getDefaultAppLauncher(boolean noIcon) {
+            // Create app image with the sole purpose to get the default app launcher
+            Path defaultAppOutputDir = TKit.workDir().resolve(String.format(
+                    "out-%d", ProcessHandle.current().pid()));
+            JPackageCommand cmd = JPackageCommand.helloAppImage().setFakeRuntime().setArgumentValue(
+                    "--dest", defaultAppOutputDir);
+
+            String launcherName;
+            if (noIcon) {
+                launcherName = "no-icon";
+                new AdditionalLauncher(launcherName).setNoIcon().applyTo(cmd);
+            } else {
+                launcherName = null;
+            }
+
+            if (!Files.isExecutable(cmd.appLauncherPath(launcherName))) {
+                cmd.execute();
+            }
+            return cmd.appLauncherPath(launcherName);
+        }
+
+        private void setIcon(Path iconPath, Path launcherPath) {
+            TKit.trace(String.format("Set icon of [%s] launcher to [%s] file",
+                    launcherPath, iconPath));
+            try {
+                launcherPath.toFile().setWritable(true, true);
+                try {
+                    long lock = 0;
+                    try {
+                        lock = (Long) lockResource.invoke(null, new Object[]{
+                            launcherPath.toAbsolutePath().normalize().toString()});
+                        if (lock == 0) {
+                            throw new WinIconVerifierException(String.format(
+                                    "Failed to lock [%s] executable",
+                                    launcherPath));
+                        }
+                        iconSwap.invoke(null, new Object[]{lock,
+                            iconPath.toAbsolutePath().normalize().toString()});
+                    } finally {
+                        if (lock != 0) {
+                            unlockResource.invoke(null, new Object[]{lock});
+                        }
+                    }
+                } catch (IllegalAccessException | InvocationTargetException ex) {
+                    throw Functional.rethrowUnchecked(ex);
+                }
+            } finally {
+                launcherPath.toFile().setWritable(false, true);
+            }
+        }
+
+        private final static WinIconVerifier instance = new WinIconVerifier();
+
+        private final Class executableRebranderClass;
+        private final Method lockResource;
+        private final Method unlockResource;
+        private final Method iconSwap;
     }
 
     private String launcherName;

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LauncherIconVerifier.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LauncherIconVerifier.java
@@ -97,6 +97,8 @@ public final class LauncherIconVerifier {
 
                 lockResource = executableRebranderClass.getDeclaredMethod(
                         "lockResource", String.class);
+                // Note: these reflection call requires
+                // --add-opens jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED
                 lockResource.setAccessible(true);
 
                 unlockResource = executableRebranderClass.getDeclaredMethod(

--- a/test/jdk/tools/jpackage/share/AddLShortcutTest.java
+++ b/test/jdk/tools/jpackage/share/AddLShortcutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,9 @@ import jdk.jpackage.test.Annotations.Test;
  * @build jdk.jpackage.test.*
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @compile AddLShortcutTest.java
- * @run main/othervm/timeout=540 -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=540 -Xmx512m
+ *  --add-opens jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED
+ *  jdk.jpackage.test.Main
  *  --jpt-run=AddLShortcutTest
  */
 

--- a/test/jdk/tools/jpackage/share/AddLauncherTest.java
+++ b/test/jdk/tools/jpackage/share/AddLauncherTest.java
@@ -52,7 +52,9 @@ import jdk.jpackage.test.CfgFile;
  * @build jdk.jpackage.test.*
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @compile AddLauncherTest.java
- * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=360 -Xmx512m
+ *  --add-opens jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED
+ *  jdk.jpackage.test.Main
  *  --jpt-run=AddLauncherTest.test
  */
 
@@ -65,7 +67,9 @@ import jdk.jpackage.test.CfgFile;
  * @build jdk.jpackage.test.*
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @compile AddLauncherTest.java
- * @run main/othervm/timeout=540 -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=540 -Xmx512m
+ *  --add-opens jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED
+ *  jdk.jpackage.test.Main
  *  --jpt-run=AddLauncherTest
  */
 

--- a/test/jdk/tools/jpackage/share/IconTest.java
+++ b/test/jdk/tools/jpackage/share/IconTest.java
@@ -53,7 +53,9 @@ import jdk.jpackage.test.Annotations.Test;
  * @build jdk.jpackage.test.*
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @compile IconTest.java
- * @run main/othervm/timeout=540 -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=540 -Xmx512m 
+ *  --add-opens jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED 
+ *  jdk.jpackage.test.Main
  *  --jpt-run=IconTest
  */
 

--- a/test/jdk/tools/jpackage/share/IconTest.java
+++ b/test/jdk/tools/jpackage/share/IconTest.java
@@ -53,8 +53,8 @@ import jdk.jpackage.test.Annotations.Test;
  * @build jdk.jpackage.test.*
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @compile IconTest.java
- * @run main/othervm/timeout=540 -Xmx512m 
- *  --add-opens jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED 
+ * @run main/othervm/timeout=540 -Xmx512m
+ *  --add-opens jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED
  *  jdk.jpackage.test.Main
  *  --jpt-run=IconTest
  */

--- a/test/jdk/tools/jpackage/share/MultiLauncherTwoPhaseTest.java
+++ b/test/jdk/tools/jpackage/share/MultiLauncherTwoPhaseTest.java
@@ -49,7 +49,9 @@ import jdk.jpackage.test.JPackageCommand;
  * @build jdk.jpackage.test.*
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @compile MultiLauncherTwoPhaseTest.java
- * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=360 -Xmx512m
+ *  --add-opens jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED
+ *  jdk.jpackage.test.Main
  *  --jpt-run=MultiLauncherTwoPhaseTest
  */
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8281682](https://bugs.openjdk.java.net/browse/JDK-8281682): Redundant .ico files in Windows app-image cause unnecessary bloat


### Reviewers
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8794/head:pull/8794` \
`$ git checkout pull/8794`

Update a local copy of the PR: \
`$ git checkout pull/8794` \
`$ git pull https://git.openjdk.java.net/jdk pull/8794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8794`

View PR using the GUI difftool: \
`$ git pr show -t 8794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8794.diff">https://git.openjdk.java.net/jdk/pull/8794.diff</a>

</details>
