### PR TITLE
8287118: Use monospace font for annotation default values

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeMemberWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeMemberWriterImpl.java
@@ -270,7 +270,7 @@ public class AnnotationTypeMemberWriterImpl extends AbstractMemberWriter
             if (value != null) {
                 var dl = HtmlTree.DL(HtmlStyle.notes);
                 dl.add(HtmlTree.DT(contents.default_));
-                dl.add(HtmlTree.DD(Text.of(value.toString())));
+                dl.add(HtmlTree.DD(HtmlTree.CODE(Text.of(value.toString()))));
                 annotationContent.add(dl);
             }
         }

--- a/test/langtools/jdk/javadoc/doclet/testAnnotationTypes/TestAnnotationTypes.java
+++ b/test/langtools/jdk/javadoc/doclet/testAnnotationTypes/TestAnnotationTypes.java
@@ -141,7 +141,7 @@ public class TestAnnotationTypes extends JavadocTester {
                     <div class="member-signature"><span class="return-type">java.lang.String</span>&nbsp;<span class="element-name">optional</span></div>
                     <dl class="notes">
                     <dt>Default:</dt>
-                    <dd>""</dd>
+                    <dd><code>""</code></dd>
                     </dl>
                     </section>
                     </li>

--- a/test/langtools/jdk/javadoc/doclet/testHtmlDefinitionListTag/TestHtmlDefinitionListTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlDefinitionListTag/TestHtmlDefinitionListTag.java
@@ -113,7 +113,7 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                 """
                     <dl class="notes">
                     <dt>Default:</dt>
-                    <dd>true</dd>
+                    <dd><code>true</code></dd>
                     </dl>""");
 
         // Test for valid HTML generation which should not comprise of empty


### PR DESCRIPTION
Now the default values of annotation interface methods are rendered in `<code>` tags like the values on the constant values page.

Compare `BeanProperties` from [JDK 18](https://docs.oracle.com/en/java/javase/18/docs/api/java.desktop/java/beans/BeanProperty.html) and [this patch](https://cr.openjdk.java.net/~liach/8287118/java.desktop/java/beans/BeanProperty.html).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287118](https://bugs.openjdk.java.net/browse/JDK-8287118): Use monospace font for annotation default values


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8822/head:pull/8822` \
`$ git checkout pull/8822`

Update a local copy of the PR: \
`$ git checkout pull/8822` \
`$ git pull https://git.openjdk.java.net/jdk pull/8822/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8822`

View PR using the GUI difftool: \
`$ git pr show -t 8822`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8822.diff">https://git.openjdk.java.net/jdk/pull/8822.diff</a>

</details>
