### PR TITLE
8287425: Remove unnecessary register push for MacroAssembler::check_klass_subtype_slow_path

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1123,7 +1123,7 @@ void MacroAssembler::check_klass_subtype_slow_path(Register sub_klass,
   if (!IS_A_TEMP(r2))    pushed_registers += r2;
   if (!IS_A_TEMP(r5))    pushed_registers += r5;
 
-  if (super_klass != r0 || UseCompressedOops) {
+  if (super_klass != r0) {
     if (!IS_A_TEMP(r0))   pushed_registers += r0;
   }
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2624,7 +2624,7 @@ void MacroAssembler::check_klass_subtype_slow_path(Register sub_klass,
     pushed_registers += x15;
   }
 
-  if (super_klass != x10 || UseCompressedOops) {
+  if (super_klass != x10) {
     if (!IS_A_TEMP(x10)) {
       pushed_registers += x10;
     }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -4153,7 +4153,7 @@ void MacroAssembler::check_klass_subtype_slow_path(Register sub_klass,
 
   // Get super_klass value into rax (even if it was in rdi or rcx).
   bool pushed_rax = false, pushed_rcx = false, pushed_rdi = false;
-  if (super_klass != rax || UseCompressedOops) {
+  if (super_klass != rax) {
     if (!IS_A_TEMP(rax)) { push(rax); pushed_rax = true; }
     mov(rax, super_klass);
   }


### PR DESCRIPTION
Hi team,

![AE98A8E7-9F6F-4722-B310-299A9A96A957](https://user-images.githubusercontent.com/38156692/170670906-2ce37a13-af21-4cf8-acbd-ca24528bc3a9.png)

Some perf results show unnecessary pushes in `MacroAssembler::check_klass_subtype_slow_path()` under `UseCompressedOops`. History logs show the original code is like [1], and it gets refactored in [JDK-6813212](https://bugs.openjdk.java.net/browse/JDK-6813212), and the counterparts of the `UseCompressedOops` in the diff are at [2] and [3], and we could see the push of rax is just because `encode_heap_oop_not_null()` would kill it, so here needs a push and restore. After that, [JDK-6964458](https://bugs.openjdk.java.net/browse/JDK-6964458) (removal of perm gen) at [4] removed [3] so that there is no need to do UseCompressedOops work in `MacroAssembler::check_klass_subtype_slow_path()`; but in that patch [2] didn't get removed, so we finally come here. As a result, [2] could also be safely removed.

(Files in [4] are folded because the patch is too large. We could manually unfold `hotspot/src/cpu/x86/vm/assembler_x86.cpp` to see that diff)

I was wondering if this minor change could be sponsored?

This enhancement is raised on behalf of Wei Kuai <kuaiwei.kw@alibaba-inc.com>.

Tested x86_64 hotspot tier1\~tier4 twice, aarch64 hotspot tier1\~tier4 once with another jdk tier1 once, and riscv64 hotspot tier1\~tier4 once.

Thanks,
Xiaolin

[1] https://github.com/openjdk/jdk/blob/de67e5294982ce197f2abd051cbb1c8aa6c29499/hotspot/src/cpu/x86/vm/interp_masm_x86_64.cpp#L273-L284
[2] https://github.com/openjdk/jdk/commit/b8dbe8d8f650124b61a4ce8b70286b5b444a3316#diff-beb6684583b0a552a99bbe4b5a21828489a6d689b32a05e1a9af8c3be9f463c3R7441-R7444
[3] https://github.com/openjdk/jdk/commit/b8dbe8d8f650124b61a4ce8b70286b5b444a3316#diff-beb6684583b0a552a99bbe4b5a21828489a6d689b32a05e1a9af8c3be9f463c3R7466-R7477
[4] https://github.com/openjdk/jdk/commit/5c58d27aac7b291b879a7a3ff6f39fca25619103#diff-beb6684583b0a552a99bbe4b5a21828489a6d689b32a05e1a9af8c3be9f463c3L9347-L9361

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287425](https://bugs.openjdk.java.net/browse/JDK-8287425): Remove unnecessary register push for MacroAssembler::check_klass_subtype_slow_path


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Contributors
 * Wei Kuai `<kuaiwei.kw@alibaba-inc.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8915/head:pull/8915` \
`$ git checkout pull/8915`

Update a local copy of the PR: \
`$ git checkout pull/8915` \
`$ git pull https://git.openjdk.java.net/jdk pull/8915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8915`

View PR using the GUI difftool: \
`$ git pr show -t 8915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8915.diff">https://git.openjdk.java.net/jdk/pull/8915.diff</a>

</details>
