### PR TITLE
8261768: SelfDestructTimer should accept seconds

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1291,10 +1291,11 @@ const intx ObjectAlignmentInBytes = 8;
   develop(bool, DebugDeoptimization, false,                                 \
           "Tracing various information while debugging deoptimization")     \
                                                                             \
-  product(intx, SelfDestructTimer, 0,                                       \
-          "Will cause VM to terminate after a given time (in minutes) "     \
-          "(0 means off)")                                                  \
-          range(0, max_intx)                                                \
+  product(double, SelfDestructTimer, 0.0,                                   \
+          "Will cause VM to terminate after a given time "                  \
+          "(in fractional minutes) "                                        \
+          "(0.0 means off)")                                                \
+          range(0.0, (double)max_intx)                                      \
                                                                             \
   product(intx, MaxJavaStackTraceDepth, 1024,                               \
           "The maximum number of lines in the stack trace for Java "        \

--- a/src/hotspot/share/runtime/vmThread.cpp
+++ b/src/hotspot/share/runtime/vmThread.cpp
@@ -382,8 +382,8 @@ void VMThread::wait_until_executed(VM_Operation* op) {
 
 static void self_destruct_if_needed() {
   // Support for self destruction
-  if ((SelfDestructTimer != 0) && !VMError::is_error_reported() &&
-      (os::elapsedTime() > (double)SelfDestructTimer * 60.0)) {
+  if ((SelfDestructTimer != 0.0) && !VMError::is_error_reported() &&
+      (os::elapsedTime() > SelfDestructTimer * 60.0)) {
     tty->print_cr("VM self-destructed");
     exit(-1);
   }


### PR DESCRIPTION
The Java VM supports a runtime flag called `SelfDestructTimer`, which if used, will automatically terminate the java process using the value, expressed in minutes.

This flag is very useful when, for example, working on VM startup performance, as it allows a sampling tool to capture the exact same time interval for clear comparison of before and after optimizations.

The only problem is that the minimum value of 1 minutes is a really long time for a computer and any data captured during that minute will have many samples to filter through.

This fix allows SelfDestructTimer to accept a fractional value of minutes, which in practical terms allows for values to be expressed as seconds, which allows more flexible control.

For example:

- `XX:SelfDestructTimer=0.0` means that the feature is **off** (default, unchanged)
- `XX:SelfDestructTimer=0.25` means **15 seconds**
- `XX:SelfDestructTimer=0.5` means **30 seconds**
- `XX:SelfDestructTimer=1.0` means **1 minute**

The implementation keeps the old semantics, so that`XX: SelfDestructTimer=1` behavior, for example, is unchanged.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8261768](https://bugs.openjdk.java.net/browse/JDK-8261768): SelfDestructTimer should accept seconds


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8849/head:pull/8849` \
`$ git checkout pull/8849`

Update a local copy of the PR: \
`$ git checkout pull/8849` \
`$ git pull https://git.openjdk.java.net/jdk pull/8849/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8849`

View PR using the GUI difftool: \
`$ git pr show -t 8849`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8849.diff">https://git.openjdk.java.net/jdk/pull/8849.diff</a>

</details>
