### PR TITLE
8287512: continuationEntry.hpp has incomplete definitions

### DIFF
--- a/src/hotspot/share/runtime/continuationEntry.cpp
+++ b/src/hotspot/share/runtime/continuationEntry.cpp
@@ -33,13 +33,11 @@
 #include "runtime/thread.inline.hpp"
 
 int ContinuationEntry::return_pc_offset = 0;
-nmethod* ContinuationEntry::continuation_enter = nullptr;
 address ContinuationEntry::return_pc = nullptr;
 
-void ContinuationEntry::set_enter_nmethod(nmethod* nm) {
+void ContinuationEntry::set_enter_nmethod(CompiledMethod* cm) {
   assert(return_pc_offset != 0, "");
-  continuation_enter = nm;
-  return_pc = nm->code_begin() + return_pc_offset;
+  return_pc = cm->code_begin() + return_pc_offset;
 }
 
 ContinuationEntry* ContinuationEntry::from_frame(const frame& f) {

--- a/src/hotspot/share/runtime/continuationEntry.hpp
+++ b/src/hotspot/share/runtime/continuationEntry.hpp
@@ -53,10 +53,9 @@ public:
 
 public:
   static int return_pc_offset; // friend gen_continuation_enter
-  static void set_enter_nmethod(nmethod* nm); // friend SharedRuntime::generate_native_wrapper
+  static void set_enter_nmethod(CompiledMethod* nm); // friend SharedRuntime::generate_native_wrapper
 
 private:
-  static nmethod* continuation_enter;
   static address return_pc;
 
 private:
@@ -123,14 +122,10 @@ public:
   }
 
   inline oop cont_oop() const;
-
-  oop scope()     const { return Continuation::continuation_scope(cont_oop()); }
+  inline oop scope() const;
+  inline static oop cont_oop_or_null(const ContinuationEntry* ce);
 
   bool is_virtual_thread() const { return _flags != 0; }
-
-  static oop cont_oop_or_null(const ContinuationEntry* ce) {
-    return ce == nullptr ? nullptr : ce->cont_oop();
-  }
 
 #ifndef PRODUCT
   void describe(FrameValues& values, int frame_no) const {

--- a/src/hotspot/share/runtime/continuationEntry.inline.hpp
+++ b/src/hotspot/share/runtime/continuationEntry.inline.hpp
@@ -36,5 +36,12 @@ inline oop ContinuationEntry::cont_oop() const {
   return NativeAccess<>::oop_load(&snapshot);
 }
 
+inline oop ContinuationEntry::cont_oop_or_null(const ContinuationEntry* ce) {
+  return ce == nullptr ? nullptr : ce->cont_oop();
+}
+
+inline oop ContinuationEntry::scope() const {
+  return Continuation::continuation_scope(cont_oop());
+}
 
 #endif // SHARE_VM_RUNTIME_CONTINUATIONENTRY_INLINE_HPP


### PR DESCRIPTION
Please review this small change, which cleans up continuationEntry.hpp and fixes incomplete definitions.
