### PR TITLE
8287463: JFR: Disable TestDevNull.java on Windows

### DIFF
--- a/test/jdk/jdk/jfr/api/recording/dump/TestDumpDevNull.java
+++ b/test/jdk/jdk/jfr/api/recording/dump/TestDumpDevNull.java
@@ -24,14 +24,13 @@
 package jdk.jfr.api.recording.dump;
 
 import java.nio.file.Path;
-
 import jdk.jfr.Recording;
 
 /**
  * @test
  * @summary Tests that it's possible to dump to /dev/null without a livelock
  * @key jfr
- * @requires vm.hasJFR
+ * @requires vm.hasJFR & (os.family != "windows")
  * @library /test/lib
  * @run main/othervm -Xlog:jfr jdk.jfr.api.recording.dump.TestDumpDevNull
  */


### PR DESCRIPTION
Could I have review of a change that disable TestDevNull.java on Windows.

Testing: jdk/jdk/jfr/api/recording/dump/TestDevNull.java

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287463](https://bugs.openjdk.java.net/browse/JDK-8287463): JFR: Disable TestDevNull.java on Windows


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8929/head:pull/8929` \
`$ git checkout pull/8929`

Update a local copy of the PR: \
`$ git checkout pull/8929` \
`$ git pull https://git.openjdk.java.net/jdk pull/8929/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8929`

View PR using the GUI difftool: \
`$ git pr show -t 8929`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8929.diff">https://git.openjdk.java.net/jdk/pull/8929.diff</a>

</details>
