### PR TITLE
remove outdated option: InteriorEntryAlignment

### DIFF
--- a/src/hotspot/cpu/aarch64/c2_init_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_init_aarch64.cpp
@@ -32,6 +32,5 @@
 extern void reg_mask_init();
 
 void Compile::pd_compiler2_init() {
-  guarantee(CodeEntryAlignment >= InteriorEntryAlignment, "" );
   reg_mask_init();
 }

--- a/src/hotspot/cpu/arm/c2_globals_arm.hpp
+++ b/src/hotspot/cpu/arm/c2_globals_arm.hpp
@@ -46,7 +46,6 @@ define_pd_global(intx, OnStackReplacePercentage,     140);
 define_pd_global(intx, ConditionalMoveLimit,         4);
 // C2 gets to use all the float/double registers
 define_pd_global(intx, FreqInlineSize,               175);
-define_pd_global(intx, InteriorEntryAlignment,       16);  // = CodeEntryAlignment
 define_pd_global(size_t, NewSizeThreadIncrease,      ScaleForWordSize(4*K));
 // The default setting 16/16 seems to work best.
 // (For _228_jack 16/16 is 2% better than 4/4, 16/4, 32/32, 32/16, or 16/32.)

--- a/src/hotspot/cpu/ppc/c2_globals_ppc.hpp
+++ b/src/hotspot/cpu/ppc/c2_globals_ppc.hpp
@@ -46,7 +46,6 @@ define_pd_global(intx, OnStackReplacePercentage,     140);
 define_pd_global(intx, ConditionalMoveLimit,         3);
 define_pd_global(intx, FreqInlineSize,               175);
 define_pd_global(intx, MinJumpTableSize,             10);
-define_pd_global(intx, InteriorEntryAlignment,       16);
 define_pd_global(size_t, NewSizeThreadIncrease,      ScaleForWordSize(4*K));
 define_pd_global(intx, RegisterCostAreaRatio,        16000);
 define_pd_global(intx, LoopUnrollLimit,              60);

--- a/src/hotspot/cpu/riscv/c2_globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_globals_riscv.hpp
@@ -46,7 +46,6 @@ define_pd_global(intx, OnStackReplacePercentage,     140);
 define_pd_global(intx, ConditionalMoveLimit,         0);
 define_pd_global(intx, FreqInlineSize,               325);
 define_pd_global(intx, MinJumpTableSize,             10);
-define_pd_global(intx, InteriorEntryAlignment,       16);
 define_pd_global(intx, NewSizeThreadIncrease, ScaleForWordSize(4*K));
 define_pd_global(intx, LoopUnrollLimit,              60);
 define_pd_global(intx, LoopPercentProfileLimit,      10);

--- a/src/hotspot/cpu/riscv/c2_init_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_init_riscv.cpp
@@ -33,6 +33,5 @@
 extern void reg_mask_init();
 
 void Compile::pd_compiler2_init() {
-  guarantee(CodeEntryAlignment >= InteriorEntryAlignment, "" );
   reg_mask_init();
 }

--- a/src/hotspot/cpu/s390/c2_globals_s390.hpp
+++ b/src/hotspot/cpu/s390/c2_globals_s390.hpp
@@ -46,7 +46,6 @@ define_pd_global(intx, OnStackReplacePercentage,     140);
 define_pd_global(intx, ConditionalMoveLimit,         4);
 define_pd_global(intx, FreqInlineSize,               175);
 // 10 prevents spill-split-recycle sanity check in JVM2008.xml.transform.
-define_pd_global(intx, InteriorEntryAlignment,       2);
 define_pd_global(size_t, NewSizeThreadIncrease,      ScaleForWordSize(4*K));
 define_pd_global(intx, RegisterCostAreaRatio,        12000);
 define_pd_global(intx, LoopUnrollLimit,              60);

