### PR TITLE
8287202: GHA: Add macOS aarch64 to the list of default platforms for workflow_dispatch event

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -10,7 +10,7 @@ on:
       platforms:
         description: "Platform(s) to execute on"
         required: true
-        default: "Linux additional (hotspot only), Linux x64, Linux x86, Windows aarch64, Windows x64, macOS x64"
+        default: "Linux additional (hotspot only), Linux x64, Linux x86, Windows aarch64, Windows x64, macOS x64, macOS aarch64"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
It seems that it was forgotten to add the macOS aarch64 platform to the default platforms of workflow_dispatch. Let's fix this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287202](https://bugs.openjdk.java.net/browse/JDK-8287202): GHA: Add macOS aarch64 to the list of default platforms for workflow_dispatch event


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8861/head:pull/8861` \
`$ git checkout pull/8861`

Update a local copy of the PR: \
`$ git checkout pull/8861` \
`$ git pull https://git.openjdk.java.net/jdk pull/8861/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8861`

View PR using the GUI difftool: \
`$ git pr show -t 8861`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8861.diff">https://git.openjdk.java.net/jdk/pull/8861.diff</a>

</details>
