### PR TITLE
8287215: Add method to scan bitmap backwards

### DIFF
--- a/src/hotspot/share/utilities/bitMap.cpp
+++ b/src/hotspot/share/utilities/bitMap.cpp
@@ -36,6 +36,8 @@ STATIC_ASSERT(sizeof(BitMap::bm_word_t) == BytesPerWord); // "Implementation ass
 typedef BitMap::bm_word_t bm_word_t;
 typedef BitMap::idx_t     idx_t;
 
+constexpr idx_t BitMap::NotFound;
+
 class ResourceBitMapAllocator : StackObj {
  public:
   bm_word_t* allocate(idx_t size_in_words) const {

--- a/src/hotspot/share/utilities/bitMap.hpp
+++ b/src/hotspot/share/utilities/bitMap.hpp
@@ -100,6 +100,13 @@ class BitMap {
   template<bm_word_t flip, bool aligned_right>
   inline idx_t get_next_bit_impl(idx_t l_index, idx_t r_index) const;
 
+  // Helper for get_prev_{zero,one}_bit variants.
+  // - flip designates whether searching for 1s or 0s.  Must be one of
+  //   find_{zeros,ones}_flip.
+  // - aligned_left is true if l_index is a priori on a bm_word_t boundary.
+  template<bm_word_t flip, bool aligned_left>
+  inline idx_t get_prev_bit_impl(idx_t l_index, idx_t r_index) const;
+
   // Values for get_next_bit_impl flip parameter.
   static const bm_word_t find_ones_flip = 0;
   static const bm_word_t find_zeros_flip = ~(bm_word_t)0;
@@ -314,6 +321,15 @@ class BitMap {
   // Like "get_next_one_offset", except requires that "r_index" is
   // aligned to bitsizeof(bm_word_t).
   idx_t get_next_one_offset_aligned_right(idx_t l_index, idx_t r_index) const;
+
+  static constexpr idx_t NotFound = ~(idx_t)0;
+  // Find the index of the first bit set scanning from r_index (inclusive) to
+  // l_index (inclusive) backwards.
+  // Returns that index or NotFound if there is no such bit in the range.
+  idx_t get_prev_one_offset(idx_t l_index, idx_t r_index) const;
+  // Same as get_prev_one_offset, except requires that "l_index" is aligned to
+  // bitsizeof(bm_word_t).
+  idx_t get_prev_one_offset_aligned_left(idx_t l_index, idx_t r_index) const;
 
   // Returns the number of bits set in the bitmap.
   idx_t count_one_bits() const;

--- a/src/hotspot/share/utilities/bitMap.hpp
+++ b/src/hotspot/share/utilities/bitMap.hpp
@@ -323,7 +323,7 @@ class BitMap {
   idx_t get_next_one_offset_aligned_right(idx_t l_index, idx_t r_index) const;
 
   static constexpr idx_t NotFound = ~(idx_t)0;
-  // Find the index of the first bit set scanning from r_index (inclusive) to
+  // Find the index of the first bit set scanning from r_index (exclusive) to
   // l_index (inclusive) backwards.
   // Returns that index or NotFound if there is no such bit in the range.
   idx_t get_prev_one_offset(idx_t l_index, idx_t r_index) const;

--- a/src/hotspot/share/utilities/bitMap.inline.hpp
+++ b/src/hotspot/share/utilities/bitMap.inline.hpp
@@ -244,8 +244,7 @@ inline BitMap::idx_t BitMap::get_prev_bit_impl(idx_t l_index, idx_t r_index) con
   // The benefit from aligned_left being true is very small. It saves
   // an operation when returning results.
 
-  // The return value of l_index (with found_bit = false) when no bit
-  // is found is arbitrary and should not be relied on.
+  // The return value of l_index when no bit is found is BitMap::NotFound.
 
   if (l_index <= r_index) {
     // Get the word containing r_index, and shift out high bits.
@@ -278,7 +277,7 @@ inline BitMap::idx_t BitMap::get_prev_bit_impl(idx_t l_index, idx_t r_index) con
           if (aligned_left || (result >= l_index)) {
             return result;
           }
-          // Result is beyond range bound; return l_index (with found_bit = false)
+          // Result is beyond range bound; return NotFound
           assert(index == limit, "invariant");
           break;
         }

--- a/src/hotspot/share/utilities/bitMap.inline.hpp
+++ b/src/hotspot/share/utilities/bitMap.inline.hpp
@@ -228,6 +228,67 @@ inline BitMap::idx_t BitMap::get_next_bit_impl(idx_t l_index, idx_t r_index) con
   return r_index;
 }
 
+template<BitMap::bm_word_t flip, bool aligned_left>
+inline BitMap::idx_t BitMap::get_prev_bit_impl(idx_t l_index, idx_t r_index) const {
+  STATIC_ASSERT(flip == find_ones_flip || flip == find_zeros_flip);
+  verify_range(l_index, r_index);
+  assert(!aligned_left || is_aligned(l_index, BitsPerWord), "l_index not aligned");
+  assert(sizeof(intptr_t) == sizeof(bm_word_t), "must be for the high bit check");
+
+  // The first word often contains an interesting bit, either due to
+  // density or because of features of the calling algorithm.  So it's
+  // important to examine that first word with a minimum of fuss,
+  // minimizing setup time for later words that will be wasted if the
+  // first word is indeed interesting.
+
+  // The benefit from aligned_left being true is very small. It saves
+  // an operation when returning results.
+
+  // The return value of l_index (with found_bit = false) when no bit
+  // is found is arbitrary and should not be relied on.
+
+  if (l_index <= r_index) {
+    // Get the word containing r_index, and shift out high bits.
+    idx_t index = to_words_align_down(r_index);
+    bm_word_t cword = (map(index) ^ flip) << (BitsPerWord - 1 - bit_in_word(r_index));
+    if (intptr_t(cword) < 0) {
+      // The first bit is similarly often interesting. When it matters
+      // (density or features of the calling algorithm make it likely
+      // the first bit is set), going straight to the next clause compares
+      // poorly with doing this check first; count_leading_zeros can be
+      // relatively expensive, plus there is the additional range check.
+      // But when the first bit isn't set, the cost of having tested for
+      // it is relatively small compared to the rest of the search.
+      return r_index;
+    } else if (cword != 0) {
+      // Flipped and shifted first word is non-zero.
+      idx_t result = r_index - count_leading_zeros(cword);
+      if (aligned_left || (result >= l_index)) {
+        return result;
+      }
+      // Result is beyond range bound.
+    } else {
+      // Flipped and shifted first word is zero.  Word search through
+      // aligned down l_index for a non-zero flipped word.
+      idx_t limit = to_words_align_down(l_index); // Minuscule savings when aligned.
+      while (index > 0 && --index >= limit) {
+        cword = map(index) ^ flip;
+        if (cword != 0) {
+          idx_t result = bit_index(index + 1) - count_leading_zeros(cword) - 1;
+          if (aligned_left || (result >= l_index)) {
+            return result;
+          }
+          // Result is beyond range bound; return l_index (with found_bit = false)
+          assert(index == limit, "invariant");
+          break;
+        }
+      }
+      // No bits in range.
+    }
+  }
+  return NotFound;
+}
+
 inline BitMap::idx_t
 BitMap::get_next_one_offset(idx_t l_offset, idx_t r_offset) const {
   return get_next_bit_impl<find_ones_flip, false>(l_offset, r_offset);
@@ -241,6 +302,16 @@ BitMap::get_next_zero_offset(idx_t l_offset, idx_t r_offset) const {
 inline BitMap::idx_t
 BitMap::get_next_one_offset_aligned_right(idx_t l_offset, idx_t r_offset) const {
   return get_next_bit_impl<find_ones_flip, true>(l_offset, r_offset);
+}
+
+inline BitMap::idx_t
+BitMap::get_prev_one_offset (idx_t l_index, idx_t r_index) const {
+  return get_prev_bit_impl<find_ones_flip, false>(l_index, r_index);
+}
+
+inline BitMap::idx_t
+BitMap::get_prev_one_offset_aligned_left(idx_t l_index, idx_t r_index) const {
+  return get_prev_bit_impl<find_ones_flip, true>(l_index, r_index);
 }
 
 template <typename BitMapClosureType>

--- a/src/hotspot/share/utilities/bitMap.inline.hpp
+++ b/src/hotspot/share/utilities/bitMap.inline.hpp
@@ -233,7 +233,6 @@ inline BitMap::idx_t BitMap::get_prev_bit_impl(idx_t l_index, idx_t r_index) con
   STATIC_ASSERT(flip == find_ones_flip || flip == find_zeros_flip);
   verify_range(l_index, r_index);
   assert(!aligned_left || is_aligned(l_index, BitsPerWord), "l_index not aligned");
-  assert(sizeof(intptr_t) == sizeof(bm_word_t), "must be for the high bit check");
 
   // The first word often contains an interesting bit, either due to
   // density or because of features of the calling algorithm.  So it's
@@ -246,10 +245,13 @@ inline BitMap::idx_t BitMap::get_prev_bit_impl(idx_t l_index, idx_t r_index) con
 
   // The return value of l_index when no bit is found is BitMap::NotFound.
 
-  if (l_index <= r_index) {
-    // Get the word containing r_index, and shift out high bits.
+  if (l_index < r_index) {
+    // Get the word containing r_index - 1 (r_index is exclusive), and shift out high bits.
+    r_index--;
     idx_t index = to_words_align_down(r_index);
     bm_word_t cword = (map(index) ^ flip) << (BitsPerWord - 1 - bit_in_word(r_index));
+
+    STATIC_ASSERT(sizeof(intptr_t) == sizeof(bm_word_t));
     if (intptr_t(cword) < 0) {
       // The first bit is similarly often interesting. When it matters
       // (density or features of the calling algorithm make it likely

--- a/src/hotspot/share/utilities/bitMap.inline.hpp
+++ b/src/hotspot/share/utilities/bitMap.inline.hpp
@@ -270,7 +270,7 @@ inline BitMap::idx_t BitMap::get_prev_bit_impl(idx_t l_index, idx_t r_index) con
       // Flipped and shifted first word is zero.  Word search through
       // aligned down l_index for a non-zero flipped word.
       idx_t limit = to_words_align_down(l_index); // Minuscule savings when aligned.
-      while (index > 0 && --index >= limit) {
+      while (index-- > limit) {
         cword = map(index) ^ flip;
         if (cword != 0) {
           idx_t result = bit_index(index + 1) - count_leading_zeros(cword) - 1;

--- a/test/hotspot/gtest/utilities/test_bitMap_search.cpp
+++ b/test/hotspot/gtest/utilities/test_bitMap_search.cpp
@@ -95,13 +95,13 @@ static idx_t compute_search_bwd_expected(idx_t search_left,
                                          idx_t search_right,
                                          idx_t left_bit,
                                          idx_t right_bit) {
-  if (search_right >= right_bit) {
+  if (search_right > right_bit) {
     if (search_left <= right_bit) {
       return right_bit;
     } else {
       return BitMap::NotFound;
     }
-  } else if (search_right >= left_bit) {
+  } else if (search_right > left_bit) {
     if (search_left <= left_bit) {
       return left_bit;
     } else {
@@ -111,6 +111,8 @@ static idx_t compute_search_bwd_expected(idx_t search_left,
     return BitMap::NotFound;
   }
 }
+
+#define PRINT_TESTCASE << " search_left " << search_left << " search_right " << search_right << " left " << left << " right " << right << " result " << result
 
 static void test_search_bwd_testcase(BitMap& test_ones,
                                      idx_t search_left,
@@ -122,11 +124,11 @@ static void test_search_bwd_testcase(BitMap& test_ones,
   idx_t exp_result = compute_search_bwd_expected(search_left, search_right, left, right);
 
   result = test_ones.get_prev_one_offset(search_left, search_right);
-  EXPECT_EQ(result, exp_result) << " search_left " << search_left << " search_right " << search_right << " left " << left << " right " << right << " result " << result;
+  EXPECT_EQ(result, exp_result) PRINT_TESTCASE;
 
   if (aligned_left) {
     result = test_ones.get_prev_one_offset_aligned_left(search_left, search_right);
-    EXPECT_EQ(result, exp_result) << " search_left " << search_left << " search_right " << search_right << " left " << left << " right " << right << " result " << result;
+    EXPECT_EQ(result, exp_result) PRINT_TESTCASE;
   }
 }
 

--- a/test/hotspot/gtest/utilities/test_bitMap_search.cpp
+++ b/test/hotspot/gtest/utilities/test_bitMap_search.cpp
@@ -91,10 +91,150 @@ bool TestIteratorFn::do_bit(size_t offset) {
   return true;
 }
 
-static idx_t compute_expected(idx_t search_start,
-                              idx_t search_end,
-                              idx_t left_bit,
-                              idx_t right_bit) {
+static idx_t compute_search_bwd_expected(idx_t search_left,
+                                         idx_t search_right,
+                                         idx_t left_bit,
+                                         idx_t right_bit) {
+  if (search_right >= right_bit) {
+    if (search_left <= right_bit) {
+      return right_bit;
+    } else {
+      return BitMap::NotFound;
+    }
+  } else if (search_right >= left_bit) {
+    if (search_left <= left_bit) {
+      return left_bit;
+    } else {
+      return BitMap::NotFound;
+    }
+  } else {
+    return BitMap::NotFound;
+  }
+}
+
+static void test_search_bwd_testcase(BitMap& test_ones,
+                                     idx_t search_left,
+                                     idx_t search_right,
+                                     idx_t left,
+                                     idx_t right,
+                                     bool aligned_left) {
+  idx_t result;
+  idx_t exp_result = compute_search_bwd_expected(search_left, search_right, left, right);
+
+  result = test_ones.get_prev_one_offset(search_left, search_right);
+  EXPECT_EQ(result, exp_result) << " search_left " << search_left << " search_right " << search_right << " left " << left << " right " << right << " result " << result;
+
+  if (aligned_left) {
+    result = test_ones.get_prev_one_offset_aligned_left(search_left, search_right);
+    EXPECT_EQ(result, exp_result) << " search_left " << search_left << " search_right " << search_right << " left " << left << " right " << right << " result " << result;
+  }
+}
+
+static void test_search_bwd_ranges(BitMap& test_ones, idx_t left, idx_t right) {
+  // Some trivial cases.
+  test_search_bwd_testcase(test_ones, left, right, left, right, false);
+  test_search_bwd_testcase(test_ones, right, right, left, right, false);
+  test_search_bwd_testcase(test_ones, left, left, left, right, false);
+
+    // Test searches with various start and end ranges.
+  for (size_t c_start = 0; c_start < search_nchunks; ++c_start) {
+    for (size_t o_start = 0; o_start < search_noffsets; ++o_start) {
+      idx_t start = c_start * search_chunk_size + search_offsets[o_start];
+      // Terminate start iteration if start is more than two full
+      // chunks beyond left.  There isn't anything new to learn by
+      // continuing the iteration, and this noticably reduces the
+      // time to run the test.
+      if (left + 2 * search_chunk_size < start) {
+        c_start = search_nchunks; // Set to limit to terminate iteration.
+        break;
+      }
+
+      for (size_t c_end = c_start; c_end < search_nchunks; ++c_end) {
+        for (size_t o_end = (c_start == c_end) ? o_start : 0;
+             o_end < search_noffsets;
+             ++o_end) {
+          idx_t end = c_end * search_chunk_size + search_offsets[o_end];
+          // Similarly to start and left, terminate end iteration if
+          // end is more than two full chunks beyond right.
+          if (right + 2 * search_chunk_size < end) {
+            c_end = search_nchunks; // Set to limit to terminate iteration.
+            break;
+          }
+          // Skip this chunk if right is much larger than max(left, start)
+          // and this chunk is one of many similar chunks in between,
+          // again to reduce testing time.
+          if (MAX2(start, left) + 2 * search_chunk_size < end) {
+            if (end + 2 * search_chunk_size < right) {
+              break;
+            }
+          }
+
+          ASSERT_LE(start, end);       // test bug if fail
+          ASSERT_LT(end, BITMAP_SIZE); // test bug if fail
+          bool aligned_left = search_offsets[o_start] == 0;
+
+          test_search_bwd_testcase(test_ones, start, end, left, right, aligned_left);
+          if (start < end) {
+            test_search_bwd_testcase(test_ones, start, MAX2(start, end - 1), left, right, aligned_left);
+          }
+        }
+      }
+    }
+  }
+}
+
+TEST(BitMap, search_bwd) {
+  CHeapBitMap test_ones(BITMAP_SIZE);
+
+  test_ones.clear_range(0, test_ones.size());
+
+  idx_t result = test_ones.get_prev_one_offset(0, test_ones.size());
+  EXPECT_EQ(result, BitMap::NotFound);
+
+  for (size_t c_left = 0; c_left < 2; ++c_left) {
+    for (size_t c_right = c_left;
+         c_right < search_nchunks;
+         (c_right == c_left + 1) ? c_right = search_nchunks -1 : ++c_right) {
+
+            // For each offset within the left chunk...
+      for (size_t o_left = 0; o_left < search_noffsets; ++o_left) {
+        // left is start of left chunk + offset.
+        idx_t left = c_left * search_chunk_size + search_offsets[o_left];
+
+        test_ones.set_bit(left);
+        EXPECT_TRUE(test_ones.at(left));
+
+        // For each offset within the right chunk and > left...
+        for (size_t o_right = (c_left == c_right) ? o_left + 1 : 0;
+             o_right < search_noffsets;
+             ++o_right) {
+          // right is start of right chunk + offset.
+          idx_t right = c_right * search_chunk_size + search_offsets[o_right];
+
+          // Install the right bit.
+          test_ones.set_bit(right);
+          EXPECT_TRUE(test_ones.at(right));
+
+          // Apply the test.
+          test_search_bwd_ranges(test_ones, left, right);
+
+          // Remove the right bit.
+          test_ones.clear_bit(right);
+          EXPECT_FALSE(test_ones.at(right));
+        }
+
+        // Remove the left bit.
+        test_ones.clear_bit(left);
+        EXPECT_FALSE(test_ones.at(left));
+      }
+    }
+  }
+}
+
+static idx_t compute_search_fwd_expected(idx_t search_start,
+                                         idx_t search_end,
+                                         idx_t left_bit,
+                                         idx_t right_bit) {
   idx_t expected = search_end;
   if (search_start <= left_bit) {
     if (left_bit < search_end) {
@@ -108,10 +248,10 @@ static idx_t compute_expected(idx_t search_start,
   return expected;
 }
 
-static void test_search_ranges(BitMap& test_ones,
-                               BitMap& test_zeros,
-                               idx_t left,
-                               idx_t right) {
+static void test_search_fwd_ranges(BitMap& test_ones,
+                                   BitMap& test_zeros,
+                                   idx_t left,
+                                   idx_t right) {
   // Test get_next_one_offset with full range of map.
   EXPECT_EQ(left, test_ones.get_next_one_offset(0));
   EXPECT_EQ(right, test_ones.get_next_one_offset(left + 1));
@@ -168,7 +308,7 @@ static void test_search_ranges(BitMap& test_ones,
           ASSERT_LE(start, end);       // test bug if fail
           ASSERT_LT(end, BITMAP_SIZE); // test bug if fail
 
-          idx_t expected = compute_expected(start, end, left, right);
+          idx_t expected = compute_search_fwd_expected(start, end, left, right);
 
           EXPECT_EQ(expected, test_ones.get_next_one_offset(start, end));
           EXPECT_EQ(expected, test_zeros.get_next_zero_offset(start, end));
@@ -179,7 +319,7 @@ static void test_search_ranges(BitMap& test_ones,
           }
 
           idx_t start2 = MIN2(expected + 1, end);
-          idx_t expected2 = compute_expected(start2, end, left, right);
+          idx_t expected2 = compute_search_fwd_expected(start2, end, left, right);
 
           EXPECT_EQ(expected2, test_ones.get_next_one_offset(start2, end));
           EXPECT_EQ(expected2, test_zeros.get_next_zero_offset(start2, end));
@@ -194,7 +334,7 @@ static void test_search_ranges(BitMap& test_ones,
   }
 }
 
-TEST(BitMap, search) {
+TEST(BitMap, search_fwd) {
   CHeapBitMap test_ones(BITMAP_SIZE);
   CHeapBitMap test_zeros(BITMAP_SIZE);
 
@@ -238,7 +378,7 @@ TEST(BitMap, search) {
           EXPECT_FALSE(test_zeros.at(right));
 
           // Apply the test.
-          test_search_ranges(test_ones, test_zeros, left, right);
+          test_search_fwd_ranges(test_ones, test_zeros, left, right);
 
           // Remove the right bit.
           test_ones.clear_bit(right);


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that adds a method to scan bitmaps backwards? This functionality is necessary for upcoming change to remove on of the mark bitmaps [JDK-8210708](https://bugs.openjdk.java.net/browse/JDK-8210708).

As such this is only an addition of that functionality with no reference (apart from the gtest) from Hotspot itself.

Testing: gtest

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287215](https://bugs.openjdk.java.net/browse/JDK-8287215): Add method to scan bitmap backwards


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8869/head:pull/8869` \
`$ git checkout pull/8869`

Update a local copy of the PR: \
`$ git checkout pull/8869` \
`$ git pull https://git.openjdk.java.net/jdk pull/8869/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8869`

View PR using the GUI difftool: \
`$ git pr show -t 8869`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8869.diff">https://git.openjdk.java.net/jdk/pull/8869.diff</a>

</details>
