### PR TITLE
8287552: riscv: Fix comment typo in li64

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.cpp
@@ -118,7 +118,7 @@ void Assembler::_li(Register Rd, int64_t imm) {
 
 void Assembler::li64(Register Rd, int64_t imm) {
    // Load upper 32 bits. upper = imm[63:32], but if imm[31] == 1 or
-   // (imm[31:28] == 0x7ff && imm[19] == 1), upper = imm[63:32] + 1.
+   // (imm[31:20] == 0x7ff && imm[19] == 1), upper = imm[63:32] + 1.
    int64_t lower = imm & 0xffffffff;
    lower -= ((lower << 44) >> 44);
    int64_t tmp_imm = ((uint64_t)(imm & 0xffffffff00000000)) + (uint64_t)lower;
@@ -273,7 +273,7 @@ void Assembler::wrap_label(Register Rt, Label &L, jal_jalr_insn insn) {
 }
 
 void Assembler::movptr_with_offset(Register Rd, address addr, int32_t &offset) {
-  uintptr_t imm64 = (uintptr_t)addr;
+  int64_t imm64 = (int64_t)addr;
 #ifndef PRODUCT
   {
     char buffer[64];
@@ -281,10 +281,10 @@ void Assembler::movptr_with_offset(Register Rd, address addr, int32_t &offset) {
     block_comment(buffer);
   }
 #endif
-  assert(is_unsigned_imm_in_range(imm64, 47, 0) || (imm64 == (uintptr_t)-1),
+  assert(is_unsigned_imm_in_range(imm64, 47, 0) || (imm64 == (int64_t)-1),
          "bit 47 overflows in address constant");
   // Load upper 31 bits
-  int32_t imm = imm64 >> 17;
+  int64_t imm = imm64 >> 17;
   int64_t upper = imm, lower = imm;
   lower = (lower << 52) >> 52;
   upper -= lower;

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1200,7 +1200,7 @@ static int patch_imm_in_li64(address branch, address target) {
   tmp_lower = (tmp_lower << 52) >> 52;
   tmp_upper -= tmp_lower;
   tmp_upper >>= 12;
-  // Load upper 32 bits. Upper = target[63:32], but if target[31] = 1 or (target[31:28] == 0x7ff && target[19] == 1),
+  // Load upper 32 bits. Upper = target[63:32], but if target[31] = 1 or (target[31:20] == 0x7ff && target[19] == 1),
   // upper = target[63:32] + 1.
   Assembler::patch(branch + 0,  31, 12, tmp_upper & 0xfffff);                       // Lui.
   Assembler::patch(branch + 4,  31, 20, tmp_lower & 0xfff);                         // Addi.


### PR DESCRIPTION
In riscv, 'imm[31:28]’ should be 'imm[31:20]' for '0x7ff' in the following two places:

src/hotspot/cpu/riscv/assembler_riscv.cpp:

```
void Assembler::li64(Register Rd, int64_t imm) {
// Load upper 32 bits. upper = imm[63:32], but if imm[31] == 1 or
// (imm[31:28] == 0x7ff && imm[19] == 1), upper = imm[63:32] + 1.
int64_t lower = imm & 0xffffffff;
```

src/hotspot/cpu/riscv/macroAssembler_riscv.cpp:

```
  // Load upper 32 bits. Upper = target[63:32], but if target[31] = 1 or (target[31:28] == 0x7ff && target[19] == 1),
  // upper = target[63:32] + 1.
```

This patch also unifies the immediate type in `movptr_with_offset` to `int64_t`.

Hotspot tier1 test on QEMU passed without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287552](https://bugs.openjdk.java.net/browse/JDK-8287552): riscv: Fix comment typo in li64


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Contributors
 * Dingli Zhang `<dingli@iscas.ac.cn>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8950/head:pull/8950` \
`$ git checkout pull/8950`

Update a local copy of the PR: \
`$ git checkout pull/8950` \
`$ git pull https://git.openjdk.java.net/jdk pull/8950/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8950`

View PR using the GUI difftool: \
`$ git pr show -t 8950`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8950.diff">https://git.openjdk.java.net/jdk/pull/8950.diff</a>

</details>
