### PR TITLE
JDK-8225013: sanity/client/SwingSet/src/ScrollPaneDemoTest.java fails on Linux

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -683,7 +683,6 @@ java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 m
 javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64
 
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all
-sanity/client/SwingSet/src/ScrollPaneDemoTest.java 8225013 linux-all
 sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all
 javax/swing/JTable/8236907/LastVisibleRow.java 8284619 macosx-all
 

--- a/test/jdk/sanity/client/SwingSet/src/ScrollPaneDemoTest.java
+++ b/test/jdk/sanity/client/SwingSet/src/ScrollPaneDemoTest.java
@@ -21,16 +21,31 @@
  * questions.
  */
 
+import com.sun.swingset3.demos.ResourceManager;
+import org.jemmy2ext.JemmyExt;
 import org.jtregext.GuiTestListener;
 import com.sun.swingset3.demos.scrollpane.ScrollPaneDemo;
 import static com.sun.swingset3.demos.scrollpane.ScrollPaneDemo.DEMO_TITLE;
 import static org.testng.AssertJUnit.*;
+
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
 import javax.swing.UIManager;
+
+import org.netbeans.jemmy.ComponentSearcher;
+import org.netbeans.jemmy.operators.ComponentOperator;
+import org.netbeans.jemmy.operators.ContainerOperator;
+import org.netbeans.jemmy.operators.JLabelOperator;
+import org.netbeans.jemmy.util.Dumper;
 import org.testng.annotations.Test;
 import org.netbeans.jemmy.ClassReference;
 import org.netbeans.jemmy.operators.JFrameOperator;
 import org.netbeans.jemmy.operators.JScrollPaneOperator;
 import org.testng.annotations.Listeners;
