### PR TITLE
8279031: Add API note to ToolProvider about being reusable/reentrant

### DIFF
--- a/src/java.base/share/classes/java/util/spi/ToolProvider.java
+++ b/src/java.base/share/classes/java/util/spi/ToolProvider.java
@@ -50,6 +50,14 @@ import java.util.stream.StreamSupport;
  * arguments that could be provided to the tool when invoking the tool
  * from the command line.
  *
+ * @apiNote
+ * It is recommended that tools implementing this interface are either
+ * reusable and reentrant, or should clearly document any limitations and
+ * restrictions. In this context, reusable means that any one instance of
+ * a tool may be a the target of multiple {@code run} method invocations,
+ * and reentrant means that multiple invocations of {@code run} may occur
+ * concurrently.
+ *
  * @since 9
  */
 public interface ToolProvider {

--- a/src/java.base/share/classes/java/util/spi/ToolProvider.java
+++ b/src/java.base/share/classes/java/util/spi/ToolProvider.java
@@ -54,7 +54,7 @@ import java.util.stream.StreamSupport;
  * It is recommended that tools implementing this interface are either
  * reusable and reentrant, or should clearly document any limitations and
  * restrictions. In this context, reusable means that any one instance of
- * a tool may be a the target of multiple {@code run} method invocations,
+ * a tool may be the target of multiple {@code run} method invocations,
  * and reentrant means that multiple invocations of {@code run} may occur
  * concurrently.
  *


### PR DESCRIPTION
This commit adds an  API note to ToolProvider about being reusable/reentrant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8279031](https://bugs.openjdk.org/browse/JDK-8279031): Add API note to ToolProvider about being reusable/reentrant
 * [JDK-8286815](https://bugs.openjdk.org/browse/JDK-8286815): Add API note to ToolProvider about being reusable/reentrant (**CSR**)


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to [035c1b14](https://git.openjdk.java.net/jdk/pull/8833/files/035c1b143709a778620e447d2f088549adfb4f58)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8833/head:pull/8833` \
`$ git checkout pull/8833`

Update a local copy of the PR: \
`$ git checkout pull/8833` \
`$ git pull https://git.openjdk.java.net/jdk pull/8833/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8833`

View PR using the GUI difftool: \
`$ git pr show -t 8833`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8833.diff">https://git.openjdk.java.net/jdk/pull/8833.diff</a>

</details>
