### PR TITLE
8287121: Fix typo in jlink's description resource key lookup

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Main.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Main.java
@@ -65,7 +65,7 @@ public class Main {
         @Override
         public Optional<String> description() {
             TaskHelper taskHelper = new TaskHelper(TaskHelper.JLINK_BUNDLE);
-            return Optional.of(taskHelper.getMessage("jlink.desciption"));
+            return Optional.of(taskHelper.getMessage("jlink.description"));
         }
 
         @Override

--- a/test/jdk/java/util/spi/ToolProviderDescriptionTest.java
+++ b/test/jdk/java/util/spi/ToolProviderDescriptionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8287121
+ * @summary test ToolProvider's description API
+ * @run main/othervm ToolProviderDescriptionTest
+ */
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.spi.ToolProvider;
+import java.util.stream.StreamSupport;
+
+public class ToolProviderDescriptionTest {
+    public static void main(String... args) throws Exception {
+        List<String> descriptions = listToolDescriptions();
+        if (descriptions.isEmpty()) {
+            throw new AssertionError("No tool observable?");
+        }
+    }
+
+    static List<String> listToolDescriptions() {
+        return StreamSupport.stream(ServiceLoader.load(ToolProvider.class).spliterator(), false)
+            .sorted(Comparator.comparing(ToolProvider::name))
+            .map(ToolProviderDescriptionTest::describeTool)
+            .toList();
+    }
+
+    static String describeTool(ToolProvider tool) {
+        String name = tool.name();
+        String description = tool.description().orElse("<tool description not available>");
+        return "%20s - %s".formatted(name, description);
+    }
+}


### PR DESCRIPTION
Commit https://github.com/openjdk/jdk/commit/655500a4f5e3abcff176599604deceefb6ca6640 for issue [JDK-8286654](https://bugs.openjdk.java.net/browse/JDK-8286654) added an optional description accessor on the `ToolProvider` interface. It included a typo in` jlink`'s description resource key lookup: `"jlink.desciption"`

This follow-up commit fixes the typo by adding the missing `r` character: `"jlink.description"`.

This commit also also adds an automated check that ensures all current and future tool provider implementations within the JDK don't throw an exception when invoking their name and description accessor methods. Specific tool names and descriptions are not expected by this general test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287121](https://bugs.openjdk.java.net/browse/JDK-8287121): Fix typo in jlink's description resource key lookup


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8825/head:pull/8825` \
`$ git checkout pull/8825`

Update a local copy of the PR: \
`$ git checkout pull/8825` \
`$ git pull https://git.openjdk.java.net/jdk pull/8825/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8825`

View PR using the GUI difftool: \
`$ git pr show -t 8825`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8825.diff">https://git.openjdk.java.net/jdk/pull/8825.diff</a>

</details>
