### PR TITLE
8277307: Pre shared key sent under both session_ticket and pre_shared_key extensions

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SessionTicketExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SessionTicketExtension.java
@@ -46,7 +46,6 @@ import java.nio.ByteBuffer;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.text.MessageFormat;
-import java.util.Arrays;
 import java.util.Locale;
 
 /**
@@ -406,8 +405,7 @@ final class SessionTicketExtension {
             // If resumption is not in progress, return an empty value
             if (!chc.isResumption || chc.resumingSession == null
                     || chc.resumingSession.getPskIdentity() == null
-                    || !Arrays.asList(ProtocolVersion.PROTOCOLS_10_12)
-                        .contains(chc.resumingSession.getProtocolVersion())) {
+                    || chc.resumingSession.getProtocolVersion().useTLS13PlusSpec()) {
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
                     SSLLogger.fine("Stateless resumption supported");
                 }

--- a/src/java.base/share/classes/sun/security/ssl/SessionTicketExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SessionTicketExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +46,7 @@ import java.nio.ByteBuffer;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.Locale;
 
 /**
@@ -403,11 +404,14 @@ final class SessionTicketExtension {
             chc.statelessResumption = true;
 
             // If resumption is not in progress, return an empty value
-            if (!chc.isResumption || chc.resumingSession == null) {
+            if (!chc.isResumption || chc.resumingSession == null
+                    || chc.resumingSession.getPskIdentity() == null
+                    || !Arrays.asList(ProtocolVersion.PROTOCOLS_10_12)
+                        .contains(chc.resumingSession.getProtocolVersion())) {
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
                     SSLLogger.fine("Stateless resumption supported");
                 }
-                return new SessionTicketSpec().getEncoded();
+                return new byte[0];
             }
 
             if (chc.localSupportedSignAlgs == null) {


### PR DESCRIPTION
Session ticket extension should only contain pre-TLS1.3 stateless session tickets; it should not be used for sending TLS1.3 pre-shared keys.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277307](https://bugs.openjdk.org/browse/JDK-8277307): Pre shared key sent under both session_ticket and pre_shared_key extensions


### Reviewers
 * [Sean Coffey](https://openjdk.java.net/census#coffeys) (@coffeys - **Reviewer**)
 * [Anthony Scarpino](https://openjdk.java.net/census#ascarpino) (@ascarpino - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8922/head:pull/8922` \
`$ git checkout pull/8922`

Update a local copy of the PR: \
`$ git checkout pull/8922` \
`$ git pull https://git.openjdk.java.net/jdk pull/8922/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8922`

View PR using the GUI difftool: \
`$ git pr show -t 8922`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8922.diff">https://git.openjdk.java.net/jdk/pull/8922.diff</a>

</details>
