### PR TITLE
8287101: CDS should check for file truncation for all regions

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1370,12 +1370,10 @@ bool FileMapInfo::init_from_file(int fd) {
 
   _file_offset = header()->header_size(); // accounts for the size of _base_archive_name
 
-  if (is_static()) {
-    // just checking the last region is sufficient since the archive is written
-    // in sequential order
-    size_t len = os::lseek(fd, 0, SEEK_END);
-    FileMapRegion* si = space_at(MetaspaceShared::last_valid_region);
-    // The last space might be empty
+  size_t len = os::lseek(fd, 0, SEEK_END);
+
+  for (int i = 0; i <= MetaspaceShared::last_valid_region; i++) {
+    FileMapRegion* si = space_at(i);
     if (si->file_offset() > len || len - si->file_offset() < si->used()) {
       fail_continue("The shared archive file has been truncated.");
       return false;


### PR DESCRIPTION
Currently, only the `last_valid_region` is checked for file truncation for a CDS archive. If serial GC is used, file truncation is not detected because the `last_valid_region` is empty so `si->file_offset() == 0`. This change is for checking file truncation for all regions.

Also add a test which truncates at the end of the file to trigger the "The shared archive file has been truncated." error.

Testing: tiers 1 and 2, also ran the test case with -XX:+UseSerialGC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287101](https://bugs.openjdk.org/browse/JDK-8287101): CDS should check for file truncation for all regions


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9004/head:pull/9004` \
`$ git checkout pull/9004`

Update a local copy of the PR: \
`$ git checkout pull/9004` \
`$ git pull https://git.openjdk.java.net/jdk pull/9004/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9004`

View PR using the GUI difftool: \
`$ git pr show -t 9004`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9004.diff">https://git.openjdk.java.net/jdk/pull/9004.diff</a>

</details>
