### PR TITLE
8236569: -Xss not multiple of 4K does not work for the main thread on macOS

### DIFF
--- a/src/java.base/macosx/native/libjli/java_md_macosx.m
+++ b/src/java.base/macosx/native/libjli/java_md_macosx.m
@@ -46,6 +46,7 @@
 
 #include <errno.h>
 #include <spawn.h>
+#include <unistd.h>
 
 struct NSAppArgs {
     int argc;
@@ -722,6 +723,16 @@ static void* ThreadJavaMain(void* args) {
     return (void*)(intptr_t)JavaMain(args);
 }
 
+static size_t alignUp(size_t stack_size) {
+    long page_size = sysconf(_SC_PAGESIZE);
+    if (stack_size % page_size == 0) {
+        return stack_size;
+    } else {
+        long pages = stack_size / page_size;
+        return page_size * (pages + 1);
+    }
+}
+
 /*
  * Block current thread and continue execution in a new thread.
  */
@@ -734,7 +745,7 @@ CallJavaMainInNewThread(jlong stack_size, void* args) {
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
 
     if (stack_size > 0) {
-        pthread_attr_setstacksize(&attr, stack_size);
+        pthread_attr_setstacksize(&attr, alignUp(stack_size));
     }
     pthread_attr_setguardsize(&attr, 0); // no pthread guard page on java threads
 

--- a/src/java.base/share/classes/sun/launcher/resources/launcher.properties
+++ b/src/java.base/share/classes/sun/launcher/resources/launcher.properties
@@ -172,6 +172,8 @@ java.launcher.X.usage=\n\
 \                      (Linux Only) show host system or container\n\
 \                      configuration and continue\n\
 \    -Xss<size>        set java thread stack size\n\
+\                      The actual size may be round up to multiple of system\n\
+\                      page size as required by the operating system.\n\
 \    -Xverify          sets the mode of the bytecode verifier\n\
 \                      Note that option -Xverify:none is deprecated and\n\
 \                      may be removed in a future release.\n\

--- a/src/java.base/share/classes/sun/launcher/resources/launcher.properties
+++ b/src/java.base/share/classes/sun/launcher/resources/launcher.properties
@@ -172,8 +172,8 @@ java.launcher.X.usage=\n\
 \                      (Linux Only) show host system or container\n\
 \                      configuration and continue\n\
 \    -Xss<size>        set java thread stack size\n\
-\                      The actual size may be round up to multiple of system\n\
-\                      page size as required by the operating system.\n\
+\                      The actual size may be rounded up to a multiple of the\n\
+\                      system page size as required by the operating system.\n\
 \    -Xverify          sets the mode of the bytecode verifier\n\
 \                      Note that option -Xverify:none is deprecated and\n\
 \                      may be removed in a future release.\n\

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -1151,6 +1151,8 @@ continues.
 Sets the thread stack size (in bytes).
 Append the letter \f[CB]k\f[R] or \f[CB]K\f[R] to indicate KB, \f[CB]m\f[R] or
 \f[CB]M\f[R] to indicate MB, or \f[CB]g\f[R] or \f[CB]G\f[R] to indicate GB.
+The actual size may be rounded up to a multiple of the system page size as
+required by the operating system.
 The default value depends on the platform:
 .RS
 .IP \[bu] 2

--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -651,6 +651,16 @@ static void* ThreadJavaMain(void* args) {
     return (void*)(intptr_t)JavaMain(args);
 }
 
+static size_t alignUp(size_t stack_size) {
+    long page_size = sysconf(_SC_PAGESIZE);
+    if (stack_size % page_size == 0) {
+        return stack_size;
+    } else {
+        long pages = stack_size / page_size;
+        return page_size * (pages + 1);
+    }
+}
+
 /*
  * Block current thread and continue execution in a new thread.
  */
@@ -663,7 +673,7 @@ CallJavaMainInNewThread(jlong stack_size, void* args) {
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
 
     if (stack_size > 0) {
-        pthread_attr_setstacksize(&attr, stack_size);
+        pthread_attr_setstacksize(&attr, alignUp(stack_size));
     }
     pthread_attr_setguardsize(&attr, 0); // no pthread guard page on java threads
 

--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -651,13 +651,17 @@ static void* ThreadJavaMain(void* args) {
     return (void*)(intptr_t)JavaMain(args);
 }
 
-static size_t alignUp(size_t stack_size) {
+static size_t adjustStackSize(size_t stack_size) {
     long page_size = sysconf(_SC_PAGESIZE);
     if (stack_size % page_size == 0) {
         return stack_size;
     } else {
         long pages = stack_size / page_size;
-        return page_size * (pages + 1);
+        // Ensure we don't go over limit
+        if (stack_size <= SIZE_MAX - page_size) {
+            pages++;
+        }
+        return page_size * pages;
     }
 }
 
@@ -673,7 +677,7 @@ CallJavaMainInNewThread(jlong stack_size, void* args) {
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
 
     if (stack_size > 0) {
-        pthread_attr_setstacksize(&attr, alignUp(stack_size));
+        pthread_attr_setstacksize(&attr, adjustStackSize(stack_size));
     }
     pthread_attr_setguardsize(&attr, 0); // no pthread guard page on java threads
 

--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -682,7 +682,7 @@ CallJavaMainInNewThread(jlong stack_size, void* args) {
             // System may require stack size to be multiple of page size
             // Retry with adjusted value
             adjusted_stack_size = adjustStackSize(stack_size);
-            if (adjusted_stack_size != stack_size) {
+            if (adjusted_stack_size != (size_t) stack_size) {
                 pthread_attr_setstacksize(&attr, adjusted_stack_size);
             }
         }

--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -678,7 +678,7 @@ CallJavaMainInNewThread(jlong stack_size, void* args) {
     size_t adjusted_stack_size;
 
     if (stack_size > 0) {
-        if (EINVAL == pthread_attr_setstacksize(&attr, stack_size)) {
+        if (pthread_attr_setstacksize(&attr, stack_size) == EINVAL) {
             // System may require stack size to be multiple of page size
             // Retry with adjusted value
             adjusted_stack_size = adjustStackSize(stack_size);


### PR DESCRIPTION
This is continuation of PR #4256 

The patch simply rounds up the specified stack size to multiple of the system page size, on systems where necessary.
The patch is based on the original PR/branch, with reflected remaining recommendations.

Please review.

Thank you,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8236569](https://bugs.openjdk.java.net/browse/JDK-8236569): -Xss not multiple of 4K does not work for the main thread on macOS


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8953/head:pull/8953` \
`$ git checkout pull/8953`

Update a local copy of the PR: \
`$ git checkout pull/8953` \
`$ git pull https://git.openjdk.java.net/jdk pull/8953/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8953`

View PR using the GUI difftool: \
`$ git pr show -t 8953`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8953.diff">https://git.openjdk.java.net/jdk/pull/8953.diff</a>

</details>
