### PR TITLE
8287333

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -127,17 +127,17 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
         Utils utils = writer.configuration().utils;
         if (utils.isExecutableElement(holder)) {
             ExecutableElement member = (ExecutableElement) holder;
-            Content output = getTagletOutput(ParamKind.TYPE_PARAMETER, member, writer,
-                    member.getTypeParameters(), utils.getTypeParamTrees(member));
-            output.add(getTagletOutput(ParamKind.PARAMETER, member, writer,
-                    member.getParameters(), utils.getParamTrees(member)));
+            Content output = getTagletOutput(member, ParamKind.TYPE_PARAMETER,
+                    utils.getTypeParamTrees(member), member.getTypeParameters(), writer);
+            output.add(getTagletOutput(member, ParamKind.PARAMETER,
+                    utils.getParamTrees(member), member.getParameters(), writer));
             return output;
         } else {
             TypeElement typeElement = (TypeElement) holder;
-            Content output = getTagletOutput(ParamKind.TYPE_PARAMETER, typeElement, writer,
-                    typeElement.getTypeParameters(), utils.getTypeParamTrees(typeElement));
-            output.add(getTagletOutput(ParamKind.RECORD_COMPONENT, typeElement, writer,
-                    typeElement.getRecordComponents(), utils.getParamTrees(typeElement)));
+            Content output = getTagletOutput(typeElement, ParamKind.TYPE_PARAMETER,
+                    utils.getTypeParamTrees(typeElement), typeElement.getTypeParameters(), writer);
+            output.add(getTagletOutput(typeElement, ParamKind.RECORD_COMPONENT,
+                    utils.getParamTrees(typeElement), typeElement.getRecordComponents(), writer));
             return output;
         }
     }
@@ -146,11 +146,10 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
      * Returns a {@code Content} representation of a list of {@code ParamTree}.
      * Tries to inherit the param tags that are missing.
      */
-    private Content getTagletOutput(ParamKind kind,
-                                    Element holder,
-                                    TagletWriter writer,
+    private Content getTagletOutput(Element holder, ParamKind kind,
+                                    List<? extends ParamTree> paramTags,
                                     List<? extends Element> formalParameters,
-                                    List<? extends ParamTree> paramTags) {
+                                    TagletWriter writer) {
         Content result = writer.getOutputInstance();
         result.add(convertParams(holder, kind, paramTags, formalParameters, writer));
         return result;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -61,24 +61,6 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
         super(DocTree.Kind.PARAM, false, EnumSet.of(Location.TYPE, Location.CONSTRUCTOR, Location.METHOD));
     }
 
-    /**
-     * Given a list of parameters, returns a name-position map.
-     * @param params the list of parameters from a type or an executable member
-     * @return a name-position map
-     */
-    private static Map<String, String> mapNameToPosition(Utils utils, List<? extends Element> params) {
-        Map<String, String> result = new HashMap<>();
-        int position = 0;
-        for (Element e : params) {
-            String name = utils.isTypeParameterElement(e)
-                    ? utils.getTypeName(e.asType(), false)
-                    : utils.getSimpleName(e);
-            result.put(name, Integer.toString(position));
-            position++;
-        }
-        return result;
-    }
-
     @Override
     public void inherit(DocFinder.Input input, DocFinder.Output output) {
         Utils utils = input.utils;
@@ -122,6 +104,24 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
         }
     }
 
+    /**
+     * Given a list of parameters, returns a name-position map.
+     * @param params the list of parameters from a type or an executable member
+     * @return a name-position map
+     */
+    private static Map<String, String> mapNameToPosition(Utils utils, List<? extends Element> params) {
+        Map<String, String> result = new HashMap<>();
+        int position = 0;
+        for (Element e : params) {
+            String name = utils.isTypeParameterElement(e)
+                    ? utils.getTypeName(e.asType(), false)
+                    : utils.getSimpleName(e);
+            result.put(name, Integer.toString(position));
+            position++;
+        }
+        return result;
+    }
+
     @Override
     public Content getAllBlockTagOutput(Element holder, TagletWriter writer) {
         Utils utils = writer.configuration().utils;
@@ -153,33 +153,6 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
                                     List<? extends ParamTree> paramTags) {
         Content result = writer.getOutputInstance();
         result.add(convertParams(holder, kind, paramTags, formalParameters, writer));
-        return result;
-    }
-
-    /**
-     * Tries to inherit documentation for a specific parameter (element).
-     * If unsuccessful, the returned content is empty.
-     */
-    private Content getInheritedTagletOutput(ParamKind kind,
-                                             Element holder,
-                                             TagletWriter writer,
-                                             Element param,
-                                             int position,
-                                             boolean isFirst) {
-        Utils utils = writer.configuration().utils;
-        Content result = writer.getOutputInstance();
-        Input input = new DocFinder.Input(writer.configuration().utils, holder, this,
-                Integer.toString(position), kind == ParamKind.TYPE_PARAMETER);
-        DocFinder.Output inheritedDoc = DocFinder.search(writer.configuration(), input);
-        if (!inheritedDoc.inlineTags.isEmpty()) {
-            String lname = kind != ParamKind.TYPE_PARAMETER
-                    ? utils.getSimpleName(param)
-                    : utils.getTypeName(param.asType(), false);
-            Content content = convertParam(inheritedDoc.holder, kind, writer,
-                    (ParamTree) inheritedDoc.holderTag,
-                    lname, isFirst);
-            result.add(content);
-        }
         return result;
     }
 
@@ -255,6 +228,33 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
                             ch.getParameterName(dt), result.isEmpty()));
                 }
             }
