### PR TITLE
8287753: [spelling] close well-established compounds

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/tree/Tree.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/tree/Tree.java
@@ -613,13 +613,13 @@ public interface Tree {
 
         /**
          * Used for instances of {@link WildcardTree} representing
-         * an extends bounded wildcard type argument.
+         * an upper-bounded wildcard type argument.
          */
         EXTENDS_WILDCARD(WildcardTree.class),
 
         /**
          * Used for instances of {@link WildcardTree} representing
-         * a super bounded wildcard type argument.
+         * a lower-bounded wildcard type argument.
          */
         SUPER_WILDCARD(WildcardTree.class),
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/AnnoConstruct.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/AnnoConstruct.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.ListBuffer;
 
 /**
- * Common super type for annotated constructs such as Types and Symbols.
+ * Common supertype for annotated constructs such as Types and Symbols.
  *
  * This class should *not* contain any fields since it would have a significant
  * impact on the javac memory footprint.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -179,7 +179,7 @@ public class Flags {
     public static final int ANONCONSTR   = 1<<29; //non-class members
 
     /**
-     * Flag to indicate the super classes of this ClassSymbol has been attributed.
+     * Flag to indicate the superclasses of this ClassSymbol has been attributed.
      */
     public static final int SUPER_OWNER_ATTRIBUTED = 1<<29; //ClassSymbols
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1362,7 +1362,7 @@ public class TypeAnnotations {
             scan(tree.typeargs);
             if (tree.def == null) {
                 scan(tree.clazz);
-            } // else super type will already have been scanned in the context of the anonymous class.
+            } // else supertype will already have been scanned in the context of the anonymous class.
             scan(tree.args);
 
             // The class body will already be scanned.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -2524,7 +2524,7 @@ public class Types {
 
             public Type visitType(Type t, Void ignored) {
                 // A note on wildcards: there is no good way to
-                // determine a supertype for a super bounded wildcard.
+                // determine a supertype for a lower-bounded wildcard.
                 return Type.noType;
             }
 
@@ -2786,17 +2786,17 @@ public class Types {
         };
     // </editor-fold>
 
-    // <editor-fold defaultstate="collapsed" desc="sub signature / override equivalence">
+    // <editor-fold defaultstate="collapsed" desc="subsignature / override equivalence">
     /**
-     * Returns true iff the first signature is a <em>sub
-     * signature</em> of the other.  This is <b>not</b> an equivalence
+     * Returns true iff the first signature is a <em>subsignature</em>
+     * of the other.  This is <b>not</b> an equivalence
      * relation.
      *
      * @jls 8.4.2 Method Signature
      * @see #overrideEquivalent(Type t, Type s)
      * @param t first signature (possibly raw).
      * @param s second signature (could be subjected to erasure).
-     * @return true if t is a sub signature of s.
+     * @return true if t is a subsignature of s.
      */
     public boolean isSubSignature(Type t, Type s) {
         return isSubSignature(t, s, true);
@@ -2817,7 +2817,7 @@ public class Types {
      * erasure).
      * @param s a signature (possible raw, could be subjected to
      * erasure).
-     * @return true if either argument is a sub signature of the other.
+     * @return true if either argument is a subsignature of the other.
      */
     public boolean overrideEquivalent(Type t, Type s) {
         return hasSameArgs(t, s) ||

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4555,7 +4555,7 @@ public class Attr extends JCTree.Visitor {
             case TYPEVAR:
                 // Normally, site.getUpperBound() shouldn't be null.
                 // It should only happen during memberEnter/attribBase
-                // when determining the super type which *must* be
+                // when determining the supertype which *must* be
                 // done before attributing the type variables.  In
                 // other words, we are seeing this illegal program:
                 // class B<T> extends A<T.foo> {}

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -4606,7 +4606,7 @@ public class Check {
                         return ; // Don't try to recover
                     }
                 }
-                // Non-Serializable super class
+                // Non-Serializable superclass
                 try {
                     ClassSymbol supertype = ((ClassSymbol)(((DeclaredType)superClass).asElement()));
                     for(var sym : supertype.getEnclosedElements()) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -3778,7 +3778,7 @@ public class Resolve {
                             types.asSuper(env.enclClass.type, c), env.enclClass.sym);
                 }
             }
-            //find a direct super type that is a subtype of 'c'
+            //find a direct supertype that is a subtype of 'c'
             for (Type i : types.directSupertypes(env.enclClass.type)) {
                 if (i.tsym.isSubClass(c, types) && i.tsym != c) {
                     log.error(pos,

--- a/src/jdk.compiler/share/classes/com/sun/tools/sjavac/comp/dependencies/NewDependencyCollector.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/sjavac/comp/dependencies/NewDependencyCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,8 +158,8 @@ public class NewDependencyCollector implements TaskListener {
             }
 
             // The completion dependency graph is not transitively closed for inheritance relations.
-            // For sjavac's purposes however, a class depends on it's super super type, so below we
-            // make sure that we include super types.
+            // For sjavac's purposes however, a class depends on its super-supertype, so below we
+            // make sure that we include supertypes.
             for (ClassSymbol cs : allSupertypes(cnode.getClassSymbol())) {
                 if (isSymbolRelevant(cp, cs)) {
                     fqDeps.add(cs.outermostClass().flatname.toString());

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkInfo.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkInfo.java
@@ -131,7 +131,7 @@ public class HtmlLinkInfo extends LinkInfo {
         EXECUTABLE_MEMBER_PARAM,
 
         /**
-         * Super interface links.
+         * Superinterface links.
          */
         SUPER_INTERFACES,
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
@@ -153,7 +153,7 @@ public class PackageWriterImpl extends HtmlDocletWriter
     private List<PackageElement> findRelatedPackages() {
         String pkgName = packageElement.getQualifiedName().toString();
 
-        // always add super package
+        // always add superpackage
         int lastdot = pkgName.lastIndexOf('.');
         String pkgPrefix = lastdot > 0 ? pkgName.substring(0, lastdot) : null;
         List<PackageElement> packages = new ArrayList<>(
@@ -168,7 +168,7 @@ public class PackageWriterImpl extends HtmlDocletWriter
             packages.addAll(subpackages);
         }
 
-        // only add sibling packages if there is a non-empty super package, we are beneath threshold,
+        // only add sibling packages if there is a non-empty superpackage, we are beneath threshold,
         // and number of siblings is beneath threshold as well
         if (hasSuperPackage && pkgPrefix != null && packages.size() <= MAX_SIBLING_PACKAGES) {
             Pattern siblingPattern = Pattern.compile(pkgPrefix.replace(".", "\\.") + "\\.\\w+");

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/ClassWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/ClassWriter.java
@@ -64,7 +64,7 @@ public interface ClassWriter {
     void addParamInfo(Content target);
 
     /**
-     * Add all super interfaces if this is an interface.
+     * Add all superinterfaces if this is an interface.
      *
      * @param target the content to which the documentation will be added
      */

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/DocletElement.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/DocletElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,7 +112,7 @@ public interface DocletElement extends Element {
     Kind getSubKind();
 
     /**
-     * Sub kind enums that this element supports.
+     * Subkind enums that this element supports.
      */
     enum Kind {
         OVERVIEW, DOCFILE;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/ClassBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/ClassBuilder.java
@@ -170,7 +170,7 @@ public class ClassBuilder extends AbstractBuilder {
     }
 
     /**
-     * If this is an interface, list all super interfaces.
+     * If this is an interface, list all superinterfaces.
      *
      * @param target the content to which the documentation will be added
      */

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/PackageSummaryBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/PackageSummaryBuilder.java
@@ -144,7 +144,7 @@ public class PackageSummaryBuilder extends AbstractBuilder {
     }
 
     /**
-     * Builds a list of "nearby" packages (subpackages, super and sibling packages).
+     * Builds a list of "nearby" packages (subpackages, superpackages, and sibling packages).
      *
      * @param summariesList the list of summaries to which the summary will be added
      */

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -1102,9 +1102,9 @@ public class Utils {
     }
 
     /**
-     * Given a class, return the closest visible super class.
+     * Given a class, return the closest visible superclass.
      * @param type the TypeMirror to be interrogated
-     * @return  the closest visible super class.  Return null if it cannot
+     * @return  the closest visible superclass.  Return null if it cannot
      *          be found.
      */
     public TypeMirror getFirstVisibleSuperClass(TypeMirror type) {
@@ -1113,10 +1113,10 @@ public class Utils {
 
 
     /**
-     * Given a class, return the closest visible super class.
+     * Given a class, return the closest visible superclass.
      *
      * @param te the TypeElement to be interrogated
-     * @return the closest visible super class.  Return null if it cannot
+     * @return the closest visible superclass.  Return null if it cannot
      *         be found.
      */
     public TypeMirror getFirstVisibleSuperClass(TypeElement te) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
@@ -75,7 +75,7 @@ import jdk.javadoc.internal.doclets.toolkit.PropertyUtils;
  * Extra Members: these are members enclosed in an undocumented
  * package-private type element, and may not be linkable (or documented),
  * however, the members of such a type element may be documented, as if
- * declared in the sub type, only if the enclosing type is not being
+ * declared in the subtype, only if the enclosing type is not being
  * documented by a filter such as -public, -protected, etc.
  * <p>
  * Visible Members: these are the members that are "visible"
@@ -205,8 +205,8 @@ public class VisibleMemberTable {
      * sole {@code {@inheritDoc}} or devoid of any API comments.
      * <p>
      * b.The list may contain (extra) members, inherited by inaccessible
-     * super types, primarily package private types. These members are
-     * required to be documented in the subtype when the super type is
+     * supertypes, primarily package private types. These members are
+     * required to be documented in the subtype when the supertype is
      * not documented.
      *
      * @param kind the member kind
@@ -307,12 +307,12 @@ public class VisibleMemberTable {
         // Add this type element first.
         result.add(te);
 
-        // Add the super classes.
+        // Add the superclasses.
         allSuperclasses.stream()
                 .map(vmt -> vmt.te)
                 .forEach(result::add);
 
-        // ... and finally the sorted super interfaces.
+        // ... and finally the sorted superinterfaces.
         allSuperinterfaces.stream()
                 .map(vmt -> vmt.te)
                 .sorted(utils.comparators.makeGeneralPurposeComparator())
@@ -419,7 +419,7 @@ public class VisibleMemberTable {
             VisibleMemberTable vmt = mcache.getVisibleMemberTable(parent);
             allSuperclasses.add(vmt);
             allSuperclasses.addAll(vmt.getAllSuperclasses());
-            // Add direct super interfaces of a super class, if any.
+            // Add direct superinterfaces of a superclass, if any.
             allSuperinterfaces.addAll(vmt.getAllSuperinterfaces());
             parents.add(vmt);
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
@@ -483,10 +483,10 @@ public class ElementsTable {
 
     /**
      * Returns the aggregate set of included packages and specified
-     * sub packages.
+     * subpackages.
      *
      * @return the aggregate set of included packages and specified
-     * sub packages
+     * subpackages
      */
     Iterable<ModulePackage> getPackagesToParse() throws IOException {
         List<ModulePackage> result = new ArrayList<>();


### PR DESCRIPTION
This is a spelling and terminology PR, not a code PR. Rationale for some of the changes are as follows:

* "Subsignature" is mentioned in JLS 8.4.2 Method Signature.
* lower- and upper- bounded wrt `super` and `extends` are mentioned in JLS 4.10.5 Type Projections.
* For "super super class" I used a great-grandparent analogy as I'm unaware of any rules on repeated prefixes in English.
* "subkind" is used on two more occasions a few lines above that change

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287753](https://bugs.openjdk.java.net/browse/JDK-8287753): [spelling] close well-established compounds


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9007/head:pull/9007` \
`$ git checkout pull/9007`

Update a local copy of the PR: \
`$ git checkout pull/9007` \
`$ git pull https://git.openjdk.java.net/jdk pull/9007/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9007`

View PR using the GUI difftool: \
`$ git pr show -t 9007`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9007.diff">https://git.openjdk.java.net/jdk/pull/9007.diff</a>

</details>
