### PR TITLE
8287748: Fix issues in java.lang.foreign package javadoc

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/package-info.java
+++ b/src/java.base/share/classes/java/lang/foreign/package-info.java
@@ -106,15 +106,16 @@
  * we can use the following code:
  *
  * {@snippet lang=java :
- * var linker = Linker.nativeLinker();
+ * Linker linker = Linker.nativeLinker();
+ * SymbolLookup stdlib = linker.defaultLookup();
  * MethodHandle strlen = linker.downcallHandle(
- *     linker.lookup("strlen").get(),
+ *     stdlib.lookup("strlen").get(),
  *     FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS)
  * );
  *
- * try (var session = MemorySession.openConfined()) {
- *     var cString = MemorySegment.allocateNative(5 + 1, session);
- *     cString.setUtf8String("Hello");
+ * try (MemorySession session = MemorySession.openConfined()) {
+ *     MemorySegment cString = MemorySegment.allocateNative(5 + 1, session);
+ *     cString.setUtf8String(0, "Hello");
  *     long len = (long)strlen.invoke(cString); // 5
  * }
  * }


### PR DESCRIPTION
This patch fixes a couple of issues in the package-level javadoc of the foreign API.
I've also dropped uses of `var`, which I think are confusing so early in the game.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287748](https://bugs.openjdk.java.net/browse/JDK-8287748): Fix issues in java.lang.foreign package javadoc


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9005/head:pull/9005` \
`$ git checkout pull/9005`

Update a local copy of the PR: \
`$ git checkout pull/9005` \
`$ git pull https://git.openjdk.java.net/jdk pull/9005/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9005`

View PR using the GUI difftool: \
`$ git pr show -t 9005`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9005.diff">https://git.openjdk.java.net/jdk/pull/9005.diff</a>

</details>
