### PR TITLE
8287526: java/nio/channels/FileChannel/LargeMapTest.java fails on 32-bit systems

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/LargeMapTest.java
+++ b/test/jdk/java/nio/channels/FileChannel/LargeMapTest.java
@@ -37,6 +37,7 @@ import static java.nio.file.StandardOpenOption.*;
  * @bug 8286637
  * @summary Ensure that memory mapping beyond 32-bit range does not cause an
  *          EXCEPTION_ACCESS_VIOLATION.
+ * @requires vm.bits == 64
  * @run main/othervm/timeout=240 LargeMapTest
  */
 public class LargeMapTest {


### PR DESCRIPTION
```
$ CONF=linux-x86-server-fastdebug make images run-test TEST=java/nio/channels/FileChannel/LargeMapTest.java

STDOUT:
32
i386
19-internal
STDERR:
java.io.IOException: Map failed
at java.base/sun.nio.ch.FileChannelImpl.mapInternal(FileChannelImpl.java:1322)
at java.base/sun.nio.ch.FileChannelImpl.map(FileChannelImpl.java:1221)
at LargeMapTest.main(LargeMapTest.java:66)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:578)
at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
at java.base/java.lang.Thread.run(Thread.java:1585)
Caused by: java.lang.OutOfMemoryError: Map failed
at java.base/sun.nio.ch.FileChannelImpl.map0(Native Method)
at java.base/sun.nio.ch.FileChannelImpl.mapInternal(FileChannelImpl.java:1319)
... 6 more
```

I think we cannot assume we would be able to map >4G on 32-bit system.

Currently obscured by [JDK-8287137](https://bugs.openjdk.java.net/browse/JDK-8287137), would manifest again after [JDK-8287520](https://bugs.openjdk.java.net/browse/JDK-8287520).

Additional testing:
 - [x] Linux x86_64 fastdebug, still passes
 - [x] Linux x86_32 fastdebug, still skipped, even after taking off the problem list

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287526](https://bugs.openjdk.java.net/browse/JDK-8287526): java/nio/channels/FileChannel/LargeMapTest.java fails on 32-bit systems


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8948/head:pull/8948` \
`$ git checkout pull/8948`

Update a local copy of the PR: \
`$ git checkout pull/8948` \
`$ git pull https://git.openjdk.java.net/jdk pull/8948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8948`

View PR using the GUI difftool: \
`$ git pr show -t 8948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8948.diff">https://git.openjdk.java.net/jdk/pull/8948.diff</a>

</details>
