### PR TITLE
8285008: JFR: jdk/jfr/jmx/streaming/TestClose.java failed with "Exception: Expected repository to be empty"

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
@@ -178,7 +178,7 @@ public abstract class AbstractEventStream implements EventStream {
         if (timeout.isNegative()) {
             throw new IllegalArgumentException("timeout value is negative");
         }
-        
+
         long nanos;
         try {
             nanos = timeout.toNanos();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
@@ -33,6 +33,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
@@ -44,7 +46,6 @@ import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.internal.LogLevel;
 import jdk.jfr.internal.LogTag;
 import jdk.jfr.internal.Logger;
-import jdk.jfr.internal.PlatformRecording;
 import jdk.jfr.internal.SecuritySupport;
 
 /*
@@ -54,7 +55,7 @@ import jdk.jfr.internal.SecuritySupport;
 public abstract class AbstractEventStream implements EventStream {
     private static final AtomicLong counter = new AtomicLong();
 
-    private final Object terminated = new Object();
+    private final CountDownLatch terminated = new CountDownLatch(1);
     private final Runnable flushOperation = () -> dispatcher().runFlushActions();
     @SuppressWarnings("removal")
     private final AccessControlContext accessControllerContext;
@@ -177,34 +178,17 @@ public abstract class AbstractEventStream implements EventStream {
         if (timeout.isNegative()) {
             throw new IllegalArgumentException("timeout value is negative");
         }
-
-        long base = System.currentTimeMillis();
-        long now = 0;
-
-        long millis;
+        
+        long nanos;
         try {
-            millis = Math.multiplyExact(timeout.getSeconds(), 1000);
+            nanos = timeout.toNanos();
         } catch (ArithmeticException a) {
-            millis = Long.MAX_VALUE;
+            nanos = Long.MAX_VALUE;
         }
-        int nanos = timeout.toNanosPart();
-        if (nanos == 0 && millis == 0) {
-            synchronized (terminated) {
-                while (!isClosed()) {
-                    terminated.wait(0);
-                }
-            }
+        if (nanos == 0) {
+            terminated.await();
         } else {
-            while (!isClosed()) {
-                long delay = millis - now;
-                if (delay <= 0) {
-                    break;
-                }
-                synchronized (terminated) {
-                    terminated.wait(delay, nanos);
-                }
-                now = System.currentTimeMillis() - base;
-            }
+            terminated.await(nanos, TimeUnit.NANOSECONDS);
         }
     }
 
@@ -275,9 +259,7 @@ public abstract class AbstractEventStream implements EventStream {
             try {
                 close();
             } finally {
-                synchronized (terminated) {
-                    terminated.notifyAll();
-                }
+                terminated.countDown();
             }
         }
     }

--- a/test/jdk/jdk/jfr/jmx/streaming/TestClose.java
+++ b/test/jdk/jdk/jfr/jmx/streaming/TestClose.java
@@ -38,7 +38,7 @@ import jdk.management.jfr.RemoteRecordingStream;
  * @summary Tests that a RemoteRecordingStream can be closed
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
- * @run main/othervm jdk.jfr.jmx.streaming.TestClose
+ * @run main/othervm -Xlog:jfr=debug jdk.jfr.jmx.streaming.TestClose
  */
 public class TestClose {
 


### PR DESCRIPTION
Could I have a review of a change that avoids a race condition.

Problem occurs if the main thread enters awaitTermination() after closed() has been called but before it has finished. If this happens, the main thread will not wait and instead proceed and check if files have been removed, potentially before this has actually happened. This can be reproduced by putting a Thread.sleep in the RecordingStream::close() method.

The solution is to check the terminated state instead of the closed state. This can be done using a CoundDownLatch in awaitTermination() which avoids much of the logic that is there today. 

I'm not sure it is the race that causes the test to fail. It could also be something related to deleting files on Windows, so I enabled logging to make it easier to diagnose. 

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285008](https://bugs.openjdk.java.net/browse/JDK-8285008): JFR: jdk/jfr/jmx/streaming/TestClose.java failed with "Exception: Expected repository to be empty"


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8927/head:pull/8927` \
`$ git checkout pull/8927`

Update a local copy of the PR: \
`$ git checkout pull/8927` \
`$ git pull https://git.openjdk.java.net/jdk pull/8927/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8927`

View PR using the GUI difftool: \
`$ git pr show -t 8927`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8927.diff">https://git.openjdk.java.net/jdk/pull/8927.diff</a>

</details>
