### PR TITLE
8287439: Problemlist more failing x86_32 tests after Record Patterns integration

### DIFF
--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -75,16 +75,24 @@ tools/sjavac/ClasspathDependencies.java                                         
 # Loom is not implemented on x86_32 yet
 
 jdk/jshell/ToolEnablePreviewTest.java                                           8286642 generic-i586
+tools/javac/annotations/typeAnnotations/classfile/Patterns.java                 8286642 generic-i586
 tools/javac/launcher/SourceLauncherTest.java                                    8286642 generic-i586
 tools/javac/patterns/CaseDefault.java                                           8286642 generic-i586
 tools/javac/patterns/DisambiguatePatterns.java                                  8286642 generic-i586
 tools/javac/patterns/EnumTypeChanges.java                                       8286642 generic-i586
+tools/javac/patterns/GenericRecordDeconstructionPattern.java                    8286642 generic-i586
 tools/javac/patterns/Guards.java                                                8286642 generic-i586
 tools/javac/patterns/InstanceofTotalPattern.java                                8286642 generic-i586
 tools/javac/patterns/LambdaCannotCapturePatternVariables.java                   8286642 generic-i586
+tools/javac/patterns/NestedDeconstructionPattern.java                           8286642 generic-i586
+tools/javac/patterns/NestedPrimitiveDeconstructionPattern.java                  8286642 generic-i586
+tools/javac/patterns/NullsInDeconstructionPatterns.java                         8286642 generic-i586
 tools/javac/patterns/NullSwitch.java                                            8286642 generic-i586
 tools/javac/patterns/Parenthesized.java                                         8286642 generic-i586
+tools/javac/patterns/PrettyTest.java                                            8286642 generic-i586
 tools/javac/patterns/SealedTypeChanges.java                                     8286642 generic-i586
 tools/javac/patterns/SimpleAndGuardPattern.java                                 8286642 generic-i586
+tools/javac/patterns/SimpleDeconstructionPattern.java                           8286642 generic-i586
 tools/javac/patterns/Switches.java                                              8286642 generic-i586
+tools/javac/patterns/TypedDeconstructionPatternExc.java                         8286642 generic-i586
 tools/javac/switchnull/SwitchNull.java                                          8286642 generic-i586


### PR DESCRIPTION
[JDK-8262889](https://bugs.openjdk.java.net/browse/JDK-8262889) brought more --enable-preview tests, which still fails due to incomplete Loom implementation. These fail in GHA too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287439](https://bugs.openjdk.java.net/browse/JDK-8287439): Problemlist more failing x86_32 tests after Record Patterns integration


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8920/head:pull/8920` \
`$ git checkout pull/8920`

Update a local copy of the PR: \
`$ git checkout pull/8920` \
`$ git pull https://git.openjdk.java.net/jdk pull/8920/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8920`

View PR using the GUI difftool: \
`$ git pr show -t 8920`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8920.diff">https://git.openjdk.java.net/jdk/pull/8920.diff</a>

</details>
