### PR TITLE
8287138: Make VerifyOption an enum class

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2408,9 +2408,9 @@ bool G1CollectedHeap::is_obj_dead_cond(const oop obj,
                                        const HeapRegion* hr,
                                        const VerifyOption vo) const {
   switch (vo) {
-  case VerifyOption_G1UsePrevMarking: return is_obj_dead(obj, hr);
-  case VerifyOption_G1UseFullMarking: return is_obj_dead_full(obj, hr);
-  default:                            ShouldNotReachHere();
+    case VerifyOption::G1UsePrevMarking: return is_obj_dead(obj, hr);
+    case VerifyOption::G1UseFullMarking: return is_obj_dead_full(obj, hr);
+    default:                            ShouldNotReachHere();
   }
   return false; // keep some compilers happy
 }
@@ -2418,9 +2418,9 @@ bool G1CollectedHeap::is_obj_dead_cond(const oop obj,
 bool G1CollectedHeap::is_obj_dead_cond(const oop obj,
                                        const VerifyOption vo) const {
   switch (vo) {
-  case VerifyOption_G1UsePrevMarking: return is_obj_dead(obj);
-  case VerifyOption_G1UseFullMarking: return is_obj_dead_full(obj);
-  default:                            ShouldNotReachHere();
+    case VerifyOption::G1UsePrevMarking: return is_obj_dead(obj);
+    case VerifyOption::G1UseFullMarking: return is_obj_dead_full(obj);
+    default:                            ShouldNotReachHere();
   }
   return false; // keep some compilers happy
 }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1219,7 +1219,7 @@ void G1ConcurrentMark::remark() {
 
   double start = os::elapsedTime();
 
-  verify_during_pause(G1HeapVerifier::G1VerifyRemark, VerifyOption_G1UsePrevMarking, "Remark before");
+  verify_during_pause(G1HeapVerifier::G1VerifyRemark, VerifyOption::G1UsePrevMarking, "Remark before");
 
   {
     GCTraceTime(Debug, gc, phases) debug("Finalize Marking", _gc_timer_cm);
@@ -1280,7 +1280,7 @@ void G1ConcurrentMark::remark() {
 
     compute_new_sizes();
 
-    verify_during_pause(G1HeapVerifier::G1VerifyRemark, VerifyOption_G1UsePrevMarking, "Remark after");
+    verify_during_pause(G1HeapVerifier::G1VerifyRemark, VerifyOption::G1UsePrevMarking, "Remark after");
 
     assert(!restart_for_overflow(), "sanity");
     // Completely reset the marking state since marking completed
@@ -1289,7 +1289,7 @@ void G1ConcurrentMark::remark() {
     // We overflowed.  Restart concurrent marking.
     _restart_for_overflow = true;
 
-    verify_during_pause(G1HeapVerifier::G1VerifyRemark, VerifyOption_G1UsePrevMarking, "Remark overflow");
+    verify_during_pause(G1HeapVerifier::G1VerifyRemark, VerifyOption::G1UsePrevMarking, "Remark overflow");
 
     // Clear the marking state because we will be restarting
     // marking due to overflowing the global mark stack.
@@ -1435,7 +1435,7 @@ void G1ConcurrentMark::cleanup() {
 
   double start = os::elapsedTime();
 
-  verify_during_pause(G1HeapVerifier::G1VerifyCleanup, VerifyOption_G1UsePrevMarking, "Cleanup before");
+  verify_during_pause(G1HeapVerifier::G1VerifyCleanup, VerifyOption::G1UsePrevMarking, "Cleanup before");
 
   if (needs_remembered_set_rebuild()) {
     GCTraceTime(Debug, gc, phases) debug("Update Remembered Set Tracking After Rebuild", _gc_timer_cm);
@@ -1445,7 +1445,7 @@ void G1ConcurrentMark::cleanup() {
     log_debug(gc, phases)("No Remembered Sets to update after rebuild");
   }
 
-  verify_during_pause(G1HeapVerifier::G1VerifyCleanup, VerifyOption_G1UsePrevMarking, "Cleanup after");
+  verify_during_pause(G1HeapVerifier::G1VerifyCleanup, VerifyOption::G1UsePrevMarking, "Cleanup after");
 
   // We need to make this be a "collection" so any collection pause that
   // races with it goes around and waits for Cleanup to finish.

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -420,5 +420,5 @@ void G1FullCollector::verify_after_marking() {
   // (including hash values) are restored to the appropriate
   // objects.
   GCTraceTime(Info, gc, verify) tm("Verifying During GC (full)");
-  _heap->verify(VerifyOption_G1UseFullMarking);
+  _heap->verify(VerifyOption::G1UseFullMarking);
 }

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
@@ -41,7 +41,7 @@ G1FullGCMarker::G1FullGCMarker(G1FullCollector* collector,
     _objarray_stack(),
     _preserved_stack(preserved_stack),
     _mark_closure(worker_id, this, G1CollectedHeap::heap()->ref_processor_stw()),
-    _verify_closure(VerifyOption_G1UseFullMarking),
+    _verify_closure(VerifyOption::G1UseFullMarking),
     _stack_closure(this),
     _cld_closure(mark_closure(), ClassLoaderData::_claim_strong),
     _mark_stats_cache(mark_stats, G1RegionMarkStatsCache::RegionMarkStatsCacheSize) {

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -97,7 +97,7 @@ class G1VerifyCodeRootOopClosure: public OopClosure {
     }
 
     // Don't check the code roots during marking verification in a full GC
-    if (_vo == VerifyOption_G1UseFullMarking) {
+    if (_vo == VerifyOption::G1UseFullMarking) {
       return;
     }
 
@@ -219,7 +219,7 @@ public:
       // word), it may not be marked, or may have been marked
       // but has since became dead, or may have been allocated
       // since the last marking.
-      if (_vo == VerifyOption_G1UseFullMarking) {
+      if (_vo == VerifyOption::G1UseFullMarking) {
         guarantee(!_g1h->is_obj_dead(o), "Full GC marking and concurrent mark mismatch");
       }
 
@@ -493,7 +493,8 @@ void G1HeapVerifier::verify(VerifyOption vo) {
   }
 
   if (failures) {
-    log_error(gc, verify)("Heap after failed verification (kind %d):", vo);
+    log_error(gc, verify)("Heap after failed verification (kind %u):",
+                          static_cast<std::underlying_type_t<VerifyOption>>(vo));
     // It helps to have the per-region information in the output to
     // help us track down what went wrong. This is why we call
     // print_extended_on() instead of print_on().
@@ -587,11 +588,11 @@ void G1HeapVerifier::verify(G1VerifyType type, VerifyOption vo, const char* msg)
 }
 
 void G1HeapVerifier::verify_before_gc(G1VerifyType type) {
-  verify(type, VerifyOption_G1UsePrevMarking, "Before GC");
+  verify(type, VerifyOption::G1UsePrevMarking, "Before GC");
 }
 
 void G1HeapVerifier::verify_after_gc(G1VerifyType type) {
-  verify(type, VerifyOption_G1UsePrevMarking, "After GC");
+  verify(type, VerifyOption::G1UsePrevMarking, "After GC");
 }
 
 

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -401,7 +401,7 @@ void HeapRegion::verify_code_roots(VerifyOption vo, bool* failures) const {
     // We're not verifying code roots.
     return;
   }
-  if (vo == VerifyOption_G1UseFullMarking) {
+  if (vo == VerifyOption::G1UseFullMarking) {
     // Marking verification during a full GC is performed after class
     // unloading, code cache unloading, etc so the code roots
     // attached to each heap region are in an inconsistent state. They won't
@@ -764,7 +764,7 @@ void HeapRegion::verify_rem_set(VerifyOption vo, bool* failures) const {
 
 void HeapRegion::verify_rem_set() const {
   bool failures = false;
-  verify_rem_set(VerifyOption_G1UsePrevMarking, &failures);
+  verify_rem_set(VerifyOption::G1UsePrevMarking, &failures);
   guarantee(!failures, "HeapRegion RemSet verification failed");
 }
 

--- a/src/hotspot/share/gc/shared/verifyOption.hpp
+++ b/src/hotspot/share/gc/shared/verifyOption.hpp
@@ -25,16 +25,18 @@
 #ifndef SHARE_GC_SHARED_VERIFYOPTION_HPP
 #define SHARE_GC_SHARED_VERIFYOPTION_HPP
 
-enum VerifyOption {
-  VerifyOption_Default = 0,
+#include "utilities/globalDefinitions.hpp"
+
+enum class VerifyOption : uint {
+  Default = 0,
 
   // G1
 
   // Use "prev" mark bitmap information using pTAMS.
-  VerifyOption_G1UsePrevMarking = VerifyOption_Default,
+  G1UsePrevMarking = Default,
   // Use "next" mark bitmap information from full gc marking. This does not
   // use (or need) TAMS.
-  VerifyOption_G1UseFullMarking = VerifyOption_G1UsePrevMarking + 1
+  G1UseFullMarking = G1UsePrevMarking + 1
 };
 
 #endif // SHARE_GC_SHARED_VERIFYOPTION_HPP

--- a/src/hotspot/share/memory/universe.hpp
+++ b/src/hotspot/share/memory/universe.hpp
@@ -359,7 +359,7 @@ class Universe: AllStatic {
   static bool should_verify_subset(uint subset);
   static void verify(VerifyOption option, const char* prefix);
   static void verify(const char* prefix) {
-    verify(VerifyOption_Default, prefix);
+    verify(VerifyOption::Default, prefix);
   }
   static void verify() {
     verify("");


### PR DESCRIPTION
Hi all,

  please review this change that make the `VerifyOption` enum an enum class as suggested in the review for [JDK-8189669](https://bugs.openjdk.java.net/browse/JDK-8189669).

Testing: local compilation, gha

Thanks,
  Thomas