### PR TITLE
8273573: [macos12] ActionListenerCalledTwiceTest.java fails on macOS 12

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -674,7 +674,6 @@ javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all
 javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-all
 javax/swing/Popup/TaskbarPositionTest.java 8065097 macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
-javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java 8273573 macosx-all
 
 # Several tests which fail on some hidpi systems/macosx12-aarch64 system
 java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64

--- a/test/jdk/javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java
+++ b/test/jdk/javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java
@@ -27,6 +27,7 @@
  * @bug 7160951 8152492 8178448
  * @summary [macosx] ActionListener called twice for JMenuItem using ScreenMenuBar
  * @author vera.akulova@oracle.com
+ * @requires (os.family == "mac")
  * @modules java.desktop/java.awt:open
  * @library /test/lib
  * @build jdk.test.lib.Platform

--- a/test/jdk/javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java
+++ b/test/jdk/javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,35 +21,37 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @key headful
  * @bug 7160951 8152492 8178448
  * @summary [macosx] ActionListener called twice for JMenuItem using ScreenMenuBar
- * @author vera.akulova@oracle.com
  * @requires (os.family == "mac")
- * @modules java.desktop/java.awt:open
- * @library /test/lib
- * @build jdk.test.lib.Platform
  * @run main ActionListenerCalledTwiceTest
  */
 
-import jdk.test.lib.Platform;
-import java.awt.*;
-import java.awt.event.*;
-import javax.swing.*;
+import java.awt.Desktop;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
 
 public class ActionListenerCalledTwiceTest {
 
-    static String menuItems[] = {"Item1", "Item2", "Item3",
-                                    "Item4", "Item5", "Item6"};
-    static KeyStroke keyStrokes[] = {
-        KeyStroke.getKeyStroke(KeyEvent.VK_E, InputEvent.META_MASK),
+    static final String[] menuItems = { "Item1", "Item2", "Item3",
+                                        "Item4", "Item5", "Item6" };
+    static final KeyStroke[] keyStrokes = {
+        KeyStroke.getKeyStroke(KeyEvent.VK_E, InputEvent.META_DOWN_MASK),
         KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0),
-        KeyStroke.getKeyStroke(KeyEvent.VK_UP, InputEvent.SHIFT_MASK),
-        KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.META_MASK),
-        KeyStroke.getKeyStroke(KeyEvent.VK_E, InputEvent.CTRL_MASK),
-        KeyStroke.getKeyStroke(KeyEvent.VK_EQUALS, InputEvent.META_MASK)
+        KeyStroke.getKeyStroke(KeyEvent.VK_UP, InputEvent.SHIFT_DOWN_MASK),
+        KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.META_DOWN_MASK),
+        KeyStroke.getKeyStroke(KeyEvent.VK_E, InputEvent.CTRL_DOWN_MASK),
+        KeyStroke.getKeyStroke(KeyEvent.VK_EQUALS, InputEvent.META_DOWN_MASK)
     };
 
     static JMenuBar bar;
@@ -57,7 +59,7 @@ public class ActionListenerCalledTwiceTest {
     static volatile int listenerCallCounter = 0;
 
     public static void main(String[] args) throws Exception {
-        if (!Platform.isOSX()) {
+        if (!System.getProperty("os.name").toLowerCase().startsWith("mac")) {
             System.out.println("This test is for MacOS only." +
                     " Automatically passed on other platforms.");
             return;
@@ -82,7 +84,10 @@ public class ActionListenerCalledTwiceTest {
 
             testForTwice(robot, "DefaultMenuBar");
         } finally {
-            SwingUtilities.invokeAndWait(() -> frame.dispose());
+            SwingUtilities.invokeAndWait(() -> {
+                frame.dispose();
+                Desktop.getDesktop().setDefaultMenuBar(null);
+            });
         }
     }
 


### PR DESCRIPTION
This test was failing consistently on same machines and at the same time as #8532.

Test failure is also no longer reproducible after #8320 fix.

This is macOS only test, so corresponding `@requires os.family` tag was added. Testing is green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273573](https://bugs.openjdk.org/browse/JDK-8273573): [macos12] ActionListenerCalledTwiceTest.java fails on macOS 12


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to [9dd14689](https://git.openjdk.java.net/jdk/pull/9003/files/9dd14689c50d6e1230aeca1724c184fcae0bca07)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9003/head:pull/9003` \
`$ git checkout pull/9003`

Update a local copy of the PR: \
`$ git checkout pull/9003` \
`$ git pull https://git.openjdk.java.net/jdk pull/9003/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9003`

View PR using the GUI difftool: \
`$ git pr show -t 9003`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9003.diff">https://git.openjdk.java.net/jdk/pull/9003.diff</a>

</details>
