### PR TITLE
8287625: ProblemList jdk/jshell/HighlightUITest.java on all platforms

### DIFF
--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -34,7 +34,7 @@
 jdk/jshell/UserJdiUserRemoteTest.java                                           8173079    linux-all
 jdk/jshell/UserInputTest.java                                                   8169536    generic-all
 jdk/jshell/ToolBasicTest.java                                                   8265357    macosx-aarch64
-jdk/jshell/HighlightUITest.java                                                 8284144    generic-aarch64,macosx-x64,linux-x64
+jdk/jshell/HighlightUITest.java                                                 8284144    generic-all
 
 ###########################################################################
 #


### PR DESCRIPTION
There is now sighting on Windows x64 in GHA as well. I think it is time to problemlist the test on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287625](https://bugs.openjdk.java.net/browse/JDK-8287625): ProblemList jdk/jshell/HighlightUITest.java on all platforms


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8965/head:pull/8965` \
`$ git checkout pull/8965`

Update a local copy of the PR: \
`$ git checkout pull/8965` \
`$ git pull https://git.openjdk.java.net/jdk pull/8965/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8965`

View PR using the GUI difftool: \
`$ git pr show -t 8965`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8965.diff">https://git.openjdk.java.net/jdk/pull/8965.diff</a>

</details>
