### PR TITLE
8287292: Improve TransformKey to pack more kinds of transforms efficiently

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -222,10 +222,10 @@ class LambdaForm {
             return basicType(type).btChar;
         }
 
-        static byte[] basicTypesOrd(Class<?>[] types) {
-            byte[] ords = new byte[types.length];
+        static int[] basicTypesOrd(Class<?>[] types) {
+            int[] ords = new int[types.length];
             for (int i = 0; i < ords.length; i++) {
-                ords[i] = (byte)basicType(types[i]).ordinal();
+                ords[i] = basicType(types[i]).ordinal();
             }
             return ords;
         }

--- a/src/java.base/share/classes/java/lang/invoke/LambdaFormEditor.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaFormEditor.java
@@ -216,17 +216,17 @@ class LambdaFormEditor {
             }
             return new TransformKey(fullBytes);
         }
-        static TransformKey of(byte kind, int b1, int b2, int[] b3456) {
-            long packedBytes = packedBytes(kind, b1, b2, b3456);
+        static TransformKey of(byte kind, int b1, int b2, int... b345) {
+            long packedBytes = packedBytes(kind, b1, b2, b345);
             if (packedBytes != 0) {
                 return new TransformKey(packedBytes);
             }
-            byte[] fullBytes = new byte[b3456.length + 3];
+            byte[] fullBytes = new byte[b345.length + 3];
             fullBytes[0] = kind;
             fullBytes[1] = bval(b1);
             fullBytes[2] = bval(b2);
-            for (int i = 0; i < b3456.length; i++) {
-                fullBytes[i + 3] = TransformKey.bval(b3456[i]);
+            for (int i = 0; i < b345.length; i++) {
+                fullBytes[i + 3] = TransformKey.bval(b345[i]);
             }
             return new TransformKey(fullBytes);
         }
@@ -249,7 +249,7 @@ class LambdaFormEditor {
             }
             if (!inRange(bitset))
                 return 0;
-            pb = pb | b2 << (2 * PACKED_BYTE_SIZE) | b1 << PACKED_BYTE_SIZE | b0;
+            pb = pb | packedBytes(b0, b1, b2);
             return pb;
         }
         private static long packedBytes(byte b0, int b1, int[] b234) {
@@ -264,7 +264,7 @@ class LambdaFormEditor {
             }
             if (!inRange(bitset))
                 return 0;
-            pb = pb | b1 << PACKED_BYTE_SIZE | b0;
+            pb = pb | packedBytes(b0, b1);
             return pb;
         }
         private static long packedBytes(byte b0, int[] b123) {
@@ -299,18 +299,18 @@ class LambdaFormEditor {
         }
         private static long packedBytes(int b0, int b1) {
             assert(inRange(b0 | b1));
-            return (  (b0 << 0*PACKED_BYTE_SIZE)
+            return (  (b0)
                     | (b1 << 1*PACKED_BYTE_SIZE));
         }
         private static long packedBytes(int b0, int b1, int b2) {
             assert(inRange(b0 | b1 | b2));
-            return (  (b0 << 0*PACKED_BYTE_SIZE)
+            return (  (b0)
                     | (b1 << 1*PACKED_BYTE_SIZE)
                     | (b2 << 2*PACKED_BYTE_SIZE));
         }
         private static long packedBytes(int b0, int b1, int b2, int b3) {
             assert(inRange(b0 | b1 | b2 | b3));
-            return (  (b0 << 0*PACKED_BYTE_SIZE)
+            return (  (b0)
                     | (b1 << 1*PACKED_BYTE_SIZE)
                     | (b2 << 2*PACKED_BYTE_SIZE)
                     | (b3 << 3*PACKED_BYTE_SIZE));

--- a/src/java.base/share/classes/java/lang/invoke/LambdaFormEditor.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaFormEditor.java
@@ -334,7 +334,7 @@ class LambdaFormEditor {
         @Override
         public int hashCode() {
             if (packedBytes != 0) {
-                return Long.hashCode(packedBytes) ^ (int)(packedBytes >> 8);
+                return Long.hashCode(packedBytes);
             }
             return Arrays.hashCode(fullBytes);
         }

--- a/src/java.base/share/classes/java/lang/invoke/LambdaFormEditor.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaFormEditor.java
@@ -204,7 +204,7 @@ class LambdaFormEditor {
             return new TransformKey(fullBytes);
         }
         static TransformKey of(byte kind, int b1, int... b234) {
-            long packedBytes = packedBytes(kind, b234);
+            long packedBytes = packedBytes(kind, b1, b234);
             if (packedBytes != 0) {
                 return new TransformKey(packedBytes);
             }


### PR DESCRIPTION
The bespoke caching scheme in `jl.invoke.LambdaFormEditor.TransformKey` allows keys to be compacted when all byte values of the key fit in 4 bits, otherwise a byte array is allocated and used. This means that all transforms with a kind value above 15 will be forced to allocate and use array comparisons.

Removing unused and folding some transforms to ensure all existing kinds can fit snugly within the 0-15 value range realize a minor improvement to footprint, speed and allocation pressure of affected transforms, e.g. ~300bytes/op reduction in the `StringConcatFactoryBootstraps` microbenchmark:

Baseline:
```
Benchmark                                                      Mode  Cnt     Score     Error   Units
SCFB.makeConcatWithConstants                                   avgt   15  2048.475 ?  69.887   ns/op
SCFB.makeConcatWithConstants:?gc.alloc.rate.norm               avgt   15  3487.311 ?  80.385    B/op
```

Patched:
```
Benchmark                                                      Mode  Cnt     Score     Error   Units
SCFB.makeConcatWithConstants                                   avgt   15  1961.985 ? 101.519   ns/op
SCFB.makeConcatWithConstants:?gc.alloc.rate.norm               avgt   15  3156.478 ? 183.600    B/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287292](https://bugs.openjdk.java.net/browse/JDK-8287292): Improve TransformKey to pack more kinds of transforms efficiently


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**) ⚠️ Review applies to [001e9d16](https://git.openjdk.java.net/jdk/pull/8881/files/001e9d1671fd3b19cf9cc0bf306fe5c062613a3c)
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - **Reviewer**) ⚠️ Review applies to [2be3b25c](https://git.openjdk.java.net/jdk/pull/8881/files/2be3b25cd95f6b5e14bbff8240559b5d244b54da)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to [612b4ece](https://git.openjdk.java.net/jdk/pull/8881/files/612b4eceb891008e0475e08116e230a49f36d6e7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8881/head:pull/8881` \
`$ git checkout pull/8881`

Update a local copy of the PR: \
`$ git checkout pull/8881` \
`$ git pull https://git.openjdk.java.net/jdk pull/8881/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8881`

View PR using the GUI difftool: \
`$ git pr show -t 8881`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8881.diff">https://git.openjdk.java.net/jdk/pull/8881.diff</a>

</details>
