### PR TITLE
8287363: null pointer should use NULL instead of 0

### DIFF
--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -133,7 +133,7 @@ Resolve(char *indir, char *cmd)
     if ((snprintf_result < 0) || (snprintf_result >= (int)sizeof(name))) {
       return NULL;
     }
-    if (!ProgramExists(name)) return 0;
+    if (!ProgramExists(name)) return NULL;
     real = JLI_MemAlloc(PATH_MAX + 2);
     if (!realpath(name, real))
         JLI_StrCpy(real, name);
@@ -158,7 +158,7 @@ FindExecName(char *program)
         return Resolve("", program+1);
 
     /* relative path? */
-    if (JLI_StrRChr(program, FILE_SEPARATOR) != 0) {
+    if (JLI_StrRChr(program, FILE_SEPARATOR) != NULL) {
         char buf[PATH_MAX+2];
         return Resolve(getcwd(cwdbuf, sizeof(cwdbuf)), program);
     }
@@ -169,10 +169,10 @@ FindExecName(char *program)
     tmp_path = JLI_MemAlloc(JLI_StrLen(path) + 2);
     JLI_StrCpy(tmp_path, path);
 
-    for (f=tmp_path; *f && result==0; ) {
+    for (f = tmp_path; *f && result == NULL; ) {
         char *s = f;
         while (*f && (*f != PATH_SEPARATOR)) ++f;
-        if (*f) *f++ = 0;
+        if (*f) *f++ = '\0';
         if (*s == FILE_SEPARATOR)
             result = Resolve(s, program);
         else {
@@ -182,7 +182,7 @@ FindExecName(char *program)
                     FILE_SEPARATOR, s);
             result = Resolve(dir, program);
         }
-        if (result != 0) break;
+        if (result != NULL) break;
     }
 
     JLI_MemFree(tmp_path);


### PR DESCRIPTION
We found using `0` as `NULL` in java_md_common.c . `0` is not a pointer, so we should use `NULL` where we want to handle it.

https://github.com/openjdk/jdk/pull/8646#discussion_r882294076

Also I found using `0` as NUL char in java_md_common.c , so I replaced it to `\0` in this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287363](https://bugs.openjdk.java.net/browse/JDK-8287363): null pointer should use NULL instead of 0


### Reviewers
 * @kristylee88 (no known github.com user name / role)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8931/head:pull/8931` \
`$ git checkout pull/8931`

Update a local copy of the PR: \
`$ git checkout pull/8931` \
`$ git pull https://git.openjdk.java.net/jdk pull/8931/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8931`

View PR using the GUI difftool: \
`$ git pr show -t 8931`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8931.diff">https://git.openjdk.java.net/jdk/pull/8931.diff</a>

</details>
