### PR TITLE
8286490: JvmtiEventControllerPrivate::set_event_callbacks CLEARING_MASK computation is incorrect

### DIFF
--- a/src/hotspot/share/prims/jvmtiEventController.cpp
+++ b/src/hotspot/share/prims/jvmtiEventController.cpp
@@ -772,7 +772,7 @@ void JvmtiEventControllerPrivate::set_event_callbacks(JvmtiEnvBase *env,
 
   env->set_event_callbacks(callbacks, size_of_callbacks);
   // Mask to clear normal event bits.
-  const jlong CLEARING_MASK = (1L >> (TOTAL_MIN_EVENT_TYPE_VAL - TOTAL_MIN_EVENT_TYPE_VAL)) - 1L;
+  const jlong CLEARING_MASK = (1L >> (JVMTI_MIN_EVENT_TYPE_VAL - TOTAL_MIN_EVENT_TYPE_VAL)) - 1L;
   // Avoid cleaning extension event bits.
   jlong enabled_bits = CLEARING_MASK & env->env_event_enable()->_event_callback_enabled.get_bits();
 

--- a/src/hotspot/share/prims/jvmtiEventController.cpp
+++ b/src/hotspot/share/prims/jvmtiEventController.cpp
@@ -771,15 +771,15 @@ void JvmtiEventControllerPrivate::set_event_callbacks(JvmtiEnvBase *env,
   flush_object_free_events(env);
 
   env->set_event_callbacks(callbacks, size_of_callbacks);
-  // Mask to clear normal event bits.
-  const jlong CLEARING_MASK = (1L << (JVMTI_MIN_EVENT_TYPE_VAL - TOTAL_MIN_EVENT_TYPE_VAL)) - 1L;
-  // Avoid cleaning extension event bits.
-  jlong enabled_bits = CLEARING_MASK & env->env_event_enable()->_event_callback_enabled.get_bits();
 
+  jlong enabled_bits = env->env_event_enable()->_event_callback_enabled.get_bits();
   for (int ei = JVMTI_MIN_EVENT_TYPE_VAL; ei <= JVMTI_MAX_EVENT_TYPE_VAL; ++ei) {
     jvmtiEvent evt_t = (jvmtiEvent)ei;
+    jlong bit_for = JvmtiEventEnabled::bit_for(evt_t);
     if (env->has_callback(evt_t)) {
-      enabled_bits |= JvmtiEventEnabled::bit_for(evt_t);
+      enabled_bits |= bit_for;
+    } else {
+      enabled_bits &= ~bit_for;
     }
   }
   env->env_event_enable()->_event_callback_enabled.set_bits(enabled_bits);

--- a/src/hotspot/share/prims/jvmtiEventController.cpp
+++ b/src/hotspot/share/prims/jvmtiEventController.cpp
@@ -772,7 +772,7 @@ void JvmtiEventControllerPrivate::set_event_callbacks(JvmtiEnvBase *env,
 
   env->set_event_callbacks(callbacks, size_of_callbacks);
   // Mask to clear normal event bits.
-  const jlong CLEARING_MASK = (1L >> (JVMTI_MIN_EVENT_TYPE_VAL - TOTAL_MIN_EVENT_TYPE_VAL)) - 1L;
+  const jlong CLEARING_MASK = (1L << (JVMTI_MIN_EVENT_TYPE_VAL - TOTAL_MIN_EVENT_TYPE_VAL)) - 1L;
   // Avoid cleaning extension event bits.
   jlong enabled_bits = CLEARING_MASK & env->env_event_enable()->_event_callback_enabled.get_bits();
 

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/VThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/VThreadTest.java
@@ -36,6 +36,8 @@ public class VThreadTest {
     static final int MSG_COUNT = 10*1000;
     static final SynchronousQueue<String> QUEUE = new SynchronousQueue<>();
 
+    static native boolean check();
+
     static void producer(String msg) throws InterruptedException {
         int ii = 1;
         long ll = 2*(long)ii;
@@ -66,6 +68,9 @@ public class VThreadTest {
         Thread consumer = Thread.ofVirtual().name("VThread-Consumer").start(CONSUMER);
         producer.join();
         consumer.join();
+        if (!check()) {
+            throw new RuntimeException("VThreadTest failed!");
+        }
     }
 
     void runTest() throws Exception {

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/libVThreadTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/libVThreadTest.cpp
@@ -604,18 +604,6 @@ Agent_OnLoad(JavaVM *jvm, char *options,
     return JNI_ERR;
   }
 
-  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, EXT_EVENT_VIRTUAL_THREAD_MOUNT, NULL);
-  if (err != JVMTI_ERROR_NONE) {
-    LOG("error in JVMTI SetEventNotificationMode: %d\n", err);
-    return JNI_ERR;
-  }
-
-  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, EXT_EVENT_VIRTUAL_THREAD_UNMOUNT, NULL);
-  if (err != JVMTI_ERROR_NONE) {
-    LOG("error in JVMTI SetEventNotificationMode: %d\n", err);
-    return JNI_ERR;
-  }
-
   err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VIRTUAL_THREAD_START, NULL);
   if (err != JVMTI_ERROR_NONE) {
     LOG("error in JVMTI SetEventNotificationMode: %d\n", err);
@@ -623,6 +611,18 @@ Agent_OnLoad(JavaVM *jvm, char *options,
   }
 
   err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VIRTUAL_THREAD_END, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    LOG("error in JVMTI SetEventNotificationMode: %d\n", err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, EXT_EVENT_VIRTUAL_THREAD_MOUNT, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    LOG("error in JVMTI SetEventNotificationMode: %d\n", err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, EXT_EVENT_VIRTUAL_THREAD_UNMOUNT, NULL);
   if (err != JVMTI_ERROR_NONE) {
     LOG("error in JVMTI SetEventNotificationMode: %d\n", err);
     return JNI_ERR;

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/libVThreadTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/libVThreadTest.cpp
@@ -40,6 +40,9 @@ static jvmtiEnv *jvmti = NULL;
 static jrawMonitorID events_monitor = NULL;
 static Tinfo tinfo[MAX_WORKER_THREADS];
 
+static int vthread_mount_count = 0;
+static int vthread_unmount_count = 0;
+static jboolean passed = JNI_TRUE;
 
 static Tinfo*
 find_tinfo(JNIEnv* jni, const char* tname) {
@@ -535,6 +538,7 @@ VirtualThreadMount(jvmtiEnv *jvmti, ...) {
   va_end(ap);
 
   RawMonitorLocker rml(jvmti, jni, events_monitor);
+  vthread_mount_count++;
   processVThreadEvent(jvmti, jni, thread, "VirtualThreadMount");
 }
 
@@ -551,6 +555,7 @@ VirtualThreadUnmount(jvmtiEnv *jvmti, ...) {
   va_end(ap);
 
   RawMonitorLocker rml(jvmti, jni, events_monitor);
+  vthread_unmount_count++;
   processVThreadEvent(jvmti, jni, thread, "VirtualThreadUnmount");
 }
 
@@ -599,18 +604,6 @@ Agent_OnLoad(JavaVM *jvm, char *options,
     return JNI_ERR;
   }
 
-  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VIRTUAL_THREAD_START, NULL);
-  if (err != JVMTI_ERROR_NONE) {
-    LOG("error in JVMTI SetEventNotificationMode: %d\n", err);
-    return JNI_ERR;
-  }
-
-  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VIRTUAL_THREAD_END, NULL);
-  if (err != JVMTI_ERROR_NONE) {
-    LOG("error in JVMTI SetEventNotificationMode: %d\n", err);
-    return JNI_ERR;
-  }
-
   err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, EXT_EVENT_VIRTUAL_THREAD_MOUNT, NULL);
   if (err != JVMTI_ERROR_NONE) {
     LOG("error in JVMTI SetEventNotificationMode: %d\n", err);
@@ -623,9 +616,42 @@ Agent_OnLoad(JavaVM *jvm, char *options,
     return JNI_ERR;
   }
 
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VIRTUAL_THREAD_START, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    LOG("error in JVMTI SetEventNotificationMode: %d\n", err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VIRTUAL_THREAD_END, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    LOG("error in JVMTI SetEventNotificationMode: %d\n", err);
+    return JNI_ERR;
+  }
+
   events_monitor = create_raw_monitor(jvmti, "Events Monitor");
   LOG("Agent_OnLoad finished\n");
   return JNI_OK;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_VThreadTest_check(JNIEnv *jni, jclass cls) {
+  LOG("\n");
+  LOG("check: started\n");
+
+  LOG("check: vthread_mount_count:   %d\n", vthread_mount_count);
+  LOG("check: vthread_unmount_count: %d\n", vthread_unmount_count);
+
+  if (vthread_mount_count == 0) {
+    passed = JNI_FALSE;
+    LOG("FAILED: vthread_mount_count == 0\n");
+  }
+  if (vthread_unmount_count == 0) {
+    passed = JNI_FALSE;
+    LOG("FAILED: vthread_unmount_count == 0\n");
+  }
+  LOG("check: finished\n");
+  LOG("\n");
+  return passed;
 }
 
 } // extern "C"


### PR DESCRIPTION
It was a typo when the original CLEARING_MASK was initially introduced:

```
 // Mask to clear normal event bits.
  const jlong CLEARING_MASK = (1L >> (TOTAL_MIN_EVENT_TYPE_VAL - TOTAL_MIN_EVENT_TYPE_VAL)) - 1L;
  // Avoid cleaning extension event bits.
  jlong enabled_bits = CLEARING_MASK & env->env_event_enable()->_event_callback_enabled.get_bits();

``` 

The first TOTAL_MIN_EVENT_TYPE_VAL has to be JVMTI_MIN_EVENT_TYPE_VAL as below:
`  const jlong CLEARING_MASK = (1L >> (JVMTI_MIN_EVENT_TYPE_VAL - TOTAL_MIN_EVENT_TYPE_VAL)) - 1L;`

Let me provide some background to understand how this mask is used.

Normal JVMTI event types are numbered from 50 to 88. There are two constants:
```
  JVMTI_MIN_EVENT_TYPE_VAL = 50
  JVMTI_MAX_EVENT_TYPE_VAL = 88
```
The extension event types are numbered from 47 to 49. There are also two constants:
```
  EXT_MIN_EVENT_TYPE_VAL = 47
  EXT_MAX_EVENT_TYPE_VAL = 49
```

There are also two additional constants:
```
  TOTAL_MIN_EVENT_TYPE_VAL = 47
  TOTAL_MAX_EVENT_TYPE_VAL = 88
```

The `enabled_bits` are shifted left by 47, so that the 0-bit in `enabled_bits` is for first extension event type. And the first normal JVMTI event type is numbered 3 in the `enabled_bits` bit mask. The `CLEARING_MASK` is used to clear only normal JVMTI event types but keep the extension event bits (0-2) unchanged.

Testing:
I'll run all JVMTI tests including nsk.jvmti tests and serviceability/jvmti tests including those added in Loom for virtual thread coverage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286490](https://bugs.openjdk.java.net/browse/JDK-8286490): JvmtiEventControllerPrivate::set_event_callbacks CLEARING_MASK computation is incorrect


### Reviewers
 * [Jaroslav Bachorik](https://openjdk.java.net/census#jbachorik) (@jbachorik - **Reviewer**) ⚠️ Review applies to [d77b8dcb](https://git.openjdk.java.net/jdk/pull/8860/files/d77b8dcb748246a81ac90d967132f74f2bb8f38a)
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - **Reviewer**) ⚠️ Review applies to [d77b8dcb](https://git.openjdk.java.net/jdk/pull/8860/files/d77b8dcb748246a81ac90d967132f74f2bb8f38a)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8860/head:pull/8860` \
`$ git checkout pull/8860`

Update a local copy of the PR: \
`$ git checkout pull/8860` \
`$ git pull https://git.openjdk.java.net/jdk pull/8860/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8860`

View PR using the GUI difftool: \
`$ git pr show -t 8860`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8860.diff">https://git.openjdk.java.net/jdk/pull/8860.diff</a>

</details>
