### PR TITLE
8210708: Use single mark bitmap in G1

### DIFF
--- a/src/hotspot/share/gc/g1/g1Arguments.cpp
+++ b/src/hotspot/share/gc/g1/g1Arguments.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, Red Hat, Inc. and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -65,6 +65,11 @@ void G1Arguments::initialize_alignments() {
   // on it.
   if (FLAG_IS_DEFAULT(G1EagerReclaimRemSetThreshold)) {
     FLAG_SET_ERGO(G1EagerReclaimRemSetThreshold, G1RemSetArrayOfCardsEntries);
+  }
+
+  size_t back_skip_granularity_bytes = (size_t)1 << G1LogBackScanSkipGranularity;
+  if (back_skip_granularity_bytes > G1HeapRegionSize) {
+    FLAG_SET_ERGO(G1LogBackScanSkipGranularity, HeapRegion::LogOfHRGrainBytes);
   }
 }
 

--- a/src/hotspot/share/gc/g1/g1BiasedArray.hpp
+++ b/src/hotspot/share/gc/g1/g1BiasedArray.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -168,7 +168,7 @@ public:
 
 protected:
   // Returns the address of the element the given address maps to
-  T* address_mapped_to(HeapWord* address) {
+  T* address_mapped_to(HeapWord* address) const {
     idx_t biased_index = ((uintptr_t)address) >> this->shift_by();
     this->verify_biased_index_inclusive_end(biased_index);
     return biased_base() + biased_index;

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -79,14 +79,14 @@ G1BlockOffsetTablePart::G1BlockOffsetTablePart(G1BlockOffsetTable* array, HeapRe
 {
 }
 
-void G1BlockOffsetTablePart::update() {
+void G1BlockOffsetTablePart::update(HeapWord* const pb) {
   HeapWord* next_addr = _hr->bottom();
   HeapWord* const limit = _hr->top();
 
   HeapWord* prev_addr;
   while (next_addr < limit) {
     prev_addr = next_addr;
-    next_addr  = prev_addr + block_size(prev_addr);
+    next_addr  = prev_addr + block_size(prev_addr, pb);
     update_for_block(prev_addr, next_addr);
   }
   assert(next_addr == limit, "Should stop the scan at the limit.");

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,6 +122,7 @@ private:
   void set_remainder_to_point_to_start_incl(size_t start, size_t end);
 
   inline size_t block_size(const HeapWord* p) const;
+  inline size_t block_size(const HeapWord* p, HeapWord* pb) const;
 
   // Returns the address of a block whose start is at most "addr".
   inline HeapWord* block_at_or_preceding(const void* addr) const;
@@ -130,7 +131,8 @@ private:
   // "q" is a block boundary that is <= "addr"; "n" is the address of the
   // next block (or the end of the space.)
   inline HeapWord* forward_to_block_containing_addr(HeapWord* q, HeapWord* n,
-                                                    const void* addr) const;
+                                                    const void* addr,
+                                                    HeapWord* pb) const;
 
   // Update BOT entries corresponding to the mem range [blk_start, blk_end).
   void update_for_block_work(HeapWord* blk_start, HeapWord* blk_end);
@@ -152,7 +154,7 @@ public:
   //  The elements of the array are initialized to zero.
   G1BlockOffsetTablePart(G1BlockOffsetTable* array, HeapRegion* hr);
 
-  void update();
+  void update(HeapWord* pb);
 
   void verify() const;
 
@@ -161,7 +163,7 @@ public:
   // namely updating of shared array entries that "point" too far
   // backwards.  This can occur, for example, when lab allocation is used
   // in a space covered by the table.)
-  inline HeapWord* block_start(const void* addr);
+  inline HeapWord* block_start(const void* addr, HeapWord* pb);
 
   void update_for_block(HeapWord* blk_start, HeapWord* blk_end) {
     if (is_crossing_card_boundary(blk_start, blk_end)) {

--- a/src/hotspot/share/gc/g1/g1CodeBlobClosure.cpp
+++ b/src/hotspot/share/gc/g1/g1CodeBlobClosure.cpp
@@ -59,7 +59,7 @@ void G1CodeBlobClosure::MarkingOopClosure::do_oop_work(T* p) {
   T oop_or_narrowoop = RawAccess<>::oop_load(p);
   if (!CompressedOops::is_null(oop_or_narrowoop)) {
     oop o = CompressedOops::decode_not_null(oop_or_narrowoop);
-    _cm->mark_in_next_bitmap(_worker_id, o);
+    _cm->mark_in_bitmap(_worker_id, o);
   }
 }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -623,7 +623,7 @@ public:
   // for all regions.
   void verify_region_attr_remset_is_tracked() PRODUCT_RETURN;
 
-  void clear_prev_bitmap_for_region(HeapRegion* hr);
+  void clear_bitmap_for_region(HeapRegion* hr);
 
   bool is_user_requested_concurrent_full_gc(GCCause::Cause cause);
 
@@ -1243,9 +1243,7 @@ public:
   // Determine if an object is dead, given only the object itself.
   // This will find the region to which the object belongs and
   // then call the region version of the same function.
-
-  // Added if it is NULL it isn't dead.
-
+  // If obj is NULL it is not dead.
   inline bool is_obj_dead(const oop obj) const;
 
   inline bool is_obj_dead_full(const oop obj, const HeapRegion* hr) const;

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -29,6 +29,7 @@
 
 #include "gc/g1/g1BarrierSet.hpp"
 #include "gc/g1/g1CollectorState.hpp"
+#include "gc/g1/g1ConcurrentMark.inline.hpp"
 #include "gc/g1/g1EvacFailureRegions.hpp"
 #include "gc/g1/g1Policy.hpp"
 #include "gc/g1/g1RemSet.hpp"
@@ -159,7 +160,7 @@ inline G1ScannerTasksQueue* G1CollectedHeap::task_queue(uint i) const {
 }
 
 inline bool G1CollectedHeap::is_marked_next(oop obj) const {
-  return _cm->next_mark_bitmap()->is_marked(obj);
+  return _cm->mark_bitmap()->is_marked(obj);
 }
 
 inline bool G1CollectedHeap::is_in_cset(oop obj) {
@@ -220,7 +221,7 @@ inline bool G1CollectedHeap::requires_barriers(stackChunkOop obj) const {
 }
 
 inline bool G1CollectedHeap::is_obj_dead(const oop obj, const HeapRegion* hr) const {
-  return hr->is_obj_dead(obj, _cm->prev_mark_bitmap());
+  return hr->is_obj_dead(obj, hr->parsable_bottom());
 }
 
 inline bool G1CollectedHeap::is_obj_dead(const oop obj) const {

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -375,10 +375,10 @@ public:
 
   virtual bool do_heap_region(HeapRegion* r) {
     assert(r->in_collection_set(), "Region %u should be in collection set", r->hrm_index());
-    _st->print_cr("  " HR_FORMAT ", P: " PTR_FORMAT "N: " PTR_FORMAT ", age: %4d",
+    _st->print_cr("  " HR_FORMAT ", TAMS: " PTR_FORMAT " PB: " PTR_FORMAT ", age: %4d",
                   HR_FORMAT_PARAMS(r),
-                  p2i(r->prev_top_at_mark_start()),
-                  p2i(r->next_top_at_mark_start()),
+                  p2i(r->top_at_mark_start()),
+                  p2i(r->parsable_bottom()),
                   r->has_surv_rate_group() ? r->age_in_surv_rate_group() : -1);
     return false;
   }

--- a/src/hotspot/share/gc/g1/g1CollectorState.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectorState.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,8 +42,8 @@ class G1CollectorState {
   // pause, it is a suggestion that the pause should start a marking
   // cycle by doing the concurrent start work. However, it is possible
   // that the concurrent marking thread is still finishing up the
-  // previous marking cycle (e.g., clearing the next marking
-  // bitmap). If that is the case we cannot start a new cycle and
+  // previous marking cycle (e.g., clearing the marking bitmap).
+  // If that is the case we cannot start a new cycle and
   // we'll have to wait for the concurrent marking thread to finish
   // what it is doing. In this case we will postpone the marking cycle
   // initiation decision for the next pause. When we eventually decide
@@ -64,9 +64,9 @@ class G1CollectorState {
   // of the concurrent start pause to the end of the Cleanup pause.
   bool _mark_or_rebuild_in_progress;
 
-  // The next bitmap is currently being cleared or about to be cleared. TAMS and bitmap
+  // The marking bitmap is currently being cleared or about to be cleared. TAMS and bitmap
   // may be out of sync.
-  bool _clearing_next_bitmap;
+  bool _clearing_bitmap;
 
   // Set during a full gc pause.
   bool _in_full_gc;
@@ -80,7 +80,7 @@ public:
     _initiate_conc_mark_if_possible(false),
 
     _mark_or_rebuild_in_progress(false),
-    _clearing_next_bitmap(false),
+    _clearing_bitmap(false),
     _in_full_gc(false) { }
 
   // Phase setters
@@ -94,7 +94,7 @@ public:
   void set_initiate_conc_mark_if_possible(bool v) { _initiate_conc_mark_if_possible = v; }
 
   void set_mark_or_rebuild_in_progress(bool v) { _mark_or_rebuild_in_progress = v; }
-  void set_clearing_next_bitmap(bool v) { _clearing_next_bitmap = v; }
+  void set_clearing_bitmap(bool v) { _clearing_bitmap = v; }
 
   // Phase getters
   bool in_young_only_phase() const { return _in_young_only_phase && !_in_full_gc; }
@@ -108,7 +108,7 @@ public:
   bool initiate_conc_mark_if_possible() const { return _initiate_conc_mark_if_possible; }
 
   bool mark_or_rebuild_in_progress() const { return _mark_or_rebuild_in_progress; }
-  bool clearing_next_bitmap() const { return _clearing_next_bitmap; }
+  bool clearing_bitmap() const { return _clearing_bitmap; }
 
   // Calculate GC Pause Type from internal state.
   G1GCPauseType young_gc_pause_type(bool concurrent_operation_is_full_mark) const;

--- a/src/hotspot/share/gc/g1/g1CollectorState.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectorState.hpp
@@ -64,8 +64,7 @@ class G1CollectorState {
   // of the concurrent start pause to the end of the Cleanup pause.
   bool _mark_or_rebuild_in_progress;
 
-  // The marking bitmap is currently being cleared or about to be cleared. TAMS and bitmap
-  // may be out of sync.
+  // The marking bitmap is currently being cleared or about to be cleared.
   bool _clearing_bitmap;
 
   // Set during a full gc pause.

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1432,7 +1432,7 @@ void G1ConcurrentMark::cleanup() {
     G1UpdateRegionsAfterRebuild cl(_g1h);
     _g1h->heap_region_iterate(&cl);
   } else {
-    log_debug(gc, phases)("No Remembered Set Tracking Update After Rebuild");
+    log_debug(gc, phases)("No Remembered Sets to update after rebuild");
   }
 
   verify_during_pause(G1HeapVerifier::G1VerifyCleanup, VerifyOption::G1UseConcMarking, "Cleanup after");

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -33,6 +33,7 @@
 #include "gc/g1/g1CollectorState.hpp"
 #include "gc/g1/g1ConcurrentMark.inline.hpp"
 #include "gc/g1/g1ConcurrentMarkThread.inline.hpp"
+#include "gc/g1/g1ConcurrentRebuildAndScrub.hpp"
 #include "gc/g1/g1DirtyCardQueue.hpp"
 #include "gc/g1/g1HeapVerifier.hpp"
 #include "gc/g1/g1OopClosures.inline.hpp"
@@ -361,15 +362,11 @@ bool G1CMRootMemRegions::wait_until_scan_finished() {
 }
 
 G1ConcurrentMark::G1ConcurrentMark(G1CollectedHeap* g1h,
-                                   G1RegionToSpaceMapper* prev_bitmap_storage,
-                                   G1RegionToSpaceMapper* next_bitmap_storage) :
+                                   G1RegionToSpaceMapper* bitmap_storage) :
   // _cm_thread set inside the constructor
   _g1h(g1h),
 
-  _mark_bitmap_1(),
-  _mark_bitmap_2(),
-  _prev_mark_bitmap(&_mark_bitmap_1),
-  _next_mark_bitmap(&_mark_bitmap_2),
+  _mark_bitmap(),
 
   _heap(_g1h->reserved()),
 
@@ -418,8 +415,7 @@ G1ConcurrentMark::G1ConcurrentMark(G1CollectedHeap* g1h,
 {
   assert(CGC_lock != NULL, "CGC_lock must be initialized");
 
-  _mark_bitmap_1.initialize(g1h->reserved(), prev_bitmap_storage);
-  _mark_bitmap_2.initialize(g1h->reserved(), next_bitmap_storage);
+  _mark_bitmap.initialize(g1h->reserved(), bitmap_storage);
 
   // Create & start ConcurrentMark thread.
   _cm_thread = new G1ConcurrentMarkThread(this);
@@ -466,7 +462,7 @@ void G1ConcurrentMark::reset() {
   // Reset all tasks, since different phases will use different number of active
   // threads. So, it's easiest to have all of them ready.
   for (uint i = 0; i < _max_num_tasks; ++i) {
-    _tasks[i]->reset(_next_mark_bitmap);
+    _tasks[i]->reset(mark_bitmap());
   }
 
   uint max_reserved_regions = _g1h->max_reserved_regions();
@@ -499,18 +495,11 @@ void G1ConcurrentMark::clear_statistics(HeapRegion* r) {
   }
 }
 
-static void clear_mark_if_set(G1CMBitMap* bitmap, HeapWord* addr) {
-  if (bitmap->is_marked(addr)) {
-    bitmap->clear(addr);
-  }
-}
-
 void G1ConcurrentMark::humongous_object_eagerly_reclaimed(HeapRegion* r) {
   assert_at_safepoint();
 
-  // Need to clear all mark bits of the humongous object.
-  clear_mark_if_set(_prev_mark_bitmap, r->bottom());
-  clear_mark_if_set(_next_mark_bitmap, r->bottom());
+  // Need to clear mark bit of the humongous object. Doing this unconditionally is fine.
+  mark_bitmap()->clear(r->bottom());
 
   if (!_g1h->collector_state()->mark_or_rebuild_in_progress()) {
     return;
@@ -586,7 +575,7 @@ public:
   static size_t chunk_size() { return M; }
 
 private:
-  // Heap region closure used for clearing the _next_mark_bitmap.
+  // Heap region closure used for clearing the _mark_bitmap.
   class G1ClearBitmapHRClosure : public HeapRegionClosure {
   private:
     G1ConcurrentMark* _cm;
@@ -610,18 +599,16 @@ private:
     }
 
     HeapWord* region_clear_limit(HeapRegion* r) {
-      // During a Concurrent Undo Mark cycle, the _next_mark_bitmap is  cleared
-      // without swapping with the _prev_mark_bitmap. Therefore, the per region
-      // next_top_at_mark_start and live_words data are current wrt
-      // _next_mark_bitmap. We use this information to only clear ranges of the
-      // bitmap that require clearing.
+      // During a Concurrent Undo Mark cycle, the per region top_at_mark_start and
+      // live_words data are current wrt to the _mark_bitmap. We use this information
+      // to only clear ranges of the bitmap that require clearing.
       if (is_clear_concurrent_undo()) {
         // No need to clear bitmaps for empty regions.
         if (_cm->live_words(r->hrm_index()) == 0) {
           assert(_bitmap->get_next_marked_addr(r->bottom(), r->end()) == r->end(), "Should not have marked bits");
           return r->bottom();
         }
-        assert(_bitmap->get_next_marked_addr(r->next_top_at_mark_start(), r->end()) == r->end(), "Should not have marked bits above ntams");
+        assert(_bitmap->get_next_marked_addr(r->top_at_mark_start(), r->end()) == r->end(), "Should not have marked bits above tams");
       }
       return r->end();
     }
@@ -630,7 +617,7 @@ private:
     G1ClearBitmapHRClosure(G1ConcurrentMark* cm, bool suspendible) :
       HeapRegionClosure(),
       _cm(cm),
-      _bitmap(cm->next_mark_bitmap()),
+      _bitmap(cm->mark_bitmap()),
       _suspendible(suspendible)
     { }
 
@@ -691,7 +678,7 @@ public:
   }
 };
 
-void G1ConcurrentMark::clear_next_bitmap(WorkerThreads* workers, bool may_yield) {
+void G1ConcurrentMark::clear_bitmap(WorkerThreads* workers, bool may_yield) {
   assert(may_yield || SafepointSynchronize::is_at_safepoint(), "Non-yielding bitmap clear only allowed at safepoint.");
 
   size_t const num_bytes_to_clear = (HeapRegion::GrainBytes * _g1h->num_regions()) / G1CMBitMap::heap_map_factor();
@@ -717,21 +704,21 @@ void G1ConcurrentMark::cleanup_for_next_mark() {
   // is the case.
   guarantee(!_g1h->collector_state()->mark_or_rebuild_in_progress(), "invariant");
 
-  clear_next_bitmap(_concurrent_workers, true);
+  clear_bitmap(_concurrent_workers, true);
 
   // Repeat the asserts from above.
   guarantee(cm_thread()->in_progress(), "invariant");
   guarantee(!_g1h->collector_state()->mark_or_rebuild_in_progress(), "invariant");
 }
 
-void G1ConcurrentMark::clear_next_bitmap(WorkerThreads* workers) {
+void G1ConcurrentMark::clear_bitmap(WorkerThreads* workers) {
   assert_at_safepoint_on_vm_thread();
   // To avoid fragmentation the full collection requesting to clear the bitmap
   // might use fewer workers than available. To ensure the bitmap is cleared
   // as efficiently as possible the number of active workers are temporarily
   // increased to include all currently created workers.
   WithActiveWorkers update(workers, workers->created_workers());
-  clear_next_bitmap(workers, false);
+  clear_bitmap(workers, false);
 }
 
 class G1PreConcurrentStartTask : public G1BatchedTask {
@@ -954,10 +941,10 @@ void G1ConcurrentMark::scan_root_region(const MemRegion* region, uint worker_id)
 #ifdef ASSERT
   HeapWord* last = region->last();
   HeapRegion* hr = _g1h->heap_region_containing(last);
-  assert(hr->is_old() || hr->next_top_at_mark_start() == hr->bottom(),
+  assert(hr->is_old() || hr->top_at_mark_start() == hr->bottom(),
          "Root regions must be old or survivor/eden but region %u is %s", hr->hrm_index(), hr->get_type_str());
-  assert(hr->next_top_at_mark_start() == region->start(),
-         "MemRegion start should be equal to nTAMS");
+  assert(hr->top_at_mark_start() == region->start(),
+         "MemRegion start should be equal to TAMS");
 #endif
 
   G1RootRegionScanClosure cl(_g1h, this, worker_id);
@@ -1025,7 +1012,7 @@ void G1ConcurrentMark::concurrent_cycle_start() {
 }
 
 void G1ConcurrentMark::concurrent_cycle_end() {
-  _g1h->collector_state()->set_clearing_next_bitmap(false);
+  _g1h->collector_state()->set_clearing_bitmap(false);
 
   _g1h->trace_heap_after_gc(_gc_tracer_cm);
 
@@ -1158,9 +1145,8 @@ class G1UpdateRemSetTrackingBeforeRebuildTask : public WorkerTask {
     }
 
     void add_marked_bytes_and_note_end(HeapRegion* hr, size_t marked_bytes) {
-      hr->add_to_marked_bytes(marked_bytes);
       _cl->do_heap_region(hr);
-      hr->note_end_of_marking();
+      hr->note_end_of_marking(marked_bytes);
     }
 
   public:
@@ -1194,13 +1180,25 @@ public:
   static const uint RegionsPerThread = 384;
 };
 
-class G1UpdateRemSetTrackingAfterRebuild : public HeapRegionClosure {
+class G1UpdateRegionsAfterRebuild : public HeapRegionClosure {
   G1CollectedHeap* _g1h;
+  bool _remsets_rebuilt;
+
 public:
-  G1UpdateRemSetTrackingAfterRebuild(G1CollectedHeap* g1h) : _g1h(g1h) { }
+  G1UpdateRegionsAfterRebuild(G1CollectedHeap* g1h, bool remsets_rebuilt) :
+    _g1h(g1h),
+    _remsets_rebuilt(remsets_rebuilt) {
+    if (!_remsets_rebuilt) {
+      log_debug(gc, phases)("No Remembered Sets to update after rebuild");
+    }
+  }
 
   virtual bool do_heap_region(HeapRegion* r) {
-    _g1h->policy()->remset_tracker()->update_after_rebuild(r);
+    // Update the remset tracking state from updating to complete
+    // if remembered sets have been rebuilt.
+    if (_remsets_rebuilt) {
+      _g1h->policy()->remset_tracker()->update_after_rebuild(r);
+    }
     return false;
   }
 };
@@ -1219,7 +1217,7 @@ void G1ConcurrentMark::remark() {
 
   double start = os::elapsedTime();
 
-  verify_during_pause(G1HeapVerifier::G1VerifyRemark, VerifyOption::G1UsePrevMarking, "Remark before");
+  verify_during_pause(G1HeapVerifier::G1VerifyRemark, VerifyOption::G1UseConcMarking, "Remark before");
 
   {
     GCTraceTime(Debug, gc, phases) debug("Finalize Marking", _gc_timer_cm);
@@ -1244,10 +1242,7 @@ void G1ConcurrentMark::remark() {
       flush_all_task_caches();
     }
 
-    // Install newly created mark bitmap as "prev".
-    swap_mark_bitmaps();
-
-    _g1h->collector_state()->set_clearing_next_bitmap(true);
+    _g1h->collector_state()->set_clearing_bitmap(true);
     {
       GCTraceTime(Debug, gc, phases) debug("Update Remembered Set Tracking Before Rebuild", _gc_timer_cm);
 
@@ -1280,7 +1275,7 @@ void G1ConcurrentMark::remark() {
 
     compute_new_sizes();
 
-    verify_during_pause(G1HeapVerifier::G1VerifyRemark, VerifyOption::G1UsePrevMarking, "Remark after");
+    verify_during_pause(G1HeapVerifier::G1VerifyRemark, VerifyOption::G1UseConcMarking, "Remark after");
 
     assert(!restart_for_overflow(), "sanity");
     // Completely reset the marking state since marking completed
@@ -1289,7 +1284,7 @@ void G1ConcurrentMark::remark() {
     // We overflowed.  Restart concurrent marking.
     _restart_for_overflow = true;
 
-    verify_during_pause(G1HeapVerifier::G1VerifyRemark, VerifyOption::G1UsePrevMarking, "Remark overflow");
+    verify_during_pause(G1HeapVerifier::G1VerifyRemark, VerifyOption::G1UseConcMarking, "Remark overflow");
 
     // Clear the marking state because we will be restarting
     // marking due to overflowing the global mark stack.
@@ -1435,17 +1430,17 @@ void G1ConcurrentMark::cleanup() {
 
   double start = os::elapsedTime();
 
-  verify_during_pause(G1HeapVerifier::G1VerifyCleanup, VerifyOption::G1UsePrevMarking, "Cleanup before");
+  verify_during_pause(G1HeapVerifier::G1VerifyCleanup, VerifyOption::G1UseConcMarking, "Cleanup before");
 
-  if (needs_remembered_set_rebuild()) {
+  {
+    // Update the remset tracking information as well as marking all regions
+    // as fully parsable.
     GCTraceTime(Debug, gc, phases) debug("Update Remembered Set Tracking After Rebuild", _gc_timer_cm);
-    G1UpdateRemSetTrackingAfterRebuild cl(_g1h);
+    G1UpdateRegionsAfterRebuild cl(_g1h, needs_remembered_set_rebuild());
     _g1h->heap_region_iterate(&cl);
-  } else {
-    log_debug(gc, phases)("No Remembered Sets to update after rebuild");
   }
 
-  verify_during_pause(G1HeapVerifier::G1VerifyCleanup, VerifyOption::G1UsePrevMarking, "Cleanup after");
+  verify_during_pause(G1HeapVerifier::G1VerifyCleanup, VerifyOption::G1UseConcMarking, "Cleanup after");
 
   // We need to make this be a "collection" so any collection pause that
   // races with it goes around and waits for Cleanup to finish.
@@ -1710,8 +1705,7 @@ void G1ConcurrentMark::preclean() {
                                      _gc_timer_cm);
 }
 
-// When sampling object counts, we already swapped the mark bitmaps, so we need to use
-// the prev bitmap determining liveness.
+// When sampling object counts, we see all objects not scrubbed as live.
 class G1ObjectCountIsAliveClosure: public BoolObjectClosure {
   G1CollectedHeap* _g1h;
 public:
@@ -1725,7 +1719,7 @@ public:
 
 void G1ConcurrentMark::report_object_count(bool mark_completed) {
   // Depending on the completion of the marking liveness needs to be determined
-  // using either the next or prev bitmap.
+  // using either the bitmap or after the cycle using the scrubbing information.
   if (mark_completed) {
     G1ObjectCountIsAliveClosure is_alive(_g1h);
     _gc_tracer_cm->report_object_count_after_gc(&is_alive);
@@ -1733,13 +1727,6 @@ void G1ConcurrentMark::report_object_count(bool mark_completed) {
     G1CMIsAliveClosure is_alive(_g1h);
     _gc_tracer_cm->report_object_count_after_gc(&is_alive);
   }
-}
-
-
-void G1ConcurrentMark::swap_mark_bitmaps() {
-  G1CMBitMap* temp = _prev_mark_bitmap;
-  _prev_mark_bitmap = _next_mark_bitmap;
-  _next_mark_bitmap = temp;
 }
 
 // Closure for marking entries in SATB buffers.
@@ -1873,8 +1860,9 @@ void G1ConcurrentMark::flush_all_task_caches() {
                        hits, misses, percent_of(hits, sum));
 }
 
-void G1ConcurrentMark::clear_range_in_prev_bitmap(MemRegion mr) {
-  _prev_mark_bitmap->clear_range(mr);
+void G1ConcurrentMark::clear_range_in_bitmap(MemRegion mr) {
+  assert_at_safepoint();
+  _mark_bitmap.clear_range(mr);
 }
 
 HeapRegion*
@@ -1897,7 +1885,7 @@ G1ConcurrentMark::claim_region(uint worker_id) {
     if (res == finger && curr_region != NULL) {
       // we succeeded
       HeapWord*   bottom        = curr_region->bottom();
-      HeapWord*   limit         = curr_region->next_top_at_mark_start();
+      HeapWord*   limit         = curr_region->top_at_mark_start();
 
       // notice that _finger == end cannot be guaranteed here since,
       // someone else might have moved the finger even further
@@ -1994,14 +1982,12 @@ void G1ConcurrentMark::verify_no_collection_set_oops() {
 }
 #endif // PRODUCT
 
-void G1ConcurrentMark::rebuild_rem_set_concurrently() {
-  // If Remark did not select any regions for RemSet rebuild,
-  // skip the rebuild remembered set phase
+void G1ConcurrentMark::rebuild_and_scrub() {
   if (!needs_remembered_set_rebuild()) {
-    log_debug(gc, marking)("Skipping Remembered Set Rebuild. No regions selected for rebuild");
-    return;
+    log_debug(gc, marking)("Skipping Remembered Set Rebuild. No regions selected for rebuild, will only scrub");
   }
-  _g1h->rem_set()->rebuild_rem_set(this, _concurrent_workers, _worker_id_offset);
+
+  G1ConcurrentRebuildAndScrub::rebuild_and_scrub(this, _concurrent_workers);
 }
 
 void G1ConcurrentMark::print_stats() {
@@ -2033,11 +2019,8 @@ void G1ConcurrentMark::concurrent_cycle_abort() {
   // marking that is interrupted by this full gc.
   {
     GCTraceTime(Debug, gc) debug("Clear Next Bitmap");
-    clear_next_bitmap(_g1h->workers());
+    clear_bitmap(_g1h->workers());
   }
-  // Note we cannot clear the previous marking bitmap here
-  // since VerifyDuringGC verifies the objects marked during
-  // a full GC against the previous bitmap.
 
   // Empty mark stack
   reset_marking_for_restart();
@@ -2101,10 +2084,8 @@ void G1ConcurrentMark::threads_do(ThreadClosure* tc) const {
 }
 
 void G1ConcurrentMark::print_on_error(outputStream* st) const {
-  st->print_cr("Marking Bits (Prev, Next): (CMBitMap*) " PTR_FORMAT ", (CMBitMap*) " PTR_FORMAT,
-               p2i(_prev_mark_bitmap), p2i(_next_mark_bitmap));
-  _prev_mark_bitmap->print_on_error(st, " Prev Bits: ");
-  _next_mark_bitmap->print_on_error(st, " Next Bits: ");
+  st->print_cr("Marking Bits: (CMBitMap*) " PTR_FORMAT, p2i(mark_bitmap()));
+  _mark_bitmap.print_on_error(st, " Bits: ");
 }
 
 static ReferenceProcessor* get_cm_oop_closure_ref_processor(G1CollectedHeap* g1h) {
@@ -2130,7 +2111,7 @@ void G1CMTask::setup_for_region(HeapRegion* hr) {
 void G1CMTask::update_region_limit() {
   HeapRegion* hr            = _curr_region;
   HeapWord* bottom          = hr->bottom();
-  HeapWord* limit           = hr->next_top_at_mark_start();
+  HeapWord* limit           = hr->top_at_mark_start();
 
   if (limit == bottom) {
     // The region was collected underneath our feet.
@@ -2144,10 +2125,10 @@ void G1CMTask::update_region_limit() {
   } else {
     assert(limit < _region_limit, "only way to get here");
     // This can happen under some pretty unusual circumstances.  An
-    // evacuation pause empties the region underneath our feet (NTAMS
-    // at bottom). We then do some allocation in the region (NTAMS
+    // evacuation pause empties the region underneath our feet (TAMS
+    // at bottom). We then do some allocation in the region (TAMS
     // stays at bottom), followed by the region being used as a GC
-    // alloc region (NTAMS will move to top() and the objects
+    // alloc region (TAMS will move to top() and the objects
     // originally below it will be grayed). All objects now marked in
     // the region are explicitly grayed, if below the global finger,
     // and we do not need in fact to scan anything else. So, we simply
@@ -2181,9 +2162,9 @@ void G1CMTask::set_cm_oop_closure(G1CMOopClosure* cm_oop_closure) {
   _cm_oop_closure = cm_oop_closure;
 }
 
-void G1CMTask::reset(G1CMBitMap* next_mark_bitmap) {
-  guarantee(next_mark_bitmap != NULL, "invariant");
-  _next_mark_bitmap              = next_mark_bitmap;
+void G1CMTask::reset(G1CMBitMap* mark_bitmap) {
+  guarantee(mark_bitmap != NULL, "invariant");
+  _mark_bitmap              = mark_bitmap;
   clear_region_fields();
 
   _calls                         = 0;
@@ -2667,7 +2648,7 @@ void G1CMTask::do_marking_step(double time_target_ms,
         giveup_current_region();
         abort_marking_if_regular_check_fail();
       } else if (_curr_region->is_humongous() && mr.start() == _curr_region->bottom()) {
-        if (_next_mark_bitmap->is_marked(mr.start())) {
+        if (_mark_bitmap->is_marked(mr.start())) {
           // The object is marked - apply the closure
           bitmap_closure.do_addr(mr.start());
         }
@@ -2675,7 +2656,7 @@ void G1CMTask::do_marking_step(double time_target_ms,
         // we can (and should) give up the current region.
         giveup_current_region();
         abort_marking_if_regular_check_fail();
-      } else if (_next_mark_bitmap->iterate(&bitmap_closure, mr)) {
+      } else if (_mark_bitmap->iterate(&bitmap_closure, mr)) {
         giveup_current_region();
         abort_marking_if_regular_check_fail();
       } else {
@@ -2893,7 +2874,7 @@ G1CMTask::G1CMTask(uint worker_id,
   _worker_id(worker_id),
   _g1h(G1CollectedHeap::heap()),
   _cm(cm),
-  _next_mark_bitmap(NULL),
+  _mark_bitmap(NULL),
   _task_queue(task_queue),
   _mark_stats_cache(mark_stats, G1RegionMarkStatsCache::RegionMarkStatsCacheSize),
   _calls(0),
@@ -2959,9 +2940,11 @@ G1CMTask::G1CMTask(uint worker_id,
 #define G1PPRL_SUM_MB_PERC_FORMAT(tag) G1PPRL_SUM_MB_FORMAT(tag) " / %1.2f %%"
 
 G1PrintRegionLivenessInfoClosure::G1PrintRegionLivenessInfoClosure(const char* phase_name) :
-  _total_used_bytes(0), _total_capacity_bytes(0),
-  _total_prev_live_bytes(0), _total_next_live_bytes(0),
-  _total_remset_bytes(0), _total_code_roots_bytes(0)
+  _total_used_bytes(0),
+  _total_capacity_bytes(0),
+  _total_live_bytes(0),
+  _total_remset_bytes(0),
+  _total_code_roots_bytes(0)
 {
   if (!log_is_enabled(Trace, gc, liveness)) {
     return;
@@ -2984,18 +2967,16 @@ G1PrintRegionLivenessInfoClosure::G1PrintRegionLivenessInfoClosure(const char* p
                           G1PPRL_ADDR_BASE_H_FORMAT
                           G1PPRL_BYTE_H_FORMAT
                           G1PPRL_BYTE_H_FORMAT
-                          G1PPRL_BYTE_H_FORMAT
                           G1PPRL_GCEFF_H_FORMAT
                           G1PPRL_BYTE_H_FORMAT
                           G1PPRL_STATE_H_FORMAT
                           G1PPRL_BYTE_H_FORMAT,
                           "type", "address-range",
-                          "used", "prev-live", "next-live", "gc-eff",
+                          "used", "live", "gc-eff",
                           "remset", "state", "code-roots");
   log_trace(gc, liveness)(G1PPRL_LINE_PREFIX
                           G1PPRL_TYPE_H_FORMAT
                           G1PPRL_ADDR_BASE_H_FORMAT
-                          G1PPRL_BYTE_H_FORMAT
                           G1PPRL_BYTE_H_FORMAT
                           G1PPRL_BYTE_H_FORMAT
                           G1PPRL_GCEFF_H_FORMAT
@@ -3003,7 +2984,7 @@ G1PrintRegionLivenessInfoClosure::G1PrintRegionLivenessInfoClosure(const char* p
                           G1PPRL_STATE_H_FORMAT
                           G1PPRL_BYTE_H_FORMAT,
                           "", "",
-                          "(bytes)", "(bytes)", "(bytes)", "(bytes/ms)",
+                          "(bytes)", "(bytes)", "(bytes/ms)",
                           "(bytes)", "", "(bytes)");
 }
 
@@ -3017,8 +2998,7 @@ bool G1PrintRegionLivenessInfoClosure::do_heap_region(HeapRegion* r) {
   HeapWord* end          = r->end();
   size_t capacity_bytes  = r->capacity();
   size_t used_bytes      = r->used();
-  size_t prev_live_bytes = r->live_bytes();
-  size_t next_live_bytes = r->next_live_bytes();
+  size_t live_bytes      = r->live_bytes();
   double gc_eff          = r->gc_efficiency();
   size_t remset_bytes    = r->rem_set()->mem_size();
   size_t code_roots_bytes = r->rem_set()->code_roots_mem_size();
@@ -3027,8 +3007,7 @@ bool G1PrintRegionLivenessInfoClosure::do_heap_region(HeapRegion* r) {
 
   _total_used_bytes      += used_bytes;
   _total_capacity_bytes  += capacity_bytes;
-  _total_prev_live_bytes += prev_live_bytes;
-  _total_next_live_bytes += next_live_bytes;
+  _total_live_bytes      += live_bytes;
   _total_remset_bytes    += remset_bytes;
   _total_code_roots_bytes += code_roots_bytes;
 
@@ -3044,13 +3023,12 @@ bool G1PrintRegionLivenessInfoClosure::do_heap_region(HeapRegion* r) {
                         G1PPRL_ADDR_BASE_FORMAT
                         G1PPRL_BYTE_FORMAT
                         G1PPRL_BYTE_FORMAT
-                        G1PPRL_BYTE_FORMAT
                         G1PPRL_GCEFF_FORMAT
                         G1PPRL_BYTE_FORMAT
                         G1PPRL_STATE_FORMAT
                         G1PPRL_BYTE_FORMAT,
                         type, p2i(bottom), p2i(end),
-                        used_bytes, prev_live_bytes, next_live_bytes, gc_efficiency.buffer(),
+                        used_bytes, live_bytes, gc_efficiency.buffer(),
                         remset_bytes, remset_type, code_roots_bytes);
 
   return false;
@@ -3069,17 +3047,14 @@ G1PrintRegionLivenessInfoClosure::~G1PrintRegionLivenessInfoClosure() {
                          " SUMMARY"
                          G1PPRL_SUM_MB_FORMAT("capacity")
                          G1PPRL_SUM_MB_PERC_FORMAT("used")
-                         G1PPRL_SUM_MB_PERC_FORMAT("prev-live")
-                         G1PPRL_SUM_MB_PERC_FORMAT("next-live")
+                         G1PPRL_SUM_MB_PERC_FORMAT("live")
                          G1PPRL_SUM_MB_FORMAT("remset")
                          G1PPRL_SUM_MB_FORMAT("code-roots"),
                          bytes_to_mb(_total_capacity_bytes),
                          bytes_to_mb(_total_used_bytes),
                          percent_of(_total_used_bytes, _total_capacity_bytes),
-                         bytes_to_mb(_total_prev_live_bytes),
-                         percent_of(_total_prev_live_bytes, _total_capacity_bytes),
-                         bytes_to_mb(_total_next_live_bytes),
-                         percent_of(_total_next_live_bytes, _total_capacity_bytes),
+                         bytes_to_mb(_total_live_bytes),
+                         percent_of(_total_live_bytes, _total_capacity_bytes),
                          bytes_to_mb(_total_remset_bytes),
                          bytes_to_mb(_total_code_roots_bytes));
 }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -216,7 +216,7 @@ private:
 // Root MemRegions are memory areas that contain objects which references are
 // roots wrt to the marking. They must be scanned before marking to maintain the
 // SATB invariant.
-// Typically they contain the areas from nTAMS to top of the regions.
+// Typically they contain the areas from TAMS to top of the regions.
 // We could scan and mark through these objects during the concurrent start pause,
 // but for pause time reasons we move this work to the concurrent phase.
 // We need to complete this procedure before the next GC because it might determine
@@ -292,10 +292,7 @@ class G1ConcurrentMark : public CHeapObj<mtGC> {
   G1CollectedHeap*        _g1h;           // The heap
 
   // Concurrent marking support structures
-  G1CMBitMap              _mark_bitmap_1;
-  G1CMBitMap              _mark_bitmap_2;
-  G1CMBitMap*             _prev_mark_bitmap; // Completed mark bitmap
-  G1CMBitMap*             _next_mark_bitmap; // Under-construction mark bitmap
+  G1CMBitMap              _mark_bitmap;
 
   // Heap bounds
   MemRegion const         _heap;
@@ -443,7 +440,7 @@ class G1ConcurrentMark : public CHeapObj<mtGC> {
 
   // Clear the next marking bitmap in parallel using the given WorkerThreads. If may_yield is
   // true, periodically insert checks to see if this method should exit prematurely.
-  void clear_next_bitmap(WorkerThreads* workers, bool may_yield);
+  void clear_bitmap(WorkerThreads* workers, bool may_yield);
 
   // Region statistics gathered during marking.
   G1RegionMarkStats* _region_mark_stats;
@@ -457,7 +454,7 @@ class G1ConcurrentMark : public CHeapObj<mtGC> {
 public:
   void add_to_liveness(uint worker_id, oop const obj, size_t size);
   // Live words in the given region as determined by concurrent marking, i.e. the amount of
-  // live words between bottom and nTAMS.
+  // live words between bottom and TAMS.
   size_t live_words(uint region) const { return _region_mark_stats[region]._live_words; }
   // Returns the liveness value in bytes.
   size_t live_bytes(uint region) const { return live_words(region) * HeapWordSize; }
@@ -516,14 +513,12 @@ public:
   bool try_stealing(uint worker_id, G1TaskQueueEntry& task_entry);
 
   G1ConcurrentMark(G1CollectedHeap* g1h,
-                   G1RegionToSpaceMapper* prev_bitmap_storage,
-                   G1RegionToSpaceMapper* next_bitmap_storage);
+                   G1RegionToSpaceMapper* bitmap_storage);
   ~G1ConcurrentMark();
 
   G1ConcurrentMarkThread* cm_thread() { return _cm_thread; }
 
-  const G1CMBitMap* const prev_mark_bitmap() const { return _prev_mark_bitmap; }
-  G1CMBitMap* next_mark_bitmap() const { return _next_mark_bitmap; }
+  G1CMBitMap* mark_bitmap() const { return (G1CMBitMap*)&_mark_bitmap; }
 
   // Calculates the number of concurrent GC threads to be used in the marking phase.
   uint calc_active_marking_workers();
@@ -540,7 +535,7 @@ public:
   void cleanup_for_next_mark();
 
   // Clear the next marking bitmap during safepoint.
-  void clear_next_bitmap(WorkerThreads* workers);
+  void clear_bitmap(WorkerThreads* workers);
 
   // These two methods do the work that needs to be done at the start and end of the
   // concurrent start pause.
@@ -563,19 +558,16 @@ public:
 
   void remark();
 
-  void swap_mark_bitmaps();
-
   void cleanup();
-  // Mark in the previous bitmap. Caution: the prev bitmap is usually read-only, so use
-  // this carefully.
-  inline void par_mark_in_prev_bitmap(oop p);
 
-  // Clears marks for all objects in the given range, for the prev or
-  // next bitmaps.  Caution: the previous bitmap is usually
-  // read-only, so use this carefully!
-  void clear_range_in_prev_bitmap(MemRegion mr);
+  // Mark in the marking bitmap. Used during evacuation failure to
+  // remember what objects need handling. Not for use during marking.
+  inline void raw_mark_in_bitmap(oop p);
 
-  inline bool is_marked_in_prev_bitmap(oop p) const;
+  // Clears marks for all objects in the given range in the marking
+  // bitmap. This should only be used clean the bitmap during a
+  // safepoint.
+  void clear_range_in_bitmap(MemRegion mr);
 
   // Verify that there are no collection set oops on the stacks (taskqueues /
   // global mark stack) and fingers (global / per-task).
@@ -592,17 +584,18 @@ public:
 
   void print_on_error(outputStream* st) const;
 
-  // Mark the given object on the next bitmap if it is below nTAMS.
-  inline bool mark_in_next_bitmap(uint worker_id, HeapRegion* const hr, oop const obj);
-  inline bool mark_in_next_bitmap(uint worker_id, oop const obj);
+  // Mark the given object on the marking bitmap if it is below TAMS.
+  inline bool mark_in_bitmap(uint worker_id, HeapRegion* const hr, oop const obj);
+  inline bool mark_in_bitmap(uint worker_id, oop const obj);
 
-  inline bool is_marked_in_next_bitmap(oop p) const;
+  inline bool is_marked_in_bitmap(oop p) const;
 
   ConcurrentGCTimer* gc_timer_cm() const { return _gc_timer_cm; }
 
 private:
-  // Rebuilds the remembered sets for chosen regions in parallel and concurrently to the application.
-  void rebuild_rem_set_concurrently();
+  // Rebuilds the remembered sets for chosen regions in parallel and concurrently
+  // to the application. Also scrubs dead objects to ensure region is parsable.
+  void rebuild_and_scrub();
 
   uint needs_remembered_set_rebuild() const { return _needs_remembered_set_rebuild; }
 
@@ -627,7 +620,7 @@ private:
   uint                        _worker_id;
   G1CollectedHeap*            _g1h;
   G1ConcurrentMark*           _cm;
-  G1CMBitMap*                 _next_mark_bitmap;
+  G1CMBitMap*                 _mark_bitmap;
   // the task queue of this task
   G1CMTaskQueue*              _task_queue;
 
@@ -733,7 +726,7 @@ public:
   // scanned.
   inline size_t scan_objArray(objArrayOop obj, MemRegion mr);
   // Resets the task; should be called right at the beginning of a marking phase.
-  void reset(G1CMBitMap* next_mark_bitmap);
+  void reset(G1CMBitMap* mark_bitmap);
   // Clears all the fields that correspond to a claimed region.
   void clear_region_fields();
 
@@ -777,14 +770,14 @@ public:
   void increment_refs_reached() { ++_refs_reached; }
 
   // Grey the object by marking it.  If not already marked, push it on
-  // the local queue if below the finger. obj is required to be below its region's NTAMS.
+  // the local queue if below the finger. obj is required to be below its region's TAMS.
   // Returns whether there has been a mark to the bitmap.
   inline bool make_reference_grey(oop obj);
 
   // Grey the object (by calling make_grey_reference) if required,
-  // e.g. obj is below its containing region's NTAMS.
+  // e.g. obj is below its containing region's TAMS.
   // Precondition: obj is a valid heap object.
-  // Returns true if the reference caused a mark to be set in the next bitmap.
+  // Returns true if the reference caused a mark to be set in the marking bitmap.
   template <class T>
   inline bool deal_with_reference(T* p);
 
@@ -841,7 +834,7 @@ class G1PrintRegionLivenessInfoClosure : public HeapRegionClosure {
   // Accumulators for these values.
   size_t _total_used_bytes;
   size_t _total_capacity_bytes;
-  size_t _total_prev_live_bytes;
+  size_t _total_live_bytes;
   size_t _total_next_live_bytes;
 
   // Accumulator for the remembered set size

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -452,7 +452,9 @@ class G1ConcurrentMark : public CHeapObj<mtGC> {
   // True when Remark pause selected regions for rebuilding.
   bool _needs_remembered_set_rebuild;
 public:
-  void add_to_liveness(uint worker_id, oop const obj, size_t size);
+  // To be called when an object is marked the first time, e.g. after a successful
+  // mark_in_bitmap call. Updates various statistics data.
+  void new_obj_marked(uint worker_id, oop const obj, size_t size);
   // Live words in the given region as determined by concurrent marking, i.e. the amount of
   // live words between bottom and TAMS.
   size_t live_words(uint region) const { return _region_mark_stats[region]._live_words; }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ inline bool G1CMIsAliveClosure::do_object_b(oop obj) {
 
   HeapRegion* hr = _g1h->heap_region_containing(cast_from_oop<HeapWord*>(obj));
   // All objects allocated since the start of marking are considered live.
-  if (hr->obj_allocated_since_next_marking(obj)) {
+  if (hr->obj_allocated_since_marking_start(obj)) {
     return true;
   }
 
@@ -75,25 +75,26 @@ inline bool G1CMSubjectToDiscoveryClosure::do_object_b(oop obj) {
   return _g1h->heap_region_containing(obj)->is_old_or_humongous_or_archive();
 }
 
-inline bool G1ConcurrentMark::mark_in_next_bitmap(uint const worker_id, oop const obj) {
+inline bool G1ConcurrentMark::mark_in_bitmap(uint const worker_id, oop const obj) {
   HeapRegion* const hr = _g1h->heap_region_containing(obj);
-  return mark_in_next_bitmap(worker_id, hr, obj);
+  return mark_in_bitmap(worker_id, hr, obj);
 }
 
-inline bool G1ConcurrentMark::mark_in_next_bitmap(uint const worker_id, HeapRegion* const hr, oop const obj) {
+inline bool G1ConcurrentMark::mark_in_bitmap(uint const worker_id, HeapRegion* const hr, oop const obj) {
   assert(hr != NULL, "just checking");
   assert(hr->is_in_reserved(obj), "Attempting to mark object at " PTR_FORMAT " that is not contained in the given region %u", p2i(obj), hr->hrm_index());
 
-  if (hr->obj_allocated_since_next_marking(obj)) {
+  if (hr->obj_allocated_since_marking_start(obj)) {
     return false;
   }
 
-  // Some callers may have stale objects to mark above nTAMS after humongous reclaim.
+  // Some callers may have stale objects to mark above TAMS after humongous reclaim.
   // Can't assert that this is a valid object at this point, since it might be in the process of being copied by another thread.
-  assert(!hr->is_continues_humongous(), "Should not try to mark object " PTR_FORMAT " in Humongous continues region %u above nTAMS " PTR_FORMAT, p2i(obj), hr->hrm_index(), p2i(hr->next_top_at_mark_start()));
+  assert(!hr->is_continues_humongous(), "Should not try to mark object " PTR_FORMAT " in Humongous continues region %u above TAMS " PTR_FORMAT, p2i(obj), hr->hrm_index(), p2i(hr->top_at_mark_start()));
 
-  bool success = _next_mark_bitmap->par_mark(obj);
+  bool success = _mark_bitmap.par_mark(obj);
   if (success) {
+    _mark_bitmap.update_back_skip_table(obj);
     add_to_liveness(worker_id, obj, obj->size());
   }
   return success;
@@ -129,7 +130,7 @@ inline void G1CMTask::push(G1TaskQueueEntry task_entry) {
   assert(task_entry.is_array_slice() || _g1h->is_in_reserved(task_entry.obj()), "invariant");
   assert(task_entry.is_array_slice() || !_g1h->is_on_master_free_list(
               _g1h->heap_region_containing(task_entry.obj())), "invariant");
-  assert(task_entry.is_array_slice() || _next_mark_bitmap->is_marked(cast_from_oop<HeapWord*>(task_entry.obj())), "invariant");
+  assert(task_entry.is_array_slice() || _mark_bitmap->is_marked(cast_from_oop<HeapWord*>(task_entry.obj())), "invariant");
 
   if (!_task_queue->push(task_entry)) {
     // The local task queue looks full. We need to push some entries
@@ -177,7 +178,7 @@ inline bool G1CMTask::is_below_finger(oop obj, HeapWord* global_finger) const {
 template<bool scan>
 inline void G1CMTask::process_grey_task_entry(G1TaskQueueEntry task_entry) {
   assert(scan || (task_entry.is_oop() && task_entry.obj()->is_typeArray()), "Skipping scan of grey non-typeArray");
-  assert(task_entry.is_array_slice() || _next_mark_bitmap->is_marked(cast_from_oop<HeapWord*>(task_entry.obj())),
+  assert(task_entry.is_array_slice() || _mark_bitmap->is_marked(cast_from_oop<HeapWord*>(task_entry.obj())),
          "Any stolen object should be a slice or marked");
 
   if (scan) {
@@ -234,7 +235,7 @@ inline void G1CMTask::abort_marking_if_regular_check_fail() {
 }
 
 inline bool G1CMTask::make_reference_grey(oop obj) {
-  if (!_cm->mark_in_next_bitmap(_worker_id, obj)) {
+  if (!_cm->mark_in_bitmap(_worker_id, obj)) {
     return false;
   }
 
@@ -286,18 +287,13 @@ inline bool G1CMTask::deal_with_reference(T* p) {
   return make_reference_grey(obj);
 }
 
-inline void G1ConcurrentMark::par_mark_in_prev_bitmap(oop p) {
-  _prev_mark_bitmap->par_mark(p);
+inline void G1ConcurrentMark::raw_mark_in_bitmap(oop p) {
+  _mark_bitmap.par_mark(p);
 }
 
-bool G1ConcurrentMark::is_marked_in_prev_bitmap(oop p) const {
+bool G1ConcurrentMark::is_marked_in_bitmap(oop p) const {
   assert(p != NULL && oopDesc::is_oop(p), "expected an oop");
-  return _prev_mark_bitmap->is_marked(cast_from_oop<HeapWord*>(p));
-}
-
-bool G1ConcurrentMark::is_marked_in_next_bitmap(oop p) const {
-  assert(p != NULL && oopDesc::is_oop(p), "expected an oop");
-  return _next_mark_bitmap->is_marked(cast_from_oop<HeapWord*>(p));
+  return _mark_bitmap.is_marked(cast_from_oop<HeapWord*>(p));
 }
 
 inline bool G1ConcurrentMark::do_yield_check() {

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
@@ -94,8 +94,7 @@ inline bool G1ConcurrentMark::mark_in_bitmap(uint const worker_id, HeapRegion* c
 
   bool success = _mark_bitmap.par_mark(obj);
   if (success) {
-    _mark_bitmap.update_back_skip_table(obj);
-    add_to_liveness(worker_id, obj, obj->size());
+    new_obj_marked(worker_id, obj, obj->size());
   }
   return success;
 }
@@ -224,8 +223,9 @@ inline void G1CMTask::update_liveness(oop const obj, const size_t obj_size) {
   _mark_stats_cache.add_live_words(_g1h->addr_to_region(cast_from_oop<HeapWord*>(obj)), obj_size);
 }
 
-inline void G1ConcurrentMark::add_to_liveness(uint worker_id, oop const obj, size_t size) {
+inline void G1ConcurrentMark::new_obj_marked(uint worker_id, oop const obj, size_t size) {
   task(worker_id)->update_liveness(obj, size);
+  _mark_bitmap.update_back_skip_table(obj);
 }
 
 inline void G1CMTask::abort_marking_if_regular_check_fail() {

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkBitMap.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkBitMap.hpp
@@ -113,8 +113,9 @@ public:
 
   // Return the address corresponding to the previous marked bit at or before
   // "addr", and after or at "limit". If there is no such bit, returns nullptr.
-  // Uses the back scan skip table to speed up the process, which must be
-  // properly initialized.
+  // Uses the back scan skip table to speed up the process in case of large areas
+  // without marked objects. The back scan skip table is expected to be properly
+  // initialized.
   inline HeapWord* get_prev_marked_addr(HeapWord* limit,
                                         const HeapWord* addr) const;
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkBitMap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkBitMap.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,25 +31,93 @@
 #include "memory/memRegion.hpp"
 #include "utilities/align.hpp"
 #include "utilities/bitMap.inline.hpp"
+#include "gc/g1/g1ConcurrentRefine.hpp"
 
-inline bool G1CMBitMap::iterate(G1CMBitMapClosure* cl, MemRegion mr) {
-  assert(!mr.is_empty(), "Does not support empty memregion to iterate over");
-  assert(_covered.contains(mr),
-         "Given MemRegion from " PTR_FORMAT " to " PTR_FORMAT " not contained in heap area",
-         p2i(mr.start()), p2i(mr.end()));
-
-  BitMap::idx_t const end_offset = addr_to_offset(mr.end());
-  BitMap::idx_t offset = _bm.get_next_one_offset(addr_to_offset(mr.start()), end_offset);
-
-  while (offset < end_offset) {
-    HeapWord* const addr = offset_to_addr(offset);
-    if (!cl->do_addr(addr)) {
-      return false;
-    }
-    size_t const obj_size = cast_to_oop(addr)->size();
-    offset = _bm.get_next_one_offset(offset + (obj_size >> _shifter), end_offset);
+inline void G1CMBackScanSkipTable::mark(HeapWord* const addr) {
+  if (!get_by_address(addr)) {
+    set_by_address(addr, true);
   }
-  return true;
+}
+
+inline HeapWord* G1CMBackScanSkipTable::find_marked_area(HeapWord* const bottom, HeapWord* const start) const {
+  assert(bottom != nullptr, "must be");
+  assert(is_aligned(bottom, mapping_granularity()), "must be");
+  assert(is_aligned(start, mapping_granularity()), "must be");
+
+  bool* cur = address_mapped_to(start - 1);
+  bool* bot = address_mapped_to(bottom);
+  assert(cur >= bot, "must be");
+
+  while (cur >= bot) {
+    if (*cur) {
+      idx_t index = pointer_delta(cur, bot, sizeof(bool));
+      HeapWord* result = bottom + index * mapping_granularity() / HeapWordSize;
+      return result;
+    }
+    cur--;
+  }
+  return nullptr;
+}
+
+inline bool G1CMBitMap::is_marked(oop obj) const { return _bitmap.is_marked(obj); }
+inline bool G1CMBitMap::is_marked(HeapWord* addr) const { return _bitmap.is_marked(addr); }
+
+inline bool G1CMBitMap::iterate(MarkBitMapClosure* cl, MemRegion mr) {
+  return _bitmap.iterate(cl, mr);
+}
+
+inline HeapWord* G1CMBitMap::get_next_marked_addr(const HeapWord* addr,
+                                                  HeapWord* const limit) const {
+  return _bitmap.get_next_marked_addr(addr, limit);
+}
+
+inline HeapWord* G1CMBitMap::get_prev_marked_addr(HeapWord* const limit,
+                                                  const HeapWord* addr) const {
+  const size_t BackSkipGranularity = _back_scan_skip_table.mapping_granularity();
+  assert((uintptr_t)addr >= BackSkipGranularity, "must be");
+
+  // Scan at least half of the backskip size immediately before trying to use it
+  // as setup is a bit expensive and it is extremely likely that there is a marked
+  // object in close vicinity.
+  HeapWord* scan_until_directly = MAX2(limit,
+                                       (HeapWord*)align_down((uintptr_t)addr - BackSkipGranularity / 2, BackSkipGranularity));
+  HeapWord* result = _bitmap.get_prev_marked_addr(scan_until_directly, addr);
+  if (result == nullptr) {
+    // No previous marked object found when scanning until scan_until_directly. If scan_until_directly
+    // is limit, then we are done - we could not find any mark in this region.
+    if (scan_until_directly == limit) {
+      return nullptr;
+    }
+    // Then use the back skip table to jump over large areas in the bitmap.
+    HeapWord* bottom_with_mark = _back_scan_skip_table.find_marked_area(limit, scan_until_directly);
+    assert(bottom_with_mark < scan_until_directly, "must scan backward");
+    // If no mark found with the backskip table either, we are done.
+    if (bottom_with_mark == nullptr) {
+      return nullptr;
+    }
+    // In the current backskip area there must be a mark. Find the first on the bitmap.
+    result = _bitmap.get_prev_marked_addr(bottom_with_mark, bottom_with_mark + BackSkipGranularity / HeapWordSize);
+    assert(result != nullptr, "must be");
+    assert(result >= bottom_with_mark, "result " PTR_FORMAT " beyond lower range " PTR_FORMAT,
+           p2i(result), p2i(bottom_with_mark));
+    assert(_bitmap.get_prev_marked_addr(result, addr) == result, "scanning directly must yield same result");
+  }
+
+  return result;
+}
+
+inline void G1CMBitMap::clear(HeapWord* addr) { _bitmap.clear(addr); }
+inline void G1CMBitMap::clear(oop obj) { _bitmap.clear(obj); }
+inline bool G1CMBitMap::par_mark(HeapWord* addr) { return _bitmap.par_mark(addr); }
+inline bool G1CMBitMap::par_mark(oop obj) { return _bitmap.par_mark(obj); }
+
+inline void G1CMBitMap::update_back_skip_table(oop obj) {
+  _back_scan_skip_table.mark(cast_from_oop<HeapWord*>(obj));
+}
+
+inline void G1CMBitMap::clear_range(MemRegion mr) {
+  _bitmap.clear_range(mr);
+  _back_scan_skip_table.clear_range(mr);
 }
 
 #endif // SHARE_GC_G1_G1CONCURRENTMARKBITMAP_INLINE_HPP

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -233,9 +233,9 @@ bool G1ConcurrentMarkThread::subphase_remark() {
   return _cm->has_aborted();
 }
 
-bool G1ConcurrentMarkThread::phase_rebuild_remembered_sets() {
-  G1ConcPhaseTimer p(_cm, "Concurrent Rebuild Remembered Sets");
-  _cm->rebuild_rem_set_concurrently();
+bool G1ConcurrentMarkThread::phase_rebuild_and_scrub() {
+  G1ConcPhaseTimer p(_cm, "Concurrent Rebuild Remembered Sets and Scrub Regions");
+  _cm->rebuild_and_scrub();
   return _cm->has_aborted();
 }
 
@@ -290,8 +290,8 @@ void G1ConcurrentMarkThread::concurrent_mark_cycle_do() {
   // Phase 3: Actual mark loop.
   if (phase_mark_loop()) return;
 
-  // Phase 4: Rebuild remembered sets.
-  if (phase_rebuild_remembered_sets()) return;
+  // Phase 4: Rebuild remembered sets and scrub dead objects.
+  if (phase_rebuild_and_scrub()) return;
 
   // Phase 5: Wait for Cleanup.
   if (phase_delay_to_keep_mmu_before_cleanup()) return;

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ class G1ConcurrentMarkThread: public ConcurrentGCThread {
   bool subphase_delay_to_keep_mmu_before_remark();
   bool subphase_remark();
 
-  bool phase_rebuild_remembered_sets();
+  bool phase_rebuild_and_scrub();
   bool phase_delay_to_keep_mmu_before_cleanup();
   bool phase_cleanup();
   bool phase_clear_bitmap_for_next_mark();

--- a/src/hotspot/share/gc/g1/g1ConcurrentRebuildAndScrub.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentRebuildAndScrub.cpp
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+
+#include "gc/g1/g1ConcurrentRebuildAndScrub.hpp"
+
+#include "gc/g1/g1ConcurrentMark.inline.hpp"
+#include "gc/g1/g1ConcurrentMarkBitMap.inline.hpp"
+#include "gc/g1/g1_globals.hpp"
+#include "gc/g1/heapRegion.inline.hpp"
+#include "gc/g1/heapRegionManager.inline.hpp"
+#include "gc/shared/suspendibleThreadSet.hpp"
+#include "gc/shared/workerThread.hpp"
+#include "logging/log.hpp"
+#include "memory/memRegion.hpp"
+#include "oops/oopsHierarchy.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+// Worker task that scans the objects in the old generation to rebuild the remembered
+// set and at the same time scrubs dead objects by replacing them with filler objects
+// to make them completely parseable.
+//
+// The remark pause recorded two pointers within the regions:
+//
+// parsable_bottom: this is the TAMS of the recent marking for that region. Objects
+//                  below that may or may not be dead (as per mark bitmap).
+//                  This task needs to remove the dead objects, replacing them
+//                  with filler objects so that they can be walked through later.
+//
+// top_at_rebuild_start (tars): at rebuild phase start we record the current top: up to
+//                              this address (live) objects need to be scanned for references
+//                              that might need to be added to the remembered sets.
+//
+// Note that bottom <= parsable_bottom <= tars; if there is no tars (i.e. NULL),
+// obviously there can not be a parsable_bottom.
+//
+// We need to scrub and scan objects to rebuild remembered sets until parsable_bottom;
+// we need to scan objects to rebuild remembered sets until tars.
+class G1RebuildRSAndScrubTask : public WorkerTask {
+  G1ConcurrentMark* _cm;
+  HeapRegionClaimer _hr_claimer;
+
+  class G1RebuildRSAndScrubRegionClosure : public HeapRegionClosure {
+    G1ConcurrentMark* _cm;
+    const G1CMBitMap* _bitmap;
+
+    G1RebuildRemSetClosure _rebuild_closure;
+
+    size_t _marked_words;
+    size_t _processed_words;
+    const size_t ProcessingYieldLimitInWords = G1RebuildRemSetChunkSize / HeapWordSize;
+
+    void reset_marked_words() {
+      _marked_words = 0;
+    }
+
+    void reset_processed_words() {
+      _processed_words = 0;
+    }
+
+    void assert_marked_words(HeapRegion* hr) {
+      assert((_marked_words * HeapWordSize) == hr->marked_bytes(),
+             "Mismatch between marking and re-calculation for region %u, %zu != %zu",
+             hr->hrm_index(), (_marked_words * HeapWordSize), hr->marked_bytes());
+    }
+
+    void add_processed_words(size_t processed) {
+      _processed_words += processed;
+      _marked_words += processed;
+    }
+
+    // Yield if enough has been processed; returns if the concurrent marking cycle
+    // has been aborted for any reason.
+    bool yield_if_necessary() {
+      if (_processed_words >= ProcessingYieldLimitInWords) {
+        reset_processed_words();
+        _cm->do_yield_check();
+      }
+      return _cm->has_aborted();
+    }
+
+    // Checks the top at rebuild start value for the given region. If the value
+    // is NULL the region has either:
+    //  - been allocated after rebuild start, or
+    //  - been eagerly reclaimed by a young collection (only humongous)
+    // In these cases we do not need to scan through the given region.
+    bool should_rebuild_or_scrub(HeapRegion* hr) {
+      return _cm->top_at_rebuild_start(hr->hrm_index()) != NULL;
+    }
+
+    // Helper used by both humongous objects and when chunking an object larger than the
+    // G1RebuildRemSetChunkSize. The heap region is needed to ensure a humongous object
+    // is not eagerly reclaimed during yielding.
+    // Returns whether marking has been aborted.
+    bool scan_large_object(HeapRegion* hr, const oop obj, MemRegion scan_range) {
+      HeapWord* start = scan_range.start();
+      HeapWord* limit = scan_range.end();
+      do {
+        MemRegion mr(start, MIN2(start + ProcessingYieldLimitInWords, limit));
+        obj->oop_iterate(&_rebuild_closure, mr);
+
+        // Update processed words and yield, for humongous objects we will yield
+        // after each chunk.
+        add_processed_words(mr.word_size());
+        bool mark_aborted = yield_if_necessary();
+        if (mark_aborted) {
+          return true;
+        } else if (!should_rebuild_or_scrub(hr)) {
+          // We need to check should_rebuild_or_scrub() again (for humongous objects)
+          // because the region might have been eagerly reclaimed during the yield.
+          log_trace(gc, marking)("Rebuild aborted for eagerly reclaimed humongous region: %u", hr->hrm_index());
+          return false;
+        }
+
+        // Step to next chunk of the humongous object
+        start = mr.end();
+      } while (start < limit);
+      return false;
+    }
+
+    // Scan for references into regions that need remembered set update for the given
+    // live object. Returns the offset to the next object.
+    size_t scan_object(HeapRegion* hr, HeapWord* current) {
+      oop obj = cast_to_oop(current);
+      size_t obj_size = obj->size();
+
+      if (obj_size > ProcessingYieldLimitInWords) {
+        // Large object, needs to be chunked to avoid stalling safepoints.
+        MemRegion mr(current, obj_size);
+        scan_large_object(hr, obj, mr);
+        // No need to add to _processed_words, this is all handled by the above call;
+        // we also ignore the marking abort result of scan_large_object - we will check
+        // again right afterwards.
+      } else {
+        // Object smaller than yield limit, process it fully.
+        obj->oop_iterate(&_rebuild_closure);
+        // Update how much we have processed. Yield check in main loop
+        // will handle this case.
+        add_processed_words(obj_size);
+      }
+
+      return obj_size;
+    }
+
+    // Scrub a range of dead objects starting at scrub_start. Will never scrub past limit.
+    HeapWord* scrub_to_next_live(HeapRegion* hr, HeapWord* scrub_start, HeapWord* limit) {
+      assert(!_bitmap->is_marked(scrub_start), "Should not scrub live object");
+
+      HeapWord* scrub_end = _bitmap->get_next_marked_addr(scrub_start, limit);
+      if (scrub_start != scrub_end) {
+        // Only scrub if range is non-empty.
+        hr->fill_range_with_dead_objects(scrub_start, scrub_end);
+        assert(hr->obj_is_scrubbed(cast_to_oop(scrub_start)), "Scrubbing failed");
+      }
+
+      // At this point make sure we are either at the scrubbing limit or that the next
+      // object is live. Need to compare to the limit first to not accidentally query the
+      // bitmap outside the committed heap.
+      assert(scrub_end == limit || _bitmap->is_marked(scrub_end),
+             "We should either step to the next live object or the limit");
+
+      // Return the next object to handle.
+      return scrub_end;
+    }
+
+    // Scan the given region from bottom to parsable_bottom. Returns whether marking has
+    // been aborted.
+    bool scan_and_scrub_to_pb(HeapRegion* hr, HeapWord* start, HeapWord* const limit) {
+
+      while (start < limit) {
+        if (_bitmap->is_marked(start)) {
+          assert(!cast_to_oop(start)->is_gc_marked(), "No live objects in G1 should be GC marked");
+          //  Live object, need to scan to rebuild remembered sets for this object.
+          start += scan_object(hr, start);
+        } else {
+          // Found dead object (which klass has potentially been unloaded). Scrub to next
+          // marked object and continue.
+          start = scrub_to_next_live(hr, start, limit);
+        }
+
+        bool mark_aborted = yield_if_necessary();
+        if (mark_aborted) {
+          return true;
+        }
+      }
+
+      hr->note_end_of_scrubbing();
+      return false;
+    }
+
+    // Scan the given region from parsable_bottom to tars. Returns whether marking has
+    // been aborted.
+    bool scan_from_pb_to_tars(HeapRegion* hr, HeapWord* start, HeapWord* const limit) {
+
+      while (start < limit) {
+        start += scan_object(hr, start);
+        // Avoid stalling safepoints and stop iteration if mark cycle has been aborted.
+        bool mark_aborted = yield_if_necessary();
+        if (mark_aborted) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    // Scan and scrub the given region to tars. Returns whether marking has
+    // been aborted.
+    bool scan_and_scrub_region(HeapRegion* hr, HeapWord* const pb) {
+      assert(should_rebuild_or_scrub(hr), "must be");
+
+      reset_marked_words();
+      log_debug(gc, marking)("Scrub and rebuild region: " HR_FORMAT " pb: " PTR_FORMAT,
+                             HR_FORMAT_PARAMS(hr), p2i(pb));
+
+      if (scan_and_scrub_to_pb(hr, hr->bottom(), pb)) {
+        log_trace(gc, marking)("Scan and scrub aborted for region: %u", hr->hrm_index());
+        return true;
+      }
+
+      // Assert that the size of marked objects from the marking matches
+      // the size of the objects which we scanned to rebuild remembered sets.
+      assert_marked_words(hr);
+
+      // Rebuild from TAMS (= parsable_bottom) to TARS.
+      if (scan_from_pb_to_tars(hr, pb, _cm->top_at_rebuild_start(hr->hrm_index()))) {
+        log_trace(gc, marking)("Rebuild aborted for region: %u (%s)", hr->hrm_index(), hr->get_short_type_str());
+        return true;
+      }
+      return false;
+    }
+
+    // Scan a humongous region for remembered set updates. Scans in chunks to avoid
+    // stalling safepoints. Returns whether the concurrent marking phase has been aborted.
+    bool scan_humongous_region(HeapRegion* hr, HeapWord* const pb) {
+      assert(should_rebuild_or_scrub(hr), "must be");
+
+      // At this point we should only have live humongous objects, that
+      // means it must either be:
+      // - marked
+      // - or seen as fully parsable, i.e. allocated after the marking started
+      oop humongous = cast_to_oop(hr->humongous_start_region()->bottom());
+      assert(_bitmap->is_marked(humongous) || pb == hr->bottom(),
+             "Humongous object not live");
+
+      reset_marked_words();
+      log_debug(gc, marking)("Rebuild for humongous region: " HR_FORMAT " pb: " PTR_FORMAT " TARS: " PTR_FORMAT,
+                             HR_FORMAT_PARAMS(hr), p2i(pb), p2i(_cm->top_at_rebuild_start(hr->hrm_index())));
+
+      // Scan the humongous object in chunks from bottom to top to rebuild remembered sets.
+      HeapWord* humongous_end = hr->humongous_start_region()->bottom() + humongous->size();
+      MemRegion mr(hr->bottom(), MIN2(hr->top(), humongous_end));
+
+      bool mark_aborted = scan_large_object(hr, humongous, mr);
+      if (mark_aborted) {
+        log_trace(gc, marking)("Rebuild aborted for region: %u (%s)", hr->hrm_index(), hr->get_short_type_str());
+        return true;
+      } else if (_bitmap->is_marked(humongous) && should_rebuild_or_scrub(hr)) {
+        // Only verify that the marked size matches the rebuilt size if this object was marked
+        // and the object should still be handled. The should handle state can change during
+        // rebuild for humongous objects that are eagerly reclaimed so we need to check this.
+        // If the object has not been marked the size from marking will be 0.
+        assert_marked_words(hr);
+      }
+      return false;
+    }
+
+  public:
+    G1RebuildRSAndScrubRegionClosure(G1ConcurrentMark* cm, uint worker_id) :
+      _cm(cm),
+      _bitmap(_cm->mark_bitmap()),
+      _rebuild_closure(G1CollectedHeap::heap(), worker_id),
+      _marked_words(0),
+      _processed_words(0) { }
+
+    bool do_heap_region(HeapRegion* hr) {
+      // Avoid stalling safepoints and stop iteration if mark cycle has been aborted.
+      _cm->do_yield_check();
+      if (_cm->has_aborted()) {
+        return true;
+      }
+
+      HeapWord* const pb = hr->parsable_bottom_acquire();
+
+      if (!should_rebuild_or_scrub(hr)) {
+        // Region has been allocated during this phase, no need to either scrub or
+        // scan to rebuild remembered sets.
+        log_trace(gc, marking)("Scrub and rebuild region skipped for " HR_FORMAT " pb: " PTR_FORMAT,
+                               HR_FORMAT_PARAMS(hr), p2i(pb));
+        assert(hr->bottom() == pb, "Region must be fully parsable");
+        return false;
+      }
+
+      bool mark_aborted;
+      if (hr->needs_scrubbing()) {
+        // Old and open archive regions need to have their dead objects scrubbed
+        // to make sure the region is parsable using object sizes.
+        mark_aborted = scan_and_scrub_region(hr, pb);
+      } else if (hr->is_humongous()) {
+        // No need to scrub humongous, but we should scan it to rebuild remsets.
+        mark_aborted = scan_humongous_region(hr, pb);
+      }
+
+      return mark_aborted;
+    }
+  };
+
+public:
+  G1RebuildRSAndScrubTask(G1ConcurrentMark* cm, bool should_rebuild, uint num_workers) :
+    WorkerTask("Scrub dead objects"),
+    _cm(cm),
+    _hr_claimer(num_workers) { }
+
+  void work(uint worker_id) {
+    SuspendibleThreadSetJoiner sts_join;
+
+    G1CollectedHeap* g1h = G1CollectedHeap::heap();
+    G1RebuildRSAndScrubRegionClosure cl(_cm, worker_id);
+    g1h->heap_region_par_iterate_from_worker_offset(&cl, &_hr_claimer, worker_id);
+  }
+};
+
+void G1ConcurrentRebuildAndScrub::rebuild_and_scrub(G1ConcurrentMark* cm, WorkerThreads* workers) {
+  uint num_workers = workers->active_workers();
+
+  G1RebuildRSAndScrubTask task(cm, true, num_workers);
+  workers->run_task(&task, num_workers);
+}

--- a/src/hotspot/share/gc/g1/g1ConcurrentRebuildAndScrub.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentRebuildAndScrub.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,20 +22,21 @@
  *
  */
 
-#ifndef SHARE_GC_SHARED_VERIFYOPTION_HPP
-#define SHARE_GC_SHARED_VERIFYOPTION_HPP
+#ifndef SHARE_GC_G1_G1CONCURRENTREBUILDANDSCRUB_HPP
+#define SHARE_GC_G1_G1CONCURRENTREBUILDANDSCRUB_HPP
 
-#include "utilities/globalDefinitions.hpp"
+#include "memory/allStatic.hpp"
 
-enum class VerifyOption : uint {
-  Default = 0,
+class G1ConcurrentMark;
+class WorkerThreads;
 
-  // G1
-  // Use mark bitmap information (from concurrent marking) using TAMS.
-  G1UseConcMarking = Default,
-  // Use mark bitmap information from full gc marking. This does not
-  // use (or need) TAMS.
-  G1UseFullMarking = G1UseConcMarking + 1
+// Rebuild and scrubbing helper class.
+class G1ConcurrentRebuildAndScrub : AllStatic {
+public:
+
+  static void rebuild_and_scrub(G1ConcurrentMark* cm, WorkerThreads* workers);
 };
 
-#endif // SHARE_GC_SHARED_VERIFYOPTION_HPP
+
+#endif /* SHARE_GC_G1_G1CONCURRENTREBUILDANDSCRUB_HPP */
+

--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -79,9 +79,9 @@ public:
 
     assert(_cm->is_marked_in_bitmap(obj), "should be correctly marked");
     if (_during_concurrent_start) {
-      // If the evacuation failure occurs during concurrent start we should add
-      // the liveness, because these marks will be kept.
-      _cm->add_to_liveness(_worker_id, obj, obj_size);
+      // If the evacuation failure occurs during concurrent start we should do
+      // any additional necessary per-object actions.
+      _cm->new_obj_marked(_worker_id, obj, obj_size);
     }
 
     _marked_words += obj_size;

--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -68,6 +68,7 @@ public:
   // dead too) already.
   size_t apply(oop obj) {
     HeapWord* obj_addr = cast_from_oop<HeapWord*>(obj);
+    size_t obj_size = obj->size();
     assert(_last_forwarded_object_end <= obj_addr, "should iterate in ascending address order");
     assert(_hr->is_in(obj_addr), "sanity");
 
@@ -76,21 +77,12 @@ public:
 
     zap_dead_objects(_last_forwarded_object_end, obj_addr);
 
-    assert(_cm->is_marked_in_prev_bitmap(obj), "should be correctly marked");
+    assert(_cm->is_marked_in_bitmap(obj), "should be correctly marked");
     if (_during_concurrent_start) {
-      // For the next marking info we'll only mark the
-      // self-forwarded objects explicitly if we are during
-      // concurrent start (since, normally, we only mark objects pointed
-      // to by roots if we succeed in copying them). By marking all
-      // self-forwarded objects we ensure that we mark any that are
-      // still pointed to be roots. During concurrent marking, and
-      // after concurrent start, we don't need to mark any objects
-      // explicitly and all objects in the CSet are considered
-      // (implicitly) live. So, we won't mark them explicitly and
-      // we'll leave them over NTAMS.
-      _cm->mark_in_next_bitmap(_worker_id, obj);
+      // If the evacuation failure occurs during concurrent start we should add
+      // the liveness, because these marks will be kept.
+      _cm->add_to_liveness(_worker_id, obj, obj_size);
     }
-    size_t obj_size = obj->size();
 
     _marked_words += obj_size;
     // Reset the markWord
@@ -103,37 +95,13 @@ public:
   }
 
   // Fill the memory area from start to end with filler objects, and update the BOT
-  // accordingly. Since we clear and use the prev bitmap for marking objects that
-  // failed evacuation, there is no work to be done there.
+  // accordingly.
   void zap_dead_objects(HeapWord* start, HeapWord* end) {
     if (start == end) {
       return;
     }
 
-    size_t gap_size = pointer_delta(end, start);
-    MemRegion mr(start, gap_size);
-    if (gap_size >= CollectedHeap::min_fill_size()) {
-      CollectedHeap::fill_with_objects(start, gap_size);
-
-      HeapWord* end_first_obj = start + cast_to_oop(start)->size();
-      _hr->update_bot_for_block(start, end_first_obj);
-      // Fill_with_objects() may have created multiple (i.e. two)
-      // objects, as the max_fill_size() is half a region.
-      // After updating the BOT for the first object, also update the
-      // BOT for the second object to make the BOT complete.
-      if (end_first_obj != end) {
-        _hr->update_bot_for_block(end_first_obj, end);
-#ifdef ASSERT
-        size_t size_second_obj = cast_to_oop(end_first_obj)->size();
-        HeapWord* end_of_second_obj = end_first_obj + size_second_obj;
-        assert(end == end_of_second_obj,
-               "More than two objects were used to fill the area from " PTR_FORMAT " to " PTR_FORMAT ", "
-               "second objects size " SIZE_FORMAT " ends at " PTR_FORMAT,
-               p2i(start), p2i(end), size_second_obj, p2i(end_of_second_obj));
-#endif
-      }
-    }
-    assert(!_cm->is_marked_in_prev_bitmap(cast_to_oop(start)), "should not be marked in prev bitmap");
+    _hr->fill_range_with_dead_objects(start, end);
   }
 
   void zap_remainder() {
@@ -164,12 +132,24 @@ public:
                                         during_concurrent_start,
                                         _worker_id);
 
-    // All objects that failed evacuation has been marked in the prev bitmap.
+    // All objects that failed evacuation has been marked in the bitmap.
     // Use the bitmap to apply the above closure to all failing objects.
-    G1CMBitMap* bitmap = const_cast<G1CMBitMap*>(_g1h->concurrent_mark()->prev_mark_bitmap());
+    G1CMBitMap* bitmap = _g1h->concurrent_mark()->mark_bitmap();
     hr->apply_to_marked_objects(bitmap, &rspc);
     // Need to zap the remainder area of the processed region.
     rspc.zap_remainder();
+    // Now clear all the marks to be ready for a new marking cyle.
+    if (!during_concurrent_start) {
+      assert(hr->top_at_mark_start() == hr->bottom(), "TAMS must be bottom to make all objects look live");
+      _g1h->clear_bitmap_for_region(hr);
+    } else {
+      assert(hr->top_at_mark_start() == hr->top(), "TAMS must be top for bitmap to have any value");
+      // Keep the bits.
+    }
+    // We never evacuate Old (non-humongous, non-archive) regions during scrubbing
+    // (only afterwards); other regions (young, humongous, archive) never need
+    // scrubbing, so the following must hold.
+    assert(hr->parsable_bottom() == hr->bottom(), "PB must be bottom to make the whole area parsable");
 
     return rspc.marked_bytes();
   }

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -67,7 +67,7 @@ static void update_derived_pointers() {
 }
 
 G1CMBitMap* G1FullCollector::mark_bitmap() {
-  return _heap->concurrent_mark()->next_mark_bitmap();
+  return _heap->concurrent_mark()->mark_bitmap();
 }
 
 ReferenceProcessor* G1FullCollector::reference_processor() {
@@ -120,7 +120,7 @@ G1FullCollector::G1FullCollector(G1CollectedHeap* heap,
     _array_queue_set(_num_workers),
     _preserved_marks_set(true),
     _serial_compaction_point(),
-    _is_alive(this, heap->concurrent_mark()->next_mark_bitmap()),
+    _is_alive(this, heap->concurrent_mark()->mark_bitmap()),
     _is_alive_mutator(heap->ref_processor_stw(), &_is_alive),
     _always_subject_to_discovery(),
     _is_subject_mutator(heap->ref_processor_stw(), &_always_subject_to_discovery),
@@ -169,10 +169,11 @@ public:
 };
 
 void G1FullCollector::prepare_collection() {
+  _heap->verify_before_full_collection(scope()->is_explicit_gc());
+
   _heap->policy()->record_full_collection_start();
 
   _heap->abort_concurrent_cycle();
-  _heap->verify_before_full_collection(scope()->is_explicit_gc());
 
   _heap->gc_prologue(true);
   _heap->retire_tlabs();
@@ -214,9 +215,8 @@ void G1FullCollector::complete_collection() {
   // update the derived pointer table.
   update_derived_pointers();
 
-  _heap->concurrent_mark()->swap_mark_bitmaps();
   // Prepare the bitmap for the next (potentially concurrent) marking.
-  _heap->concurrent_mark()->clear_next_bitmap(_heap->workers());
+  _heap->concurrent_mark()->clear_bitmap(_heap->workers());
 
   _heap->prepare_heap_for_mutators();
 

--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
@@ -68,7 +68,7 @@ public:
   }
 };
 
-void G1FullGCCompactTask::G1CompactRegionClosure::clear_in_prev_bitmap(oop obj) {
+void G1FullGCCompactTask::G1CompactRegionClosure::clear_in_bitmap(oop obj) {
   assert(_bitmap->is_marked(obj), "Should only compact marked objects");
   _bitmap->clear(obj);
 }
@@ -77,7 +77,7 @@ size_t G1FullGCCompactTask::G1CompactRegionClosure::apply(oop obj) {
   size_t size = obj->size();
   if (!obj->is_forwarded()) {
     // Object not moving, but clear the mark to allow reuse of the bitmap.
-    clear_in_prev_bitmap(obj);
+    clear_in_bitmap(obj);
     return size;
   }
 
@@ -94,7 +94,7 @@ size_t G1FullGCCompactTask::G1CompactRegionClosure::apply(oop obj) {
 
   // Clear the mark for the compacted object to allow reuse of the
   // bitmap without an additional clearing step.
-  clear_in_prev_bitmap(obj);
+  clear_in_bitmap(obj);
   return size;
 }
 
@@ -105,7 +105,7 @@ void G1FullGCCompactTask::compact_region(HeapRegion* hr) {
   if (!collector()->is_free(hr->hrm_index())) {
     // The compaction closure not only copies the object to the new
     // location, but also clears the bitmap for it. This is needed
-    // for bitmap verification and to be able to use the prev_bitmap
+    // for bitmap verification and to be able to use the bitmap
     // for evacuation failures in the next young collection. Testing
     // showed that it was better overall to clear bit by bit, compared
     // to clearing the whole region at the end. This difference was

--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public:
 
   class G1CompactRegionClosure : public StackObj {
     G1CMBitMap* _bitmap;
-    void clear_in_prev_bitmap(oop object);
+    void clear_in_bitmap(oop object);
   public:
     G1CompactRegionClosure(G1CMBitMap* bitmap) : _bitmap(bitmap) { }
     size_t apply(oop object);

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -139,7 +139,8 @@ bool G1FullGCPrepareTask::G1ResetMetadataClosure::do_heap_region(HeapRegion* hr)
       hr->update_bot();
     }
 
-    if (_collector->is_skip_compacting(region_idx)) {
+    if (_collector->is_skip_compacting(region_idx) &&
+        hr->needs_scrubbing_during_full_gc()) {
       scrub_skip_compacting_region(hr);
     }
   }
@@ -167,9 +168,7 @@ void G1FullGCPrepareTask::G1CalculatePointersClosure::prepare_for_compaction(Hea
 }
 
 void G1FullGCPrepareTask::G1ResetMetadataClosure::scrub_skip_compacting_region(HeapRegion* hr) {
-  if (!hr->needs_scrubbing_during_full_gc()) {
-    return;
-  }
+  assert(hr->needs_scrubbing_during_full_gc(), "must be");
 
   HeapWord* limit = hr->top();
   HeapWord* current_obj = hr->bottom();

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
@@ -95,6 +95,7 @@ private:
     G1FullCollector* _collector;
 
     void reset_region_metadata(HeapRegion* hr);
+    void scrub_skip_compacting_region(HeapRegion* hr);
 
   public:
     G1ResetMetadataClosure(G1FullCollector* collector);

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,12 +73,11 @@ public:
 #ifndef PRODUCT
   // Make sure that the given bitmap has no marked objects in the
   // range [from,limit). If it does, print an error message and return
-  // false. Otherwise, just return true. bitmap_name should be "prev"
-  // or "next".
-  bool verify_no_bits_over_tams(const char* bitmap_name, const G1CMBitMap* const bitmap,
+  // false. Otherwise, just return true.
+  bool verify_no_bits_over_tams(const G1CMBitMap* const bitmap,
                                 HeapWord* from, HeapWord* limit);
 
-  // Verify that the prev / next bitmap range [tams,end) for the given
+  // Verify that the marking bitmap range [tams,end) for the given
   // region has no marks. Return true if all is well, false if errors
   // are detected.
   bool verify_bitmaps(const char* caller, HeapRegion* hr);

--- a/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,7 +108,7 @@ inline void G1RootRegionScanClosure::do_oop_work(T* p) {
     return;
   }
   oop obj = CompressedOops::decode_not_null(heap_oop);
-  _cm->mark_in_next_bitmap(_worker_id, obj);
+  _cm->mark_in_bitmap(_worker_id, obj);
 }
 
 template <class T>
@@ -210,7 +210,7 @@ void G1ParCopyHelper::mark_object(oop obj) {
   assert(!_g1h->heap_region_containing(obj)->in_collection_set(), "should not mark objects in the CSet");
 
   // We know that the object is not moving so it's safe to read its size.
-  _cm->mark_in_next_bitmap(_worker_id, obj);
+  _cm->mark_in_bitmap(_worker_id, obj);
 }
 
 void G1ParCopyHelper::trim_queue_partially() {

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -624,8 +624,8 @@ oop G1ParScanThreadState::handle_evacuation_failure_par(oop old, markWord m, siz
     HeapRegion* r = _g1h->heap_region_containing(old);
 
     // Objects failing evacuation will turn into old objects since the regions
-    // are relabeled as such. We mark the failing objects in the prev bitmap and
-    // later use it to handle all failed objects.
+    // are relabeled as such. We mark the failing objects in the marking bitmap
+    // and later use it to handle all failed objects.
     _g1h->mark_evac_failure_object(old);
 
     if (_evac_failure_regions->record(r->hrm_index())) {

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -448,7 +448,7 @@ void G1Policy::record_full_collection_end() {
   collector_state()->set_initiate_conc_mark_if_possible(need_to_start_conc_mark("end of Full GC"));
   collector_state()->set_in_concurrent_start_gc(false);
   collector_state()->set_mark_or_rebuild_in_progress(false);
-  collector_state()->set_clearing_next_bitmap(false);
+  collector_state()->set_clearing_bitmap(false);
 
   _eden_surv_rate_group->start_adding_regions();
   // also call this on any additional surv rate groups

--- a/src/hotspot/share/gc/g1/g1RegionMarkStatsCache.hpp
+++ b/src/hotspot/share/gc/g1/g1RegionMarkStatsCache.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,8 +35,8 @@
 //
 // This includes
 // * the number of live words gathered during marking for the area from bottom
-// to ntams. This is an exact measure.
-// The code corrects later for the live data between ntams and top.
+// to tams. This is an exact measure.
+// The code corrects later for the live data between tams and top.
 struct G1RegionMarkStats {
   size_t _live_words;
 

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1260,25 +1260,35 @@ class G1MergeHeapRootsTask : public WorkerTask {
     G1MergeCardSetStats stats() const { return _stats; }
   };
 
-  // Closure to clear the prev bitmap for any old region in the collection set.
+  // Closure to make sure that the marking bitmap is clear for any old region in
+  // the collection set.
   // This is needed to be able to use the bitmap for evacuation failure handling.
   class G1ClearBitmapClosure : public HeapRegionClosure {
     G1CollectedHeap* _g1h;
+
     void assert_bitmap_clear(HeapRegion* hr, const G1CMBitMap* bitmap) {
       assert(bitmap->get_next_marked_addr(hr->bottom(), hr->end()) == hr->end(),
-             "Bitmap should have no mark for young regions");
+             "Bitmap should have no mark for region %u", hr->hrm_index());
     }
+
   public:
     G1ClearBitmapClosure(G1CollectedHeap* g1h) : _g1h(g1h) { }
 
     bool do_heap_region(HeapRegion* hr) {
       assert(_g1h->is_in_cset(hr), "Should only be used iterating the collection set");
-      // Young regions should always have cleared bitmaps, so only clear old.
-      if (hr->is_old()) {
-        _g1h->clear_prev_bitmap_for_region(hr);
+
+      // Evacuation failure uses the bitmap to record evacuation failed objects,
+      // so the bitmap for the regions in the collection set must be cleared if not already.
+      //
+      // A clear bitmap is obvious for young regions as we never mark through them;
+      // old regions are only in the collection set after the concurrent cycle completed,
+      // so their bitmaps must also be clear except when the pause occurs during the
+      // concurrent bitmap clear. At that point the region's bitmap may contain mark
+      // while being in the collection set at the same time.
+      if (_g1h->collector_state()->clearing_bitmap() && hr->is_old()) {
+        _g1h->clear_bitmap_for_region(hr);
       } else {
-        assert(hr->is_young(), "Should only be young and old regions in collection set");
-        assert_bitmap_clear(hr, _g1h->concurrent_mark()->prev_mark_bitmap());
+        assert_bitmap_clear(hr, _g1h->concurrent_mark()->mark_bitmap());
       }
       return false;
     }
@@ -1789,267 +1799,4 @@ void G1RemSet::print_summary_info() {
     LogStream ls(log.trace());
     current.print_on(&ls);
   }
-}
-
-class G1RebuildRemSetTask: public WorkerTask {
-  // Aggregate the counting data that was constructed concurrently
-  // with marking.
-  class G1RebuildRemSetHeapRegionClosure : public HeapRegionClosure {
-    G1ConcurrentMark* _cm;
-    G1RebuildRemSetClosure _update_cl;
-
-    // Applies _update_cl to the references of the given object, limiting objArrays
-    // to the given MemRegion. Returns the amount of words actually scanned.
-    size_t scan_for_references(oop const obj, MemRegion mr) {
-      size_t const obj_size = obj->size();
-      // All non-objArrays and objArrays completely within the mr
-      // can be scanned without passing the mr.
-      if (!obj->is_objArray() || mr.contains(MemRegion(cast_from_oop<HeapWord*>(obj), obj_size))) {
-        obj->oop_iterate(&_update_cl);
-        return obj_size;
-      }
-      // This path is for objArrays crossing the given MemRegion. Only scan the
-      // area within the MemRegion.
-      obj->oop_iterate(&_update_cl, mr);
-      return mr.intersection(MemRegion(cast_from_oop<HeapWord*>(obj), obj_size)).word_size();
-    }
-
-    // A humongous object is live (with respect to the scanning) either
-    // a) it is marked on the bitmap as such
-    // b) its TARS is larger than TAMS, i.e. has been allocated during marking.
-    bool is_humongous_live(oop const humongous_obj, const G1CMBitMap* const bitmap, HeapWord* tams, HeapWord* tars) const {
-      return bitmap->is_marked(humongous_obj) || (tars > tams);
-    }
-
-    // Iterator over the live objects within the given MemRegion.
-    class LiveObjIterator : public StackObj {
-      const G1CMBitMap* const _bitmap;
-      const HeapWord* _tams;
-      const MemRegion _mr;
-      HeapWord* _current;
-
-      bool is_below_tams() const {
-        return _current < _tams;
-      }
-
-      bool is_live(HeapWord* obj) const {
-        return !is_below_tams() || _bitmap->is_marked(obj);
-      }
-
-      HeapWord* bitmap_limit() const {
-        return MIN2(const_cast<HeapWord*>(_tams), _mr.end());
-      }
-
-      void move_if_below_tams() {
-        if (is_below_tams() && has_next()) {
-          _current = _bitmap->get_next_marked_addr(_current, bitmap_limit());
-        }
-      }
-    public:
-      LiveObjIterator(const G1CMBitMap* const bitmap, const HeapWord* tams, const MemRegion mr, HeapWord* first_oop_into_mr) :
-          _bitmap(bitmap),
-          _tams(tams),
-          _mr(mr),
-          _current(first_oop_into_mr) {
-
-        assert(_current <= _mr.start(),
-               "First oop " PTR_FORMAT " should extend into mr [" PTR_FORMAT ", " PTR_FORMAT ")",
-               p2i(first_oop_into_mr), p2i(mr.start()), p2i(mr.end()));
-
-        // Step to the next live object within the MemRegion if needed.
-        if (is_live(_current)) {
-          // Non-objArrays were scanned by the previous part of that region.
-          if (_current < mr.start() && !cast_to_oop(_current)->is_objArray()) {
-            _current += cast_to_oop(_current)->size();
-            // We might have positioned _current on a non-live object. Reposition to the next
-            // live one if needed.
-            move_if_below_tams();
-          }
-        } else {
-          // The object at _current can only be dead if below TAMS, so we can use the bitmap.
-          // immediately.
-          _current = _bitmap->get_next_marked_addr(_current, bitmap_limit());
-          assert(_current == _mr.end() || is_live(_current),
-                 "Current " PTR_FORMAT " should be live (%s) or beyond the end of the MemRegion (" PTR_FORMAT ")",
-                 p2i(_current), BOOL_TO_STR(is_live(_current)), p2i(_mr.end()));
-        }
-      }
-
-      void move_to_next() {
-        _current += next()->size();
-        move_if_below_tams();
-      }
-
-      oop next() const {
-        oop result = cast_to_oop(_current);
-        assert(is_live(_current),
-               "Object " PTR_FORMAT " must be live TAMS " PTR_FORMAT " below %d mr " PTR_FORMAT " " PTR_FORMAT " outside %d",
-               p2i(_current), p2i(_tams), _tams > _current, p2i(_mr.start()), p2i(_mr.end()), _mr.contains(result));
-        return result;
-      }
-
-      bool has_next() const {
-        return _current < _mr.end();
-      }
-    };
-
-    // Rebuild remembered sets in the part of the region specified by mr and hr.
-    // Objects between the bottom of the region and the TAMS are checked for liveness
-    // using the given bitmap. Objects between TAMS and TARS are assumed to be live.
-    // Returns the number of live words between bottom and TAMS.
-    size_t rebuild_rem_set_in_region(const G1CMBitMap* const bitmap,
-                                     HeapWord* const top_at_mark_start,
-                                     HeapWord* const top_at_rebuild_start,
-                                     HeapRegion* hr,
-                                     MemRegion mr) {
-      size_t marked_words = 0;
-
-      if (hr->is_humongous()) {
-        oop const humongous_obj = cast_to_oop(hr->humongous_start_region()->bottom());
-        if (is_humongous_live(humongous_obj, bitmap, top_at_mark_start, top_at_rebuild_start)) {
-          // We need to scan both [bottom, TAMS) and [TAMS, top_at_rebuild_start);
-          // however in case of humongous objects it is sufficient to scan the encompassing
-          // area (top_at_rebuild_start is always larger or equal to TAMS) as one of the
-          // two areas will be zero sized. I.e. TAMS is either
-          // the same as bottom or top(_at_rebuild_start). There is no way TAMS has a different
-          // value: this would mean that TAMS points somewhere into the object.
-          assert(hr->top() == top_at_mark_start || hr->top() == top_at_rebuild_start,
-                 "More than one object in the humongous region?");
-          humongous_obj->oop_iterate(&_update_cl, mr);
-          return top_at_mark_start != hr->bottom() ? mr.intersection(MemRegion(cast_from_oop<HeapWord*>(humongous_obj), humongous_obj->size())).byte_size() : 0;
-        } else {
-          return 0;
-        }
-      }
-
-      for (LiveObjIterator it(bitmap, top_at_mark_start, mr, hr->block_start(mr.start())); it.has_next(); it.move_to_next()) {
-        oop obj = it.next();
-        size_t scanned_size = scan_for_references(obj, mr);
-        if (cast_from_oop<HeapWord*>(obj) < top_at_mark_start) {
-          marked_words += scanned_size;
-        }
-      }
-
-      return marked_words * HeapWordSize;
-    }
-public:
-  G1RebuildRemSetHeapRegionClosure(G1CollectedHeap* g1h,
-                                   G1ConcurrentMark* cm,
-                                   uint worker_id) :
-    HeapRegionClosure(),
-    _cm(cm),
-    _update_cl(g1h, worker_id) { }
-
-    bool do_heap_region(HeapRegion* hr) {
-      if (_cm->has_aborted()) {
-        return true;
-      }
-
-      uint const region_idx = hr->hrm_index();
-      DEBUG_ONLY(HeapWord* const top_at_rebuild_start_check = _cm->top_at_rebuild_start(region_idx);)
-      assert(top_at_rebuild_start_check == NULL ||
-             top_at_rebuild_start_check > hr->bottom(),
-             "A TARS (" PTR_FORMAT ") == bottom() (" PTR_FORMAT ") indicates the old region %u is empty (%s)",
-             p2i(top_at_rebuild_start_check), p2i(hr->bottom()),  region_idx, hr->get_type_str());
-
-      size_t total_marked_bytes = 0;
-      size_t const chunk_size_in_words = G1RebuildRemSetChunkSize / HeapWordSize;
-
-      HeapWord* const top_at_mark_start = hr->prev_top_at_mark_start();
-
-      HeapWord* cur = hr->bottom();
-      while (true) {
-        // After every iteration (yield point) we need to check whether the region's
-        // TARS changed due to e.g. eager reclaim.
-        HeapWord* const top_at_rebuild_start = _cm->top_at_rebuild_start(region_idx);
-        if (top_at_rebuild_start == NULL) {
-          return false;
-        }
-
-        MemRegion next_chunk = MemRegion(hr->bottom(), top_at_rebuild_start).intersection(MemRegion(cur, chunk_size_in_words));
-        if (next_chunk.is_empty()) {
-          break;
-        }
-
-        const Ticks start = Ticks::now();
-        size_t marked_bytes = rebuild_rem_set_in_region(_cm->prev_mark_bitmap(),
-                                                        top_at_mark_start,
-                                                        top_at_rebuild_start,
-                                                        hr,
-                                                        next_chunk);
-        Tickspan time = Ticks::now() - start;
-
-        log_trace(gc, remset, tracking)("Rebuilt region %u "
-                                        "live " SIZE_FORMAT " "
-                                        "time %.3fms "
-                                        "marked bytes " SIZE_FORMAT " "
-                                        "bot " PTR_FORMAT " "
-                                        "TAMS " PTR_FORMAT " "
-                                        "TARS " PTR_FORMAT,
-                                        region_idx,
-                                        _cm->live_bytes(region_idx),
-                                        time.seconds() * 1000.0,
-                                        marked_bytes,
-                                        p2i(hr->bottom()),
-                                        p2i(top_at_mark_start),
-                                        p2i(top_at_rebuild_start));
-
-        if (marked_bytes > 0) {
-          total_marked_bytes += marked_bytes;
-        }
-        cur += chunk_size_in_words;
-
-        _cm->do_yield_check();
-        if (_cm->has_aborted()) {
-          return true;
-        }
-      }
-      // In the final iteration of the loop the region might have been eagerly reclaimed.
-      // Simply filter out those regions. We can not just use region type because there
-      // might have already been new allocations into these regions.
-      DEBUG_ONLY(HeapWord* const top_at_rebuild_start = _cm->top_at_rebuild_start(region_idx);)
-      assert(top_at_rebuild_start == NULL ||
-             total_marked_bytes == hr->marked_bytes(),
-             "Marked bytes " SIZE_FORMAT " for region %u (%s) in [bottom, TAMS) do not match calculated marked bytes " SIZE_FORMAT " "
-             "(" PTR_FORMAT " " PTR_FORMAT " " PTR_FORMAT ")",
-             total_marked_bytes, hr->hrm_index(), hr->get_type_str(), hr->marked_bytes(),
-             p2i(hr->bottom()), p2i(top_at_mark_start), p2i(top_at_rebuild_start));
-       // Abort state may have changed after the yield check.
-      return _cm->has_aborted();
-    }
-  };
-
-  HeapRegionClaimer _hr_claimer;
-  G1ConcurrentMark* _cm;
-
-  uint _worker_id_offset;
-public:
-  G1RebuildRemSetTask(G1ConcurrentMark* cm,
-                      uint n_workers,
-                      uint worker_id_offset) :
-      WorkerTask("G1 Rebuild Remembered Set"),
-      _hr_claimer(n_workers),
-      _cm(cm),
-      _worker_id_offset(worker_id_offset) {
-  }
-
-  void work(uint worker_id) {
-    SuspendibleThreadSetJoiner sts_join;
-
-    G1CollectedHeap* g1h = G1CollectedHeap::heap();
-
-    G1RebuildRemSetHeapRegionClosure cl(g1h, _cm, _worker_id_offset + worker_id);
-    g1h->heap_region_par_iterate_from_worker_offset(&cl, &_hr_claimer, worker_id);
-  }
-};
-
-void G1RemSet::rebuild_rem_set(G1ConcurrentMark* cm,
-                               WorkerThreads* workers,
-                               uint worker_id_offset) {
-  uint num_workers = workers->active_workers();
-
-  G1RebuildRemSetTask cl(cm,
-                         num_workers,
-                         worker_id_offset);
-  workers->run_task(&cl, num_workers);
 }

--- a/src/hotspot/share/gc/g1/g1RemSet.hpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -147,10 +147,6 @@ public:
 
   // Print accumulated summary info from the last time called.
   void print_periodic_summary_info(const char* header, uint period_count);
-
-  // Rebuilds the remembered set by scanning from bottom to TARS for all regions
-  // using the given workers.
-  void rebuild_rem_set(G1ConcurrentMark* cm, WorkerThreads* workers, uint worker_id_offset);
 };
 
 #endif // SHARE_GC_G1_G1REMSET_HPP

--- a/src/hotspot/share/gc/g1/g1RemSetTrackingPolicy.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetTrackingPolicy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,19 +62,17 @@ void G1RemSetTrackingPolicy::update_at_free(HeapRegion* r) {
 
 static void print_before_rebuild(HeapRegion* r, bool selected_for_rebuild, size_t total_live_bytes, size_t live_bytes) {
   log_trace(gc, remset, tracking)("Before rebuild region %u "
-                                  "(ntams: " PTR_FORMAT ") "
-                                  "total_live_bytes " SIZE_FORMAT " "
+                                  "(tams: " PTR_FORMAT ") "
+                                  "total_live_bytes %zu "
                                   "selected %s "
-                                  "(live_bytes " SIZE_FORMAT " "
-                                  "next_marked " SIZE_FORMAT " "
-                                  "marked " SIZE_FORMAT " "
+                                  "(live_bytes %zu "
+                                  "marked %zu "
                                   "type %s)",
                                   r->hrm_index(),
-                                  p2i(r->next_top_at_mark_start()),
+                                  p2i(r->top_at_mark_start()),
                                   total_live_bytes,
                                   BOOL_TO_STR(selected_for_rebuild),
                                   live_bytes,
-                                  r->next_marked_bytes(),
                                   r->marked_bytes(),
                                   r->get_type_str());
 }
@@ -116,8 +114,8 @@ bool G1RemSetTrackingPolicy::update_before_rebuild(HeapRegion* r, size_t live_by
 
   assert(!r->rem_set()->is_updating(), "Remembered set of region %u is updating before rebuild", r->hrm_index());
 
-  size_t between_ntams_and_top = (r->top() - r->next_top_at_mark_start()) * HeapWordSize;
-  size_t total_live_bytes = live_bytes + between_ntams_and_top;
+  size_t between_tams_and_top = (r->top() - r->top_at_mark_start()) * HeapWordSize;
+  size_t total_live_bytes = live_bytes + between_tams_and_top;
 
   bool selected_for_rebuild = false;
   // For old regions, to be of interest for rebuilding the remembered set the following must apply:
@@ -163,15 +161,13 @@ void G1RemSetTrackingPolicy::update_after_rebuild(HeapRegion* r) {
     }
     G1ConcurrentMark* cm = G1CollectedHeap::heap()->concurrent_mark();
     log_trace(gc, remset, tracking)("After rebuild region %u "
-                                    "(ntams " PTR_FORMAT " "
-                                    "liveness " SIZE_FORMAT " "
-                                    "next_marked_bytes " SIZE_FORMAT " "
-                                    "remset occ " SIZE_FORMAT " "
-                                    "size " SIZE_FORMAT ")",
+                                    "(tams " PTR_FORMAT " "
+                                    "liveness %zu "
+                                    "remset occ %zu "
+                                    "size %zu)",
                                     r->hrm_index(),
-                                    p2i(r->next_top_at_mark_start()),
+                                    p2i(r->top_at_mark_start()),
                                     cm->live_bytes(r->hrm_index()),
-                                    r->next_marked_bytes(),
                                     r->rem_set()->occupied(),
                                     r->rem_set()->mem_size());
   }

--- a/src/hotspot/share/gc/g1/g1SATBMarkQueueSet.cpp
+++ b/src/hotspot/share/gc/g1/g1SATBMarkQueueSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,10 +53,10 @@ SATBMarkQueue& G1SATBMarkQueueSet::satb_queue_for_thread(Thread* const t) const 
 // be a NULL pointer.  NULL pointers are pre-filtered and never
 // inserted into a SATB buffer.
 //
-// An entry that is below the NTAMS pointer for the containing heap
+// An entry that is below the TAMS pointer for the containing heap
 // region requires marking. Such an entry must point to a valid object.
 //
-// An entry that is at least the NTAMS pointer for the containing heap
+// An entry that is at least the TAMS pointer for the containing heap
 // region might be any of the following, none of which should be marked.
 //
 // * A reference to an object allocated since marking started.
@@ -75,7 +75,7 @@ SATBMarkQueue& G1SATBMarkQueueSet::satb_queue_for_thread(Thread* const t) const 
 //   humongous object is recorded and then reclaimed, the reference
 //   becomes stale.
 //
-// The stale reference cases are implicitly handled by the NTAMS
+// The stale reference cases are implicitly handled by the TAMS
 // comparison. Because of the possibility of stale references, buffer
 // processing must be somewhat circumspect and not assume entries
 // in an unfiltered buffer refer to valid objects.
@@ -87,7 +87,7 @@ static inline bool requires_marking(const void* entry, G1CollectedHeap* g1h) {
 
   HeapRegion* region = g1h->heap_region_containing(entry);
   assert(region != NULL, "No region for " PTR_FORMAT, p2i(entry));
-  if (entry >= region->next_top_at_mark_start()) {
+  if (entry >= region->top_at_mark_start()) {
     return false;
   }
 

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -390,13 +390,13 @@ class G1PrepareEvacuationTask : public WorkerTask {
         _g1h->set_humongous_reclaim_candidate(index, false);
         _g1h->register_region_with_region_attr(hr);
       }
-      log_debug(gc, humongous)("Humongous region %u (object size " SIZE_FORMAT " @ " PTR_FORMAT ") remset " SIZE_FORMAT " code roots " SIZE_FORMAT " marked %d reclaim candidate %d type array %d",
+      log_debug(gc, humongous)("Humongous region %u (object size %zu @ " PTR_FORMAT ") remset %zu code roots %zu marked %d reclaim candidate %d type array %d",
                                index,
                                cast_to_oop(hr->bottom())->size() * HeapWordSize,
                                p2i(hr->bottom()),
                                hr->rem_set()->occupied(),
                                hr->rem_set()->code_roots_list_length(),
-                               _g1h->concurrent_mark()->next_mark_bitmap()->is_marked(hr->bottom()),
+                               _g1h->concurrent_mark()->mark_bitmap()->is_marked(hr->bottom()),
                                _g1h->is_humongous_reclaim_candidate(index),
                                cast_to_oop(hr->bottom())->is_typeArray()
                               );

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -205,11 +205,10 @@ public:
     G1CollectedHeap* g1h = G1CollectedHeap::heap();
     G1ConcurrentMark* const cm = g1h->concurrent_mark();
     cm->humongous_object_eagerly_reclaimed(r);
-    assert(!cm->is_marked_in_prev_bitmap(obj) && !cm->is_marked_in_next_bitmap(obj),
-           "Eagerly reclaimed humongous region %u should not be marked at all but is in prev %s next %s",
+    assert(!cm->is_marked_in_bitmap(obj),
+           "Eagerly reclaimed humongous region %u should not be marked at all but is in bitmap %s",
            region_idx,
-           BOOL_TO_STR(cm->is_marked_in_prev_bitmap(obj)),
-           BOOL_TO_STR(cm->is_marked_in_next_bitmap(obj)));
+           BOOL_TO_STR(cm->is_marked_in_bitmap(obj)));
     _humongous_objects_reclaimed++;
     do {
       HeapRegion* next = g1h->next_region_in_humongous(r);

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -378,6 +378,12 @@
           "Allows collections to be triggered proactively based on the      \
            number of free regions and the expected survival rates in each   \
            section of the heap.")                                           \
+                                                                            \
+  product(size_t, G1LogBackScanSkipGranularity, 16, EXPERIMENTAL,           \
+          "Log of the granularity (step) size of the backwards scan table " \
+          "used for finding marks on the bitmap below parsable bottom "     \
+          "scrubbing.")                                                     \
+          range(14, NOT_LP64(25) LP64_ONLY(29))                             \
                                                                             \
   GC_G1_EVACUATION_FAILURE_FLAGS(develop,                                   \
                     develop_pd,                                             \

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -274,7 +274,8 @@ void HeapRegion::report_region_type_change(G1HeapRegionTraceType::Type to) {
 void HeapRegion::note_self_forwarding_removal_start(bool during_concurrent_start,
                                                     bool during_conc_mark) {
   // We always scrub the region to make sure the entire region is
-  // parsable after the removal, and update _marked_bytes.
+  // parsable after the self-forwarding point removal, and update _marked_bytes
+  // at the end.
   _marked_bytes = 0;
 
   if (during_concurrent_start) {

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,7 +104,6 @@ void HeapRegion::handle_evacuation_failure() {
   uninstall_surv_rate_group();
   clear_young_index_in_cset();
   set_old();
-  _next_marked_bytes = 0;
 }
 
 void HeapRegion::unlink_from_list() {
@@ -124,8 +123,6 @@ void HeapRegion::hr_clear(bool clear_space) {
   reset_pre_dummy_top();
 
   rem_set()->clear_locked();
-
-  zero_marked_bytes();
 
   init_top_at_mark_start();
   if (clear_space) clear(SpaceDecorator::Mangle);
@@ -238,8 +235,10 @@ HeapRegion::HeapRegion(uint hrm_index,
 #ifdef ASSERT
   _containing_set(NULL),
 #endif
-  _prev_top_at_mark_start(NULL), _next_top_at_mark_start(NULL),
-  _prev_marked_bytes(0), _next_marked_bytes(0),
+  _top_at_mark_start(NULL),
+  _parsable_bottom(NULL),
+  _garbage_bytes(0),
+  _marked_bytes(0),
   _young_index_in_cset(-1),
   _surv_rate_group(NULL), _age_index(G1SurvRateGroup::InvalidAgeIndex), _gc_efficiency(-1.0),
   _node_index(G1NUMA::UnknownNodeIndex)
@@ -274,31 +273,27 @@ void HeapRegion::report_region_type_change(G1HeapRegionTraceType::Type to) {
 
 void HeapRegion::note_self_forwarding_removal_start(bool during_concurrent_start,
                                                     bool during_conc_mark) {
-  // We always recreate the prev marking info and we'll explicitly
-  // mark all objects we find to be self-forwarded on the prev
-  // bitmap. So all objects need to be below PTAMS.
-  _prev_marked_bytes = 0;
+  // We always scrub the region to make sure the entire region is
+  // parsable after the removal, and update _marked_bytes.
+  _marked_bytes = 0;
 
   if (during_concurrent_start) {
     // During concurrent start, we'll also explicitly mark all objects
-    // we find to be self-forwarded on the next bitmap. So all
-    // objects need to be below NTAMS.
-    _next_top_at_mark_start = top();
-    _next_marked_bytes = 0;
+    // we find to be self-forwarded in the marking bitmap. So all
+    // objects need to be below TAMS.
+    _top_at_mark_start = top();
   } else if (during_conc_mark) {
     // During concurrent mark, all objects in the CSet (including
     // the ones we find to be self-forwarded) are implicitly live.
-    // So all objects need to be above NTAMS.
-    _next_top_at_mark_start = bottom();
-    _next_marked_bytes = 0;
+    // So all objects need to be above TAMS.
+    _top_at_mark_start = bottom();
   }
 }
 
 void HeapRegion::note_self_forwarding_removal_end(size_t marked_bytes) {
   assert(marked_bytes <= used(),
          "marked: " SIZE_FORMAT " used: " SIZE_FORMAT, marked_bytes, used());
-  _prev_top_at_mark_start = top();
-  _prev_marked_bytes = marked_bytes;
+  _marked_bytes = marked_bytes;
 }
 
 // Code roots support
@@ -456,8 +451,8 @@ void HeapRegion::print_on(outputStream* st) const {
   } else {
     st->print("|  ");
   }
-  st->print("|TAMS " PTR_FORMAT ", " PTR_FORMAT "| %s ",
-               p2i(prev_top_at_mark_start()), p2i(next_top_at_mark_start()), rem_set()->get_state_str());
+  st->print("|TAMS " PTR_FORMAT "| PB " PTR_FORMAT "| %s ",
+               p2i(top_at_mark_start()), p2i(parsable_bottom_acquire()), rem_set()->get_state_str());
   if (UseNUMA) {
     G1NUMA* numa = G1NUMA::numa();
     if (node_index() < numa->num_active_nodes()) {
@@ -479,6 +474,7 @@ protected:
   VerifyOption _vo;
 
 public:
+
   G1VerificationClosure(G1CollectedHeap* g1h, VerifyOption vo) :
     _g1h(g1h), _ct(g1h->card_table()),
     _containing_obj(NULL), _failures(false), _n_failures(0), _vo(vo) {
@@ -523,14 +519,15 @@ public:
     if (!CompressedOops::is_null(heap_oop)) {
       oop obj = CompressedOops::decode_not_null(heap_oop);
       bool failed = false;
-      if (!_g1h->is_in(obj) || _g1h->is_obj_dead_cond(obj, _vo)) {
+      bool is_in_heap = _g1h->is_in(obj);
+      if (!is_in_heap || _g1h->is_obj_dead_cond(obj, _vo)) {
         MutexLocker x(ParGCRareEvent_lock, Mutex::_no_safepoint_check_flag);
 
         if (!_failures) {
           log.error("----------");
         }
         ResourceMark rm;
-        if (!_g1h->is_in(obj)) {
+        if (!is_in_heap) {
           HeapRegion* from = _g1h->heap_region_containing((HeapWord*)p);
           log.error("Field " PTR_FORMAT " of live obj " PTR_FORMAT " in region " HR_FORMAT,
                     p2i(p), p2i(_containing_obj), HR_FORMAT_PARAMS(from));
@@ -764,7 +761,7 @@ void HeapRegion::verify_rem_set(VerifyOption vo, bool* failures) const {
 
 void HeapRegion::verify_rem_set() const {
   bool failures = false;
-  verify_rem_set(VerifyOption::G1UsePrevMarking, &failures);
+  verify_rem_set(VerifyOption::G1UseConcMarking, &failures);
   guarantee(!failures, "HeapRegion RemSet verification failed");
 }
 
@@ -790,7 +787,7 @@ void HeapRegion::update_bot_for_block(HeapWord* start, HeapWord* end) {
 void HeapRegion::object_iterate(ObjectClosure* blk) {
   HeapWord* p = bottom();
   while (p < top()) {
-    if (block_is_obj(p)) {
+    if (block_is_obj(p, parsable_bottom())) {
       blk->do_object(cast_to_oop(p));
     }
     p += block_size(p);
@@ -804,4 +801,23 @@ void HeapRegion::fill_with_dummy_object(HeapWord* address, size_t word_size, boo
   }
   // Fill in the object.
   CollectedHeap::fill_with_object(address, word_size, zap);
+}
+
+void HeapRegion::fill_range_with_dead_objects(HeapWord* start, HeapWord* end) {
+  size_t range_size = pointer_delta(end, start);
+  if (range_size >= CollectedHeap::min_fill_size()) {
+    // Fill the dead range with objects. G1 might need to create two objects if
+    // the range is larger than half a region, which is the max_fill_size().
+    CollectedHeap::fill_with_objects(start, range_size);
+    HeapWord* current = start;
+    do {
+      // Update the BOT if the a threshold is crossed.
+      size_t obj_size = cast_to_oop(current)->size();
+      update_bot_for_block(current, current + obj_size);
+
+      // Advance to the next object.
+      current += obj_size;
+      guarantee(current <= end, "Should never go past end");
+    } while (current != end);
+  }
 }

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -291,6 +291,8 @@ private:
   inline HeapWord* do_oops_on_memregion_in_humongous(MemRegion mr,
                                                      Closure* cl);
 
+  inline bool is_marked_in_bitmap(oop obj) const;
+
   inline HeapWord* next_live_in_unparsable(G1CMBitMap* bitmap, const HeapWord* p, HeapWord* limit) const;
   inline HeapWord* next_live_in_unparsable(const HeapWord* p, HeapWord* limit) const;
 

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,7 +101,7 @@ public:
     assert(is_in(pre_dummy_top) && pre_dummy_top <= top(), "pre-condition");
     _pre_dummy_top = pre_dummy_top;
   }
-  HeapWord* pre_dummy_top() { return (_pre_dummy_top == NULL) ? top() : _pre_dummy_top; }
+  HeapWord* pre_dummy_top() const { return (_pre_dummy_top == NULL) ? top() : _pre_dummy_top; }
   void reset_pre_dummy_top() { _pre_dummy_top = NULL; }
 
   // Returns true iff the given the heap  region contains the
@@ -144,14 +144,26 @@ private:
   // This version synchronizes with other calls to par_allocate_impl().
   inline HeapWord* par_allocate_impl(size_t min_word_size, size_t desired_word_size, size_t* actual_word_size);
 
+  // Find a live object spanning over the given address or starting at it. Returns
+  // nullptr if there is no such object.
+  inline HeapWord* prev_live_spanning_into_in_unparsable(const G1CMBitMap* bitmap, HeapWord* start) const;
+
+  // Finds a block spanning into start that is less than parsable_bottom and returns
+  // its address. Nullptr if there is no such block.
+  inline HeapWord* block_start_using_bitmap(HeapWord* start, HeapWord* pb) const;
 public:
-  HeapWord* block_start(const void* p);
+  HeapWord* block_start(const void* addr, HeapWord* const pb);
 
   void object_iterate(ObjectClosure* blk);
 
   // At the given address create an object with the given size. If the region
   // is old the BOT will be updated if the object spans a threshold.
   void fill_with_dummy_object(HeapWord* address, size_t word_size, bool zap = true);
+
+  // Create objects in the given range. The BOT will be updated if needed and
+  // the created objects will have their header marked to show that they are
+  // dead.
+  void fill_range_with_dead_objects(HeapWord* start, HeapWord* end);
 
   // All allocations are done without updating the BOT. The BOT
   // needs to be kept in sync for old generation regions and
@@ -173,16 +185,20 @@ public:
   void reset_skip_compacting_after_full_gc();
 
   // All allocated blocks are occupied by objects in a HeapRegion
-  bool block_is_obj(const HeapWord* p) const;
+  bool block_is_obj(const HeapWord* p, HeapWord* pb) const;
 
-  // Returns whether the given object is dead based on TAMS and bitmap.
-  // An object is dead iff a) it was not allocated since the last mark (>TAMS), b) it
-  // is not marked (bitmap).
-  bool is_obj_dead(const oop obj, const G1CMBitMap* const prev_bitmap) const;
+  bool obj_is_scrubbed(oop obj) const;
+
+  // Returns whether the given object is dead based on TAMS and mark word.
+  // For an object to be considered dead it must be below TAMS and be
+  // marked in the header.
+  bool is_obj_dead(oop obj, HeapWord* pb) const;
+  bool is_obj_dead_size_below_pb(oop obj, HeapWord* pb, size_t& block_size) const;
 
   // Returns the object size for all valid block starts
   // and the amount of unallocated words if called on top()
   size_t block_size(const HeapWord* p) const;
+  size_t block_size(const HeapWord* p, HeapWord* pb) const;
 
   // Scans through the region using the bitmap to determine what
   // objects to call size_t ApplyToMarkedClosure::apply(oop) for.
@@ -190,7 +206,7 @@ public:
   inline void apply_to_marked_objects(G1CMBitMap* bitmap, ApplyToMarkedClosure* closure);
 
   void update_bot() {
-    _bot_part.update();
+    _bot_part.update(parsable_bottom());
   }
 
 private:
@@ -222,21 +238,27 @@ private:
   // word until the top and/or end of the region, and is the part
   // of the region for which no marking was done, i.e. objects may
   // have been allocated in this part since the last mark phase.
-  // "prev" is the top at the start of the last completed marking.
-  // "next" is the top at the start of the in-progress marking (if any.)
-  HeapWord* _prev_top_at_mark_start;
-  HeapWord* _next_top_at_mark_start;
+  HeapWord* _top_at_mark_start;
 
+  // The area above this limit is parsable using obj->size(). This limit
+  // is equal to bottom except from Remark and until the region has been
+  // scrubbed concurrently. The scrubbing ensures
+  // that all dead objects (with possibly unloaded classes) have been
+  // replaced with dummy objects that are parsable. Below this limit the
+  // marking bitmap must be used to determine size and liveness.
+  HeapWord* volatile _parsable_bottom;
+
+  // Amount of dead data in the region.
+  size_t _garbage_bytes;
   // We use concurrent marking to determine the amount of live data
   // in each heap region.
-  size_t _prev_marked_bytes;    // Bytes known to be live via last completed marking.
-  size_t _next_marked_bytes;    // Bytes known to be live via in-progress marking.
+  size_t _marked_bytes;    // Bytes known to be live via last completed marking.
 
   void init_top_at_mark_start() {
-    assert(_prev_marked_bytes == 0 &&
-           _next_marked_bytes == 0,
-           "Must be called after zero_marked_bytes.");
-    _prev_top_at_mark_start = _next_top_at_mark_start = bottom();
+    _top_at_mark_start = bottom();
+    _parsable_bottom = bottom();
+    _garbage_bytes = 0;
+    _marked_bytes = 0;
   }
 
   // Data for young region survivor prediction.
@@ -253,12 +275,11 @@ private:
 
   void report_region_type_change(G1HeapRegionTraceType::Type to);
 
-  // Returns whether the given object address refers to a dead object, and either the
-  // size of the object (if live) or the size of the block (if dead) in size.
-  // May
-  // - only called with obj < top()
-  // - not called on humongous objects or archive regions
-  inline bool is_obj_dead_with_size(const oop obj, const G1CMBitMap* const prev_bitmap, size_t* size) const;
+  template <class Closure, bool is_gc_active>
+  inline HeapWord* oops_on_memregion_iterate(MemRegion mr, Closure* cl);
+
+  template <class Closure, bool is_gc_active>
+  inline HeapWord* oops_on_memregion_iterate_in_unparsable(MemRegion mr, HeapWord* pb, Closure* cl);
 
   // Iterate over the references covered by the given MemRegion in a humongous
   // object and apply the given closure to them.
@@ -269,12 +290,12 @@ private:
   // mutator).
   template <class Closure, bool is_gc_active>
   inline HeapWord* do_oops_on_memregion_in_humongous(MemRegion mr,
-                                                     Closure* cl,
-                                                     G1CollectedHeap* g1h);
+                                                     Closure* cl);
 
-  // Returns the block size of the given (dead, potentially having its class unloaded) object
-  // starting at p extending to at most the prev TAMS using the given mark bitmap.
-  inline size_t block_size_using_bitmap(const HeapWord* p, const G1CMBitMap* const prev_bitmap) const;
+  inline bool is_marked_in_bitmap(oop obj) const;
+  inline HeapWord* next_live_in_unparsable(G1CMBitMap* bitmap, const HeapWord* p, HeapWord* limit) const;
+  inline HeapWord* next_live_in_unparsable(const HeapWord* p, HeapWord* limit) const;
+
 public:
   HeapRegion(uint hrm_index,
              G1BlockOffsetTable* bot,
@@ -322,25 +343,13 @@ public:
   static void setup_heap_region_size(size_t max_heap_size);
 
   // The number of bytes marked live in the region in the last marking phase.
-  size_t marked_bytes()    { return _prev_marked_bytes; }
-  size_t live_bytes() {
-    return (top() - prev_top_at_mark_start()) * HeapWordSize + marked_bytes();
-  }
-
-  // The number of bytes counted in the next marking.
-  size_t next_marked_bytes() { return _next_marked_bytes; }
-  // The number of bytes live wrt the next marking.
-  size_t next_live_bytes() {
-    return
-      (top() - next_top_at_mark_start()) * HeapWordSize + next_marked_bytes();
+  size_t marked_bytes() const { return _marked_bytes; }
+  size_t live_bytes() const {
+    return byte_size(bottom(), top()) - garbage_bytes();
   }
 
   // A lower bound on the amount of garbage bytes in the region.
-  size_t garbage_bytes() {
-    size_t used_at_mark_start_bytes =
-      (prev_top_at_mark_start() - bottom()) * HeapWordSize;
-    return used_at_mark_start_bytes - marked_bytes();
-  }
+  size_t garbage_bytes() const { return _garbage_bytes; }
 
   // Return the amount of bytes we'll reclaim if we collect this
   // region. This includes not only the known garbage bytes in the
@@ -353,18 +362,15 @@ public:
   }
 
   // An upper bound on the number of live bytes in the region.
-  size_t max_live_bytes() { return used() - garbage_bytes(); }
+  size_t max_live_bytes() const { return used() - garbage_bytes(); }
 
-  void add_to_marked_bytes(size_t incr_bytes) {
-    _next_marked_bytes = _next_marked_bytes + incr_bytes;
-  }
-
-  void zero_marked_bytes()      {
-    _prev_marked_bytes = _next_marked_bytes = 0;
-  }
   // Get the start of the unmarked area in this region.
-  HeapWord* prev_top_at_mark_start() const { return _prev_top_at_mark_start; }
-  HeapWord* next_top_at_mark_start() const { return _next_top_at_mark_start; }
+  HeapWord* top_at_mark_start() const { return _top_at_mark_start; }
+
+  // Retrieve parsable bottom; since it may be modified concurrently, outside a
+  // safepoint the _acquire method must be used.
+  HeapWord* parsable_bottom() const;
+  HeapWord* parsable_bottom_acquire() const;
 
   // Note the start or end of marking. This tells the heap region
   // that the collector is about to start or has finished (concurrently)
@@ -374,10 +380,24 @@ public:
   // all fields related to the next marking info.
   inline void note_start_of_marking();
 
-  // Notify the region that concurrent marking has finished. Copy the
-  // (now finalized) next marking info fields into the prev marking
-  // info fields.
-  inline void note_end_of_marking();
+  // Notify the region that concurrent marking has finished. Passes the number of
+  // bytes between bottom and TAMS.
+  inline void note_end_of_marking(size_t marked_bytes);
+
+  // Notify the region that scrubbing has completed.
+  inline void note_end_of_scrubbing();
+
+  // During the concurrent scrubbing phase, can there be any areas with unloaded
+  // classes in that region?
+  // This set only includes old and open archive regions - humongous regions only
+  // contain a single object which is either dead or live, contents of closed archive
+  // regions never die (so is always contiguous), and young regions are never even
+  // considered during concurrent scrub.
+  bool needs_scrubbing() const { return is_old() || is_open_archive(); }
+  // Same question as above, during full gc. Full gc needs to scrub any region that
+  // might be skipped for compaction. This includes young generation regions as the
+  // region relabeling to old happens later than scrubbing.
+  bool needs_scrubbing_during_full_gc() const { return is_young() || needs_scrubbing(); }
 
   const char* get_type_str() const { return _type.get_str(); }
   const char* get_short_type_str() const { return _type.get_short_str(); }
@@ -535,14 +555,12 @@ public:
 
   void record_surv_words_in_group(size_t words_survived);
 
-  // Determine if an object has been allocated since the last
-  // mark performed by the collector. This returns true iff the object
-  // is within the unmarked area of the region.
-  bool obj_allocated_since_prev_marking(oop obj) const {
-    return cast_from_oop<HeapWord*>(obj) >= prev_top_at_mark_start();
-  }
-  bool obj_allocated_since_next_marking(oop obj) const {
-    return cast_from_oop<HeapWord*>(obj) >= next_top_at_mark_start();
+  // Determine if an object is in the parsable or the to-be-scrubbed area.
+  inline bool obj_in_parsable_area(const HeapWord* addr, HeapWord* pb) const;
+  inline bool obj_in_scrubbing_area(oop obj, HeapWord* pb) const;
+
+  bool obj_allocated_since_marking_start(oop obj) const {
+    return cast_from_oop<HeapWord*>(obj) >= top_at_mark_start();
   }
 
   // Update the region state after a failed evacuation.

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -190,8 +190,7 @@ public:
   bool obj_is_scrubbed(oop obj) const;
 
   // Returns whether the given object is dead based on TAMS and mark word.
-  // For an object to be considered dead it must be below TAMS and be
-  // marked in the header.
+  // For an object to be considered dead it must be below TAMS and scrubbed.
   bool is_obj_dead(oop obj, HeapWord* pb) const;
   bool is_obj_dead_size_below_pb(oop obj, HeapWord* pb, size_t& block_size) const;
 
@@ -240,12 +239,12 @@ private:
   // have been allocated in this part since the last mark phase.
   HeapWord* _top_at_mark_start;
 
-  // The area above this limit is parsable using obj->size(). This limit
+  // The area above this limit is fully parsable. This limit
   // is equal to bottom except from Remark and until the region has been
-  // scrubbed concurrently. The scrubbing ensures
-  // that all dead objects (with possibly unloaded classes) have been
-  // replaced with dummy objects that are parsable. Below this limit the
-  // marking bitmap must be used to determine size and liveness.
+  // scrubbed concurrently. The scrubbing ensures that all dead objects (with
+  // possibly unloaded classes) have beenreplaced with filler objects that
+  // are parsable. Below this limit the marking bitmap must be used to
+  // determine size and liveness.
   HeapWord* volatile _parsable_bottom;
 
   // Amount of dead data in the region.
@@ -292,7 +291,6 @@ private:
   inline HeapWord* do_oops_on_memregion_in_humongous(MemRegion mr,
                                                      Closure* cl);
 
-  inline bool is_marked_in_bitmap(oop obj) const;
   inline HeapWord* next_live_in_unparsable(G1CMBitMap* bitmap, const HeapWord* p, HeapWord* limit) const;
   inline HeapWord* next_live_in_unparsable(const HeapWord* p, HeapWord* limit) const;
 
@@ -388,7 +386,7 @@ public:
   inline void note_end_of_scrubbing();
 
   // During the concurrent scrubbing phase, can there be any areas with unloaded
-  // classes in that region?
+  // classes in this region?
   // This set only includes old and open archive regions - humongous regions only
   // contain a single object which is either dead or live, contents of closed archive
   // regions never die (so is always contiguous), and young regions are never even

--- a/src/hotspot/share/gc/g1/heapRegionManager.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionManager.cpp
@@ -67,14 +67,12 @@ HeapRegionManager::HeapRegionManager() :
   _committed_map(),
   _allocated_heapregions_length(0),
   _regions(), _heap_mapper(NULL),
-  _prev_bitmap_mapper(NULL),
-  _next_bitmap_mapper(NULL),
+  _bitmap_mapper(NULL),
   _free_list("Free list", new MasterFreeRegionListChecker())
 { }
 
 void HeapRegionManager::initialize(G1RegionToSpaceMapper* heap_storage,
-                                   G1RegionToSpaceMapper* prev_bitmap,
-                                   G1RegionToSpaceMapper* next_bitmap,
+                                   G1RegionToSpaceMapper* bitmap,
                                    G1RegionToSpaceMapper* bot,
                                    G1RegionToSpaceMapper* cardtable,
                                    G1RegionToSpaceMapper* card_counts) {
@@ -82,8 +80,7 @@ void HeapRegionManager::initialize(G1RegionToSpaceMapper* heap_storage,
 
   _heap_mapper = heap_storage;
 
-  _prev_bitmap_mapper = prev_bitmap;
-  _next_bitmap_mapper = next_bitmap;
+  _bitmap_mapper = bitmap;
 
   _bot_mapper = bot;
   _cardtable_mapper = cardtable;
@@ -189,8 +186,7 @@ void HeapRegionManager::commit_regions(uint index, size_t num_regions, WorkerThr
   _heap_mapper->commit_regions(index, num_regions, pretouch_workers);
 
   // Also commit auxiliary data
-  _prev_bitmap_mapper->commit_regions(index, num_regions, pretouch_workers);
-  _next_bitmap_mapper->commit_regions(index, num_regions, pretouch_workers);
+  _bitmap_mapper->commit_regions(index, num_regions, pretouch_workers);
 
   _bot_mapper->commit_regions(index, num_regions, pretouch_workers);
   _cardtable_mapper->commit_regions(index, num_regions, pretouch_workers);
@@ -216,8 +212,7 @@ void HeapRegionManager::uncommit_regions(uint start, uint num_regions) {
   _heap_mapper->uncommit_regions(start, num_regions);
 
   // Also uncommit auxiliary data
-  _prev_bitmap_mapper->uncommit_regions(start, num_regions);
-  _next_bitmap_mapper->uncommit_regions(start, num_regions);
+  _bitmap_mapper->uncommit_regions(start, num_regions);
 
   _bot_mapper->uncommit_regions(start, num_regions);
   _cardtable_mapper->uncommit_regions(start, num_regions);
@@ -270,8 +265,7 @@ void HeapRegionManager::deactivate_regions(uint start, uint num_regions) {
 
 void HeapRegionManager::clear_auxiliary_data_structures(uint start, uint num_regions) {
   // Signal marking bitmaps to clear the given regions.
-  _prev_bitmap_mapper->signal_mapping_changed(start, num_regions);
-  _next_bitmap_mapper->signal_mapping_changed(start, num_regions);
+  _bitmap_mapper->signal_mapping_changed(start, num_regions);
   // Signal G1BlockOffsetTable to clear the given regions.
   _bot_mapper->signal_mapping_changed(start, num_regions);
   // Signal G1CardTable to clear the given regions.
@@ -282,15 +276,13 @@ void HeapRegionManager::clear_auxiliary_data_structures(uint start, uint num_reg
 
 MemoryUsage HeapRegionManager::get_auxiliary_data_memory_usage() const {
   size_t used_sz =
-    _prev_bitmap_mapper->committed_size() +
-    _next_bitmap_mapper->committed_size() +
+    _bitmap_mapper->committed_size() +
     _bot_mapper->committed_size() +
     _cardtable_mapper->committed_size() +
     _card_counts_mapper->committed_size();
 
   size_t committed_sz =
-    _prev_bitmap_mapper->reserved_size() +
-    _next_bitmap_mapper->reserved_size() +
+    _bitmap_mapper->reserved_size() +
     _bot_mapper->reserved_size() +
     _cardtable_mapper->reserved_size() +
     _card_counts_mapper->reserved_size();

--- a/src/hotspot/share/gc/g1/heapRegionManager.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,8 +123,7 @@ class HeapRegionManager: public CHeapObj<mtGC> {
 
   G1HeapRegionTable _regions;
   G1RegionToSpaceMapper* _heap_mapper;
-  G1RegionToSpaceMapper* _prev_bitmap_mapper;
-  G1RegionToSpaceMapper* _next_bitmap_mapper;
+  G1RegionToSpaceMapper* _bitmap_mapper;
   FreeRegionList _free_list;
 
   void expand(uint index, uint num_regions, WorkerThreads* pretouch_workers = NULL);
@@ -162,8 +161,7 @@ public:
   HeapRegionManager();
 
   void initialize(G1RegionToSpaceMapper* heap_storage,
-                  G1RegionToSpaceMapper* prev_bitmap,
-                  G1RegionToSpaceMapper* next_bitmap,
+                  G1RegionToSpaceMapper* bitmap,
                   G1RegionToSpaceMapper* bot,
                   G1RegionToSpaceMapper* cardtable,
                   G1RegionToSpaceMapper* card_counts);

--- a/test/hotspot/gtest/gc/g1/test_heapRegion.cpp
+++ b/test/hotspot/gtest/gc/g1/test_heapRegion.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,12 +75,12 @@ void VM_HeapRegionApplyToMarkedObjectsTest::doit() {
   HeapRegion* region = heap->heap_region_containing(heap->bottom_addr_for_region(0));
 
   // Mark some "oops" in the bitmap.
-  G1CMBitMap* bitmap = heap->concurrent_mark()->next_mark_bitmap();
-  bitmap->mark(region->bottom());
-  bitmap->mark(region->bottom() + MARK_OFFSET_1);
-  bitmap->mark(region->bottom() + MARK_OFFSET_2);
-  bitmap->mark(region->bottom() + MARK_OFFSET_3);
-  bitmap->mark(region->end());
+  G1CMBitMap* bitmap = heap->concurrent_mark()->mark_bitmap();
+  bitmap->par_mark(region->bottom());
+  bitmap->par_mark(region->bottom() + MARK_OFFSET_1);
+  bitmap->par_mark(region->bottom() + MARK_OFFSET_2);
+  bitmap->par_mark(region->bottom() + MARK_OFFSET_3);
+  bitmap->par_mark(region->end());
 
   VerifyAndCountMarkClosure cl(bitmap);
 

--- a/test/hotspot/jtreg/gc/g1/TestLargePageUseForAuxMemory.java
+++ b/test/hotspot/jtreg/gc/g1/TestLargePageUseForAuxMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ public class TestLargePageUseForAuxMemory {
         // being checked. In case of a large page allocation failure the output will
         // include logs like this for the affected data structure:
         // [0.048s][debug][gc,heap,coops] Reserve regular memory without large pages
-        // [0.048s][info ][pagesize     ] Next Bitmap: ... page_size=4K ...
+        // [0.048s][info ][pagesize     ] Mark Bitmap: ... page_size=4K ...
         //
         // The pattern passed in should match the second line.
         String failureMatch = output.firstMatch("Reserve regular memory without large pages\\n.*" + pattern, 1);
@@ -101,9 +101,8 @@ public class TestLargePageUseForAuxMemory {
         checkSize(output, expectedPageSize, "Card Counts Table: .*page_size=([^ ]+)");
     }
 
-    static void checkBitmaps(OutputAnalyzer output, long expectedPageSize) throws Exception {
-        checkSize(output, expectedPageSize, "Prev Bitmap: .*page_size=([^ ]+)");
-        checkSize(output, expectedPageSize, "Next Bitmap: .*page_size=([^ ]+)");
+    static void checkBitmap(OutputAnalyzer output, long expectedPageSize) throws Exception {
+        checkSize(output, expectedPageSize, "Mark Bitmap: .*page_size=([^ ]+)");
     }
 
     static void testVM(String what, long heapsize, boolean cardsShouldUseLargePages, boolean bitmapShouldUseLargePages) throws Exception {
@@ -124,10 +123,10 @@ public class TestLargePageUseForAuxMemory {
         // Only expect large page size if large pages are enabled.
         if (largePagesEnabled(output)) {
             checkSmallTables(output, (cardsShouldUseLargePages ? largePageSize : smallPageSize));
-            checkBitmaps(output, (bitmapShouldUseLargePages ? largePageSize : smallPageSize));
+            checkBitmap(output, (bitmapShouldUseLargePages ? largePageSize : smallPageSize));
         } else {
             checkSmallTables(output, smallPageSize);
-            checkBitmaps(output, smallPageSize);
+            checkBitmap(output, smallPageSize);
         }
         output.shouldHaveExitValue(0);
 
@@ -143,7 +142,7 @@ public class TestLargePageUseForAuxMemory {
 
         output = new OutputAnalyzer(pb.start());
         checkSmallTables(output, smallPageSize);
-        checkBitmaps(output, smallPageSize);
+        checkBitmap(output, smallPageSize);
         output.shouldHaveExitValue(0);
     }
 


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that removes one of the mark bitmaps in G1 to save memory?

Previously G1 used two mark bitmaps, one that has been in use for current liveness determination ("prev bitmap"), one that is currently being built ("next bitmap"); these two then were swapped during the remark pause.

G1 needed the current liveness information to determine whether an object (and the corresponding klass) below the respective top-at-mark-start is live, i.e. could be read from.
The mechanism is described in detail in the "Garbage-First Garbage Collection Paper" by Detlefs et al ([doi](https://doi.org/10.1145%2F1029873.1029879)).

This mechanism has several drawbacks:
* you need twice the space than actually necessary as we will see; this space is significant as a bitmap adds ~1.5% of Java heap size to the G1 native memory usage
* during scanning the cards you need to rely a lot on walking the bitmaps (below tams) which is extra work, and actually most of the time it is the case that the tams is at the end of the region

The alternative presented here is to reformat the holes between objects with filler objects; this is a traditional sweep over the heap which has originally been considered fairly expensive. However since JDK 11 G1 already does that sweep anyway when rebuilding remembered sets, and during this investigation it has been shown that reformatting the holes is "for free".

That reformatting not only includes actually stuffing filler objects into these holes, but also updating the BOT concurrently.

This concurrency has some drawback: after class unloading (in the remark pause) and before the Cleanup pause (which indicates the end of the concurrent rebuilding of the remsets and scrubbing the regions phase) using the BOT needs some care:

* during GC actually there is no issue: the BOT is at least stable in that it can not change while accessing it; the BOT may still point to dead objects, but these can be found using the bitmap.
* during concurrent refinement we can not use the BOT, and must completely rely on the bitmap for object start and liveness information; the BOT functionality can be emulated by scanning the bitmap backwards (until start of the region) for a marked object; if that objects spans into the area we want to scan we have found the first object into the area we want to scan - otherwise we need to scan forward within the area we want to scan.
Scanning backwards is a somewhat slow process, particularly since we do not know how far back the last previous object actually is: for this reason this change introduces a `Back scan skip table", which is like a very coarse bitmap (64k bytes/"mark" by default - that's 16 bytes per MB of heap, i.e. 0.0015% of the heap - configurable) that aids in scanning back very large areas.
Testing showed that the need for this back scan skip table is extremely seldom (like ten occurrences in millions of attempts), but if so, these skips are substantial.

Above I mentioned that there is a distinction between objects that can be parsed directly and objects for which we need to use the bitmap. For this reason the code introduces a per-region new marker called `parsable_bottom` (typically called `pb` in the code, similar to `tams`) that indicates from which address within the region the heap is parsable.

Let me describe the relation of `tams` and `pb` during the various phases in gc:

Young-only gcs (and initial state):
`pb` = `tams` = `tars` = `bottom`; card scanning always uses the BOT/direct scanning of the heap
```
bottom  top
|       |  
v       v
+---------------------+
|                     |
+---------------------|
^
|
tams, pb, tars
```
During Concurrent Mark Start until Remark: `tams` = `top`, `pb` = `bottom`; concurrent marking runs; we can still use BOT/direct scanning of the heap for refinement and gc card scan.
Marking not only marks objects from `bottom` to `tams`, but also sets a flag in the back scan skip table on a fairly coarse basis.
```
bottom    top
|         |  
v         v
+---------------------+
|                     |
+---------------------|
^         ^
|         |
pb        tams
```
From Remark -> Cleanup: `pb` = `tams`; `tams` = `bottom`; `tars` = `top`; Remark unloaded classes, so we set `pb` to `tams`; in the region at addresses < tams we might encounter unparsable objects. This means that during this time, refinement can not use the BOT to find objects spanning into the card it wants to scan as described above. Use the bitmap for that.

Rebuild the remembered sets from `bottom` to `tars`, and scrub the heap from `bottom` to `pb`.

Note that the change sets `pb` incrementally (and concurrently) back to `bottom` as a region finishes scrubbing to decrease the size of the area we need to use the bitmap as BOT replacement.
Scrubbing means: put filler objects in holes of dead objects, and update the BOT according to these filler objects.
```
bottom        top
|             |  
v             v
+---------------------+
|                     |
+---------------------|
^         ^   ^
|         |   |
tams      pb  (tars)
```
As soon as scrubbing finishes on a per-region basis: Set `pb` to `bottom` - the whole region is now parsable again. At Cleanup, all regions are scrubbed.

Evacuation failure handling: evacuation failure handling has been modified to accomodate this:
* evac failure expects that the bitmap is clear for regions to (intermittently) mark live objects there. This still applies - the young collection needs to clear old gen regions, but only after the Cleanup pause (G1 can only have mixed gcs after cleanup) because only at that point marks may still be left from the marking on the bitmap of old regions. The young gc just clears those (and only those) at the beginning of gc. It also clears the bitmaps of old gen regions in the remove self-forwards phase.
* evac failure of young regions is handled as before: after evacuation failure the region is left as old gen region with marks below `tams` in the concurrent start pause, otherwise the bitmap is cleared.

Thanks go to @kstefanj  for the initial prototype, @walulyai for taking over for a bit. I'll add both as contributors/authors.

Testing: tier1-5 (multiple times), tier1-8 (with a slightly older version that does not contain latest cleanups, will do again)

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #8869 must be integrated first

### Issue
 * [JDK-8210708](https://bugs.openjdk.java.net/browse/JDK-8210708): Use single mark bitmap in G1


### Contributors
 * Stefan Johansson `<sjohanss@openjdk.org>`
 * Ivan Walulya `<iwalulya@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8884/head:pull/8884` \
`$ git checkout pull/8884`

Update a local copy of the PR: \
`$ git checkout pull/8884` \
`$ git pull https://git.openjdk.java.net/jdk pull/8884/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8884`

View PR using the GUI difftool: \
`$ git pr show -t 8884`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8884.diff">https://git.openjdk.java.net/jdk/pull/8884.diff</a>

</details>
