### PR TITLE
8287517: C2: assert(vlen_in_bytes == 64) failed: 2

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -1501,7 +1501,7 @@ void C2_MacroAssembler::load_vector(XMMRegister dst, AddressLiteral src, int vle
 
 void C2_MacroAssembler::load_iota_indices(XMMRegister dst, Register scratch, int vlen_in_bytes) {
   ExternalAddress addr(StubRoutines::x86::vector_iota_indices());
-  if (vlen_in_bytes == 4) {
+  if (vlen_in_bytes <= 4) {
     movdl(dst, addr);
   } else if (vlen_in_bytes == 8) {
     movq(dst, addr);

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1846,6 +1846,7 @@ const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType 
       if (size_in_bits > 256 && !VM_Version::supports_avx512bw()) {
         return false;
       }
+      break;
     case Op_VectorCastB2X:
     case Op_VectorCastS2X:
     case Op_VectorCastI2X:

--- a/test/hotspot/jtreg/compiler/vectorization/TestSmallVectorPopIndex.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestSmallVectorPopIndex.java
@@ -26,22 +26,22 @@
 * @bug 8287517
 * @summary Test bug fix for JDK-8287517 related to fuzzer test failure in x86_64
 * @requires vm.compiler2.enabled
-* @run main/othervm -Xcomp -XX:CompileOnly=compiler/vectorization/cr8287517.test -XX:MaxVectorSize=8 compiler.vectorization.cr8287517
+* @run main/othervm -Xcomp -XX:CompileOnly=compiler/vectorization/TestSmallVectorPopIndex.test -XX:MaxVectorSize=8 compiler.vectorization.TestSmallVectorPopIndex
 */
 
 package compiler.vectorization;
 
-public class cr8287517 {
+public class TestSmallVectorPopIndex {
     private static final int count = 1000;
 
     private static float[] f;
 
     public static void main(String args[]) {
-        cr8287517 t = new cr8287517();
+        TestSmallVectorPopIndex t = new TestSmallVectorPopIndex();
         t.test();
     }
 
-    public cr8287517() {
+    public TestSmallVectorPopIndex() {
         f = new float[count];
     }
 

--- a/test/hotspot/jtreg/compiler/vectorization/cr8287517.java
+++ b/test/hotspot/jtreg/compiler/vectorization/cr8287517.java
@@ -26,8 +26,6 @@
 * @bug 8287517
 * @summary Test bug fix for JDK-8287517 related to fuzzer test failure in x86_64
 * @requires vm.compiler2.enabled
-* @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") |
-*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*sve.*")
 * @run main/othervm -Xcomp -XX:CompileOnly=compiler/vectorization/cr8287517.test -XX:MaxVectorSize=8 compiler.vectorization.cr8287517
 */
 

--- a/test/hotspot/jtreg/compiler/vectorization/cr8287517.java
+++ b/test/hotspot/jtreg/compiler/vectorization/cr8287517.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+* @test
+* @bug 8287517
+* @summary Test bug fix for JDK-8287517 related to fuzzer test failure in x86_64
+* @requires vm.compiler2.enabled
+* @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") |
+*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*sve.*")
+* @run main/othervm -Xcomp -XX:CompileOnly=compiler/vectorization/cr8287517.test -XX:MaxVectorSize=8 compiler.vectorization.cr8287517
+*/
+
+package compiler.vectorization;
+
+public class cr8287517 {
+    private static final int count = 1000;
+
+    private static float[] f;
+
+    public static void main(String args[]) {
+        cr8287517 t = new cr8287517();
+        t.test();
+    }
+
+    public cr8287517() {
+        f = new float[count];
+    }
+
+    public void test() {
+        for (int i = 0; i < count; i++) {
+            f[i] = i * i + 100;
+        }
+        checkResult();
+    }
+
+    public void checkResult() {
+        for (int i = 0; i < count; i++) {
+            float expected = i * i  + 100;
+            if (f[i] != expected) {
+                throw new RuntimeException("Invalid result: f[" + i + "] = " + f[i] + " != " + expected);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixed the assertion in load_iota_indices when the length passed is less than 4.
Also fixed the missing break in x86.ad match_rule_supported_vector() for PopulateIndex case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287517](https://bugs.openjdk.java.net/browse/JDK-8287517): C2: assert(vlen_in_bytes == 64) failed: 2


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [37639f5f](https://git.openjdk.java.net/jdk/pull/8961/files/37639f5f808368a0389fd899f59f61eabb3926ec)
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**) ⚠️ Review applies to [37639f5f](https://git.openjdk.java.net/jdk/pull/8961/files/37639f5f808368a0389fd899f59f61eabb3926ec)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [37639f5f](https://git.openjdk.java.net/jdk/pull/8961/files/37639f5f808368a0389fd899f59f61eabb3926ec)
 * [Fei Gao](https://openjdk.java.net/census#fgao) (@fg1417 - Author) ⚠️ Review applies to [37639f5f](https://git.openjdk.java.net/jdk/pull/8961/files/37639f5f808368a0389fd899f59f61eabb3926ec)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8961/head:pull/8961` \
`$ git checkout pull/8961`

Update a local copy of the PR: \
`$ git checkout pull/8961` \
`$ git pull https://git.openjdk.java.net/jdk pull/8961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8961`

View PR using the GUI difftool: \
`$ git pr show -t 8961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8961.diff">https://git.openjdk.java.net/jdk/pull/8961.diff</a>

</details>
