### PR TITLE
8287165: JFR: Add logging to jdk/jfr/api/consumer/recordingstream/TestOnEvent.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -763,7 +763,6 @@ jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209 generic-
 jdk/jfr/event/os/TestThreadContextSwitches.java                 8247776 windows-all
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
-jdk/jfr/api/consumer/recordingstream/TestOnEvent.java           8255404 linux-x64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
 
 ############################################################################

--- a/test/jdk/jdk/jfr/api/consumer/recordingstream/TestOnEvent.java
+++ b/test/jdk/jdk/jfr/api/consumer/recordingstream/TestOnEvent.java
@@ -149,25 +149,33 @@ public class TestOnEvent {
     }
 
     private static void testOnEventAfterStart() {
+        log("Entering testOnEventAfterStart()");
         try (RecordingStream r = new RecordingStream()) {
             EventProducer p = new EventProducer();
             p.start();
             Thread addHandler = new Thread(() ->  {
                 r.onEvent(e -> {
                     // Got event, close stream
+                    log("Executing onEvent");
                     r.close();
+                    log("RecordingStream closed");
                 });
             });
             r.onFlush(() ->  {
                 // Only add handler once
                 if (!"started".equals(addHandler.getName()))  {
                     addHandler.setName("started");
+                    log("About to start addHandler thread");
                     addHandler.start();
                 }
             });
+            log("About to start RecordingStream");
             r.start();
+            log("About to kill EventProducer");
             p.kill();
+            log("EventProducer killed");
         }
+        log("Leaving testOnEventAfterStart()");
     }
 
     // Starts recording stream and ensures stream


### PR DESCRIPTION
Could I have review of PR that adds logging to a test that fails intermittently. Drawback of adding logging is that it might prevent race conditions to occur, but keeping the test on problem list prevents other use cases of the onEvent-method to be tested. 

Testing: test/jdk/jdk/jfr/api/consumer/recordingstream/TestOnEvent.java

We can revisit the main issue https://bugs.openjdk.java.net/browse/JDK-8255404 in 6-12 months if hasn't failed. 

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287165](https://bugs.openjdk.java.net/browse/JDK-8287165): JFR: Add logging to jdk/jfr/api/consumer/recordingstream/TestOnEvent.java


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8847/head:pull/8847` \
`$ git checkout pull/8847`

Update a local copy of the PR: \
`$ git checkout pull/8847` \
`$ git pull https://git.openjdk.java.net/jdk pull/8847/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8847`

View PR using the GUI difftool: \
`$ git pr show -t 8847`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8847.diff">https://git.openjdk.java.net/jdk/pull/8847.diff</a>

</details>
