### PR TITLE
8287246: DSAKeyValue should check for missing params instead of relying on KeyFactory provider

### DIFF
--- a/src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMKeyValue.java
+++ b/src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMKeyValue.java
@@ -302,8 +302,9 @@ public abstract class DOMKeyValue<K extends PublicKey> extends DOMStructure impl
             }
             // P, Q, and G are optional according to the XML Signature
             // Recommendation as they might be known from application context,
-            // but this implementation does not support that, so they are
-            // required.
+            // but this implementation does not provide a mechanism or API for
+            // an application to supply the missing parameters, so they are
+            // required to be specified.
             Element curElem =
                 DOMUtils.getFirstChildElement(kvtElem, "P", XMLSignature.XMLNS);
             BigInteger p = decode(curElem);

--- a/src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMKeyValue.java
+++ b/src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMKeyValue.java
@@ -21,7 +21,7 @@
  * under the License.
  */
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.jcp.xml.dsig.internal.dom;
 
@@ -300,35 +300,22 @@ public abstract class DOMKeyValue<K extends PublicKey> extends DOMStructure impl
                         ("unable to create DSA KeyFactory: " + e.getMessage());
                 }
             }
-            Element curElem = DOMUtils.getFirstChildElement(kvtElem);
-            if (curElem == null) {
-                throw new MarshalException("KeyValue must contain at least one type");
-            }
-            // check for P and Q
-            BigInteger p = null;
-            BigInteger q = null;
-            if ("P".equals(curElem.getLocalName()) && XMLSignature.XMLNS.equals(curElem.getNamespaceURI())) {
-                p = decode(curElem);
-                curElem = DOMUtils.getNextSiblingElement(curElem, "Q", XMLSignature.XMLNS);
-                q = decode(curElem);
-                curElem = DOMUtils.getNextSiblingElement(curElem);
-            }
-            BigInteger g = null;
-            if (curElem != null
-                && "G".equals(curElem.getLocalName()) && XMLSignature.XMLNS.equals(curElem.getNamespaceURI())) {
-                g = decode(curElem);
-                curElem = DOMUtils.getNextSiblingElement(curElem, "Y", XMLSignature.XMLNS);
-            }
-            BigInteger y = null;
-            if (curElem != null) {
-                y = decode(curElem);
-                curElem = DOMUtils.getNextSiblingElement(curElem);
-            }
-            //if (curElem != null && "J".equals(curElem.getLocalName())) {
-                //j = new DOMCryptoBinary(curElem.getFirstChild());
-                // curElem = DOMUtils.getNextSiblingElement(curElem);
-            //}
-            //@@@ do we care about j, pgenCounter or seed?
+            // P, Q, and G are optional according to the XML Signature
+            // Recommendation as they might be known from application context,
+            // but this implementation does not support that, so they are
+            // required.
+            Element curElem =
+                DOMUtils.getFirstChildElement(kvtElem, "P", XMLSignature.XMLNS);
+            BigInteger p = decode(curElem);
+            curElem =
+                DOMUtils.getNextSiblingElement(curElem, "Q", XMLSignature.XMLNS);
+            BigInteger q = decode(curElem);
+            curElem =
+                DOMUtils.getNextSiblingElement(curElem, "G", XMLSignature.XMLNS);
+            BigInteger g = decode(curElem);
+            curElem =
+                DOMUtils.getNextSiblingElement(curElem, "Y", XMLSignature.XMLNS);
+            BigInteger y = decode(curElem);
             DSAPublicKeySpec spec = new DSAPublicKeySpec(y, p, q, g);
             return (DSAPublicKey) generatePublicKey(dsakf, spec);
         }


### PR DESCRIPTION
Please review this fix to the XML Signature implementation to check for null or missing DSA parameters and throw a MarshalException before trying to create a DSA public key from its XML encoding. This will allow the code to fail earlier and not depend on the underlying provider to detect illegal or missing parameters.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287246](https://bugs.openjdk.java.net/browse/JDK-8287246): DSAKeyValue should check for missing params instead of relying on KeyFactory provider


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**) ⚠️ Review applies to [e53e205c](https://git.openjdk.java.net/jdk/pull/8870/files/e53e205cf8d57e0e1bd171cc837bba4c20859dc1)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8870/head:pull/8870` \
`$ git checkout pull/8870`

Update a local copy of the PR: \
`$ git checkout pull/8870` \
`$ git pull https://git.openjdk.java.net/jdk pull/8870/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8870`

View PR using the GUI difftool: \
`$ git pr show -t 8870`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8870.diff">https://git.openjdk.java.net/jdk/pull/8870.diff</a>

</details>
