### PR TITLE
8287340: Refactor old code using StringTokenizer in locale related code

### DIFF
--- a/src/java.base/share/classes/sun/util/cldr/CLDRLocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/cldr/CLDRLocaleProviderAdapter.java
@@ -33,14 +33,12 @@ import java.text.spi.BreakIteratorProvider;
 import java.text.spi.CollatorProvider;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.spi.CalendarDataProvider;
 import java.util.spi.CalendarNameProvider;
@@ -63,13 +61,13 @@ public class CLDRLocaleProviderAdapter extends JRELocaleProviderAdapter {
 
     // parent locales map
     private static volatile Map<Locale, Locale> parentLocalesMap;
-    // language aliases map
-    private static volatile Map<String,String> langAliasesMap;
     // cache to hold  locale to locale mapping for language aliases.
     private static final Map<Locale, Locale> langAliasesCache;
+    // cache the available locales
+    private static volatile Locale[] AVAILABLE_LOCALES;
+
     static {
         parentLocalesMap = new ConcurrentHashMap<>();
-        langAliasesMap = new ConcurrentHashMap<>();
         langAliasesCache = new ConcurrentHashMap<>();
         // Assuming these locales do NOT have irregular parent locales.
         parentLocalesMap.put(Locale.ROOT, Locale.ROOT);
@@ -175,29 +173,19 @@ public class CLDRLocaleProviderAdapter extends JRELocaleProviderAdapter {
 
     @Override
     public Locale[] getAvailableLocales() {
-        Set<String> all = createLanguageTagSet("AvailableLocales");
-        Locale[] locs = new Locale[all.size()];
-        int index = 0;
-        for (String tag : all) {
-            locs[index++] = Locale.forLanguageTag(tag);
+        if (AVAILABLE_LOCALES == null) {
+            AVAILABLE_LOCALES = createLanguageTagSet("AvailableLocales").stream()
+                .map(Locale::forLanguageTag)
+                .toArray(Locale[]::new);
         }
-        return locs;
+        return AVAILABLE_LOCALES;
     }
 
     private static Locale applyAliases(Locale loc) {
-        if (langAliasesMap.isEmpty()) {
-            langAliasesMap = baseMetaInfo.getLanguageAliasMap();
-        }
-        Locale locale = langAliasesCache.get(loc);
-        if (locale == null) {
-            String locTag = loc.toLanguageTag();
-            Locale aliasLocale = langAliasesMap.containsKey(locTag)
-                    ? Locale.forLanguageTag(langAliasesMap.get(locTag)) : loc;
-            langAliasesCache.putIfAbsent(loc, aliasLocale);
-            return aliasLocale;
-        } else {
-            return locale;
-        }
+        return langAliasesCache.computeIfAbsent(loc, l -> {
+            var alias = baseMetaInfo.getLanguageAliasMap().get(l.toLanguageTag());
+            return alias != null ? Locale.forLanguageTag(alias) : l;
+        });
     }
 
     @Override
@@ -220,15 +208,9 @@ public class CLDRLocaleProviderAdapter extends JRELocaleProviderAdapter {
                 supportedLocaleString = nonBaseTags;
             }
         }
-        if (supportedLocaleString == null) {
-            return Collections.emptySet();
-        }
-        StringTokenizer tokens = new StringTokenizer(supportedLocaleString);
-        Set<String> tagset = new HashSet<>((tokens.countTokens() * 4 + 2) / 3);
-        while (tokens.hasMoreTokens()) {
-            tagset.add(tokens.nextToken());
-        }
-        return tagset;
+        return supportedLocaleString != null ?
+                Set.of(supportedLocaleString.split("\s+")) :
+                Collections.emptySet();
     }
 
     // Implementation of ResourceBundleBasedAdapter

--- a/src/java.base/share/classes/sun/util/locale/provider/JRELocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/JRELocaleProviderAdapter.java
@@ -36,15 +36,13 @@ import java.text.spi.DateFormatProvider;
 import java.text.spi.DateFormatSymbolsProvider;
 import java.text.spi.DecimalFormatSymbolsProvider;
 import java.text.spi.NumberFormatProvider;
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.ServiceLoader;
-import java.util.ServiceConfigurationError;
 import java.util.Set;
-import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.spi.CalendarDataProvider;
@@ -454,16 +452,9 @@ public class JRELocaleProviderAdapter extends LocaleProviderAdapter implements R
 
     protected Set<String> createLanguageTagSet(String category) {
         String supportedLocaleString = createSupportedLocaleString(category);
-        if (supportedLocaleString == null) {
-            return Collections.emptySet();
-        }
-        StringTokenizer tokens = new StringTokenizer(supportedLocaleString);
-        Set<String> tagset = new HashSet<>((tokens.countTokens() * 4 + 2) / 3);
-        while (tokens.hasMoreTokens()) {
-            tagset.add(tokens.nextToken());
-        }
-
-        return tagset;
+        return supportedLocaleString != null ?
+            Set.of(supportedLocaleString.split("\s+")) :
+            Collections.emptySet();
     }
 
     private static String createSupportedLocaleString(String category) {
@@ -520,28 +511,17 @@ public class JRELocaleProviderAdapter extends LocaleProviderAdapter implements R
             throw new InternalError("No available locales for JRE");
         }
 
-        StringTokenizer localeStringTokenizer = new StringTokenizer(supportedLocaleString);
-
-        int length = localeStringTokenizer.countTokens();
-        Locale[] locales = new Locale[length + 1];
-        locales[0] = Locale.ROOT;
-        for (int i = 1; i <= length; i++) {
-            String currentToken = localeStringTokenizer.nextToken();
-            switch (currentToken) {
-                case "ja-JP-JP":
-                    locales[i] = JRELocaleConstants.JA_JP_JP;
-                    break;
-                case "no-NO-NY":
-                    locales[i] = JRELocaleConstants.NO_NO_NY;
-                    break;
-                case "th-TH-TH":
-                    locales[i] = JRELocaleConstants.TH_TH_TH;
-                    break;
-                default:
-                    locales[i] = Locale.forLanguageTag(currentToken);
-            }
-        }
-        return locales;
+        return Arrays.stream(supportedLocaleString.split("\s+"))
+            .map(t -> {
+                return switch (t) {
+                    case "ja-JP-JP" -> JRELocaleConstants.JA_JP_JP;
+                    case "no-NO-NY" -> JRELocaleConstants.NO_NO_NY;
+                    case "th-TH-TH" -> JRELocaleConstants.TH_TH_TH;
+                    default -> Locale.forLanguageTag(t);
+                };
+            })
+            .distinct()
+            .toArray(Locale[]::new);
     }
 
     @Override

--- a/src/java.base/share/classes/sun/util/locale/provider/JRELocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/JRELocaleProviderAdapter.java
@@ -26,7 +26,6 @@
 package sun.util.locale.provider;
 
 import java.security.AccessController;
-import java.security.AccessControlException;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -435,7 +434,7 @@ public class JRELocaleProviderAdapter extends LocaleProviderAdapter implements R
      */
     @Override
     public Locale[] getAvailableLocales() {
-        return AvailableJRELocales.localeList.clone();
+        return AvailableJRELocales.localeList;
     }
 
     public Set<String> getLanguageTagSet(String category) {

--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleProviderAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import java.text.spi.DateFormatSymbolsProvider;
 import java.text.spi.DecimalFormatSymbolsProvider;
 import java.text.spi.NumberFormatProvider;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -308,23 +309,16 @@ public abstract class LocaleProviderAdapter {
     }
 
     public static Locale[] toLocaleArray(Set<String> tags) {
-        Locale[] locs = new Locale[tags.size() + 1];
-        int index = 0;
-        locs[index++] = Locale.ROOT;
-        for (String tag : tags) {
-            switch (tag) {
-            case "ja-JP-JP":
-                locs[index++] = JRELocaleConstants.JA_JP_JP;
-                break;
-            case "th-TH-TH":
-                locs[index++] = JRELocaleConstants.TH_TH_TH;
-                break;
-            default:
-                locs[index++] = Locale.forLanguageTag(tag);
-                break;
-            }
-        }
-        return locs;
+        return tags.stream()
+            .map(t -> {
+                return switch (t) {
+                    case "ja-JP-JP" -> JRELocaleConstants.JA_JP_JP;
+                    case "no-NO-NY" -> JRELocaleConstants.NO_NO_NY;
+                    case "th-TH-TH" -> JRELocaleConstants.TH_TH_TH;
+                    default -> Locale.forLanguageTag(t);
+                };
+            })
+            .toArray(Locale[]::new);
     }
 
     /**

--- a/test/jdk/sun/util/locale/provider/Bug8038436.java
+++ b/test/jdk/sun/util/locale/provider/Bug8038436.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8038436 8158504 8065555 8167143 8167273 8189272
+ * @bug 8038436 8158504 8065555 8167143 8167273 8189272 8287340
  * @summary Test for changes in 8038436
  * @modules java.base/sun.util.locale.provider
  *          java.base/sun.util.spi
@@ -32,18 +32,9 @@
  * @run main/othervm  -Djava.locale.providers=COMPAT Bug8038436  availlocs
  */
 
-import java.security.CodeSource;
-import java.security.Permission;
-import java.security.PermissionCollection;
-import java.security.Permissions;
-import java.security.Policy;
-import java.security.ProtectionDomain;
 import java.util.Arrays;
-import java.util.Formatter;
-import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Locale;
-import java.util.stream.Collectors;
 import sun.util.locale.provider.LocaleProviderAdapter;
 
 public class Bug8038436 {
@@ -61,73 +52,74 @@ public class Bug8038436 {
     }
 
 
-    static final String[] bipLocs = ("ar, ar-JO, ar-LB, ar-SY, be, be-BY, bg, " +
-        "bg-BG, ca, ca-ES, cs, cs-CZ, da, da-DK, de, de-AT, de-CH, de-DE, " +
-        "de-LU, el, el-CY, el-GR, en, en-AU, en-CA, en-GB, en-IE, en-IN, " +
-        "en-MT, en-NZ, en-PH, en-SG, en-US, en-ZA, es, es-AR, es-BO, es-CL, " +
-        "es-CO, es-CR, es-DO, es-EC, es-ES, es-GT, es-HN, es-MX, es-NI, " +
-        "es-PA, es-PE, es-PR, es-PY, es-SV, es-US, es-UY, es-VE, et, et-EE, " +
-        "fi, fi-FI, fr, fr-BE, fr-CA, fr-CH, fr-FR, ga, ga-IE, he, he-IL, " +
-        "hi-IN, hr, hr-HR, hu, hu-HU, id, id-ID, is, is-IS, it, it-CH, it-IT, " +
-        "ja, ja-JP, ko, ko-KR, lt, lt-LT, lv, lv-LV, mk, mk-MK, ms, ms-MY, mt, " +
-        "mt-MT, nb, nb-NO, nl, nl-BE, nl-NL, nn-NO, no, no-NO, no-NO, pl, pl-PL, pt, pt-BR, " +
-        "pt-PT, ro, ro-RO, ru, ru-RU, sk, sk-SK, sl, sl-SI, sq, sq-AL, sr, " +
-        "sr-BA, sr-CS, sr-Latn, sr-Latn-ME, sr-ME, sr-RS, sv, sv-SE, th, th-TH, " +
-        "tr, tr-TR, uk, uk-UA, und, vi, vi-VN, zh, zh-CN, zh-HK, zh-Hans-CN, " +
-        "zh-Hans-SG, zh-Hant-HK, zh-Hant-TW, zh-SG, zh-TW, ").split(",\\s*");
+    static final String[] bipLocs = (", ar, ar_JO, ar_LB, ar_SY, be, be_BY, bg, " +
+        "bg_BG, ca, ca_ES, cs, cs_CZ, da, da_DK, de, de_AT, de_CH, de_DE, " +
+        "de_LU, el, el_CY, el_GR, en, en_AU, en_CA, en_GB, en_IE, en_IN, " +
+        "en_MT, en_NZ, en_PH, en_SG, en_US, en_ZA, es, es_AR, es_BO, es_CL, " +
+        "es_CO, es_CR, es_DO, es_EC, es_ES, es_GT, es_HN, es_MX, es_NI, " +
+        "es_PA, es_PE, es_PR, es_PY, es_SV, es_US, es_UY, es_VE, et, et_EE, " +
+        "fi, fi_FI, fr, fr_BE, fr_CA, fr_CH, fr_FR, ga, ga_IE, he, he_IL, " +
+        "hi_IN, hr, hr_HR, hu, hu_HU, id, id_ID, is, is_IS, it, it_CH, it_IT, " +
+        "ja, ja_JP, ko, ko_KR, lt, lt_LT, lv, lv_LV, mk, mk_MK, ms, ms_MY, mt, " +
+        "mt_MT, nb, nb_NO, nl, nl_BE, nl_NL, nn_NO, no, no_NO, no_NO_NY, pl, pl_PL, pt, pt_BR, " +
+        "pt_PT, ro, ro_RO, ru, ru_RU, sk, sk_SK, sl, sl_SI, sq, sq_AL, sr, " +
+        "sr_BA, sr_CS, sr_ME, sr_ME_#Latn, sr_RS, sr__#Latn, sv, sv_SE, th, th_TH, " +
+        "tr, tr_TR, uk, uk_UA, vi, vi_VN, zh, zh_CN, zh_CN_#Hans, zh_HK, " +
+        "zh_HK_#Hant, zh_SG, zh_SG_#Hans, zh_TW, zh_TW_#Hant, ").split(",\\s*");
+
     static final String[] dfpLocs = bipLocs;
     static final String[] datefspLocs = bipLocs;
     static final String[] decimalfspLocs = bipLocs;
     static final String[] calnpLocs = bipLocs;
-    static final String[] cpLocs = ("ar, be, bg, ca, cs, da, el, es, et, fi, " +
-        "fr, he, hi, hr, hu, is, ja, ko, lt, lv, mk, nb, nb-NO, nn-NO, no, pl, ro, ru, sk, sl, " +
-        "sq, sr, sr-Latn, sv, th, tr, uk, und, vi, zh, zh-HK, zh-Hant-HK, " +
-        "zh-Hant-TW, zh-TW, ").split(",\\s*");
-    static final String[] nfpLocs = ("ar, ar-AE, ar-BH, ar-DZ, ar-EG, ar-IQ, " +
-        "ar-JO, ar-KW, ar-LB, ar-LY, ar-MA, ar-OM, ar-QA, ar-SA, ar-SD, ar-SY, " +
-        "ar-TN, ar-YE, be, be-BY, bg, bg-BG, ca, ca-ES, cs, cs-CZ, da, da-DK, " +
-        "de, de-AT, de-CH, de-DE, de-LU, el, el-CY, el-GR, en, en-AU, " +
-        "en-CA, en-GB, en-IE, en-IN, en-MT, en-NZ, en-PH, en-SG, en-US, en-ZA, " +
-        "es, es-AR, es-BO, es-CL, es-CO, es-CR, es-CU, es-DO, es-EC, es-ES, " +
-        "es-GT, es-HN, es-MX, es-NI, es-PA, es-PE, es-PR, es-PY, es-SV, es-US, " +
-        "es-UY, es-VE, et, et-EE, fi, fi-FI, fr, fr-BE, fr-CA, fr-CH, fr-FR, " +
-        "fr-LU, ga, ga-IE, he, he-IL, hi, hi-IN, hr, hr-HR, hu, hu-HU, id, " +
-        "id-ID, is, is-IS, it, it-CH, it-IT, ja, ja-JP, " +
-        "ja-JP-u-ca-japanese-x-lvariant-JP, ko, ko-KR, lt, lt-LT, lv, lv-LV, " +
-        "mk, mk-MK, ms, ms-MY, mt, mt-MT, nb, nb-NO, nl, nl-BE, nl-NL, nn-NO, " +
-        "nn-NO, no, no-NO, pl, pl-PL, pt, pt-BR, pt-PT, ro, ro-RO, ru, ru-RU, " +
-        "sk, sk-SK, sl, sl-SI, sq, sq-AL, sr, sr-BA, sr-CS, sr-Latn, " +
-        "sr-Latn-BA, sr-Latn-ME, sr-Latn-RS, sr-ME, sr-RS, sv, sv-SE, th, " +
-        "th-TH, th-TH-u-nu-thai-x-lvariant-TH, tr, tr-TR, uk, uk-UA, und, vi, " +
-        "vi-VN, zh, zh-CN, zh-HK, zh-Hans-CN, zh-Hans-SG, zh-Hant-HK, " +
-        "zh-Hant-TW, zh-SG, zh-TW, ").split(",\\s*");
-    static final String[] currencynpLocs = ("ar-AE, ar-BH, ar-DZ, ar-EG, ar-IQ, " +
-        "ar-JO, ar-KW, ar-LB, ar-LY, ar-MA, ar-OM, ar-QA, ar-SA, ar-SD, ar-SY, " +
-        "ar-TN, ar-YE, be-BY, bg-BG, ca-ES, cs-CZ, da-DK, de, de-AT, de-CH, " +
-        "de-DE, de-LU, el-CY, el-GR, en-AU, en-CA, en-GB, en-IE, en-IN, " +
-        "en-MT, en-NZ, en-PH, en-SG, en-US, en-ZA, es, es-AR, es-BO, es-CL, " +
-        "es-CO, es-CR, es-CU, es-DO, es-EC, es-ES, es-GT, es-HN, es-MX, es-NI, " +
-        "es-PA, es-PE, es-PR, es-PY, es-SV, es-US, es-UY, es-VE, et-EE, fi-FI, " +
-        "fr, fr-BE, fr-CA, fr-CH, fr-FR, fr-LU, ga-IE, he-IL, hi-IN, hr-HR, " +
-        "hu-HU, id-ID, is-IS, it, it-CH, it-IT, ja, ja-JP, ko, ko-KR, lt-LT, " +
-        "lv-LV, mk-MK, ms-MY, mt-MT, nb,  nb-NO, nl-BE, nl-NL, nn-NO, no-NO, pl-PL, pt, pt-BR, " +
-        "pt-PT, ro-RO, ru-RU, sk-SK, sl-SI, sq-AL, sr-BA, sr-CS, sr-Latn-BA, " +
-        "sr-Latn-ME, sr-Latn-RS, sr-ME, sr-RS, sv, sv-SE, th-TH, tr-TR, uk-UA, " +
-        "und, vi-VN, zh-CN, zh-HK, zh-Hans-CN, zh-Hans-SG, zh-Hant-HK, " +
-        "zh-Hant-TW, zh-SG, zh-TW, ").split(",\\s*");
-    static final String[] lnpLocs = ("ar, be, bg, ca, cs, da, de, el, el-CY, " +
-        "en, en-MT, en-PH, en-SG, es, es-US, et, fi, fr, ga, he, hi, hr, hu, " +
-        "id, is, it, ja, ko, lt, lv, mk, ms, mt, nb, nb-NO, nl, nn-NO, no, no-NO, pl, pt, pt-BR, " +
-        "pt-PT, ro, ru, sk, sl, sq, sr, sr-Latn, sv, th, tr, uk, und, vi, zh, " +
-        "zh-HK, zh-Hans-SG, zh-Hant-HK, zh-Hant-TW, zh-SG, zh-TW, ").split(",\\s*");
-    static final String[] tznpLocs = ("de, en, en-CA, en-GB, en-IE, es, fr, hi, " +
-        "it, ja, ko, nb,  nb-NO, nn-NO, pt-BR, sv, und, zh-CN, zh-HK, zh-Hans-CN, zh-Hant-HK, " +
-        "zh-Hant-TW, zh-TW, ").split(",\\s*");
-    static final String[] caldpLocs = ("ar, be, bg, ca, cs, da, de, el, el-CY, " +
-        "en, en-GB, en-IE, en-MT, es, es-ES, es-US, et, fi, fr, fr-CA, he, hi, " +
-        "hr, hu, id-ID, is, it, ja, ko, lt, lv, mk, ms-MY, mt, mt-MT, nb, nb-NO, nl, nn-NO, no, " +
-        "pl, pt, pt-BR, pt-PT, ro, ru, sk, sl, sq, sr, sr-Latn-BA, sr-Latn-ME, " +
-        "sr-Latn-RS, sv, th, tr, uk, und, vi, zh, ").split(",\\s*");
+    static final String[] cpLocs = (", ar, be, bg, ca, cs, da, el, es, et, fi, " +
+        "fr, he, hi, hr, hu, is, ja, ko, lt, lv, mk, nb, nb_NO, nn_NO, no, pl, ro, ru, sk, sl, " +
+        "sq, sr, sr__#Latn, sv, th, tr, uk, vi, zh, zh_HK, zh_HK_#Hant, " +
+        "zh_TW, zh_TW_#Hant, ").split(",\\s*");
+    static final String[] nfpLocs = (", ar, ar_AE, ar_BH, ar_DZ, ar_EG, ar_IQ, " +
+        "ar_JO, ar_KW, ar_LB, ar_LY, ar_MA, ar_OM, ar_QA, ar_SA, ar_SD, ar_SY, " +
+        "ar_TN, ar_YE, be, be_BY, bg, bg_BG, ca, ca_ES, cs, cs_CZ, da, da_DK, " +
+        "de, de_AT, de_CH, de_DE, de_LU, el, el_CY, el_GR, en, en_AU, " +
+        "en_CA, en_GB, en_IE, en_IN, en_MT, en_NZ, en_PH, en_SG, en_US, en_ZA, " +
+        "es, es_AR, es_BO, es_CL, es_CO, es_CR, es_CU, es_DO, es_EC, es_ES, " +
+        "es_GT, es_HN, es_MX, es_NI, es_PA, es_PE, es_PR, es_PY, es_SV, es_US, " +
+        "es_UY, es_VE, et, et_EE, fi, fi_FI, fr, fr_BE, fr_CA, fr_CH, fr_FR, " +
+        "fr_LU, ga, ga_IE, he, he_IL, hi, hi_IN, hr, hr_HR, hu, hu_HU, id, " +
+        "id_ID, is, is_IS, it, it_CH, it_IT, ja, ja_JP, " +
+        "ja_JP_JP_#u-ca-japanese, ko, ko_KR, lt, lt_LT, lv, lv_LV, " +
+        "mk, mk_MK, ms, ms_MY, mt, mt_MT, nb, nb_NO, nl, nl_BE, nl_NL, nn_NO, " +
+        "no, no_NO, no_NO_NY, pl, pl_PL, pt, pt_BR, pt_PT, ro, ro_RO, ru, ru_RU, " +
+        "sk, sk_SK, sl, sl_SI, sq, sq_AL, sr, sr_BA, sr_BA_#Latn, sr_CS, sr_ME, " +
+        "sr_ME_#Latn, sr_RS, sr_RS_#Latn, sr__#Latn, sv, sv_SE, th, " +
+        "th_TH, th_TH_TH_#u-nu-thai, tr, tr_TR, uk, uk_UA, vi, " +
+        "vi_VN, zh, zh_CN, zh_CN_#Hans, zh_HK, zh_HK_#Hant, zh_SG, zh_SG_#Hans, " +
+        "zh_TW, zh_TW_#Hant, ").split(",\\s*");
+    static final String[] currencynpLocs = (", ar_AE, ar_BH, ar_DZ, ar_EG, ar_IQ, " +
+        "ar_JO, ar_KW, ar_LB, ar_LY, ar_MA, ar_OM, ar_QA, ar_SA, ar_SD, ar_SY, " +
+        "ar_TN, ar_YE, be_BY, bg_BG, ca_ES, cs_CZ, da_DK, de, de_AT, de_CH, " +
+        "de_DE, de_LU, el_CY, el_GR, en_AU, en_CA, en_GB, en_IE, en_IN, " +
+        "en_MT, en_NZ, en_PH, en_SG, en_US, en_ZA, es, es_AR, es_BO, es_CL, " +
+        "es_CO, es_CR, es_CU, es_DO, es_EC, es_ES, es_GT, es_HN, es_MX, es_NI, " +
+        "es_PA, es_PE, es_PR, es_PY, es_SV, es_US, es_UY, es_VE, et_EE, fi_FI, " +
+        "fr, fr_BE, fr_CA, fr_CH, fr_FR, fr_LU, ga_IE, he_IL, hi_IN, hr_HR, " +
+        "hu_HU, id_ID, is_IS, it, it_CH, it_IT, ja, ja_JP, ko, ko_KR, lt_LT, " +
+        "lv_LV, mk_MK, ms_MY, mt_MT, nb,  nb_NO, nl_BE, nl_NL, nn_NO, no_NO, pl_PL, pt, pt_BR, " +
+        "pt_PT, ro_RO, ru_RU, sk_SK, sl_SI, sq_AL, sr_BA, sr_BA_#Latn, sr_CS, " +
+        "sr_ME, sr_ME_#Latn, sr_RS, sr_RS_#Latn, sv, sv_SE, th_TH, tr_TR, uk_UA, " +
+        "vi_VN, zh_CN, zh_CN_#Hans, zh_HK, zh_HK_#Hant, zh_SG, zh_SG_#Hans, " +
+        "zh_TW, zh_TW_#Hant, ").split(",\\s*");
+    static final String[] lnpLocs = (", ar, be, bg, ca, cs, da, de, el, el_CY, " +
+        "en, en_MT, en_PH, en_SG, es, es_US, et, fi, fr, ga, he, hi, hr, hu, " +
+        "id, is, it, ja, ko, lt, lv, mk, ms, mt, nb, nb_NO, nl, nn_NO, no, no_NO_NY, pl, pt, pt_BR, " +
+        "pt_PT, ro, ru, sk, sl, sq, sr, sr__#Latn, sv, th, tr, uk, vi, zh, " +
+        "zh_HK, zh_HK_#Hant, zh_SG, zh_SG_#Hans, zh_TW, zh_TW_#Hant, ").split(",\\s*");
+    static final String[] tznpLocs = (", de, en, en_CA, en_GB, en_IE, es, fr, hi, " +
+        "it, ja, ko, nb,  nb_NO, nn_NO, pt_BR, sv, zh_CN, zh_CN_#Hans, zh_HK, zh_HK_#Hant, " +
+        "zh_TW, zh_TW_#Hant, ").split(",\\s*");
+    static final String[] caldpLocs = (", ar, be, bg, ca, cs, da, de, el, el_CY, " +
+        "en, en_GB, en_IE, en_MT, es, es_ES, es_US, et, fi, fr, fr_CA, he, hi, " +
+        "hr, hu, id_ID, is, it, ja, ko, lt, lv, mk, ms_MY, mt, mt_MT, nb, nb_NO, nl, nn_NO, no, " +
+        "pl, pt, pt_BR, pt_PT, ro, ru, sk, sl, sq, sr, sr_BA_#Latn, sr_ME_#Latn, sr_RS_#Latn, " +
+        "sv, th, tr, uk, vi, zh, ").split(",\\s*");
     static final String[] calpLocs = caldpLocs;
 
     /*
@@ -167,18 +159,15 @@ public class Bug8038436 {
 
     private static void checkAvailableLocales(String testName, Locale[] got, String[] expected) {
         System.out.println("Testing available locales for " + testName);
-        List<Locale> gotList = Arrays.asList(got).stream()
-            .map(Locale::toLanguageTag)
+        List<String> gotList = Arrays.stream(got)
+            .map(Locale::toString)
             .sorted()
-            .map(Locale::forLanguageTag)
-            .collect(Collectors.toList());
-        List<Locale> expectedList = Arrays.asList(expected).stream()
-            .map(Locale::forLanguageTag)
-            .collect(Collectors.toList());
+            .toList();
+        List<String> expectedList = Arrays.stream(expected)
+            .toList();
 
         if (!gotList.equals(expectedList)) {
-            throw new RuntimeException("\n" + gotList.toString() + "\n is not equal to \n" +
-                                       expectedList.toString());
+            throw new RuntimeException("\n" + gotList + "\n is not equal to \n" + expectedList);
         }
     }
 }


### PR DESCRIPTION
Refactoring some old code in locale providers. The test case data have also been modified due to:
- There's a bug in `LocaleProviderAdapter.toLocaleArray()` where it did not handle the case for `no-NO-NY`.
- `Locale.toLanguageTag()` won't handle legacy Java locales, e.g., `ja_JP_JP` and falls back, so comparing locales using language tags does not work for those locales. Changed to compare with `Locale.toString()` instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287340](https://bugs.openjdk.java.net/browse/JDK-8287340): Refactor old code using StringTokenizer in locale related code


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [6b1169e2](https://git.openjdk.java.net/jdk/pull/8960/files/6b1169e266b9d21864f886ef574dd64116fa2cb0)
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to [6b1169e2](https://git.openjdk.java.net/jdk/pull/8960/files/6b1169e266b9d21864f886ef574dd64116fa2cb0)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8960/head:pull/8960` \
`$ git checkout pull/8960`

Update a local copy of the PR: \
`$ git checkout pull/8960` \
`$ git pull https://git.openjdk.java.net/jdk pull/8960/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8960`

View PR using the GUI difftool: \
`$ git pr show -t 8960`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8960.diff">https://git.openjdk.java.net/jdk/pull/8960.diff</a>

</details>
