### PR TITLE
8287484 JFR: Seal RecordedObject

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
@@ -57,8 +57,9 @@ import jdk.jfr.internal.tool.PrettyWriter;
  *
  * @since 9
  */
-public class RecordedObject {
-
+public sealed class RecordedObject 
+   permits RecordedEvent, RecordedClassLoader, RecordedClass, RecordedMethod,
+           RecordedStackTrace, RecordedFrame, RecordedThread, RecordedThreadGroup {
     static{
         JdkJfrConsumer access = new JdkJfrConsumer() {
             @Override

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
@@ -57,7 +57,7 @@ import jdk.jfr.internal.tool.PrettyWriter;
  *
  * @since 9
  */
-public sealed class RecordedObject 
+public sealed class RecordedObject
    permits RecordedEvent, RecordedClassLoader, RecordedClass, RecordedMethod,
            RecordedStackTrace, RecordedFrame, RecordedThread, RecordedThreadGroup {
     static{


### PR DESCRIPTION
Could I have a review of an enhancement. The RecordedObject class is not meant to be subclasses outside the jdk.jfr.consumer package. Today it is prevented by a package private constructor. It would be good to make it explicit by making the class sealed.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287484](https://bugs.openjdk.java.net/browse/JDK-8287484): JFR: Seal RecordedObject


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8930/head:pull/8930` \
`$ git checkout pull/8930`

Update a local copy of the PR: \
`$ git checkout pull/8930` \
`$ git pull https://git.openjdk.java.net/jdk pull/8930/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8930`

View PR using the GUI difftool: \
`$ git pr show -t 8930`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8930.diff">https://git.openjdk.java.net/jdk/pull/8930.diff</a>

</details>
