### PR TITLE
JDK-8228990: JFR: TestNetworkUtilizationEvent.java expects 2+ Network interfaces on Linux but finding 1

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -756,7 +756,6 @@ javax/script/Test7.java                                         8239361 generic-
 
 # jdk_jfr
 
-jdk/jfr/event/runtime/TestNetworkUtilizationEvent.java          8228990 macosx-all,linux-all,windows-all
 jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209 generic-all
 jdk/jfr/event/os/TestThreadContextSwitches.java                 8247776 windows-all
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64

--- a/test/jdk/jdk/jfr/event/runtime/TestNetworkUtilizationEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestNetworkUtilizationEvent.java
@@ -59,25 +59,17 @@ public class TestNetworkUtilizationEvent {
         String msg = "hello!";
         byte[] buf = msg.getBytes();
         forceEndChunk();
-        // Send a few packets both to the loopback address as well to an
-        // external
+        // Send a few packets to the loopback address
         DatagramPacket packet = new DatagramPacket(buf, buf.length, InetAddress.getLoopbackAddress(), 12345);
-        for (int i = 0; i < packetSendCount; ++i) {
-            socket.send(packet);
-        }
-        packet = new DatagramPacket(buf, buf.length, InetAddress.getByName("10.0.0.0"), 12345);
         for (int i = 0; i < packetSendCount; ++i) {
             socket.send(packet);
         }
         forceEndChunk();
         socket.close();
-        // Now there should have been traffic on at least two different
-        // interfaces
         recording.stop();
 
         Set<String> networkInterfaces = new HashSet<>();
         List<RecordedEvent> events = Events.fromRecording(recording);
-        Events.hasEvents(events);
         for (RecordedEvent event : events) {
             System.out.println(event);
             Events.assertField(event, "writeRate").atLeast(0L).atMost(1000L * Integer.MAX_VALUE);
@@ -87,13 +79,10 @@ public class TestNetworkUtilizationEvent {
                 networkInterfaces.add(event.getString("networkInterface"));
             }
         }
-
-        if (Platform.isWindows()) {
-            // Windows does not track statistics for the loopback
-            // interface
+        // Windows does not track statistics for the loopback
+        // interface
+        if (!Platform.isWindows()) {
             Asserts.assertGreaterThanOrEqual(networkInterfaces.size(), 1);
-        } else {
-            Asserts.assertGreaterThanOrEqual(networkInterfaces.size(), 2);
         }
     }
 


### PR DESCRIPTION
Could I have a review of a PR that changes the test for the Network Utilization event so it only validates the loopback interface. 

The test fail intermittently on the real network interface, so it's been on the problem list for years. This means the event hasn't got any testing. If there is an interest and resources to investigate this further, a separate issue can be filed to add back testing for more than the loopback interface.

Testing: 
Running /test/jdk/jdk/jfr/event/runtime/TestNetworkUtilizationEvent.java 400 times on Mac, Linux and Windows.

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8228990](https://bugs.openjdk.java.net/browse/JDK-8228990): JFR: TestNetworkUtilizationEvent.java expects 2+ Network interfaces on Linux but finding 1


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8841/head:pull/8841` \
`$ git checkout pull/8841`

Update a local copy of the PR: \
`$ git checkout pull/8841` \
`$ git pull https://git.openjdk.java.net/jdk pull/8841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8841`

View PR using the GUI difftool: \
`$ git pr show -t 8841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8841.diff">https://git.openjdk.java.net/jdk/pull/8841.diff</a>

</details>
