### PR TITLE
8287430  MemorySessionImpl::addOrCleanupIfFail does not rethrow exceptions

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
@@ -97,16 +97,13 @@ public abstract non-sealed class MemorySessionImpl implements Scoped, MemorySess
             addInternal(resource);
         } catch (Throwable ex) {
             resource.cleanup();
+            throw ex;
         }
     }
 
     void addInternal(ResourceList.ResourceCleanup resource) {
-        try {
-            checkValidStateSlow();
-            resourceList.add(resource);
-        } catch (ScopedMemoryAccess.ScopedAccessError err) {
-            throw new IllegalStateException("Already closed");
-        }
+        checkValidStateSlow();
+        resourceList.add(resource);
     }
 
     protected MemorySessionImpl(Thread owner, ResourceList resourceList, Cleaner cleaner) {

--- a/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
@@ -103,6 +103,12 @@ public abstract non-sealed class MemorySessionImpl implements Scoped, MemorySess
 
     void addInternal(ResourceList.ResourceCleanup resource) {
         checkValidStateSlow();
+        // Note: from here on we no longer check the session state. Two cases are possible: either the resource cleanup
+        // is added to the list when the session is still open, in which case everything works ok; or the resource
+        // cleanup is added while the session is being closed. In this latter case, what matters is whether we have already
+        // called `ResourceList::cleanup` to run all the cleanup actions. If not, we can still add this resource
+        // to the list (and, in case of an add vs. close race, it might happen that the cleanup action will be
+        // called immediately after).
         resourceList.add(resource);
     }
 


### PR DESCRIPTION
This patch fix a missing rethrow in `MemorySessionImpl::addOrCleanupIfFail`. As noted in the JBS issue, this bug does not affect correctness, but it delays error reporting.

Writing a test for this is nearly impossible, given that (a) a memory resource created against a closed session would be inaccessible by clients (because the session is closed!), and (b) because of the narrow window in which the problem might manifest (for this problem to occur, a session state change would have to occur between the first state check and when the cleanup action list is updated).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287430](https://bugs.openjdk.java.net/browse/JDK-8287430): MemorySessionImpl::addOrCleanupIfFail does not rethrow exceptions


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8917/head:pull/8917` \
`$ git checkout pull/8917`

Update a local copy of the PR: \
`$ git checkout pull/8917` \
`$ git pull https://git.openjdk.java.net/jdk pull/8917/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8917`

View PR using the GUI difftool: \
`$ git pr show -t 8917`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8917.diff">https://git.openjdk.java.net/jdk/pull/8917.diff</a>

</details>
