### PR TITLE
8287378: GHA: Update cygwin to fix issues in langtools tests on Windows

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -921,7 +921,7 @@ jobs:
 
       - name: Install cygwin
         run: |
-          Start-Process -FilePath "$HOME\cygwin\setup-x86_64.exe" -ArgumentList "--quiet-mode --packages cygwin=3.2.0-1,autoconf,make,zip,unzip --root $HOME\cygwin\cygwin64 --local-package-dir $HOME\cygwin\packages --site http://mirrors.kernel.org/sourceware/cygwin --no-desktop --no-shortcuts --no-startmenu --no-admin" -Wait -NoNewWindow
+          Start-Process -FilePath "$HOME\cygwin\setup-x86_64.exe" -ArgumentList "--quiet-mode --packages cygwin=3.3.5-1,autoconf,make,zip,unzip --root $HOME\cygwin\cygwin64 --local-package-dir $HOME\cygwin\packages --site http://mirrors.kernel.org/sourceware/cygwin --no-desktop --no-shortcuts --no-startmenu --no-admin" -Wait -NoNewWindow
 
       - name: Checkout the source
         uses: actions/checkout@v3
@@ -1020,7 +1020,7 @@ jobs:
 
       - name: Install cygwin
         run: |
-          Start-Process -FilePath "$HOME\cygwin\setup-x86_64.exe" -ArgumentList "--quiet-mode --packages cygwin=3.2.0-1,autoconf,make,zip,unzip --root $HOME\cygwin\cygwin64 --local-package-dir $HOME\cygwin\packages --site http://mirrors.kernel.org/sourceware/cygwin --no-desktop --no-shortcuts --no-startmenu --no-admin" -Wait -NoNewWindow
+          Start-Process -FilePath "$HOME\cygwin\setup-x86_64.exe" -ArgumentList "--quiet-mode --packages cygwin=3.3.5-1,autoconf,make,zip,unzip --root $HOME\cygwin\cygwin64 --local-package-dir $HOME\cygwin\packages --site http://mirrors.kernel.org/sourceware/cygwin --no-desktop --no-shortcuts --no-startmenu --no-admin" -Wait -NoNewWindow
 
       - name: Checkout the source
         uses: actions/checkout@v3
@@ -1202,7 +1202,7 @@ jobs:
 
       - name: Install cygwin
         run: |
-          Start-Process -FilePath "$HOME\cygwin\setup-x86_64.exe" -ArgumentList "--quiet-mode --packages cygwin=3.2.0-1,autoconf,make,zip,unzip --root $HOME\cygwin\cygwin64 --local-package-dir $HOME\cygwin\packages --site http://mirrors.kernel.org/sourceware/cygwin --no-desktop --no-shortcuts --no-startmenu --no-admin" -Wait -NoNewWindow
+          Start-Process -FilePath "$HOME\cygwin\setup-x86_64.exe" -ArgumentList "--quiet-mode --packages cygwin=3.3.5-1,autoconf,make,zip,unzip --root $HOME\cygwin\cygwin64 --local-package-dir $HOME\cygwin\packages --site http://mirrors.kernel.org/sourceware/cygwin --no-desktop --no-shortcuts --no-startmenu --no-admin" -Wait -NoNewWindow
 
       - name: Restore jtreg artifact
         id: jtreg_restore


### PR DESCRIPTION
This fixes the Windows GHA test failures that popped up short time ago, e.g. [these](https://github.com/RealCLanger/jdk/runs/6598399845)

Failing tests:
tools/javac/Paths/MineField.sh
tools/javac/Paths/wcMineField.sh

I've debugged it and it comes down to calls to javac/java in the test through env are failing with RC 127. E.g. here:
https://github.com/openjdk/jdk/blob/e44465d4d6eaddebfc5a1b149223aa8332affa8b/test/langtools/tools/javac/Paths/MineField.sh#L218

Don't know why but I figured that the test failure goes away with current cygwin.

It should be ok to update cygwin now because the bug that made JDK-8276854 necessary seems to be fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287378](https://bugs.openjdk.java.net/browse/JDK-8287378): GHA: Update cygwin to fix issues in langtools tests on Windows


### Reviewers
 * [Andrey Turbanov](https://openjdk.java.net/census#aturbanov) (@turbanoff - Committer)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8903/head:pull/8903` \
`$ git checkout pull/8903`

Update a local copy of the PR: \
`$ git checkout pull/8903` \
`$ git pull https://git.openjdk.java.net/jdk pull/8903/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8903`

View PR using the GUI difftool: \
`$ git pr show -t 8903`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8903.diff">https://git.openjdk.java.net/jdk/pull/8903.diff</a>

</details>
