### PR TITLE
8287433: [PPC64] g1_write_barrier_pre needs extension for Loom

### DIFF
--- a/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.cpp
@@ -193,22 +193,38 @@ void G1BarrierSetAssembler::g1_write_barrier_pre(MacroAssembler* masm, Decorator
 
   // Determine necessary runtime invocation preservation measures
   const bool needs_frame = preservation_level >= MacroAssembler::PRESERVATION_FRAME_LR;
-  assert(preservation_level <= MacroAssembler::PRESERVATION_FRAME_LR,
-         "g1_write_barrier_pre doesn't support preservation levels higher than PRESERVATION_FRAME_LR");
+  const bool preserve_gp_registers = preservation_level >= MacroAssembler::PRESERVATION_FRAME_LR_GP_REGS;
+  const bool preserve_fp_registers = preservation_level >= MacroAssembler::PRESERVATION_FRAME_LR_GP_FP_REGS;
+  int nbytes_save = 0;
 
   // May need to preserve LR. Also needed if current frame is not compatible with C calling convention.
   if (needs_frame) {
+    if (preserve_gp_registers) {
+      nbytes_save = (MacroAssembler::num_volatile_gp_regs
+                     + (preserve_fp_registers ? MacroAssembler::num_volatile_fp_regs : 0)
+                    ) * BytesPerWord;
+      __ save_volatile_gprs(R1_SP, -nbytes_save, preserve_fp_registers);
+    }
+
     __ save_LR_CR(tmp1);
-    __ push_frame_reg_args(0, tmp2);
+    __ push_frame_reg_args(nbytes_save, tmp2);
   }
 
-  if (pre_val->is_volatile() && preloaded) { __ mr(nv_save, pre_val); } // Save pre_val across C call if it was preloaded.
+  if (pre_val->is_volatile() && preloaded && !preserve_gp_registers) {
+    __ mr(nv_save, pre_val); // Save pre_val across C call if it was preloaded.
+  }
   __ call_VM_leaf(CAST_FROM_FN_PTR(address, G1BarrierSetRuntime::write_ref_field_pre_entry), pre_val, R16_thread);
-  if (pre_val->is_volatile() && preloaded) { __ mr(pre_val, nv_save); } // restore
+  if (pre_val->is_volatile() && preloaded && !preserve_gp_registers) {
+    __ mr(pre_val, nv_save); // restore
+  }
 
   if (needs_frame) {
     __ pop_frame();
     __ restore_LR_CR(tmp1);
+
+    if (preserve_gp_registers) {
+      __ restore_volatile_gprs(R1_SP, -nbytes_save, preserve_fp_registers);
+    }
   }
 
   __ bind(filtered);


### PR DESCRIPTION
Loom uses `c2i_entry_barrier` which needs to preserve more registers than currently implemented in `g1_write_barrier_pre`. See JBS for details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287433](https://bugs.openjdk.java.net/browse/JDK-8287433): [PPC64] g1_write_barrier_pre needs extension for Loom


### Reviewers
 * [Richard Reingruber](https://openjdk.java.net/census#rrich) (@reinrich - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8918/head:pull/8918` \
`$ git checkout pull/8918`

Update a local copy of the PR: \
`$ git checkout pull/8918` \
`$ git pull https://git.openjdk.java.net/jdk pull/8918/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8918`

View PR using the GUI difftool: \
`$ git pr show -t 8918`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8918.diff">https://git.openjdk.java.net/jdk/pull/8918.diff</a>

</details>
