### PR TITLE
8287544: Replace uses of StringBuffer with StringBuilder in java.naming

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapName.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -128,7 +128,7 @@ public final class LdapName implements Name {
             return unparsed;
         }
 
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         for (int i = rdns.size() - 1; i >= 0; i--) {
             if (i < rdns.size() - 1) {
                 buf.append(',');
@@ -618,7 +618,7 @@ public final class LdapName implements Name {
         }
 
         public String toString() {
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
             for (int i = 0; i < tvs.size(); i++) {
                 if (i > 0) {
                     buf.append('+');
@@ -798,7 +798,7 @@ public final class LdapName implements Name {
 
             final String escapees = ",=+<>#;\"\\";
             char[] chars = val.toCharArray();
-            StringBuffer buf = new StringBuffer(2 * val.length());
+            StringBuilder buf = new StringBuilder(2 * val.length());
 
             // Find leading and trailing whitespace.
             int lead;   // index of first char that is not leading whitespace
@@ -830,7 +830,7 @@ public final class LdapName implements Name {
          */
         private static String escapeBinaryValue(byte[] val) {
 
-            StringBuffer buf = new StringBuffer(1 + 2 * val.length);
+            StringBuilder buf = new StringBuilder(1 + 2 * val.length);
             buf.append("#");
 
             for (int i = 0; i < val.length; i++) {
@@ -887,7 +887,7 @@ public final class LdapName implements Name {
                 --end;
             }
 
-            StringBuffer buf = new StringBuffer(end - beg);
+            StringBuilder buf = new StringBuilder(end - beg);
             int esc = -1; // index of the last escaped character
 
             for (int i = beg; i < end; i++) {

--- a/src/java.naming/share/classes/javax/naming/NameImpl.java
+++ b/src/java.naming/share/classes/javax/naming/NameImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -337,11 +337,11 @@ class NameImpl {
         return (false);
     }
 */
-    private final String stringifyComp(String comp) {
+    private String stringifyComp(String comp) {
         int len = comp.length();
         boolean escapeSeparator = false, escapeSeparator2 = false;
         String beginQuote = null, endQuote = null;
-        StringBuffer strbuf = new StringBuffer(len);
+        StringBuilder strbuf = new StringBuilder(len);
 
         // determine whether there are any separators; if so escape
         // or quote them
@@ -449,7 +449,7 @@ class NameImpl {
     }
 
     public String toString() {
-        StringBuffer answer = new StringBuffer();
+        StringBuilder answer = new StringBuilder();
         String comp;
         boolean compsAllEmpty = true;
         int size = components.size();


### PR DESCRIPTION
StringBuffer is a legacy synchronized class. StringBuilder is a direct replacement to StringBuffer which generally have better performance.
There are some code that still uses StringBuffer in java.naming which could be migrated to `StringBuilder`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287544](https://bugs.openjdk.java.net/browse/JDK-8287544): Replace uses of StringBuffer with StringBuilder in java.naming


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)
 * [Vyom Tewari](https://openjdk.java.net/census#vtewari) (@vyommani - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8942/head:pull/8942` \
`$ git checkout pull/8942`

Update a local copy of the PR: \
`$ git checkout pull/8942` \
`$ git pull https://git.openjdk.java.net/jdk pull/8942/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8942`

View PR using the GUI difftool: \
`$ git pr show -t 8942`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8942.diff">https://git.openjdk.java.net/jdk/pull/8942.diff</a>

</details>
