### PR TITLE
8287157: Clean up G1Policy::next_gc_should_be_mixed()

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -683,8 +683,7 @@ void G1Policy::record_young_collection_end(bool concurrent_operation_is_full_mar
   } else if (G1GCPauseTypeHelper::is_mixed_pause(this_pause)) {
     // This is a mixed GC. Here we decide whether to continue doing more
     // mixed GCs or not.
-    if (!next_gc_should_be_mixed("continue mixed GCs",
-                                 "do not continue mixed GCs")) {
+    if (!next_gc_should_be_mixed("do not continue mixed GCs")) {
       collector_state()->set_in_young_only_phase(true);
 
       clear_collection_set_candidates();
@@ -1125,7 +1124,7 @@ void G1Policy::record_concurrent_mark_cleanup_end(bool has_rebuilt_remembered_se
   if (has_rebuilt_remembered_sets) {
     G1CollectionSetCandidates* candidates = G1CollectionSetChooser::build(_g1h->workers(), _g1h->num_regions());
     _collection_set->set_candidates(candidates);
-    mixed_gc_pending = next_gc_should_be_mixed("request mixed gcs", "request young-only gcs");
+    mixed_gc_pending = next_gc_should_be_mixed("request young-only gcs");
   }
 
   if (log_is_enabled(Trace, gc, liveness)) {
@@ -1248,16 +1247,16 @@ void G1Policy::abort_time_to_mixed_tracking() {
   _concurrent_start_to_mixed.reset();
 }
 
-bool G1Policy::next_gc_should_be_mixed(const char* true_action_str,
-                                       const char* false_action_str) const {
+bool G1Policy::next_gc_should_be_mixed(const char* no_candidates_str) const {
   G1CollectionSetCandidates* candidates = _collection_set->candidates();
 
   if (candidates == NULL || candidates->is_empty()) {
-    log_debug(gc, ergo)("%s (candidate old regions not available)", false_action_str);
+    log_debug(gc, ergo)("%s (candidate old regions not available)", no_candidates_str);
     return false;
   }
-  // Go through all regions - we already pruned regions not worth collecting
-  // during candidate selection.
+  // Otherwise always continue mixed collection. There is no other reason to stop the
+  // mixed phase than there are no more candidates. All candidates not pruned earlier
+  // during candidate selection are worth collecting.
   return true;
 }
 

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -331,8 +331,7 @@ public:
   void record_concurrent_mark_cleanup_start();
   void record_concurrent_mark_cleanup_end(bool has_rebuilt_remembered_sets);
 
-  bool next_gc_should_be_mixed(const char* true_action_str,
-                               const char* false_action_str) const;
+  bool next_gc_should_be_mixed(const char* no_candidates_str) const;
 
   // Amount of allowed waste in bytes in the collection set.
   size_t allowed_waste_in_collection_set() const;


### PR DESCRIPTION
Hi all,

  can I have reviews for some minor cleanup in `G1Policy::next_gc_should_be_mixed()`, removing an unused parameter and arguably improving the comment inside.

Testing: local compilation.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287157](https://bugs.openjdk.java.net/browse/JDK-8287157): Clean up G1Policy::next_gc_should_be_mixed()


### Reviewers
 * @kristylee88 (no known github.com user name / role)
 * [Leo Korinth](https://openjdk.java.net/census#lkorinth) (@lkorinth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8844/head:pull/8844` \
`$ git checkout pull/8844`

Update a local copy of the PR: \
`$ git checkout pull/8844` \
`$ git pull https://git.openjdk.java.net/jdk pull/8844/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8844`

View PR using the GUI difftool: \
`$ git pr show -t 8844`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8844.diff">https://git.openjdk.java.net/jdk/pull/8844.diff</a>

</details>
