### PR TITLE
8287153: Whitespace typos in HeapRegion class

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -117,7 +117,7 @@ public:
   // given address.
   bool is_in_reserved(const void* p) const { return _bottom <= p && p < _end; }
 
-  size_t capacity()     const { return byte_size(bottom(), end()); }
+  size_t capacity() const { return byte_size(bottom(), end()); }
   size_t used() const { return byte_size(bottom(), top()); }
   size_t free() const { return byte_size(top(), end()); }
 

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -140,7 +140,7 @@ inline bool HeapRegion::is_obj_dead(const oop obj, const G1CMBitMap* const prev_
          !is_closed_archive();
 }
 
-inline size_t HeapRegion::block_size(const HeapWord *addr) const {
+inline size_t HeapRegion::block_size(const HeapWord* addr) const {
   assert(addr < top(), "precondition");
 
   if (block_is_obj(addr)) {


### PR DESCRIPTION
Hi all,

  please review this trivial? fix to change some whitespace in the `HeapRegion` class.

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287153](https://bugs.openjdk.java.net/browse/JDK-8287153): Whitespace typos in HeapRegion class


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8838/head:pull/8838` \
`$ git checkout pull/8838`

Update a local copy of the PR: \
`$ git checkout pull/8838` \
`$ git pull https://git.openjdk.java.net/jdk pull/8838/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8838`

View PR using the GUI difftool: \
`$ git pr show -t 8838`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8838.diff">https://git.openjdk.java.net/jdk/pull/8838.diff</a>

</details>
