### PR TITLE
8287249: Zero: Missing BarrierSetNMethod::arm() method

### DIFF
--- a/src/hotspot/cpu/zero/gc/shared/barrierSetNMethod_zero.cpp
+++ b/src/hotspot/cpu/zero/gc/shared/barrierSetNMethod_zero.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,10 @@
 #include "utilities/debug.hpp"
 
 void BarrierSetNMethod::deoptimize(nmethod* nm, address* return_address_ptr) {
+  ShouldNotReachHere();
+}
+
+void BarrierSetNMethod::arm(nmethod* nm, int value) {
   ShouldNotReachHere();
 }
 


### PR DESCRIPTION
Please review this trivial patch that adds missing method in Zero

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287249](https://bugs.openjdk.java.net/browse/JDK-8287249): Zero: Missing BarrierSetNMethod::arm() method


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8873/head:pull/8873` \
`$ git checkout pull/8873`

Update a local copy of the PR: \
`$ git checkout pull/8873` \
`$ git pull https://git.openjdk.java.net/jdk pull/8873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8873`

View PR using the GUI difftool: \
`$ git pr show -t 8873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8873.diff">https://git.openjdk.java.net/jdk/pull/8873.diff</a>

</details>
