### PR TITLE
8286625: C2 fails with assert(!n->is_Store() && !n->is_LoadStore()) failed: no node with a side effect

### DIFF
--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -26,6 +26,7 @@
 #include "opto/loopnode.hpp"
 #include "opto/addnode.hpp"
 #include "opto/callnode.hpp"
+#include "opto/castnode.hpp"
 #include "opto/connode.hpp"
 #include "opto/convertnode.hpp"
 #include "opto/loopnode.hpp"
@@ -1401,6 +1402,10 @@ ProjNode* PhaseIdealLoop::insert_initial_skeleton_predicate(IfNode* iff, IdealLo
   register_new_node(max_value, new_proj);
   max_value = new AddINode(opaque_init, max_value);
   register_new_node(max_value, new_proj);
+  // init + (current stride - initial stride) is within the loop so narrow its type by leveraging the type of the iv Phi
+  max_value = new CastIINode(max_value, loop->_head->as_CountedLoop()->phi()->bottom_type());
+  register_new_node(max_value, predicate_proj);
+
   bol = rc_predicate(loop, new_proj, scale, offset, max_value, limit, stride, rng, (stride > 0) != (scale > 0), overflow, negate);
   opaque_bol = new Opaque4Node(C, bol, _igvn.intcon(1));
   C->add_skeleton_predicate_opaq(opaque_bol);
@@ -1408,6 +1413,7 @@ ProjNode* PhaseIdealLoop::insert_initial_skeleton_predicate(IfNode* iff, IdealLo
   new_proj = create_new_if_for_predicate(predicate_proj, NULL, reason, overflow ? Op_If : iff->Opcode());
   _igvn.replace_input_of(new_proj->in(0), 1, opaque_bol);
   assert(max_value->outcnt() > 0, "should be used");
+  assert(skeleton_predicate_has_opaque(new_proj->in(0)->as_If()), "unexpected");
 
   return new_proj;
 }

--- a/test/hotspot/jtreg/compiler/loopopts/TestOverUnrolling2.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestOverUnrolling2.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8286625
+ * @summary C2 fails with assert(!n->is_Store() && !n->is_LoadStore()) failed: no node with a side effect
+ * @run main/othervm -XX:-BackgroundCompilation -XX:+StressIGVN -XX:StressSeed=4232417824 TestOverUnrolling2
+ * @run main/othervm -XX:-BackgroundCompilation -XX:+StressIGVN TestOverUnrolling2
+ */
+
+public class TestOverUnrolling2 {
+   public static void main(String[] args) {
+        final byte[] large = new byte[1000];
+        final byte[] src = new byte[16];
+        for (int i = 0; i < 20_000; i++) {
+            test_helper(large, large);
+            test(src);
+        }
+   }
+
+    private static void test(byte[] src) {
+        byte[] array = new byte[16];
+        test_helper(src, array);
+    }
+
+    private static void test_helper(byte[] src, byte[] array) {
+        for (int i = 0; i < src.length; i++) {
+            array[array.length - 1 - i] = src[i];
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/TestOverUnrolling2.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestOverUnrolling2.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8286625
+ * @key stress
  * @summary C2 fails with assert(!n->is_Store() && !n->is_LoadStore()) failed: no node with a side effect
  * @run main/othervm -XX:-BackgroundCompilation -XX:+StressIGVN -XX:StressSeed=4232417824 TestOverUnrolling2
  * @run main/othervm -XX:-BackgroundCompilation -XX:+StressIGVN TestOverUnrolling2


### PR DESCRIPTION
It's another case where because of overunrolling, the main loop is
never executed but not optimized out and the type of some
CastII/ConvI2L for a range check conflicts with the type of its input
resulting in a broken graph for the main loop.

This is supposed to have been solved by skeleton predicates. There's
indeed a predicate that should catch that the loop is unreachable but
it doesn't constant fold. The shape of the predicate is:

(CmpUL (SubL 15 (ConvI2L (AddI (CastII int:>=1) 15) minint..maxint)) 16)

I propose adding a CastII, that is in this case:

(CmpUL (SubL 15 (ConvI2L (CastII (AddI (CastII int:>=1) 15) 0..max-1) minint..maxint)) 16)

The justification for the CastII is that the skeleton predicate is a
predicate for a specific iteration of the loop. That iteration of the
loop must be in the range of the iv Phi.

With the extra CastII, the AddI can be pushed through the CastII and
ConvI2L and the check constant folds. Actually, with the extra CastII,
the predicate is not implemented with a CmpUL but a CmpU because the
code can tell there's no risk of overflow (I did force the use of
CmpUL as an experiment and the CmpUL does constant fold)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286625](https://bugs.openjdk.org/browse/JDK-8286625): C2 fails with assert(!n->is_Store() && !n->is_LoadStore()) failed: no node with a side effect


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [8f4a999a](https://git.openjdk.java.net/jdk/pull/8996/files/8f4a999a97a41fef360bc14b3ea3a2f9a92aa237)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [8f4a999a](https://git.openjdk.java.net/jdk/pull/8996/files/8f4a999a97a41fef360bc14b3ea3a2f9a92aa237)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8996/head:pull/8996` \
`$ git checkout pull/8996`

Update a local copy of the PR: \
`$ git checkout pull/8996` \
`$ git pull https://git.openjdk.java.net/jdk pull/8996/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8996`

View PR using the GUI difftool: \
`$ git pr show -t 8996`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8996.diff">https://git.openjdk.java.net/jdk/pull/8996.diff</a>

</details>
