### PR TITLE
8287558: Remove remset coarsening stats during g1 remset summary printing

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
@@ -52,7 +52,6 @@ void G1RemSetSummary::update() {
 
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
   g1h->concurrent_refine()->threads_do(&collector);
-  _coarsenings = HeapRegionRemSet::coarsen_stats();
 
   set_sampling_task_vtime(g1h->rem_set()->sampling_task_vtime());
 }
@@ -70,7 +69,6 @@ double G1RemSetSummary::rs_thread_vtime(uint thread) const {
 }
 
 G1RemSetSummary::G1RemSetSummary(bool should_update) :
-  _coarsenings(),
   _num_vtimes(G1ConcurrentRefine::max_num_threads()),
   _rs_threads_vtimes(NEW_C_HEAP_ARRAY(double, _num_vtimes, mtGC)),
   _sampling_task_vtime(0.0f) {
@@ -90,8 +88,6 @@ void G1RemSetSummary::set(G1RemSetSummary* other) {
   assert(other != NULL, "just checking");
   assert(_num_vtimes == other->_num_vtimes, "just checking");
 
-  _coarsenings = other->_coarsenings;
-
   memcpy(_rs_threads_vtimes, other->_rs_threads_vtimes, sizeof(double) * _num_vtimes);
 
   set_sampling_task_vtime(other->sampling_task_vtime());
@@ -100,8 +96,6 @@ void G1RemSetSummary::set(G1RemSetSummary* other) {
 void G1RemSetSummary::subtract_from(G1RemSetSummary* other) {
   assert(other != NULL, "just checking");
   assert(_num_vtimes == other->_num_vtimes, "just checking");
-
-  _coarsenings.subtract_from(other->_coarsenings);
 
   for (uint i = 0; i < _num_vtimes; i++) {
     set_rs_thread_vtime(i, other->rs_thread_vtime(i) - rs_thread_vtime(i));
@@ -328,8 +322,6 @@ public:
 };
 
 void G1RemSetSummary::print_on(outputStream* out) {
-  out->print("Coarsening: ");
-  _coarsenings.print_on(out);
   out->print_cr("  Concurrent refinement threads times (s)");
   out->print("     ");
   for (uint i = 0; i < _num_vtimes; i++) {

--- a/src/hotspot/share/gc/g1/g1RemSetSummary.hpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.hpp
@@ -34,8 +34,6 @@ class G1RemSet;
 // A G1RemSetSummary manages statistical information about the G1RemSet
 
 class G1RemSetSummary {
-  G1CardSetCoarsenStats _coarsenings;
-
   size_t _num_vtimes;
   double* _rs_threads_vtimes;
 


### PR DESCRIPTION
Remset summary printing prints coarsening statistics in addition to remset summaries; that information is either duplicated with "Coarsening (recent)" printouts (with gc+remset=debug) at GC start or all-zeros at GC end.

Given that Remset summary printing is enabled with gc+remset=trace which covers the recent/all coarsening statistics, the coarsening statistics during remset summary are somewhat duplicate (or useless for the after-gc one).

Remove the coarsening statistics from the remset summaries.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287558](https://bugs.openjdk.java.net/browse/JDK-8287558): Remove remset coarsening stats during g1 remset summary printing


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8971/head:pull/8971` \
`$ git checkout pull/8971`

Update a local copy of the PR: \
`$ git checkout pull/8971` \
`$ git pull https://git.openjdk.java.net/jdk pull/8971/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8971`

View PR using the GUI difftool: \
`$ git pr show -t 8971`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8971.diff">https://git.openjdk.java.net/jdk/pull/8971.diff</a>

</details>
