### PR TITLE
8286846: test/jdk/javax/swing/plaf/aqua/CustomComboBoxFocusTest.java fails on mac aarch64

### DIFF
--- a/test/jdk/javax/swing/plaf/aqua/CustomComboBoxFocusTest.java
+++ b/test/jdk/javax/swing/plaf/aqua/CustomComboBoxFocusTest.java
@@ -139,9 +139,9 @@ public class CustomComboBoxFocusTest {
                 if ((Math.abs(red1 - red2) > colorTolerance) ||
                     (Math.abs(green1 - green2) > colorTolerance) ||
                     (Math.abs(blue1 - blue2) > colorTolerance)) {
-		    System.out.println("x " + x + " y " + y +
-				    " refRGB " + refRGB +
-				    " customRGB " + customRGB);
+                    System.out.println("x " + x + " y " + y +
+                                       " refRGB " + refRGB +
+                                       " customRGB " + customRGB);
                     return false;
                 }
             }

--- a/test/jdk/javax/swing/plaf/aqua/CustomComboBoxFocusTest.java
+++ b/test/jdk/javax/swing/plaf/aqua/CustomComboBoxFocusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,15 @@
  * @test
  * @key headful
  * @bug     8073001 8081764
+ * @requires (os.family == "mac")
  * @summary Test verifies that combo box with custom editor renders
  *          focus ring around arrow button correctly.
- * @library /test/lib
- * @build jdk.test.lib.Platform
  * @run     main CustomComboBoxFocusTest
  */
 
 import java.awt.AWTException;
 import java.awt.Component;
+import java.awt.Color;
 import java.awt.GridLayout;
 import java.awt.Point;
 import java.awt.Rectangle;
@@ -55,29 +55,24 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 
-import jdk.test.lib.Platform;
-
 public class CustomComboBoxFocusTest {
 
     private static CustomComboBoxFocusTest test = null;
+    static int colorTolerance = 5;
 
-    public static void main(String[] args) {
-        if (!Platform.isOSX()) {
+    public static void main(String[] args) throws Exception {
+        if (!System.getProperty("os.name").toLowerCase().contains("os x")) {
             System.out.println("Only Mac platform test. Test is skipped for other OS.");
             return;
         }
 
-        try {
-            SwingUtilities.invokeAndWait(new Runnable() {
-                public void run() {
-                    test = new CustomComboBoxFocusTest();
-                }
-            });
-        } catch (InterruptedException | InvocationTargetException e ) {
-            throw new RuntimeException("Test failed.", e);
-        }
+        SwingUtilities.invokeAndWait(new Runnable() {
+            public void run() {
+                test = new CustomComboBoxFocusTest();
+            }
+        });
 
-        SwingUtilities.invokeLater(test.init);
+        SwingUtilities.invokeAndWait(test.init);
 
         try {
             System.out.println("Wait for screenshots...");
@@ -130,7 +125,23 @@ public class CustomComboBoxFocusTest {
 
         for (int y = 0; y < h; y++) {
             for (int x = 0; x < w; x++) {
-                if (a.getRGB(x, y) != b.getRGB(x, y)) {
+                Color refRGB = new Color(a.getRGB(x,y));
+                Color customRGB = new Color(b.getRGB(x,y));
+
+                int red1 = refRGB.getRed();
+                int blue1 = refRGB.getBlue();
+                int green1 = refRGB.getGreen();
+
+                int red2 = customRGB.getRed();
+                int blue2 = customRGB.getBlue();
+                int green2 = customRGB.getGreen();
+
+                if ((Math.abs(red1 - red2) > colorTolerance) ||
+                    (Math.abs(green1 - green2) > colorTolerance) ||
+                    (Math.abs(blue1 - blue2) > colorTolerance)) {
+		    System.out.println("x " + x + " y " + y +
+				    " refRGB " + refRGB +
+				    " customRGB " + customRGB);
                     return false;
                 }
             }
@@ -222,6 +233,7 @@ public class CustomComboBoxFocusTest {
             f.add(p);
 
             f.pack();
+            f.setLocationRelativeTo(null);
             f.setVisible(true);
         }
 


### PR DESCRIPTION
Test was failing intermiitently in iMac M1 system owing to minimalistic color difference of 1 
```
x 13 y 0 refRGB ffeeeeee customRGB ffefeeee
x 0 y 0 refRGB ffefefef customRGB ffefeeef
```

so added color tolerance check. 
Also, added other stability fixes..
Several iteration of test passed in intended M1 and x64 system.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286846](https://bugs.openjdk.java.net/browse/JDK-8286846): test/jdk/javax/swing/plaf/aqua/CustomComboBoxFocusTest.java fails on mac aarch64


### Reviewers
 * [Tejesh R](https://openjdk.java.net/census#tr) (@TejeshR13 - Author)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.java.net/census#honkar) (@honkar-jdk - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8864/head:pull/8864` \
`$ git checkout pull/8864`

Update a local copy of the PR: \
`$ git checkout pull/8864` \
`$ git pull https://git.openjdk.java.net/jdk pull/8864/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8864`

View PR using the GUI difftool: \
`$ git pr show -t 8864`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8864.diff">https://git.openjdk.java.net/jdk/pull/8864.diff</a>

</details>
