### PR TITLE
8189669: Deduplicate VerifyOption documentation

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1297,16 +1297,6 @@ public:
   void prepare_for_verify() override;
 
   // Perform verification.
-
-  // vo == UsePrevMarking -> use "prev" marking information,
-  // vo == UseFullMarking -> use "next" marking bitmap but no TAMS
-  //
-  // NOTE: Only the "prev" marking information is guaranteed to be
-  // consistent most of the time, so most calls to this should use
-  // vo == UsePrevMarking.
-  // Currently there is only one place where this is called with
-  // vo == UseFullMarking, which is to verify the marking during a
-  // full GC.
   void verify(VerifyOption vo) override;
 
   // WhiteBox testing support.

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -51,9 +51,8 @@ private:
   G1CollectedHeap* _g1h;
   VerifyOption     _vo;
   bool             _failures;
+
 public:
-  // _vo == UsePrevMarking -> use "prev" marking information,
-  // _vo == UseFullMarking -> use "next" marking bitmap but no TAMS
   VerifyRootsClosure(VerifyOption vo) :
     _g1h(G1CollectedHeap::heap()),
     _vo(vo),
@@ -203,9 +202,8 @@ private:
   size_t _live_bytes;
   HeapRegion *_hr;
   VerifyOption _vo;
+
 public:
-  // _vo == UsePrevMarking -> use "prev" marking information,
-  // _vo == UseFullMarking -> use "next" marking bitmap but no TAMS.
   VerifyObjsInRegionClosure(HeapRegion *hr, VerifyOption vo)
     : _live_bytes(0), _hr(hr), _vo(vo) {
     _g1h = G1CollectedHeap::heap();
@@ -354,9 +352,8 @@ class VerifyRegionClosure: public HeapRegionClosure {
 private:
   VerifyOption     _vo;
   bool             _failures;
+
 public:
-  // _vo == UsePrevMarking -> use "prev" marking information,
-  // _vo == UseFullMarking -> use "next" marking bitmap but no TAMS
   VerifyRegionClosure(VerifyOption vo)
     : _vo(vo),
       _failures(false) {}
@@ -423,8 +420,6 @@ private:
   HeapRegionClaimer _hrclaimer;
 
 public:
-  // _vo == UsePrevMarking -> use "prev" marking information,
-  // _vo == UseFullMarking -> use "next" marking bitmap but no TAMS
   G1VerifyTask(G1CollectedHeap* g1h, VerifyOption vo) :
       WorkerTask("Verify task"),
       _g1h(g1h),

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.hpp
@@ -59,16 +59,6 @@ public:
   static bool should_verify(G1VerifyType type);
 
   // Perform verification.
-
-  // vo == UsePrevMarking -> use "prev" marking information,
-  // vo == UseFullMarking -> use "next" marking bitmap but no TAMS
-  //
-  // NOTE: Only the "prev" marking information is guaranteed to be
-  // consistent most of the time, so most calls to this should use
-  // vo == UsePrevMarking.
-  // Currently there is only one place where this is called with
-  // vo == UseFullMarking, which is to verify the marking during a
-  // full GC.
   void verify(VerifyOption vo);
 
   // verify_region_sets_optional() is planted in the code for

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -477,9 +477,8 @@ protected:
   bool _failures;
   int _n_failures;
   VerifyOption _vo;
+
 public:
-  // _vo == UsePrevMarking -> use "prev" marking information,
-  // _vo == UseFullMarking -> use "next" marking bitmap but no TAMS.
   G1VerificationClosure(G1CollectedHeap* g1h, VerifyOption vo) :
     _g1h(g1h), _ct(g1h->card_table()),
     _containing_obj(NULL), _failures(false), _n_failures(0), _vo(vo) {

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -581,15 +581,6 @@ public:
   void print() const;
   void print_on(outputStream* st) const;
 
-  // vo == UsePrevMarking -> use "prev" marking information,
-  // vo == UseFullMarking -> use "next" marking bitmap but no TAMS
-  //
-  // NOTE: Only the "prev" marking information is guaranteed to be
-  // consistent most of the time, so most calls to this should use
-  // vo == UsePrevMarking.
-  // Currently there is only one place where this is called with
-  // vo == UseFullMarking, which is to verify the marking during a
-  // full GC.
   void verify(VerifyOption vo, bool *failures) const;
 
   void verify_rem_set(VerifyOption vo, bool *failures) const;

--- a/src/hotspot/share/gc/shared/verifyOption.hpp
+++ b/src/hotspot/share/gc/shared/verifyOption.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,11 +26,15 @@
 #define SHARE_GC_SHARED_VERIFYOPTION_HPP
 
 enum VerifyOption {
-      VerifyOption_Default = 0,
+  VerifyOption_Default = 0,
 
-      // G1
-      VerifyOption_G1UsePrevMarking = VerifyOption_Default,
-      VerifyOption_G1UseFullMarking = VerifyOption_G1UsePrevMarking + 1
+  // G1
+
+  // Use "prev" mark bitmap information using pTAMS.
+  VerifyOption_G1UsePrevMarking = VerifyOption_Default,
+  // Use "next" mark bitmap information from full gc marking. This does not
+  // use (or need) TAMS.
+  VerifyOption_G1UseFullMarking = VerifyOption_G1UsePrevMarking + 1
 };
 
 #endif // SHARE_GC_SHARED_VERIFYOPTION_HPP


### PR DESCRIPTION
Hi all,

  can I have quick reviews for this trivial? change that deduplicates some documentation?

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8189669](https://bugs.openjdk.java.net/browse/JDK-8189669): Deduplicate VerifyOption documentation


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8809/head:pull/8809` \
`$ git checkout pull/8809`

Update a local copy of the PR: \
`$ git checkout pull/8809` \
`$ git pull https://git.openjdk.java.net/jdk pull/8809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8809`

View PR using the GUI difftool: \
`$ git pr show -t 8809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8809.diff">https://git.openjdk.java.net/jdk/pull/8809.diff</a>

</details>
