### PR TITLE
8287150: Remove HeapRegion::block_start_const declaration without definition

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -130,8 +130,6 @@ private:
 
   void clear(bool mangle_space);
 
-  HeapWord* block_start_const(const void* p) const;
-
   void mangle_unused_area() PRODUCT_RETURN;
 
   // Try to allocate at least min_word_size and up to desired_size from this region.


### PR DESCRIPTION
Hi,

  please review this trivial change to remove an unused declaration without definition.

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287150](https://bugs.openjdk.java.net/browse/JDK-8287150): Remove HeapRegion::block_start_const declaration without definition


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8834/head:pull/8834` \
`$ git checkout pull/8834`

Update a local copy of the PR: \
`$ git checkout pull/8834` \
`$ git pull https://git.openjdk.java.net/jdk pull/8834/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8834`

View PR using the GUI difftool: \
`$ git pr show -t 8834`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8834.diff">https://git.openjdk.java.net/jdk/pull/8834.diff</a>

</details>
