### PR TITLE
8287113: JFR: Periodic task thread uses period for method sampling events

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -85,7 +85,7 @@ public final class MetadataRepository {
                 // annotations, such as Period and Threshold.
                 if (pEventType.hasPeriod()) {
                     pEventType.setEventHook(true);
-                    if (!(Type.EVENT_NAME_PREFIX + "ExecutionSample").equals(type.getName())) {
+                    if (!pEventType.isMethodSampling()) {
                         requestHooks.add(new RequestHook(pEventType));
                     }
                 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformEventType.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformEventType.java
@@ -327,4 +327,8 @@ public final class PlatformEventType extends Type {
     public void setLargeSize() {
         largeSize = true;
     }
+
+    public boolean isMethodSampling() {
+        return isMethodSampling;
+    }
 }


### PR DESCRIPTION
Could I have a review of a change that excludes the native method sampling event type from the JFR Periodic Task thread. Sampling is done in native code, not in the periodic task thread. 

The method sampling event (jdk.ExecutionSample) was already excluded, but jdk.NativeMethodSample was missing. This lead to the periodic task thread waking up 50 times per second instead of once (when using the default configuration). Each time the thread waits an unnecessary JavaMonitorWait event was emitted.

Testing: jdk/jdk/jfr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287113](https://bugs.openjdk.java.net/browse/JDK-8287113): JFR: Periodic task thread uses period for method sampling events


### Reviewers
 * [Jaroslav Bachorik](https://openjdk.java.net/census#jbachorik) (@jbachorik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8824/head:pull/8824` \
`$ git checkout pull/8824`

Update a local copy of the PR: \
`$ git checkout pull/8824` \
`$ git pull https://git.openjdk.java.net/jdk pull/8824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8824`

View PR using the GUI difftool: \
`$ git pr show -t 8824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8824.diff">https://git.openjdk.java.net/jdk/pull/8824.diff</a>

</details>
