### PR TITLE
8287637: Loom: Mismatched VirtualThread::state accessor

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2233,8 +2233,8 @@ oop java_lang_VirtualThread::continuation(oop vthread) {
   return cont;
 }
 
-u2 java_lang_VirtualThread::state(oop vthread) {
-  return vthread->short_field_acquire(_state_offset);
+int java_lang_VirtualThread::state(oop vthread) {
+  return vthread->int_field_acquire(_state_offset);
 }
 
 JavaThreadStatus java_lang_VirtualThread::map_state_to_thread_status(int state) {

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -628,7 +628,7 @@ class java_lang_VirtualThread : AllStatic {
   static oop vthread_scope();
   static oop carrier_thread(oop vthread);
   static oop continuation(oop vthread);
-  static u2 state(oop vthread);
+  static int state(oop vthread);
   static JavaThreadStatus map_state_to_thread_status(int state);
   static bool notify_jvmti_events();
   static void set_notify_jvmti_events(bool enable);


### PR DESCRIPTION
Found this by reading the code, no test failure detected yet.

The field is defined on Java side as:

```
    // virtual thread state, accessed by VM
    private volatile int state;
```

The field is defined on VM side as:

```
  macro(_state_offset,                     k, "state",              int_signature,               false)
```

And yet, it is accessed as `short`:

```
u2 java_lang_VirtualThread::state(oop vthread) {
  return vthread->short_field_acquire(_state_offset);
}
```

I think this is just asking for trouble on different endianness: the partial `u2` read from `int` field can read the "higher" two bytes, not the "lower" two bytes.

Additional testing:
 - [x] Linux x86_64 fastdebug, `jdk_loom hotspot_loom`
 - [x] Linux AArch64 fastdebug, `jdk_loom hotspot_loom`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287637](https://bugs.openjdk.java.net/browse/JDK-8287637): Loom: Mismatched VirtualThread::state accessor


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8967/head:pull/8967` \
`$ git checkout pull/8967`

Update a local copy of the PR: \
`$ git checkout pull/8967` \
`$ git pull https://git.openjdk.java.net/jdk pull/8967/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8967`

View PR using the GUI difftool: \
`$ git pr show -t 8967`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8967.diff">https://git.openjdk.java.net/jdk/pull/8967.diff</a>

</details>
