### PR TITLE
8287052: comparing double to max_intx gives unexpected results

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -131,11 +131,15 @@ intx CompilerConfig::scaled_compile_threshold(intx threshold, double scale) {
   } else {
     double v = threshold * scale;
     assert(v >= 0, "must be");
-    if (v > max_intx) {
+    if (g_isnan(v) || !g_isfinite(v)) {
       return max_intx;
-    } else {
-      return (intx)(v);
     }
+    int exp;
+    (void) frexp(v, &exp);
+    if (exp > 63) {
+      return max_intx;
+    }
+    return (intx)(v);
   }
 }
 


### PR DESCRIPTION
It isn't safe to compare a double to 2^63-1 because the latter will be changed to 2^63 when converting to a double.
This fixes a compiler warning with clang-12 and prevents the code from returning a negative value in some cases (observed on x64 with g++).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287052](https://bugs.openjdk.java.net/browse/JDK-8287052): comparing double to max_intx gives unexpected results


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8798/head:pull/8798` \
`$ git checkout pull/8798`

Update a local copy of the PR: \
`$ git checkout pull/8798` \
`$ git pull https://git.openjdk.java.net/jdk pull/8798/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8798`

View PR using the GUI difftool: \
`$ git pr show -t 8798`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8798.diff">https://git.openjdk.java.net/jdk/pull/8798.diff</a>

</details>
