### PR TITLE
8287438: IGV: scheduling crashes on non-block-start Region with multiple predecessors

### DIFF
--- a/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
+++ b/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
@@ -183,8 +183,10 @@ public class ServerCompilerScheduler implements Scheduler {
                 } else if (controlSuccs.get(n).size() == 1) {
                     // One successor: end the block if it is a block start node.
                     Node s = controlSuccs.get(n).iterator().next();
-                    if (s.isBlockStart) {
-                        // Block start: end the block.
+                    if (s.isBlockStart || isDummy(n)) {
+                        // Block start or n is a dummy node: end the block. The
+                        // second condition handles ill-formed graphs where join
+                        // Region nodes are not marked as block starts.
                         blockTerminators.add(n);
                         stack.push(s);
                         break;
@@ -708,6 +710,10 @@ public class ServerCompilerScheduler implements Scheduler {
 
     private static boolean isControl(Node n) {
         return n.inputNode.getProperties().get("category").equals("control");
+    }
+
+    private static boolean isDummy(Node n) {
+        return n.inputNode == null;
     }
 
     // Whether b1 dominates b2. Used only for checking the schedule.


### PR DESCRIPTION
IGV scheduling crashes when breaking critical edges that target Region nodes not marked with the `is_block_start` property, by failing to create an appropriate basic block between the source and the destination of the critical edge (see the JBS bug report for more detail). This changeset ensures that such a basic block is created even when the destination node is not marked with `is_block_start`.

#### Testing

- Tested manually on the [graph](https://bugs.openjdk.java.net/secure/attachment/99125/failure.zip) reported in the JBS issue.

- Tested automatically that scheduling tens of thousands of graphs (by instrumenting IGV to schedule parsed graphs eagerly and running `java -Xcomp -XX:-TieredCompilation -XX:PrintIdealGraphLevel=4`) does trigger any exception or assertion failure.
