### PR TITLE
8286177: C2: "failed: non-reduction loop contains reduction nodes" assert failure

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -110,8 +110,6 @@ bool SuperWord::transform_loop(IdealLoopTree* lpt, bool do_optimization) {
     return false; // skip malformed counted loop
   }
 
-  assert(!lpt->has_reduction_nodes() || cl->is_reduction_loop(),
-         "non-reduction loop contains reduction nodes");
   if (cl->is_rce_post_loop() && cl->is_reduction_loop()) {
     // Post loop vectorization doesn't support reductions
     return false;
@@ -2398,6 +2396,11 @@ bool SuperWord::output() {
   if (_packset.length() == 0) {
     return false;
   }
+
+  // Check that the loop to be vectorized does not have inconsistent reduction
+  // information, which would likely lead to a miscompilation.
+  assert(!lpt()->has_reduction_nodes() || cl->is_reduction_loop(),
+         "non-reduction loop contains reduction nodes");
 
 #ifndef PRODUCT
   if (TraceLoopOpts) {

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestHoistedReductionNode.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestHoistedReductionNode.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8286177
+ * @summary Test that inconsistent reduction node-loop state does not trigger
+ *          assertion failures when the inconsistency does not lead to a
+ *          miscompilation.
+ * @run main/othervm -Xbatch compiler.loopopts.superword.TestHoistedReductionNode
+ */
+package compiler.loopopts.superword;
+
+public class TestHoistedReductionNode {
+
+    static boolean b = true;
+
+    static int test() {
+        int acc = 0;
+        int i = 0;
+        do {
+            int j = 0;
+            do {
+                if (b) {
+                    acc += j;
+                }
+                j++;
+            } while (j < 5);
+            i++;
+        } while (i < 100);
+        return acc;
+
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; i++) {
+            test();
+        }
+    }
+}


### PR DESCRIPTION
[JDK-8279622](https://bugs.openjdk.java.net/browse/JDK-8279622) introduced an assertion in the SLP analysis verifying that the examined loop does not contain inconsistent reduction information. The assertion is placed at the beginning of the SLP analysis, and can fail even for loops that are not vectorizable by SLP (and hence without risk of being miscompiled). This is the case for the [reported issue](https://bugs.openjdk.java.net/browse/JDK-8286177) and for many other recent failures triggered by JavaFuzzer-generated test cases. This changeset postpones the assertion to the SLP output phase to ensure that it only fails when the program really risks being miscompiled.

Given that many transformations can invalidate reduction information (see for example the JBS reports for [JDK-8261147](https://bugs.openjdk.java.net/browse/JDK-8261147), [JDK-8279622](https://bugs.openjdk.java.net/browse/JDK-8279622), and [JDK-8286177](https://bugs.openjdk.java.net/browse/JDK-8286177)), a more fundamental fix would be to remove the possibility of inconsistent reduction information by construction, by running the reduction analysis on-demand. I have filed a [RFE](https://bugs.openjdk.java.net/browse/JDK-8287087) to explore this idea after JDK 19.

#### Testing

  - hs-tier1-5 (windows-x64, linux-x64, linux-aarch64, and macosx-x64; debug mode).
  - Tested that the assertion, in its new placement, would still have caught the bug reported in [JDK-8279622](https://bugs.openjdk.java.net/browse/JDK-8279622) in the original scenario.
  - Tested that the assertion, in its new placement, does not fail for 27 JavaFuzzer-generated test cases that trigger the assertion in its original placement.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286177](https://bugs.openjdk.java.net/browse/JDK-8286177): C2: "failed: non-reduction loop contains reduction nodes" assert failure


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8805/head:pull/8805` \
`$ git checkout pull/8805`

Update a local copy of the PR: \
`$ git checkout pull/8805` \
`$ git pull https://git.openjdk.java.net/jdk pull/8805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8805`

View PR using the GUI difftool: \
`$ git pr show -t 8805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8805.diff">https://git.openjdk.java.net/jdk/pull/8805.diff</a>

</details>
