### PR TITLE
8287352: DockerTestUtils::execute shows incorrect elapsed time

### DIFF
--- a/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
@@ -269,7 +269,6 @@ public class DockerTestUtils {
      * @throws Exception
      */
     public static OutputAnalyzer execute(String... command) throws Exception {
-
         ProcessBuilder pb = new ProcessBuilder(command);
         System.out.println("[COMMAND]\n" + Utils.getCommandLine(pb));
 
@@ -280,12 +279,12 @@ public class DockerTestUtils {
 
         int max = MAX_LINES_TO_COPY_FOR_CHILD_STDOUT;
         String stdout = output.getStdout();
-        String stdoutTrimmed = trimLines(stdout, max);
+        String stdoutLimited = limitLines(stdout, max);
         System.out.println("[ELAPSED: " + (System.currentTimeMillis() - started) + " ms]");
         System.out.println("[STDERR]\n" + output.getStderr());
-        System.out.println("[STDOUT]\n" + stdoutTrimmed);
-        if (stdout != stdoutTrimmed) {
-            System.out.printf("Child process STDOUT is trimmed to %d lines\n",
+        System.out.println("[STDOUT]\n" + stdoutLimited);
+        if (stdout != stdoutLimited) {
+            System.out.printf("Child process STDOUT is limited to %d lines\n",
                               max);
         }
 
@@ -304,7 +303,7 @@ public class DockerTestUtils {
     }
 
 
-    private static String trimLines(String buffer, int nrOfLines) {
+    private static String limitLines(String buffer, int nrOfLines) {
         List<String> l = Arrays.asList(buffer.split("\\R"));
         if (l.size() < nrOfLines) {
             return buffer;

--- a/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
@@ -278,14 +278,19 @@ public class DockerTestUtils {
         long pid = p.pid();
         OutputAnalyzer output = new OutputAnalyzer(p);
 
-        String stdoutLogFile = String.format("docker-stdout-%d.log", pid);
+        int max = MAX_LINES_TO_COPY_FOR_CHILD_STDOUT;
+        String stdout = output.getStdout();
+        String stdoutTrimmed = trimLines(stdout, max);
         System.out.println("[ELAPSED: " + (System.currentTimeMillis() - started) + " ms]");
         System.out.println("[STDERR]\n" + output.getStderr());
-        System.out.println("[STDOUT]\n" +
-                           trimLines(output.getStdout(),MAX_LINES_TO_COPY_FOR_CHILD_STDOUT));
-        System.out.printf("Child process STDOUT is trimmed to %d lines \n",
-                           MAX_LINES_TO_COPY_FOR_CHILD_STDOUT);
-        writeOutputToFile(output.getStdout(), stdoutLogFile);
+        System.out.println("[STDOUT]\n" + stdoutTrimmed);
+        if (stdout != stdoutTrimmed) {
+            System.out.printf("Child process STDOUT is trimmed to %d lines\n",
+                              max);
+        }
+
+        String stdoutLogFile = String.format("docker-stdout-%d.log", pid);
+        writeOutputToFile(stdout, stdoutLogFile);
         System.out.println("Full child process STDOUT was saved to " + stdoutLogFile);
 
         return output;


### PR DESCRIPTION
Please review this small change to improve the test reporting:

- Calculating elapsed time after child process has exited
- Do not print `"Child process STDOUT is trimmed ..."` unless the lines are really trimmed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287352](https://bugs.openjdk.java.net/browse/JDK-8287352): DockerTestUtils::execute shows incorrect elapsed time


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [6a225656](https://git.openjdk.java.net/jdk/pull/8897/files/6a225656b9f76e1bc3c3ab25a8f9269363506128)
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8897/head:pull/8897` \
`$ git checkout pull/8897`

Update a local copy of the PR: \
`$ git checkout pull/8897` \
`$ git pull https://git.openjdk.java.net/jdk pull/8897/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8897`

View PR using the GUI difftool: \
`$ git pr show -t 8897`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8897.diff">https://git.openjdk.java.net/jdk/pull/8897.diff</a>

</details>
