### PR TITLE
JDK-8287524: Improve checkboxes to select releases on deprecated API page

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
@@ -27,7 +27,6 @@ package jdk.javadoc.internal.doclets.formats.html;
 
 import com.sun.source.doctree.DeprecatedTree;
 import java.util.List;
-import java.util.ListIterator;
 
 import javax.lang.model.element.Element;
 
@@ -81,19 +80,22 @@ public class DeprecatedListWriter extends SummaryListWriter<DeprecatedAPIListBui
     @Override
     protected void addExtraSection(DeprecatedAPIListBuilder list, Content content) {
         List<String> releases = configuration.deprecatedAPIListBuilder.releases;
-        if (!releases.isEmpty()) {
+        if (releases.size() > 1) {
             Content tabs = HtmlTree.DIV(HtmlStyle.checkboxes, contents.getContent(
                     "doclet.Deprecated_API_Checkbox_Label"));
             for (int i = 0; i < releases.size(); i++) {
-                int releaseIndex = i + 1;
                 String release = releases.get(i);
+                String releaseIndex = release.isEmpty() ? "" : Integer.toString(i + 1);
+                Content releaseLabel = release.isEmpty()
+                        ? contents.getContent("doclet.Deprecated_API_Checkbox_Other_Releases")
+                        : Text.of(release);
                 HtmlId htmlId = HtmlId.of("release-" + releaseIndex);
                 tabs.add(HtmlTree.LABEL(htmlId.name(),
                                 HtmlTree.INPUT("checkbox", htmlId)
                                         .put(HtmlAttr.CHECKED, "")
                                         .put(HtmlAttr.ONCLICK,
                                                 "toggleGlobal(this, '" + releaseIndex + "', 3)"))
-                        .add(HtmlTree.SPAN(Text.of(release))));
+                        .add(HtmlTree.SPAN(releaseLabel)));
             }
             content.add(tabs);
         }
@@ -122,10 +124,12 @@ public class DeprecatedListWriter extends SummaryListWriter<DeprecatedAPIListBui
     protected void addTableTabs(Table table, String headingKey) {
         List<String> releases = configuration.deprecatedAPIListBuilder.releases;
         if (!releases.isEmpty()) {
+            table.setGridStyle(HtmlStyle.threeColumnReleaseSummary);
+        }
+        if (releases.size() > 1) {
             table.setDefaultTab(getTableCaption(headingKey))
                     .setAlwaysShowDefaultTab(true)
-                    .setRenderTabs(false)
-                    .setGridStyle(HtmlStyle.threeColumnReleaseSummary);
+                    .setRenderTabs(false);
             for (String release : releases) {
                 Content tab = TERMINALLY_DEPRECATED_KEY.equals(headingKey)
                         ? contents.getContent("doclet.Terminally_Deprecated_In_Release", release)

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
@@ -84,7 +84,8 @@ public class DeprecatedListWriter extends SummaryListWriter<DeprecatedAPIListBui
             Content tabs = HtmlTree.DIV(HtmlStyle.checkboxes, contents.getContent(
                     "doclet.Deprecated_API_Checkbox_Label"));
             for (int i = 0; i < releases.size(); i++) {
-                tabs.add(getReleaseCheckbox(releases.get(i), i));
+                // Table column ids are 1-based
+                tabs.add(getReleaseCheckbox(releases.get(i), i + 1));
             }
             content.add(tabs);
         }
@@ -100,8 +101,7 @@ public class DeprecatedListWriter extends SummaryListWriter<DeprecatedAPIListBui
                 ? contents.getContent("doclet.Deprecated_API_Checkbox_Other_Releases")
                 : Text.of(name);
         HtmlId htmlId = HtmlId.of("release-" + index);
-        // Table column ids are 1-based
-        String releaseId = isOtherReleases ? "" : Integer.toString(index + 1);
+        String releaseId = isOtherReleases ? "" : Integer.toString(index);
         return HtmlTree.LABEL(htmlId.name(),
                         HtmlTree.INPUT("checkbox", htmlId)
                                 .put(HtmlAttr.CHECKED, "")

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
@@ -84,23 +84,30 @@ public class DeprecatedListWriter extends SummaryListWriter<DeprecatedAPIListBui
             Content tabs = HtmlTree.DIV(HtmlStyle.checkboxes, contents.getContent(
                     "doclet.Deprecated_API_Checkbox_Label"));
             for (int i = 0; i < releases.size(); i++) {
-                String release = releases.get(i);
-                String releaseIndex = release.isEmpty() ? "" : Integer.toString(i + 1);
-                Content releaseLabel = release.isEmpty()
-                        ? contents.getContent("doclet.Deprecated_API_Checkbox_Other_Releases")
-                        : Text.of(release);
-                HtmlId htmlId = HtmlId.of("release-" + releaseIndex);
-                tabs.add(HtmlTree.LABEL(htmlId.name(),
-                                HtmlTree.INPUT("checkbox", htmlId)
-                                        .put(HtmlAttr.CHECKED, "")
-                                        .put(HtmlAttr.ONCLICK,
-                                                "toggleGlobal(this, '" + releaseIndex + "', 3)"))
-                        .add(HtmlTree.SPAN(releaseLabel)));
+                tabs.add(getReleaseCheckbox(releases.get(i), i));
             }
             content.add(tabs);
         }
         addSummaryAPI(list.getForRemoval(), HtmlIds.FOR_REMOVAL,
                 TERMINALLY_DEPRECATED_KEY, "doclet.Element", content);
+    }
+
+    private Content getReleaseCheckbox(String name, int index) {
+        // Empty string represents other/uncategorized releases. Since we can't make any assumptions
+        // about release names this is arguably the safest way to avoid naming collisions.
+        boolean isOtherReleases = name.isEmpty();
+        Content releaseLabel = isOtherReleases
+                ? contents.getContent("doclet.Deprecated_API_Checkbox_Other_Releases")
+                : Text.of(name);
+        HtmlId htmlId = HtmlId.of("release-" + index);
+        // Table column ids are 1-based
+        String releaseId = isOtherReleases ? "" : Integer.toString(index + 1);
+        return HtmlTree.LABEL(htmlId.name(),
+                        HtmlTree.INPUT("checkbox", htmlId)
+                                .put(HtmlAttr.CHECKED, "")
+                                .put(HtmlAttr.ONCLICK,
+                                        "toggleGlobal(this, '" + releaseId + "', 3)"))
+                .add(HtmlTree.SPAN(releaseLabel));
     }
 
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/NewAPIListWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/NewAPIListWriter.java
@@ -79,7 +79,7 @@ public class NewAPIListWriter extends SummaryListWriter<NewAPIBuilder> {
     @Override
     protected void addExtraSection(NewAPIBuilder list, Content content) {
         List<String> releases = configuration.newAPIPageBuilder.releases;
-        if (!releases.isEmpty()) {
+        if (releases.size() > 1) {
             Content tabs = HtmlTree.DIV(HtmlStyle.checkboxes,
                     contents.getContent("doclet.New_API_Checkbox_Label"));
             for (int i = 0; i < releases.size(); i++) {
@@ -98,12 +98,12 @@ public class NewAPIListWriter extends SummaryListWriter<NewAPIBuilder> {
 
     @Override
     protected void addTableTabs(Table table, String headingKey) {
+        table.setGridStyle(HtmlStyle.threeColumnReleaseSummary);
         List<String> releases = configuration.newAPIPageBuilder.releases;
-        if (!releases.isEmpty()) {
+        if (releases.size() > 1) {
             table.setDefaultTab(getTableCaption(headingKey))
                     .setAlwaysShowDefaultTab(true)
-                    .setRenderTabs(false)
-                    .setGridStyle(HtmlStyle.threeColumnReleaseSummary);
+                    .setRenderTabs(false);
             for (String release : releases) {
                 table.addTab(
                         releases.size() == 1

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SummaryListWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SummaryListWriter.java
@@ -132,6 +132,8 @@ public class SummaryListWriter<L extends SummaryAPIListBuilder> extends SubWrite
             }
         }
         bodyContents.addMainContent(content);
+        // The script below enables checkboxes in the page and invokes their click handler
+        // to restore any previous state, which unfortunately doesn't work on all browsers.
         bodyContents.addMainContent(new Script("""
                 document.addEventListener("DOMContentLoaded", function(e) {
                     document.querySelectorAll('input[type="checkbox"]').forEach(

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SummaryListWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SummaryListWriter.java
@@ -133,12 +133,18 @@ public class SummaryListWriter<L extends SummaryAPIListBuilder> extends SubWrite
         }
         bodyContents.addMainContent(content);
         // The script below enables checkboxes in the page and invokes their click handler
-        // to restore any previous state, which unfortunately doesn't work on all browsers.
+        // to restore any previous state when the page is loaded via back/forward button.
         bodyContents.addMainContent(new Script("""
                 document.addEventListener("DOMContentLoaded", function(e) {
                     document.querySelectorAll('input[type="checkbox"]').forEach(
-                        function(c, i) {
+                        function(c) {
                             c.disabled = false;
+                            c.onclick();
+                        });
+                    });
+                window.addEventListener("load", function(e) {
+                    document.querySelectorAll('input[type="checkbox"]').forEach(
+                        function(c) {
                             c.onclick();
                         });
                     });

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SummaryListWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SummaryListWriter.java
@@ -34,6 +34,7 @@ import javax.lang.model.element.PackageElement;
 import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlId;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle;
+import jdk.javadoc.internal.doclets.formats.html.markup.Script;
 import jdk.javadoc.internal.doclets.formats.html.markup.TagName;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlTree;
 import jdk.javadoc.internal.doclets.formats.html.Navigation.PageMode;
@@ -131,6 +132,15 @@ public class SummaryListWriter<L extends SummaryAPIListBuilder> extends SubWrite
             }
         }
         bodyContents.addMainContent(content);
+        bodyContents.addMainContent(new Script("""
+                document.addEventListener("DOMContentLoaded", function(e) {
+                    document.querySelectorAll('input[type="checkbox"]').forEach(
+                        function(c, i) {
+                            c.disabled = false;
+                            c.onclick();
+                        });
+                    });
+                """).asContent());
         bodyContents.setFooter(getFooter());
         body.add(bodyContents);
         printHtmlDocument(null, description, body);
@@ -140,7 +150,7 @@ public class SummaryListWriter<L extends SummaryAPIListBuilder> extends SubWrite
      * Add the index link.
      *
      * @param id the id for the link
-     * @param headingKey
+     * @param headingKey the key for the heading content
      * @param content the content to which the index link will be added
      */
     protected void addIndexLink(HtmlId id, String headingKey, Content content) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
@@ -110,6 +110,7 @@ doclet.tag.invalid_input=invalid input: ''{0}''
 doclet.tag.invalid=invalid @{0}
 doclet.Deprecated_API=Deprecated API
 doclet.Deprecated_API_Checkbox_Label=Show API deprecated in:
+doclet.Deprecated_API_Checkbox_Other_Releases=other
 doclet.Deprecated_Elements=Deprecated {0}
 doclet.Deprecated_Elements_Release_Column_Header=Deprecated in
 doclet.Deprecated_In_Release=Deprecated in {0}

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/script.js
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/script.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,18 +91,15 @@ function sortTable(header, columnIndex, columns) {
         var ka = makeComparable(a[columnIndex].textContent);
         var kb = makeComparable(b[columnIndex].textContent);
         if (ka < kb)
-            return -1;
+            return descending ? 1 : -1;
         if (ka > kb)
-            return 1;
+            return descending ? -1 : 1;
         return 0;
     };
     var sorted = rows.sort(comparator);
-    if (descending) {
-        sorted = sorted.reverse();
-    }
     var visible = 0;
     sorted.forEach(function(row) {
-        if (row[0].style.display === '') {
+        if (row[0].style.display !== 'none') {
             var isEvenRow = visible++ % 2 === 0;
         }
         row.forEach(function(cell) {
@@ -118,11 +115,17 @@ function toggleGlobal(checkbox, selected, columns) {
     var display = checkbox.checked ? '' : 'none';
     document.querySelectorAll("div.table-tabs").forEach(function(t) {
         var id = t.parentElement.getAttribute("id");
-        selectedClass = id + "-tab" + selected;
+        var selectedClass = id + "-tab" + selected;
+        // if selected is empty string it selects all uncategorized entries
+        var selectUncategorized = !Boolean(selected);
         var visible = 0;
         document.querySelectorAll('div.' + id)
             .forEach(function(elem) {
-                if (elem.classList.contains(selectedClass)) {
+                if (selectUncategorized) {
+                    if (elem.className.indexOf(selectedClass) === -1) {
+                        elem.style.display = display;
+                    }
+                } else if (elem.classList.contains(selectedClass)) {
                     elem.style.display = display;
                 }
                 if (elem.style.display === '') {
@@ -260,9 +263,4 @@ document.addEventListener("DOMContentLoaded", function(e) {
     if (!location.hash) {
         history.replaceState(contentDiv.scrollTop, document.title);
     }
-    document.querySelectorAll('input[type="checkbox"]').forEach(
-        function(c, i) {
-            c.disabled = false;
-            toggleGlobal(c, String(i + 1), 3)
-        });
 });

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/DeprecatedAPIListBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/DeprecatedAPIListBuilder.java
@@ -38,17 +38,32 @@ public class DeprecatedAPIListBuilder extends SummaryAPIListBuilder {
 
     private SortedSet<Element> forRemoval;
     public final List<String> releases;
+    private final Set<String> foundReleases;
 
     /**
      * Constructor.
      *
      * @param configuration the current configuration of the doclet
-     * @param releases list of releases
+     * @param since list of releases passed via <code>--since</code> option
      */
-    public DeprecatedAPIListBuilder(BaseConfiguration configuration, List<String> releases) {
+    public DeprecatedAPIListBuilder(BaseConfiguration configuration, List<String> since) {
         super(configuration, configuration.utils::isDeprecated);
-        this.releases = releases;
+        this.foundReleases = new HashSet<>();
         buildSummaryAPIInfo();
+        // The releases list is set to the intersection of releases defined via `--since` option
+        // and actually occurring values of `Deprecated.since` in documented deprecated elements.
+        // If there are `Deprecated.since` values not contained in the `--since` option list
+        // an empty string is added to the releases list which causes the writer to generate
+        // a checkbox for other (unlisted) releases.
+        List<String> releases = new ArrayList<>(since);
+        if (!releases.isEmpty()) {
+            releases.retainAll(foundReleases);
+            if (!releases.containsAll(foundReleases)) {
+                // Empty string is added for other releases, including the default value ""
+                releases.add("");
+            }
+        }
+        this.releases = Collections.unmodifiableList(releases);
     }
 
     public SortedSet<Element> getForRemoval() {
@@ -60,6 +75,7 @@ public class DeprecatedAPIListBuilder extends SummaryAPIListBuilder {
 
     @Override
     protected void handleElement(Element e) {
+        foundReleases.add(utils.getDeprecatedSince(e));
         if (utils.isDeprecatedForRemoval(e)) {
             getForRemoval().add(e);
         }

--- a/test/langtools/jdk/javadoc/doclet/testNewApiList/TestNewApiList.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewApiList/TestNewApiList.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug      8263468 8269401 8268422
+ * @bug      8263468 8269401 8268422 8287524
  * @summary  New page for "recent" new API
  * @library  ../../lib
  * @modules  jdk.javadoc/jdk.javadoc.internal.tool
@@ -476,10 +476,10 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Element</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Deprecated in</div>
                 <div class="table-header col-last">Description</div>
-                <div class="col-summary-item-name even-row-color for-removal for-removal-tab6"><a hr\
+                <div class="col-summary-item-name even-row-color for-removal for-removal-tab1"><a hr\
                 ef="mdl/pkg/TestAnnotation.html#required()">pkg.TestAnnotation.required()</a></div>
-                <div class="col-second even-row-color for-removal for-removal-tab6">5</div>
-                <div class="col-last even-row-color for-removal for-removal-tab6"></div>
+                <div class="col-second even-row-color for-removal for-removal-tab1">3.2</div>
+                <div class="col-last even-row-color for-removal for-removal-tab1"></div>
                 </div>""",
             """
                 <div id="method">
@@ -491,10 +491,10 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Method</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Deprecated in</div>
                 <div class="table-header col-last">Description</div>
-                <div class="col-summary-item-name even-row-color method method-tab6"><a href="mdl/pk\
+                <div class="col-summary-item-name even-row-color method method-tab1"><a href="mdl/pk\
                 g/TestAnnotation.html#required()">pkg.TestAnnotation.required()</a></div>
-                <div class="col-second even-row-color method method-tab6">5</div>
-                <div class="col-last even-row-color method method-tab6"></div>
+                <div class="col-second even-row-color method method-tab1">3.2</div>
+                <div class="col-last even-row-color method method-tab1"></div>
                 </div>""",
             """
                 <div id="constructor">
@@ -506,10 +506,10 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Constructor</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Deprecated in</div>
                 <div class="table-header col-last">Description</div>
-                <div class="col-summary-item-name even-row-color constructor constructor-tab6"><a hr\
-                ef="mdl/pkg/TestClass.html#%3Cinit%3E()">pkg.TestClass()</a></div>
-                <div class="col-second even-row-color constructor constructor-tab6">5</div>
-                <div class="col-last even-row-color constructor constructor-tab6"></div>
+                <div class="col-summary-item-name even-row-color constructor"><a href="mdl/pkg/TestC\
+                lass.html#%3Cinit%3E()">pkg.TestClass()</a></div>
+                <div class="col-second even-row-color constructor">6</div>
+                <div class="col-last even-row-color constructor"></div>
                 </div>""",
             """
                 <div id="enum-constant">
@@ -521,10 +521,10 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Enum Constant</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Deprecated in</div>
                 <div class="table-header col-last">Description</div>
-                <div class="col-summary-item-name even-row-color enum-constant enum-constant-tab6"><\
+                <div class="col-summary-item-name even-row-color enum-constant enum-constant-tab2"><\
                 a href="mdl/pkg/TestEnum.html#DEPRECATED">pkg.TestEnum.DEPRECATED</a></div>
-                <div class="col-second even-row-color enum-constant enum-constant-tab6">5</div>
-                <div class="col-last even-row-color enum-constant enum-constant-tab6"></div>
+                <div class="col-second even-row-color enum-constant enum-constant-tab2">5</div>
+                <div class="col-last even-row-color enum-constant enum-constant-tab2"></div>
                 </div>""",
             """
                 <div id="annotation-interface-member">
@@ -537,9 +537,9 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Deprecated in</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color annotation-interface-member annotat\
-                ion-interface-member-tab6"><a href="mdl/pkg/TestAnnotation.html#required()">pkg.TestAnnotation.required()</a></div>
-                <div class="col-second even-row-color annotation-interface-member annotation-interface-member-tab6">5</div>
-                <div class="col-last even-row-color annotation-interface-member annotation-interface-member-tab6"></div>
+                ion-interface-member-tab1"><a href="mdl/pkg/TestAnnotation.html#required()">pkg.TestAnnotation.required()</a></div>
+                <div class="col-second even-row-color annotation-interface-member annotation-interface-member-tab1">3.2</div>
+                <div class="col-last even-row-color annotation-interface-member annotation-interface-member-tab1"></div>
                 </div>""");
     }
 
@@ -553,53 +553,46 @@ public class TestNewApiList extends JavadocTester {
                 <li><a href="#constructor">Constructors</a></li>
                 </ul>
                 </div>
-                <div class="checkboxes">Show API added in:<label for="release-1">""");
+                <ul class="block-list">""");
     }
 
     private void checkSingleReleaseNewElements() {
         checkOutput("new-list.html", true,
                 """
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>New Methods</span></div>
-                </div>
-                <div id="method.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="method-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Method</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Added in</div>
                 <div class="table-header col-last">Description</div>
-                <div class="col-summary-item-name even-row-color method method-tab1"><a href="mdl/pk\
-                g/TestClass.html#overloadedMethod(java.lang.String)">pkg.TestClass.overloadedMethod<\
-                wbr>(String)</a></div>
-                <div class="col-second even-row-color method method-tab1">5</div>
-                <div class="col-last even-row-color method method-tab1">
+                <div class="col-summary-item-name even-row-color"><a href="mdl/pkg/TestClass.html#ov\
+                erloadedMethod(java.lang.String)">pkg.TestClass.overloadedMethod<wbr>(String)</a></div>
+                <div class="col-second even-row-color">5</div>
+                <div class="col-last even-row-color">
                 <div class="block">TestClass overloaded method.</div>
                 </div>
-                <div class="col-summary-item-name odd-row-color method method-tab1"><a href="mdl/pkg\
-                /TestRecord.html#x()">pkg.TestRecord.x()</a></div>
-                <div class="col-second odd-row-color method method-tab1">5</div>
-                <div class="col-last odd-row-color method method-tab1">
+                <div class="col-summary-item-name odd-row-color"><a href="mdl/pkg/TestRecord.html#x(\
+                )">pkg.TestRecord.x()</a></div>
+                <div class="col-second odd-row-color">5</div>
+                <div class="col-last odd-row-color">
                 <div class="block">Test record getter.</div>
                 </div>""",
             """
                 <div id="constructor">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>New Constructors</span></div>
-                </div>
-                <div id="constructor.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="constructor-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Constructor</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Added in</div>
                 <div class="table-header col-last">Description</div>
-                <div class="col-summary-item-name even-row-color constructor constructor-tab1"><a hr\
-                ef="mdl/pkg/TestError.html#%3Cinit%3E()">pkg.TestError()</a></div>
-                <div class="col-second even-row-color constructor constructor-tab1">5</div>
-                <div class="col-last even-row-color constructor constructor-tab1">
+                <div class="col-summary-item-name even-row-color"><a href="mdl/pkg/TestError.html#%3\
+                Cinit%3E()">pkg.TestError()</a></div>
+                <div class="col-second even-row-color">5</div>
+                <div class="col-last even-row-color">
                 <div class="block">Test error constructor.</div>
                 </div>
-                <div class="col-summary-item-name odd-row-color constructor constructor-tab1"><a hre\
-                f="mdl/pkg/TestException.html#%3Cinit%3E()">pkg.TestException()</a></div>
-                <div class="col-second odd-row-color constructor constructor-tab1">5</div>
-                <div class="col-last odd-row-color constructor constructor-tab1">
+                <div class="col-summary-item-name odd-row-color"><a href="mdl/pkg/TestException.html\
+                #%3Cinit%3E()">pkg.TestException()</a></div>
+                <div class="col-second odd-row-color">5</div>
+                <div class="col-last odd-row-color">
                 <div class="block">Exception constructor.</div>
                 </div>""");
     }
@@ -628,10 +621,10 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Element</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Deprecated in</div>
                 <div class="table-header col-last">Description</div>
-                <div class="col-summary-item-name even-row-color for-removal for-removal-tab1"><a hr\
-                ef="mdl/pkg/TestAnnotation.html#required()">pkg.TestAnnotation.required()</a></div>
-                <div class="col-second even-row-color for-removal for-removal-tab1">5</div>
-                <div class="col-last even-row-color for-removal for-removal-tab1"></div>
+                <div class="col-summary-item-name even-row-color for-removal"><a href="mdl/pkg/TestA\
+                nnotation.html#required()">pkg.TestAnnotation.required()</a></div>
+                <div class="col-second even-row-color for-removal">3.2</div>
+                <div class="col-last even-row-color for-removal"></div>
                 </div>""",
             """
                 <div id="method">
@@ -643,10 +636,10 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Method</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Deprecated in</div>
                 <div class="table-header col-last">Description</div>
-                <div class="col-summary-item-name even-row-color method method-tab1"><a href="mdl/pk\
-                g/TestAnnotation.html#required()">pkg.TestAnnotation.required()</a></div>
-                <div class="col-second even-row-color method method-tab1">5</div>
-                <div class="col-last even-row-color method method-tab1"></div>
+                <div class="col-summary-item-name even-row-color method"><a href="mdl/pkg/TestAnnota\
+                tion.html#required()">pkg.TestAnnotation.required()</a></div>
+                <div class="col-second even-row-color method">3.2</div>
+                <div class="col-last even-row-color method"></div>
                 </div>""",
             """
                 <div id="constructor">
@@ -658,10 +651,10 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Constructor</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Deprecated in</div>
                 <div class="table-header col-last">Description</div>
-                <div class="col-summary-item-name even-row-color constructor constructor-tab1"><a hr\
-                ef="mdl/pkg/TestClass.html#%3Cinit%3E()">pkg.TestClass()</a></div>
-                <div class="col-second even-row-color constructor constructor-tab1">5</div>
-                <div class="col-last even-row-color constructor constructor-tab1"></div>
+                <div class="col-summary-item-name even-row-color constructor"><a href="mdl/pkg/TestC\
+                lass.html#%3Cinit%3E()">pkg.TestClass()</a></div>
+                <div class="col-second even-row-color constructor">6</div>
+                <div class="col-last even-row-color constructor"></div>
                 </div>""");
     }
 
@@ -786,22 +779,19 @@ public class TestNewApiList extends JavadocTester {
                 <li><a href="#constructor">Constructors</a></li>
                 </ul>
                 </div>
-                <div class="checkboxes">Show API deprecated in:<label for="release-1">
+                <ul class="block-list">
                 """,
             """
                 <div id="constructor">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>Deprecated Constructors</span></div>
-                </div>
-                <div id="constructor.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="constructor-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Constructor</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Deprecated in</div>
                 <div class="table-header col-last">Description</div>
-                <div class="col-summary-item-name even-row-color constructor constructor-tab4"><a hr\
-                ef="pkg/TestClass.html#%3Cinit%3E()">pkg.TestClass()</a></div>
-                <div class="col-second even-row-color constructor constructor-tab4">5</div>
-                <div class="col-last even-row-color constructor constructor-tab4"></div>
+                <div class="col-summary-item-name even-row-color"><a href="pkg/TestClass.html#%3Cini\
+                t%3E()">pkg.TestClass()</a></div>
+                <div class="col-second even-row-color">5</div>
+                <div class="col-last even-row-color"></div>
                 </div>""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testNewApiList/mdl/pkg/TestAnnotation.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewApiList/mdl/pkg/TestAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,10 +38,10 @@ import java.lang.annotation.Documented;
     String optional() default "unknown";
 
     /**
-     *  Required annotation interface element.
+     * Required annotation interface element.
      * @since 2.0b
      */
-    @Deprecated(forRemoval=true,since="5")
+    @Deprecated(forRemoval=true,since="3.2")
     int required();
 
     /**

--- a/test/langtools/jdk/javadoc/doclet/testNewApiList/mdl/pkg/TestClass.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewApiList/mdl/pkg/TestClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ public class TestClass {
      * TestClass constructor.
      * @since 2.0b
      */
-    @Deprecated(since="5")
+    @Deprecated(since="6")
     public TestClass() {}
 
     /**


### PR DESCRIPTION
The original purpose of this issue was to fix the problems of elements on the deprecated API list that can't be deselected because their release is not included in the list of checkboxes at the top of the page. This is fixed here by adding a checkbox for all elements/releases not included in the list if necessary. 

While working on it I discovered a few corner cases that produce undesirable output for the deprecated list. This includes the case of a single release (where a checkbox doesn't make any sense) and the case of some or all releases not having any occurrences in the `since` element of deprecated elements (in which case the checkbox is useless as well). A more detailed description of these cases is available in the [JBS issue](https://bugs.openjdk.java.net/browse/JDK-8287524).

As examples for the output generated with this change I uploaded JDK API docs:

http://cr.openjdk.java.net/~hannesw/8287524/api.00/deprecated-list.html

To illustrate behaviour in corner cases mentioned above I also uploaded deprecated pages generated by the `TestNewAPIListWriter` test (which despite its name also tests the "extended" deprecated list).

http://cr.openjdk.java.net/~hannesw/8287524/test.00/TestNewApiList/out-multi/deprecated-list.html
http://cr.openjdk.java.net/~hannesw/8287524/test.00/TestNewApiList/out-none/deprecated-list.html
http://cr.openjdk.java.net/~hannesw/8287524/test.00/TestNewApiList/out-package/deprecated-list.html
http://cr.openjdk.java.net/~hannesw/8287524/test.00/TestNewApiList/out-single/deprecated-list.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287524](https://bugs.openjdk.java.net/browse/JDK-8287524): Improve checkboxes to select releases on deprecated API page


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8973/head:pull/8973` \
`$ git checkout pull/8973`

Update a local copy of the PR: \
`$ git checkout pull/8973` \
`$ git pull https://git.openjdk.java.net/jdk pull/8973/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8973`

View PR using the GUI difftool: \
`$ git pr show -t 8973`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8973.diff">https://git.openjdk.java.net/jdk/pull/8973.diff</a>

</details>
