### PR TITLE
8286960: Test serviceability/jvmti/vthread/SuspendResume2 crashed: missing ThreadsListHandle in calling context

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -929,13 +929,13 @@ JvmtiEnv::GetAllThreads(jint* threads_count_ptr, jthread** threads_ptr) {
 jvmtiError
 JvmtiEnv::SuspendThread(jthread thread) {
   JavaThread* current = JavaThread::current();
-  ThreadsListHandle tlh(current);
 
   jvmtiError err;
   JavaThread* java_thread = NULL;
   oop thread_oop = NULL;
   {
     JvmtiVTMSTransitionDisabler disabler(true);
+    ThreadsListHandle tlh(current);
 
     err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_oop);
     if (err != JVMTI_ERROR_NONE) {
@@ -960,13 +960,13 @@ JvmtiEnv::SuspendThread(jthread thread) {
 jvmtiError
 JvmtiEnv::SuspendThreadList(jint request_count, const jthread* request_list, jvmtiError* results) {
   JavaThread* current = JavaThread::current();
-  ThreadsListHandle tlh(current);
   HandleMark hm(current);
   Handle self_tobj = Handle(current, NULL);
   int self_idx = -1;
 
   {
     JvmtiVTMSTransitionDisabler disabler(true);
+    ThreadsListHandle tlh(current);
 
     for (int i = 0; i < request_count; i++) {
       JavaThread *java_thread = NULL;
@@ -1013,18 +1013,19 @@ JvmtiEnv::SuspendAllVirtualThreads(jint except_count, const jthread* except_list
     return JVMTI_ERROR_NONE; // Nothing to do when there are no virtual threads;
   }
   JavaThread* current = JavaThread::current();
-  ThreadsListHandle tlh(current);
-  jvmtiError err = JvmtiEnvBase::check_thread_list(except_count, except_list);
-  if (err != JVMTI_ERROR_NONE) {
-    return err;
-  }
   HandleMark hm(current);
   Handle self_tobj = Handle(current, NULL);
 
   {
     ResourceMark rm(current);
     JvmtiVTMSTransitionDisabler disabler(true);
+    ThreadsListHandle tlh(current);
     GrowableArray<jthread>* elist = new GrowableArray<jthread>(except_count);
+
+    jvmtiError err = JvmtiEnvBase::check_thread_list(except_count, except_list);
+    if (err != JVMTI_ERROR_NONE) {
+      return err;
+    }
 
     // Collect threads from except_list for which resumed status must be restored.
     for (int idx = 0; idx < except_count; idx++) {

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1778,8 +1778,8 @@ bool JavaThread::java_suspend() {
   assert(!is_VTMS_transition_disabler(), "no suspend allowed for VTMS transition disablers");
 #endif
 
-  guarantee(Thread::is_JavaThread_protected_by_TLH(/* target */ this),
-            "missing ThreadsListHandle in calling context.");
+  guarantee(Thread::is_JavaThread_protected(/* target */ this),
+            "target JavaThread is not protected in calling context.");
   return this->handshake_state()->suspend();
 }
 


### PR DESCRIPTION
A part of this issue was contributed with the following changeset:

commit ea23e7333e03abb4aca3e9f3854bab418a4b70e2
Author: Daniel D. Daugherty <[dcubed@openjdk.org](mailto:dcubed@openjdk.org)>
Date: Mon Nov 8 14:45:04 2021 +0000

    8249004: Reduce ThreadsListHandle overhead in relation to direct handshakes
    Reviewed-by: coleenp, sspitsyn, dholmes, rehn

The following change in `src/hotspot/share/runtime/thread.cpp` added new assert:
```
bool JavaThread::java_suspend() {
- ThreadsListHandle tlh;
- if (!tlh.includes(this)) {
- log_trace(thread, suspend)("JavaThread:" INTPTR_FORMAT " not on ThreadsList, no suspension", p2i(this));
- return false;
- }
+ guarantee(Thread::is_JavaThread_protected(this, /* checkTLHOnly */ true),
 + "missing ThreadsListHandle in calling context.");
  return this->handshake_state()->suspend();
}
```
This new assert misses a check for target thread as being current `JavaThread`.

Also, the JVMTI SuspendThread is protected with TLH:
```
JvmtiEnv::SuspendThread(jthread thread) {
  JavaThread* current = JavaThread::current();
  ThreadsListHandle tlh(current);              <= TLS defined here!!!

   oop thread_oop = NULL;
   {
     JvmtiVTMSTransitionDisabler disabler(true); 
```

However, it is possible that a new carrier thread (and an associated `JavaThread`) can be created after the `TLH` was set and the target virtual thread can be mounted on new carrier thread. Then target virtual thread will be associated with newly created `JavaThread` which is unprotected by the TLH.
The right way to be protected from this situation it is to prevent mount state transitions with `JvmtiVTMSTransitionDisabler` before the TLH is set as in the change below:

```
@@ -929,13 +929,13 @@ JvmtiEnv::GetAllThreads(jint* threads_count_ptr, jthread** threads_ptr) {
 jvmtiError
 JvmtiEnv::SuspendThread(jthread thread) {
   JavaThread* current = JavaThread::current();
-  ThreadsListHandle tlh(current);

   jvmtiError err;
   JavaThread* java_thread = NULL;
   oop thread_oop = NULL;
   {
     JvmtiVTMSTransitionDisabler disabler(true);
+    ThreadsListHandle tlh(current);

     err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_oop);
     if (err != JVMTI_ERROR_NONE) {

```

This problem exist in all JVMTI Suspend functions:
 `SuspendThread`, `SuspendThreadList` and `SuspendAllVirtualThreads`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286960](https://bugs.openjdk.java.net/browse/JDK-8286960): Test serviceability/jvmti/vthread/SuspendResume2 crashed: missing ThreadsListHandle in calling context


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8878/head:pull/8878` \
`$ git checkout pull/8878`

Update a local copy of the PR: \
`$ git checkout pull/8878` \
`$ git pull https://git.openjdk.java.net/jdk pull/8878/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8878`

View PR using the GUI difftool: \
`$ git pr show -t 8878`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8878.diff">https://git.openjdk.java.net/jdk/pull/8878.diff</a>

</details>
