### PR TITLE
8287686: Add assertion to ensure that disarm value offset < 128

### DIFF
--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -158,7 +158,11 @@ class Thread: public ThreadShadow {
   }
 
   static ByteSize nmethod_disarmed_offset() {
-    return byte_offset_of(Thread, _nmethod_disarm_value);
+    ByteSize offset = byte_offset_of(Thread, _nmethod_disarm_value);
+    // At least on x86_64, nmethod entry barrier encodes disarmed value offset
+    // in instruction as disp8 immed
+    assert(in_bytes(offset) < 128, "Offset >= 128");
+    return offset;
   }
 
  private:


### PR DESCRIPTION
Please review this trivial patch to ensure disarm value offset is less than 128.

At least on x86_64, nmethod entry barrier encodes disarmed value offset as disp8 immed, overflowing the value can result crashes, see [JDK-8244420](https://bugs.openjdk.java.net/browse/JDK-8244420) for details.

Test:

- [x] jdk_loom and hotspot_loom on Linux x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287686](https://bugs.openjdk.java.net/browse/JDK-8287686): Add assertion to ensure that disarm value offset < 128


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8977/head:pull/8977` \
`$ git checkout pull/8977`

Update a local copy of the PR: \
`$ git checkout pull/8977` \
`$ git pull https://git.openjdk.java.net/jdk pull/8977/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8977`

View PR using the GUI difftool: \
`$ git pr show -t 8977`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8977.diff">https://git.openjdk.java.net/jdk/pull/8977.diff</a>

</details>
