### PR TITLE
8287200: Test java/lang/management/ThreadMXBean/VirtualThreadDeadlocks.java timed out after JDK-8287103

### DIFF
--- a/test/jdk/java/lang/management/ThreadMXBean/VirtualThreadDeadlocks.java
+++ b/test/jdk/java/lang/management/ThreadMXBean/VirtualThreadDeadlocks.java
@@ -97,7 +97,7 @@ public class VirtualThreadDeadlocks {
     private static void awaitBlocked(Thread thread) throws InterruptedException {
         while (thread.getState() != Thread.State.BLOCKED) {
             Thread.sleep(10);
-            if (thread.getState() == Thread.State.TERMINATED) {
+            if (!thread.isAlive()) {
                 throw new RuntimeException("Thread " + thread + " is terminated.");
             }
         }

--- a/test/jdk/java/lang/management/ThreadMXBean/VirtualThreadDeadlocks.java
+++ b/test/jdk/java/lang/management/ThreadMXBean/VirtualThreadDeadlocks.java
@@ -35,13 +35,14 @@
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
 import java.util.Arrays;
+import java.util.concurrent.CyclicBarrier;
 import java.util.stream.Stream;
 
 public class VirtualThreadDeadlocks {
     private static final Object LOCK1 = new Object();
     private static final Object LOCK2 = new Object();
 
-    private static volatile boolean lock2Held;
+    private static final CyclicBarrier barrier = new CyclicBarrier(2);
 
     /**
      * PP = test deadlock with two platform threads
@@ -56,9 +57,7 @@ public class VirtualThreadDeadlocks {
                 : Thread.ofVirtual();
         Thread thread1 = builder1.start(() -> {
             synchronized (LOCK1) {
-                while (!lock2Held) {
-                    try { Thread.sleep(10); } catch (Exception e) { }
-                }
+                try { barrier.await(); } catch (Exception ie) {}
                 synchronized (LOCK2) { }
             }
         });
@@ -70,7 +69,7 @@ public class VirtualThreadDeadlocks {
                 : Thread.ofVirtual();
         Thread thread2 = builder2.start(() -> {
             synchronized (LOCK2) {
-                lock2Held = true;
+                try { barrier.await(); } catch (Exception ie) {}
                 synchronized (LOCK1) { }
             }
         });
@@ -98,6 +97,9 @@ public class VirtualThreadDeadlocks {
     private static void awaitBlocked(Thread thread) throws InterruptedException {
         while (thread.getState() != Thread.State.BLOCKED) {
             Thread.sleep(10);
+            if (thread.getState() == Thread.State.TERMINATED) {
+                throw new RuntimeException("Thread " + thread + " is terminated.");
+            }
         }
     }
 


### PR DESCRIPTION
Need to use proper synchronization.

The CyclicBarriers might move the thread to WAITING state but not BLOCKED. So it should not confuse existing checks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287200](https://bugs.openjdk.java.net/browse/JDK-8287200): Test java/lang/management/ThreadMXBean/VirtualThreadDeadlocks.java timed out after  JDK-8287103


### Reviewers
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to [3402eb82](https://git.openjdk.java.net/jdk/pull/8874/files/3402eb82380ce7e92581eace2b35e6e03a8e48e5)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [3402eb82](https://git.openjdk.java.net/jdk/pull/8874/files/3402eb82380ce7e92581eace2b35e6e03a8e48e5)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8874/head:pull/8874` \
`$ git checkout pull/8874`

Update a local copy of the PR: \
`$ git checkout pull/8874` \
`$ git pull https://git.openjdk.java.net/jdk pull/8874/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8874`

View PR using the GUI difftool: \
`$ git pr show -t 8874`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8874.diff">https://git.openjdk.java.net/jdk/pull/8874.diff</a>

</details>
