### PR TITLE
8287155: Additional make typos

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -890,8 +890,8 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
 # $2 - Prefix for compiler variables (either BUILD_ or nothing).
 AC_DEFUN([FLAGS_SETUP_GCC6_COMPILER_FLAGS],
 [
-  # These flags are required for GCC 6 builds as undefined behaviour in OpenJDK code
-  # runs afoul of the more aggressive versions of these optimisations.
+  # These flags are required for GCC 6 builds as undefined behavior in OpenJDK code
+  # runs afoul of the more aggressive versions of these optimizations.
   # Notably, value range propagation now assumes that the this pointer of C++
   # member functions is non-null.
   NO_DELETE_NULL_POINTER_CHECKS_CFLAG="-fno-delete-null-pointer-checks"

--- a/make/autoconf/flags.m4
+++ b/make/autoconf/flags.m4
@@ -295,7 +295,7 @@ AC_DEFUN_ONCE([FLAGS_PRE_TOOLCHAIN],
   # FIXME: Don't really know how to do with this, but this was the old behavior
   GLOBAL_CPPFLAGS="$SYSROOT_CFLAGS"
 
-  # FIXME: For compatilibity, export this as EXTRA_CFLAGS for now.
+  # FIXME: For compatibility, export this as EXTRA_CFLAGS for now.
   EXTRA_CFLAGS="$MACHINE_FLAG $USER_CFLAGS"
   EXTRA_CXXFLAGS="$MACHINE_FLAG $USER_CXXFLAGS"
   EXTRA_LDFLAGS="$MACHINE_FLAG $USER_LDFLAGS"

--- a/make/autoconf/lib-hsdis.m4
+++ b/make/autoconf/lib-hsdis.m4
@@ -47,7 +47,7 @@ AC_DEFUN([LIB_SETUP_HSDIS_CAPSTONE],
     fi
   else
     if test "x$OPENJDK_TARGET_OS" = xwindows; then
-      # There is no way to auto-detect capstone on Windowos
+      # There is no way to auto-detect capstone on Windows
       AC_MSG_NOTICE([You must specify capstone location using --with-capstone=<path>])
       AC_MSG_ERROR([Cannot continue])
     fi

--- a/make/autoconf/lib-std.m4
+++ b/make/autoconf/lib-std.m4
@@ -31,7 +31,7 @@
 ################################################################################
 AC_DEFUN_ONCE([LIB_SETUP_STD_LIBS],
 [
-  # statically link libstdc++ before C++ ABI is stablized on Linux unless
+  # statically link libstdc++ before C++ ABI is stabilized on Linux unless
   # dynamic build is configured on command line.
   AC_ARG_WITH([stdc++lib], [AS_HELP_STRING([--with-stdc++lib=<static>,<dynamic>,<default>],
       [force linking of the C++ runtime on Linux to either static or dynamic, default is static with dynamic as fallback])],

--- a/make/autoconf/platform.m4
+++ b/make/autoconf/platform.m4
@@ -384,7 +384,7 @@ AC_DEFUN([PLATFORM_EXTRACT_TARGET_AND_BUILD],
   fi
 ])
 
-# Check if a reduced build (32-bit on 64-bit platforms) is requested, and modify behaviour
+# Check if a reduced build (32-bit on 64-bit platforms) is requested, and modify behavior
 # accordingly. Must be done after setting up build and target system, but before
 # doing anything else with these values.
 AC_DEFUN([PLATFORM_SETUP_TARGET_CPU_BITS],

--- a/make/autoconf/toolchain_microsoft.m4
+++ b/make/autoconf/toolchain_microsoft.m4
@@ -317,7 +317,7 @@ AC_DEFUN([TOOLCHAIN_FIND_VISUAL_STUDIO],
       eval MSVCP_NAME="\${VS_MSVCP_${VS_VERSION}}"
       eval USE_UCRT="\${VS_USE_UCRT_${VS_VERSION}}"
       eval VS_SUPPORTED="\${VS_SUPPORTED_${VS_VERSION}}"
-      # The rest of the variables are already evaled while probing
+      # The rest of the variables are already evaluated while probing
       AC_MSG_NOTICE([Found $VS_DESCRIPTION])
       break
     fi

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -837,7 +837,7 @@ var getJibProfilesProfiles = function (input, common, data) {
         [ "", common.open_suffix ].forEach(function (suffix) {
             var cmpBaselineName = name + suffix + "-cmp-baseline";
             profiles[cmpBaselineName] = clone(profiles[name + suffix]);
-            // Only compare the images target. This should pressumably be expanded
+            // Only compare the images target. This should presumably be expanded
             // to include more build targets when possible.
             profiles[cmpBaselineName].default_make_targets = [ "images", "test-image" ];
             if (name == "linux-x64") {

--- a/make/devkit/createWindowsDevkit.sh
+++ b/make/devkit/createWindowsDevkit.sh
@@ -107,7 +107,7 @@ POTENTIAL_INI_FILES="Common7/IDE/wdexpress.isolation.ini Common7/IDE/devenv.isol
 for f in $POTENTIAL_INI_FILES; do
     if [ -f "$VS_INSTALL_DIR/$f" ]; then
         VS_VERSION_SP="$(grep ^SemanticVersion= "$VS_INSTALL_DIR/$f")"
-        # Remove SemnaticVersion=
+        # Remove SemanticVersion=
         VS_VERSION_SP="${VS_VERSION_SP#*=}"
         # Remove suffix of too detailed numbering starting with +
         VS_VERSION_SP="${VS_VERSION_SP%+*}"

--- a/make/ide/idea/jdk/template/src/idea/JdkIdeaAntLogger.java
+++ b/make/ide/idea/jdk/template/src/idea/JdkIdeaAntLogger.java
@@ -254,7 +254,7 @@ public final class JdkIdeaAntLogger extends DefaultLogger {
     /** flag - is this the first target we encounter? */
     boolean firstTarget = true;
 
-    /** flag - should subsequenet failures be suppressed ? */
+    /** flag - should subsequent failures be suppressed ? */
     boolean suppressTaskFailures = false;
 
     /** flag - have we ran into a javac crash ? */

--- a/make/ide/idea/langtools/template/src/idea/LangtoolsIdeaAntLogger.java
+++ b/make/ide/idea/langtools/template/src/idea/LangtoolsIdeaAntLogger.java
@@ -243,7 +243,7 @@ public final class LangtoolsIdeaAntLogger extends DefaultLogger {
     /** flag - is this the first target we encounter? */
     boolean firstTarget = true;
 
-    /** flag - should subsequenet failures be suppressed ? */
+    /** flag - should subsequent failures be suppressed ? */
     boolean suppressTaskFailures = false;
 
     /** flag - have we ran into a javac crash ? */

--- a/make/ide/netbeans/langtools/build.xml
+++ b/make/ide/netbeans/langtools/build.xml
@@ -40,7 +40,7 @@
         That would reduce the list of Ant targets that get displayed for this
         file, but it also complicates the interface between the project build
         file and the main build file. For example, some imported targets
-        would have to be reclared, properties would have to be restructured,
+        would have to be redeclared, properties would have to be restructured,
         and it would be harder to run results (e.g. in properties) from nested
         targets.
      -->

--- a/make/langtools/build.xml
+++ b/make/langtools/build.xml
@@ -42,7 +42,7 @@
 
  build
    |-bin (scripts to invoke various tools, javac etc.)
-   |-genrsc (generated sources - i.e. properties)
+   |-gensrc (generated sources - i.e. properties)
    |-modules (compiled classes in a modular layout)
    |-jtreg (test work/results)
    |-toolclasses (tools used for building - like the property compiler)

--- a/make/scripts/logger.sh
+++ b/make/scripts/logger.sh
@@ -22,11 +22,11 @@
 # questions.
 #
 
-# Usage: ./logger.sh theloggfile acommand arg1 arg2
+# Usage: ./logger.sh thelogfile acommand arg1 arg2
 #
 # Execute acommand with args, in such a way that
 # both stdout and stderr from acommand are appended to
-# theloggfile.
+# thelogfile.
 #
 # Preserve stdout and stderr, so that the stdout
 # from logger.sh is the same from acommand and equally


### PR DESCRIPTION
Testing ispell + shell magic to locate typos. It worked, but is not scalable to the entire JDK. :-( Keep the fixes for the problems found in the make directory, though.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287155](https://bugs.openjdk.java.net/browse/JDK-8287155): Additional make typos


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8837/head:pull/8837` \
`$ git checkout pull/8837`

Update a local copy of the PR: \
`$ git checkout pull/8837` \
`$ git pull https://git.openjdk.java.net/jdk pull/8837/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8837`

View PR using the GUI difftool: \
`$ git pr show -t 8837`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8837.diff">https://git.openjdk.java.net/jdk/pull/8837.diff</a>

</details>
