### PR TITLE
8287695: Use String.contains() instead of String.indexOf() in jdk.hotspot.agent

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -279,7 +279,7 @@ public class CommandProcessor {
     }
 
     void quote(String s) {
-        if (s.indexOf(" ") == -1) {
+        if (!s.contains(" ")) {
             out.print(s);
         } else {
             out.print("\"");
@@ -342,7 +342,7 @@ public class CommandProcessor {
 
 
     Address lookup(String symbol) {
-        if (symbol.indexOf("::") != -1) {
+        if (symbol.contains("::")) {
             String[] parts = symbol.split("::");
             StringBuilder mangled = new StringBuilder("__1c");
             for (int i = 0; i < parts.length; i++) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ByteCodeRewriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ByteCodeRewriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,13 +27,9 @@ package sun.jvm.hotspot.tools.jcore;
 import sun.jvm.hotspot.oops.*;
 import sun.jvm.hotspot.interpreter.*;
 import sun.jvm.hotspot.utilities.*;
-import sun.jvm.hotspot.debugger.*;
 import sun.jvm.hotspot.runtime.*;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.security.AccessControlContext;
-import java.security.PrivilegedExceptionAction;
-import java.security.PrivilegedActionException;
 
 public class ByteCodeRewriter
 {
@@ -92,7 +88,7 @@ public class ByteCodeRewriter
        case 2: cpCacheIndex = method.getBytecodeByteArg(bci); break;
        case 3: cpCacheIndex = method.getBytecodeShortArg(bci); break;
        case 5:
-           if (fmt.indexOf("__") >= 0)
+           if (fmt.contains("__"))
                cpCacheIndex = method.getBytecodeShortArg(bci);
            else
                cpCacheIndex = method.getBytecodeIntArg(bci);
@@ -102,15 +98,15 @@ public class ByteCodeRewriter
 
        if (cpCache == null) {
           return (short) cpCacheIndex;
-       } else if (fmt.indexOf("JJJJ") >= 0) {
+       } else if (fmt.contains("JJJJ")) {
           // Invokedynamic require special handling
           cpCacheIndex = ~cpCacheIndex;
           cpCacheIndex = bytes.swapInt(cpCacheIndex);
           return (short) cpCache.getEntryAt(cpCacheIndex).getConstantPoolIndex();
-       } else if (fmt.indexOf("JJ") >= 0) {
+       } else if (fmt.contains("JJ")) {
           // change byte-ordering and go via cache
           return (short) cpCache.getEntryAt((int) (0xFFFF & bytes.swapShort((short)cpCacheIndex))).getConstantPoolIndex();
-       } else if (fmt.indexOf("j") >= 0) {
+       } else if (fmt.contains("j")) {
           // go via cache
           return (short) cpCache.getEntryAt((int) (0xFF & cpCacheIndex)).getConstantPoolIndex();
        } else {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/StreamMonitor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/StreamMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class StreamMonitor implements Runnable {
 
     boolean matches(String str) {
       for (int i = 0; i < triggerStrings.length; i++) {
-        if (str.indexOf(triggerStrings[i]) == -1) {
+        if (!str.contains(triggerStrings[i])) {
           return false;
         }
       }
@@ -198,7 +198,7 @@ public class StreamMonitor implements Runnable {
 
             // Check wait string
             if ((waitString != null) &&
-                (str.indexOf(waitString) != -1)) {
+                str.contains(waitString)) {
               waitStringSeen = true;
               notifyAll();
             }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/SystemDictionaryHelper.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/SystemDictionaryHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,10 +27,7 @@ package sun.jvm.hotspot.utilities;
 import java.util.*;
 import sun.jvm.hotspot.classfile.*;
 import sun.jvm.hotspot.oops.*;
-import sun.jvm.hotspot.memory.*;
 import sun.jvm.hotspot.runtime.*;
-import sun.jvm.hotspot.utilities.Observable;
-import sun.jvm.hotspot.utilities.Observer;
 
 public class SystemDictionaryHelper {
    static {
@@ -84,7 +81,7 @@ public class SystemDictionaryHelper {
       Vector<InstanceKlass> tmp = new Vector<>();
       for (int i = 0; i < tmpKlasses.length; i++) {
          String name = tmpKlasses[i].getName().asString();
-         if (name.indexOf(namePart) != -1) {
+         if (name.contains(namePart)) {
             tmp.add(tmpKlasses[i]);
          }
       }


### PR DESCRIPTION
`String.contains` was introduced in Java 5.
Some code in jdk.hotspot.agent still uses old approach with `String.indexOf` to check if String contains specified substring.
I propose to migrate such usages. Makes code shorter and easier to read.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287695](https://bugs.openjdk.java.net/browse/JDK-8287695): Use String.contains() instead of String.indexOf() in jdk.hotspot.agent


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8966/head:pull/8966` \
`$ git checkout pull/8966`

Update a local copy of the PR: \
`$ git checkout pull/8966` \
`$ git pull https://git.openjdk.java.net/jdk pull/8966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8966`

View PR using the GUI difftool: \
`$ git pr show -t 8966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8966.diff">https://git.openjdk.java.net/jdk/pull/8966.diff</a>

</details>
