### PR TITLE
8287724: Fix various issues with msys2

### DIFF
--- a/make/autoconf/boot-jdk.m4
+++ b/make/autoconf/boot-jdk.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -126,16 +126,18 @@ AC_DEFUN([BOOTJDK_DO_CHECK],
 AC_DEFUN([BOOTJDK_CHECK_ARGUMENTS],
 [
   if test "x$with_boot_jdk" != x; then
-    if test -d "$with_boot_jdk"; then
-      BOOT_JDK=$with_boot_jdk
+    BOOT_JDK_ARG="$with_boot_jdk"
+    UTIL_FIXUP_PATH(BOOT_JDK_ARG)
+    if test -d "$BOOT_JDK_ARG"; then
+      BOOT_JDK=$BOOT_JDK_ARG
       BOOT_JDK_FOUND=maybe
-    elif test -f "$with_boot_jdk"; then
-      case "$with_boot_jdk" in
+    elif test -f "$BOOT_JDK_ARG"; then
+      case "$BOOT_JDK_ARG" in
         *.tar.gz )
             BOOT_JDK_SUPPORT_DIR=$CONFIGURESUPPORT_OUTPUTDIR/boot-jdk
             $RM -rf $BOOT_JDK_SUPPORT_DIR
             $MKDIR -p $BOOT_JDK_SUPPORT_DIR
-            $GUNZIP -c $with_boot_jdk | $TAR xf - -C $BOOT_JDK_SUPPORT_DIR
+            $GUNZIP -c $BOOT_JDK_ARG | $TAR xf - -C $BOOT_JDK_SUPPORT_DIR
 
             # Try to find javac to determine BOOT_JDK path
             BOOT_JDK_JAVAC_PATH=`$FIND $BOOT_JDK_SUPPORT_DIR | $GREP "/bin/javac"`

--- a/make/autoconf/platform.m4
+++ b/make/autoconf/platform.m4
@@ -218,7 +218,7 @@ AC_DEFUN([PLATFORM_EXTRACT_VARS_FROM_OS],
       VAR_OS=windows
       VAR_OS_ENV=windows.wsl
       ;;
-    *msys*)
+    *msys* | *mingw*)
       VAR_OS=windows
       VAR_OS_ENV=windows.msys2
       ;;


### PR DESCRIPTION
I encountered a bunch of issues when running with msys2 on Windows (but one of them could have happened on cygwin as well).

* fixpath must set MSYS2_ARG_CONV_EXCL="*" before running cmd.exe to figure out the temp directory, or msys might interfere with the command line to cmd.

* Paths like "/c/s/source/jdk", meaning to point to "c:\s\source\jdk", would be interpreted by fixpath as "/cs:\source\jdk", since the leading "/c" would be considered a prefix. This is not a problem on cygwin, where the /cygpath prefix makes paths unambiguous. I countered this by checking if the file exists (as written, or just the basepath, or the first 3 parts of the path). If so, I treat it as a filename, rather than a prefix.

* Configure is supposed to handle windows-style input paths, but `--with-bootjdk=c:\java\jdk-17` or similar would break, since we started to look for files in that directory without having to normalized the path first.

* Finally, configure.guess sometimes reports msys as `mingw` and sometimes as `msys`, depending on the value of MSYSTEM. (And for some values, the old autoconf-configure.guess breaks -- I did not bother fixing this.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287724](https://bugs.openjdk.java.net/browse/JDK-8287724): Fix various issues with msys2


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8989/head:pull/8989` \
`$ git checkout pull/8989`

Update a local copy of the PR: \
`$ git checkout pull/8989` \
`$ git pull https://git.openjdk.java.net/jdk pull/8989/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8989`

View PR using the GUI difftool: \
`$ git pr show -t 8989`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8989.diff">https://git.openjdk.java.net/jdk/pull/8989.diff</a>

</details>
