### PR TITLE
8287312: G1: Early return on first failure in VerifyRegionClosure

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -367,9 +367,17 @@ public:
     guarantee(!r->is_young() || r->rem_set()->is_complete(), "Remembered set for Young region %u must be complete, is %s", r->hrm_index(), r->rem_set()->get_state_str());
     // Humongous and old regions regions might be of any state, so can't check here.
     guarantee(!r->is_free() || !r->rem_set()->is_tracked(), "Remembered set for free region %u must be untracked, is %s", r->hrm_index(), r->rem_set()->get_state_str());
-    // Verify that the continues humongous regions' remembered set state matches the
-    // one from the starts humongous region.
-    if (r->is_continues_humongous()) {
+
+    // For archive regions, verify there are no heap pointers to non-pinned regions.
+    if (r->is_closed_archive()) {
+      VerifyObjectInArchiveRegionClosure verify_oop_pointers(r, false);
+      r->object_iterate(&verify_oop_pointers);
+    } else if (r->is_open_archive()) {
+      VerifyObjsInRegionClosure verify_open_archive_oop(r, _vo);
+      r->object_iterate(&verify_open_archive_oop);
+    } else if (r->is_continues_humongous()) {
+      // Verify that the continues humongous regions' remembered set state
+      // matches the one from the starts humongous region.
       if (r->rem_set()->get_state_str() != r->humongous_start_region()->rem_set()->get_state_str()) {
          log_error(gc, verify)("Remset states differ: Region %u (%s) remset %s with starts region %u (%s) remset %s",
                                r->hrm_index(),
@@ -380,18 +388,7 @@ public:
                                r->humongous_start_region()->rem_set()->get_state_str());
          _failures = true;
       }
-    }
-    // For archive regions, verify there are no heap pointers to
-    // non-pinned regions. For all others, verify liveness info.
-    if (r->is_closed_archive()) {
-      VerifyObjectInArchiveRegionClosure verify_oop_pointers(r, false);
-      r->object_iterate(&verify_oop_pointers);
-      return true;
-    } else if (r->is_open_archive()) {
-      VerifyObjsInRegionClosure verify_open_archive_oop(r, _vo);
-      r->object_iterate(&verify_open_archive_oop);
-      return true;
-    } else if (!r->is_continues_humongous()) {
+    } else {
       bool failures = false;
       r->verify(_vo, &failures);
       if (failures) {
@@ -406,7 +403,9 @@ public:
         }
       }
     }
-    return false; // stop the region iteration if we hit a failure
+
+    // stop the region iteration if we hit a failure
+    return _failures;
   }
 };
 


### PR DESCRIPTION
Simple restructuring to match the intent of the comment.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287312](https://bugs.openjdk.org/browse/JDK-8287312): G1: Early return on first failure in VerifyRegionClosure


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/8882/head:pull/8882` \
`$ git checkout pull/8882`

Update a local copy of the PR: \
`$ git checkout pull/8882` \
`$ git pull https://git.openjdk.org/jdk pull/8882/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8882`

View PR using the GUI difftool: \
`$ git pr show -t 8882`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/8882.diff">https://git.openjdk.org/jdk/pull/8882.diff</a>

</details>
