### PR TITLE
8275303: sun/java2d/pipe/InterpolationQualityTest.java fails with D3D basic render driver

### DIFF
--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DBadHardware.h
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DBadHardware.h
@@ -54,6 +54,9 @@ static const ADAPTER_INFO badHardware[] = {
     // All Intel Chips.
     { 0x8086, ALL_DEVICEIDS, NO_VERSION, OS_ALL },
 
+    // Microsoft Basic Render Driver (as maybe used in VMs such as VirtualBox)
+    { 0x1414, 0x008c, NO_VERSION, OS_ALL },
+
     // ATI Mobility Radeon X1600, X1400, X1450, X1300, X1350
     // Reason: workaround for 6613066, 6687166
     // X1300 (four sub ids)


### PR DESCRIPTION
This adds the Microsoft Basic Render Driver to our "bad hardware" list so that we don't use that pipeline there.
We have at least the one test that fails there and I am not sure we get any benefit from this.
I'm sure Microsoft need to provide for apps that have only a D3D option, but that isn't the JDK case.

FYI there was a PR a while back about problem listing that failing test : https://github.com/openjdk/jdk/pull/5930
but we don't need to do that with this change - nor worry about similar problems with other tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8275303](https://bugs.openjdk.java.net/browse/JDK-8275303): sun/java2d/pipe/InterpolationQualityTest.java fails with D3D basic render driver


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8797/head:pull/8797` \
`$ git checkout pull/8797`

Update a local copy of the PR: \
`$ git checkout pull/8797` \
`$ git pull https://git.openjdk.java.net/jdk pull/8797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8797`

View PR using the GUI difftool: \
`$ git pr show -t 8797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8797.diff">https://git.openjdk.java.net/jdk/pull/8797.diff</a>

</details>
