### PR TITLE
JDK-8279513: jdk/javadoc/doclet/testDocletExample/TestDocletExample.java fails after 8278795

### DIFF
--- a/test/langtools/TEST.ROOT
+++ b/test/langtools/TEST.ROOT
@@ -9,7 +9,7 @@
 # should be taken to handle test failures of intermittent or
 # randomness tests.
 
-keys=intermittent randomness
+keys=intermittent randomness needs-src needs-src-jdk_javadoc
 
 # Group definitions
 groups=TEST.groups

--- a/test/langtools/jdk/javadoc/doclet/testDocletExample/TestDocletExample.java
+++ b/test/langtools/jdk/javadoc/doclet/testDocletExample/TestDocletExample.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8272944
  * @summary Use snippets in jdk.javadoc documentation
+ * @key needs-src needs-src-jdk_javadoc
  * @library /tools/lib ../../lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
@@ -53,11 +54,12 @@ public class TestDocletExample extends TestRunner {
         t.runTests(m -> new Object[] { Path.of(m.getName()) });
     }
 
-    SnippetUtils snippets = new SnippetUtils("jdk.javadoc");
+    SnippetUtils snippets;
     ToolBox tb = new ToolBox();
 
-    TestDocletExample() {
+    TestDocletExample() throws SnippetUtils.ConfigurationException {
         super(System.out);
+        snippets = new SnippetUtils("jdk.javadoc");
     }
 
     @Test
@@ -65,6 +67,9 @@ public class TestDocletExample extends TestRunner {
         var docletPkg = snippets.getElements().getPackageElement("jdk.javadoc.doclet");
         var dc = snippets.getDocTrees().getDocCommentTree(docletPkg);
         var entryPointSnippet = snippets.getSnippetById(dc, "entry-point");
+        if (entryPointSnippet == null) {
+            throw new Error("Cannot find snippet \"entry-point\"");
+        }
         var entryPointCode = entryPointSnippet.getBody().getBody();
         var code = """
                 class C {
@@ -89,6 +94,9 @@ public class TestDocletExample extends TestRunner {
         var docletPkg = snippets.getElements().getPackageElement("jdk.javadoc.doclet");
         var dc = snippets.getDocTrees().getDocCommentTree(docletPkg);
         var exampleSnippet = snippets.getSnippetById(dc, "Example.java");
+        if (exampleSnippet == null) {
+            throw new Error("Cannot find snippet \"Example.java\"");
+        }
         var exampleCode = exampleSnippet.getBody().getBody();
 
         // compile it

--- a/test/langtools/tools/lib/snippets/SnippetUtils.java
+++ b/test/langtools/tools/lib/snippets/SnippetUtils.java
@@ -24,6 +24,7 @@
 package snippets;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URI;
@@ -86,6 +87,16 @@ import com.sun.source.util.JavacTask;
  * code to compile and run snippets, where that is appropriate.
  */
 public class SnippetUtils {
+    /**
+     * Exception used to report a configuration issue that prevents
+     * the test from executing as expected.
+     */
+    public static class ConfigurationException extends Exception {
+        public ConfigurationException(String message) {
+            super(message);
+        }
+    }
+
     private static final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
 
     private final StandardJavaFileManager fileManager;
@@ -105,8 +116,10 @@ public class SnippetUtils {
      * @param modules the modules
      *
      * @throws IllegalArgumentException if no modules are specified
+     * @throws ConfigurationException if the main source directory cannot be found
+     *                                or if a module's source directory cannot be found
      */
-    public SnippetUtils(String... modules) {
+    public SnippetUtils(String... modules) throws ConfigurationException {
         this(findSourceDir(), null, null, Set.of(modules));
     }
 
@@ -126,13 +139,29 @@ public class SnippetUtils {
      * @param modules the modules
      *
      * @throws IllegalArgumentException if no modules are specified
+     * @throws ConfigurationException if {@code srcDir} does not exist
+     *                                or if a module's source directory cannot be found
      */
-    public SnippetUtils(Path srcDir, PrintWriter pw, DiagnosticListener<JavaFileObject> dl, Set<String> modules) {
+    public SnippetUtils(Path srcDir, PrintWriter pw, DiagnosticListener<JavaFileObject> dl, Set<String> modules)
+            throws ConfigurationException {
         if (modules.isEmpty()) {
             throw new IllegalArgumentException("no modules specified");
         }
 
+        if (!Files.exists(srcDir)) {
+            throw new ConfigurationException("directory not found: " + srcDir);
+        }
+
         this.srcDir = srcDir;
+
+        for (var m : modules) {
+            var moduleSourceDir = getModuleSourceDir(m);
+            if (!Files.exists(moduleSourceDir)) {
+                throw new ConfigurationException(("cannot find source directory for " + m
+                        + ": " + moduleSourceDir));
+            }
+        }
+
         fileManager = compiler.getStandardFileManager(dl, null, null);
 
         List<String> opts = new ArrayList<>();
@@ -528,7 +557,7 @@ public class SnippetUtils {
         return SourceKind.OTHER;
     }
 
-    private static Path findSourceDir() {
+    private static Path findSourceDir() throws ConfigurationException {
         String testSrc = System.getProperty("test.src");
         Path p = Path.of(testSrc).toAbsolutePath();
         while (p.getParent() != null) {
@@ -538,6 +567,6 @@ public class SnippetUtils {
             }
             p = p.getParent();
         }
-        throw new IllegalArgumentException("Cannot find src/ from " + testSrc);
+        throw new ConfigurationException("Cannot find src/ from " + testSrc);
     }
 }


### PR DESCRIPTION
Please review a test-only fix to make a recent new test more robust.

The test was not fundamentally broken, so the essential functionality remains the same. However, it does assume access to the `src/jdk.javadoc` directory, and crashed when that was not available.

The mitigation is two-fold: 

1. introduce and use a new `SnippetUtils.ConfigurationException` that is thrown when the test cannot find the necessary directories.
2. introduce and use 2 new test-suite keywords, `needs-src` `needs-src-jdk_javadoc` that can be used on the jtreg command-line to filter out this test, and any similar tests in the future.

Tested locally, manually, by temporarily renaming key directories, to test the different code paths.  In all cases, if the test is run and any necessary directories are missing, the test _will still fail_, but now with a more useful and specific exception and detail message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279513](https://bugs.openjdk.java.net/browse/JDK-8279513): jdk/javadoc/doclet/testDocletExample/TestDocletExample.java  fails after 8278795


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8796/head:pull/8796` \
`$ git checkout pull/8796`

Update a local copy of the PR: \
`$ git checkout pull/8796` \
`$ git pull https://git.openjdk.java.net/jdk pull/8796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8796`

View PR using the GUI difftool: \
`$ git pr show -t 8796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8796.diff">https://git.openjdk.java.net/jdk/pull/8796.diff</a>

</details>
