### PR TITLE
8287073: NPE from CgroupV2Subsystem.getInstance()

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
@@ -108,7 +108,7 @@ public class CgroupSubsystemFactory {
         Map<String, CgroupInfo> infos = result.getInfos();
         if (result.isCgroupV2()) {
             // For unified it doesn't matter which controller we pick.
-            CgroupInfo anyController = infos.get(MEMORY_CTRL);
+            CgroupInfo anyController = infos.values().iterator().next();
             CgroupSubsystem subsystem = CgroupV2Subsystem.getInstance(anyController);
             return subsystem != null ? new CgroupMetrics(subsystem) : null;
         } else {

--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -109,11 +110,11 @@ public class CgroupSubsystemFactory {
         if (result.isCgroupV2()) {
             // For unified it doesn't matter which controller we pick.
             CgroupInfo anyController = infos.values().iterator().next();
-            CgroupSubsystem subsystem = CgroupV2Subsystem.getInstance(anyController);
+            CgroupSubsystem subsystem = CgroupV2Subsystem.getInstance(Objects.requireNonNull(anyController));
             return new CgroupMetrics(subsystem);
         } else {
             CgroupV1Subsystem subsystem = CgroupV1Subsystem.getInstance(infos);
-            return new CgroupV1MetricsImpl(subsystem);
+            return subsystem != null ? new CgroupV1MetricsImpl(subsystem) : null;
         }
     }
 

--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
@@ -110,10 +110,10 @@ public class CgroupSubsystemFactory {
             // For unified it doesn't matter which controller we pick.
             CgroupInfo anyController = infos.values().iterator().next();
             CgroupSubsystem subsystem = CgroupV2Subsystem.getInstance(anyController);
-            return subsystem != null ? new CgroupMetrics(subsystem) : null;
+            return new CgroupMetrics(subsystem);
         } else {
             CgroupV1Subsystem subsystem = CgroupV1Subsystem.getInstance(infos);
-            return subsystem != null ? new CgroupV1MetricsImpl(subsystem) : null;
+            return new CgroupV1MetricsImpl(subsystem);
         }
     }
 


### PR DESCRIPTION
Following the logic from the comment directly above the changed line, since it doesn't matter which controller we pick, pick any available controller instead of the one called "memory" specifically. This way we are guarded against getting `null` as `anyController`, which is being immediately passed down to `CgroupV2Subsystem.getInstance()` that is unprepared to accept `null` values. 

It is also worth noting that the previous checks (such as that at line 89) make sure that there exist at least one controller in the map.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287073](https://bugs.openjdk.java.net/browse/JDK-8287073): NPE from CgroupV2Subsystem.getInstance()


### Reviewers
 * [Vladimir Kempik](https://openjdk.java.net/census#vkempik) (@VladimirKempik - Committer) ⚠️ Review applies to [f17af433](https://git.openjdk.java.net/jdk/pull/8803/files/f17af433f651ba60dfcca0914e1a99b2ebb7a7a3)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8803/head:pull/8803` \
`$ git checkout pull/8803`

Update a local copy of the PR: \
`$ git checkout pull/8803` \
`$ git pull https://git.openjdk.java.net/jdk pull/8803/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8803`

View PR using the GUI difftool: \
`$ git pr show -t 8803`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8803.diff">https://git.openjdk.java.net/jdk/pull/8803.diff</a>

</details>
