### PR TITLE
JDK-8287606: standardize spelling of subtype and supertype etc in comments

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/Reporter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/Reporter.java
@@ -49,7 +49,7 @@ import com.sun.source.util.DocTreePath;
  * means the output that is the expected result of executing some operation,
  * such as the command-line help that is generated when using a {@code --help} option,
  * and "diagnostic output" refers to any errors, warnings and other output that is
- * a side-effect of executing the operation.
+ * a side effect of executing the operation.
  *
  * <p>The exact manner in which diagnostics are output is unspecified and depends
  * on the enclosing context. For example:

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractTreeWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractTreeWriter.java
@@ -41,7 +41,7 @@ import java.util.TreeSet;
 
 /**
  * Abstract class to print the class hierarchy page for all the Classes. This
- * is sub-classed by {@link PackageTreeWriter} and {@link TreeWriter} to
+ * is subclassed by {@link PackageTreeWriter} and {@link TreeWriter} to
  * generate the Package Tree and global Tree(for all the classes and packages)
  * pages.
  */
@@ -66,12 +66,12 @@ public abstract class AbstractTreeWriter extends HtmlDocletWriter {
     }
 
     /**
-     * Add each level of the class tree. For each sub-class or
-     * sub-interface indents the next level information.
-     * Recurses itself to add sub-classes info.
+     * Add each level of the class tree. For each subclass or
+     * subinterface indents the next level information.
+     * Recurses itself to add subclasses info.
      *
      * @param parent the superclass or superinterface of the sset
-     * @param collection  a collection of the sub-classes at this level
+     * @param collection  a collection of the subclasses at this level
      * @param hierarchy the hierarchy for which we are generating a tree
      * @param content the content to which the level information will be added
      */

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Navigation.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Navigation.java
@@ -100,11 +100,11 @@ public class Navigation {
     }
 
     /**
-     * An interface to provide links for the sub-navigation area.
+     * An interface to provide links for the subnavigation area.
      */
     public interface SubNavLinks {
         /**
-         * {@return a list of links to display in the sub-navigation area}
+         * {@return a list of links to display in the subnavigation area}
          * Links should be wrapped in {@code HtmlTree.LI} elements as they are
          * displayed within an unordered list.
          */
@@ -350,9 +350,9 @@ public class Navigation {
     }
 
     /**
-     * Adds the summary links to the sub-navigation.
+     * Adds the summary links to the subnavigation.
      *
-     * @param target the content to which the sub-navigation will be added
+     * @param target the content to which the subnavigation will be added
      * @param nested whether to create a flat or nested list
      */
     private void addSummaryLinks(Content target, boolean nested) {
@@ -381,7 +381,7 @@ public class Navigation {
     }
 
     /**
-     * Adds the detail links to sub-navigation.
+     * Adds the detail links to subnavigation.
      *
      * @param target the content to which the links will be added
      * @param nested whether to create a flat or nested list

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseConfiguration.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseConfiguration.java
@@ -87,7 +87,7 @@ import jdk.javadoc.internal.doclets.toolkit.util.VisibleMemberTable;
 import jdk.javadoc.internal.doclint.DocLint;
 
 /**
- * Configure the output based on the options. Doclets should sub-class
+ * Configure the output based on the options. Doclets should subclass
  * BaseConfiguration, to configure and add their own options. This class contains
  * all user options which are supported by the standard doclet.
  */

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseOptions.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseOptions.java
@@ -298,7 +298,7 @@ public abstract class BaseOptions {
     /**
      * Value for command-line option {@code --override-methods summary}
      * or {@code --override-methods detail}.
-     * Specifies whether those methods that override a super-type's method
+     * Specifies whether those methods that override a supertype's method
      * with no changes to the API contract should be summarized in the
      * footnote section.
      */
@@ -1048,7 +1048,7 @@ public abstract class BaseOptions {
     /**
      * Value for command-line option {@code --override-methods summary}
      * or {@code --override-methods detail}.
-     * Specifies whether those methods that override a super-type's method
+     * Specifies whether those methods that override a supertype's method
      * with no changes to the API contract should be summarized in the
      * footnote section.
      */

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/AbstractMemberBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/AbstractMemberBuilder.java
@@ -36,8 +36,8 @@ import jdk.javadoc.internal.doclets.toolkit.util.VisibleMemberTable.Kind;
 
 /**
  * The superclass for all member builders.  Member builders are only executed
- * within Class Builders.  They essentially build sub-components.  For example,
- * method documentation is a sub-component of class documentation.
+ * within Class Builders.  They essentially build subcomponents.  For example,
+ * method documentation is a subcomponent of class documentation.
  */
 public abstract class AbstractMemberBuilder extends AbstractBuilder {
 
@@ -57,7 +57,7 @@ public abstract class AbstractMemberBuilder extends AbstractBuilder {
     }
 
     /**
-     * This method is not supported by sub-builders.
+     * This method is not supported by subbuilders.
      *
      * @throws AssertionError always
      */

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/ClassTree.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/ClassTree.java
@@ -280,8 +280,8 @@ public class ClassTree {
 
     /**
      * For the interface passed get the interfaces which it extends, and then
-     * put this interface in the sub-interface set of those interfaces. Do it
-     * recursively. If an interface doesn't have super-interface just attach
+     * put this interface in the subinterface set of those interfaces. Do it
+     * recursively. If an interface doesn't have superinterface just attach
      * that interface in the set of all the baseInterfaces.
      *
      * @param typeElement Interface under consideration.
@@ -305,18 +305,18 @@ public class ClassTree {
     }
 
     /**
-     * Return the sub-class set for the class passed.
+     * Return the subclass set for the class passed.
      *
-     * @param typeElement class whose sub-class set is required.
+     * @param typeElement class whose subclass set is required.
      */
     public SortedSet<TypeElement> subClasses(TypeElement typeElement) {
         return hierarchies.get(HierarchyKind.CLASSES).subtypes(typeElement);
     }
 
     /**
-     * Return the sub-interface set for the interface passed.
+     * Return the subinterface set for the interface passed.
      *
-     * @param typeElement interface whose sub-interface set is required.
+     * @param typeElement interface whose subinterface set is required.
      */
     public SortedSet<TypeElement> subInterfaces(TypeElement typeElement) {
         return hierarchies.get(HierarchyKind.INTERFACES).subtypes(typeElement);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -777,13 +777,13 @@ public class Utils {
     }
 
     /**
-     * Returns all the implemented super-interfaces of a given type,
-     * in the case of classes, include all the super-interfaces of
-     * the supertype. The super-interfaces are collected before the
-     * super-interfaces of the supertype.
+     * Returns all the implemented superinterfaces of a given type,
+     * in the case of classes, include all the superinterfaces of
+     * the supertype. The superinterfaces are collected before the
+     * superinterfaces of the supertype.
      *
-     * @param  te the type element to get the super-interfaces for.
-     * @return the list of super-interfaces.
+     * @param  te the type element to get the superinterfaces for.
+     * @return the list of superinterfaces.
      */
     public Set<TypeMirror> getAllInterfaces(TypeElement te) {
         Set<TypeMirror> results = new LinkedHashSet<>();
@@ -2810,7 +2810,7 @@ public class Utils {
     }
 
     /**
-     * An element can have flags that place it into some sub-categories, like
+     * An element can have flags that place it into some subcategories, like
      * being a preview or a deprecated element.
      */
     public enum ElementFlag {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
@@ -294,8 +294,8 @@ public class VisibleMemberTable {
     /**
      * Returns a set of visible type elements in this type element's lineage.
      * <p>
-     * This method returns the super-types in the inheritance
-     * order C, B, A, j.l.O. The super-interfaces however are
+     * This method returns the supertypes in the inheritance
+     * order C, B, A, j.l.O. The superinterfaces however are
      * alpha sorted and appended to the resulting set.
      *
      * @return the set of visible classes in this map

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
@@ -806,7 +806,7 @@ public class ElementsTable {
     /**
      * Returns an aggregated list of java file objects from the items
      * specified on the command line. The packages specified should not
-     * recurse, however sub-packages should recurse into the sub directories.
+     * recurse, however subpackages should recurse into the subdirectories.
      * @return a list of java file objects
      * @throws IOException if an error occurs
      */


### PR DESCRIPTION
Please review a trivial fix to remove unnecessary hyphens from compound words in comments,
as suggested in an earlier review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287606](https://bugs.openjdk.java.net/browse/JDK-8287606): standardize spelling of subtype and supertype etc in comments


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8964/head:pull/8964` \
`$ git checkout pull/8964`

Update a local copy of the PR: \
`$ git checkout pull/8964` \
`$ git pull https://git.openjdk.java.net/jdk pull/8964/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8964`

View PR using the GUI difftool: \
`$ git pr show -t 8964`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8964.diff">https://git.openjdk.java.net/jdk/pull/8964.diff</a>

</details>
