### PR TITLE
8287318: ConcurrentModificationException in sun.net.httpserver.ServerImpl$Dispatcher

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -379,9 +379,7 @@ class ServerImpl implements TimeSource {
                     // modified (leading to ConcurrentModificationException) due to
                     // any subsequent select operations that we invoke on the
                     // selector (in this same thread).
-                    final Set<SelectionKey> copy = new HashSet<>(selected);
-                    // iterate over the copy
-                    for (final SelectionKey key : copy) {
+                    for (final SelectionKey key : selected.toArray(SelectionKey[]::new)) {
                         // remove the key from the original selected keys (live) Set
                         selected.remove(key);
                         if (key.equals (listenerKey)) {

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -374,10 +374,16 @@ class ServerImpl implements TimeSource {
 
                     /* process the selected list now  */
                     Set<SelectionKey> selected = selector.selectedKeys();
-                    Iterator<SelectionKey> iter = selected.iterator();
-                    while (iter.hasNext()) {
-                        SelectionKey key = iter.next();
-                        iter.remove ();
+                    // create a copy of the selected keys so that we can iterate over it
+                    // and at the same time not worry about the underlying Set being
+                    // modified (leading to ConcurrentModificationException) due to
+                    // any subsequent select operations that we invoke on the
+                    // selector (in this same thread).
+                    final Set<SelectionKey> copy = new HashSet<>(selected);
+                    // iterate over the copy
+                    for (final SelectionKey key : copy) {
+                        // remove the key from the original selected keys (live) Set
+                        selected.remove(key);
                         if (key.equals (listenerKey)) {
                             if (terminating) {
                                 continue;


### PR DESCRIPTION
Can I please get a review of this change which addresses the issue noted in https://bugs.openjdk.java.net/browse/JDK-8287318?

The `ServerImpl` has a `Dispatcher` thread which uses a `Selector` to select keys of interested. The selected keys is then iterated over and each key is removed through the iterator. This is fine as long as the selector isn't then used to invoke select operation(s) while the iterator is still in use. Doing so leads to the underlying Set being potentially modified with updates to the selected keys. As a result any subsequent use of the iterator will lead to `ConcurrentModificationException` as seen in the linked issue.

The commit here fixes that by creating a copy of the selected keys and iterating over it so that any subsequent select operation on the selector won't have impact on the Set that is being iterated upon. 

No new tests have been added given the intermittent nature of this issue. Existing tier1, tier2 and tier3 tests passed without any related failures, after this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287318](https://bugs.openjdk.java.net/browse/JDK-8287318): ConcurrentModificationException in sun.net.httpserver.ServerImpl$Dispatcher


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8898/head:pull/8898` \
`$ git checkout pull/8898`

Update a local copy of the PR: \
`$ git checkout pull/8898` \
`$ git pull https://git.openjdk.java.net/jdk pull/8898/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8898`

View PR using the GUI difftool: \
`$ git pr show -t 8898`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8898.diff">https://git.openjdk.java.net/jdk/pull/8898.diff</a>

</details>
