### PR TITLE
8287169: compiler/arguments/TestCompileThresholdScaling.java fails on x86_32 after JDK-8287052

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -136,10 +136,12 @@ intx CompilerConfig::scaled_compile_threshold(intx threshold, double scale) {
     }
     int exp;
     (void) frexp(v, &exp);
-    if (exp > 63) {
+    if (exp > LP64_ONLY(63) NOT_LP64(31)) {
       return max_intx;
     }
-    return (intx)(v);
+    intx r = (intx)(v);
+    assert(r >= 0, "must be");
+    return r;
   }
 }
 

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -136,7 +136,8 @@ intx CompilerConfig::scaled_compile_threshold(intx threshold, double scale) {
     }
     int exp;
     (void) frexp(v, &exp);
-    if (exp > LP64_ONLY(63) NOT_LP64(31)) {
+    int max_exp = sizeof(intx) * BitsPerByte - 1;
+    if (exp > max_exp) {
       return max_intx;
     }
     intx r = (intx)(v);


### PR DESCRIPTION
See the bug report, recent regression. I believe the code makes the unwarranted assumption that we run on 64-bit platform, and thus caps at > 2^63 only. It should also cap at > 2^31 for 32-bit platforms.

Attn @dean-long.

Testing:
 - [x] Affected test on Linux x86_64 fastdebug (still passes)
 - [x] Affected test on Linux x86_32 fastdebug (now passes)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287169](https://bugs.openjdk.java.net/browse/JDK-8287169): compiler/arguments/TestCompileThresholdScaling.java fails on x86_32 after JDK-8287052


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8851/head:pull/8851` \
`$ git checkout pull/8851`

Update a local copy of the PR: \
`$ git checkout pull/8851` \
`$ git pull https://git.openjdk.java.net/jdk pull/8851/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8851`

View PR using the GUI difftool: \
`$ git pr show -t 8851`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8851.diff">https://git.openjdk.java.net/jdk/pull/8851.diff</a>

</details>
