### PR TITLE
8286940: [IR Framework] Allow IR tests to build and use Whitebox without -DSkipWhiteBoxInstall=true

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestSuperwordFailsUnrolling.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestSuperwordFailsUnrolling.java
@@ -34,7 +34,7 @@ import sun.hotspot.WhiteBox;
  * @build sun.hotspot.WhiteBox
  * @requires vm.compiler2.enabled
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -DSkipWhiteBoxInstall=true -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI compiler.c2.irTests.TestSuperwordFailsUnrolling
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI compiler.c2.irTests.TestSuperwordFailsUnrolling
  */
 
 public class TestSuperwordFailsUnrolling {

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -23,11 +23,13 @@
 
 package compiler.lib.ir_framework;
 
-import compiler.lib.ir_framework.driver.*;
+import compiler.lib.ir_framework.driver.FlagVMProcess;
+import compiler.lib.ir_framework.driver.TestVMException;
+import compiler.lib.ir_framework.driver.TestVMProcess;
 import compiler.lib.ir_framework.driver.irmatching.IRMatcher;
 import compiler.lib.ir_framework.driver.irmatching.IRViolationException;
 import compiler.lib.ir_framework.shared.*;
-import compiler.lib.ir_framework.test.*;
+import compiler.lib.ir_framework.test.TestVM;
 import jdk.test.lib.Platform;
 import jdk.test.lib.Utils;
 import jdk.test.lib.helpers.ClassFileInstaller;
@@ -36,6 +38,10 @@ import sun.hotspot.WhiteBox;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -137,7 +143,6 @@ public class TestFramework {
     public static final boolean EXCLUDELIST = !System.getProperty("Exclude", "").isEmpty();
     private static final boolean REPORT_STDOUT = Boolean.getBoolean("ReportStdout");
     // Only used for internal testing and should not be used for normal user testing.
-    private static final boolean SKIP_WHITEBOX_INSTALL = Boolean.getBoolean("SkipWhiteBoxInstall");
 
     private static final String RERUN_HINT = """
                                                #############################################################
@@ -314,7 +319,7 @@ public class TestFramework {
      * set test class.
      */
     public void start() {
-        if (!SKIP_WHITEBOX_INSTALL) {
+        if (shouldInstallWhiteBox()) {
             installWhiteBox();
         }
         disableIRVerificationIfNotFeasible();
@@ -334,6 +339,27 @@ public class TestFramework {
         } else {
             startWithScenarios();
         }
+    }
+
+    /**
+     * Try to load the Whitebox class with a user dir custom class loader. If the user has already built the Whitebox,
+     * we can load it. Otherwise, the framework needs to install it.
+     * @return true if the framework needs to install the Whitebox
+     */
+    private boolean shouldInstallWhiteBox() {
+        try {
+            URL url = Path.of(System.getProperty("user.dir")).toUri().toURL();
+            URLClassLoader userDirClassLoader =
+                    URLClassLoader.newInstance(new URL[] {url}, TestFramework.class.getClassLoader().getParent());
+            Class.forName(WhiteBox.class.getName(), false, userDirClassLoader);
+        } catch (MalformedURLException e) {
+            throw new TestFrameworkException("corrupted user.dir property", e);
+        } catch (ClassNotFoundException e) {
+            // We need to manually install the WhiteBox if we cannot load the WhiteBox class from the user directory
+            // This happens when the user test does not explicitly install the WhiteBox as part of the test.
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -342,7 +342,7 @@ public class TestFramework {
     }
 
     /**
-     * Try to load the Whitebox class with a user directory custom class loader. If the user has already built the
+     * Try to load the Whitebox class from the user directory with a custom class loader. If the user has already built the
      * Whitebox, we can load it. Otherwise, the framework needs to install it.
      *
      * @return true if the framework needs to install the Whitebox

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -342,8 +342,9 @@ public class TestFramework {
     }
 
     /**
-     * Try to load the Whitebox class with a user dir custom class loader. If the user has already built the Whitebox,
-     * we can load it. Otherwise, the framework needs to install it.
+     * Try to load the Whitebox class with a user directory custom class loader. If the user has already built the
+     * Whitebox, we can load it. Otherwise, the framework needs to install it.
+     *
      * @return true if the framework needs to install the Whitebox
      */
     private boolean shouldInstallWhiteBox() {
@@ -355,7 +356,7 @@ public class TestFramework {
         } catch (MalformedURLException e) {
             throw new TestFrameworkException("corrupted user.dir property", e);
         } catch (ClassNotFoundException e) {
-            // We need to manually install the WhiteBox if we cannot load the WhiteBox class from the user directory
+            // We need to manually install the WhiteBox if we cannot load the WhiteBox class from the user directory.
             // This happens when the user test does not explicitly install the WhiteBox as part of the test.
             return true;
         }

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestCompLevels.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestCompLevels.java
@@ -37,7 +37,7 @@ import java.lang.reflect.Method;
  * @library /test/lib /
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -DSkipWhiteBoxInstall=true -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                   -Xbatch -XX:+WhiteBoxAPI ir_framework.tests.TestCompLevels
  */
 

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestControls.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestControls.java
@@ -41,7 +41,7 @@ import java.util.regex.Pattern;
  * @library /test/lib /
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -DSkipWhiteBoxInstall=true -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                   -Xbatch -XX:+WhiteBoxAPI ir_framework.tests.TestControls
  */
 

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestIRMatching.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestIRMatching.java
@@ -43,7 +43,7 @@ import java.util.regex.Pattern;
  * @library /test/lib /testlibrary_tests /
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm/timeout=240 -Xbootclasspath/a:. -DSkipWhiteBoxInstall=true -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                               -XX:+WhiteBoxAPI -DPrintIREncoding=true  ir_framework.tests.TestIRMatching
  */
 


### PR DESCRIPTION
Currently, the IR framework always tries to install the Whitebox by moving the Whitebox class file to the JTreg class path. However, when a test already builds the Whitebox and uses it as part of the test, we cannot access it on certain platforms. On Windows, for example, we'll get the following exception:
```
Caused by: java.nio.file.FileSystemException: sun\hotspot\WhiteBox.class: The process cannot access the file because it is being used by another process
```
To mitigate this problem, one can specify `-DSkipWhiteBoxInstall=true` which was already done in [JDK-8283187](https://bugs.openjdk.java.net/browse/JDK-8283187). But this is not a good solution as the user should not need to worry about the inner workings of the IR framework.

I propose to get rid of this flag by reworking the Whitebox installation process.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286940](https://bugs.openjdk.org/browse/JDK-8286940): [IR Framework] Allow IR tests to build and use Whitebox without -DSkipWhiteBoxInstall=true


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [0b0b7d37](https://git.openjdk.java.net/jdk/pull/8879/files/0b0b7d371233e4117ae5f3b88efccd519be67528)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [0b0b7d37](https://git.openjdk.java.net/jdk/pull/8879/files/0b0b7d371233e4117ae5f3b88efccd519be67528)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8879/head:pull/8879` \
`$ git checkout pull/8879`

Update a local copy of the PR: \
`$ git checkout pull/8879` \
`$ git pull https://git.openjdk.java.net/jdk pull/8879/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8879`

View PR using the GUI difftool: \
`$ git pr show -t 8879`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8879.diff">https://git.openjdk.java.net/jdk/pull/8879.diff</a>

</details>
