### PR TITLE
[PATCH] Avoid redundant HashMap.containsKey call in MimeTypesFileTypeDetector.putIfAbsent

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/MimeTypesFileTypeDetector.java
+++ b/src/java.base/unix/classes/sun/nio/fs/MimeTypesFileTypeDetector.java
@@ -188,10 +188,9 @@ class MimeTypesFileTypeDetector extends AbstractFileTypeDetector {
 
     private void putIfAbsent(String key, String value) {
         if (key != null && !key.isEmpty() &&
-            value != null && !value.isEmpty() &&
-            !mimeTypeMap.containsKey(key))
+            value != null && !value.isEmpty())
         {
-            mimeTypeMap.put(key, value);
+            mimeTypeMap.putIfAbsent(key, value);
         }
     }
 }


### PR DESCRIPTION
Only non-null values are put into `Map<String,String> mimeTypeMap`. It means, we can replace `containsKey`+`put` calls with single `putIfAbsent` call. It makes code a bit cleaner and faster.

https://github.com/openjdk/jdk/blob/3d2d039538b906cedd9188ed94b7ba55c275ff7f/src/java.base/unix/classes/sun/nio/fs/MimeTypesFileTypeDetector.java#L189-L196