+        }
+        return result;
+    }
+
+    /**
+     * Tries to inherit documentation for a specific parameter (element).
+     * If unsuccessful, the returned content is empty.
+     */
+    private Content getInheritedTagletOutput(ParamKind kind,
+                                             Element holder,
+                                             TagletWriter writer,
+                                             Element param,
+                                             int position,
+                                             boolean isFirst) {
+        Utils utils = writer.configuration().utils;
+        Content result = writer.getOutputInstance();
+        Input input = new DocFinder.Input(writer.configuration().utils, holder, this,
+                Integer.toString(position), kind == ParamKind.TYPE_PARAMETER);
+        DocFinder.Output inheritedDoc = DocFinder.search(writer.configuration(), input);
+        if (!inheritedDoc.inlineTags.isEmpty()) {
+            String lname = kind != ParamKind.TYPE_PARAMETER
+                    ? utils.getSimpleName(param)
+                    : utils.getTypeName(param.asType(), false);
+            Content content = convertParam(inheritedDoc.holder, kind, writer,
+                    (ParamTree) inheritedDoc.holderTag,
+                    lname, isFirst);
+            result.add(content);
         }
         return result;
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -152,7 +152,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
                                     List<? extends Element> formalParameters,
                                     List<? extends ParamTree> paramTags) {
         Content result = writer.getOutputInstance();
-        result.add(processParamTags(holder, kind, paramTags, formalParameters, writer));
+        result.add(convertParams(holder, kind, paramTags, formalParameters, writer));
         return result;
     }
 
@@ -197,11 +197,11 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
      *
      * @param kind the kind of <em>all</em> parameters in the lists
      */
-    private Content processParamTags(Element e,
-                                     ParamKind kind,
-                                     List<? extends ParamTree> paramTags,
-                                     List<? extends Element> formalParameters,
-                                     TagletWriter writer) {
+    private Content convertParams(Element e,
+                                  ParamKind kind,
+                                  List<? extends ParamTree> paramTags,
+                                  List<? extends Element> formalParameters,
+                                  TagletWriter writer) {
         Map<String, ParamTree> tagOfPosition = new HashMap<>();
         Messages messages = writer.configuration().getMessages();
         CommentHelper ch = writer.configuration().utils.getCommentHelper(e);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -247,17 +247,14 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
         // Document declared parameters for which tag documentation is available
         // (either directly or inherited) in order of their declaration.
         Content result = writer.getOutputInstance();
-        var first = true;
         for (int i = 0; i < formalParameters.size(); i++) {
             ParamTree dt = tagOfPosition.get(Integer.toString(i));
             if (dt != null) {
                 result.add(processParamTag(e, kind, writer, dt,
-                        ch.getParameterName(dt), first));
-                first = false;
+                        ch.getParameterName(dt), result.isEmpty()));
             } else if (writer.configuration().utils.isMethod(e)) {
                 result.add(getInheritedTagletOutput(kind, e, writer,
-                        formalParameters.get(i), i, first));
-                first = false;
+                        formalParameters.get(i), i, result.isEmpty()));
             }
         }
         if (paramTags.size() > tagOfPosition.size()) {
@@ -266,8 +263,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
             for (ParamTree dt : paramTags) {
                 if (!tagOfPosition.containsValue(dt)) {
                     result.add(processParamTag(e, kind, writer, dt,
-                            ch.getParameterName(dt), first));
-                    first = false;
+                            ch.getParameterName(dt), result.isEmpty()));
                 }
             }
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -189,14 +189,17 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
     }
 
     /**
-     * Given an array of {@code @param DocTree}s representing this
-     * tag, return its string representation.  Print a warning for param
-     * tags that do not map to parameters.  Print a warning for param
-     * tags that are duplicated.
+     * Returns a {@code Content} representation of a list of {@code ParamTree}.
      *
-     * @param paramTags the array of {@code @param DocTree} to convert.
-     * @param writer the TagletWriter that will write this tag.
-     * @return the Content representation of this {@code @param DocTree}.
+     * Warns about {@code @param} tags that do not map to parameter elements
+     * and param tags that are duplicated.
+     *
+     * @param e the element
+     * @param kind the kind of all parameters in the lists
+     * @param paramTags the list of {@code ParamTree}
+     * @param formalParameters the list of parameter elements
+     * @param writer the TagletWriter that will write this tag
+     * @return the {@code Content} representation
      */
     private Content processParamTags(Element e,
                                      ParamKind kind,

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -73,7 +73,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
             String name = utils.isTypeParameterElement(e)
                     ? utils.getTypeName(e.asType(), false)
                     : utils.getSimpleName(e);
-            result.put(name, String.valueOf(position));
+            result.put(name, Integer.toString(position));
             position++;
         }
         return result;
@@ -96,7 +96,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
                         ? utils.getTypeName(e.asType(), false)
                         : utils.getSimpleName(e);
                 if (pname.contentEquals(target)) {
-                    input.tagId = String.valueOf(i);
+                    input.tagId = Integer.toString(i);
                     break;
                 }
             }
