### PR TITLE
8276836: Error in javac caused by switch expression without result expressions: Internal error: stack sim error

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Code.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Code.java
@@ -621,7 +621,7 @@ public class Code {
             markDead();
             break;
         case athrow:
-            state.pop(1);
+            state.pop(state.stacksize);
             markDead();
             break;
         case lstore_0:

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -860,6 +860,10 @@ public class Gen extends JCTree.Visitor {
      *  @param pt      The expression's expected type (proto-type).
      */
     public Item genExpr(JCTree tree, Type pt) {
+        if (!code.isAlive()) {
+            return items.makeStackItem(pt);
+        }
+
         Type prevPt = this.pt;
         try {
             if (tree.type.constValue() != null) {

--- a/test/langtools/tools/javac/switchexpr/SwitchExpressionNoValue.java
+++ b/test/langtools/tools/javac/switchexpr/SwitchExpressionNoValue.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8276836
+ * @summary Check that switch expression with no value does not crash the compiler.
+ * @library /tools/lib /tools/javac/lib
+ * @modules
+ *      java.base/jdk.internal
+ *      jdk.compiler/com.sun.tools.javac.api
+ *      jdk.compiler/com.sun.tools.javac.file
+ *      jdk.compiler/com.sun.tools.javac.main
+ *      jdk.compiler/com.sun.tools.javac.util
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @build combo.ComboTestHelper
+ * @compile SwitchExpressionNoValue.java
+ * @run main/othervm SwitchExpressionNoValue
+ */
+
+import combo.ComboInstance;
+import combo.ComboParameter;
+import combo.ComboTask;
+import combo.ComboTestHelper;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import java.util.Objects;
+import javax.tools.Diagnostic;
+import toolbox.ToolBox;
+
+import javax.tools.JavaFileObject;
+
+public class SwitchExpressionNoValue extends ComboInstance<SwitchExpressionNoValue> {
+    protected ToolBox tb;
+
+    SwitchExpressionNoValue() {
+        super();
+        tb = new ToolBox();
+    }
+
+    public static void main(String... args) throws Exception {
+        new ComboTestHelper<SwitchExpressionNoValue>()
+                .withDimension("SWITCH_EXPRESSION", (x, method) -> x.switchExpression = method, SwitchExpression.values())
+                .withDimension("EXPRESSION", (x, expression) -> x.expression = expression, Expression.values())
+                .withDimension("CONTEXT", (x, context) -> x.context = context, Context.values())
+                .withFilter(test -> test.context.expressionType == test.expression.expressionType &&
+                                    test.context.expressionType == test.switchExpression.expressionType)
+                .run(SwitchExpressionNoValue::new);
+    }
+
+    private SwitchExpression switchExpression;
+    private Expression expression;
+    private Context context;
+
+    private static final String MAIN_TEMPLATE =
+            """
+            public class Test {
+                public static void doTest() {
+                    #{CONTEXT}
+                }
+                static int i;
+                static int[] arr = new int[0];
+                static void m(int i, Object o, int j) {}
+            }
+            """;
+
+    @Override
+    protected void doWork() throws Throwable {
+        Path base = Paths.get(".");
+
+        ComboTask task = newCompilationTask()
+                .withSourceFromTemplate(MAIN_TEMPLATE, pname -> switch (pname) {
+                        case "SWITCH_EXPRESSION" -> switchExpression;
+                        case "EXPRESSION" -> expression;
+                        case "CONTEXT" -> context;
+                        default -> throw new UnsupportedOperationException(pname);
+                    })
+                .withOption("--enable-preview")
+                .withOption("-source")
+                .withOption(String.valueOf(Runtime.version().feature()));
+
+        task.generate(result -> {
+            try {
+                if (result.hasErrors()) {
+                    throw new AssertionError(result.diagnosticsForKind(Diagnostic.Kind.ERROR));
+                }
+                Iterator<? extends JavaFileObject> filesIt = result.get().iterator();
+                JavaFileObject file = filesIt.next();
+                if (filesIt.hasNext()) {
+                    throw new IllegalStateException("More than one classfile returned!");
+                }
+                byte[] data = file.openInputStream().readAllBytes();
+                ClassLoader inMemoryLoader = new ClassLoader() {
+                    protected Class<?> findClass(String name) throws ClassNotFoundException {
+                        if ("Test".equals(name)) {
+                            return defineClass(name, data, 0, data.length);
+                        }
+                        return super.findClass(name);
+                    }
+                };
+                Class<?> test = Class.forName("Test", false, inMemoryLoader);
+                try {
+                java.lang.reflect.Method doTest = test.getDeclaredMethod("doTest");
+                    doTest.invoke(null);
+                    throw new AssertionError("No expected exception!");
+                } catch (Throwable ex) {
+                    while (ex instanceof InvocationTargetException) {
+                        ex = ((InvocationTargetException) ex).getCause();
+                    }
+                    if (ex instanceof RuntimeException && "test".equals(ex.getMessage())) {
+                        //OK
+                    } else {
+                        throw new IllegalStateException(ex);
+                    }
+                }
+            } catch (Throwable ex) {
+                throw new IllegalStateException(ex);
+            }
+        });
+    }
+
+    private void assertEquals(Object o1, Object o2) {
+        if (!Objects.equals(o1, o2)) {
+            throw new AssertionError();
+        }
+    }
+
+    public enum SwitchExpression implements ComboParameter {
+        INT("switch (i) { case 0 -> throw new RuntimeException(\"test\"); default -> {if (true) throw new RuntimeException(\"test\"); else yield 0; } }", ExpressionType.INT),
+        BOOLEAN("switch (i) { case 0 -> throw new RuntimeException(\"test\"); default -> {if (true) throw new RuntimeException(\"test\"); else yield true; } }", ExpressionType.BOOLEAN)
+        ;
+        private final String expression;
+        private final ExpressionType expressionType;
+
+        private SwitchExpression(String expression, ExpressionType expressionType) {
+            this.expression = expression;
+            this.expressionType = expressionType;
+        }
+
+        @Override
+        public String expand(String optParameter) {
+            return expression;
+        }
+    }
+
+    public enum Expression implements ComboParameter {
+        SIMPLE("#{SWITCH_EXPRESSION}", ExpressionType.INT),
+        BINARY_SIMPLE("3 + #{SWITCH_EXPRESSION}", ExpressionType.INT),
+        BINARY_LONGER1("3 + #{SWITCH_EXPRESSION} + #{SWITCH_EXPRESSION} + #{SWITCH_EXPRESSION}", ExpressionType.INT),
+        BINARY_LONGER2("3 + switch (0) { default -> 0; } + #{SWITCH_EXPRESSION} + #{SWITCH_EXPRESSION}", ExpressionType.INT),
+        BINARY_LONGER3("3 + #{SWITCH_EXPRESSION} + switch (0) { default -> 0; } + #{SWITCH_EXPRESSION}", ExpressionType.INT),
+        BINARY_BOOLEAN("\"\".isEmpty() && #{SWITCH_EXPRESSION}", ExpressionType.BOOLEAN),
+        ;
+        private final String expression;
+        private final ExpressionType expressionType;
+
+        private Expression(String expression, ExpressionType expressionType) {
+            this.expression = expression;
+            this.expressionType = expressionType;
+        }
+
+        @Override
+        public String expand(String optParameter) {
+            return expression;
+        }
+    }
+
+    public enum Context implements ComboParameter {
+        ASSIGNMENT("i = #{EXPRESSION};", ExpressionType.INT),
+        COMPOUND_ASSIGNMENT("i += #{EXPRESSION};", ExpressionType.INT),
+        METHOD_INVOCATION("m(0, #{EXPRESSION}, 0);", ExpressionType.INT),
+        ARRAY_DEREF("arr[#{EXPRESSION}] = 0;", ExpressionType.INT),
+        IF("if (#{EXPRESSION});", ExpressionType.BOOLEAN),
+        WHILE("while (#{EXPRESSION});", ExpressionType.BOOLEAN)
+        ;
+        private final String code;
+        private final ExpressionType expressionType;
+        private Context(String code, ExpressionType expressionType) {
+            this.code = code;
+            this.expressionType = expressionType;
+        }
+        @Override
+        public String expand(String optParameter) {
+            return code;
+        }
+    }
+
+    enum ExpressionType {
+        INT,
+        BOOLEAN;
+    }
+}


### PR DESCRIPTION
Normally, a switch expression must yield a value. But, there are cases where the switch expression has a value in the javac frontend, but, due to optimizations, not when the code is generated. For example:
```
int i = 1 + switch (0) { default -> {if (true) throw new RuntimeException(); else yield 0; } };
```

javac will optimize the else section away, and the switch expression will always end abruptly. But, javac's simulated stack will still contain the left value of the binary operator, which will never be removed, and javac will consequently fail:
```
.java:2: error: Internal error: stack sim error on t()
    private void t() {
                     ^
1 error
```

The proposed solution is twofold:
- the throw statement/instruction should clear the stack, which adheres more closely to the runtime behavior of the instruction. This is the change in `Code`.
- skipping code generation for expressions when the code is not "alive", as such code does not have any sense. This is similar to how statements are generated. This is the change in `Gen`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276836](https://bugs.openjdk.java.net/browse/JDK-8276836): Error in javac caused by switch expression without result expressions: Internal error: stack sim error


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8867/head:pull/8867` \
`$ git checkout pull/8867`

Update a local copy of the PR: \
`$ git checkout pull/8867` \
`$ git pull https://git.openjdk.java.net/jdk pull/8867/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8867`

View PR using the GUI difftool: \
`$ git pr show -t 8867`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8867.diff">https://git.openjdk.java.net/jdk/pull/8867.diff</a>

</details>
