### PR TITLE
8287119: Add Distrust.java to ProblemList

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -628,6 +628,8 @@ sun/security/provider/PolicyParser/ExtDirsChange.java           8039280 generic-
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
 sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java 8277970 linux-all,macosx-x64
 
+sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java    8287109 generic-all
+
 ############################################################################
 
 # jdk_sound


### PR DESCRIPTION
It will take me some time to figure out what to do with expired certificates. We can either remove those test scenarios, perform backdated validation or allow those expired scenarios to be treated as pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287119](https://bugs.openjdk.java.net/browse/JDK-8287119): Add Distrust.java to ProblemList


### Reviewers
 * [Bradford Wetmore](https://openjdk.java.net/census#wetmore) (@bradfordwetmore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8823/head:pull/8823` \
`$ git checkout pull/8823`

Update a local copy of the PR: \
`$ git checkout pull/8823` \
`$ git pull https://git.openjdk.java.net/jdk pull/8823/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8823`

View PR using the GUI difftool: \
`$ git pr show -t 8823`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8823.diff">https://git.openjdk.java.net/jdk/pull/8823.diff</a>

</details>
