### PR TITLE
Print top-level exception when snippet fails to read file

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SnippetTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SnippetTaglet.java
@@ -230,7 +230,7 @@ public class SnippetTaglet extends BaseTaglet {
                 }
             } catch (IOException | IllegalArgumentException e) { // TODO: test this when JDK-8276892 is integrated
                 // JavaFileManager.getFileForInput can throw IllegalArgumentException in certain cases
-                throw new BadSnippetException(a, "doclet.exception.read.file", v, e.getCause());
+                throw new BadSnippetException(a, "doclet.exception.read.file", v, e);
             }
 
             if (fileObject == null) {
@@ -242,7 +242,7 @@ public class SnippetTaglet extends BaseTaglet {
                 externalContent = fileObject.getCharContent(true).toString();
             } catch (IOException e) {  // TODO: test this when JDK-8276892 is integrated
                 throw new BadSnippetException(a, "doclet.exception.read.file",
-                        fileObject.getName(), e.getCause());
+                        fileObject.getName(), e);
             }
         }
 


### PR DESCRIPTION
When using a snippet as follows (on Windows): `{@snippet file=baz\Baz.java }`, javadoc prints the error:
```
src\foo\foo\Foo.java:14: error: Error reading file: baz\Baz.java
{@snippet file=baz\Baz.java }
          ^
        (null)
```

which is unhelpful. So rather than printing the exception's cause (which is `null` in the example above), it seems better to print the top-level exception itself.

PS: I'll need help from someone to create a JBS issue & sponsor this PR