### PR TITLE
8233269: Improve handling of JAVA_ARGS

### DIFF
--- a/make/common/modules/LauncherCommon.gmk
+++ b/make/common/modules/LauncherCommon.gmk
@@ -87,8 +87,8 @@ define SetupBuildLauncherBody
     $1_MAIN_MODULE := $(MODULE)
   endif
 
-  $1_JAVA_ARGS += -ms8m
   ifneq ($$($1_MAIN_CLASS), )
+    $1_JAVA_ARGS += -ms8m
     $1_LAUNCHER_CLASS := -m $$($1_MAIN_MODULE)/$$($1_MAIN_CLASS)
   endif
 
@@ -97,9 +97,12 @@ define SetupBuildLauncherBody
       $$(addprefix -J, $$($1_EXTRA_JAVA_ARGS)), "$$a"$(COMMA) )) }'
     $1_CFLAGS += -DEXTRA_JAVA_ARGS=$$($1_EXTRA_JAVA_ARGS_STR)
   endif
-  $1_JAVA_ARGS_STR := '{ $$(strip $$(foreach a, \
-      $$(addprefix -J, $$($1_JAVA_ARGS)) $$($1_LAUNCHER_CLASS), "$$a"$(COMMA) )) }'
-  $1_CFLAGS += -DJAVA_ARGS=$$($1_JAVA_ARGS_STR)
+
+  ifneq ($$($1_JAVA_ARGS), )
+    $1_JAVA_ARGS_STR := '{ $$(strip $$(foreach a, \
+        $$(addprefix -J, $$($1_JAVA_ARGS)) $$($1_LAUNCHER_CLASS), "$$a"$(COMMA) )) }'
+    $1_CFLAGS += -DJAVA_ARGS=$$($1_JAVA_ARGS_STR)
+  endif
 
   ifeq ($(call isTargetOs, macosx), true)
     ifeq ($$($1_MACOSX_PRIVILEGED), true)


### PR DESCRIPTION
LauncherCommon.gmk is unfortunately defining JAVA_ARGS with `-J-ms8m` option for all JDK launchers, including java launcher.
JAVA_ARGS  should not be defined for java launcher (in contrast to the other JDK launchers), and the command line option `-J-ms8m` is obsolete for java launcher.

Proposed patch removes JAVA_ARGS from java launcher, while keeping status quo for all other JDK launchers.
The patch of LauncherCommon.gmk identifies java launcher by undefined MAIN_CLASS.

Thanks for review,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233269](https://bugs.openjdk.java.net/browse/JDK-8233269): Improve handling of JAVA_ARGS


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8972/head:pull/8972` \
`$ git checkout pull/8972`

Update a local copy of the PR: \
`$ git checkout pull/8972` \
`$ git pull https://git.openjdk.java.net/jdk pull/8972/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8972`

View PR using the GUI difftool: \
`$ git pr show -t 8972`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8972.diff">https://git.openjdk.java.net/jdk/pull/8972.diff</a>

</details>
