### PR TITLE
8287089: G1: Change const <type>* name to <type>* const name in arguments

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -121,16 +121,16 @@ private:
   // at "end" to point back to the card before "start"; [start, end]
   void set_remainder_to_point_to_start_incl(size_t start, size_t end);
 
-  inline size_t block_size(const HeapWord* p) const;
+  inline size_t block_size(HeapWord* const p) const;
 
   // Returns the address of a block whose start is at most "addr".
-  inline HeapWord* block_at_or_preceding(const void* addr) const;
+  inline HeapWord* block_at_or_preceding(void* const addr) const;
 
   // Return the address of the beginning of the block that contains "addr".
   // "q" is a block boundary that is <= "addr"; "n" is the address of the
   // next block (or the end of the space.)
   inline HeapWord* forward_to_block_containing_addr(HeapWord* q, HeapWord* n,
-                                                    const void* addr) const;
+                                                    void* const addr) const;
 
   // Update BOT entries corresponding to the mem range [blk_start, blk_end).
   void update_for_block_work(HeapWord* blk_start, HeapWord* blk_end);
@@ -161,7 +161,7 @@ public:
   // namely updating of shared array entries that "point" too far
   // backwards.  This can occur, for example, when lab allocation is used
   // in a space covered by the table.)
-  inline HeapWord* block_start(const void* addr);
+  inline HeapWord* block_start(void* const addr);
 
   void update_for_block(HeapWord* blk_start, HeapWord* blk_end) {
     if (is_crossing_card_boundary(blk_start, blk_end)) {

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
@@ -32,7 +32,7 @@
 #include "runtime/atomic.hpp"
 #include "oops/oop.inline.hpp"
 
-inline HeapWord* G1BlockOffsetTablePart::block_start(const void* addr) {
+inline HeapWord* G1BlockOffsetTablePart::block_start(void* const addr) {
   assert(addr >= _hr->bottom() && addr < _hr->top(), "invalid address");
   HeapWord* q = block_at_or_preceding(addr);
   HeapWord* n = q + block_size(q);
@@ -95,11 +95,11 @@ inline HeapWord* G1BlockOffsetTable::address_for_index(size_t index) const {
   return result;
 }
 
-inline size_t G1BlockOffsetTablePart::block_size(const HeapWord* p) const {
+inline size_t G1BlockOffsetTablePart::block_size(HeapWord* const p) const {
   return _hr->block_size(p);
 }
 
-inline HeapWord* G1BlockOffsetTablePart::block_at_or_preceding(const void* addr) const {
+inline HeapWord* G1BlockOffsetTablePart::block_at_or_preceding(void* const addr) const {
 #ifdef ASSERT
   if (!_hr->is_continues_humongous()) {
     // For non-ContinuesHumongous regions, the first obj always starts from bottom.
@@ -126,7 +126,7 @@ inline HeapWord* G1BlockOffsetTablePart::block_at_or_preceding(const void* addr)
 }
 
 inline HeapWord* G1BlockOffsetTablePart::forward_to_block_containing_addr(HeapWord* q, HeapWord* n,
-                                                                          const void* addr) const {
+                                                                          void* const addr) const {
   while (n <= addr) {
     // When addr is not covered by the block starting at q we need to
     // step forward until we find the correct block. With the BOT

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2346,12 +2346,12 @@ void G1CollectedHeap::par_iterate_regions_array(HeapRegionClosure* cl,
   } while (cur_pos != start_pos);
 }
 
-HeapWord* G1CollectedHeap::block_start(const void* addr) const {
+HeapWord* G1CollectedHeap::block_start(void* const addr) const {
   HeapRegion* hr = heap_region_containing(addr);
   return hr->block_start(addr);
 }
 
-bool G1CollectedHeap::block_is_obj(const HeapWord* addr) const {
+bool G1CollectedHeap::block_is_obj(HeapWord* const addr) const {
   HeapRegion* hr = heap_region_containing(addr);
   return hr->block_is_obj(addr);
 }
@@ -3317,7 +3317,7 @@ HeapRegion* G1CollectedHeap::alloc_highest_free_region() {
   return NULL;
 }
 
-void G1CollectedHeap::mark_evac_failure_object(const oop obj, uint worker_id) const {
+void G1CollectedHeap::mark_evac_failure_object(const oop obj) const {
   // All objects failing evacuation are live. What we'll do is
   // that we'll update the prev marking info so that they are
   // all under PTAMS and explicitly marked.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1044,9 +1044,9 @@ public:
 
   // Return "TRUE" iff the given object address is within the collection
   // set. Assumes that the reference points into the heap.
-  inline bool is_in_cset(const HeapRegion *hr);
-  inline bool is_in_cset(oop obj);
-  inline bool is_in_cset(HeapWord* addr);
+  inline bool is_in_cset(const HeapRegion *hr) const;
+  inline bool is_in_cset(const oop obj) const;
+  inline bool is_in_cset(HeapWord* const addr) const;
 
   inline bool is_in_cset_or_humongous(const oop obj);
 
@@ -1058,7 +1058,7 @@ public:
 
  public:
 
-  inline G1HeapRegionAttr region_attr(const void* obj) const;
+  inline G1HeapRegionAttr region_attr(void* const obj) const;
   inline G1HeapRegionAttr region_attr(uint idx) const;
 
   MemRegion reserved() const {
@@ -1167,11 +1167,11 @@ public:
   // address "addr".  We say "blocks" instead of "object" since some heaps
   // may not pack objects densely; a chunk may either be an object or a
   // non-object.
-  HeapWord* block_start(const void* addr) const;
+  HeapWord* block_start(void* const addr) const;
 
   // Requires "addr" to be the start of a block, and returns "TRUE" iff
   // the block is an object.
-  bool block_is_obj(const HeapWord* addr) const;
+  bool block_is_obj(HeapWord* const addr) const;
 
   // Section on thread-local allocation buffers (TLABs)
   // See CollectedHeap for semantics.
@@ -1234,7 +1234,7 @@ public:
   bool check_young_list_empty();
 #endif
 
-  bool is_marked_next(oop obj) const;
+  bool is_marked_next(const oop obj) const;
 
   // Determine if an object is dead, given the object and also
   // the region to which the object belongs.
@@ -1243,16 +1243,14 @@ public:
   // Determine if an object is dead, given only the object itself.
   // This will find the region to which the object belongs and
   // then call the region version of the same function.
-
-  // Added if it is NULL it isn't dead.
-
+  // NULL obj are not considered dead.
   inline bool is_obj_dead(const oop obj) const;
 
   inline bool is_obj_dead_full(const oop obj, const HeapRegion* hr) const;
   inline bool is_obj_dead_full(const oop obj) const;
 
   // Mark the live object that failed evacuation in the prev bitmap.
-  void mark_evac_failure_object(const oop obj, uint worker_id) const;
+  void mark_evac_failure_object(const oop obj) const;
 
   G1ConcurrentMark* concurrent_mark() const { return _cm; }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -158,19 +158,19 @@ inline G1ScannerTasksQueue* G1CollectedHeap::task_queue(uint i) const {
   return _task_queues->queue(i);
 }
 
-inline bool G1CollectedHeap::is_marked_next(oop obj) const {
+inline bool G1CollectedHeap::is_marked_next(const oop obj) const {
   return _cm->next_mark_bitmap()->is_marked(obj);
 }
 
-inline bool G1CollectedHeap::is_in_cset(oop obj) {
+inline bool G1CollectedHeap::is_in_cset(const oop obj) const {
   return is_in_cset(cast_from_oop<HeapWord*>(obj));
 }
 
-inline bool G1CollectedHeap::is_in_cset(HeapWord* addr) {
+inline bool G1CollectedHeap::is_in_cset(HeapWord* const addr) const {
   return _region_attr.is_in_cset(addr);
 }
 
-bool G1CollectedHeap::is_in_cset(const HeapRegion* hr) {
+bool G1CollectedHeap::is_in_cset(const HeapRegion* hr) const {
   return _region_attr.is_in_cset(hr);
 }
 
@@ -178,7 +178,7 @@ bool G1CollectedHeap::is_in_cset_or_humongous(const oop obj) {
   return _region_attr.is_in_cset_or_humongous(cast_from_oop<HeapWord*>(obj));
 }
 
-G1HeapRegionAttr G1CollectedHeap::region_attr(const void* addr) const {
+G1HeapRegionAttr G1CollectedHeap::region_attr(void* const addr) const {
   return _region_attr.at((HeapWord*)addr);
 }
 

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -626,7 +626,7 @@ oop G1ParScanThreadState::handle_evacuation_failure_par(oop old, markWord m, siz
     // Objects failing evacuation will turn into old objects since the regions
     // are relabeled as such. We mark the failing objects in the prev bitmap and
     // later use it to handle all failed objects.
-    _g1h->mark_evac_failure_object(old, _worker_id);
+    _g1h->mark_evac_failure_object(old);
 
     if (_evac_failure_regions->record(r->hrm_index())) {
       _g1h->hr_printer()->evac_failure(r);

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -101,7 +101,7 @@ public:
     assert(is_in(pre_dummy_top) && pre_dummy_top <= top(), "pre-condition");
     _pre_dummy_top = pre_dummy_top;
   }
-  HeapWord* pre_dummy_top() { return (_pre_dummy_top == NULL) ? top() : _pre_dummy_top; }
+  HeapWord* pre_dummy_top() const { return (_pre_dummy_top == NULL) ? top() : _pre_dummy_top; }
   void reset_pre_dummy_top() { _pre_dummy_top = NULL; }
 
   // Returns true iff the given the heap  region contains the
@@ -117,7 +117,7 @@ public:
   // given address.
   bool is_in_reserved(const void* p) const { return _bottom <= p && p < _end; }
 
-  size_t capacity()     const { return byte_size(bottom(), end()); }
+  size_t capacity() const { return byte_size(bottom(), end()); }
   size_t used() const { return byte_size(bottom(), top()); }
   size_t free() const { return byte_size(top(), end()); }
 
@@ -129,8 +129,6 @@ private:
   void reset_after_full_gc_common();
 
   void clear(bool mangle_space);
-
-  HeapWord* block_start_const(const void* p) const;
 
   void mangle_unused_area() PRODUCT_RETURN;
 
@@ -147,7 +145,7 @@ private:
   inline HeapWord* par_allocate_impl(size_t min_word_size, size_t desired_word_size, size_t* actual_word_size);
 
 public:
-  HeapWord* block_start(const void* p);
+  HeapWord* block_start(void* const p);
 
   void object_iterate(ObjectClosure* blk);
 
@@ -175,7 +173,7 @@ public:
   void reset_skip_compacting_after_full_gc();
 
   // All allocated blocks are occupied by objects in a HeapRegion
-  bool block_is_obj(const HeapWord* p) const;
+  bool block_is_obj(HeapWord* const p) const;
 
   // Returns whether the given object is dead based on TAMS and bitmap.
   // An object is dead iff a) it was not allocated since the last mark (>TAMS), b) it
@@ -184,7 +182,7 @@ public:
 
   // Returns the object size for all valid block starts
   // and the amount of unallocated words if called on top()
-  size_t block_size(const HeapWord* p) const;
+  size_t block_size(HeapWord* const p) const;
 
   // Scans through the region using the bitmap to determine what
   // objects to call size_t ApplyToMarkedClosure::apply(oop) for.
@@ -276,7 +274,7 @@ private:
 
   // Returns the block size of the given (dead, potentially having its class unloaded) object
   // starting at p extending to at most the prev TAMS using the given mark bitmap.
-  inline size_t block_size_using_bitmap(const HeapWord* p, const G1CMBitMap* const prev_bitmap) const;
+  inline size_t block_size_using_bitmap(HeapWord* const p, const G1CMBitMap* const prev_bitmap) const;
 public:
   HeapRegion(uint hrm_index,
              G1BlockOffsetTable* bot,

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -79,7 +79,7 @@ inline HeapWord* HeapRegion::par_allocate_impl(size_t min_word_size,
   } while (true);
 }
 
-inline HeapWord* HeapRegion::block_start(const void* p) {
+inline HeapWord* HeapRegion::block_start(void* const p) {
   return _bot_part.block_start(p);
 }
 
@@ -102,7 +102,7 @@ inline bool HeapRegion::is_obj_dead_with_size(const oop obj, const G1CMBitMap* c
   return obj_is_dead;
 }
 
-inline bool HeapRegion::block_is_obj(const HeapWord* p) const {
+inline bool HeapRegion::block_is_obj(HeapWord* const p) const {
   assert(p >= bottom() && p < top(), "precondition");
   assert(!is_continues_humongous(), "p must point to block-start");
   // When class unloading is enabled it is not safe to only consider top() to conclude if the
@@ -118,7 +118,7 @@ inline bool HeapRegion::block_is_obj(const HeapWord* p) const {
   return true;
 }
 
-inline size_t HeapRegion::block_size_using_bitmap(const HeapWord* addr, const G1CMBitMap* const prev_bitmap) const {
+inline size_t HeapRegion::block_size_using_bitmap(HeapWord* const addr, const G1CMBitMap* const prev_bitmap) const {
   assert(ClassUnloading,
          "All blocks should be objects if class unloading isn't used, so this method should not be called. "
          "HR: [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ") "
@@ -140,7 +140,7 @@ inline bool HeapRegion::is_obj_dead(const oop obj, const G1CMBitMap* const prev_
          !is_closed_archive();
 }
 
-inline size_t HeapRegion::block_size(const HeapWord *addr) const {
+inline size_t HeapRegion::block_size(HeapWord* const addr) const {
   assert(addr < top(), "precondition");
 
   if (block_is_obj(addr)) {


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that fixes as few `const` modifiers, making them more consistent; mostly changing `const <type>* something` to `<type>* const something` as in many cases the pointer value should be constant, not the thing that is pointed to.

I also considered changing `const <typedef> something` where `typedef` is a pointer type (e.g. `oop` is `oopDesc*`), but `const oop something` is equal to `oop const something` (it only concerns `oop` in our code) to minimize the changes. If you think we should change these argument declarations to `oop const something` to be similar to other code, I can do that.

This is a preparatory change for [JDK-8210708](https://bugs.openjdk.java.net/browse/JDK-8210708) where some of the affected method get another parameter, and it looks weird to have e.g. `block_start(const HeapWord* addr, HeapWord* const pb)`, i.e. two parameters where although both are meant to be constant pointers, they have different `const`s.

Testing: local compilation, GHA

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287089](https://bugs.openjdk.java.net/browse/JDK-8287089): G1: Change const <type>* name to <type>* const name in arguments


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8815/head:pull/8815` \
`$ git checkout pull/8815`

Update a local copy of the PR: \
`$ git checkout pull/8815` \
`$ git pull https://git.openjdk.java.net/jdk pull/8815/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8815`

View PR using the GUI difftool: \
`$ git pr show -t 8815`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8815.diff">https://git.openjdk.java.net/jdk/pull/8815.diff</a>

</details>
