### PR TITLE
8287135: Calculation of jmm_GetMemoryUsage is wrong

### DIFF
--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -750,7 +750,7 @@ JVM_ENTRY(jobject, jmm_GetMemoryUsage(JNIEnv* env, jboolean heap))
 
     for (int i = 0; i < MemoryService::num_memory_pools(); i++) {
       MemoryPool* pool = MemoryService::get_memory_pool(i);
-      if (pool->is_codeheap() || pool->is_metaspace()) {
+      if (pool->is_non_heap()) {
         MemoryUsage u = pool->get_memory_usage();
         total_used += u.used();
         total_committed += u.committed();

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -736,9 +736,11 @@ JVM_ENTRY(jobject, jmm_GetMemoryUsage(JNIEnv* env, jboolean heap))
   MemoryUsage usage;
 
   if (heap) {
+    // HeapUsage = GC heap
     usage = Universe::heap()->memory_usage();
   } else {
     // Calculate the memory usage by summing up the pools.
+    // NonHeapUsage = CodeHeaps + Metaspace
     size_t total_init = 0;
     size_t total_used = 0;
     size_t total_committed = 0;
@@ -748,7 +750,7 @@ JVM_ENTRY(jobject, jmm_GetMemoryUsage(JNIEnv* env, jboolean heap))
 
     for (int i = 0; i < MemoryService::num_memory_pools(); i++) {
       MemoryPool* pool = MemoryService::get_memory_pool(i);
-      if (pool->is_non_heap()) {
+      if (pool->is_codeheap() || pool->is_metaspace()) {
         MemoryUsage u = pool->get_memory_usage();
         total_used += u.used();
         total_committed += u.committed();

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -736,11 +736,9 @@ JVM_ENTRY(jobject, jmm_GetMemoryUsage(JNIEnv* env, jboolean heap))
   MemoryUsage usage;
 
   if (heap) {
-    // HeapUsage = GC heap
     usage = Universe::heap()->memory_usage();
   } else {
     // Calculate the memory usage by summing up the pools.
-    // NonHeapUsage = CodeHeaps + Metaspace
     size_t total_init = 0;
     size_t total_used = 0;
     size_t total_committed = 0;

--- a/src/hotspot/share/services/memoryPool.cpp
+++ b/src/hotspot/share/services/memoryPool.cpp
@@ -184,6 +184,9 @@ MemoryUsage CodeHeapPool::get_memory_usage() {
   return MemoryUsage(initial_size(), used, committed, maxSize);
 }
 
+// Any NonHeap pools would be counted into Non-Heap memory by MemoryMXBean.getNonHeapMemoryUsage.
+// Make sure that it behaves as you expected if you want to add a new type of NonHeap pool, and
+// update comments in jmm_GetMemoryUsage
 MetaspacePool::MetaspacePool() :
   MemoryPool("Metaspace", NonHeap, 0, calculate_max_size(), true, false) { }
 
@@ -199,16 +202,4 @@ size_t MetaspacePool::used_in_bytes() {
 size_t MetaspacePool::calculate_max_size() const {
   return !FLAG_IS_DEFAULT(MaxMetaspaceSize) ? MaxMetaspaceSize :
                                               MemoryUsage::undefined_size();
-}
-
-CompressedKlassSpacePool::CompressedKlassSpacePool() :
-  MemoryPool("Compressed Class Space", NonHeap, 0, CompressedClassSpaceSize, true, false) { }
-
-size_t CompressedKlassSpacePool::used_in_bytes() {
-  return MetaspaceUtils::used_bytes(Metaspace::ClassType);
-}
-
-MemoryUsage CompressedKlassSpacePool::get_memory_usage() {
-  MetaspaceStats stats = MetaspaceUtils::get_statistics(Metaspace::ClassType);
-  return MemoryUsage(initial_size(), stats.used(), stats.committed(), max_size());
 }

--- a/src/hotspot/share/services/memoryPool.cpp
+++ b/src/hotspot/share/services/memoryPool.cpp
@@ -184,9 +184,8 @@ MemoryUsage CodeHeapPool::get_memory_usage() {
   return MemoryUsage(initial_size(), used, committed, maxSize);
 }
 
-// Any NonHeap pools would be counted into Non-Heap memory by MemoryMXBean.getNonHeapMemoryUsage.
-// Make sure that it behaves as you expected if you want to add a new type of NonHeap pool, and
-// update comments in jmm_GetMemoryUsage
+// Note, any NonHeap pools would be counted into Non-Heap memory by MemoryMXBean.getNonHeapMemoryUsage.
+// Make sure that it behaves as you expected if you want to add a new type of NonHeap pool
 MetaspacePool::MetaspacePool() :
   MemoryPool("Metaspace", NonHeap, 0, calculate_max_size(), true, false) { }
 

--- a/src/hotspot/share/services/memoryPool.hpp
+++ b/src/hotspot/share/services/memoryPool.hpp
@@ -136,6 +136,9 @@ class MemoryPool : public CHeapObj<mtInternal> {
   virtual size_t      used_in_bytes() = 0;
   virtual bool        is_collected_pool()         { return false; }
   virtual MemoryUsage get_last_collection_usage() { return _after_gc_usage; }
+  virtual bool        is_codeheap()               { return false; }
+  virtual bool        is_metaspace()              { return false; }
+  virtual bool        is_compressed_klass_space() { return false; }
 };
 
 class CollectedMemoryPool : public MemoryPool {
@@ -152,6 +155,8 @@ public:
   CodeHeapPool(CodeHeap* codeHeap, const char* name, bool support_usage_threshold);
   MemoryUsage get_memory_usage();
   size_t used_in_bytes()            { return _codeHeap->allocated_capacity(); }
+
+  bool is_codeheap() override { return true; }
 };
 
 class MetaspacePool : public MemoryPool {
@@ -160,6 +165,7 @@ class MetaspacePool : public MemoryPool {
   MetaspacePool();
   MemoryUsage get_memory_usage();
   size_t used_in_bytes();
+  bool is_metaspace() override { return true; }
 };
 
 class CompressedKlassSpacePool : public MemoryPool {
@@ -167,6 +173,7 @@ class CompressedKlassSpacePool : public MemoryPool {
   CompressedKlassSpacePool();
   MemoryUsage get_memory_usage();
   size_t used_in_bytes();
+  bool is_compressed_klass_space() override { return true; }
 };
 
 #endif // SHARE_SERVICES_MEMORYPOOL_HPP

--- a/src/hotspot/share/services/memoryPool.hpp
+++ b/src/hotspot/share/services/memoryPool.hpp
@@ -168,12 +168,4 @@ class MetaspacePool : public MemoryPool {
   bool is_metaspace() override { return true; }
 };
 
-class CompressedKlassSpacePool : public MemoryPool {
- public:
-  CompressedKlassSpacePool();
-  MemoryUsage get_memory_usage();
-  size_t used_in_bytes();
-  bool is_compressed_klass_space() override { return true; }
-};
-
 #endif // SHARE_SERVICES_MEMORYPOOL_HPP

--- a/src/hotspot/share/services/memoryPool.hpp
+++ b/src/hotspot/share/services/memoryPool.hpp
@@ -136,9 +136,6 @@ class MemoryPool : public CHeapObj<mtInternal> {
   virtual size_t      used_in_bytes() = 0;
   virtual bool        is_collected_pool()         { return false; }
   virtual MemoryUsage get_last_collection_usage() { return _after_gc_usage; }
-  virtual bool        is_codeheap()               { return false; }
-  virtual bool        is_metaspace()              { return false; }
-  virtual bool        is_compressed_klass_space() { return false; }
 };
 
 class CollectedMemoryPool : public MemoryPool {
@@ -155,8 +152,6 @@ public:
   CodeHeapPool(CodeHeap* codeHeap, const char* name, bool support_usage_threshold);
   MemoryUsage get_memory_usage();
   size_t used_in_bytes()            { return _codeHeap->allocated_capacity(); }
-
-  bool is_codeheap() override { return true; }
 };
 
 class MetaspacePool : public MemoryPool {
@@ -165,7 +160,6 @@ class MetaspacePool : public MemoryPool {
   MetaspacePool();
   MemoryUsage get_memory_usage();
   size_t used_in_bytes();
-  bool is_metaspace() override { return true; }
 };
 
 #endif // SHARE_SERVICES_MEMORYPOOL_HPP

--- a/src/hotspot/share/services/memoryService.cpp
+++ b/src/hotspot/share/services/memoryService.cpp
@@ -51,7 +51,6 @@ MemoryManager*   MemoryService::_code_cache_manager    = NULL;
 GrowableArray<MemoryPool*>* MemoryService::_code_heap_pools =
     new (ResourceObj::C_HEAP, mtServiceability) GrowableArray<MemoryPool*>(init_code_heap_pools_size, mtServiceability);
 MemoryPool*      MemoryService::_metaspace_pool        = NULL;
-MemoryPool*      MemoryService::_compressed_class_pool = NULL;
 
 class GcThreadCountClosure: public ThreadClosure {
  private:

--- a/src/hotspot/share/services/memoryService.cpp
+++ b/src/hotspot/share/services/memoryService.cpp
@@ -112,13 +112,6 @@ void MemoryService::add_metaspace_memory_pools() {
   _metaspace_pool = new MetaspacePool();
   mgr->add_pool(_metaspace_pool);
   _pools_list->append(_metaspace_pool);
-
-  if (UseCompressedClassPointers) {
-    _compressed_class_pool = new CompressedKlassSpacePool();
-    mgr->add_pool(_compressed_class_pool);
-    _pools_list->append(_compressed_class_pool);
-  }
-
   _managers_list->append(mgr);
 }
 

--- a/src/hotspot/share/services/memoryService.hpp
+++ b/src/hotspot/share/services/memoryService.hpp
@@ -57,7 +57,6 @@ private:
   static GrowableArray<MemoryPool*>*    _code_heap_pools;
 
   static MemoryPool*                    _metaspace_pool;
-  static MemoryPool*                    _compressed_class_pool;
 
 public:
   static void set_universe_heap(CollectedHeap* heap);
@@ -91,9 +90,6 @@ public:
   }
   static void track_metaspace_memory_usage() {
     track_memory_pool_usage(_metaspace_pool);
-  }
-  static void track_compressed_class_memory_usage() {
-    track_memory_pool_usage(_compressed_class_pool);
   }
   static void track_memory_pool_usage(MemoryPool* pool);
 

--- a/test/hotspot/jtreg/gc/metaspace/TestMetaspaceMemoryPool.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestMetaspaceMemoryPool.java
@@ -32,15 +32,12 @@ import static jdk.test.lib.Asserts.*;
  * @bug 8000754
  * @summary Tests that a MemoryPoolMXBeans is created for metaspace and that a
  *          MemoryManagerMXBean is created.
- * @requires vm.bits == 64 & vm.opt.final.UseCompressedOops == true
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops gc.metaspace.TestMetaspaceMemoryPool
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:MaxMetaspaceSize=60m gc.metaspace.TestMetaspaceMemoryPool
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers gc.metaspace.TestMetaspaceMemoryPool
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:CompressedClassSpaceSize=60m gc.metaspace.TestMetaspaceMemoryPool
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions gc.metaspace.TestMetaspaceMemoryPool
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:MaxMetaspaceSize=60m gc.metaspace.TestMetaspaceMemoryPool
  */
 public class TestMetaspaceMemoryPool {
     public static void main(String[] args) {
@@ -48,13 +45,6 @@ public class TestMetaspaceMemoryPool {
 
         boolean isMetaspaceMaxDefined = InputArguments.containsPrefix("-XX:MaxMetaspaceSize");
         verifyMemoryPool(getMemoryPool("Metaspace"), isMetaspaceMaxDefined);
-
-        if (Platform.is64bit()) {
-            if (InputArguments.contains("-XX:+UseCompressedOops")) {
-                MemoryPoolMXBean cksPool = getMemoryPool("Compressed Class Space");
-                verifyMemoryPool(cksPool, true);
-            }
-        }
     }
 
     private static void verifyThatMetaspaceMemoryManagerExists() {

--- a/test/hotspot/jtreg/gc/metaspace/TestPerfCountersAndMemoryPools.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestPerfCountersAndMemoryPools.java
@@ -39,16 +39,11 @@ import gc.testlibrary.PerfCounters;
  * @modules java.base/jdk.internal.misc
  *          java.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xlog:class+load,class+unload=trace -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:+UseSerialGC -XX:+UsePerfData -Xint gc.metaspace.TestPerfCountersAndMemoryPools
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xlog:class+load,class+unload=trace -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:+UseSerialGC -XX:+UsePerfData -Xint gc.metaspace.TestPerfCountersAndMemoryPools
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xlog:class+load,class+unload=trace -XX:+UseSerialGC -XX:+UsePerfData -Xint gc.metaspace.TestPerfCountersAndMemoryPools
  */
 public class TestPerfCountersAndMemoryPools {
     public static void main(String[] args) throws Exception {
         checkMemoryUsage("Metaspace", "sun.gc.metaspace");
-
-        if (InputArguments.contains("-XX:+UseCompressedClassPointers") && Platform.is64bit()) {
-            checkMemoryUsage("Compressed Class Space", "sun.gc.compressedclassspace");
-        }
     }
 
     private static MemoryPoolMXBean getMemoryPool(String memoryPoolName) {

--- a/test/hotspot/jtreg/vmTestbase/metaspace/gc/MemoryUsageTest.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/gc/MemoryUsageTest.java
@@ -27,9 +27,6 @@ package metaspace.gc;
  * Test observers the progress on used/committed memory.
  * MemoryPoolMXBean is used for that purpose.
  *
- * Depending on command line option the test checks either Metaspace or
- * Compressed Class Space area.
- *
  * This test checks two things:
  * 1) Loading/Unloading classes doesn't cause memory increase
  * 2) Loading classes causes permanent increase of memory.
@@ -127,18 +124,8 @@ public class MemoryUsageTest extends MetaspaceBaseGC {
         }
     }
 
-    /**
-     * Looks up for memory pool name.
-     * @param args command line options
-     */
     @Override
     protected void parseArgs(String[] args) {
-    }
-
-    private void printUsage() {
-        System.err.println("Usage: ");
-        System.err.println("java [-Xms..] [-XX:MetaspaceSize=..]  [-XX:MaxMetaspaceSize=..] \\");
-        System.err.println("    " + MemoryUsageTest.class.getCanonicalName());
     }
 
     /**

--- a/test/hotspot/jtreg/vmTestbase/metaspace/gc/MemoryUsageTest.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/gc/MemoryUsageTest.java
@@ -36,7 +36,7 @@ package metaspace.gc;
  */
 public class MemoryUsageTest extends MetaspaceBaseGC {
 
-    private String pool_name;
+    private final String pool_name = "Metaspace";
 
     public static void main(String[] args) {
         new MemoryUsageTest().run(args);
@@ -133,26 +133,12 @@ public class MemoryUsageTest extends MetaspaceBaseGC {
      */
     @Override
     protected void parseArgs(String[] args) {
-        if (args.length != 1) {
-            printUsage();
-            throw new Fault("MemoryPool is not specified");
-        }
-
-        String a = args[0];
-        if (a.equalsIgnoreCase("-pool:compressed")) {
-             pool_name = "Compressed Class Space";
-        } else if (a.equalsIgnoreCase("-pool:metaspace")) {
-             pool_name = "Metaspace";
-        } else {
-            printUsage();
-            throw new Fault("Unrecongnized argument: " + a);
-        }
     }
 
     private void printUsage() {
         System.err.println("Usage: ");
         System.err.println("java [-Xms..] [-XX:MetaspaceSize=..]  [-XX:MaxMetaspaceSize=..] \\");
-        System.err.println("    " + MemoryUsageTest.class.getCanonicalName() + " -pool:<metaspace|compressed>");
+        System.err.println("    " + MemoryUsageTest.class.getCanonicalName());
     }
 
     /**

--- a/test/hotspot/jtreg/vmTestbase/metaspace/gc/memoryUsageLargeComp/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/gc/memoryUsageLargeComp/TestDescription.java
@@ -36,6 +36,5 @@
  *      -XX:MinMetaspaceFreeRatio=90
  *      -XX:MaxMetaspaceFreeRatio=99
  *      metaspace.gc.MemoryUsageTest
- *      -pool:compressed
  */
 

--- a/test/hotspot/jtreg/vmTestbase/metaspace/gc/memoryUsageLargeMeta/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/gc/memoryUsageLargeMeta/TestDescription.java
@@ -36,6 +36,5 @@
  *      -XX:MinMetaspaceFreeRatio=1
  *      -XX:MaxMetaspaceFreeRatio=10
  *      metaspace.gc.MemoryUsageTest
- *      -pool:metaspace
  */
 

--- a/test/hotspot/jtreg/vmTestbase/metaspace/gc/memoryUsageSmallComp/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/gc/memoryUsageSmallComp/TestDescription.java
@@ -35,6 +35,5 @@
  *      -XX:MinMetaspaceFreeRatio=10
  *      -XX:MaxMetaspaceFreeRatio=30
  *      metaspace.gc.MemoryUsageTest
- *      -pool:compressed
  */
 

--- a/test/hotspot/jtreg/vmTestbase/metaspace/gc/memoryUsageSmallMeta/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/gc/memoryUsageSmallMeta/TestDescription.java
@@ -35,6 +35,5 @@
  *      -XX:MinMetaspaceFreeRatio=70
  *      -XX:MaxMetaspaceFreeRatio=90
  *      metaspace.gc.MemoryUsageTest
- *      -pool:metaspace
  */
 

--- a/test/hotspot/jtreg/vmTestbase/metaspace/shrink_grow/CompressedClassSpaceSize/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/shrink_grow/CompressedClassSpaceSize/TestDescription.java
@@ -32,7 +32,6 @@
  * @requires vm.opt.final.ClassUnloading
  * @library /vmTestbase /test/lib
  * @run main/othervm
- *      -DrequiresCompressedClassSpace=true
  *      -XX:MaxMetaspaceSize=100m
  *      -XX:CompressedClassSpaceSize=10m
  *      -Xlog:gc*:gc.log

--- a/test/hotspot/jtreg/vmTestbase/metaspace/shrink_grow/ShrinkGrowTest/ShrinkGrowTest.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/shrink_grow/ShrinkGrowTest/ShrinkGrowTest.java
@@ -114,12 +114,6 @@ public class ShrinkGrowTest {
      * Just exits if passes or throws an Error if failed.
      */
     public void run() {
-        if (System.getProperty("requiresCompressedClassSpace") != null &&
-                   !isCompressedClassSpaceAvailable()) {
-                System.out.println("Not applicalbe, Compressed Class Space is required");
-            return;
-        }
-
         try {
             log("Bootstrapping string concatenation for " + whoAmI );
             go();
@@ -238,15 +232,6 @@ public class ShrinkGrowTest {
             String message = error.getMessage();
         return message != null && (message.contains("Metaspace") ||
                         message.contains("Compressed class space"));
-    }
-
-    boolean isCompressedClassSpaceAvailable() {
-        for (MemoryPoolMXBean pool : ManagementFactory.getMemoryPoolMXBeans()) {
-            if (pool.getName().equalsIgnoreCase("Compressed class space")) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/gp/GarbageUtils.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/gp/GarbageUtils.java
@@ -50,7 +50,7 @@ public final class GarbageUtils {
         public static enum OOM_TYPE {
             ANY (),
             HEAP("Java heap space"),
-            METASPACE("Metaspace", "Compressed class space");
+            METASPACE("Metaspace");
 
             private final String[] expectedStrings;
             OOM_TYPE(String... expectedStrings) {

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/indy/stress/gc/lotsOfCallSites/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/indy/stress/gc/lotsOfCallSites/Test.java
@@ -124,11 +124,11 @@ public class Test extends MlvmTest {
         return count;
     }
 
-    private MemoryPoolMXBean getClassMetadataMemoryPoolMXBean() {
-    MemoryMXBean mbean = ManagementFactory.getMemoryMXBean();
-    for (MemoryPoolMXBean memPool : ManagementFactory.getMemoryPoolMXBeans()) {
+    private MemoryPoolMXBean getMetaspaceMemoryPoolMXBean() {
+        MemoryMXBean mbean = ManagementFactory.getMemoryMXBean();
+        for (MemoryPoolMXBean memPool : ManagementFactory.getMemoryPoolMXBeans()) {
             String name = memPool.getName();
-        if ((name.contains("Compressed class space") || name.contains("Metaspace")) && memPool.getUsage() != null) {
+            if (name.contains("Metaspace") && memPool.getUsage() != null) {
                 return memPool;
             }
         }
@@ -140,8 +140,8 @@ public class Test extends MlvmTest {
         setHeapDumpAfter(heapDumpOpt);
 
         final byte[] classBytes = FileUtils.readClass(TESTEE_CLASS_NAME);
-        final MemoryPoolMXBean classMetadataPoolMXB = getClassMetadataMemoryPoolMXBean();
-        final String memPoolName = classMetadataPoolMXB == null ? "" : classMetadataPoolMXB.getName();
+        final MemoryPoolMXBean metaspacePoolMXB = getMetaspaceMemoryPoolMXBean();
+        final String memPoolName = metaspacePoolMXB == null ? "" : metaspacePoolMXB.getName();
 
         int removedEntries = 0;
 
@@ -156,8 +156,8 @@ public class Test extends MlvmTest {
 
                 if (stresser.getIteration() % 1000 == 0) {
                     Env.traceNormal("Iterations: " + stresser.getIteration() + " removed entries: " + removedEntries);
-                    if (TERMINATE_ON_FULL_METASPACE && classMetadataPoolMXB != null) {
-                        MemoryUsage mu = classMetadataPoolMXB.getUsage();
+                    if (TERMINATE_ON_FULL_METASPACE && metaspacePoolMXB != null) {
+                        MemoryUsage mu = metaspacePoolMXB.getUsage();
                         Env.traceNormal(memPoolName + " usage: " + mu);
                         if  (mu.getUsed() >= mu.getMax() * 9 / 10) {
                             Env.traceNormal(memPoolName + " is nearly out of space: " + mu + ". Terminating.");

--- a/test/jdk/java/lang/management/MemoryMXBean/LowMemoryTest2.sh
+++ b/test/jdk/java/lang/management/MemoryMXBean/LowMemoryTest2.sh
@@ -60,19 +60,6 @@ go() {
 go -noclassgc -XX:MaxMetaspaceSize=32m -XX:+UseSerialGC LowMemoryTest2
 go -noclassgc -XX:MaxMetaspaceSize=32m -XX:+UseParallelGC LowMemoryTest2
 
-# Test class metaspace - might hit MaxMetaspaceSize instead if
-# UseCompressedClassPointers is off or if 32 bit.
-#
-# (note: This is very shaky and that shakiness exposes a problem with MemoryMXBean:
-#
-#  MemoryMXBean defines "used" "committed" and "max" (see java/lang/management/MemoryUsage.java)
-#  This abstraction misses a definition for "address space exhausted" which with the new Metaspace (jep387)
-#  can happen before committed/used hits any trigger. We now commit only on demand and therefore class loaders
-#  can sit atop of uncommitted address space, denying new loaders address space. In the old Metaspace,
-#  we would have committed the space right away and therefore the MemoryMXBean "committed" trigger
-#  would have fired. In the new Metaspace, we don't commit, so the MemoryMXBean does not fire.
-go -noclassgc -XX:MaxMetaspaceSize=4m LowMemoryTest2
-
 echo ''
 if [ $failures -gt 0 ];
   then echo "$failures test(s) failed";

--- a/test/jdk/java/lang/management/MemoryMXBean/LowMemoryTest2.sh
+++ b/test/jdk/java/lang/management/MemoryMXBean/LowMemoryTest2.sh
@@ -71,7 +71,7 @@ go -noclassgc -XX:MaxMetaspaceSize=32m -XX:+UseParallelGC LowMemoryTest2
 #  can sit atop of uncommitted address space, denying new loaders address space. In the old Metaspace,
 #  we would have committed the space right away and therefore the MemoryMXBean "committed" trigger
 #  would have fired. In the new Metaspace, we don't commit, so the MemoryMXBean does not fire.
-go -noclassgc -XX:MaxMetaspaceSize=16m -XX:CompressedClassSpaceSize=4m LowMemoryTest2
+go -noclassgc -XX:MaxMetaspaceSize=4m LowMemoryTest2
 
 echo ''
 if [ $failures -gt 0 ];

--- a/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
@@ -79,6 +79,16 @@ public class MemoryTest {
     // - Metaspace
     // - Compressed Class Space (if compressed class pointers are used)
 
+    // Hotspot VM 19 removes Compressed Class Space pool as it's a part of Metaspace
+    // It expected to have the following memory pools:
+    // - HEAP      G1 Eden Space
+    // - HEAP      G1 Old Gen
+    // - HEAP      G1 Survivor Space
+    // - NON_HEAP  CodeHeap 'non-nmethods' (between one and three depending on the -XX:SegmentedCodeCache option)
+    // - NON_HEAP  Metaspace
+    // - NON_HEAP  CodeHeap 'profiled nmethods'
+    // - NON_HEAP  CodeHeap 'non-profiled nmethods'
+
     private static int[] expectedMinNumPools = new int[2];
     private static int[] expectedMaxNumPools = new int[2];
     private static int expectedNumGCMgrs;


### PR DESCRIPTION
It seems that calculation of MemoryMXBean.getNonHeapMemoryUsage(jmm_GetMemoryUsage) is wrong.

Currently, `NonHeapUsage=CodeCache+Metaspace(ClassTypeSpace+NonClassTypeSpace)+CompressedClassSpace(ClassTypeSpace)`

==> CodeHeap 'non-nmethods' 1532544 (Used)
==> CodeHeap 'profiled nmethods' 0
==> CodeHeap 'non-profiled nmethods' 13952
==> Metaspace 506696
==> Compressed Class Space 43312
init = 7667712(7488K) used = 2096504(2047K) committed = 8454144(8256K) max = -1(-1K)

In this way, getNonHeapMemoryUsage is larger than it ought to be, it should be `NonHeapUsage = CodeCache + Metaspace`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287135](https://bugs.openjdk.org/browse/JDK-8287135): Calculation of jmm_GetMemoryUsage is wrong


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/8831/head:pull/8831` \
`$ git checkout pull/8831`

Update a local copy of the PR: \
`$ git checkout pull/8831` \
`$ git pull https://git.openjdk.org/jdk pull/8831/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8831`

View PR using the GUI difftool: \
`$ git pr show -t 8831`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/8831.diff">https://git.openjdk.org/jdk/pull/8831.diff</a>

</details>
