### PR TITLE
8287696: Avoid redundant Hashtable.containsKey call in JarVerifier.doneWithMeta

### DIFF
--- a/src/java.base/share/classes/java/util/jar/JarVerifier.java
+++ b/src/java.base/share/classes/java/util/jar/JarVerifier.java
@@ -199,8 +199,6 @@ class JarVerifier {
 
         // don't compute the digest for this entry
         mev.setEntry(null, je);
-
-        return;
     }
 
     /**
@@ -430,8 +428,8 @@ class JarVerifier {
         manDig = null;
         // MANIFEST.MF is always treated as signed and verified,
         // move its signers from sigFileSigners to verifiedSigners.
-        if (sigFileSigners.containsKey(manifestName)) {
-            CodeSigner[] codeSigners = sigFileSigners.remove(manifestName);
+        CodeSigner[] codeSigners = sigFileSigners.remove(manifestName);
+        if (codeSigners != null) {
             verifiedSigners.put(manifestName, codeSigners);
         }
     }
@@ -837,7 +835,6 @@ class JarVerifier {
     private List<CodeSigner[]> jarCodeSigners;
 
     private synchronized List<CodeSigner[]> getJarCodeSigners() {
-        CodeSigner[] signers;
         if (jarCodeSigners == null) {
             HashSet<CodeSigner[]> set = new HashSet<>();
             set.addAll(signerMap().values());
@@ -861,8 +858,6 @@ class JarVerifier {
     }
 
     public CodeSource getCodeSource(URL url, JarFile jar, JarEntry je) {
-        CodeSigner[] signers;
-
         return mapSignersToCodeSource(url, getCodeSigners(jar, je));
     }
 


### PR DESCRIPTION
Hashtable doesn't allow `null` values. So, instead of pair `containsKey`/`remove` calls, we can directly call `remove` and then compare result with `null`.
https://github.com/openjdk/jdk/blob/2c461acfebd28fe5ef62805cbb004f91a3b18f08/src/java.base/share/classes/java/util/jar/JarVerifier.java#L433-L436

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287696](https://bugs.openjdk.org/browse/JDK-8287696): Avoid redundant Hashtable.containsKey call in JarVerifier.doneWithMeta


### Reviewers
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/8935/head:pull/8935` \
`$ git checkout pull/8935`

Update a local copy of the PR: \
`$ git checkout pull/8935` \
`$ git pull https://git.openjdk.org/jdk pull/8935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8935`

View PR using the GUI difftool: \
`$ git pr show -t 8935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/8935.diff">https://git.openjdk.org/jdk/pull/8935.diff</a>

</details>
