### PR TITLE
8271406: Kitchensink failed with "assert(early->flag() == current->flag()) failed: Should be the same"

### DIFF
--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -793,7 +793,8 @@ void MemDetailDiffReporter::old_virtual_memory_site(const VirtualMemoryAllocatio
 
 void MemDetailDiffReporter::diff_virtual_memory_site(const VirtualMemoryAllocationSite* early,
   const VirtualMemoryAllocationSite* current) const {
-  assert(early->flag() == current->flag(), "Should be the same");
+  assert(early->flag() == current->flag() || early->flag() == mtNone,
+    "Expect the same flag, but %s != %s", NMTUtil::flag_to_name(early->flag()),NMTUtil::flag_to_name(current->flag()));
   diff_virtual_memory_site(current->call_stack(), current->reserved(), current->committed(),
     early->reserved(), early->committed(), current->flag());
 }


### PR DESCRIPTION
There is a narrow race window if nmt baseline is executed between reserving a virtual region and setting it nmt type, that can result the assertion failure.

Thanks @coleenp for testing the patch, as it is an Oracle internal test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271406](https://bugs.openjdk.java.net/browse/JDK-8271406): Kitchensink failed with "assert(early->flag() == current->flag()) failed: Should be the same"


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8906/head:pull/8906` \
`$ git checkout pull/8906`

Update a local copy of the PR: \
`$ git checkout pull/8906` \
`$ git pull https://git.openjdk.java.net/jdk pull/8906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8906`

View PR using the GUI difftool: \
`$ git pr show -t 8906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8906.diff">https://git.openjdk.java.net/jdk/pull/8906.diff</a>

</details>
