### PR TITLE
8286045: Use ForceGC for cleaner test cases

### DIFF
--- a/test/jdk/javax/security/auth/callback/PasswordCallback/CheckCleanerBound.java
+++ b/test/jdk/javax/security/auth/callback/PasswordCallback/CheckCleanerBound.java
@@ -25,14 +25,16 @@
  * @test
  * @bug 8284910
  * @summary Check that the cleaner is not bound to the PasswordCallback object
+ * @library /test/lib/
+ * @build jdk.test.lib.util.ForceGC
+ * @run main/othervm CheckCleanerBound
  */
 
 import javax.security.auth.callback.PasswordCallback;
-import java.util.WeakHashMap;
+import java.lang.ref.WeakReference;
+import jdk.test.lib.util.ForceGC;
 
 public final class CheckCleanerBound {
-    private final static WeakHashMap<PasswordCallback, ?> weakHashMap =
-            new WeakHashMap<>();
 
     public static void main(String[] args) throws Exception {
         // Create an object
@@ -40,20 +42,15 @@ public final class CheckCleanerBound {
                 new PasswordCallback("Password: ", false);
         passwordCallback.setPassword("ThisIsAPassword".toCharArray());
 
-        weakHashMap.put(passwordCallback, null);
+        WeakReference<PasswordCallback> weakRef =
+                new WeakReference<>(passwordCallback);
         passwordCallback = null;
-
-        // Check if the PasswordCallback object could be collected.
-        // Wait to trigger the cleanup.
-        for (int i = 0; i < 10 && weakHashMap.size() != 0; i++) {
-            System.gc();
-            Thread.sleep(100);
-        }
 
         // Check if the object has been collected.  The collection will not
         // happen if the cleaner implementation in PasswordCallback is bound
         // to the PasswordCallback object.
-        if (weakHashMap.size() > 0) {
+        ForceGC gc = new ForceGC();
+        if (!gc.await(() -> weakRef.get() == null)) {
             throw new RuntimeException(
                 "PasswordCallback object is not released");
         }

--- a/test/jdk/sun/security/jgss/GssContextCleanup.java
+++ b/test/jdk/sun/security/jgss/GssContextCleanup.java
@@ -26,6 +26,8 @@
  * @bug 8284490
  * @summary Remove finalizer method in java.security.jgss
  * @key intermittent
+ * @library /test/lib/
+ * @build jdk.test.lib.util.ForceGC
  * @run main/othervm GssContextCleanup
  */
 
@@ -33,11 +35,11 @@ import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSCredential;
 import org.ietf.jgss.GSSManager;
 
-import java.util.WeakHashMap;
+import java.lang.ref.WeakReference;
+
+import jdk.test.lib.util.ForceGC;
 
 public final class GssContextCleanup {
-    private final static WeakHashMap<GSSContext, ?> whm = new WeakHashMap<>();
-
     public static void main(String[] args) throws Exception {
         // Enable debug log so that the failure analysis could be easier.
         System.setProperty("sun.security.nativegss.debug", "true");
@@ -48,17 +50,12 @@ public final class GssContextCleanup {
         // Create an object
         GSSManager manager = GSSManager.getInstance();
         GSSContext context = manager.createContext((GSSCredential)null);
-        whm.put(context, null);
+        WeakReference<GSSContext> weakRef = new WeakReference<>(context);
         context = null;
 
-        // Wait to trigger the cleanup.
-        for (int i = 0; i < 10 && whm.size() > 0; i++) {
-            System.gc();
-            Thread.sleep(100);
-        }
-
         // Check if the object has been collected.
-        if (whm.size() > 0) {
+        ForceGC gc = new ForceGC();
+        if (!gc.await(() -> weakRef.get() == null)) {
             throw new RuntimeException("GSSContext object is not released");
         }
     }

--- a/test/jdk/sun/security/jgss/GssNameCleanup.java
+++ b/test/jdk/sun/security/jgss/GssNameCleanup.java
@@ -26,17 +26,19 @@
  * @bug 8284490
  * @summary Remove finalizer method in java.security.jgss
  * @key intermittent
+ * @library /test/lib/
+ * @build jdk.test.lib.util.ForceGC
  * @run main/othervm GssNameCleanup
  */
 
-import java.util.WeakHashMap;
+import java.lang.ref.WeakReference;
 import org.ietf.jgss.GSSManager;
 import org.ietf.jgss.GSSName;
 import org.ietf.jgss.GSSException;
 
-public final class GssNameCleanup {
-    private final static WeakHashMap<GSSName, ?> whm = new WeakHashMap<>();
+import jdk.test.lib.util.ForceGC;
 
+public final class GssNameCleanup {
     public static void main(String[] args) throws Exception {
         // Enable debug log so that the failure analysis could be easier.
         System.setProperty("sun.security.nativegss.debug", "true");
@@ -49,24 +51,19 @@ public final class GssNameCleanup {
         try {
             GSSName name =
                 manager.createName("u1", GSSName.NT_USER_NAME);
-            whm.put(name, null);
+            WeakReference<GSSName> weakRef = new WeakReference<>(name);
             name = null;
+
+            // Check if the object has been collected.
+            ForceGC gc = new ForceGC();
+            if (!gc.await(() -> weakRef.get() == null)) {
+                throw new RuntimeException("GSSName object is not released");
+            }
         } catch (GSSException gsse) {
             // createName() could fail if the local default realm
             // cannot be located.  Just ignore the test case for
             // such circumstances.
             System.out.println("Ignore this test case: " + gsse);
-        }
-
-        // Wait to trigger the cleanup.
-        for (int i = 0; i < 10 && whm.size() > 0; i++) {
-            System.gc();
-            Thread.sleep(100);
-        }
-
-        // Check if the object has been collected.
-        if (whm.size() > 0) {
-            throw new RuntimeException("GSSName object is not released");
         }
     }
 }


### PR DESCRIPTION
Hi,

May I have the test case update reviewed?

This patch is trying to use ForceGC for cleaner test cases.  As would make the test more stable and easier to maintain.

Thanks,
Xuelei

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286045](https://bugs.openjdk.java.net/browse/JDK-8286045): Use ForceGC for cleaner test cases


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8885/head:pull/8885` \
`$ git checkout pull/8885`

Update a local copy of the PR: \
`$ git checkout pull/8885` \
`$ git pull https://git.openjdk.java.net/jdk pull/8885/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8885`

View PR using the GUI difftool: \
`$ git pr show -t 8885`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8885.diff">https://git.openjdk.java.net/jdk/pull/8885.diff</a>

</details>
