### PR TITLE
8287550: Improve stack bang sp update granularity

### DIFF
--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -1116,6 +1116,7 @@ void TemplateInterpreterGenerator::bang_stack_shadow_pages(bool native_call) {
   __ cmp(sp, rscratch1);
   __ br(Assembler::LS, L_done);
   __ mov(rscratch1, sp);
+  __ andr(rscratch1, rscratch1, ~((uint64_t)page_size - 1));
   __ str(rscratch1, Address(rthread, JavaThread::shadow_zone_growth_watermark()));
 
   __ bind(L_done);

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -793,7 +793,13 @@ void TemplateInterpreterGenerator::bang_stack_shadow_pages(bool native_call) {
   // Otherwise, the next time around the check above would pass the safe limit.
   __ cmpptr(rsp, Address(thread, JavaThread::shadow_zone_safe_limit()));
   __ jccb(Assembler::belowEqual, L_done);
+#ifdef _LP64
+  __ movptr(rscratch1, rsp);
+  __ andptr(rscratch1, ~(page_size - 1));
+  __ movptr(Address(thread, JavaThread::shadow_zone_growth_watermark()), rscratch1);
+#else
   __ movptr(Address(thread, JavaThread::shadow_zone_growth_watermark()), rsp);
+#endif
 
   __ bind(L_done);
 


### PR DESCRIPTION
Align sp to page boundary when set to growth watermark in interpreter.

The performance tests for a JMH case are shown below.
[stack_bang_sp_align.csv](https://github.com/openjdk/jdk/files/8803249/stack_bang_sp_align.csv)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287550](https://bugs.openjdk.java.net/browse/JDK-8287550): Improve stack bang sp update granularity


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8951/head:pull/8951` \
`$ git checkout pull/8951`

Update a local copy of the PR: \
`$ git checkout pull/8951` \
`$ git pull https://git.openjdk.java.net/jdk pull/8951/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8951`

View PR using the GUI difftool: \
`$ git pr show -t 8951`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8951.diff">https://git.openjdk.java.net/jdk/pull/8951.diff</a>

</details>