+
+import java.awt.MediaTracker;
+import java.awt.Rectangle;
+import java.awt.Toolkit;
 
 /*
  * @test
@@ -46,9 +61,13 @@ import org.testng.annotations.Listeners;
  * @build org.jemmy2ext.JemmyExt
  * @build com.sun.swingset3.demos.scrollpane.ScrollPaneDemo
  * @run testng/timeout=600 ScrollPaneDemoTest
+
  */
 @Listeners(GuiTestListener.class)
 public class ScrollPaneDemoTest {
+
+    public static final String IMAGE_DESCRIPTION =
+            new ResourceManager(ScrollPaneDemo.class).getString("ScrollPaneDemo.crayons");
 
     @Test(dataProvider = "availableLookAndFeels", dataProviderClass = TestHelpers.class)
     public void test(String lookAndFeel) throws Exception {
@@ -57,7 +76,9 @@ public class ScrollPaneDemoTest {
         new ClassReference(ScrollPaneDemo.class.getName()).startApplication();
 
         JFrameOperator frame = new JFrameOperator(DEMO_TITLE);
-        JScrollPaneOperator jspo = new JScrollPaneOperator(frame);
+        ContainerOperator<ScrollPaneDemo> scrollPaneDemo =
+                new ContainerOperator<>(frame, c -> c instanceof ScrollPaneDemo);
+        JScrollPaneOperator jspo = new JScrollPaneOperator(scrollPaneDemo);
 
         // Set initial scrollbar positions
         int initialVerticalValue = jspo.getVerticalScrollBar().getValue();
@@ -65,6 +86,25 @@ public class ScrollPaneDemoTest {
 
         System.out.println("Initial Vertical Value = " + jspo.getVerticalScrollBar().getValue());
         System.out.println("Initial HoriZontal Value = " + jspo.getHorizontalScrollBar().getValue());
+
+        JLabelOperator imageLabel = new JLabelOperator(scrollPaneDemo, c -> {
+            if(c instanceof JLabel) {
+                var icon = ((JLabel)c).getIcon();
+                if(icon instanceof ImageIcon) {
+                    return ((ImageIcon)icon).getDescription().equals(IMAGE_DESCRIPTION);
+                }
+            }
+            return false;
+        });
+        imageLabel.waitState(c -> ((ImageIcon)((JLabel)c).getIcon()).getImageLoadStatus() == MediaTracker.COMPLETE);
+
+        //this additional instrumentation is related to JDK-8225013
+        //after the image has been completely loaded, the UI is supposed to be functional
+        //screenshot and dump are created to know what else to wait for, should the test fail again
+        JemmyExt.save(
+                JemmyExt.getRobot().createScreenCapture(new Rectangle(Toolkit.getDefaultToolkit().getScreenSize())),
+                "after-image-load");
+        Dumper.dumpAll("after-image-load.xml");
 
         // Check scroll to Bottom
         {

--- a/test/jdk/sanity/client/SwingSet/src/ScrollPaneDemoTest.java
+++ b/test/jdk/sanity/client/SwingSet/src/ScrollPaneDemoTest.java
@@ -32,8 +32,6 @@ import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.UIManager;
 
-import org.netbeans.jemmy.ComponentSearcher;
-import org.netbeans.jemmy.operators.ComponentOperator;
 import org.netbeans.jemmy.operators.ContainerOperator;
 import org.netbeans.jemmy.operators.JLabelOperator;
 import org.netbeans.jemmy.util.Dumper;
@@ -44,8 +42,6 @@ import org.netbeans.jemmy.operators.JScrollPaneOperator;
 import org.testng.annotations.Listeners;
 
 import java.awt.MediaTracker;
-import java.awt.Rectangle;
-import java.awt.Toolkit;
 
 /*
  * @test
@@ -87,15 +83,9 @@ public class ScrollPaneDemoTest {
         System.out.println("Initial Vertical Value = " + jspo.getVerticalScrollBar().getValue());
         System.out.println("Initial HoriZontal Value = " + jspo.getHorizontalScrollBar().getValue());
 
-        JLabelOperator imageLabel = new JLabelOperator(scrollPaneDemo, c -> {
-            if(c instanceof JLabel) {
-                var icon = ((JLabel)c).getIcon();
-                if(icon instanceof ImageIcon) {
-                    return ((ImageIcon)icon).getDescription().equals(IMAGE_DESCRIPTION);
-                }
-            }
-            return false;
-        });
+        JLabelOperator imageLabel = new JLabelOperator(scrollPaneDemo, c ->
+            c instanceof JLabel label && label.getIcon() instanceof ImageIcon imageIcon &&
+                    imageIcon.getDescription().equals(IMAGE_DESCRIPTION));
         imageLabel.waitState(c -> ((ImageIcon)((JLabel)c).getIcon()).getImageLoadStatus() == MediaTracker.COMPLETE);
 
         //this additional instrumentation is related to JDK-8225013

--- a/test/jdk/sanity/client/SwingSet/src/ScrollPaneDemoTest.java
+++ b/test/jdk/sanity/client/SwingSet/src/ScrollPaneDemoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,11 +100,9 @@ public class ScrollPaneDemoTest {
 
         //this additional instrumentation is related to JDK-8225013
         //after the image has been completely loaded, the UI is supposed to be functional
-        //screenshot and dump are created to know what else to wait for, should the test fail again
-        JemmyExt.save(
-                JemmyExt.getRobot().createScreenCapture(new Rectangle(Toolkit.getDefaultToolkit().getScreenSize())),
-                "after-image-load");
-        Dumper.dumpAll("after-image-load.xml");
+        //screenshot and dump are created to capture the state of the UI, should the test fail again
+        JemmyExt.save(JemmyExt.capture(), "after-image-load");
+        Dumper.dumpAll("after-image-load-" + JemmyExt.lafShortName() + "xml");
 
         // Check scroll to Bottom
         {

--- a/test/jdk/sanity/client/lib/Extensions/src/org/jemmy2ext/JemmyExt.java
+++ b/test/jdk/sanity/client/lib/Extensions/src/org/jemmy2ext/JemmyExt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -319,9 +319,16 @@ public class JemmyExt {
         }
     }
 
+    public static BufferedImage capture() {
+        return capture(new Rectangle(Toolkit.getDefaultToolkit().getScreenSize()));
+    }
+
     public static BufferedImage capture(ComponentOperator operator) {
-        Rectangle boundary = new Rectangle(operator.getLocationOnScreen(),
-                operator.getSize());
+        return capture(new Rectangle(operator.getLocationOnScreen(),
+                    operator.getSize()));
+    }
+
+    public static BufferedImage capture(Rectangle boundary) {
         return getRobot().createScreenCapture(boundary);
     }
 
@@ -403,7 +410,7 @@ public class JemmyExt {
         }
     }
 
-    private static String lafShortName() { return UIManager.getLookAndFeel().getClass().getSimpleName(); }
+    public static String lafShortName() { return UIManager.getLookAndFeel().getClass().getSimpleName(); }
 
     /**
      * Trying to capture as much information as possible. Currently it includes


### PR DESCRIPTION
Before the fix the test was failing around 1 time in fifty runs. After the fix the test did not fail in ~ 1k runs.
Additional instrumentation is added to save useful information on the UI state, should the failure happen again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8225013](https://bugs.openjdk.java.net/browse/JDK-8225013): sanity/client/SwingSet/src/ScrollPaneDemoTest.java fails on Linux


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8848/head:pull/8848` \
`$ git checkout pull/8848`

Update a local copy of the PR: \
`$ git checkout pull/8848` \
`$ git pull https://git.openjdk.java.net/jdk pull/8848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8848`

View PR using the GUI difftool: \
`$ git pr show -t 8848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8848.diff">https://git.openjdk.java.net/jdk/pull/8848.diff</a>

</details>
