### PR TITLE
8287103: java/lang/management/ThreadMXBean/VirtualThreadDeadlocks.java fails with Xcomp

### DIFF
--- a/test/jdk/java/lang/management/ThreadMXBean/VirtualThreadDeadlocks.java
+++ b/test/jdk/java/lang/management/ThreadMXBean/VirtualThreadDeadlocks.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @bug 8284161 8287103
  * @summary Test ThredMXBean.findMonitorDeadlockedThreads with cycles of
  *   platform and virtual threads in deadlock
  * @compile --enable-preview -source ${jdk.version} VirtualThreadDeadlocks.java
@@ -40,7 +41,8 @@ public class VirtualThreadDeadlocks {
     private static final Object LOCK1 = new Object();
     private static final Object LOCK2 = new Object();
 
-    private static volatile boolean lock2Obtained = false;
+    private static volatile boolean lock2Held;
+
     /**
      * PP = test deadlock with two platform threads
      * PV = test deadlock with one platform thread and one virtual thread
@@ -54,7 +56,7 @@ public class VirtualThreadDeadlocks {
                 : Thread.ofVirtual();
         Thread thread1 = builder1.start(() -> {
             synchronized (LOCK1) {
-                while (!lock2Obtained) {
+                while (!lock2Held) {
                     try { Thread.sleep(10); } catch (Exception e) { }
                 }
                 synchronized (LOCK2) { }
@@ -68,7 +70,7 @@ public class VirtualThreadDeadlocks {
                 : Thread.ofVirtual();
         Thread thread2 = builder2.start(() -> {
             synchronized (LOCK2) {
-                lock2Obtained = true;
+                lock2Held = true;
                 synchronized (LOCK1) { }
             }
         });

--- a/test/jdk/java/lang/management/ThreadMXBean/VirtualThreadDeadlocks.java
+++ b/test/jdk/java/lang/management/ThreadMXBean/VirtualThreadDeadlocks.java
@@ -40,6 +40,7 @@ public class VirtualThreadDeadlocks {
     private static final Object LOCK1 = new Object();
     private static final Object LOCK2 = new Object();
 
+    private static volatile boolean lock2Obtained = false;
     /**
      * PP = test deadlock with two platform threads
      * PV = test deadlock with one platform thread and one virtual thread
@@ -53,7 +54,9 @@ public class VirtualThreadDeadlocks {
                 : Thread.ofVirtual();
         Thread thread1 = builder1.start(() -> {
             synchronized (LOCK1) {
-                try { Thread.sleep(1000); } catch (Exception e) { }
+                while (!lock2Obtained) {
+                    try { Thread.sleep(10); } catch (Exception e) { }
+                }
                 synchronized (LOCK2) { }
             }
         });
@@ -65,7 +68,7 @@ public class VirtualThreadDeadlocks {
                 : Thread.ofVirtual();
         Thread thread2 = builder2.start(() -> {
             synchronized (LOCK2) {
-                try { Thread.sleep(1000); } catch (Exception e) { }
+                lock2Obtained = true;
                 synchronized (LOCK1) { }
             }
         });


### PR DESCRIPTION
Sync improved in test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287103](https://bugs.openjdk.java.net/browse/JDK-8287103): java/lang/management/ThreadMXBean/VirtualThreadDeadlocks.java fails with Xcomp


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8821/head:pull/8821` \
`$ git checkout pull/8821`

Update a local copy of the PR: \
`$ git checkout pull/8821` \
`$ git pull https://git.openjdk.java.net/jdk pull/8821/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8821`

View PR using the GUI difftool: \
`$ git pr show -t 8821`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8821.diff">https://git.openjdk.java.net/jdk/pull/8821.diff</a>

</details>
