### PR TITLE
8280481: Duplicated static stubs in NMethod Stub Code section

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3810,12 +3810,8 @@ encode %{
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
-      // Emit stub for static call
-      address stub = CompiledStaticCall::emit_to_interp_stub(cbuf);
-      if (stub == NULL) {
-        ciEnv::current()->record_failure("CodeCache is full");
-        return;
-      }
+      assert(_method->is_loaded(), "must be loaded");
+      cbuf.shared_stub_to_interp_for(_method->get_Method(), cbuf.insts_mark());
     }
 
     _masm.clear_inst_mark();

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3810,8 +3810,7 @@ encode %{
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
-      if (CodeBuffer::supports_shared_stubs() &&
-          _method->is_loaded() &&
+      if (UseSharedStubs && _method->is_loaded() &&
           (!_optimized_virtual || _method->is_final_method())) {
         // Postpone creating a stub to the interpreter because
         // it might be shared among calls of the same Java method.

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3810,8 +3810,20 @@ encode %{
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
-      assert(_method->is_loaded(), "must be loaded");
-      cbuf.shared_stub_to_interp_for(_method->get_Method(), cbuf.insts_mark());
+      if (CodeBuffer::supports_shared_stubs() &&
+          _method->is_loaded() &&
+          (!_optimized_virtual || _method->is_final_method())) {
+        // Postpone creating a stub to the interpreter because
+        // it might be shared among calls of the same Java method.
+        cbuf.shared_stub_to_interp_for(_method->get_Method(), cbuf.insts_mark());
+      } else {
+        // Emit stub for static call
+        address stub = CompiledStaticCall::emit_to_interp_stub(cbuf);
+        if (stub == NULL) {
+          ciEnv::current()->record_failure("CodeCache is full");
+          return;
+        }
+      }
     }
 
     _masm.clear_inst_mark();

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3813,7 +3813,7 @@ encode %{
       if (CodeBuffer::supports_shared_stubs() && _method->can_be_statically_bound()) {
         // Calls of the same statically bound method can share
         // a stub to the interpreter.
-        cbuf.shared_stub_to_interp_for(_method, cbuf.insts_mark());
+        cbuf.shared_stub_to_interp_for(_method, cbuf.insts()->mark_off());
       } else {
         // Emit stub for static call
         address stub = CompiledStaticCall::emit_to_interp_stub(cbuf);

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3810,11 +3810,10 @@ encode %{
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
-      if (UseSharedStubs && _method->is_loaded() &&
-          (!_optimized_virtual || _method->is_final_method())) {
-        // Postpone creating a stub to the interpreter because
-        // it might be shared among calls of the same Java method.
-        cbuf.shared_stub_to_interp_for(_method->get_Method(), cbuf.insts_mark());
+      if (CodeBuffer::supports_shared_stubs() && _method->can_be_statically_bound()) {
+        // Calls of the same statically bound method can share
+        // a stub to the interpreter.
+        cbuf.shared_stub_to_interp_for(_method, cbuf.insts_mark());
       } else {
         // Emit stub for static call
         address stub = CompiledStaticCall::emit_to_interp_stub(cbuf);

--- a/src/hotspot/cpu/aarch64/codeBuffer_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/codeBuffer_aarch64.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include "precompiled.hpp"
 #include "asm/codeBuffer.hpp"
 #include "asm/macroAssembler.hpp"
 #include "ci/ciEnv.hpp"

--- a/src/hotspot/cpu/aarch64/codeBuffer_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/codeBuffer_aarch64.cpp
@@ -27,5 +27,5 @@
 #include "asm/macroAssembler.hpp"
 
 bool CodeBuffer::pd_finalize_stubs() {
-  return emit_shared_stubs_to_interp<MacroAssembler>(this, &_shared_stub_to_interp_requests);
+  return emit_shared_stubs_to_interp<MacroAssembler>(this, _shared_stub_to_interp_requests);
 }

--- a/src/hotspot/cpu/aarch64/codeBuffer_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/codeBuffer_aarch64.cpp
@@ -23,28 +23,9 @@
  */
 
 #include "precompiled.hpp"
-#include "asm/codeBuffer.hpp"
+#include "asm/codeBuffer.inline.hpp"
 #include "asm/macroAssembler.hpp"
-#include "ci/ciEnv.hpp"
-#include "code/compiledIC.hpp"
 
-bool CodeBuffer::emit_shared_stubs_to_interp() {
-  MacroAssembler masm(this);
-  LinkedListIterator<SharedStubToInterpRequest> it(_shared_stub_to_interp_requests.head());
-  SharedStubToInterpRequest* request = it.next();
-  while (request != NULL) {
-    address stub = masm.start_a_stub(CompiledStaticCall::to_interp_stub_size());
-    if (stub == NULL) {
-      ciEnv::current()->record_failure("CodeCache is full");
-      return false;
-    }
-    Method* method = request->shared_method();
-    do {
-      masm.relocate(static_stub_Relocation::spec(request->caller_pc()));
-      request = it.next();
-    } while (request != NULL && request->shared_method() == method);
-    masm.emit_static_call_stub();
-    masm.end_a_stub();
-  }
-  return true;
+bool CodeBuffer::pd_finalize_stubs() {
+  return emit_shared_stubs_to_interp<MacroAssembler>(this, _shared_stub_to_interp_requests);
 }

--- a/src/hotspot/cpu/aarch64/codeBuffer_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/codeBuffer_aarch64.cpp
@@ -27,5 +27,5 @@
 #include "asm/macroAssembler.hpp"
 
 bool CodeBuffer::pd_finalize_stubs() {
-  return emit_shared_stubs_to_interp<MacroAssembler>(this, _shared_stub_to_interp_requests);
+  return emit_shared_stubs_to_interp<MacroAssembler>(this, &_shared_stub_to_interp_requests);
 }

--- a/src/hotspot/cpu/aarch64/codeBuffer_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/codeBuffer_aarch64.hpp
@@ -28,8 +28,13 @@
 
 private:
   void pd_initialize() {}
+  bool emit_shared_stubs_to_interp();
+  bool pd_finalize_stubs() {
+    return emit_shared_stubs_to_interp();
+  }
 
 public:
   void flush_bundle(bool start_new_bundle) {}
+  static bool supports_shared_stubs() { return true; }
 
 #endif // CPU_AARCH64_CODEBUFFER_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/codeBuffer_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/codeBuffer_aarch64.hpp
@@ -28,13 +28,9 @@
 
 private:
   void pd_initialize() {}
-  bool emit_shared_stubs_to_interp();
-  bool pd_finalize_stubs() {
-    return emit_shared_stubs_to_interp();
-  }
+  bool pd_finalize_stubs();
 
 public:
   void flush_bundle(bool start_new_bundle) {}
-  static bool supports_shared_stubs() { return true; }
 
 #endif // CPU_AARCH64_CODEBUFFER_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/codeBuffer_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/codeBuffer_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/aarch64/codeBuffer_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/codeBuffer_aarch64.hpp
@@ -32,5 +32,6 @@ private:
 
 public:
   void flush_bundle(bool start_new_bundle) {}
+  static constexpr bool supports_shared_stubs() { return true; }
 
 #endif // CPU_AARCH64_CODEBUFFER_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -129,10 +129,6 @@ void VM_Version::initialize() {
     }
   }
 
-  if (FLAG_IS_DEFAULT(UseSharedStubs)) {
-    FLAG_SET_DEFAULT(UseSharedStubs, true);
-  }
-
   // Enable vendor specific features
 
   // Ampere eMAG

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -129,6 +129,10 @@ void VM_Version::initialize() {
     }
   }
 
+  if (FLAG_IS_DEFAULT(UseSharedStubs)) {
+    FLAG_SET_DEFAULT(UseSharedStubs, true);
+  }
+
   // Enable vendor specific features
 
   // Ampere eMAG

--- a/src/hotspot/cpu/arm/codeBuffer_arm.hpp
+++ b/src/hotspot/cpu/arm/codeBuffer_arm.hpp
@@ -27,11 +27,9 @@
 
 private:
   void pd_initialize() {}
-  bool emit_shared_stubs_to_interp() { Unimplemented(); return true; }
   bool pd_finalize_stubs() { return true; }
 
 public:
   void flush_bundle(bool start_new_bundle) {}
-  static bool supports_shared_stubs() { return false; }
 
 #endif // CPU_ARM_CODEBUFFER_ARM_HPP

--- a/src/hotspot/cpu/arm/codeBuffer_arm.hpp
+++ b/src/hotspot/cpu/arm/codeBuffer_arm.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,12 @@
 
 private:
   void pd_initialize() {}
-  bool pd_finalize_stubs() { return true; }
+  bool pd_finalize_stubs() {
+    if (_finalize_stubs) {
+      Unimplemented();
+    }
+    return true;
+  }
 
 public:
   void flush_bundle(bool start_new_bundle) {}

--- a/src/hotspot/cpu/arm/codeBuffer_arm.hpp
+++ b/src/hotspot/cpu/arm/codeBuffer_arm.hpp
@@ -36,5 +36,6 @@ private:
 
 public:
   void flush_bundle(bool start_new_bundle) {}
+  static constexpr bool supports_shared_stubs() { return false; }
 
 #endif // CPU_ARM_CODEBUFFER_ARM_HPP

--- a/src/hotspot/cpu/arm/codeBuffer_arm.hpp
+++ b/src/hotspot/cpu/arm/codeBuffer_arm.hpp
@@ -27,8 +27,11 @@
 
 private:
   void pd_initialize() {}
+  bool emit_shared_stubs_to_interp() { Unimplemented(); return true; }
+  bool pd_finalize_stubs() { return true; }
 
 public:
   void flush_bundle(bool start_new_bundle) {}
+  static bool supports_shared_stubs() { return false; }
 
 #endif // CPU_ARM_CODEBUFFER_ARM_HPP

--- a/src/hotspot/cpu/ppc/codeBuffer_ppc.hpp
+++ b/src/hotspot/cpu/ppc/codeBuffer_ppc.hpp
@@ -28,8 +28,11 @@
 
 private:
   void pd_initialize() {}
+  bool emit_shared_stubs_to_interp() { Unimplemented(); return true; }
+  bool pd_finalize_stubs() { return true; }
 
 public:
   void flush_bundle(bool start_new_bundle) {}
+  static bool supports_shared_stubs() { return false; }
 
 #endif // CPU_PPC_CODEBUFFER_PPC_HPP

--- a/src/hotspot/cpu/ppc/codeBuffer_ppc.hpp
+++ b/src/hotspot/cpu/ppc/codeBuffer_ppc.hpp
@@ -28,11 +28,9 @@
 
 private:
   void pd_initialize() {}
-  bool emit_shared_stubs_to_interp() { Unimplemented(); return true; }
   bool pd_finalize_stubs() { return true; }
 
 public:
   void flush_bundle(bool start_new_bundle) {}
-  static bool supports_shared_stubs() { return false; }
 
 #endif // CPU_PPC_CODEBUFFER_PPC_HPP

--- a/src/hotspot/cpu/ppc/codeBuffer_ppc.hpp
+++ b/src/hotspot/cpu/ppc/codeBuffer_ppc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2013 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -28,7 +28,12 @@
 
 private:
   void pd_initialize() {}
-  bool pd_finalize_stubs() { return true; }
+  bool pd_finalize_stubs() {
+    if (_finalize_stubs) {
+      Unimplemented();
+    }
+    return true;
+  }
 
 public:
   void flush_bundle(bool start_new_bundle) {}

--- a/src/hotspot/cpu/ppc/codeBuffer_ppc.hpp
+++ b/src/hotspot/cpu/ppc/codeBuffer_ppc.hpp
@@ -37,5 +37,6 @@ private:
 
 public:
   void flush_bundle(bool start_new_bundle) {}
+  static constexpr bool supports_shared_stubs() { return false; }
 
 #endif // CPU_PPC_CODEBUFFER_PPC_HPP

--- a/src/hotspot/cpu/riscv/codeBuffer_riscv.hpp
+++ b/src/hotspot/cpu/riscv/codeBuffer_riscv.hpp
@@ -38,5 +38,6 @@ private:
 
 public:
   void flush_bundle(bool start_new_bundle) {}
+  static constexpr bool supports_shared_stubs() { return false; }
 
 #endif // CPU_RISCV_CODEBUFFER_RISCV_HPP

--- a/src/hotspot/cpu/riscv/codeBuffer_riscv.hpp
+++ b/src/hotspot/cpu/riscv/codeBuffer_riscv.hpp
@@ -29,11 +29,9 @@
 
 private:
   void pd_initialize() {}
-  bool emit_shared_stubs_to_interp() { Unimplemented(); return true; }
   bool pd_finalize_stubs() { return true; }
 
 public:
   void flush_bundle(bool start_new_bundle) {}
-  static bool supports_shared_stubs() { return false; }
 
 #endif // CPU_RISCV_CODEBUFFER_RISCV_HPP

--- a/src/hotspot/cpu/riscv/codeBuffer_riscv.hpp
+++ b/src/hotspot/cpu/riscv/codeBuffer_riscv.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -29,7 +29,12 @@
 
 private:
   void pd_initialize() {}
-  bool pd_finalize_stubs() { return true; }
+  bool pd_finalize_stubs() {
+    if (_finalize_stubs) {
+      Unimplemented();
+    }
+    return true;
+  }
 
 public:
   void flush_bundle(bool start_new_bundle) {}

--- a/src/hotspot/cpu/s390/codeBuffer_s390.hpp
+++ b/src/hotspot/cpu/s390/codeBuffer_s390.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2016 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -28,7 +28,12 @@
 
  private:
   void pd_initialize() {}
-  bool pd_finalize_stubs() { return true; }
+  bool pd_finalize_stubs() {
+    if (_finalize_stubs) {
+      Unimplemented();
+    }
+    return true;
+  }
 
  public:
   void flush_bundle(bool start_new_bundle) {}

--- a/src/hotspot/cpu/s390/codeBuffer_s390.hpp
+++ b/src/hotspot/cpu/s390/codeBuffer_s390.hpp
@@ -39,5 +39,6 @@
   void flush_bundle(bool start_new_bundle) {}
 
   void getCpuData(const CodeBuffer * const cb) {}
+  static constexpr bool supports_shared_stubs() { return false; }
 
 #endif // CPU_S390_CODEBUFFER_S390_HPP

--- a/src/hotspot/cpu/s390/codeBuffer_s390.hpp
+++ b/src/hotspot/cpu/s390/codeBuffer_s390.hpp
@@ -28,12 +28,10 @@
 
  private:
   void pd_initialize() {}
-  bool emit_shared_stubs_to_interp() { Unimplemented(); return true; }
   bool pd_finalize_stubs() { return true; }
 
  public:
   void flush_bundle(bool start_new_bundle) {}
-  static bool supports_shared_stubs() { return false; }
 
   void getCpuData(const CodeBuffer * const cb) {}
 

--- a/src/hotspot/cpu/s390/codeBuffer_s390.hpp
+++ b/src/hotspot/cpu/s390/codeBuffer_s390.hpp
@@ -28,9 +28,12 @@
 
  private:
   void pd_initialize() {}
+  bool emit_shared_stubs_to_interp() { Unimplemented(); return true; }
+  bool pd_finalize_stubs() { return true; }
 
  public:
   void flush_bundle(bool start_new_bundle) {}
+  static bool supports_shared_stubs() { return false; }
 
   void getCpuData(const CodeBuffer * const cb) {}
 

--- a/src/hotspot/cpu/x86/codeBuffer_x86.cpp
+++ b/src/hotspot/cpu/x86/codeBuffer_x86.cpp
@@ -27,5 +27,5 @@
 #include "asm/macroAssembler.hpp"
 
 bool CodeBuffer::pd_finalize_stubs() {
-  return emit_shared_stubs_to_interp<MacroAssembler, Assembler::imm_operand>(this, _shared_stub_to_interp_requests);
+  return emit_shared_stubs_to_interp<MacroAssembler, Assembler::imm_operand>(this, &_shared_stub_to_interp_requests);
 }

--- a/src/hotspot/cpu/x86/codeBuffer_x86.cpp
+++ b/src/hotspot/cpu/x86/codeBuffer_x86.cpp
@@ -27,5 +27,5 @@
 #include "asm/macroAssembler.hpp"
 
 bool CodeBuffer::pd_finalize_stubs() {
-  return emit_shared_stubs_to_interp<MacroAssembler, Assembler::imm_operand>(this, &_shared_stub_to_interp_requests);
+  return emit_shared_stubs_to_interp<MacroAssembler, Assembler::imm_operand>(this, _shared_stub_to_interp_requests);
 }

--- a/src/hotspot/cpu/x86/codeBuffer_x86.cpp
+++ b/src/hotspot/cpu/x86/codeBuffer_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,18 +22,29 @@
  *
  */
 
-#ifndef CPU_X86_CODEBUFFER_X86_HPP
-#define CPU_X86_CODEBUFFER_X86_HPP
+#include "precompiled.hpp"
+#include "asm/codeBuffer.hpp"
+#include "asm/macroAssembler.hpp"
+#include "ci/ciEnv.hpp"
+#include "code/compiledIC.hpp"
 
-private:
-  void pd_initialize() {}
-  bool emit_shared_stubs_to_interp();
-  bool pd_finalize_stubs() {
-    return emit_shared_stubs_to_interp();
+bool CodeBuffer::emit_shared_stubs_to_interp() {
+  MacroAssembler masm(this);
+  LinkedListIterator<SharedStubToInterpRequest> it(_shared_stub_to_interp_requests.head());
+  SharedStubToInterpRequest* request = it.next();
+  while (request != NULL) {
+    address stub = masm.start_a_stub(CompiledStaticCall::to_interp_stub_size());
+    if (stub == NULL) {
+      ciEnv::current()->record_failure("CodeCache is full");
+      return false;
+    }
+    Method* method = request->shared_method();
+    do {
+      masm.relocate(static_stub_Relocation::spec(request->caller_pc()), Assembler::imm_operand);
+      request = it.next();
+    } while (request != NULL && request->shared_method() == method);
+    masm.emit_static_call_stub();
+    masm.end_a_stub();
   }
-
-public:
-  void flush_bundle(bool start_new_bundle) {}
-  static bool supports_shared_stubs() { return true; }
-
-#endif // CPU_X86_CODEBUFFER_X86_HPP
+  return true;
+}

--- a/src/hotspot/cpu/x86/codeBuffer_x86.hpp
+++ b/src/hotspot/cpu/x86/codeBuffer_x86.hpp
@@ -27,8 +27,11 @@
 
 private:
   void pd_initialize() {}
+  bool emit_shared_stubs_to_interp() { Unimplemented(); return true; }
+  bool pd_finalize_stubs() { return true; }
 
 public:
   void flush_bundle(bool start_new_bundle) {}
+  static bool supports_shared_stubs() { return false; }
 
 #endif // CPU_X86_CODEBUFFER_X86_HPP

--- a/src/hotspot/cpu/x86/codeBuffer_x86.hpp
+++ b/src/hotspot/cpu/x86/codeBuffer_x86.hpp
@@ -31,5 +31,6 @@ private:
 
 public:
   void flush_bundle(bool start_new_bundle) {}
+  static constexpr bool supports_shared_stubs() { return true; }
 
 #endif // CPU_X86_CODEBUFFER_X86_HPP

--- a/src/hotspot/cpu/x86/codeBuffer_x86.hpp
+++ b/src/hotspot/cpu/x86/codeBuffer_x86.hpp
@@ -27,10 +27,7 @@
 
 private:
   void pd_initialize() {}
-  bool emit_shared_stubs_to_interp();
-  bool pd_finalize_stubs() {
-    return emit_shared_stubs_to_interp();
-  }
+  bool pd_finalize_stubs();
 
 public:
   void flush_bundle(bool start_new_bundle) {}

--- a/src/hotspot/cpu/x86/codeBuffer_x86.hpp
+++ b/src/hotspot/cpu/x86/codeBuffer_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/codeBuffer_x86.hpp
+++ b/src/hotspot/cpu/x86/codeBuffer_x86.hpp
@@ -31,6 +31,5 @@ private:
 
 public:
   void flush_bundle(bool start_new_bundle) {}
-  static bool supports_shared_stubs() { return true; }
 
 #endif // CPU_X86_CODEBUFFER_X86_HPP

--- a/src/hotspot/cpu/x86/compiledIC_x86.cpp
+++ b/src/hotspot/cpu/x86/compiledIC_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/compiledIC_x86.cpp
+++ b/src/hotspot/cpu/x86/compiledIC_x86.cpp
@@ -55,10 +55,7 @@ address CompiledStaticCall::emit_to_interp_stub(CodeBuffer &cbuf, address mark) 
   }
   // Static stub relocation stores the instruction address of the call.
   __ relocate(static_stub_Relocation::spec(mark), Assembler::imm_operand);
-  // Static stub relocation also tags the Method* in the code-stream.
-  __ mov_metadata(rbx, (Metadata*) NULL);  // Method is zapped till fixup time.
-  // This is recognized as unresolved by relocs/nativeinst/ic code.
-  __ jump(RuntimeAddress(__ pc()));
+  __ emit_static_call_stub();
 
   assert(__ pc() - base <= to_interp_stub_size(), "wrong stub size");
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1328,6 +1328,13 @@ void MacroAssembler::ic_call(address entry, jint method_index) {
   call(AddressLiteral(entry, rh));
 }
 
+void MacroAssembler::emit_static_call_stub() {
+  // Static stub relocation also tags the Method* in the code-stream.
+  mov_metadata(rbx, (Metadata*) NULL);  // Method is zapped till fixup time.
+  // This is recognized as unresolved by relocs/nativeinst/ic code.
+  jump(RuntimeAddress(pc()));
+}
+
 // Implementation of call_VM versions
 
 void MacroAssembler::call_VM(Register oop_result,

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -865,6 +865,8 @@ public:
   // Emit the CompiledIC call idiom
   void ic_call(address entry, jint method_index = 0);
 
+  void emit_static_call_stub();
+
   // Jumps
 
   // NOTE: these jumps transfer to the effective address of dst NOT

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -2056,10 +2056,6 @@ void VM_Version::initialize() {
   detect_virt_stub = CAST_TO_FN_PTR(detect_virt_stub_t,
                                      g.generate_detect_virt());
 
-  if (FLAG_IS_DEFAULT(UseSharedStubs)) {
-    FLAG_SET_DEFAULT(UseSharedStubs, true);
-  }
-
   get_processor_features();
 
   LP64_ONLY(Assembler::precompute_instructions();)

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -2056,6 +2056,10 @@ void VM_Version::initialize() {
   detect_virt_stub = CAST_TO_FN_PTR(detect_virt_stub_t,
                                      g.generate_detect_virt());
 
+  if (FLAG_IS_DEFAULT(UseSharedStubs)) {
+    FLAG_SET_DEFAULT(UseSharedStubs, true);
+  }
+
   get_processor_features();
 
   LP64_ONLY(Assembler::precompute_instructions();)

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -1817,7 +1817,7 @@ encode %{
       if (CodeBuffer::supports_shared_stubs() && _method->can_be_statically_bound()) {
         // Calls of the same statically bound method can share
         // a stub to the interpreter.
-        cbuf.shared_stub_to_interp_for(_method->get_Method(), mark);
+        cbuf.shared_stub_to_interp_for(_method, mark);
       } else {
         // Emit stubs for static call.
         address stub = CompiledStaticCall::emit_to_interp_stub(cbuf, mark);

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -1814,10 +1814,9 @@ encode %{
                      rspec, RELOC_DISP32);
       __ post_call_nop();
       address mark = cbuf.insts_mark();
-      if (UseSharedStubs && _method->is_loaded() &&
-          (!_optimized_virtual || _method->is_final_method())) {
-        // Postpone creating a stub to the interpreter because
-        // it might be shared among calls of the same Java method.
+      if (CodeBuffer::supports_shared_stubs() && _method->can_be_statically_bound()) {
+        // Calls of the same statically bound method can share
+        // a stub to the interpreter.
         cbuf.shared_stub_to_interp_for(_method->get_Method(), mark);
       } else {
         // Emit stubs for static call.

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -1813,11 +1813,20 @@ encode %{
       emit_d32_reloc(cbuf, ($meth$$method - (int)(cbuf.insts_end()) - 4),
                      rspec, RELOC_DISP32);
       __ post_call_nop();
-      // Emit stubs for static call.
-      address stub = CompiledStaticCall::emit_to_interp_stub(cbuf);
-      if (stub == NULL) {
-        ciEnv::current()->record_failure("CodeCache is full");
-        return;
+      address mark = cbuf.insts_mark();
+      if (CodeBuffer::supports_shared_stubs() &&
+          _method->is_loaded() &&
+          (!_optimized_virtual || _method->is_final_method())) {
+        // Postpone creating a stub to the interpreter because
+        // it might be shared among calls of the same Java method.
+        cbuf.shared_stub_to_interp_for(_method->get_Method(), mark);
+      } else {
+        // Emit stubs for static call.
+        address stub = CompiledStaticCall::emit_to_interp_stub(cbuf, mark);
+        if (stub == NULL) {
+          ciEnv::current()->record_failure("CodeCache is full");
+          return;
+        }
       }
     }
   %}

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -1814,8 +1814,7 @@ encode %{
                      rspec, RELOC_DISP32);
       __ post_call_nop();
       address mark = cbuf.insts_mark();
-      if (CodeBuffer::supports_shared_stubs() &&
-          _method->is_loaded() &&
+      if (UseSharedStubs && _method->is_loaded() &&
           (!_optimized_virtual || _method->is_final_method())) {
         // Postpone creating a stub to the interpreter because
         // it might be shared among calls of the same Java method.

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -1817,7 +1817,7 @@ encode %{
       if (CodeBuffer::supports_shared_stubs() && _method->can_be_statically_bound()) {
         // Calls of the same statically bound method can share
         // a stub to the interpreter.
-        cbuf.shared_stub_to_interp_for(_method, mark);
+        cbuf.shared_stub_to_interp_for(_method, cbuf.insts()->mark_off());
       } else {
         // Emit stubs for static call.
         address stub = CompiledStaticCall::emit_to_interp_stub(cbuf, mark);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -2168,12 +2168,20 @@ encode %{
                                                   : static_call_Relocation::spec(method_index);
       emit_d32_reloc(cbuf, (int) ($meth$$method - ((intptr_t) cbuf.insts_end()) - 4),
                      rspec, RELOC_DISP32);
-      // Emit stubs for static call.
       address mark = cbuf.insts_mark();
-      address stub = CompiledStaticCall::emit_to_interp_stub(cbuf, mark);
-      if (stub == NULL) {
-        ciEnv::current()->record_failure("CodeCache is full");
-        return;
+      if (CodeBuffer::supports_shared_stubs() &&
+          _method->is_loaded() &&
+          (!_optimized_virtual || _method->is_final_method())) {
+        // Postpone creating a stub to the interpreter because
+        // it might be shared among calls of the same Java method.
+        cbuf.shared_stub_to_interp_for(_method->get_Method(), mark);
+      } else {
+        // Emit stubs for static call.
+        address stub = CompiledStaticCall::emit_to_interp_stub(cbuf, mark);
+        if (stub == NULL) {
+          ciEnv::current()->record_failure("CodeCache is full");
+          return;
+        }
       }
     }
     _masm.clear_inst_mark();

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -2172,7 +2172,7 @@ encode %{
       if (CodeBuffer::supports_shared_stubs() && _method->can_be_statically_bound()) {
         // Calls of the same statically bound method can share
         // a stub to the interpreter.
-        cbuf.shared_stub_to_interp_for(_method->get_Method(), mark);
+        cbuf.shared_stub_to_interp_for(_method, mark);
       } else {
         // Emit stubs for static call.
         address stub = CompiledStaticCall::emit_to_interp_stub(cbuf, mark);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -2169,8 +2169,7 @@ encode %{
       emit_d32_reloc(cbuf, (int) ($meth$$method - ((intptr_t) cbuf.insts_end()) - 4),
                      rspec, RELOC_DISP32);
       address mark = cbuf.insts_mark();
-      if (CodeBuffer::supports_shared_stubs() &&
-          _method->is_loaded() &&
+      if (UseSharedStubs && _method->is_loaded() &&
           (!_optimized_virtual || _method->is_final_method())) {
         // Postpone creating a stub to the interpreter because
         // it might be shared among calls of the same Java method.

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -2172,7 +2172,7 @@ encode %{
       if (CodeBuffer::supports_shared_stubs() && _method->can_be_statically_bound()) {
         // Calls of the same statically bound method can share
         // a stub to the interpreter.
-        cbuf.shared_stub_to_interp_for(_method, mark);
+        cbuf.shared_stub_to_interp_for(_method, cbuf.insts()->mark_off());
       } else {
         // Emit stubs for static call.
         address stub = CompiledStaticCall::emit_to_interp_stub(cbuf, mark);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -2169,10 +2169,9 @@ encode %{
       emit_d32_reloc(cbuf, (int) ($meth$$method - ((intptr_t) cbuf.insts_end()) - 4),
                      rspec, RELOC_DISP32);
       address mark = cbuf.insts_mark();
-      if (UseSharedStubs && _method->is_loaded() &&
-          (!_optimized_virtual || _method->is_final_method())) {
-        // Postpone creating a stub to the interpreter because
-        // it might be shared among calls of the same Java method.
+      if (CodeBuffer::supports_shared_stubs() && _method->can_be_statically_bound()) {
+        // Calls of the same statically bound method can share
+        // a stub to the interpreter.
         cbuf.shared_stub_to_interp_for(_method->get_Method(), mark);
       } else {
         // Emit stubs for static call.

--- a/src/hotspot/cpu/zero/codeBuffer_zero.hpp
+++ b/src/hotspot/cpu/zero/codeBuffer_zero.hpp
@@ -34,5 +34,7 @@
     }
     return true;
   }
+ public:
+  static constexpr bool supports_shared_stubs() { return false; }
 
 #endif // CPU_ZERO_CODEBUFFER_ZERO_HPP

--- a/src/hotspot/cpu/zero/codeBuffer_zero.hpp
+++ b/src/hotspot/cpu/zero/codeBuffer_zero.hpp
@@ -28,5 +28,10 @@
 
  private:
   void pd_initialize() {}
+  bool emit_shared_stubs_to_interp() { Unimplemented(); return true; }
+  bool pd_finalize_stubs() { return true; }
+
+ public:
+  static bool supports_shared_stubs() { return false; }
 
 #endif // CPU_ZERO_CODEBUFFER_ZERO_HPP

--- a/src/hotspot/cpu/zero/codeBuffer_zero.hpp
+++ b/src/hotspot/cpu/zero/codeBuffer_zero.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2007 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -28,6 +28,11 @@
 
  private:
   void pd_initialize() {}
-  bool pd_finalize_stubs() { return true; }
+  bool pd_finalize_stubs() {
+    if (_finalize_stubs) {
+      Unimplemented();
+    }
+    return true;
+  }
 
 #endif // CPU_ZERO_CODEBUFFER_ZERO_HPP

--- a/src/hotspot/cpu/zero/codeBuffer_zero.hpp
+++ b/src/hotspot/cpu/zero/codeBuffer_zero.hpp
@@ -28,10 +28,6 @@
 
  private:
   void pd_initialize() {}
-  bool emit_shared_stubs_to_interp() { Unimplemented(); return true; }
   bool pd_finalize_stubs() { return true; }
-
- public:
-  static bool supports_shared_stubs() { return false; }
 
 #endif // CPU_ZERO_CODEBUFFER_ZERO_HPP

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -987,11 +987,11 @@ void CodeBuffer::finalize_stubs() {
   _finalize_stubs = false;
 }
 
-void CodeBuffer::shared_stub_to_interp_for(Method* method, address caller_pc) {
+void CodeBuffer::shared_stub_to_interp_for(ciMethod* callee, address caller_pc) {
   if (_shared_stub_to_interp_requests == NULL) {
     _shared_stub_to_interp_requests = new SharedStubToInterpRequests(8);
   }
-  SharedStubToInterpRequest request(method, caller_pc);
+  SharedStubToInterpRequest request(callee, caller_pc);
   _shared_stub_to_interp_requests->push(request);
   _finalize_stubs = true;
 }

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -989,10 +989,7 @@ void CodeBuffer::finalize_stubs() {
 
 void CodeBuffer::shared_stub_to_interp_for(Method* method, address caller_pc) {
   SharedStubToInterpRequest request(method, caller_pc);
-  auto node = _shared_stub_to_interp_requests.find_node(request);
-  auto new_node = (node == NULL) ? _shared_stub_to_interp_requests.add(request)
-                                 : _shared_stub_to_interp_requests.insert_after(request, node);
-  assert(new_node != NULL, "sanity");
+  _shared_stub_to_interp_requests.push(request);
   _finalize_stubs = true;
 }
 

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -989,7 +989,7 @@ void CodeBuffer::finalize_stubs() {
 
 void CodeBuffer::shared_stub_to_interp_for(Method* method, address caller_pc) {
   if (_shared_stub_to_interp_requests == NULL) {
-    _shared_stub_to_interp_requests = new SharedStubToInterpRequests();
+    _shared_stub_to_interp_requests = new SharedStubToInterpRequests(8);
   }
   SharedStubToInterpRequest request(method, caller_pc);
   _shared_stub_to_interp_requests->push(request);

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -988,8 +988,11 @@ void CodeBuffer::finalize_stubs() {
 }
 
 void CodeBuffer::shared_stub_to_interp_for(Method* method, address caller_pc) {
+  if (_shared_stub_to_interp_requests == NULL) {
+    _shared_stub_to_interp_requests = new SharedStubToInterpRequests();
+  }
   SharedStubToInterpRequest request(method, caller_pc);
-  _shared_stub_to_interp_requests.push(request);
+  _shared_stub_to_interp_requests->push(request);
   _finalize_stubs = true;
 }
 

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -987,11 +987,11 @@ void CodeBuffer::finalize_stubs() {
   _finalize_stubs = false;
 }
 
-void CodeBuffer::shared_stub_to_interp_for(ciMethod* callee, address caller_pc) {
+void CodeBuffer::shared_stub_to_interp_for(ciMethod* callee, csize_t call_offset) {
   if (_shared_stub_to_interp_requests == NULL) {
     _shared_stub_to_interp_requests = new SharedStubToInterpRequests(8);
   }
-  SharedStubToInterpRequest request(callee, caller_pc);
+  SharedStubToInterpRequest request(callee, call_offset);
   _shared_stub_to_interp_requests->push(request);
   _finalize_stubs = true;
 }

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -24,6 +24,9 @@
 
 #include "precompiled.hpp"
 #include "asm/codeBuffer.hpp"
+#include "asm/macroAssembler.hpp"
+#include "ci/ciEnv.hpp"
+#include "code/compiledIC.hpp"
 #include "code/oopRecorder.inline.hpp"
 #include "compiler/disassembler.hpp"
 #include "logging/log.hpp"
@@ -441,6 +444,7 @@ void CodeBuffer::compute_final_layout(CodeBuffer* dest) const {
   address buf = dest->_total_start;
   csize_t buf_offset = 0;
   assert(dest->_total_size >= total_content_size(), "must be big enough");
+  assert(!_finalize_stubs, "non-finalized stubs");
 
   {
     // not sure why this is here, but why not...
@@ -977,6 +981,43 @@ void CodeBuffer::log_section_sizes(const char* name) {
     }
     xtty->print_cr("</blob>");
   }
+}
+
+static bool emit_shared_stubs_to_interp(const SharedStubToInterpRequests& requests, MacroAssembler* masm) {
+  LinkedListIterator<SharedStubToInterpRequest> it(requests.head());
+  SharedStubToInterpRequest* request = it.next();
+  while (request != NULL) {
+    address stub = masm->start_a_stub(CompiledStaticCall::to_interp_stub_size());
+    if (stub == NULL) {
+      ciEnv::current()->record_failure("CodeCache is full");
+      return false;
+    }
+    Method* method = request->shared_method();
+    do {
+      masm->relocate(static_stub_Relocation::spec(request->caller_pc()));
+      request = it.next();
+    } while (request != NULL && request->shared_method() == method);
+    masm->emit_static_call_stub();
+    masm->end_a_stub();
+  }
+  return true;
+}
+
+void CodeBuffer::finalize_stubs() {
+  MacroAssembler masm(this);
+  if (!emit_shared_stubs_to_interp(_shared_stub_to_interp_requests, &masm)) {
+    return;
+  }
+  _finalize_stubs = false;
+}
+
+void CodeBuffer::shared_stub_to_interp_for(Method* method, address caller_pc) {
+  SharedStubToInterpRequest request(method, caller_pc);
+  auto node = _shared_stub_to_interp_requests.find_node(request);
+  auto new_node = (node == NULL) ? _shared_stub_to_interp_requests.add(request)
+                                 : _shared_stub_to_interp_requests.insert_after(request, node);
+  assert(new_node != NULL, "sanity");
+  _finalize_stubs = true;
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -347,7 +347,7 @@ class Scrubber {
 // Calls of Java mehtods need stubs to the interpreter. Calls sharing the same Java method
 // can share a stub to interpreter.
 // A SharedStubToInterpRequest describes a request for a shared stub to the interpreter.
-class SharedStubToInterpRequest {
+class SharedStubToInterpRequest: public ResourceObj {
  private:
   Method* _shared_method;
   address _caller_pc;

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -37,6 +37,7 @@ class Compile;
 class BufferBlob;
 class CodeBuffer;
 class Label;
+class ciMethod;
 
 class CodeOffsets: public StackObj {
 public:
@@ -347,16 +348,16 @@ class Scrubber {
 // Calls of Java mehtods need stubs to the interpreter. Calls sharing the same Java method
 // can share a stub to interpreter.
 // A SharedStubToInterpRequest describes a request for a shared stub to the interpreter.
-class SharedStubToInterpRequest: public ResourceObj {
+class SharedStubToInterpRequest : public ResourceObj {
  private:
-  Method* _shared_method;
+  ciMethod* _shared_method;
   address _caller_pc;
 
  public:
-  SharedStubToInterpRequest(Method* method = NULL, address caller_pc = NULL) : _shared_method(method),
+  SharedStubToInterpRequest(ciMethod* method = NULL, address caller_pc = NULL) : _shared_method(method),
       _caller_pc(caller_pc) {}
 
-  Method* shared_method() const { return _shared_method; }
+  ciMethod* shared_method() const { return _shared_method; }
   address caller_pc() const { return _caller_pc; }
 };
 typedef GrowableArray<SharedStubToInterpRequest> SharedStubToInterpRequests;
@@ -710,7 +711,7 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
   void finalize_stubs();
 
   // Request for a shared stub to the interpreter
-  void shared_stub_to_interp_for(Method* call, address caller_pc);
+  void shared_stub_to_interp_for(ciMethod* callee, address caller_pc);
 
 #ifndef PRODUCT
  public:

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -29,7 +29,7 @@
 #include "code/relocInfo.hpp"
 #include "utilities/align.hpp"
 #include "utilities/debug.hpp"
-#include "utilities/linkedlist.hpp"
+#include "utilities/growableArray.hpp"
 #include "utilities/macros.hpp"
 
 class PhaseCFG;
@@ -353,17 +353,13 @@ class SharedStubToInterpRequest {
   address _caller_pc;
 
  public:
-  SharedStubToInterpRequest(Method* method, address caller_pc = NULL) : _shared_method(method),
+  SharedStubToInterpRequest(Method* method = NULL, address caller_pc = NULL) : _shared_method(method),
       _caller_pc(caller_pc) {}
 
-  bool equals(const SharedStubToInterpRequest& request) const {
-    return _shared_method == request._shared_method;
-  }
-
-  Method* shared_method() { return _shared_method; }
-  address caller_pc() { return _caller_pc; }
+  Method* shared_method() const { return _shared_method; }
+  address caller_pc() const { return _caller_pc; }
 };
-typedef LinkedListImpl<SharedStubToInterpRequest> SharedStubToInterpRequests;
+typedef GrowableArray<SharedStubToInterpRequest> SharedStubToInterpRequests;
 
 // A CodeBuffer describes a memory space into which assembly
 // code is generated.  This memory space usually occupies the

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -433,7 +433,7 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
 
   address      _last_insn;      // used to merge consecutive memory barriers, loads or stores.
 
-  SharedStubToInterpRequests _shared_stub_to_interp_requests; // used to collect requests for shared iterpreter stubs
+  SharedStubToInterpRequests* _shared_stub_to_interp_requests; // used to collect requests for shared iterpreter stubs
   bool         _finalize_stubs; // Indicate if we need to finalize stubs to make CodeBuffer final.
 
 #ifndef PRODUCT
@@ -454,6 +454,7 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
     _overflow_arena  = NULL;
     _last_insn       = NULL;
     _finalize_stubs  = false;
+    _shared_stub_to_interp_requests = NULL;
 
 #ifndef PRODUCT
     _decode_begin    = NULL;

--- a/src/hotspot/share/asm/codeBuffer.inline.hpp
+++ b/src/hotspot/share/asm/codeBuffer.inline.hpp
@@ -31,7 +31,7 @@
 
 template <typename MacroAssembler, int relocate_format = 0>
 bool emit_shared_stubs_to_interp(CodeBuffer* cb, SharedStubToInterpRequests* shared_stub_to_interp_requests) {
-  if (shared_stub_to_interp_requests->is_empty()) {
+  if (shared_stub_to_interp_requests == NULL) {
     return true;
   }
   auto by_shared_method = [](SharedStubToInterpRequest* r1, SharedStubToInterpRequest* r2) {

--- a/src/hotspot/share/asm/codeBuffer.inline.hpp
+++ b/src/hotspot/share/asm/codeBuffer.inline.hpp
@@ -52,7 +52,7 @@ bool emit_shared_stubs_to_interp(CodeBuffer* cb, SharedStubToInterpRequests* sha
       return false;
     }
 
-    Method* method = shared_stub_to_interp_requests->at(i).shared_method();
+    ciMethod* method = shared_stub_to_interp_requests->at(i).shared_method();
     do {
       masm.relocate(static_stub_Relocation::spec(shared_stub_to_interp_requests->at(i).caller_pc()), relocate_format);
       ++i;

--- a/src/hotspot/share/asm/codeBuffer.inline.hpp
+++ b/src/hotspot/share/asm/codeBuffer.inline.hpp
@@ -30,29 +30,41 @@
 #include "code/compiledIC.hpp"
 
 template <typename MacroAssembler, int relocate_format = 0>
-bool emit_shared_stubs_to_interp(CodeBuffer* cb, const SharedStubToInterpRequests& shared_stub_to_interp_requests) {
+bool emit_shared_stubs_to_interp(CodeBuffer* cb, SharedStubToInterpRequests* shared_stub_to_interp_requests) {
+  if (shared_stub_to_interp_requests->is_empty()) {
+    return true;
+  }
+  auto by_shared_method = [](SharedStubToInterpRequest* r1, SharedStubToInterpRequest* r2) {
+    if (r1->shared_method() < r2->shared_method()) {
+      return -1;
+    } else if (r1->shared_method() > r2->shared_method()) {
+      return 1;
+    } else {
+      return 0;
+    }
+  };
+  shared_stub_to_interp_requests->sort(by_shared_method);
   MacroAssembler masm(cb);
-  LinkedListIterator<SharedStubToInterpRequest> it(shared_stub_to_interp_requests.head());
-  SharedStubToInterpRequest* request = it.next();
   int relocations_created = 0;
-  while (request != NULL) {
+  for (int i = 0; i < shared_stub_to_interp_requests->length();) {
     address stub = masm.start_a_stub(CompiledStaticCall::to_interp_stub_size());
     if (stub == NULL) {
       ciEnv::current()->record_failure("CodeCache is full");
       return false;
     }
-    Method* method = request->shared_method();
+
+    Method* method = shared_stub_to_interp_requests->at(i).shared_method();
     do {
-      masm.relocate(static_stub_Relocation::spec(request->caller_pc()), relocate_format);
-      request = it.next();
+      masm.relocate(static_stub_Relocation::spec(shared_stub_to_interp_requests->at(i).caller_pc()), relocate_format);
+      ++i;
       ++relocations_created;
-    } while (request != NULL && request->shared_method() == method);
+    } while (i < shared_stub_to_interp_requests->length() && shared_stub_to_interp_requests->at(i).shared_method() == method);
     masm.emit_static_call_stub();
     masm.end_a_stub();
   }
 
   if (relocations_created > 1 && UseNewCode) {
-    tty->print_cr("Requests %d", (int)shared_stub_to_interp_requests.size());
+    tty->print_cr("Requests %d", (int)shared_stub_to_interp_requests->length());
     tty->print_cr("Saved %d", (relocations_created-1)*CompiledStaticCall::to_interp_stub_size());
   }
   return true;

--- a/src/hotspot/share/asm/codeBuffer.inline.hpp
+++ b/src/hotspot/share/asm/codeBuffer.inline.hpp
@@ -45,7 +45,6 @@ bool emit_shared_stubs_to_interp(CodeBuffer* cb, SharedStubToInterpRequests* sha
   };
   shared_stub_to_interp_requests->sort(by_shared_method);
   MacroAssembler masm(cb);
-  int relocations_created = 0;
   for (int i = 0; i < shared_stub_to_interp_requests->length();) {
     address stub = masm.start_a_stub(CompiledStaticCall::to_interp_stub_size());
     if (stub == NULL) {
@@ -57,15 +56,9 @@ bool emit_shared_stubs_to_interp(CodeBuffer* cb, SharedStubToInterpRequests* sha
     do {
       masm.relocate(static_stub_Relocation::spec(shared_stub_to_interp_requests->at(i).caller_pc()), relocate_format);
       ++i;
-      ++relocations_created;
     } while (i < shared_stub_to_interp_requests->length() && shared_stub_to_interp_requests->at(i).shared_method() == method);
     masm.emit_static_call_stub();
     masm.end_a_stub();
-  }
-
-  if (relocations_created > 1 && UseNewCode) {
-    tty->print_cr("Requests %d", (int)shared_stub_to_interp_requests->length());
-    tty->print_cr("Saved %d", (relocations_created-1)*CompiledStaticCall::to_interp_stub_size());
   }
   return true;
 }

--- a/src/hotspot/share/asm/codeBuffer.inline.hpp
+++ b/src/hotspot/share/asm/codeBuffer.inline.hpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_ASM_CODEBUFFER_INLINE_HPP
+#define SHARE_ASM_CODEBUFFER_INLINE_HPP
+
+#include "asm/codeBuffer.hpp"
+#include "ci/ciEnv.hpp"
+#include "code/compiledIC.hpp"
+
+template <typename MacroAssembler, int relocate_format = 0>
+bool emit_shared_stubs_to_interp(CodeBuffer* cb, const SharedStubToInterpRequests& shared_stub_to_interp_requests) {
+  MacroAssembler masm(cb);
+  LinkedListIterator<SharedStubToInterpRequest> it(shared_stub_to_interp_requests.head());
+  SharedStubToInterpRequest* request = it.next();
+  int relocations_created = 0;
+  while (request != NULL) {
+    address stub = masm.start_a_stub(CompiledStaticCall::to_interp_stub_size());
+    if (stub == NULL) {
+      ciEnv::current()->record_failure("CodeCache is full");
+      return false;
+    }
+    Method* method = request->shared_method();
+    do {
+      masm.relocate(static_stub_Relocation::spec(request->caller_pc()), relocate_format);
+      request = it.next();
+      ++relocations_created;
+    } while (request != NULL && request->shared_method() == method);
+    masm.emit_static_call_stub();
+    masm.end_a_stub();
+  }
+
+  if (relocations_created > 1 && UseNewCode) {
+    tty->print_cr("Requests %d", (int)shared_stub_to_interp_requests.size());
+    tty->print_cr("Saved %d", (relocations_created-1)*CompiledStaticCall::to_interp_stub_size());
+  }
+  return true;
+}
+
+#endif // SHARE_ASM_CODEBUFFER_INLINE_HPP

--- a/src/hotspot/share/asm/codeBuffer.inline.hpp
+++ b/src/hotspot/share/asm/codeBuffer.inline.hpp
@@ -54,7 +54,8 @@ bool emit_shared_stubs_to_interp(CodeBuffer* cb, SharedStubToInterpRequests* sha
 
     ciMethod* method = shared_stub_to_interp_requests->at(i).shared_method();
     do {
-      masm.relocate(static_stub_Relocation::spec(shared_stub_to_interp_requests->at(i).caller_pc()), relocate_format);
+      address caller_pc = cb->insts_begin() + shared_stub_to_interp_requests->at(i).call_offset();
+      masm.relocate(static_stub_Relocation::spec(caller_pc), relocate_format);
       ++i;
     } while (i < shared_stub_to_interp_requests->length() && shared_stub_to_interp_requests->at(i).shared_method() == method);
     masm.emit_static_call_stub();

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -456,8 +456,11 @@ void LIR_Assembler::emit_call(LIR_OpJavaCall* op) {
   // must align calls sites, otherwise they can't be updated atomically
   align_call(op->code());
 
-  // emit the static call stub stuff out of line
-  emit_static_call_stub();
+  if (op->code() == lir_static_call && op->method()->is_loaded()) {
+    _masm->code()->shared_stub_to_interp_for(op->method()->get_Method(), pc());
+  } else {
+    emit_static_call_stub();
+  }
   CHECK_BAILOUT();
 
   switch (op->code()) {

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -449,6 +449,11 @@ void LIR_Assembler::emit_rtcall(LIR_OpRTCall* op) {
   rt_call(op->result_opr(), op->addr(), op->arguments(), op->tmp(), op->info());
 }
 
+static bool can_use_shared_stub_for(LIR_OpJavaCall* op) {
+  return CodeBuffer::supports_shared_stubs() &&
+         op->method()->is_loaded() &&
+         (op->code() == lir_static_call || op->method()->is_final_method());
+}
 
 void LIR_Assembler::emit_call(LIR_OpJavaCall* op) {
   verify_oop_map(op->info());
@@ -456,8 +461,9 @@ void LIR_Assembler::emit_call(LIR_OpJavaCall* op) {
   // must align calls sites, otherwise they can't be updated atomically
   align_call(op->code());
 
-  if (CodeBuffer::supports_shared_stubs() && op->code() == lir_static_call
-      && op->method()->is_loaded()) {
+  if (can_use_shared_stub_for(op)) {
+    // Postpone creating a stub to the interpreter.
+    // It might be shared among calls of the same Java method.
     _masm->code()->shared_stub_to_interp_for(op->method()->get_Method(), pc());
   } else {
     emit_static_call_stub();

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -450,7 +450,7 @@ void LIR_Assembler::emit_rtcall(LIR_OpRTCall* op) {
 }
 
 static bool can_use_shared_stub_for(LIR_OpJavaCall* op) {
-  return CodeBuffer::supports_shared_stubs() &&
+  return UseSharedStubs &&
          op->method()->is_loaded() &&
          (op->code() == lir_static_call || op->method()->is_final_method());
 }

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -458,7 +458,8 @@ void LIR_Assembler::emit_call(LIR_OpJavaCall* op) {
   if (CodeBuffer::supports_shared_stubs() && op->method()->can_be_statically_bound()) {
     // Calls of the same statically bound method can share
     // a stub to the interpreter.
-    _masm->code()->shared_stub_to_interp_for(op->method(), pc());
+    CodeBuffer::csize_t call_offset = pc() - _masm->code()->insts_begin();
+    _masm->code()->shared_stub_to_interp_for(op->method(), call_offset);
   } else {
     emit_static_call_stub();
   }

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -456,7 +456,8 @@ void LIR_Assembler::emit_call(LIR_OpJavaCall* op) {
   // must align calls sites, otherwise they can't be updated atomically
   align_call(op->code());
 
-  if (op->code() == lir_static_call && op->method()->is_loaded()) {
+  if (CodeBuffer::supports_shared_stubs() && op->code() == lir_static_call
+      && op->method()->is_loaded()) {
     _masm->code()->shared_stub_to_interp_for(op->method()->get_Method(), pc());
   } else {
     emit_static_call_stub();

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -449,22 +449,16 @@ void LIR_Assembler::emit_rtcall(LIR_OpRTCall* op) {
   rt_call(op->result_opr(), op->addr(), op->arguments(), op->tmp(), op->info());
 }
 
-static bool can_use_shared_stub_for(LIR_OpJavaCall* op) {
-  return UseSharedStubs &&
-         op->method()->is_loaded() &&
-         (op->code() == lir_static_call || op->method()->is_final_method());
-}
-
 void LIR_Assembler::emit_call(LIR_OpJavaCall* op) {
   verify_oop_map(op->info());
 
   // must align calls sites, otherwise they can't be updated atomically
   align_call(op->code());
 
-  if (can_use_shared_stub_for(op)) {
-    // Postpone creating a stub to the interpreter.
-    // It might be shared among calls of the same Java method.
-    _masm->code()->shared_stub_to_interp_for(op->method()->get_Method(), pc());
+  if (CodeBuffer::supports_shared_stubs() && op->method()->can_be_statically_bound()) {
+    // Calls of the same statically bound method can share
+    // a stub to the interpreter.
+    _masm->code()->shared_stub_to_interp_for(op->method(), pc());
   } else {
     emit_static_call_stub();
   }

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1117,6 +1117,10 @@ void ciEnv::register_method(ciMethod* target,
     }
 #endif
 
+    if (!failing()) {
+      code_buffer->finalize_stubs();
+    }
+
     if (failing()) {
       // While not a true deoptimization, it is a preemptive decompile.
       MethodData* mdo = method()->method_data();

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2052,9 +2052,9 @@ const intx ObjectAlignmentInBytes = 8;
              "Mark all threads after a safepoint, and clear on a modify "   \
              "fence. Add cleanliness checks.")                              \
                                                                             \
-  develop(bool, TraceOptimizedUpcallStubs, false,                              \
-                "Trace optimized upcall stub generation")                      \
-  product(bool, UseSharedStubs, true, DIAGNOSTIC,                          \
+  develop(bool, TraceOptimizedUpcallStubs, false,                           \
+                "Trace optimized upcall stub generation")                   \
+  product(bool, UseSharedStubs, false, DIAGNOSTIC,                          \
                 "Allow sharing stubs whether it is possible")               \
                                                                             \
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2054,9 +2054,6 @@ const intx ObjectAlignmentInBytes = 8;
                                                                             \
   develop(bool, TraceOptimizedUpcallStubs, false,                           \
                 "Trace optimized upcall stub generation")                   \
-  product(bool, UseSharedStubs, false, DIAGNOSTIC,                          \
-                "Allow sharing stubs whether it is possible")               \
-                                                                            \
 
 // end of RUNTIME_FLAGS
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2054,7 +2054,7 @@ const intx ObjectAlignmentInBytes = 8;
                                                                             \
   develop(bool, TraceOptimizedUpcallStubs, false,                              \
                 "Trace optimized upcall stub generation")                      \
-  product(bool, UseSharedStubs, false, DIAGNOSTIC,                          \
+  product(bool, UseSharedStubs, true, DIAGNOSTIC,                          \
                 "Allow sharing stubs whether it is possible")               \
                                                                             \
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2054,6 +2054,9 @@ const intx ObjectAlignmentInBytes = 8;
                                                                             \
   develop(bool, TraceOptimizedUpcallStubs, false,                              \
                 "Trace optimized upcall stub generation")                      \
+  product(bool, UseSharedStubs, false, DIAGNOSTIC,                          \
+                "Allow sharing stubs whether it is possible")               \
+                                                                            \
 
 // end of RUNTIME_FLAGS
 

--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
@@ -61,7 +61,7 @@ public class SharedStubToInterpTest {
             throw new RuntimeException("Unknown compiler: " + compiler);
         }
         command.add("-Xbatch");
-        command.add("-XX:+UseSharedStubs");
+        //command.add("-XX:+UseSharedStubs");
         command.add("-XX:CompileCommand=compileonly," + testClassName + "::" + "test");
         command.add("-XX:CompileCommand=dontinline," + testClassName + "::" + "test");
         command.add("-XX:CompileCommand=print," + testClassName + "::" + "test");

--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/**
+ * @test SharedStubToInterpTest
+ * @summary Checks that stubs to the interpreter can be shared for static or final method.
+ * @bug 8280481
+ * @library /test/lib
+ *
+ * @requires os.arch=="aarch64"
+ *
+ * @run driver compiler.sharedstubs.SharedStubToInterpTest c2 StaticMethodTest
+ * @run driver compiler.sharedstubs.SharedStubToInterpTest c1 StaticMethodTest
+ * @run driver compiler.sharedstubs.SharedStubToInterpTest c2 FinalClassTest
+ * @run driver compiler.sharedstubs.SharedStubToInterpTest c1 FinalClassTest
+ * @run driver compiler.sharedstubs.SharedStubToInterpTest c2 FinalMethodTest
+ * @run driver compiler.sharedstubs.SharedStubToInterpTest c1 FinalMethodTest
+ */
+
+package compiler.sharedstubs;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.ListIterator;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class SharedStubToInterpTest {
+    public static void main(String[] args) throws Exception {
+        String compiler = args[0];
+        String testClassName = SharedStubToInterpTest.class.getName() + "$" + args[1];
+        ArrayList<String> command = new ArrayList<String>();
+        command.add("-XX:+IgnoreUnrecognizedVMOptions");
+        command.add("-XX:+UnlockDiagnosticVMOptions");
+        if (compiler.equals("c2")) {
+            command.add("-XX:-TieredCompilation");
+        } else if (compiler.equals("c1")) {
+            command.add("-XX:TieredStopAtLevel=1");
+        } else {
+            throw new RuntimeException("Unknown compiler: " + compiler);
+        }
+        command.add("-Xbatch");
+        command.add("-XX:CompileCommand=compileonly," + testClassName + "::" + "test");
+        command.add("-XX:CompileCommand=dontinline," + testClassName + "::" + "test");
+        command.add("-XX:CompileCommand=print," + testClassName + "::" + "test");
+        command.add("-XX:CompileCommand=exclude," + testClassName + "::" + "log");
+        command.add("-XX:CompileCommand=dontinline," + testClassName + "::" + "log");
+        command.add(testClassName);
+        command.add("a");
+        command.add("b");
+        command.add("c");
+
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(command);
+
+        OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
+
+        analyzer.shouldHaveExitValue(0);
+
+        System.out.println(analyzer.getOutput());
+
+        checkOutput(analyzer);
+    }
+
+    private static String skipTo(Iterator<String> iter, String substring) {
+        while (iter.hasNext()) {
+            String nextLine = iter.next();
+            if (nextLine.contains(substring)) {
+                return nextLine;
+            }
+        }
+        return null;
+    }
+
+    private static void checkOutput(OutputAnalyzer output) {
+        Iterator<String> iter = output.asLines().listIterator();
+
+        String match = skipTo(iter, "Compiled method");
+        while (match != null && !match.contains("Test::test")) {
+            match = skipTo(iter, "Compiled method");
+        }
+        if (match == null) {
+            throw new RuntimeException("Missing compiler output for the method 'test'");
+        }
+
+        // Shared static stubs are put after Deopt Handler Code.
+        match = skipTo(iter, "[Deopt Handler Code]");
+        if (match == null) {
+            throw new RuntimeException("The start of Deopt Handler Code not found");
+        }
+        int foundStaticStubs = 0;
+        while (iter.hasNext()) {
+            if (iter.next().contains("{static_stub}")) {
+                foundStaticStubs += 1;
+            }
+        }
+
+        final int expectedStaticStubs = 1;
+        if (foundStaticStubs != expectedStaticStubs) {
+            throw new RuntimeException("Found static stubs: " + foundStaticStubs + "; Expected static stubs: " + expectedStaticStubs);
+        }
+    }
+
+    public static class StaticMethodTest {
+        static void log(int i) {
+        }
+
+        static void test(int i, String[] args) {
+            if (i % args.length == 0) {
+                log(i);
+            } else {
+                log(i);
+            }
+        }
+
+        public static void main(String[] args) {
+            for (int i = 1; i < 50_000; ++i) {
+                test(i, args);
+            }
+        }
+    }
+
+    public static final class FinalClassTest {
+        void log(int i) {
+        }
+
+        void test(int i, String[] args) {
+            if (i % args.length == 0) {
+                log(i);
+            } else {
+                log(i);
+            }
+        }
+
+        public static void main(String[] args) {
+            FinalClassTest tFC = new FinalClassTest();
+            for (int i = 1; i < 50_000; ++i) {
+                tFC.test(i,args);
+            }
+        }
+    }
+
+    public static class FinalMethodTest {
+        final void log(int i) {
+        }
+
+        void test(int i, String[] args) {
+            if (i % args.length == 0) {
+                log(i);
+            } else {
+                log(i);
+            }
+        }
+
+        public static void main(String[] args) {
+            FinalMethodTest tFM = new FinalMethodTest();
+            for (int i = 1; i < 50_000; ++i) {
+                tFM.test(i,args);
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
@@ -61,6 +61,7 @@ public class SharedStubToInterpTest {
             throw new RuntimeException("Unknown compiler: " + compiler);
         }
         command.add("-Xbatch");
+        command.add("-XX:+UseSharedStubs");
         command.add("-XX:CompileCommand=compileonly," + testClassName + "::" + "test");
         command.add("-XX:CompileCommand=dontinline," + testClassName + "::" + "test");
         command.add("-XX:CompileCommand=print," + testClassName + "::" + "test");

--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
@@ -61,7 +61,6 @@ public class SharedStubToInterpTest {
             throw new RuntimeException("Unknown compiler: " + compiler);
         }
         command.add("-Xbatch");
-        //command.add("-XX:+UseSharedStubs");
         command.add("-XX:CompileCommand=compileonly," + testClassName + "::" + "test");
         command.add("-XX:CompileCommand=dontinline," + testClassName + "::" + "test");
         command.add("-XX:CompileCommand=print," + testClassName + "::" + "test");

--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
@@ -28,7 +28,7 @@
  * @bug 8280481
  * @library /test/lib
  *
- * @requires os.arch=="aarch64"
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="i386" | os.arch=="x86" | os.arch=="aarch64"
  *
  * @run driver compiler.sharedstubs.SharedStubToInterpTest c2 StaticMethodTest
  * @run driver compiler.sharedstubs.SharedStubToInterpTest c1 StaticMethodTest
@@ -104,7 +104,7 @@ public class SharedStubToInterpTest {
         }
 
         // Shared static stubs are put after Deopt Handler Code.
-        match = skipTo(iter, "[Deopt Handler Code]");
+        match = skipTo(iter, "{runtime_call DeoptimizationBlob}");
         if (match == null) {
             throw new RuntimeException("The start of Deopt Handler Code not found");
         }


### PR DESCRIPTION
Calls of Java methods have stubs to the interpreter for the cases when an invoked Java method is not compiled. Calls of static Java methods and final Java methods have statically bound information about a callee during compilation. Such calls can share stubs to the interpreter.

Each stub to the interpreter has a relocation record (accessed via `relocInfo`) which provides an address of the stub and an address of its owner. `relocInfo` has an offset which is an offset from the previously know relocatable address. The address of a stub is calculated as the address provided by the previous `relocInfo` plus the offset.

Each Java call has:
- A relocation for a call site.
- A relocation for a stub to the interpreter.
- A stub to the interpreter.
- If far jumps are used (arm64 case):
  - A trampoline relocation.
  - A trampoline.

We cannot avoid creating relocations. They are needed to support patching call sites and stubs.

One approach to create shared stubs to keep track of created stubs. If the needed stub exist we use its address and create only needed relocation information. The `relocInfo` for a created stub will have a positive offset. As relocations for different stubs can be created after that, a relocation for a shared stub will have a negative offset relative to the address provided by the previous relocation:
```
reloc1  ---> 0x0: stub1
reloc2  ---> 0x4: stub2 (reloc2.addr = reloc1.addr + reloc2.offset = 0x0 + 4)
reloc3  ---> 0x0: stub1 (reloc3.addr = reloc2.addr + reloc3.offset = 0x4 - 4)
```
According to [relocInfo.hpp](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/code/relocInfo.hpp#L237):
```
// [About Offsets] Relative offsets are supplied to this module as
// positive byte offsets, but they may be internally stored scaled
// and/or negated, depending on what is most compact for the target
// system.  Since the object pointed to by the offset typically
// precedes the relocation address, it is profitable to store
// these negative offsets as positive numbers, but this decision
// is internal to the relocation information abstractions.
```
However, `CodeSection` does not support negative offsets. It [assumes](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/asm/codeBuffer.hpp#L195) addresses relocations pointing at grow upward:
```
class CodeSection {
...
 private:
...
    address     _locs_point;      // last relocated position (grows upward)
...
  void    set_locs_point(address pc) {
    assert(pc >= locs_point(), "relocation addr may not decrease");
    assert(allocates2(pc),     "relocation addr must be in this section");
    _locs_point = pc;
  }
```
Negative offsets reduce the offset range by half. This can cause the increase of filler records, the empty `relocInfo` records to reduce offset values. Also negative offsets are only needed for `static_stub_type`, but other 13 types don’t need them.

This PR implements another approach: postponed creation of stubs. First we collect requests for creating shared stubs. Then we have the finalisation phase, where shared stubs are created in `CodeBuffer`. This approach does not need negative offsets. Supported platforms are x86, x86_64 and aarch64.

**Results from [Renaissance 0.14.0](https://github.com/renaissance-benchmarks/renaissance/releases/tag/v0.14.0)**
Note: 'Nmethods with shared stubs' is the total number of nmethods counted during benchmark's run. 'Final # of nmethods' is a number of nmethods in CodeCache when JVM exited.
- AArch64
```
+------------------+-------------+----------------------------+---------------------+
|    Benchmark     | Saved bytes | Nmethods with shared stubs | Final # of nmethods |
+------------------+-------------+----------------------------+---------------------+
| dotty            |      820544 |                       4592 |               18872 |
| dec-tree         |      405280 |                       2580 |               22335 |
| naive-bayes      |      392384 |                       2586 |               21184 |
| log-regression   |      362208 |                       2450 |               20325 |
| als              |      306048 |                       2226 |               18161 |
| finagle-chirper  |      262304 |                       2087 |               12675 |
| movie-lens       |      250112 |                       1937 |               13617 |
| gauss-mix        |      173792 |                       1262 |               10304 |
| finagle-http     |      164320 |                       1392 |               11269 |
| page-rank        |      155424 |                       1175 |               10330 |
| chi-square       |      140384 |                       1028 |                9480 |
| akka-uct         |      115136 |                        541 |                3941 |
| reactors         |       43264 |                        335 |                2503 |
| scala-stm-bench7 |       42656 |                        326 |                3310 |
| philosophers     |       36576 |                        256 |                2902 |
| scala-doku       |       35008 |                        231 |                2695 |
| rx-scrabble      |       32416 |                        273 |                2789 |
| future-genetic   |       29408 |                        260 |                2339 |
| scrabble         |       27968 |                        225 |                2477 |
| par-mnemonics    |       19584 |                        168 |                1689 |
| fj-kmeans        |       19296 |                        156 |                1647 |
| scala-kmeans     |       18080 |                        140 |                1629 |
| mnemonics        |       17408 |                        143 |                1512 |
+------------------+-------------+----------------------------+---------------------+
```
- X86_64
```
+------------------+-------------+----------------------------+---------------------+
|    Benchmark     | Saved bytes | Nmethods with shared stubs | Final # of nmethods |
+------------------+-------------+----------------------------+---------------------+
| dotty            |      337065 |                       4403 |               19135 |
| dec-tree         |      183045 |                       2559 |               22071 |
| naive-bayes      |      176460 |                       2450 |               19782 |
| log-regression   |      162555 |                       2410 |               20648 |
| als              |      121275 |                       1980 |               17179 |
| movie-lens       |      111915 |                       1842 |               13020 |
| finagle-chirper  |      106350 |                       1947 |               12726 |
| gauss-mix        |       81975 |                       1251 |               10474 |
| finagle-http     |       80895 |                       1523 |               12294 |
| page-rank        |       68940 |                       1146 |               10124 |
| chi-square       |       62130 |                        974 |                9315 |
| akka-uct         |       50220 |                        555 |                4263 |
| reactors         |       23385 |                        371 |                2544 |
| philosophers     |       17625 |                        259 |                2865 |
| scala-stm-bench7 |       17235 |                        295 |                3230 |
| scala-doku       |       15600 |                        214 |                2698 |
| rx-scrabble      |       14190 |                        262 |                2770 |
| future-genetic   |       13155 |                        253 |                2318 |
| scrabble         |       12300 |                        217 |                2352 |
| fj-kmeans        |        8985 |                        157 |                1616 |
| par-mnemonics    |        8535 |                        155 |                1684 |
| scala-kmeans     |        8250 |                        138 |                1624 |
| mnemonics        |        7485 |                        134 |                1522 |
+------------------+-------------+----------------------------+---------------------+
```

**Testing: fastdebug and release builds for x86, x86_64 and aarch64**
- `tier1`...`tier4`: Passed
- `hotspot/jtreg/compiler/sharedstubs`: Passed
