### PR TITLE
8287139: aarch64 intrinsic for unsignedMultiplyHigh

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -11132,7 +11132,7 @@ instruct mulHiL_rReg(iRegLNoSp dst, iRegL src1, iRegL src2, rFlagsReg cr)
   match(Set dst (MulHiL src1 src2));
 
   ins_cost(INSN_COST * 7);
-  format %{ "smulh   $dst, $src1, $src2, \t# mulhi" %}
+  format %{ "smulh   $dst, $src1, $src2\t# mulhi" %}
 
   ins_encode %{
     __ smulh(as_Register($dst$$reg),
@@ -11148,7 +11148,7 @@ instruct umulHiL_rReg(iRegLNoSp dst, iRegL src1, iRegL src2, rFlagsReg cr)
   match(Set dst (UMulHiL src1 src2));
 
   ins_cost(INSN_COST * 7);
-  format %{ "umulh   $dst, $src1, $src2, \t# umulhi" %}
+  format %{ "umulh   $dst, $src1, $src2\t# umulhi" %}
 
   ins_encode %{
     __ umulh(as_Register($dst$$reg),

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -11143,6 +11143,22 @@ instruct mulHiL_rReg(iRegLNoSp dst, iRegL src1, iRegL src2, rFlagsReg cr)
   ins_pipe(lmul_reg_reg);
 %}
 
+instruct umulHiL_rReg(iRegLNoSp dst, iRegL src1, iRegL src2, rFlagsReg cr)
+%{
+  match(Set dst (UMulHiL src1 src2));
+
+  ins_cost(INSN_COST * 7);
+  format %{ "umulh   $dst, $src1, $src2, \t# umulhi" %}
+
+  ins_encode %{
+    __ umulh(as_Register($dst$$reg),
+             as_Register($src1$$reg),
+             as_Register($src2$$reg));
+  %}
+
+  ins_pipe(lmul_reg_reg);
+%}
+
 // Combined Integer Multiply & Add/Sub
 
 instruct maddI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, iRegIorL2I src3) %{


### PR DESCRIPTION
Adds aarch64 intrinsic support for `Math.unsignedMultiplyHigh()`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287139](https://bugs.openjdk.java.net/browse/JDK-8287139): aarch64 intrinsic for unsignedMultiplyHigh


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**) ⚠️ Review applies to [14905156](https://git.openjdk.java.net/jdk/pull/8840/files/1490515633cae69fc80fc6b626285cd2798b0a7d)
 * [Nick Gasson](https://openjdk.java.net/census#ngasson) (@nick-arm - **Reviewer**)
 * @kristylee88 (no known github.com user name / role) ⚠️ Review applies to [14905156](https://git.openjdk.java.net/jdk/pull/8840/files/1490515633cae69fc80fc6b626285cd2798b0a7d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8840/head:pull/8840` \
`$ git checkout pull/8840`

Update a local copy of the PR: \
`$ git checkout pull/8840` \
`$ git pull https://git.openjdk.java.net/jdk pull/8840/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8840`

View PR using the GUI difftool: \
`$ git pr show -t 8840`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8840.diff">https://git.openjdk.java.net/jdk/pull/8840.diff</a>

</details>
