### PR TITLE
JDK-8287194: build failure on riscv after JDK-8286825

### DIFF
--- a/src/hotspot/cpu/riscv/downcallLinker_riscv.cpp
+++ b/src/hotspot/cpu/riscv/downcallLinker_riscv.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,16 +24,16 @@
  */
 
 #include "precompiled.hpp"
-#include "prims/universalNativeInvoker.hpp"
+#include "prims/downcallLinker.hpp"
 #include "utilities/debug.hpp"
 
-RuntimeStub* DowncallLinker::make_native_invoker(BasicType* signature,
-                                                 int num_args,
-                                                 BasicType ret_bt,
-                                                 const ABIDescriptor& abi,
-                                                 const GrowableArray<VMReg>& input_registers,
-                                                 const GrowableArray<VMReg>& output_registers,
-                                                 bool needs_return_buffer) {
+RuntimeStub* DowncallLinker::make_downcall_stub(BasicType* signature,
+                                                int num_args,
+                                                BasicType ret_bt,
+                                                const ABIDescriptor& abi,
+                                                const GrowableArray<VMReg>& input_registers,
+                                                const GrowableArray<VMReg>& output_registers,
+                                                bool needs_return_buffer) {
   Unimplemented();
   return nullptr;
 }


### PR DESCRIPTION
[JDK-8286825](https://bugs.openjdk.java.net/browse/JDK-8286825) made some renaming of hotspot file and method, the following naming changes are missing in riscv:
- universalNativeInvoker*--> downcallLinker*
- 'native invoker' -> 'downcall stub'

Additional testing:
-  [x] riscv release build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287194](https://bugs.openjdk.java.net/browse/JDK-8287194): build failure on riscv after JDK-8286825


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8859/head:pull/8859` \
`$ git checkout pull/8859`

Update a local copy of the PR: \
`$ git checkout pull/8859` \
`$ git pull https://git.openjdk.java.net/jdk pull/8859/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8859`

View PR using the GUI difftool: \
`$ git pr show -t 8859`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8859.diff">https://git.openjdk.java.net/jdk/pull/8859.diff</a>

</details>
