### PR TITLE
8276549: Improve documentation about ContainerPtr encoding

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -232,7 +232,7 @@ public:
   // for Howl (0b11) is assumed to be the same as the last two bits for "FullCardSet"; this
   // has been done in various places to not be required to check for a "FullCardSet" first
   // all the time in iteration code (only if there is a Howl card set container, that is
-  // fairly uncommon). 
+  // fairly uncommon).
   using ContainerPtr = void*;
   static const uintptr_t ContainerInlinePtr      = 0x0;
   static const uintptr_t ContainerArrayOfCards   = 0x1;

--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -201,7 +201,7 @@ public:
   //
   // Possible encodings:
   //
-  // 0...00000 free               (Empty, should never happen)
+  // 0...00000 free               (Empty, should never happen on a top-level ContainerPtr)
   // 1...11111 full               All card indexes in the whole area this ContainerPtr covers are part of this container.
   // X...XXX00 inline-ptr-cards   A handful of card indexes covered by this ContainerPtr are encoded within the ContainerPtr.
   // X...XXX01 array of cards     The container is a contiguous array of card indexes.
@@ -209,11 +209,31 @@ public:
   // X...XXX11 howl               This is a card set container containing an array of ContainerPtr, with each ContainerPtr
   //                              limited to a sub-range of the original range. Currently only one level of this
   //                              container is supported.
-  using ContainerPtr = void*;
+  //
+  // The container's pointer starts off with an inline container and is then subsequently
+  // coarsened as more cards are added.
+  //
   // Coarsening happens in the order below:
-  // ContainerInlinePtr -> ContainerArrayOfCards -> ContainerHowl -> Full
-  // Corsening of containers inside the ContainerHowl happens in the order:
-  // ContainerInlinePtr -> ContainerArrayOfCards -> ContainerBitMap -> Full
+  //   ContainerInlinePtr -> ContainerArrayOfCards -> ContainerHowl -> Full
+  //
+  // There is intentionally no bitmap based container that covers a full region; first,
+  // a whole region is covered very well (and more flexibly) using the howl container and
+  // even then the overhead of the ContainerPtr array with all-bitmaps vs. a single bitmap
+  // is negligible, and most importantly transferring such a Howl container to a
+  // "Full Region Bitmap" is fairly hard without missing entries that are added by
+  // concurrent threads.
+  //
+  // Howl containers are basically arrays of containers. An entry starts off with
+  // Free. Further corsening of containers inside the ContainerHowl happens in the order:
+  //
+  //   ContainerInlinePtr -> ContainerArrayOfCards -> ContainerBitMap -> Full
+  //
+  // Throughout the code it is assumed (and checked) that the last two bits of the encoding
+  // for Howl (0b11) is assumed to be the same as the last two bits for "FullCardSet"; this
+  // has been done in various places to not be required to check for a "FullCardSet" first
+  // all the time in iteration code (only if there is a Howl card set container, that is
+  // fairly uncommon). 
+  using ContainerPtr = void*;
   static const uintptr_t ContainerInlinePtr      = 0x0;
   static const uintptr_t ContainerArrayOfCards   = 0x1;
   static const uintptr_t ContainerBitMap         = 0x2;

--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -226,7 +226,7 @@ public:
   // Howl containers are basically arrays of containers. An entry starts off with
   // Free. Further corsening of containers inside the ContainerHowl happens in the order:
   //
-  //   ContainerInlinePtr -> ContainerArrayOfCards -> ContainerBitMap -> Full
+  //   Free -> ContainerInlinePtr -> ContainerArrayOfCards -> ContainerBitMap -> Full
   //
   // Throughout the code it is assumed (and checked) that the last two bits of the encoding
   // for Howl (0b11) is assumed to be the same as the last two bits for "FullCardSet"; this


### PR DESCRIPTION
Hi all,

  can I have reviews for this trivial? change to add some more documentation to `G1CardSet::ContainerPtr`?

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8276549](https://bugs.openjdk.java.net/browse/JDK-8276549): Improve documentation about ContainerPtr encoding


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8811/head:pull/8811` \
`$ git checkout pull/8811`

Update a local copy of the PR: \
`$ git checkout pull/8811` \
`$ git pull https://git.openjdk.java.net/jdk pull/8811/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8811`

View PR using the GUI difftool: \
`$ git pr show -t 8811`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8811.diff">https://git.openjdk.java.net/jdk/pull/8811.diff</a>

</details>
