### PR TITLE
8287491: compiler/jvmci/errors/TestInvalidDebugInfo.java fails new assert: assert((uint)t < T_CONFLICT + 1) failed: invalid type #

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -46,7 +46,6 @@
 compiler/ciReplay/TestSAServer.java 8029528 generic-all
 compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java 8225370 generic-all
 compiler/jvmci/compilerToVM/GetFlagValueTest.java 8204459 generic-all
-compiler/jvmci/errors/TestInvalidDebugInfo.java 8287491 generic-all
 compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java 8262901 macosx-aarch64
 compiler/tiered/LevelTransitionTest.java 8067651 generic-all
 

--- a/test/hotspot/jtreg/compiler/jvmci/errors/TestInvalidDebugInfo.java
+++ b/test/hotspot/jtreg/compiler/jvmci/errors/TestInvalidDebugInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -153,20 +153,20 @@ public class TestInvalidDebugInfo extends CodeInstallerTest {
     @Test(expected = JVMCIError.class)
     public void testUnexpectedTypeInCPURegister() {
         Register reg = getRegister(arch.getPlatformKind(JavaKind.Int), 0);
-        test(new JavaValue[]{reg.asValue()}, new JavaKind[]{JavaKind.Illegal}, 1, 0, 0);
+        test(new JavaValue[]{reg.asValue()}, new JavaKind[]{JavaKind.Void}, 1, 0, 0);
     }
 
     @Test(expected = JVMCIError.class)
     public void testUnexpectedTypeInFloatRegister() {
         Register reg = getRegister(arch.getPlatformKind(JavaKind.Float), 0);
-        test(new JavaValue[]{reg.asValue()}, new JavaKind[]{JavaKind.Illegal}, 1, 0, 0);
+        test(new JavaValue[]{reg.asValue()}, new JavaKind[]{JavaKind.Void}, 1, 0, 0);
     }
 
     @Test(expected = JVMCIError.class)
     public void testUnexpectedTypeOnStack() {
         ValueKind<?> kind = new TestValueKind(codeCache.getTarget().arch, JavaKind.Int);
         StackSlot value = StackSlot.get(kind, 8, false);
-        test(new JavaValue[]{value}, new JavaKind[]{JavaKind.Illegal}, 1, 0, 0);
+        test(new JavaValue[]{value}, new JavaKind[]{JavaKind.Void}, 1, 0, 0);
     }
 
     @Test(expected = JVMCIError.class)


### PR DESCRIPTION
We saw new assertion error after [JDK-8286562](https://bugs.openjdk.java.net/browse/JDK-8286562) ( #8646 )

```
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/home/ysuenaga/github-forked/jdk/src/hotspot/share/utilities/globalDefinitions.hpp:735), pid=2619, tid=2635
#  assert((uint)t < T_CONFLICT + 1) failed: invalid type
```

It was caused by passing `JavaKind.Illegal` to slot kind at TestInvalidDebugInfo.java . We should pass `JavaKind.Void` instead of `JavKind.Illegal`.

See JBS for more details (I attached hs_err log).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287491](https://bugs.openjdk.java.net/browse/JDK-8287491): compiler/jvmci/errors/TestInvalidDebugInfo.java fails new assert:  assert((uint)t < T_CONFLICT + 1) failed: invalid type #


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Doug Simon](https://openjdk.java.net/census#dnsimon) (@dougxc - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8954/head:pull/8954` \
`$ git checkout pull/8954`

Update a local copy of the PR: \
`$ git checkout pull/8954` \
`$ git pull https://git.openjdk.java.net/jdk pull/8954/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8954`

View PR using the GUI difftool: \
`$ git pr show -t 8954`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8954.diff">https://git.openjdk.java.net/jdk/pull/8954.diff</a>

</details>
