### PR TITLE
8287080: Document format of thread dump in JSON format

### DIFF
--- a/src/jdk.management/share/classes/com/sun/management/HotSpotDiagnosticMXBean.java
+++ b/src/jdk.management/share/classes/com/sun/management/HotSpotDiagnosticMXBean.java
@@ -165,7 +165,13 @@ public interface HotSpotDiagnosticMXBean extends PlatformManagedObject {
          */
         TEXT_PLAIN,
         /**
-         * JSON (JavaScript Object Notation) format.
+         * JSON (JavaScript Object Notation) format
+         * (<a href="https://tools.ietf.org/html/rfc8259">RFC 8259</a>).
+         *
+         * <p> <a href="doc-files/threadDump.schema.json">threadDump.schema.json</a>
+         * describes the thread dump format in draft
+         * <a href="https://tools.ietf.org/html/draft-json-schema-language-02">
+         * JSON Schema Language version 2</a>.
          */
         JSON,
     }

--- a/src/jdk.management/share/classes/com/sun/management/doc-files/threadDump.schema.json
+++ b/src/jdk.management/share/classes/com/sun/management/doc-files/threadDump.schema.json
@@ -1,0 +1,99 @@
+{
+  "type": "object",
+  "properties": {
+    "threadDump": {
+      "type": "object",
+      "properties": {
+        "processId": {
+          "type": "integer",
+          "description": "The native process id of the Java virtual machine."
+        },
+        "time": {
+          "type": "string",
+          "description": "The time in ISO 8601 format when the thread dump was generated."
+        },
+        "runtimeVersion": {
+          "type": "string",
+          "description": "The runtime version, see java.lang.Runtime.version()."
+        },
+        "threadContainers": {
+          "type": "array",
+          "description": "The array of thread containers.",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "container": {
+                  "type": "string",
+                  "description": "The container name. The container name is unique."
+                },
+                "parent": {
+                  "type": ["string", "null"],
+                  "description": "The parent container name or null for the root container."
+                },
+                "owner": {
+                  "type": ["integer", "null"],
+                  "description": "The thread identifier of the owner thread or null if not owned."
+                },
+                "threads": {
+                  "type": "array",
+                  "description": "The array of threads in the thread container.",
+                  "items": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "tid": {
+                          "type": "integer",
+                          "description": "The thread identifier, see java.lang.Thread.threadId()."
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "The thread name."
+                        },
+                        "stack": {
+                          "type": "array",
+                          "description": "The thread stack. The first element is the top of the stack.",
+                          "items": [
+                            {
+                              "type": "string",
+                              "description": "A stack trace element, see java.lang.StackTraceElement."
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "tid",
+                        "name",
+                        "stack"
+                      ]
+                    }
+                  ]
+                },
+                "threadCount": {
+                  "type": "integer",
+                  "description": "The number of threads in the thread container."
+                }
+              },
+              "required": [
+                "container",
+                "parent",
+                "owner",
+                "threads",
+                "threadCount"
+              ]
+            }
+          ]
+        }
+      },
+      "required": [
+        "processId",
+        "time",
+        "runtimeVersion",
+        "threadContainers"
+      ]
+    }
+  },
+  "required": [
+    "threadDump"
+  ]
+}


### PR DESCRIPTION
JEP 425 added a preview API to generate a thread dump in JSON format. This format needs to be documented.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request to be approved
- [ ] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287080](https://bugs.openjdk.java.net/browse/JDK-8287080): Document format of thread dump in JSON format


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8807/head:pull/8807` \
`$ git checkout pull/8807`

Update a local copy of the PR: \
`$ git checkout pull/8807` \
`$ git pull https://git.openjdk.java.net/jdk pull/8807/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8807`

View PR using the GUI difftool: \
`$ git pr show -t 8807`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8807.diff">https://git.openjdk.java.net/jdk/pull/8807.diff</a>

</details>
