### PR TITLE
8287740 NSAccessibilityShowMenuAction not working for text editors

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -614,8 +614,11 @@ static jobject sAccessibilityClass = NULL;
                 [fActions setObject:action forKey:NSAccessibilityPickAction];
                 [fActionSelectors addObject:[sActionSelectors objectForKey:NSAccessibilityPickAction]];
             } else {
-                [fActions setObject:action forKey:[sActions objectForKey:[action getDescription]]];
-                [fActionSelectors addObject:[sActionSelectors objectForKey:[sActions objectForKey:[action getDescription]]]];
+                NSString *nsActionName = [sActions objectForKey:[action getDescription]];
+                if (nsActionName != nil) {
+                    [fActions setObject:action forKey:nsActionName];
+                    [fActionSelectors addObject:[sActionSelectors objectForKey:nsActionName]];
+                }
             }
             [action release];
         }

--- a/test/jdk/java/awt/a11y/AccessibleActionsTest.java
+++ b/test/jdk/java/awt/a11y/AccessibleActionsTest.java
@@ -40,6 +40,8 @@ import javax.swing.tree.TreePath;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
 import java.util.Hashtable;
 import java.util.concurrent.CountDownLatch;
 
@@ -92,6 +94,31 @@ public class AccessibleActionsTest extends AccessibleComponentTest {
     super.createUI(panel, "AccessibleActionsTest");
   }
 
+  private void createEditableTextArea() {
+    AccessibleComponentTest.INSTRUCTIONS = "INSTRUCTIONS:\n"
+            + "Check a11y show context menu in editable JTextArea.\n\n"
+            + "Turn screen reader on and press Tab to move to the text area and vo+shif+m.\n\n"
+            + "If the menu appears  tab further and press PASS, otherwise press FAIL.";
+
+    JTextArea textArea = new MyTextArea("some text to edit");
+    JLabel label = new JLabel(textArea.getText().length() + " chars");
+    label.setLabelFor(textArea);
+    textArea.setEditable(true);
+    textArea.addKeyListener(new KeyAdapter() {
+      @Override
+      public void keyReleased(KeyEvent e) {
+        label.setText(String.valueOf(textArea.getText().length()) + " chars");
+      }
+    });
+
+    JPanel panel = new JPanel();
+    panel.setLayout(new FlowLayout());
+    panel.add(textArea);
+    panel.add(label);
+    exceptionString = "Editable text area test failed!";
+    super.createUI(panel, "AccessibleTextTest");
+  }
+
   public static void main(String[] args) throws Exception {
     AccessibleActionsTest test = new AccessibleActionsTest();
 
@@ -105,6 +132,14 @@ public class AccessibleActionsTest extends AccessibleComponentTest {
 
     countDownLatch = test.createCountDownLatch();
     SwingUtilities.invokeLater(test::createTree);
+    countDownLatch.await();
+
+    if (!testResult) {
+      throw new RuntimeException(a11yTest.exceptionString);
+    }
+
+    countDownLatch = test.createCountDownLatch();
+    SwingUtilities.invokeLater(test::createEditableTextArea);
     countDownLatch.await();
 
     if (!testResult) {
@@ -167,17 +202,70 @@ public class AccessibleActionsTest extends AccessibleComponentTest {
       }
     }
 
-    private static JPopupMenu createPopup() {
-      JPopupMenu popup = new JPopupMenu("MENU");
-      popup.add("One");
-      popup.add("Two");
-      popup.add("Three");
-      return popup;
-    }
+
 
     private static void changeText(JLabel label, String text) {
       label.setText(text);
     }
 
+  }
+
+  private static class MyTextArea extends JTextArea {
+
+    public MyTextArea(String some_text_to_edit) {
+    }
+
+    @Override
+    public AccessibleContext getAccessibleContext() {
+      if (accessibleContext == null) {
+        accessibleContext = new MyAccessibleJTextArea();
+      }
+      return accessibleContext;
+    }
+
+    private class MyAccessibleJTextArea extends JTextArea.AccessibleJTextArea {
+      @Override
+      public AccessibleAction getAccessibleAction() {
+        return new AccessibleAction() {
+          @Override
+          public int getAccessibleActionCount() {
+            AccessibleAction aa = MyAccessibleJTextArea.super.getAccessibleAction();
+            if (aa == null) {
+              return 1;
+            }
+            int count = aa.getAccessibleActionCount();
+            return aa.getAccessibleActionCount() + 1;
+}
+
+          @Override
+          public String getAccessibleActionDescription(int i) {
+            AccessibleAction aa = MyAccessibleJTextArea.super.getAccessibleAction();
+            if ((aa != null) && (i >= 0) && (i < aa.getAccessibleActionCount())) {
+              return aa.getAccessibleActionDescription(i);
+            }
+            return AccessibleAction.TOGGLE_POPUP;
+          }
+
+          @Override
+          public boolean doAccessibleAction(int i) {
+            AccessibleAction aa = MyAccessibleJTextArea.super.getAccessibleAction();
+            if ((aa != null) && (i >= 0) && (i < aa.getAccessibleActionCount())) {
+              return aa.doAccessibleAction(i);
+            }
+            JPopupMenu popup = createPopup();
+            popup.show(MyTextArea.this, 0, 0);
+            return true;
+          }
+        };
+      }
+    }
+  }
+
+  private static JPopupMenu createPopup() {
+    JPopupMenu popup = new JPopupMenu("MENU");
+    popup.add("One");
+    popup.add("Two");
+    popup.add("Three");
+    return popup;
   }
 }

--- a/test/jdk/java/awt/a11y/AccessibleActionsTest.java
+++ b/test/jdk/java/awt/a11y/AccessibleActionsTest.java
@@ -97,7 +97,8 @@ public class AccessibleActionsTest extends AccessibleComponentTest {
   private void createEditableTextArea() {
     AccessibleComponentTest.INSTRUCTIONS = "INSTRUCTIONS:\n"
             + "Check a11y show context menu in editable JTextArea.\n\n"
-            + "Turn screen reader on and press Tab to move to the text area and vo+shif+m.\n\n"
+            + "Turn screen reader on and press Tab to move to the text area\n"
+            + "Perform the VO action \"Open a shortcut menu\" (VO+Shift+m)\n\n"
             + "If the menu appears  tab further and press PASS, otherwise press FAIL.";
 
     JTextArea textArea = new MyTextArea("some text to edit");


### PR DESCRIPTION
The NSAccessibilityShouMinuAction action does not show the menu for the text element. 
Steps to reproduce: 
1. redefine the accessible context with the addition of the toggle popup action; 
2. run on macOS with VoiceOver enabled; 
3. try to call the context menu in the editor by pressing vo+shift+m.

@azuev-java please review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287740](https://bugs.openjdk.java.net/browse/JDK-8287740): NSAccessibilityShowMenuAction not working for text editors


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**) ⚠️ Review applies to [50601c12](https://git.openjdk.java.net/jdk/pull/8997/files/50601c1202c881cb130ba9cd1a4923d1294ec7dc)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8997/head:pull/8997` \
`$ git checkout pull/8997`

Update a local copy of the PR: \
`$ git checkout pull/8997` \
`$ git pull https://git.openjdk.java.net/jdk pull/8997/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8997`

View PR using the GUI difftool: \
`$ git pr show -t 8997`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8997.diff">https://git.openjdk.java.net/jdk/pull/8997.diff</a>

</details>
