### PR TITLE
8284849: Add deoptimization to unified logging

### DIFF
--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -67,6 +67,7 @@ class outputStream;
   LOG_TAG(dcmd) \
   LOG_TAG(decoder) \
   LOG_TAG(defaultmethods) \
+  LOG_TAG(deoptimization) \
   LOG_TAG(director) \
   NOT_PRODUCT(LOG_TAG(downcall)) \
   LOG_TAG(dump) \

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1933,19 +1933,19 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
     { // Log Deoptimization event for JFR, UL and event system
       Method* tm = trap_method();
       char* name_sig = tm->name_and_sig_as_C_string();
-      const char* reason_name = Deoptimization::trap_reason_name(reason);
-      const char* reason_action = Deoptimization::trap_action_name(action);
+      const char* reason_name = trap_reason_name(reason);
+      const char* reason_action = trap_action_name(action);
       JFR_ONLY(post_deoptimization_event(nm, tm, trap_bci, trap_bc, reason, action);)
-      log_debug(deoptimization)("cid: %d osr: %s level: %d %s @ %d %s -> %s",
+      log_debug(deoptimization)("cid=%d %s pc=" INTPTR_FORMAT " relative_pc=" INTPTR_FORMAT " level=%d %s @ %d %s -> %s",
                                 nm->compile_id(),
-                                (nm->is_osr_method() ? "true" : "false"),
+                                (nm->is_osr_method() ? "osr" : ""),
+                                p2i(fr.pc()),
+                                fr.pc() - nm->code_begin(),
                                 nm->comp_level(),
                                 name_sig,
                                 trap_bci,
                                 reason_name,
                                 reason_action);
-
-      // Log a message
       Events::log_deopt_message(current, "Uncommon trap: reason=%s action=%s pc=" INTPTR_FORMAT " method=%s @ %d %s",
                                 reason_name, reason_action, p2i(fr.pc()),
                                 name_sig, trap_bci, nm->compiler_name());

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1936,16 +1936,15 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
       const char* reason_name = Deoptimization::trap_reason_name(reason);
       const char* reason_action = Deoptimization::trap_action_name(action);
       JFR_ONLY(post_deoptimization_event(nm, tm, trap_bci, trap_bc, reason, action);)
-      if (Log(deoptimization)::is_info()) {
-        log_debug(deoptimization)("cid: %d osr: %s level: %d %s @ %d %s -> %s",
-                                  nm->compile_id(),
-                                  (nm->is_osr_method() ? "true" : "false"),
-                                  nm->comp_level(),
-                                  name_sig,
-                                  trap_bci,
-                                  reason_name,
-                                  reason_action);
-        }
+      log_debug(deoptimization)("cid: %d osr: %s level: %d %s @ %d %s -> %s",
+                                nm->compile_id(),
+                                (nm->is_osr_method() ? "true" : "false"),
+                                nm->comp_level(),
+                                name_sig,
+                                trap_bci,
+                                reason_name,
+                                reason_action);
+
       // Log a message
       Events::log_deopt_message(current, "Uncommon trap: reason=%s action=%s pc=" INTPTR_FORMAT " method=%s @ %d %s",
                                 reason_name, reason_action, p2i(fr.pc()),

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1838,24 +1838,23 @@ static void post_deoptimization_event(CompiledMethod* nm,
 
 #endif // INCLUDE_JFR
 
-void Deoptimization::print_ul(CompiledMethod* nm, intptr_t pc, frame& fr, int trap_bci,
+void Deoptimization::print_ul(CompiledMethod* nm, Method* tm, intptr_t pc, frame& fr, int trap_bci,
                               const char* reason_name, const char* reason_action) {
   LogTarget(Debug, deoptimization) lt;
-  bool is_osr = nm->is_osr_method();
   if (lt.is_enabled()) {
     LogStream ls(lt);
+    bool is_osr = nm->is_osr_method();
     ls.print("cid=%d%s level=%d",
              nm->compile_id(), (is_osr ? " osr" : ""), nm->comp_level());
-    nm->method()->print_short_name(&ls);
+    ls.print("%s", tm->name_and_sig_as_C_string());
     ls.print(" trap_bci=%d ", trap_bci);
     if (is_osr) {
       ls.print("osr_bci=%d ", nm->osr_entry_bci());
     }
     ls.print("%s ", reason_name);
     ls.print("%s ", reason_action);
-    ls.print("pc=" INTPTR_FORMAT " relative_pc=" INTPTR_FORMAT,
+    ls.print_cr("pc=" INTPTR_FORMAT " relative_pc=" INTPTR_FORMAT,
              pc, fr.pc() - nm->code_begin());
-    ls.cr();
   }
 }
 
@@ -1959,7 +1958,7 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
       intptr_t pc = p2i(fr.pc());
 
       JFR_ONLY(post_deoptimization_event(nm, tm, trap_bci, trap_bc, reason, action);)
-      print_ul(nm, pc, fr, trap_bci, reason_name, reason_action);
+      print_ul(nm, tm, pc, fr, trap_bci, reason_name, reason_action);
       Events::log_deopt_message(current, "Uncommon trap: reason=%s action=%s pc=" INTPTR_FORMAT " method=%s @ %d %s",
                                 reason_name, reason_action, pc,
                                 tm->name_and_sig_as_C_string(), trap_bci, nm->compiler_name());

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1838,15 +1838,15 @@ static void post_deoptimization_event(CompiledMethod* nm,
 
 #endif // INCLUDE_JFR
 
-void Deoptimization::print_ul(CompiledMethod* nm, Method* tm, intptr_t pc, frame& fr, int trap_bci,
+void log_deopt(CompiledMethod* nm, Method* tm, intptr_t pc, frame& fr, int trap_bci,
                               const char* reason_name, const char* reason_action) {
   LogTarget(Debug, deoptimization) lt;
   if (lt.is_enabled()) {
     LogStream ls(lt);
     bool is_osr = nm->is_osr_method();
-    ls.print("cid=%d%s level=%d",
-             nm->compile_id(), (is_osr ? " osr" : ""), nm->comp_level());
-    ls.print("%s", tm->name_and_sig_as_C_string());
+    ls.print("cid=%4d %s level=%d",
+             nm->compile_id(), (is_osr ? "osr" : "   "), nm->comp_level());
+    ls.print(" %s", tm->name_and_sig_as_C_string());
     ls.print(" trap_bci=%d ", trap_bci);
     if (is_osr) {
       ls.print("osr_bci=%d ", nm->osr_entry_bci());
@@ -1958,7 +1958,7 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
       intptr_t pc = p2i(fr.pc());
 
       JFR_ONLY(post_deoptimization_event(nm, tm, trap_bci, trap_bc, reason, action);)
-      print_ul(nm, tm, pc, fr, trap_bci, reason_name, reason_action);
+      log_deopt(nm, tm, pc, fr, trap_bci, reason_name, reason_action);
       Events::log_deopt_message(current, "Uncommon trap: reason=%s action=%s pc=" INTPTR_FORMAT " method=%s @ %d %s",
                                 reason_name, reason_action, pc,
                                 tm->name_and_sig_as_C_string(), trap_bci, nm->compiler_name());

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1837,6 +1837,15 @@ static void post_deoptimization_event(CompiledMethod* nm,
 
 #endif // INCLUDE_JFR
 
+void Deoptimization::print_ul(CompiledMethod* nm, intptr_t pc, frame& fr, const char* name_sig,
+                              int trap_bci, int osr_bci, const char* reason_name,
+                              const char* reason_action) {
+  log_debug(deoptimization)(
+      "cid=%d %s pc=" INTPTR_FORMAT " relative_pc=" INTPTR_FORMAT " level=%d %s @ %d %d %s -> %s",
+      nm->compile_id(), (nm->is_osr_method() ? "%" : ""), pc, fr.pc() - nm->code_begin(),
+      nm->comp_level(), name_sig, trap_bci, osr_bci, reason_name, reason_action);
+}
+
 JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint trap_request)) {
   HandleMark hm(current);
 
@@ -1931,23 +1940,18 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
       get_method_data(current, profiled_method, create_if_missing);
 
     { // Log Deoptimization event for JFR, UL and event system
+      bool is_osr = nm->is_osr_method();
+      int osr_bci = is_osr ? nm->osr_entry_bci() : -1;
       Method* tm = trap_method();
       char* name_sig = tm->name_and_sig_as_C_string();
       const char* reason_name = trap_reason_name(reason);
       const char* reason_action = trap_action_name(action);
+      intptr_t pc = p2i(fr.pc());
+
       JFR_ONLY(post_deoptimization_event(nm, tm, trap_bci, trap_bc, reason, action);)
-      log_debug(deoptimization)("cid=%d %s pc=" INTPTR_FORMAT " relative_pc=" INTPTR_FORMAT " level=%d %s @ %d %s -> %s",
-                                nm->compile_id(),
-                                (nm->is_osr_method() ? "osr" : ""),
-                                p2i(fr.pc()),
-                                fr.pc() - nm->code_begin(),
-                                nm->comp_level(),
-                                name_sig,
-                                trap_bci,
-                                reason_name,
-                                reason_action);
+      print_ul(nm, pc, fr, name_sig, trap_bci, osr_bci, reason_name, reason_action);
       Events::log_deopt_message(current, "Uncommon trap: reason=%s action=%s pc=" INTPTR_FORMAT " method=%s @ %d %s",
-                                reason_name, reason_action, p2i(fr.pc()),
+                                reason_name, reason_action, pc,
                                 name_sig, trap_bci, nm->compiler_name());
     }
 

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -22,7 +22,6 @@
  *
  */
 
-#include "logging/logLevel.hpp"
 #include "precompiled.hpp"
 #include "jvm.h"
 #include "classfile/javaClasses.inline.hpp"
@@ -40,6 +39,7 @@
 #include "interpreter/interpreter.hpp"
 #include "interpreter/oopMapCache.hpp"
 #include "logging/log.hpp"
+#include "logging/logLevel.hpp"
 #include "logging/logMessage.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/oopFactory.hpp"

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1844,17 +1844,17 @@ void Deoptimization::print_ul(CompiledMethod* nm, intptr_t pc, frame& fr, int tr
   bool is_osr = nm->is_osr_method();
   if (lt.is_enabled()) {
     LogStream ls(lt);
-    ls.print("cid=%d %s pc=" INTPTR_FORMAT " relative_pc=" INTPTR_FORMAT " level=%d",
-             nm->compile_id(), (is_osr ? "%" : ""), pc, fr.pc() - nm->code_begin(),
-             nm->comp_level());
+    ls.print("cid=%d%s level=%d",
+             nm->compile_id(), (is_osr ? " osr" : ""), nm->comp_level());
     nm->method()->print_short_name(&ls);
-    ls.print(" @ ");
-    ls.print("%d ", trap_bci);
+    ls.print(" trap_bci=%d ", trap_bci);
     if (is_osr) {
-      ls.print("%d ", nm->osr_entry_bci());
+      ls.print("osr_bci=%d ", nm->osr_entry_bci());
     }
     ls.print("%s ", reason_name);
-    ls.print("%s", reason_action);
+    ls.print("%s ", reason_action);
+    ls.print("pc=" INTPTR_FORMAT " relative_pc=" INTPTR_FORMAT,
+             pc, fr.pc() - nm->code_begin());
     ls.cr();
   }
 }

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1838,7 +1838,7 @@ static void post_deoptimization_event(CompiledMethod* nm,
 
 #endif // INCLUDE_JFR
 
-void log_deopt(CompiledMethod* nm, Method* tm, intptr_t pc, frame& fr, int trap_bci,
+static void log_deopt(CompiledMethod* nm, Method* tm, intptr_t pc, frame& fr, int trap_bci,
                               const char* reason_name, const char* reason_action) {
   LogTarget(Debug, deoptimization) lt;
   if (lt.is_enabled()) {

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -165,12 +165,11 @@ public:
 #endif
 
   private:
+    static void print_ul(CompiledMethod* nm, intptr_t pc, frame& fr, int trap_bci,
+                         const char* reason_name, const char* reason_action);
 
-  static void print_ul(CompiledMethod* nm, intptr_t pc, frame& fr, int trap_bci, int osr_bci,
-                       const char* reason_name, const char* reason_action);
-
-  // Does the actual work for deoptimizing a single frame
-  static void deoptimize_single_frame(JavaThread* thread, frame fr, DeoptReason reason);
+    // Does the actual work for deoptimizing a single frame
+    static void deoptimize_single_frame(JavaThread* thread, frame fr, DeoptReason reason);
 
 #if COMPILER2_OR_JVMCI
   // Deoptimize objects, that is reallocate and relock them, just before they

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -166,9 +166,8 @@ public:
 
   private:
 
-  static void print_ul(CompiledMethod* nm, intptr_t pc, frame& fr, const char* name_sig,
-                       int trap_bci, int osr_bci, const char* reason_name,
-                       const char* reason_action);
+  static void print_ul(CompiledMethod* nm, intptr_t pc, frame& fr, int trap_bci, int osr_bci,
+                       const char* reason_name, const char* reason_action);
 
   // Does the actual work for deoptimizing a single frame
   static void deoptimize_single_frame(JavaThread* thread, frame fr, DeoptReason reason);

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -44,7 +44,8 @@ class Deoptimization : AllStatic {
   friend class VMStructs;
   friend class EscapeBarrier;
 
- public:
+
+public:
   // What condition caused the deoptimization?
   // Note: Keep this enum in sync. with Deoptimization::_trap_reason_name.
   enum DeoptReason {
@@ -164,6 +165,11 @@ class Deoptimization : AllStatic {
 #endif
 
   private:
+
+  static void print_ul(CompiledMethod* nm, intptr_t pc, frame& fr, const char* name_sig,
+                       int trap_bci, int osr_bci, const char* reason_name,
+                       const char* reason_action);
+
   // Does the actual work for deoptimizing a single frame
   static void deoptimize_single_frame(JavaThread* thread, frame fr, DeoptReason reason);
 

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -164,12 +164,12 @@ public:
   static oop get_cached_box(AutoBoxObjectValue* bv, frame* fr, RegisterMap* reg_map, TRAPS);
 #endif
 
-  private:
-    static void print_ul(CompiledMethod* nm, intptr_t pc, frame& fr, int trap_bci,
-                         const char* reason_name, const char* reason_action);
+private:
+  static void print_ul(CompiledMethod* nm, intptr_t pc, frame& fr, int trap_bci,
+                       const char* reason_name, const char* reason_action);
 
-    // Does the actual work for deoptimizing a single frame
-    static void deoptimize_single_frame(JavaThread* thread, frame fr, DeoptReason reason);
+  // Does the actual work for deoptimizing a single frame
+  static void deoptimize_single_frame(JavaThread* thread, frame fr, DeoptReason reason);
 
 #if COMPILER2_OR_JVMCI
   // Deoptimize objects, that is reallocate and relock them, just before they

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -165,7 +165,7 @@ public:
 #endif
 
 private:
-  static void print_ul(CompiledMethod* nm, intptr_t pc, frame& fr, int trap_bci,
+  static void print_ul(CompiledMethod* nm, Method* tm, intptr_t pc, frame& fr, int trap_bci,
                        const char* reason_name, const char* reason_action);
 
   // Does the actual work for deoptimizing a single frame

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -165,9 +165,6 @@ public:
 #endif
 
 private:
-  static void print_ul(CompiledMethod* nm, Method* tm, intptr_t pc, frame& fr, int trap_bci,
-                       const char* reason_name, const char* reason_action);
-
   // Does the actual work for deoptimizing a single frame
   static void deoptimize_single_frame(JavaThread* thread, frame fr, DeoptReason reason);
 

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -44,8 +44,7 @@ class Deoptimization : AllStatic {
   friend class VMStructs;
   friend class EscapeBarrier;
 
-
-public:
+ public:
   // What condition caused the deoptimization?
   // Note: Keep this enum in sync. with Deoptimization::_trap_reason_name.
   enum DeoptReason {
@@ -164,7 +163,7 @@ public:
   static oop get_cached_box(AutoBoxObjectValue* bv, frame* fr, RegisterMap* reg_map, TRAPS);
 #endif
 
-private:
+  private:
   // Does the actual work for deoptimizing a single frame
   static void deoptimize_single_frame(JavaThread* thread, frame fr, DeoptReason reason);
 


### PR DESCRIPTION
This PR adds a new "deoptimization" tag and a new log message on the info level mimicking JFR's deoptimization event. In the future this tag will be used to add trace level information, hopefully replacing TraceDeoptimization. JFR's event also captures the stacktrace, which this does not (happy to add this if considered important).

An example output looks like this: 

```
[1.324s][debug][deoptimization] cid=236 level=4java.util.concurrent.locks.ReentrantLock$Sync.tryRelease(I)Z trap_bci=26 unstable_if reinterpret pc=0x00007f8b30bf8b94 relative_pc=0x0000000000000174
```

Passes tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284849](https://bugs.openjdk.org/browse/JDK-8284849): Add deoptimization to unified logging


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - **Reviewer**) ⚠️ Review applies to [4f488d95](https://git.openjdk.org/jdk/pull/8812/files/4f488d95f7116d0c39c4057408c3bc0714bf2739)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Xin Liu](https://openjdk.java.net/census#xliu) (@navyxliu - Committer) ⚠️ Review applies to [864460f9](https://git.openjdk.org/jdk/pull/8812/files/864460f9e483c632bcab954d768abd81201de716)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/8812/head:pull/8812` \
`$ git checkout pull/8812`

Update a local copy of the PR: \
`$ git checkout pull/8812` \
`$ git pull https://git.openjdk.org/jdk pull/8812/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8812`

View PR using the GUI difftool: \
`$ git pr show -t 8812`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/8812.diff">https://git.openjdk.org/jdk/pull/8812.diff</a>

</details>
