### PR TITLE
8287097: (fs) Files::copy requires an undocumented permission when copying from the default file system to a non-default file system

### DIFF
--- a/src/java.base/share/classes/java/nio/file/CopyMoveHelper.java
+++ b/src/java.base/share/classes/java/nio/file/CopyMoveHelper.java
@@ -117,6 +117,7 @@ class CopyMoveHelper {
                                                    PosixFileAttributes.class,
                                                    linkOptions);
             } catch (SecurityException ignored) {
+                // okay to continue if RuntimePermission("accessUserInformation") not granted
             }
         }
         if (sourceAttrs == null)
@@ -167,6 +168,7 @@ class CopyMoveHelper {
                     try {
                         targetPosixView.setPermissions(sourcePosixAttrs.permissions());
                     } catch (SecurityException ignored) {
+                        // okay to continue if RuntimePermission("accessUserInformation") not granted
                     }
                 }
             } catch (Throwable x) {

--- a/src/java.base/share/classes/java/nio/file/CopyMoveHelper.java
+++ b/src/java.base/share/classes/java/nio/file/CopyMoveHelper.java
@@ -164,7 +164,10 @@ class CopyMoveHelper {
 
                 if (sourceAttrs instanceof PosixFileAttributes sourcePosixAttrs &&
                     targetView instanceof PosixFileAttributeView targetPosixView) {
-                    targetPosixView.setPermissions(sourcePosixAttrs.permissions());
+                    try {
+                        targetPosixView.setPermissions(sourcePosixAttrs.permissions());
+                    } catch (SecurityException ignored) {
+                    }
                 }
             } catch (Throwable x) {
                 // rollback

--- a/src/java.base/share/classes/java/nio/file/CopyMoveHelper.java
+++ b/src/java.base/share/classes/java/nio/file/CopyMoveHelper.java
@@ -110,13 +110,20 @@ class CopyMoveHelper {
             Files.getFileAttributeView(source, PosixFileAttributeView.class);
 
         // attributes of source file
-        BasicFileAttributes sourceAttrs = sourcePosixView != null ?
-            Files.readAttributes(source,
-                                 PosixFileAttributes.class,
-                                 linkOptions) :
-            Files.readAttributes(source,
-                                 BasicFileAttributes.class,
-                                 linkOptions);
+        BasicFileAttributes sourceAttrs = null;
+        if (sourcePosixView != null) {
+            try {
+                sourceAttrs = Files.readAttributes(source,
+                                                   PosixFileAttributes.class,
+                                                   linkOptions);
+            } catch (SecurityException ignored) {
+            }
+        }
+        if (sourceAttrs == null)
+            sourceAttrs = Files.readAttributes(source,
+                                               BasicFileAttributes.class,
+                                               linkOptions);
+        assert sourceAttrs != null;
 
         if (sourceAttrs.isSymbolicLink())
             throw new IOException("Copying of symbolic links not supported");

--- a/test/jdk/java/nio/file/Files/CopyToNonDefaultFS.java
+++ b/test/jdk/java/nio/file/Files/CopyToNonDefaultFS.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8245194
+ * @run main/othervm/java.security.policy=copy.policy CopyToNonDefaultFS
+ * @summary Test for exception copying from default to non-default file system
+ */
+
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.channels.*;
+import java.nio.file.*;
+import java.util.*;
+
+import static java.nio.file.StandardOpenOption.*;
+
+public class CopyToNonDefaultFS {
+    public static void main(String... args) throws IOException {
+        Path source = Files.createTempFile(Path.of("."), "tmp", ".dat");
+        try (FileChannel fc = FileChannel.open(source, CREATE, WRITE)) {
+            fc.position(8191);
+            fc.write(ByteBuffer.wrap(new byte[] {27}));
+        }
+
+        Path zip = Path.of("out.zip");
+        zip.toFile().deleteOnExit();
+        Map<String,String> env =
+            Map.of("create", String.valueOf(Files.notExists(zip)));
+
+        ClassLoader cl = CopyToNonDefaultFS.class.getClassLoader();
+        try (FileSystem fileSystem = FileSystems.newFileSystem(zip, env, cl)) {
+            Path p = fileSystem.getPath(source.getFileName().toString());
+            Files.copy(source, p);
+        }
+    }
+}

--- a/test/jdk/java/nio/file/Files/copy.policy
+++ b/test/jdk/java/nio/file/Files/copy.policy
@@ -1,0 +1,4 @@
+grant {
+    permission java.io.FilePermission "<<ALL FILES>>", "read,write";
+    permission java.io.FilePermission "out.zip", "delete";
+};


### PR DESCRIPTION
Ignore the `SecurityException` thrown while trying to retrieve the POSIX attributes when a `SecurityManager` is set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287097](https://bugs.openjdk.java.net/browse/JDK-8287097): (fs) Files::copy requires an undocumented permission when copying from the default file system to a non-default file system


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**) ⚠️ Review applies to [384d8e30](https://git.openjdk.java.net/jdk/pull/8963/files/384d8e30c83e7e17efde608c5a649de72a775fdb)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8963/head:pull/8963` \
`$ git checkout pull/8963`

Update a local copy of the PR: \
`$ git checkout pull/8963` \
`$ git pull https://git.openjdk.java.net/jdk pull/8963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8963`

View PR using the GUI difftool: \
`$ git pr show -t 8963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8963.diff">https://git.openjdk.java.net/jdk/pull/8963.diff</a>

</details>