--- a/src/hotspot/cpu/s390/c2_init_s390.cpp
+++ b/src/hotspot/cpu/s390/c2_init_s390.cpp
@@ -30,5 +30,4 @@
 // Processor dependent initialization for z/Architecture.
 
 void Compile::pd_compiler2_init() {
-  guarantee(CodeEntryAlignment >= InteriorEntryAlignment, "");
 }

--- a/src/hotspot/cpu/x86/c2_globals_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_globals_x86.hpp
@@ -46,7 +46,6 @@ define_pd_global(intx, FreqInlineSize,               325);
 define_pd_global(intx, MinJumpTableSize,             10);
 define_pd_global(intx, LoopPercentProfileLimit,      10);
 #ifdef AMD64
-define_pd_global(intx,  InteriorEntryAlignment,      16);
 define_pd_global(size_t, NewSizeThreadIncrease,     ScaleForWordSize(4*K));
 define_pd_global(intx,  LoopUnrollLimit,             60);
 // InitialCodeCacheSize derived from specjbb2000 run.
@@ -56,7 +55,6 @@ define_pd_global(uintx, CodeCacheExpansionSize,      64*K);
 // Ergonomics related flags
 define_pd_global(uint64_t, MaxRAM,                   128ULL*G);
 #else
-define_pd_global(intx,  InteriorEntryAlignment,      4);
 define_pd_global(size_t, NewSizeThreadIncrease,      4*K);
 define_pd_global(intx,  LoopUnrollLimit,             50);     // Design center runs on 1.3.1
 // InitialCodeCacheSize derived from specjbb2000 run.

