### PR TITLE
8287154: java/nio/channels/FileChannel/LargeMapTest.java does not compile

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/LargeMapTest.java
+++ b/test/jdk/java/nio/channels/FileChannel/LargeMapTest.java
@@ -61,7 +61,7 @@ public class LargeMapTest {
         ByteBuffer bb = ByteBuffer.allocateDirect(BUFSIZ);
 
         try (FileChannel fc = FileChannel.open(p, READ, WRITE);) {
-            MemorySegment mbb = MemorySegment.ofByteBuffer(bb);
+            MemorySegment mbb = MemorySegment.ofBuffer(bb);
             MemorySegment mappedMemorySegment =
                 fc.map(FileChannel.MapMode.READ_WRITE, 0, p.toFile().length(),
                        MemorySession.openImplicit());


### PR DESCRIPTION
The patch pushed as part of https://git.openjdk.java.net/jdk/pull/8701 conflicts with a test added as part of PR https://github.com/openjdk/jdk/pull/8686.

That is, the test introduced in the latter patch depends on `MemorySegment.ofByteBuffer` which has been renamed to `ofBuffer` as part of the former patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287154](https://bugs.openjdk.java.net/browse/JDK-8287154): java/nio/channels/FileChannel/LargeMapTest.java does not compile


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8839/head:pull/8839` \
`$ git checkout pull/8839`

Update a local copy of the PR: \
`$ git checkout pull/8839` \
`$ git pull https://git.openjdk.java.net/jdk pull/8839/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8839`

View PR using the GUI difftool: \
`$ git pr show -t 8839`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8839.diff">https://git.openjdk.java.net/jdk/pull/8839.diff</a>

</details>
