### PR TITLE
8287766: Unnecessary Vector usage in LdapClient

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapClient.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package com.sun.jndi.ldap;
 
 import java.io.*;
+import java.util.ArrayList;
 import java.util.Locale;
 import java.util.Vector;
 import java.util.Hashtable;
@@ -1577,15 +1578,15 @@ public final class LdapClient implements PooledConnection {
 
 
     private void notifyUnsolicited(Object e) {
-        Vector<LdapCtx> unsolicitedCopy;
+        ArrayList<LdapCtx> unsolicitedCopy;
         synchronized (unsolicited) {
-            unsolicitedCopy = new Vector<>(unsolicited);
+            unsolicitedCopy = new ArrayList<>(unsolicited);
             if (e instanceof NamingException) {
                 unsolicited.setSize(0);  // no more listeners after exception
             }
         }
         for (int i = 0; i < unsolicitedCopy.size(); i++) {
-            unsolicitedCopy.elementAt(i).fireUnsolicited(e);
+            unsolicitedCopy.get(i).fireUnsolicited(e);
         }
     }
 


### PR DESCRIPTION
In [JDK-8273098](https://bugs.openjdk.java.net/browse/JDK-8273098) I missed one place, where Vector could be replaced with ArrayList.
Usage of thread-safe collection `Vector` is unnecessary. It's recommended to use `ArrayList` if a thread-safe implementation is not needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287766](https://bugs.openjdk.java.net/browse/JDK-8287766): Unnecessary Vector usage in LdapClient


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Vyom Tewari](https://openjdk.java.net/census#vtewari) (@vyommani - Committer)
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8940/head:pull/8940` \
`$ git checkout pull/8940`

Update a local copy of the PR: \
`$ git checkout pull/8940` \
`$ git pull https://git.openjdk.java.net/jdk pull/8940/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8940`

View PR using the GUI difftool: \
`$ git pr show -t 8940`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8940.diff">https://git.openjdk.java.net/jdk/pull/8940.diff</a>

</details>
