### PR TITLE
8287104: AddressChangeListener thread inherits CCL and can cause memory leak for webapp-servers

### DIFF
--- a/src/java.base/windows/classes/sun/net/dns/ResolverConfigurationImpl.java
+++ b/src/java.base/windows/classes/sun/net/dns/ResolverConfigurationImpl.java
@@ -199,7 +199,7 @@ public final class ResolverConfigurationImpl
         init0();
 
         // start the address listener thread
-        String name = "Net-address-change-listener";
+        String name = "Jndi-Dns-address-change-listener";
         Thread addrChangeListener = InnocuousThread.newSystemThread(name,
                 new AddressChangeListener());
         addrChangeListener.setDaemon(true);

--- a/src/java.base/windows/classes/sun/net/dns/ResolverConfigurationImpl.java
+++ b/src/java.base/windows/classes/sun/net/dns/ResolverConfigurationImpl.java
@@ -46,7 +46,7 @@ public final class ResolverConfigurationImpl
 
     // Addresses have changed. We default to true to make sure we
     // resolve the first time it is requested.
-    private static volatile boolean changed = true;
+    private static boolean changed = true;
 
     // Time of last refresh.
     private static long lastRefresh;

--- a/src/java.base/windows/classes/sun/net/dns/ResolverConfigurationImpl.java
+++ b/src/java.base/windows/classes/sun/net/dns/ResolverConfigurationImpl.java
@@ -25,6 +25,8 @@
 
 package sun.net.dns;
 
+import jdk.internal.misc.InnocuousThread;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -37,14 +39,14 @@ public final class ResolverConfigurationImpl
     extends ResolverConfiguration
 {
     // Lock held whilst loading configuration or checking
-    private static Object lock = new Object();
+    private static final Object lock = new Object();
 
     // Resolver options
     private final Options opts;
 
     // Addresses have changed. We default to true to make sure we
     // resolve the first time it is requested.
-    private static boolean changed = true;
+    private static volatile boolean changed = true;
 
     // Time of last refresh.
     private static long lastRefresh;
@@ -169,7 +171,8 @@ public final class ResolverConfigurationImpl
 
     // --- Address Change Listener
 
-    static class AddressChangeListener extends Thread {
+    static class AddressChangeListener implements Runnable {
+        @Override
         public void run() {
             for (;;) {
                 // wait for configuration to change
@@ -196,9 +199,11 @@ public final class ResolverConfigurationImpl
         init0();
 
         // start the address listener thread
-        AddressChangeListener thr = new AddressChangeListener();
-        thr.setDaemon(true);
-        thr.start();
+        String name = "Net-address-change-listener";
+        Thread addrChangeListener = InnocuousThread.newSystemThread(name,
+                new AddressChangeListener());
+        addrChangeListener.setDaemon(true);
+        addrChangeListener.start();
     }
 }
 


### PR DESCRIPTION
Can I please get a review of this change which addresses https://bugs.openjdk.java.net/browse/JDK-8287104?

The change in this commit now uses an `InnocuousThread` to create a thread with `null` context classloader. The `Runnable` task of this thread just invokes a native method through JNI to be notified of IP addresses change of the host. As such any specific thread context classloader isn't necessary in this thread.

Additionally, this commit does some minor changes like making the `lock` member variable `final` and also marking the `changed` member variable as `volatile`. These changes aren't necessary for this fix, but I think would be good to have while we are changing this part of the code.

Finally, the thread that we create here, now has a specific name `Net-address-change-listener` instead of the usual system wide auto-generated name.

No new tests have been added for this change. Existing tier1, tier2 and tier3 tests have been run and no related failures have been noticed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287104](https://bugs.openjdk.java.net/browse/JDK-8287104): AddressChangeListener thread inherits CCL and can cause memory leak for webapp-servers


### Reviewers
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8827/head:pull/8827` \
`$ git checkout pull/8827`

Update a local copy of the PR: \
`$ git checkout pull/8827` \
`$ git pull https://git.openjdk.java.net/jdk pull/8827/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8827`

View PR using the GUI difftool: \
`$ git pr show -t 8827`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8827.diff">https://git.openjdk.java.net/jdk/pull/8827.diff</a>

</details>
