### PR TITLE
8286895: InternalError: Exception during analyze

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -2851,6 +2851,12 @@ public class Flow {
         }
 
         @Override
+        public void visitTypeTest(JCInstanceOf tree) {
+            scanExpr(tree.expr);
+            scan(tree.pattern);
+        }
+
+        @Override
         public void visitBindingPattern(JCBindingPattern tree) {
             scan(tree.var);
             initParam(tree.var);

--- a/test/langtools/jdk/jshell/ErrorRecoveryTest.java
+++ b/test/langtools/jdk/jshell/ErrorRecoveryTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8270139 8273039
+ * @bug 8270139 8273039 8286895
  * @summary Verify error recovery in JShell
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
@@ -53,6 +53,14 @@ public class ErrorRecoveryTest extends KullaTesting {
 
     public void testBrokenName() {
         assertEval("int strictfp = 0;",
+                   DiagCheck.DIAG_ERROR,
+                   DiagCheck.DIAG_IGNORE,
+                   ste(MAIN_SNIPPET, NONEXISTENT, REJECTED, false, null));
+    }
+
+    public void testBooleanPatternExpression() {
+        assertEval("Number n = 0;");
+        assertEval("if (!n instanceof Integer i) {}",
                    DiagCheck.DIAG_ERROR,
                    DiagCheck.DIAG_IGNORE,
                    ste(MAIN_SNIPPET, NONEXISTENT, REJECTED, false, null));

--- a/test/langtools/tools/javac/recovery/NoCrashForError.java
+++ b/test/langtools/tools/javac/recovery/NoCrashForError.java
@@ -1,0 +1,14 @@
+/**
+ * @test /nodynamiccopyright/
+ * @bug 8286895
+ * @summary Verify that errors don't crash the compiler.
+ * @compile/fail/ref=NoCrashForError.out -XDshould-stop.at=FLOW -XDdev -XDrawDiagnostics NoCrashForError.java
+ */
+public class NoCrashForError {
+    private void JDK8286895() {
+        Number n = 17;
+        if (! n instanceof Integer i) {
+            System.out.println("not Integer");
+        }
+    }
+}

--- a/test/langtools/tools/javac/recovery/NoCrashForError.out
+++ b/test/langtools/tools/javac/recovery/NoCrashForError.out
@@ -1,0 +1,2 @@
+NoCrashForError.java:10:13: compiler.err.operator.cant.be.applied: !, java.lang.Number
+1 error


### PR DESCRIPTION
Consider code like:
```
Number n = 0;
if (!n instanceof Integer i) {}
```
javac parses this like:
```
Number n = 0;
if ((!n) instanceof Integer i) {}
```

This is obviously erroneous, and will report an error in `Attr`, but if this code gets to `Flow`, like in JShell, then it will split the `inits`/`uninits` of variables to the `true`/`false` inits while processing the unary negation. But, then, the `instanceof` operator will try to declare a variable, which will fail with on an assertion, as that shouldn't be done when the inits are split to `true`/`false`:
```
Caused by: java.lang.AssertionError
        at jdk.compiler/com.sun.tools.javac.util.Assert.error(Assert.java:155)
        at jdk.compiler/com.sun.tools.javac.util.Assert.check(Assert.java:46)
        at jdk.compiler/com.sun.tools.javac.util.Bits.excl(Bits.java:220)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$AssignAnalyzer.newVar(Flow.java:1883)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$AssignAnalyzer.visitVarDef(Flow.java:2261)
        at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCVariableDecl.accept(JCTree.java:1027)
        at jdk.compiler/com.sun.tools.javac.tree.TreeScanner.scan(TreeScanner.java:49)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$BaseAnalyzer.scan(Flow.java:444)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$AssignAnalyzer.scan(Flow.java:1743)
        at jdk.compiler/com.sun.tools.javac.tree.TreeScanner.visitBindingPattern(TreeScanner.java:307)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$AssignAnalyzer.visitBindingPattern(Flow.java:2848)
...
```

The proposed solution is to use `scanExpr` when handling the `instanceof`'s expression, which will merge the `true`/`false` inits, and let the variable be declared.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286895](https://bugs.openjdk.java.net/browse/JDK-8286895): InternalError: Exception during analyze


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8866/head:pull/8866` \
`$ git checkout pull/8866`

Update a local copy of the PR: \
`$ git checkout pull/8866` \
`$ git pull https://git.openjdk.java.net/jdk pull/8866/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8866`

View PR using the GUI difftool: \
`$ git pr show -t 8866`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8866.diff">https://git.openjdk.java.net/jdk/pull/8866.diff</a>

</details>
