### PR TITLE
8287663 Add a regression test for JDK-8287073

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
@@ -86,7 +86,10 @@ public class CgroupSubsystemFactory {
         } catch (IOException | UncheckedIOException e) {
             return null;
         }
+        return create(optResult);
+    }
 
+    public static CgroupMetrics create(Optional<CgroupTypeResult> optResult) {
         if (optResult.isEmpty()) {
             return null;
         }

--- a/test/jdk/jdk/internal/platform/cgroup/TestCgroupSubsystemFactory.java
+++ b/test/jdk/jdk/internal/platform/cgroup/TestCgroupSubsystemFactory.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -50,7 +51,7 @@ import jdk.test.lib.util.FileUtils;
 
 /*
  * @test
- * @bug 8287107
+ * @bug 8287107 8287073
  * @key cgroups
  * @requires os.family == "linux"
  * @modules java.base/jdk.internal.platform
@@ -66,6 +67,7 @@ public class TestCgroupSubsystemFactory {
     private Path cgroupv1CgInfoZeroHierarchy;
     private Path cgroupv1MntInfoZeroHierarchy;
     private Path cgroupv2CgInfoZeroHierarchy;
+    private Path cgroupv2CgInfoZeroMinimal;
     private Path cgroupv2MntInfoZeroHierarchy;
     private Path cgroupv1CgInfoNonZeroHierarchy;
     private Path cgroupv1MntInfoNonZeroHierarchy;
@@ -127,6 +129,9 @@ public class TestCgroupSubsystemFactory {
             "net_cls 0 1 1\n" +
             "blkio 0 1 1\n" +
             "perf_event 0 1 1 ";
+    private String cgroupsZeroHierarchyMinimal =
+            "#subsys_name hierarchy num_cgroups enabled\n" +
+            "cpu 0 1 1\n";
     private String mntInfoHybrid =
             "30 23 0:26 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:4 - tmpfs tmpfs ro,seclabel,mode=755\n" +
             "31 30 0:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:5 - cgroup2 none rw,seclabel,nsdelegate\n" +
@@ -306,6 +311,9 @@ public class TestCgroupSubsystemFactory {
             cgroupv1MountInfoCgroupsOnlyCPUCtrl = Paths.get(existingDirectory.toString(), "self_mountinfo_cpu_only_controller");
             Files.writeString(cgroupv1MountInfoCgroupsOnlyCPUCtrl, mntInfoCpuOnly);
 
+            cgroupv2CgInfoZeroMinimal = Paths.get(existingDirectory.toString(), "cgv2_proc_cgroups_minimal");
+            Files.writeString(cgroupv2CgInfoZeroMinimal, cgroupsZeroHierarchyMinimal);
+
             cgroupv2CgInfoNoZeroHierarchyOnlyFreezer = Paths.get(existingDirectory.toString(), "cgroups_cgv2_non_zero_only_freezer");
             Files.writeString(cgroupv2CgInfoNoZeroHierarchyOnlyFreezer, cgroupsNonZeroHierarchyOnlyFreezer);
 
@@ -478,6 +486,30 @@ public class TestCgroupSubsystemFactory {
         assertEquals(memoryInfo.getMountPoint(), cpuInfo.getMountPoint());
         assertEquals(memoryInfo.getMountRoot(), cpuInfo.getMountRoot());
         assertEquals("/sys/fs/cgroup", cpuInfo.getMountPoint());
+    }
+
+    /*
+     * On some systems the memory controller might not show up in /proc/cgroups
+     * which may provoke a NPE on instantiation. See bug 8287073.
+     */
+    @Test
+    public void testZeroHierarchyCgroupsV2Minimal() throws IOException {
+        String cgroups = cgroupv2CgInfoZeroMinimal.toString();
+        String mountInfo = cgroupv2MntInfoZeroHierarchy.toString();
+        String selfCgroup = cgroupv2SelfCgroup.toString();
+        Optional<CgroupTypeResult> result = CgroupSubsystemFactory.determineType(mountInfo, cgroups, selfCgroup);
+
+        assertTrue("Expected non-empty cgroup result", result.isPresent());
+        CgroupTypeResult res = result.get();
+
+        assertTrue("zero hierarchy ids with mounted controllers expected cgroups v2", res.isCgroupV2());
+        assertNull("Only cpu controller present", res.getInfos().get("memory"));
+        try {
+            CgroupSubsystemFactory.create(result);
+            // pass
+        } catch (NullPointerException e) {
+            fail("Missing memory controller should not cause any NPE");
+        }
     }
 
     @Test(expected = IOException.class)


### PR DESCRIPTION
This adds a regression test for a recent fix (JDK-8287073). I've restructured the linux specific JDK code to call a separate static function to enable this test. It'll help future tests too.

Testing:
- [x] Container tests continue to pass + GHA
- [x] New regression test fails prior the code fix of JDK-8287073 and passes with it