### PR TITLE
8287336: GHA: Workflows break on patch versions

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -78,7 +78,10 @@ jobs:
           FEATURE=${{ fromJson(steps.check_deps.outputs.dependencies).DEFAULT_VERSION_FEATURE }}
           INTERIM=${{ fromJson(steps.check_deps.outputs.dependencies).DEFAULT_VERSION_INTERIM }}
           UPDATE=${{ fromJson(steps.check_deps.outputs.dependencies).DEFAULT_VERSION_UPDATE }}
-          if [ "x${UPDATE}" != "x0" ]; then
+          PATCH=${{ fromJson(steps.check_deps.outputs.dependencies).DEFAULT_VERSION_PATCH }}
+          if [ "x${PATCH}" != "x0" ]; then
+             V=${FEATURE}.${INTERIM}.${UPDATE}.${PATCH}
+          elif [ "x${UPDATE}" != "x0" ]; then
              V=${FEATURE}.${INTERIM}.${UPDATE}
           elif [ "x${INTERIM}" != "x0" ]; then
              V={FEATURE}.${INTERIM}


### PR DESCRIPTION
This fixes the issue on GHA when the branch contains a patch version.

Here you can see the problem: https://github.com/openjdk-bots/jdk18u/actions/runs/2385040187
And here you see how it looks if it's fixed: https://github.com/RealCLanger/jdk18u/actions/runs/2384983103

I plan to backport this fix to 18u, where the problem currently occurs, immediately.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287336](https://bugs.openjdk.java.net/browse/JDK-8287336): GHA: Workflows break on patch versions


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8888/head:pull/8888` \
`$ git checkout pull/8888`

Update a local copy of the PR: \
`$ git checkout pull/8888` \
`$ git pull https://git.openjdk.java.net/jdk pull/8888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8888`

View PR using the GUI difftool: \
`$ git pr show -t 8888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8888.diff">https://git.openjdk.java.net/jdk/pull/8888.diff</a>

</details>
