### PR TITLE
8286978: SIGBUS in libz during CDS initialization

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
@@ -232,7 +232,7 @@ public class SharedArchiveConsistency {
         // insert  bytes in data section
         System.out.println("\n5. Insert bytes at beginning of data section, should fail\n");
         String insertBytes = startNewArchive("insert-bytes");
-        CDSArchiveUtils.insertBytesRandomlyAfterHeader(orgJsaFile, insertBytes, new byte[4096]);
+        CDSArchiveUtils.insertBytesRandomlyAfterHeader(orgJsaFile, insertBytes);
         testAndCheck(verifyExecArgs);
 
         // delete bytes in data section forward

--- a/test/lib/jdk/test/lib/cds/CDSArchiveUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSArchiveUtils.java
@@ -417,11 +417,8 @@ public class CDSArchiveUtils {
                                      long length) throws Exception {
         long position = offset;
         long count = length;
-        long n = count;
-        // The count != offset check is for handling the case where the length
-        // of the outputChannel is shorter than the inputChannel.
-        while (count > 0 && n > 0 && count != offset) {
-            n = (long)outputChannel.transferFrom(inputChannel, position, count);
+        while (count > 0 && inputChannel.position() < inputChannel.size()) {
+            long n = outputChannel.transferFrom(inputChannel, position, count);
             if (n < 0 || n > count) {
                 throw new RuntimeException("Incorrect transfer length n = " + n
                                            + " (expected 0 <= n <= " + length + ")");
@@ -455,7 +452,6 @@ public class CDSArchiveUtils {
             long orgSize = inputChannel.size();
             transferFrom(inputChannel, outputChannel, 0, offset);
             inputChannel.position(offset + nBytes);
-            long length = orgSize - nBytes;
             transferFrom(inputChannel, outputChannel, offset, orgSize - nBytes);
         }
         return dstFile;


### PR DESCRIPTION
Please review this fix to ensure all requested bytes are transferred by calling `FileChannel.transferFrom` in a loop and checking its return value.

Tested by running the SharedArchiveConsistency.java test on linux-aarch64 30 times on each of the following tier3 options:

- `-XX:+CreateCoredumpOnCrash -XX:+UseSerialGC `
- `-XX:+CreateCoredumpOnCrash -XX:+UseParallelGC -XX:+UseNUMA`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286978](https://bugs.openjdk.java.net/browse/JDK-8286978): SIGBUS in libz during CDS initialization


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8799/head:pull/8799` \
`$ git checkout pull/8799`

Update a local copy of the PR: \
`$ git checkout pull/8799` \
`$ git pull https://git.openjdk.java.net/jdk pull/8799/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8799`

View PR using the GUI difftool: \
`$ git pr show -t 8799`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8799.diff">https://git.openjdk.java.net/jdk/pull/8799.diff</a>

</details>
