### PR TITLE
8285558: IGV: scheduling crashes on control-unreachable CFG nodes

### DIFF
--- a/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
+++ b/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
@@ -327,20 +327,6 @@ public class ServerCompilerScheduler implements Scheduler {
             schedulePinned();
             buildDominators();
             scheduleLatest();
-
-            InputBlock noBlock = null;
-            for (InputNode n : graph.getNodes()) {
-                if (graph.getBlock(n) == null) {
-                    if (noBlock == null) {
-                        noBlock = graph.addArtificialBlock();
-                        blocks.add(noBlock);
-                    }
-
-                    graph.setBlock(n, noBlock);
-                }
-                assert graph.getBlock(n) != null;
-            }
-
             scheduleLocal();
             check();
             reportWarnings();
@@ -631,6 +617,12 @@ public class ServerCompilerScheduler implements Scheduler {
                 if (controlSuccs.get(ctrlIn).size() == 1) {
                     block = controlSuccs.get(ctrlIn).get(0).block;
                 }
+            }
+            if (block == null) {
+                // This can happen for blockless CFG nodes that are not
+                // control-reachable from the root even after connecting orphans
+                // and widows (e.g. in disconnected control cycles).
+                continue;
             }
             n.block = block;
             block.addNode(n.inputNode.getId());

--- a/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
+++ b/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
@@ -53,6 +53,7 @@ public class ServerCompilerScheduler implements Scheduler {
         public static final String WARNING_NOT_MARKED_WITH_BLOCK_START = "Region not marked with is_block_start";
         public static final String WARNING_CFG_AND_INPUT_TO_PHI = "CFG node is a phi input";
         public static final String WARNING_PHI_NON_DOMINATING_INPUTS = "Phi input that does not dominate the phi's input block";
+        public static final String WARNING_CONTROL_UNREACHABLE_CFG = "Control-unreachable CFG node";
 
         public InputNode inputNode;
         public Set<Node> succs = new HashSet<>();
@@ -881,6 +882,9 @@ public class ServerCompilerScheduler implements Scheduler {
             // Check that region nodes are well-formed.
             if (isRegion(n) && !n.isBlockStart) {
                 n.addWarning(Node.WARNING_NOT_MARKED_WITH_BLOCK_START);
+            }
+            if (n.isCFG && n.block == null) {
+                n.addWarning(Node.WARNING_CONTROL_UNREACHABLE_CFG);
             }
             if (!isPhi(n)) {
                 continue;


### PR DESCRIPTION
This changeset relaxes IGV's schedule approximation algorithm to handle CFG nodes that are not reachable from the root node via a control path. This is done by 1) removing the assumption that, after `ServerCompilerScheduler::buildBlocks()`, `Node::block` is non-null for CFG nodes; and 2) leaving the assignment of blockless nodes to an artificial "no block" to `InputGraph::ensureNodesInBlocks()`, which is always called after running the schedule approximation algorithm.

Additionally, the changeset marks unreachable CFG nodes with a warning, making it easier to identify ill-formed graphs:

![screenshot of IGV graph where some nodes are marked with a warning](https://user-images.githubusercontent.com/8792647/170678998-bffc293f-90ce-45e7-9aea-7cc5ab184026.png)

#### Testing

- Tested manually on the two graphs reported in the [JBS issue](https://bugs.openjdk.java.net/browse/JDK-8285558).

- Tested automatically that scheduling tens of thousands of graphs (by instrumenting IGV to schedule parsed graphs eagerly and running `java -Xcomp -XX:-TieredCompilation -XX:PrintIdealGraphLevel=4`) does not introduce any exception or assertion failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285558](https://bugs.openjdk.java.net/browse/JDK-8285558): IGV: scheduling crashes on control-unreachable CFG nodes


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8916/head:pull/8916` \
`$ git checkout pull/8916`

Update a local copy of the PR: \
`$ git checkout pull/8916` \
`$ git pull https://git.openjdk.java.net/jdk pull/8916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8916`

View PR using the GUI difftool: \
`$ git pr show -t 8916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8916.diff">https://git.openjdk.java.net/jdk/pull/8916.diff</a>

</details>
