### PR TITLE
8287338: tools/javac/api/snippets/TestJavaxToolsSnippets.java failing tier1 on all platforms

### DIFF
--- a/test/langtools/tools/javac/api/snippets/TestJavaxToolsSnippets.java
+++ b/test/langtools/tools/javac/api/snippets/TestJavaxToolsSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ public class TestJavaxToolsSnippets extends TestRunner {
     SnippetUtils snippets = new SnippetUtils("java.compiler");
     ToolBox tb = new ToolBox();
 
-    TestJavaxToolsSnippets() {
+    TestJavaxToolsSnippets() throws SnippetUtils.ConfigurationException {
         super(System.err);
     }
 


### PR DESCRIPTION
This fixes tier1 failures caused by JDK-8279513. Test results pending.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287338](https://bugs.openjdk.java.net/browse/JDK-8287338): tools/javac/api/snippets/TestJavaxToolsSnippets.java failing tier1 on all platforms


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8890/head:pull/8890` \
`$ git checkout pull/8890`

Update a local copy of the PR: \
`$ git checkout pull/8890` \
`$ git pull https://git.openjdk.java.net/jdk pull/8890/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8890`

View PR using the GUI difftool: \
`$ git pr show -t 8890`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8890.diff">https://git.openjdk.java.net/jdk/pull/8890.diff</a>

</details>
