### PR TITLE
8282470: Eliminate useless sign extension before some subword integer operations

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2762,44 +2762,150 @@ bool StoreNode::cmp( const Node &n ) const {
   return (&n == this);          // Always fail except on self
 }
 
-//------------------------------Ideal_masked_input-----------------------------
-// Check for a useless mask before a partial-word store
-// (StoreB ... (AndI valIn conIa) )
-// If (conIa & mask == mask) this simplifies to
-// (StoreB ... (valIn) )
-Node *StoreNode::Ideal_masked_input(PhaseGVN *phase, uint mask) {
-  Node *val = in(MemNode::ValueIn);
-  if( val->Opcode() == Op_AndI ) {
-    const TypeInt *t = phase->type( val->in(2) )->isa_int();
-    if( t && t->is_con() && (t->get_con() & mask) == mask ) {
-      set_req_X(MemNode::ValueIn, val->in(1), phase);
-      return this;
+//------------------------------used_only_for_this_opcode--------------
+// Check if all use nodes of the given node have the same opcode as
+// current node, *this.
+bool StoreNode::used_only_for_this_opcode(Node* node) {
+  for (DUIterator_Fast imax, i = node->fast_outs(imax); i < imax; i++) {
+    Node* use = node->fast_out(i);
+    if (use->Opcode() != Opcode()) {
+      return false;
     }
   }
-  return NULL;
+  return true;
 }
 
+//------------------------------no_need_sign_extension-----------------------
+// Check whether the given operation on byte/short types holds that the upper
+// bits of the operands have no influence on real lower bits of the
+// operation result. If so, there is no need to do any sign extension before
+// the given subword interger operation. So that we can optimize it out by
+// StoreNode::Ideal_masked_or_sign_extended_input.
+bool StoreNode::no_need_sign_extension(int opc) {
+  switch (opc) {
+    case Op_AddI:
+    case Op_SubI:
+    case Op_NegI:
+    case Op_MulI:
+    case Op_XorI:
+    case Op_AndI:
+    case Op_OrI:
+    case Op_LShiftI:
+      return true;
+  }
+  return false;
+}
 
-//------------------------------Ideal_sign_extended_input----------------------
-// Check for useless sign-extension before a partial-word store
-// (StoreB ... (RShiftI _ (LShiftI _ valIn conIL ) conIR) )
-// If (conIL == conIR && conIR <= num_bits)  this simplifies to
-// (StoreB ... (valIn) )
-Node *StoreNode::Ideal_sign_extended_input(PhaseGVN *phase, int num_bits) {
-  Node *val = in(MemNode::ValueIn);
-  if( val->Opcode() == Op_RShiftI ) {
-    const TypeInt *t = phase->type( val->in(2) )->isa_int();
-    if( t && t->is_con() && (t->get_con() <= num_bits) ) {
-      Node *shl = val->in(1);
-      if( shl->Opcode() == Op_LShiftI ) {
-        const TypeInt *t2 = phase->type( shl->in(2) )->isa_int();
-        if( t2 && t2->is_con() && (t2->get_con() == t->get_con()) ) {
-          set_req_X(MemNode::ValueIn, shl->in(1), phase);
-          return this;
+//------------------------------is_masked_input-------------------------
+// Check if the node can be recognized as the pattern:
+// (AndI valIn conIa) and (conIa & mask == mask)
+bool StoreNode::is_masked_input(Node* input, PhaseGVN* phase, uint mask) {
+  if (input->Opcode() == Op_AndI) {
+    const TypeInt* t = phase->type(input->in(2))->isa_int();
+    if (t && t->is_con() && (t->get_con() & mask) == mask) {
+      return true;
+    }
+  }
+  return false;
+}
+
+//----------------------------is_sign_extended_input-----------------------
+// Check if the node can be recognized as the pattern
+// (RShiftI _ (LShiftI _ valIn conIL ) conIR) and (conIL == conIR && conIR <= num_bits)
+bool StoreNode::is_sign_extended_input(Node* input, PhaseGVN* phase, int num_bits) {
+  if (input->Opcode() == Op_RShiftI) {
+    const TypeInt* t = phase->type(input->in(2))->isa_int();
+    if (t && t->is_con() && (t->get_con() <= num_bits)) {
+      Node* shl = input->in(1);
+      if (shl->Opcode() == Op_LShiftI) {
+        const TypeInt* t2 = phase->type(shl->in(2))->isa_int();
+        if (t2 && t2->is_con() && (t2->get_con() == t->get_con())) {
+          return true;
         }
       }
     }
   }
+  return false;
+}
+
+Node* StoreNode::search_val_input(PhaseGVN* phase, uint mask, int num_bits, Node* val, int &idx) {
+  Node* orig_value = NULL;
+  for (uint i = 1; i < val->req(); ++i) {
+    // Further constraint for no_need_sign_extension():
+    // Only the first operand of LSfhitI is optimizable,
+    // i.e. its upper bits have no influence to the result.
+    if (val->Opcode() == Op_LShiftI && i != 1) {
+      break;
+    }
+    if (is_masked_input(val->in(i), phase, mask)) {
+      idx = i;
+      orig_value = val->in(i)->in(1);
+      break;
+    }
+    if (is_sign_extended_input(val->in(i), phase, num_bits)) {
+      idx = i;
+      orig_value = val->in(i)->in(1)->in(1);
+      break;
+    }
+  }
+  return orig_value;
+}
+
+//------------------------------Ideal_masked_or_sign_extended_input-----------------------------
+// Check for a useless mask or useless sign-extension before a subword store
+Node* StoreNode::Ideal_masked_or_sign_extended_input(PhaseGVN* phase, uint mask, int num_bits) {
+  Node* val = in(MemNode::ValueIn);
+  // (StoreB ... (AndI valIn conIa) )
+  // If (conIa & mask == mask) this simplifies to
+  // (StoreB ... (valIn) )
+  if (is_masked_input(val, phase, mask)) {
+    set_req_X(MemNode::ValueIn, val->in(1), phase);
+    return this;
+  }
+
+  // (StoreB ... (RShiftI _ (LShiftI _ valIn conIL ) conIR) )
+  // If (conIL == conIR && conIR <= num_bits)  this simplifies to
+  // (StoreB ... (valIn) )
+  if (is_sign_extended_input(val, phase, num_bits)) {
+    Node* shl = val->in(1);
+    set_req_X(MemNode::ValueIn, shl->in(1), phase);
+    return this;
+  }
+
+  if (no_need_sign_extension(val->Opcode())) {
+    Node* orig_value = NULL;
+    int idx = 0;
+    Node* new_val = val;
+    // (StoreB ... (AddI (AndI valIn1 conIa) valIn2 )
+    // If (conIa & mask == mask) this simplifies to
+    // (StoreB ... (AddI valIn1, valIn2) )
+    // (StoreB ... (AddI (RShiftI _ (LShiftI _ valIn1 conIL ) conIR) valIn2) )
+    // If (conIL == conIR && conIR <= num_bits)  this simplifies to
+    // (StoreB ... (AddI valIn1, valIn2) )
+    orig_value = search_val_input(phase, mask, num_bits, val, idx);
+
+    for (uint i = 1; i < val->req() && orig_value == NULL; ++i) {
+      if (val->Opcode() == Op_LShiftI && i != 1) {
+        break;
+      }
+      new_val = val->in(i);
+      // (StoreB ... (AddI (AddI (RShiftI _ (LShiftI _ valIn1 conIL ) conIR) valIn2) valIn3) )
+      // If (conIL == conIR && conIR <= num_bits)  this simplifies to
+      // (StoreB ... (AddI (AddI valIn1, valIn2) valIn3) )
+      orig_value = search_val_input(phase, mask, num_bits, val->in(i), idx);
+    }
+
+    PhaseIterGVN* igvn = phase->is_IterGVN();
+    if (igvn != NULL && orig_value != NULL && used_only_for_this_opcode(val)) {
+      igvn->replace_input_of(new_val, idx, orig_value);
+      return this;
+    } else if (igvn == NULL && orig_value != NULL) {
+      // We can try it again during the next IGVN once the graph is cleaner.
+      phase->record_for_igvn(this);
+    }
+
+  }
+
   return NULL;
 }
 
@@ -2856,11 +2962,8 @@ MemBarNode* StoreNode::trailing_membar() const {
 // If the store is from an AND mask that leaves the low bits untouched, then
 // we can skip the AND operation.  If the store is from a sign-extension
 // (a left shift, then right shift) we can skip both.
-Node *StoreBNode::Ideal(PhaseGVN *phase, bool can_reshape){
-  Node *progress = StoreNode::Ideal_masked_input(phase, 0xFF);
-  if( progress != NULL ) return progress;
-
-  progress = StoreNode::Ideal_sign_extended_input(phase, 24);
+Node* StoreBNode::Ideal(PhaseGVN* phase, bool can_reshape){
+  Node* progress = StoreNode::Ideal_masked_or_sign_extended_input(phase, 0xFF, 24);
   if( progress != NULL ) return progress;
 
   // Finally check the default case
@@ -2870,12 +2973,10 @@ Node *StoreBNode::Ideal(PhaseGVN *phase, bool can_reshape){
 //=============================================================================
 //------------------------------Ideal------------------------------------------
 // If the store is from an AND mask that leaves the low bits untouched, then
-// we can skip the AND operation
-Node *StoreCNode::Ideal(PhaseGVN *phase, bool can_reshape){
-  Node *progress = StoreNode::Ideal_masked_input(phase, 0xFFFF);
-  if( progress != NULL ) return progress;
-
-  progress = StoreNode::Ideal_sign_extended_input(phase, 16);
+// we can skip the AND operation. If the store is from a sign-extension
+// (a left shift, then right shift) we can skip both.
+Node* StoreCNode::Ideal(PhaseGVN* phase, bool can_reshape){
+  Node* progress = StoreNode::Ideal_masked_or_sign_extended_input(phase, 0xFFFF, 16);
   if( progress != NULL ) return progress;
 
   // Finally check the default case

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -559,8 +559,12 @@ protected:
   virtual bool cmp( const Node &n ) const;
   virtual bool depends_only_on_test() const { return false; }
 
-  Node *Ideal_masked_input       (PhaseGVN *phase, uint mask);
-  Node *Ideal_sign_extended_input(PhaseGVN *phase, int  num_bits);
+  bool used_only_for_this_opcode(Node* in);
+  bool no_need_sign_extension(int opc);
+  bool is_masked_input(Node* input, PhaseGVN* phase, uint mask);
+  bool is_sign_extended_input(Node* input, PhaseGVN* phase, int num_bits);
+  Node* search_val_input(PhaseGVN* phase, uint mask, int num_bits, Node* val, int &idx);
+  Node* Ideal_masked_or_sign_extended_input(PhaseGVN* phase, uint mask, int num_bits);
 
 public:
   // We must ensure that stores of object references will be visible

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestIRStoreCorBAddIMask.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestIRStoreCorBAddIMask.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+import java.util.Random;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+
+/*
+ * @test
+ * @bug 8282470
+ * @summary C2: Optimize patterns like s = (short) ((x << Imm) >> Imm + y) when Imm < 16 and apply the optimization to byte and char.
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.TestIRStoreCorBAddIMask
+ */
+public class TestIRStoreCorBAddIMask {
+
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    private static final int[] SPECIAL_IN = {
+        0, 0x1, 0x8, 0xF, 0x3F, 0x7C, 0x7F, 0x80, 0x81, 0x8F, 0xF3, 0xF8, 0xFF,
+        0x38FF, 0x3FFF, 0x8F8F, 0x8FFF, 0x7FF3, 0x7FFF, 0xFF33, 0xFFF8, 0xFFFF, 0xFFFFFF,
+        Integer.MAX_VALUE, Integer.MIN_VALUE
+    };
+
+    private byte BYTE_OUT = 0;
+    private char CHAR_OUT = 0;
+    private short SHORT_OUT = 0;
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @Test
+    @Arguments({Argument.DEFAULT, Argument.DEFAULT})
+    @IR(failOn = {IRNode.LSHIFT_I, IRNode.RSHIFT_I})
+    @IR(counts = {IRNode.ADD_I, "1", IRNode.STORE_B, "1"})
+    public void testByte0(int x, int y) {
+        BYTE_OUT = (byte) (((x << 24) >> 24) + y); // transformed to (byte) (x + y)
+    }
+
+    @Test
+    @Arguments({Argument.DEFAULT, Argument.DEFAULT})
+    @IR(failOn = {IRNode.LSHIFT_I, IRNode.RSHIFT_I})
+    @IR(counts = {IRNode.MUL_I, "1", IRNode.STORE_B, "1"})
+    public void testByte1(int x, int y) {
+        BYTE_OUT = (byte) (((x << 8) >> 8) * y); // transformed to (byte) (x * y)
+    }
+
+    @Test
+    @Arguments({Argument.DEFAULT, Argument.DEFAULT})
+    @IR(failOn = {IRNode.LSHIFT_I, IRNode.RSHIFT_I})
+    @IR(counts = {IRNode.SUB_I, "1", IRNode.STORE_B, "1"})
+    public void testByte2(int x, int y) {
+        BYTE_OUT = (byte) (((x << 16) >> 16) - y); // transformed to (byte) (x - y)
+    }
+
+    @Test
+    @Arguments({Argument.DEFAULT})
+    @IR(failOn = {IRNode.LSHIFT_I, IRNode.RSHIFT_I})
+    @IR(counts = {IRNode.SUB_I, "1", IRNode.STORE_B, "1"})
+    public void testByte3(int x) {
+        BYTE_OUT = (byte) (-((x << 16) >> 16)); // transformed to (byte) (-x)
+    }
+
+    @Test
+    @Arguments({Argument.DEFAULT, Argument.DEFAULT})
+    @IR(counts = {IRNode.LSHIFT_I, "1", IRNode.RSHIFT_I, "1", IRNode.OR_I, "1", IRNode.STORE_B, "1"})
+    public void testByte4(int x, int y) {
+        BYTE_OUT = (byte) (((x << 25) >> 25) | y); // no transformation
+    }
+
+    @Test
+    @Arguments({Argument.DEFAULT, Argument.DEFAULT})
+    @IR(failOn = {IRNode.AND_I})
+    @IR(counts = {IRNode.XOR_I, "1", IRNode.STORE_B, "1"})
+    public void testByte5(int x, int y) {
+        BYTE_OUT = (byte) ((x & 0xFF) ^ y); // transformed to (byte) (x ^ y)
+    }
+
+    @Test
+    @Arguments({Argument.DEFAULT, Argument.DEFAULT})
+    @IR(counts = {IRNode.AND_I, "2", IRNode.STORE_B, "1"})
+    public void testByte6(int x, int y) {
+        BYTE_OUT = (byte) ((x & 0xF) & y); // no transformation
+    }
+
+    @Test
+    @Arguments({Argument.DEFAULT, Argument.DEFAULT})
+    @IR(failOn = {IRNode.AND_I})
+    @IR(counts = {IRNode.ADD_I, "1", IRNode.STORE_C, "1"})
+    public void testChar0(int x, int y) {
+        CHAR_OUT = (char) ((x & 0xFFFF) + y); // transformed to (char) (x + y)
+    }
+
+    @Test
+    @Arguments({Argument.DEFAULT, Argument.DEFAULT})
+    @IR(failOn = {IRNode.AND_I})
+    @IR(counts = {IRNode.MUL_I, "1", IRNode.STORE_C, "1"})
+    public void testChar1(int x, int y) {
+        CHAR_OUT = (char) ((x & 0xFFFF) * y); // transformed to (char) (x * y)
+    }
+
+    @Test
+    @Arguments({Argument.DEFAULT, Argument.DEFAULT})
+    @IR(failOn = {IRNode.AND_I})
+    @IR(counts = {IRNode.SUB_I, "1", IRNode.STORE_C, "1"})
+    public void testChar2(int x, int y) {
+        CHAR_OUT = (char) ((x & 0xFFFF) - y); // transformed to (char) (x - y)
+    }
+
+    @Test
+    @Arguments({Argument.DEFAULT, Argument.DEFAULT})
+    @IR(counts = {IRNode.AND_I, "2", IRNode.STORE_C, "1"})
+    public void testChar3(int x, int y) {
+        CHAR_OUT = (char) ((x & 0xFF) & y); // no transformation
+    }
+
+    @Test
+    @Arguments({Argument.DEFAULT, Argument.DEFAULT})
+    @IR(failOn = {IRNode.LSHIFT_I, IRNode.RSHIFT_I})
+    @IR(counts = {IRNode.OR_I, "1", IRNode.STORE_C, "1"})
+    public void testShort0(int x, int y) {
+        SHORT_OUT = (short) (((x << 16) >> 16) | y); // transformed to (short) (x | y)
+    }
+
+    @Test
+    @Arguments({Argument.DEFAULT, Argument.DEFAULT})
+    @IR(failOn = {IRNode.LSHIFT_I, IRNode.RSHIFT_I})
+    @IR(counts = {IRNode.AND_I, "1", IRNode.STORE_C, "1"})
+    public void testShort1(int x, int y) {
+        SHORT_OUT = (short) (((x << 10) >> 10) & y); // transformed to (short) (x & y)
+    }
+
+    @Test
+    @Arguments({Argument.DEFAULT, Argument.DEFAULT})
+    @IR(counts = {IRNode.LSHIFT_I, "1", IRNode.RSHIFT_I, "1", IRNode.XOR_I, "1", IRNode.STORE_C, "1"})
+    public void testShort2(int x, int y) {
+        SHORT_OUT = (short) (((x << 18) >> 18) ^ y); // no transformation
+    }
+
+    @Test
+    @Arguments({Argument.DEFAULT, Argument.DEFAULT})
+    @IR(failOn = {IRNode.RSHIFT_I})
+    @IR(counts = {IRNode.LSHIFT_I, "1", IRNode.STORE_C, "1"})
+    public void testShort3(int x, int y) {
+        SHORT_OUT = (short) (((x << 16) >> 16) << y); // transformed to (short) (x << y)
+    }
+
+    @Test
+    public void checkTest(int x, int y) {
+        testByte0(x, y);
+        Asserts.assertEquals((byte)(((x << 24) >> 24) + y), BYTE_OUT);
+        testByte1(x, y);
+        Asserts.assertEquals((byte)(((x << 8) >> 8) * y), BYTE_OUT);
+        testByte2(x, y);
+        Asserts.assertEquals((byte)(((x << 16) >> 16) - y), BYTE_OUT);
+        testByte3(x);
+        Asserts.assertEquals((byte)(-((x << 16) >> 16)), BYTE_OUT);
+        testByte4(x, y);
+        Asserts.assertEquals((byte)(((x << 25) >> 25) | y), BYTE_OUT);
+        testByte5(x, y);
+        Asserts.assertEquals((byte)((x & 0xFF) ^ y), BYTE_OUT);
+        testByte6(x, y);
+        Asserts.assertEquals((byte)((x & 0xF) & y), BYTE_OUT);
+        testChar0(x, y);
+        Asserts.assertEquals((char)((x & 0xFFFF) + y), CHAR_OUT);
+        testChar1(x, y);
+        Asserts.assertEquals((char)((x & 0xFFFF) * y), CHAR_OUT);
+        testChar2(x, y);
+        Asserts.assertEquals((char)((x & 0xFFFF) - y), CHAR_OUT);
+        testChar3(x, y);
+        Asserts.assertEquals((char)((x & 0xFF) & y), CHAR_OUT);
+        testShort0(x, y);
+        Asserts.assertEquals((short)(((x << 16) >> 16) | y), SHORT_OUT);
+        testShort1(x, y);
+        Asserts.assertEquals((short)(((x << 10) >> 10) & y), SHORT_OUT);
+        testShort2(x, y);
+        Asserts.assertEquals((short)(((x << 18) >> 18) ^ y), SHORT_OUT);
+        testShort3(x, y);
+        Asserts.assertEquals((short)(((x << 16) >> 16) << y), SHORT_OUT);
+    }
+
+    @Run(test = "checkTest")
+    public void checkTest_runner() {
+        int x = RANDOM.nextInt();
+        int y = RANDOM.nextInt();
+        checkTest(x, y);
+        for (int i = 0; i < SPECIAL_IN.length; ++i) {
+            for (int j = 0; j < SPECIAL_IN.length; ++j) {
+                checkTest(SPECIAL_IN[i], SPECIAL_IN[j]);
+            }
+        }
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -147,6 +147,8 @@ public class IRNode {
     public static final String ABS_F = START + "AbsF" + MID + END;
     public static final String ABS_D = START + "AbsD" + MID + END;
     public static final String AND = START + "And(I|L)" + MID + END;
+    public static final String OR_I = START + "OrI" + MID + END;
+    public static final String OR_L = START + "OrL" + MID + END;
     public static final String AND_I = START + "AndI" + MID + END;
     public static final String AND_L = START + "AndL" + MID + END;
     public static final String XOR_I = START + "XorI" + MID + END;

--- a/test/micro/org/openjdk/bench/vm/compiler/TypeVectorOperations.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/TypeVectorOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,8 +37,11 @@ public abstract class TypeVectorOperations {
 
     private byte[] bytesA;
     private byte[] bytesB;
+    private byte[] bytesC;
     private byte[] resB;
-    private short[] shorts;
+    private short[] shortA;
+    private short[] shortB;
+    private short[] shortC;
     private short[] resS;
     private int[] ints;
     private int[] resI;
@@ -58,7 +61,9 @@ public abstract class TypeVectorOperations {
         bytesA = new byte[COUNT];
         bytesB = new byte[COUNT];
         resB = new byte[COUNT];
-        shorts = new short[COUNT];
+        shortA = new short[COUNT];
+        shortB = new short[COUNT];
+        shortC = new short[COUNT];
         resS = new short[COUNT];
         ints = new int[COUNT];
         resI = new int[COUNT];
@@ -70,7 +75,8 @@ public abstract class TypeVectorOperations {
         resF = new float[COUNT];
 
         for (int i = 0; i < COUNT; i++) {
-            shorts[i] = (short) r.nextInt(Short.MAX_VALUE + 1);
+            shortA[i] = (short) r.nextInt(Short.MAX_VALUE + 1);
+            shortB[i] = (short) r.nextInt(Short.MAX_VALUE + 1);
             ints[i] = r.nextInt();
             longs[i] = r.nextLong();
             floats[i] = r.nextFloat();
@@ -121,10 +127,26 @@ public abstract class TypeVectorOperations {
     }
 
     @Benchmark
+    public void addB() {
+        for (int i = 0; i < COUNT; i++) {
+            bytesC[i] = (byte) (bytesA[i] + 3);
+            resB[i] = (byte) (bytesC[i] + bytesB[i]);
+        }
+    }
+
+    @Benchmark
     public void absS() {
         for (int i = 0; i < COUNT; i++) {
-            short a = shorts[i];
+            short a = shortA[i];
             resS[i] = (short) (Math.abs((short) a));
+        }
+    }
+
+    @Benchmark
+    public void addS() {
+        for (int i = 0; i < COUNT; i++) {
+            shortC[i] = (short) (shortA[i] + 3);
+            resS[i] = (short) (shortC[i] + shortB[i]);
         }
     }
 


### PR DESCRIPTION
draft for https://github.com/openjdk/jdk/pull/7954#issuecomment-1142115648

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282470](https://bugs.openjdk.java.net/browse/JDK-8282470): Eliminate useless sign extension before some subword integer operations


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8968/head:pull/8968` \
`$ git checkout pull/8968`

Update a local copy of the PR: \
`$ git checkout pull/8968` \
`$ git pull https://git.openjdk.java.net/jdk pull/8968/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8968`

View PR using the GUI difftool: \
`$ git pr show -t 8968`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8968.diff">https://git.openjdk.java.net/jdk/pull/8968.diff</a>

</details>
