### PR TITLE
8287107: CgroupSubsystemFactory.setCgroupV2Path asserts with freezer controller

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
@@ -149,6 +149,10 @@ public class CgroupSubsystemFactory {
             case MEMORY_CTRL:   infos.put(MEMORY_CTRL, info); break;
             case BLKIO_CTRL:    infos.put(BLKIO_CTRL, info); break;
             case PIDS_CTRL:     infos.put(PIDS_CTRL, info); break;
+            default:
+                // There are some controllers (such as freezer) that Java doesn't
+                // care about. Just ignore them. These are not considered in the
+                // anyCgroupsV1Controller/anyCgroupsV1Controller checks.
             }
         }
 
@@ -220,6 +224,11 @@ public class CgroupSubsystemFactory {
      */
     private static void setCgroupV2Path(Map<String, CgroupInfo> infos,
                                         String[] tokens) {
+        String name = tokens[1];
+        if (!name.equals("")) {
+            // This is probably a v1 controller that we have ignored (e.g., freezer)
+            return;
+        }
         int hierarchyId = Integer.parseInt(tokens[0]);
         String cgroupPath = tokens[2];
         for (CgroupInfo info: infos.values()) {

--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
@@ -146,7 +146,7 @@ public class CgroupSubsystemFactory {
             // Only the following controllers are important to Java. All
             // other controllers (such as freezer) are ignored and
             // are not considered in the checks below for
-            // anyCgroupsV1Controller/anyCgroupsV1Controller.
+            // anyCgroupsV1Controller/anyCgroupsV2Controller.
             case CPU_CTRL:      infos.put(CPU_CTRL, info); break;
             case CPUACCT_CTRL:  infos.put(CPUACCT_CTRL, info); break;
             case CPUSET_CTRL:   infos.put(CPUSET_CTRL, info); break;

--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
@@ -226,7 +226,8 @@ public class CgroupSubsystemFactory {
                                         String[] tokens) {
         String name = tokens[1];
         if (!name.equals("")) {
-            // This is probably a v1 controller that we have ignored (e.g., freezer)
+            // This must be a v1 controller that we have ignored (e.g., freezer)
+            assert infos.get(name) == null;
             return;
         }
         int hierarchyId = Integer.parseInt(tokens[0]);

--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
@@ -143,16 +143,16 @@ public class CgroupSubsystemFactory {
             }
             CgroupInfo info = CgroupInfo.fromCgroupsLine(line);
             switch (info.getName()) {
+            // Only the following controllers are important to Java. All
+            // other controllers (such as freezer) are ignored and
+            // are not considered in the checks below for
+            // anyCgroupsV1Controller/anyCgroupsV1Controller.
             case CPU_CTRL:      infos.put(CPU_CTRL, info); break;
             case CPUACCT_CTRL:  infos.put(CPUACCT_CTRL, info); break;
             case CPUSET_CTRL:   infos.put(CPUSET_CTRL, info); break;
             case MEMORY_CTRL:   infos.put(MEMORY_CTRL, info); break;
             case BLKIO_CTRL:    infos.put(BLKIO_CTRL, info); break;
             case PIDS_CTRL:     infos.put(PIDS_CTRL, info); break;
-            default:
-                // There are some controllers (such as freezer) that Java doesn't
-                // care about. Just ignore them. These are not considered in the
-                // anyCgroupsV1Controller/anyCgroupsV1Controller checks.
             }
         }
 

--- a/test/hotspot/jtreg/containers/cgroup/CgroupSubsystemFactory.java
+++ b/test/hotspot/jtreg/containers/cgroup/CgroupSubsystemFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Red Hat Inc.
+ * Copyright (c) 2020, 2022, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test CgroupSubsystemFactory
+ * @bug 8287107
  * @key cgroups
  * @requires os.family == "linux"
  * @library /testlibrary /test/lib
@@ -72,6 +73,9 @@ public class CgroupSubsystemFactory {
     private Path cgroupV2SelfCgroup;
     private Path cgroupV2MntInfoMissingCgroupv2;
     private Path cgroupv1MntInfoMissingMemoryController;
+    private Path cgroupv2CgInfoNoZeroHierarchyOnlyFreezer;
+    private Path cgroupv2MntInfoNoZeroHierarchyOnlyFreezer;
+    private Path cgroupv2SelfNoZeroHierarchyOnlyFreezer;
     private String procSelfCgroupHybridContent = "11:hugetlb:/\n" +
             "10:devices:/user.slice\n" +
             "9:pids:/user.slice/user-15263.slice/user@15263.service\n" +
@@ -176,6 +180,30 @@ public class CgroupSubsystemFactory {
             "35 26 0:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime - cgroup systemd rw,name=systemd\n" +
             "26 18 0:19 / /sys/fs/cgroup rw,relatime - tmpfs none rw,size=4k,mode=755\n";
 
+    // We have a mix of V1 and V2 controllers, but none of the V1 controllers
+    // are used by Java, so the JDK should start in V2 mode.
+    private String cgroupsNonZeroHierarchyOnlyFreezer =
+            "#subsys_name hierarchy  num_cgroups  enabled\n" +
+            "cpuset  0  171  1\n" +
+            "cpu  0  171  1\n" +
+            "cpuacct  0  171  1\n" +
+            "blkio  0  171  1\n" +
+            "memory  0  171  1\n" +
+            "devices  0  171  1\n" +
+            "freezer  1  1  1\n" +
+            "net_cls  0  171  1\n" +
+            "perf_event  0  171  1\n" +
+            "net_prio  0  171  1\n" +
+            "hugetlb  0  171  1\n" +
+            "pids  0  171  1\n" +
+            "rdma  0  171  1\n" +
+            "misc  0  171  1\n";
+    private String cgroupv1SelfOnlyFreezerContent = "1:freezer:/\n" +
+            "0::/user.slice/user-1000.slice/session-2.scope";
+    private String mntInfoOnlyFreezerInV1 =
+            "32 23 0:27 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime shared:9 - cgroup2 cgroup2 rw,nsdelegate,memory_recursiveprot\n" +
+            "911 32 0:47 / /sys/fs/cgroup/freezer rw,relatime shared:476 - cgroup freezer rw,freezer\n";
+
     private void setup() {
         try {
             existingDirectory = Utils.createTempDirectory(CgroupSubsystemFactory.class.getSimpleName());
@@ -227,6 +255,15 @@ public class CgroupSubsystemFactory {
 
             cgroupv1MountInfoJoinControllers = Paths.get(existingDirectory.toString(), "mntinfo_cgv1_join_controllers");
             Files.writeString(cgroupv1MountInfoJoinControllers, mntInfoCgroupv1JoinControllers);
+
+            cgroupv2CgInfoNoZeroHierarchyOnlyFreezer = Paths.get(existingDirectory.toString(), "cgroups_cgv2_non_zero_only_freezer");
+            Files.writeString(cgroupv2CgInfoNoZeroHierarchyOnlyFreezer, cgroupsNonZeroHierarchyOnlyFreezer);
+
+            cgroupv2SelfNoZeroHierarchyOnlyFreezer = Paths.get(existingDirectory.toString(), "self_cgroup_non_zero_only_freezer");
+            Files.writeString(cgroupv2SelfNoZeroHierarchyOnlyFreezer, cgroupv1SelfOnlyFreezerContent);
+
+            cgroupv2MntInfoNoZeroHierarchyOnlyFreezer = Paths.get(existingDirectory.toString(), "self_mountinfo_cgv2_non_zero_only_freezer");
+            Files.writeString(cgroupv2MntInfoNoZeroHierarchyOnlyFreezer, mntInfoOnlyFreezerInV1);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -334,6 +371,15 @@ public class CgroupSubsystemFactory {
         System.out.println("testCgroupv1HybridMntInfoOrder PASSED!");
     }
 
+    public void testNonZeroHierarchyOnlyFreezer(WhiteBox wb) {
+        String cgroups = cgroupv2CgInfoNoZeroHierarchyOnlyFreezer.toString();
+        String mountInfo = cgroupv2MntInfoNoZeroHierarchyOnlyFreezer.toString();
+        String selfCgroup = cgroupv2SelfNoZeroHierarchyOnlyFreezer.toString();
+        int retval = wb.validateCgroup(cgroups, selfCgroup, mountInfo);
+        Asserts.assertEQ(CGROUPS_V2, retval, "All V1 controllers are ignored");
+        Asserts.assertTrue(isValidCgroup(retval));
+        System.out.println("testNonZeroHierarchyOnlyFreezer PASSED!");
+    }
 
     public static void main(String[] args) throws Exception {
         WhiteBox wb = WhiteBox.getWhiteBox();
@@ -350,6 +396,7 @@ public class CgroupSubsystemFactory {
             test.testCgroupv1MultipleCpusetMounts(wb, test.cgroupv1MntInfoDoubleCpuset);
             test.testCgroupv1MultipleCpusetMounts(wb, test.cgroupv1MntInfoDoubleCpuset2);
             test.testCgroupv1JoinControllerCombo(wb);
+            test.testNonZeroHierarchyOnlyFreezer(wb);
         } finally {
             test.teardown();
         }

--- a/test/jdk/jdk/internal/platform/cgroup/TestCgroupSubsystemFactory.java
+++ b/test/jdk/jdk/internal/platform/cgroup/TestCgroupSubsystemFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Red Hat Inc.
+ * Copyright (c) 2020, 2022, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,12 +50,13 @@ import jdk.test.lib.util.FileUtils;
 
 /*
  * @test
+ * @bug 8287107
  * @key cgroups
  * @requires os.family == "linux"
  * @modules java.base/jdk.internal.platform
  *          java.base/jdk.internal.platform.cgroupv1
  * @library /test/lib
- * @run junit/othervm TestCgroupSubsystemFactory
+ * @run junit/othervm -esa TestCgroupSubsystemFactory
  */
 public class TestCgroupSubsystemFactory {
 
@@ -79,6 +80,9 @@ public class TestCgroupSubsystemFactory {
     private Path cgroupv1CgroupsOnlyCPUCtrl;
     private Path cgroupv1SelfCgroupsOnlyCPUCtrl;
     private Path cgroupv1MountInfoCgroupsOnlyCPUCtrl;
+    private Path cgroupv2CgInfoNoZeroHierarchyOnlyFreezer;
+    private Path cgroupv2MntInfoNoZeroHierarchyOnlyFreezer;
+    private Path cgroupv2SelfNoZeroHierarchyOnlyFreezer;
     private String mntInfoEmpty = "";
     private String cgroupsNonZeroJoinControllers =
             "#subsys_name hierarchy num_cgroups enabled\n" +
@@ -219,6 +223,30 @@ public class TestCgroupSubsystemFactory {
             "0::/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-3c00b338-5b65-439f-8e97-135e183d135d.scope\n";
     private String cgroupv2SelfCgroupContent = "0::/user.slice/user-1000.slice/session-2.scope";
 
+    // We have a mix of V1 and V2 controllers, but none of the V1 controllers
+    // are used by Java, so the JDK should start in V2 mode.
+    private String cgroupsNonZeroHierarchyOnlyFreezer =
+            "#subsys_name hierarchy  num_cgroups  enabled\n" +
+            "cpuset  0  171  1\n" +
+            "cpu  0  171  1\n" +
+            "cpuacct  0  171  1\n" +
+            "blkio  0  171  1\n" +
+            "memory  0  171  1\n" +
+            "devices  0  171  1\n" +
+            "freezer  1  1  1\n" +
+            "net_cls  0  171  1\n" +
+            "perf_event  0  171  1\n" +
+            "net_prio  0  171  1\n" +
+            "hugetlb  0  171  1\n" +
+            "pids  0  171  1\n" +
+            "rdma  0  171  1\n" +
+            "misc  0  171  1\n";
+    private String cgroupv1SelfOnlyFreezerContent = "1:freezer:/\n" +
+            "0::/user.slice/user-1000.slice/session-2.scope";
+    private String mntInfoOnlyFreezerInV1 =
+            "32 23 0:27 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime shared:9 - cgroup2 cgroup2 rw,nsdelegate,memory_recursiveprot\n" +
+            "911 32 0:47 / /sys/fs/cgroup/freezer rw,relatime shared:476 - cgroup freezer rw,freezer\n";
+
     @Before
     public void setup() {
         try {
@@ -277,6 +305,15 @@ public class TestCgroupSubsystemFactory {
 
             cgroupv1MountInfoCgroupsOnlyCPUCtrl = Paths.get(existingDirectory.toString(), "self_mountinfo_cpu_only_controller");
             Files.writeString(cgroupv1MountInfoCgroupsOnlyCPUCtrl, mntInfoCpuOnly);
+
+            cgroupv2CgInfoNoZeroHierarchyOnlyFreezer = Paths.get(existingDirectory.toString(), "cgroups_cgv2_non_zero_only_freezer");
+            Files.writeString(cgroupv2CgInfoNoZeroHierarchyOnlyFreezer, cgroupsNonZeroHierarchyOnlyFreezer);
+
+            cgroupv2SelfNoZeroHierarchyOnlyFreezer = Paths.get(existingDirectory.toString(), "self_cgroup_non_zero_only_freezer");
+            Files.writeString(cgroupv2SelfNoZeroHierarchyOnlyFreezer, cgroupv1SelfOnlyFreezerContent);
+
+            cgroupv2MntInfoNoZeroHierarchyOnlyFreezer = Paths.get(existingDirectory.toString(), "self_mountinfo_cgv2_non_zero_only_freezer");
+            Files.writeString(cgroupv2MntInfoNoZeroHierarchyOnlyFreezer, mntInfoOnlyFreezerInV1);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -401,6 +438,26 @@ public class TestCgroupSubsystemFactory {
         Optional<CgroupTypeResult> result = CgroupSubsystemFactory.determineType(mountInfo, cgroups, selfCgroup);
 
         assertTrue("zero hierarchy ids with no mounted controllers => empty result", result.isEmpty());
+    }
+
+    @Test
+    public void testNonZeroHierarchyOnlyFreezer() throws IOException {
+        String cgroups = cgroupv2CgInfoNoZeroHierarchyOnlyFreezer.toString();
+        String mountInfo = cgroupv2MntInfoNoZeroHierarchyOnlyFreezer.toString();
+        String selfCgroup = cgroupv2SelfNoZeroHierarchyOnlyFreezer.toString();
+        Optional<CgroupTypeResult> result = CgroupSubsystemFactory.determineType(mountInfo, cgroups, selfCgroup);
+
+        assertTrue("Expected non-empty cgroup result", result.isPresent());
+        CgroupTypeResult res = result.get();
+
+        assertTrue("if all mounted v1 controllers are ignored, we should user cgroups v2", res.isCgroupV2());
+        CgroupInfo memoryInfo = res.getInfos().get("memory");
+        assertEquals("/user.slice/user-1000.slice/session-2.scope", memoryInfo.getCgroupPath());
+        CgroupInfo cpuInfo = res.getInfos().get("cpu");
+        assertEquals(memoryInfo.getCgroupPath(), cpuInfo.getCgroupPath());
+        assertEquals(memoryInfo.getMountPoint(), cpuInfo.getMountPoint());
+        assertEquals(memoryInfo.getMountRoot(), cpuInfo.getMountRoot());
+        assertEquals("/sys/fs/cgroup", cpuInfo.getMountPoint());
     }
 
     @Test


### PR DESCRIPTION
This PR fixes a bug found on an Ubuntu host that's mostly running with cgroupv2, but there's a controller (freezer) that is mounted in cgroupv1 mode.

The container support code in the VM and JDK checks if we have simultaneously mounted v1 and v2 containers. If so, we revert to "hybrid" mode (which is essentially v1).

However, the "hybrid checks" only considers the following controllers that Java cares about:

- cpu
- cpuacct
- cpuset
- blkio
- memory
- pids

If only "freezer" is mounted in v1 mode, Java will start in V2 mode. Later, when `setCgroupV2Path()` sees the first line in /proc/self/cgroup, it runs into the assert.

```
$ cat /proc/self/cgroup
1:freezer:/
0::/user.slice/user-1001.slice/session-85.scope
```

The fix is simple -- when we get to `setCgroupV2Path()`, we have already decided that the system has not mounted any v1 controllers that we care about, so we should just ignore all the v1 controllers (which has a non-empty name).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287107](https://bugs.openjdk.java.net/browse/JDK-8287107): CgroupSubsystemFactory.setCgroupV2Path asserts with freezer controller


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer) ⚠️ Review applies to [c4d8354d](https://git.openjdk.java.net/jdk/pull/8858/files/c4d8354d2abfbb96098d4d1bf462f4715d26f2fe)
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**) ⚠️ Review applies to [1f17b6e8](https://git.openjdk.java.net/jdk/pull/8858/files/1f17b6e85c7eaef3c7f0ea368ece3268c0d14e6a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8858/head:pull/8858` \
`$ git checkout pull/8858`

Update a local copy of the PR: \
`$ git checkout pull/8858` \
`$ git pull https://git.openjdk.java.net/jdk pull/8858/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8858`

View PR using the GUI difftool: \
`$ git pr show -t 8858`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8858.diff">https://git.openjdk.java.net/jdk/pull/8858.diff</a>

</details>