@@ -246,7 +246,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
         // (either directly or inherited) in order of their declaration.
         Content result = writer.getOutputInstance();
         for (int i = 0; i < formalParameters.size(); i++) {
-            ParamTree dt = tagOfPosition.get(String.valueOf(i));
+            ParamTree dt = tagOfPosition.get(Integer.toString(i));
             if (dt != null) {
                 result.add(processParamTag(e, kind, writer, dt,
                         ch.getParameterName(dt), result.isEmpty()));

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -75,23 +75,23 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
             String target = ch.getParameterName(tag);
             for (int i = 0; i < parameters.size(); i++) {
                 Element e = parameters.get(i);
-                String pname = input.isTypeVariableParamTag
+                String candidate = input.isTypeVariableParamTag
                         ? utils.getTypeName(e.asType(), false)
                         : utils.getSimpleName(e);
-                if (pname.equals(target)) {
+                if (candidate.equals(target)) {
                     input.tagId = Integer.toString(i);
                     break;
                 }
             }
         }
-        ExecutableElement md = (ExecutableElement) input.element;
-        CommentHelper ch = utils.getCommentHelper(md);
+        ExecutableElement ee = (ExecutableElement) input.element;
+        CommentHelper ch = utils.getCommentHelper(ee);
         List<? extends ParamTree> tags = input.isTypeVariableParamTag
-                ? utils.getTypeParamTrees(md)
-                : utils.getParamTrees(md);
+                ? utils.getTypeParamTrees(ee)
+                : utils.getParamTrees(ee);
         List<? extends Element> parameters = input.isTypeVariableParamTag
-                ? md.getTypeParameters()
-                : md.getParameters();
+                ? ee.getTypeParameters()
+                : ee.getParameters();
         Map<String, String> positionOfName = mapNameToPosition(utils, parameters);
         for (ParamTree tag : tags) {
             String paramName = ch.getParameterName(tag);
@@ -234,12 +234,12 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
                 Integer.toString(position), kind == ParamKind.TYPE_PARAMETER);
         DocFinder.Output inheritedDoc = DocFinder.search(writer.configuration(), input);
         if (!inheritedDoc.inlineTags.isEmpty()) {
-            String lname = kind != ParamKind.TYPE_PARAMETER
+            String name = kind != ParamKind.TYPE_PARAMETER
                     ? utils.getSimpleName(param)
                     : utils.getTypeName(param.asType(), false);
             Content content = convertParam(inheritedDoc.holder, kind, writer,
                     (ParamTree) inheritedDoc.holderTag,
-                    lname, isFirst);
+                    name, isFirst);
             result.add(content);
         }
         return result;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -143,15 +143,8 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
     }
 
     /**
-     * Given an array of {@code @param DocTree}s, return its string representation.
-     * Try to inherit the param tags that are missing.
-     *
-     * @param holder            the element that holds the param tags.
-     * @param writer            the TagletWriter that will write this tag.
-     * @param formalParameters  The array of parameters (from type or executable
-     *                          member) to check.
-     *
-     * @return the content representation of these {@code @param DocTree}s.
+     * Returns a {@code Content} representation of a list of {@code ParamTree}.
+     * Tries to inherit the param tags that are missing.
      */
     private Content getTagletOutput(ParamKind kind,
                                     Element holder,
@@ -164,7 +157,8 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
     }
 
     /**
-     * Try to inherit documentation for a specific parameter.
+     * Tries to inherit documentation for a specific parameter (element).
+     * If unsuccessful, the returned content is empty.
      */
     private Content getInheritedTagletOutput(ParamKind kind,
                                              Element holder,
@@ -181,7 +175,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
             String lname = kind != ParamKind.TYPE_PARAMETER
                     ? utils.getSimpleName(param)
                     : utils.getTypeName(param.asType(), false);
-            Content content = processParamTag(inheritedDoc.holder, kind, writer,
+            Content content = convertParam(inheritedDoc.holder, kind, writer,
                     (ParamTree) inheritedDoc.holderTag,
                     lname, isFirst);
             result.add(content);
@@ -201,12 +195,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
      * <p> This method warns about {@code @param} tags that do not map to
      * parameter elements and param tags that are duplicated. </p>
      *
-     * @param e the element
-     * @param kind the kind of all parameters in the lists
-     * @param paramTags the list of {@code ParamTree}
-     * @param formalParameters the list of parameter elements
-     * @param writer the TagletWriter that will write this tag
-     * @return the {@code Content} representation
+     * @param kind the kind of <em>all</em> parameters in the lists
      */
     private Content processParamTags(Element e,
                                      ParamKind kind,
@@ -250,7 +239,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
         for (int i = 0; i < formalParameters.size(); i++) {
             ParamTree dt = tagOfPosition.get(Integer.toString(i));
             if (dt != null) {
-                result.add(processParamTag(e, kind, writer, dt,
+                result.add(convertParam(e, kind, writer, dt,
                         ch.getParameterName(dt), result.isEmpty()));
             } else if (writer.configuration().utils.isMethod(e)) {
                 result.add(getInheritedTagletOutput(kind, e, writer,
@@ -262,7 +251,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
             // These are erroneous but we generate them anyway.
             for (ParamTree dt : paramTags) {
                 if (!tagOfPosition.containsValue(dt)) {
-                    result.add(processParamTag(e, kind, writer, dt,
+                    result.add(convertParam(e, kind, writer, dt,
                             ch.getParameterName(dt), result.isEmpty()));
                 }
             }
@@ -271,24 +260,15 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
     }
 
     /**
-     * Convert an individual {@code ParamTree} to {@code Content}.
-     *
-     * @param e               the owner element
-     * @param kind            the kind of param tag
-     * @param writer          the taglet writer for output writing.
-     * @param paramTag        the tag whose inline tags will be printed.
-     * @param name            the name of the parameter.  We can't rely on
-     *                        the name in the param tag because we might be
-     *                        inheriting documentation.
-     * @param isFirstParam    true if this is the first param tag being printed.
-     *
+     * Converts an individual {@code ParamTree} to {@code Content}, which is
+     * prepended with the header if the parameter is first in the list.
      */
-    private Content processParamTag(Element e,
-                                    ParamKind kind,
-                                    TagletWriter writer,
-                                    ParamTree paramTag,
-                                    String name,
-                                    boolean isFirstParam) {
+    private Content convertParam(Element e,
+                                 ParamKind kind,
+                                 TagletWriter writer,
+                                 ParamTree paramTag,
+                                 String name,
+                                 boolean isFirstParam) {
         Content result = writer.getOutputInstance();
         if (isFirstParam) {
             result.add(writer.getParamHeader(kind));

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -83,19 +83,20 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
     public void inherit(DocFinder.Input input, DocFinder.Output output) {
         Utils utils = input.utils;
         if (input.tagId == null) {
-            input.isTypeVariableParamTag = ((ParamTree) input.docTreeInfo.docTree()).isTypeParameter();
+            var tag = (ParamTree) input.docTreeInfo.docTree();
+            input.isTypeVariableParamTag = tag.isTypeParameter();
             ExecutableElement ee = (ExecutableElement) input.docTreeInfo.element();
             CommentHelper ch = utils.getCommentHelper(ee);
             List<? extends Element> parameters = input.isTypeVariableParamTag
                     ? ee.getTypeParameters()
                     : ee.getParameters();
-            String target = ch.getParameterName((ParamTree) input.docTreeInfo.docTree());
+            String target = ch.getParameterName(tag);
             for (int i = 0; i < parameters.size(); i++) {
                 Element e = parameters.get(i);
                 String pname = input.isTypeVariableParamTag
                         ? utils.getTypeName(e.asType(), false)
                         : utils.getSimpleName(e);
-                if (pname.contentEquals(target)) {
+                if (pname.equals(target)) {
                     input.tagId = Integer.toString(i);
                     break;
                 }
@@ -112,7 +113,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
         Map<String, String> positionOfName = mapNameToPosition(utils, parameters);
         for (ParamTree tag : tags) {
             String paramName = ch.getParameterName(tag);
-            if (positionOfName.containsKey(paramName) && positionOfName.get(paramName).equals((input.tagId))) {
+            if (positionOfName.containsKey(paramName) && positionOfName.get(paramName).equals(input.tagId)) {
                 output.holder = input.element;
                 output.holderTag = tag;
                 output.inlineTags = ch.getBody(tag);
@@ -163,7 +164,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
     }
 
     /**
-     * Try to get the inherited taglet documentation for a specific parameter.
+     * Try to inherit documentation for a specific parameter.
      */
     private Content getInheritedTagletOutput(ParamKind kind,
                                              Element holder,

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -191,8 +191,13 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
     /**
      * Returns a {@code Content} representation of a list of {@code ParamTree}.
      *
-     * Warns about {@code @param} tags that do not map to parameter elements
-     * and param tags that are duplicated.
+     * <p> This method:
+     * <ul>
+     *   <li> correlates ParamTree with Element by name
+     *   <li> warns about {@code @param} tags that do not map to parameter
+     *        elements and param tags that are duplicated
+     * </ul>
+     * </p>
      *
      * @param e the element
      * @param kind the kind of all parameters in the lists

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -127,32 +127,19 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
         Utils utils = writer.configuration().utils;
         if (utils.isExecutableElement(holder)) {
             ExecutableElement member = (ExecutableElement) holder;
-            Content output = getTagletOutput(member, ParamKind.TYPE_PARAMETER,
+            Content output = convertParams(member, ParamKind.TYPE_PARAMETER,
                     utils.getTypeParamTrees(member), member.getTypeParameters(), writer);
-            output.add(getTagletOutput(member, ParamKind.PARAMETER,
+            output.add(convertParams(member, ParamKind.PARAMETER,
                     utils.getParamTrees(member), member.getParameters(), writer));
             return output;
         } else {
             TypeElement typeElement = (TypeElement) holder;
-            Content output = getTagletOutput(typeElement, ParamKind.TYPE_PARAMETER,
+            Content output = convertParams(typeElement, ParamKind.TYPE_PARAMETER,
                     utils.getTypeParamTrees(typeElement), typeElement.getTypeParameters(), writer);
-            output.add(getTagletOutput(typeElement, ParamKind.RECORD_COMPONENT,
+            output.add(convertParams(typeElement, ParamKind.RECORD_COMPONENT,
                     utils.getParamTrees(typeElement), typeElement.getRecordComponents(), writer));
             return output;
         }
-    }
-
-    /**
-     * Returns a {@code Content} representation of a list of {@code ParamTree}.
-     * Tries to inherit the param tags that are missing.
-     */
-    private Content getTagletOutput(Element holder, ParamKind kind,
-                                    List<? extends ParamTree> paramTags,
-                                    List<? extends Element> formalParameters,
-                                    TagletWriter writer) {
-        Content result = writer.getOutputInstance();
-        result.add(convertParams(holder, kind, paramTags, formalParameters, writer));
-        return result;
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -246,14 +246,17 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
         // Document declared parameters for which tag documentation is available
         // (either directly or inherited) in order of their declaration.
         Content result = writer.getOutputInstance();
+        var first = true;
         for (int i = 0; i < formalParameters.size(); i++) {
             ParamTree dt = tagOfPosition.get(Integer.toString(i));
             if (dt != null) {
                 result.add(processParamTag(e, kind, writer, dt,
-                        ch.getParameterName(dt), result.isEmpty()));
+                        ch.getParameterName(dt), first));
+                first = false;
             } else if (writer.configuration().utils.isMethod(e)) {
                 result.add(getInheritedTagletOutput(kind, e, writer,
-                        formalParameters.get(i), i, result.isEmpty()));
+                        formalParameters.get(i), i, first));
+                first = false;
             }
         }
         if (paramTags.size() > tagOfPosition.size()) {
@@ -262,7 +265,8 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
             for (ParamTree dt : paramTags) {
                 if (!tagOfPosition.containsValue(dt)) {
                     result.add(processParamTag(e, kind, writer, dt,
-                            ch.getParameterName(dt), result.isEmpty()));
+                            ch.getParameterName(dt), first));
+                    first = false;
                 }
             }
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -191,13 +191,14 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
     /**
      * Returns a {@code Content} representation of a list of {@code ParamTree}.
      *
-     * <p> This method:
-     * <ul>
-     *   <li> correlates ParamTree with Element by name
-     *   <li> warns about {@code @param} tags that do not map to parameter
-     *        elements and param tags that are duplicated
-     * </ul>
-     * </p>
+     * <p> This method correlates {@code ParamTree} with {@code Element} by
+     * name. Once it's done, a particular {@code ParamTree} is addressed by the
+     * position (index) of the correlated {@code Element} in the list of formal
+     * parameter elements. This is needed for documentation inheritance as
+     * an inherited parameter may be named differently. </p>
+     *
+     * <p> This method warns about {@code @param} tags that do not map to
+     * parameter elements and param tags that are duplicated. </p>
      *
      * @param e the element
      * @param kind the kind of all parameters in the lists
@@ -242,7 +243,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
                 }
             }
         }
-        // Document declared parameters for which taglet documentation is available
+        // Document declared parameters for which tag documentation is available
         // (either directly or inherited) in order of their declaration.
         Content result = writer.getOutputInstance();
         for (int i = 0; i < formalParameters.size(); i++) {
@@ -256,7 +257,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
             }
         }
         if (paramTags.size() > tagOfPosition.size()) {
-            // Generate documentation for remaining taglets that do not match a declared parameter.
+            // Generate documentation for remaining tags that do not match a declared parameter.
             // These are erroneous but we generate them anyway.
             for (ParamTree dt : paramTags) {
                 if (!tagOfPosition.containsValue(dt)) {
@@ -269,7 +270,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
     }
 
     /**
-     * Convert the individual ParamTag into Content.
+     * Convert an individual {@code ParamTree} to {@code Content}.
      *
      * @param e               the owner element
      * @param kind            the kind of param tag

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -69,9 +69,6 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
      * @return a name-rank number map.
      */
     private static Map<String, String> getRankMap(Utils utils, List<? extends Element> params) {
-        if (params == null) {
-            return null;
-        }
         HashMap<String, String> result = new HashMap<>();
         int rank = 0;
         for (Element e : params) {
@@ -94,7 +91,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
             List<? extends Element> parameters = input.isTypeVariableParamTag
                     ? ee.getTypeParameters()
                     : ee.getParameters();
-            String target = ch.getParameterName(input.docTreeInfo.docTree());
+            String target = ch.getParameterName((ParamTree) input.docTreeInfo.docTree());
             for (int i = 0; i < parameters.size(); i++) {
                 Element e = parameters.get(i);
                 String pname = input.isTypeVariableParamTag
@@ -108,14 +105,14 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
         }
         ExecutableElement md = (ExecutableElement) input.element;
         CommentHelper ch = utils.getCommentHelper(md);
-        List<? extends DocTree> tags = input.isTypeVariableParamTag
+        List<? extends ParamTree> tags = input.isTypeVariableParamTag
                 ? utils.getTypeParamTrees(md)
                 : utils.getParamTrees(md);
         List<? extends Element> parameters = input.isTypeVariableParamTag
                 ? md.getTypeParameters()
                 : md.getParameters();
         Map<String, String> rankMap = getRankMap(utils, parameters);
-        for (DocTree tag : tags) {
+        for (ParamTree tag : tags) {
             String paramName = ch.getParameterName(tag);
             if (rankMap.containsKey(paramName) && rankMap.get(paramName).equals((input.tagId))) {
                 output.holder = input.element;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -206,7 +206,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
                                      List<? extends ParamTree> paramTags,
                                      List<? extends Element> formalParameters,
                                      TagletWriter writer) {
-        Map<String, ParamTree> documented = new HashMap<>();
+        Map<String, ParamTree> tagOfPosition = new HashMap<>();
         Messages messages = writer.configuration().getMessages();
         CommentHelper ch = writer.configuration().utils.getCommentHelper(e);
         if (!paramTags.isEmpty()) {
@@ -224,7 +224,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
                 }
                 String position = positionOfName.get(name);
                 if (position != null) {
-                    if (documented.containsKey(position)) {
+                    if (tagOfPosition.containsKey(position)) {
                         String key = switch (kind) {
                             case PARAMETER -> "doclet.Parameters_dup_warn";
                             case TYPE_PARAMETER -> "doclet.TypeParameters_dup_warn";
@@ -232,7 +232,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
                         };
                         messages.warning(ch.getDocTreePath(dt), key, paramName);
                     } else {
-                        documented.put(position, dt);
+                        tagOfPosition.put(position, dt);
                     }
                 }
             }
@@ -241,7 +241,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
         // (either directly or inherited) in order of their declaration.
         Content result = writer.getOutputInstance();
         for (int i = 0; i < formalParameters.size(); i++) {
-            ParamTree dt = documented.get(String.valueOf(i));
+            ParamTree dt = tagOfPosition.get(String.valueOf(i));
             if (dt != null) {
                 result.add(processParamTag(e, kind, writer, dt,
                         ch.getParameterName(dt), result.isEmpty()));
@@ -250,11 +250,11 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
                         formalParameters.get(i), i, result.isEmpty()));
             }
         }
-        if (paramTags.size() > documented.size()) {
+        if (paramTags.size() > tagOfPosition.size()) {
             // Generate documentation for remaining taglets that do not match a declared parameter.
             // These are erroneous but we generate them anyway.
             for (ParamTree dt : paramTags) {
-                if (!documented.containsValue(dt)) {
+                if (!tagOfPosition.containsValue(dt)) {
                     result.add(processParamTag(e, kind, writer, dt,
                             ch.getParameterName(dt), result.isEmpty()));
                 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -64,29 +64,29 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
     @Override
     public void inherit(DocFinder.Input input, DocFinder.Output output) {
         Utils utils = input.utils;
-        Element exception;
+        Element target;
         CommentHelper ch = utils.getCommentHelper(input.element);
         if (input.tagId == null) {
-            exception = input.docTreeInfo.docTree() instanceof ThrowsTree tt
+            target = input.docTreeInfo.docTree() instanceof ThrowsTree tt
                     ? ch.getException(tt) : null;
-            input.tagId = exception == null
+            input.tagId = target == null
                     ? ch.getExceptionName(input.docTreeInfo.docTree()).getSignature()
-                    : utils.getFullyQualifiedName(exception);
+                    : utils.getFullyQualifiedName(target);
         } else {
-            exception = input.utils.findClass(input.element, input.tagId);
+            target = input.utils.findClass(input.element, input.tagId);
         }
 
         for (ThrowsTree tt : input.utils.getThrowsTrees(input.element)) {
-            Element exc = ch.getException(tt);
-            if (exc != null && (input.tagId.equals(utils.getSimpleName(exc)) ||
-                    (input.tagId.equals(utils.getFullyQualifiedName(exc))))) {
+            Element candidate = ch.getException(tt);
+            if (candidate != null && (input.tagId.equals(utils.getSimpleName(candidate)) ||
+                    (input.tagId.equals(utils.getFullyQualifiedName(candidate))))) {
                 output.holder = input.element;
                 output.holderTag = tt;
                 output.inlineTags = ch.getBody(output.holderTag);
                 output.tagList.add(tt);
-            } else if (exception != null && exc != null &&
-                    utils.isTypeElement(exc) && utils.isTypeElement(exception) &&
-                    utils.isSubclassOf((TypeElement) exc, (TypeElement) exception)) {
+            } else if (target != null && candidate != null &&
+                    utils.isTypeElement(candidate) && utils.isTypeElement(target) &&
+                    utils.isSubclassOf((TypeElement) candidate, (TypeElement) target)) {
                 output.tagList.add(tt);
             }
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -87,7 +87,7 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
                 output.inlineTags = ch.getBody(output.holderTag);
                 output.tagList.add(tag);
             } else if (target != null && candidate != null &&
-                    utils.isTypeElement(candidate) && utils.isTypeElement(target) &&
+                    utils.isTypeElement(candidate) && utils.isTypeElement(target) && // FIXME: can they be anything else other than type elements?
                     utils.isSubclassOf((TypeElement) candidate, (TypeElement) target)) {
                 output.tagList.add(tag);
             }
@@ -108,7 +108,7 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
         Map<List<? extends ThrowsTree>, ExecutableElement> tagsMap = new LinkedHashMap<>();
         tagsMap.put(utils.getThrowsTrees(execHolder), execHolder);
         Content result = writer.getOutputInstance();
-        HashSet<String> alreadyDocumented = new HashSet<>();
+        Set<String> alreadyDocumented = new HashSet<>();
         if (!tagsMap.isEmpty()) {
             result.add(throwsTagsOutput(tagsMap, writer, alreadyDocumented, typeSubstitutions, true));
         }
@@ -147,21 +147,21 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
     /**
      * Returns the generated content for a collection of {@code @throws} tags.
      *
-     * @param throwTags         the collection of tags to be converted
+     * @param throwsTags        the collection of tags to be converted
      * @param writer            the taglet-writer used by the doclet
      * @param alreadyDocumented the set of exceptions that have already been documented
      * @param allowDuplicates   {@code true} if we allow duplicate tags to be documented
      * @return the generated content for the tags
      */
-    protected Content throwsTagsOutput(Map<List<? extends ThrowsTree>, ExecutableElement> throwTags,
+    protected Content throwsTagsOutput(Map<List<? extends ThrowsTree>, ExecutableElement> throwsTags,
                                        TagletWriter writer,
                                        Set<String> alreadyDocumented,
                                        Map<String, TypeMirror> typeSubstitutions,
                                        boolean allowDuplicates) {
         Utils utils = writer.configuration().utils;
         Content result = writer.getOutputInstance();
-        if (!throwTags.isEmpty()) {
-            for (Entry<List<? extends ThrowsTree>, ExecutableElement> entry : throwTags.entrySet()) {
+        if (!throwsTags.isEmpty()) {
+            for (Entry<List<? extends ThrowsTree>, ExecutableElement> entry : throwsTags.entrySet()) {
                 CommentHelper ch = utils.getCommentHelper(entry.getValue());
                 Element e = entry.getValue();
                 for (ThrowsTree dt : entry.getKey()) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -53,7 +53,8 @@ import jdk.javadoc.internal.doclets.toolkit.util.DocFinder.Input;
 import jdk.javadoc.internal.doclets.toolkit.util.Utils;
 
 /**
- * A taglet that represents the {@code @throws} tag.
+ * A taglet that processes {@link ThrowsTree}, which represents tags like
+ * {@code @throws} and {@code @exception}.
  */
 public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
 
@@ -215,7 +216,7 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
                     List<? extends ThrowsTree> inheritedTags = inheritedDoc.tagList.stream()
                             .map(t -> (ThrowsTree) t)
                             .toList();
-                    declaredExceptionTags.put(inheritedTags, (ExecutableElement) inheritedDoc.holder);
+                    ExecutableElement r = declaredExceptionTags.put(inheritedTags, (ExecutableElement) inheritedDoc.holder);
                 }
             }
             result.add(throwsTagsOutput(declaredExceptionTags, writer, alreadyDocumented,
@@ -227,6 +228,7 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
     private Content linkToUndocumentedDeclaredExceptions(List<? extends TypeMirror> declaredExceptionTypes,
                                                          Set<String> alreadyDocumented,
                                                          TagletWriter writer) {
+        // TODO: assert declaredExceptionTypes are instantiated
         Utils utils = writer.configuration().utils;
         Content result = writer.getOutputInstance();
         for (TypeMirror declaredExceptionType : declaredExceptionTypes) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -158,8 +158,8 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
         Utils utils = writer.configuration().utils;
         Content result = writer.getOutputInstance();
         for (Entry<List<? extends ThrowsTree>, ExecutableElement> entry : throwsTags.entrySet()) {
-            CommentHelper ch = utils.getCommentHelper(entry.getValue());
             Element e = entry.getValue();
+            CommentHelper ch = utils.getCommentHelper(e);
             for (ThrowsTree dt : entry.getKey()) {
                 Element te = ch.getException(dt);
                 String excName = ch.getExceptionName(dt).toString();

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -110,8 +110,7 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
         Content result = writer.getOutputInstance();
         Set<String> alreadyDocumented = new HashSet<>();
         result.add(throwsTagsOutput(tagsMap, writer, alreadyDocumented, typeSubstitutions, true));
-        result.add(inheritThrowsDocumentation(holder,
-                thrownTypes, alreadyDocumented, typeSubstitutions, writer));
+        result.add(inheritThrowsDocumentation(holder, thrownTypes, alreadyDocumented, typeSubstitutions, writer));
         result.add(linkToUndocumentedDeclaredExceptions(thrownTypes, alreadyDocumented, writer));
         return result;
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -229,15 +229,11 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
         return result;
     }
 
-    /**
-     * Add links for exceptions that are declared but not documented.
-     */
     private Content linkToUndocumentedDeclaredExceptions(List<? extends TypeMirror> declaredExceptionTypes,
                                                          Set<String> alreadyDocumented,
                                                          TagletWriter writer) {
         Utils utils = writer.configuration().utils;
         Content result = writer.getOutputInstance();
-        //Add links to the exceptions declared but not documented.
         for (TypeMirror declaredExceptionType : declaredExceptionTypes) {
             TypeElement te = utils.asTypeElement(declaredExceptionType);
             if (te != null &&

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -109,9 +109,7 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
         tagsMap.put(utils.getThrowsTrees(execHolder), execHolder);
         Content result = writer.getOutputInstance();
         Set<String> alreadyDocumented = new HashSet<>();
-        if (!tagsMap.isEmpty()) {
-            result.add(throwsTagsOutput(tagsMap, writer, alreadyDocumented, typeSubstitutions, true));
-        }
+        result.add(throwsTagsOutput(tagsMap, writer, alreadyDocumented, typeSubstitutions, true));
         result.add(inheritThrowsDocumentation(holder,
                 thrownTypes, alreadyDocumented, typeSubstitutions, writer));
         result.add(linkToUndocumentedDeclaredExceptions(thrownTypes, alreadyDocumented, writer));

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -160,31 +160,29 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
                                        boolean allowDuplicates) {
         Utils utils = writer.configuration().utils;
         Content result = writer.getOutputInstance();
-        if (!throwsTags.isEmpty()) {
-            for (Entry<List<? extends ThrowsTree>, ExecutableElement> entry : throwsTags.entrySet()) {
-                CommentHelper ch = utils.getCommentHelper(entry.getValue());
-                Element e = entry.getValue();
-                for (ThrowsTree dt : entry.getKey()) {
-                    Element te = ch.getException(dt);
-                    String excName = ch.getExceptionName(dt).toString();
-                    TypeMirror substituteType = typeSubstitutions.get(excName);
-                    if ((!allowDuplicates) &&
-                            (alreadyDocumented.contains(excName) ||
-                                    (te != null && alreadyDocumented.contains(utils.getFullyQualifiedName(te, false)))) ||
-                            (substituteType != null && alreadyDocumented.contains(substituteType.toString()))) {
-                        continue;
-                    }
-                    if (alreadyDocumented.isEmpty()) {
-                        result.add(writer.getThrowsHeader());
-                    }
-                    result.add(writer.throwsTagOutput(e, dt, substituteType));
-                    if (substituteType != null) {
-                        alreadyDocumented.add(substituteType.toString());
-                    } else {
-                        alreadyDocumented.add(te != null
-                                ? utils.getFullyQualifiedName(te, false)
-                                : excName);
-                    }
+        for (Entry<List<? extends ThrowsTree>, ExecutableElement> entry : throwsTags.entrySet()) {
+            CommentHelper ch = utils.getCommentHelper(entry.getValue());
+            Element e = entry.getValue();
+            for (ThrowsTree dt : entry.getKey()) {
+                Element te = ch.getException(dt);
+                String excName = ch.getExceptionName(dt).toString();
+                TypeMirror substituteType = typeSubstitutions.get(excName);
+                if ((!allowDuplicates) &&
+                        (alreadyDocumented.contains(excName) ||
+                                (te != null && alreadyDocumented.contains(utils.getFullyQualifiedName(te, false)))) ||
+                        (substituteType != null && alreadyDocumented.contains(substituteType.toString()))) {
+                    continue;
+                }
+                if (alreadyDocumented.isEmpty()) {
+                    result.add(writer.getThrowsHeader());
+                }
+                result.add(writer.throwsTagOutput(e, dt, substituteType));
+                if (substituteType != null) {
+                    alreadyDocumented.add(substituteType.toString());
+                } else {
+                    alreadyDocumented.add(te != null
+                            ? utils.getFullyQualifiedName(te, false)
+                            : excName);
                 }
             }
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -120,7 +120,7 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
 
     /**
      * Returns a map of substitutions for a list of thrown types with the original type-variable
-     * name as key and the instantiated type as value. If no types need to be substituted
+     * name as a key and the instantiated type as a value. If no types need to be substituted
      * an empty map is returned.
      * @param declaredThrownTypes the originally declared thrown types.
      * @param instantiatedThrownTypes the thrown types in the context of the current type.
@@ -129,15 +129,15 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
     private Map<String, TypeMirror> getSubstitutedThrownTypes(Types types,
                                                               List<? extends TypeMirror> declaredThrownTypes,
                                                               List<? extends TypeMirror> instantiatedThrownTypes) {
-        if (!instantiatedThrownTypes.equals(declaredThrownTypes)) {
+        if (!declaredThrownTypes.equals(instantiatedThrownTypes)) {
             Map<String, TypeMirror> map = new HashMap<>();
-            Iterator<? extends TypeMirror> i1 = instantiatedThrownTypes.iterator();
-            Iterator<? extends TypeMirror> i2 = declaredThrownTypes.iterator();
+            Iterator<? extends TypeMirror> i1 = declaredThrownTypes.iterator();
+            Iterator<? extends TypeMirror> i2 = instantiatedThrownTypes.iterator();
             while (i1.hasNext() && i2.hasNext()) {
                 TypeMirror t1 = i1.next();
                 TypeMirror t2 = i2.next();
                 if (!types.isSameType(t1, t2))
-                    map.put(t2.toString(), t1);
+                    map.put(t1.toString(), t2);
             }
             return map;
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -67,27 +67,29 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
         Element target;
         CommentHelper ch = utils.getCommentHelper(input.element);
         if (input.tagId == null) {
-            target = input.docTreeInfo.docTree() instanceof ThrowsTree tt
-                    ? ch.getException(tt) : null;
+            var tag = (ThrowsTree) input.docTreeInfo.docTree();
+            target = ch.getException(tag);
             input.tagId = target == null
-                    ? ch.getExceptionName(input.docTreeInfo.docTree()).getSignature()
+                    ? ch.getExceptionName(tag).getSignature()
                     : utils.getFullyQualifiedName(target);
         } else {
             target = input.utils.findClass(input.element, input.tagId);
         }
 
-        for (ThrowsTree tt : input.utils.getThrowsTrees(input.element)) {
-            Element candidate = ch.getException(tt);
+        // TODO warn if target == null as we cannot guarantee type-match, but at most FQN-match.
+
+        for (ThrowsTree tag : input.utils.getThrowsTrees(input.element)) {
+            Element candidate = ch.getException(tag);
             if (candidate != null && (input.tagId.equals(utils.getSimpleName(candidate)) ||
                     (input.tagId.equals(utils.getFullyQualifiedName(candidate))))) {
                 output.holder = input.element;
-                output.holderTag = tt;
+                output.holderTag = tag;
                 output.inlineTags = ch.getBody(output.holderTag);
-                output.tagList.add(tt);
+                output.tagList.add(tag);
             } else if (target != null && candidate != null &&
                     utils.isTypeElement(candidate) && utils.isTypeElement(target) &&
                     utils.isSubclassOf((TypeElement) candidate, (TypeElement) target)) {
-                output.tagList.add(tt);
+                output.tagList.add(tag);
             }
         }
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
@@ -547,10 +547,8 @@ public class CommentHelper {
         return dtree.getKind() == SEE ? ((SeeTree)dtree).getReference() : null;
     }
 
-    public ReferenceTree getExceptionName(DocTree dtree) {
-        return (dtree.getKind() == THROWS || dtree.getKind() == EXCEPTION)
-                ? ((ThrowsTree)dtree).getExceptionName()
-                : null;
+    public ReferenceTree getExceptionName(ThrowsTree tt) {
+        return tt.getExceptionName();
     }
 
     public IdentifierTree getName(DocTree dtree) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
@@ -125,19 +125,8 @@ public class CommentHelper {
         }
     }
 
-    public boolean isTypeParameter(DocTree dtree) {
-        if (dtree.getKind() == PARAM) {
-            return ((ParamTree)dtree).isTypeParameter();
-        }
-        return false;
-    }
-
-    public String getParameterName(DocTree dtree) {
-        if (dtree.getKind() == PARAM) {
-            return ((ParamTree) dtree).getName().getName().toString();
-        } else {
-            return null;
-        }
+    public String getParameterName(ParamTree p) {
+        return p.getName().getName().toString();
     }
 
     Element getElement(ReferenceTree rtree) {


### PR DESCRIPTION
A cleanup to facilitate fixing bugs like JDK-6509045: `{@inheritDoc}` only copies one instance of the specified exception.