### PR TITLE
8287263: java/nio/channels/FileChannel/LargeMapTest.java times out on Windows

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -562,8 +562,6 @@ java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc6
 
 java/nio/channels/DatagramChannel/ManySourcesAndTargets.java    8264385 macosx-aarch64
 
-java/nio/channels/FileChannel/LargeMapTest.java                 8286980 windows-all
-
 ############################################################################
 
 # jdk_rmi

--- a/test/jdk/java/nio/channels/FileChannel/LargeMapTest.java
+++ b/test/jdk/java/nio/channels/FileChannel/LargeMapTest.java
@@ -37,7 +37,7 @@ import static java.nio.file.StandardOpenOption.*;
  * @bug 8286637
  * @summary Ensure that memory mapping beyond 32-bit range does not cause an
  *          EXCEPTION_ACCESS_VIOLATION.
- * @run main/othervm LargeMapTest
+ * @run main/othervm/timeout=240 LargeMapTest
  */
 public class LargeMapTest {
     private static final String FILE = "test.dat";


### PR DESCRIPTION
Double the timeout to avoid spurious failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287263](https://bugs.openjdk.java.net/browse/JDK-8287263): java/nio/channels/FileChannel/LargeMapTest.java times out on Windows


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8875/head:pull/8875` \
`$ git checkout pull/8875`

Update a local copy of the PR: \
`$ git checkout pull/8875` \
`$ git pull https://git.openjdk.java.net/jdk pull/8875/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8875`

View PR using the GUI difftool: \
`$ git pr show -t 8875`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8875.diff">https://git.openjdk.java.net/jdk/pull/8875.diff</a>

</details>
