### PR TITLE
8281695: jtreg test com/sun/jndi/ldap/LdapPoolTimeoutTest.java fails intermittently in nightly run

### DIFF
--- a/test/jdk/com/sun/jndi/ldap/LdapTimeoutTest.java
+++ b/test/jdk/com/sun/jndi/ldap/LdapTimeoutTest.java
@@ -41,6 +41,7 @@ import javax.naming.directory.SearchControls;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.net.NoRouteToHostException;
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
@@ -124,8 +125,14 @@ public class LdapTimeoutTest {
             try {
                 f.get();
             } catch (ExecutionException e) {
-                failedCount++;
-                e.getCause().printStackTrace(System.out);
+                Throwable cause = e.getCause();
+                if (!(cause instanceof NoRouteToHostException) && cause.getCause() != null) {
+                    cause = cause.getCause();
+                }
+                if (!(cause instanceof NoRouteToHostException)) {
+                    failedCount++;
+                    cause.printStackTrace(System.out);
+                }
             }
         }
         if (failedCount > 0)


### PR DESCRIPTION
Test change to silently pass if the test environment encounters a NoRouteToHostException. These are intermittent at the moment but I will attempt to find an alternative to the use of example.com in some follow up work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Failed to retrieve information on issue `8281695`. Please make sure it exists and is accessible.

### Issue
 * ⚠️ Failed to retrieve information on issue `8281695`.


### Reviewers
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8925/head:pull/8925` \
`$ git checkout pull/8925`

Update a local copy of the PR: \
`$ git checkout pull/8925` \
`$ git pull https://git.openjdk.java.net/jdk pull/8925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8925`

View PR using the GUI difftool: \
`$ git pr show -t 8925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8925.diff">https://git.openjdk.java.net/jdk/pull/8925.diff</a>

</details>
