### PR TITLE
8287437: Temporarily disable Continuations::enabled() for platforms which don't have an implementation, yet

### DIFF
--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -412,7 +412,11 @@ void Continuations::init() {
 // While virtual threads are in Preview, there are some VM mechanisms we disable if continuations aren't used
 // See NMethodSweeper::do_stack_scanning and nmethod::is_not_on_continuation_stack
 bool Continuations::enabled() {
+#if defined(PPC64) || defined(S390) || defined(RISCV) || defined(ARM32) || defined(IA32)
+  return false;
+#else
   return Arguments::enable_preview();
+#endif
 }
 
 // We initialize the _gc_epoch to 2, because previous_completed_gc_marking_cycle

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -412,10 +412,10 @@ void Continuations::init() {
 // While virtual threads are in Preview, there are some VM mechanisms we disable if continuations aren't used
 // See NMethodSweeper::do_stack_scanning and nmethod::is_not_on_continuation_stack
 bool Continuations::enabled() {
-#if defined(PPC64) || defined(S390) || defined(RISCV) || defined(ARM32) || defined(IA32)
-  return false;
-#else
+#if defined(AMD64) || defined(AARCH64)
   return Arguments::enable_preview();
+#else
+  return false;
 #endif
 }
 


### PR DESCRIPTION
Hello,

I'd like to disable `Continuations::enabled()` for platforms, which don't support Loom, yet. This enables working on Panama which is also controlled by `--enable-preview`.

I'm proposing this for all platforms which have an unresolved porting issue here:
[JDK-8284161](https://bugs.openjdk.java.net/browse/JDK-8284161)

Please review and provide feedback if this makes sense for your platform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287437](https://bugs.openjdk.java.net/browse/JDK-8287437): Temporarily disable Continuations::enabled() for platforms which don't have an implementation, yet


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Richard Reingruber](https://openjdk.java.net/census#rrich) (@reinrich - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8919/head:pull/8919` \
`$ git checkout pull/8919`

Update a local copy of the PR: \
`$ git checkout pull/8919` \
`$ git pull https://git.openjdk.java.net/jdk pull/8919/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8919`

View PR using the GUI difftool: \
`$ git pr show -t 8919`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8919.diff">https://git.openjdk.java.net/jdk/pull/8919.diff</a>

</details>
