### PR TITLE
8287741: Fix of JDK-8287107 (unused cgv1 freezer controller) was incomplete

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -260,7 +260,13 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
       }
     }
     if (is_cgroupsV2) {
+      // On some systems we have mixed cgroups v1 and cgroups v2 controllers (e.g. freezer on cg1 and
+      // all relevant controllers on cg2). Only set the cgroup path when we see a hierarchy id of 0.
+      if (hierarchy_id != 0) {
+        continue;
+      }
       for (int i = 0; i < CG_INFO_LENGTH; i++) {
+        assert(cg_infos[i]._cgroup_path == NULL, "cgroup path must only be set once");
         cg_infos[i]._cgroup_path = os::strdup(cgroup_path);
       }
     }


### PR DESCRIPTION
Please review this hotspot fix follow-up of JDK-8287107. The test which exercised this code was already added with  JDK-8287107. I've now added an assert ensuring that we don't set the cgroup path multiple times. The fix is essentially the same as on the JDK side, skip setting the cgroup path when the hierarchy is non-zero which is equivalent to the empty string match that was done in the Java code.

Testing:
- [x] `test/hotspot/jtreg/containers/cgroup/CgroupSubsystemFactory.java` with fastdebug on x86_64. Asserts before the code fix, passes after.
- [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287741](https://bugs.openjdk.org/browse/JDK-8287741): Fix of JDK-8287107 (unused cgv1 freezer controller) was incomplete


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to [5c4cdc27](https://git.openjdk.java.net/jdk/pull/9001/files/5c4cdc27c275f4d8f1a5b50e27d2c933938373f8)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9001/head:pull/9001` \
`$ git checkout pull/9001`

Update a local copy of the PR: \
`$ git checkout pull/9001` \
`$ git pull https://git.openjdk.java.net/jdk pull/9001/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9001`

View PR using the GUI difftool: \
`$ git pr show -t 9001`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9001.diff">https://git.openjdk.java.net/jdk/pull/9001.diff</a>

</details>