--- a/src/hotspot/cpu/x86/c2_init_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_init_x86.cpp
@@ -33,7 +33,6 @@
 extern void reg_mask_init();
 
 void Compile::pd_compiler2_init() {
-  guarantee(CodeEntryAlignment >= InteriorEntryAlignment, "" );
   // QQQ presumably all 64bit cpu's support this. Seems like the ifdef could
   // simply be left out.
 #ifndef AMD64

--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -75,10 +75,8 @@ void Block_List::print() {
 #endif
 
 uint Block::code_alignment() const {
-  // Check for Root block
-  if (_pre_order == 0) return CodeEntryAlignment;
-  // Check for Start block
-  if (_pre_order == 1) return InteriorEntryAlignment;
+  // Start block alignment is provided by instructions CodeSection
+
   // Check for loop alignment
   if (has_loop_alignment()) return loop_alignment();
 

--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -67,11 +67,6 @@
           "in the prologue of every nmethod")                               \
           range(0, 128)                                                     \
                                                                             \
-  product_pd(intx, InteriorEntryAlignment,                                  \
-          "Code alignment for interior entry points "                       \
-          "in generated code (in bytes)")                                   \
-          constraint(InteriorEntryAlignmentConstraintFunc, AfterErgo)       \
-                                                                            \
   product(intx, MaxLoopPad, (OptoLoopAlignment-1),                          \
           "Align a loop if padding size in bytes is less or equal to this " \
           "value")                                                          \

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -329,40 +329,6 @@ JVMFlag::Error InitArrayShortSizeConstraintFunc(intx value, bool verbose) {
 }
 
 #ifdef COMPILER2
-JVMFlag::Error InteriorEntryAlignmentConstraintFunc(intx value, bool verbose) {
-  if (InteriorEntryAlignment > CodeEntryAlignment) {
-    JVMFlag::printError(verbose,
-                       "InteriorEntryAlignment (" INTX_FORMAT ") must be "
-                       "less than or equal to CodeEntryAlignment (" INTX_FORMAT ")\n",
-                       InteriorEntryAlignment, CodeEntryAlignment);
-    return JVMFlag::VIOLATES_CONSTRAINT;
-  }
-
-  if (!is_power_of_2(value)) {
-     JVMFlag::printError(verbose,
-                         "InteriorEntryAlignment (" INTX_FORMAT ") must be "
-                         "a power of two\n", InteriorEntryAlignment);
-     return JVMFlag::VIOLATES_CONSTRAINT;
-   }
-
-  int minimum_alignment = 16;
-#if defined(X86) && !defined(AMD64)
-  minimum_alignment = 4;
-#elif defined(S390)
-  minimum_alignment = 2;
-#endif
-
-  if (InteriorEntryAlignment < minimum_alignment) {
-    JVMFlag::printError(verbose,
-                        "InteriorEntryAlignment (" INTX_FORMAT ") must be "
-                        "greater than or equal to %d\n",
-                        InteriorEntryAlignment, minimum_alignment);
-    return JVMFlag::VIOLATES_CONSTRAINT;
-  }
-
-  return JVMFlag::SUCCESS;
-}
-
 JVMFlag::Error NodeLimitFudgeFactorConstraintFunc(intx value, bool verbose) {
   if (value < MaxNodeLimit * 2 / 100 || value > MaxNodeLimit * 40 / 100) {
     JVMFlag::printError(verbose,

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.hpp
@@ -54,7 +54,6 @@
   f(ccstrlist, DisableIntrinsicConstraintFunc)          \
   f(ccstrlist, ControlIntrinsicConstraintFunc)          \
 COMPILER2_PRESENT(                                      \
-  f(intx,  InteriorEntryAlignmentConstraintFunc)        \
   f(intx,  NodeLimitFudgeFactorConstraintFunc)          \
   f(uintx, LoopStripMiningIterConstraintFunc)           \
 )


### PR DESCRIPTION
The InteriorEntryAlignment is an outdated option. The only place it is used is opto/block.cpp:
```cpp
uint Block::code_alignment() const {
  // Check for Root block
  if (_pre_order == 0) return CodeEntryAlignment;
  // Check for Start block
  if (_pre_order == 1) return InteriorEntryAlignment;
  // Check for loop alignment
  if (has_loop_alignment()) return loop_alignment();
}
```
In fact, _pre_order value is always >0 at generation phase. And CodeEntryAlignment padding is applied for first (Start) block by SECT_INSTS CodeSection alignment. So there is no need to align it more in opto/block.cpp.

**Update.**

1. In fact, option removal is a long process:
- https://wiki.openjdk.java.net/display/csr/Main
- https://wiki.openjdk.java.net/display/HotSpot/Hotspot+Command-line+Flags%3A+Kinds%2C+Lifecycle+and+the+CSR+Process
- https://bugs.openjdk.java.net/browse/JDK-8274564

**The correct Block::code_alignment code analysis**

block#0 (root block) does not need any alignment because
  - code buffer is well aligned
  - block#0 is the first code generated into the buffer

block#1 needs some alignment when block#0 is not empty
  - it happens when [Entry Point] co-exist with [Verified Entry Point] in a method:
    -  in this case unverified Entry Point goes to block#0 (see MachUEPNode), and verified Entry Point, as usual, stays in block#1
  - though [Verified Entry Point] is not an internal code entry, it is just another public entry point, so the CodeEntryAlignment value would be correct for (_pre_order == 1) case
  - same time CodeEntryAlignment is pretty big, it will blow up the code size with the big padding in between [Entry Point] and [Verified Entry Point]
    - for reference, InteriorEntryAlignment/CodeEntryAlignment values are: 
    - arm:16/16, aarch:16/64, x86:16(4)/32(16), riscv:16/64, ppc:16/128, s390:2/64

**Solution**
  - CodeEntryAlignment must be decreased for all platforms
    - this change requires proper preformance measurement
  - start block Block::code_alignment code will be changed to: if (_pre_order == 1) return CodeEntryAlignment;
  - with the last InteriorEntryAlignment option usage removal the option removal process can be started

_I'm closing the PR for now as it's not the right time to continue with it_

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8902/head:pull/8902` \
`$ git checkout pull/8902`

Update a local copy of the PR: \
`$ git checkout pull/8902` \
`$ git pull https://git.openjdk.java.net/jdk pull/8902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8902`

View PR using the GUI difftool: \
`$ git pr show -t 8902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8902.diff">https://git.openjdk.java.net/jdk/pull/8902.diff</a>

</details>
