### PR TITLE
8287497: Use String.contains() instead of String.indexOf() in java.naming

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapAttribute.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -157,7 +157,7 @@ final class LdapAttribute extends BasicAttribute {
             // remove any security credentials - otherwise the serialized form
             // would store them in the clear
             for (String key : realEnv.keySet()){
-                if (key.indexOf("security") != -1 ) {
+                if (key.contains("security")) {
 
                     //if we need to remove props, we must do it to a clone
                     //of the environment. cloning is expensive, so we only do

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapClient.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -759,9 +759,9 @@ public final class LdapClient implements PooledConnection {
                                    Hashtable<String, Boolean> binaryAttrs) {
         String id = attrid.toLowerCase(Locale.ENGLISH);
 
-        return ((id.indexOf(";binary") != -1) ||
+        return id.contains(";binary") ||
             defaultBinaryAttrs.containsKey(id) ||
-            ((binaryAttrs != null) && (binaryAttrs.containsKey(id))));
+            ((binaryAttrs != null) && (binaryAttrs.containsKey(id)));
     }
 
     // package entry point; used by Connection

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/ext/StartTlsResponseImpl.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/ext/StartTlsResponseImpl.java
@@ -426,7 +426,7 @@ public final class StartTlsResponseImpl extends StartTlsResponse {
              * hostname verification is not done for anonymous ciphers
              */
             String cipher = session.getCipherSuite();
-            if (cipher != null && (cipher.indexOf("_anon_") != -1)) {
+            if (cipher != null && cipher.contains("_anon_")) {
                 return true;
             }
             throw e;

--- a/src/java.naming/share/classes/javax/naming/NameImpl.java
+++ b/src/java.naming/share/classes/javax/naming/NameImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,7 +95,7 @@ class NameImpl {
         } else if (isA(name, i, syntaxSeparator2)) {
             i += syntaxSeparator2.length();
         }
-        return (i);
+        return i;
     }
 
     private final int extractComp(String name, int i, int len, Vector<String> comps)
@@ -346,7 +346,7 @@ class NameImpl {
         // determine whether there are any separators; if so escape
         // or quote them
         if (syntaxSeparator != null &&
-            comp.indexOf(syntaxSeparator) >= 0) {
+            comp.contains(syntaxSeparator)) {
             if (syntaxBeginQuote1 != null) {
                 beginQuote = syntaxBeginQuote1;
                 endQuote = syntaxEndQuote1;
@@ -357,7 +357,7 @@ class NameImpl {
                 escapeSeparator = true;
         }
         if (syntaxSeparator2 != null &&
-            comp.indexOf(syntaxSeparator2) >= 0) {
+            comp.contains(syntaxSeparator2)) {
             if (syntaxBeginQuote1 != null) {
                 if (beginQuote == null) {
                     beginQuote = syntaxBeginQuote1;
@@ -445,7 +445,7 @@ class NameImpl {
                 start = false;
             }
         }
-        return (strbuf.toString());
+        return strbuf.toString();
     }
 
     public String toString() {
@@ -469,7 +469,7 @@ class NameImpl {
         }
         if (compsAllEmpty && (size >= 1) && (syntaxSeparator != null))
             answer = answer.append(syntaxSeparator);
-        return (answer.toString());
+        return answer.toString();
     }
 
     public boolean equals(Object obj) {
@@ -544,7 +544,7 @@ class NameImpl {
     }
 
     public int size() {
-        return (components.size());
+        return components.size();
     }
 
     public Enumeration<String> getAll() {


### PR DESCRIPTION
`String.contains` was introduced in Java 5.
Some code in java.naming still uses old approach with `String.indexOf` to check if String contains specified substring.
I propose to migrate such usages. Makes code shorter and easier to read.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287497](https://bugs.openjdk.java.net/browse/JDK-8287497): Use String.contains() instead of String.indexOf() in java.naming


### Reviewers
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8938/head:pull/8938` \
`$ git checkout pull/8938`

Update a local copy of the PR: \
`$ git checkout pull/8938` \
`$ git pull https://git.openjdk.java.net/jdk pull/8938/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8938`

View PR using the GUI difftool: \
`$ git pr show -t 8938`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8938.diff">https://git.openjdk.java.net/jdk/pull/8938.diff</a>

</details>
