### PR TITLE
8287761: Make the logging of J2DBench stable

### DIFF
--- a/src/demo/share/java2d/J2DBench/src/j2dbench/Result.java
+++ b/src/demo/share/java2d/J2DBench/src/j2dbench/Result.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,11 +40,11 @@
 
 package j2dbench;
 
-import java.util.Vector;
-import java.util.Hashtable;
-import java.util.Enumeration;
 import java.io.PrintWriter;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Vector;
 
 public class Result {
     public static final int RATE_UNKNOWN    = 0;
@@ -243,7 +243,7 @@ public class Result {
     int repsPerRun;
     int unitsPerRep;
     Vector times;
-    Hashtable modifiers;
+    LinkedHashMap modifiers;
     Throwable error;
 
     public Result(Test test) {
@@ -277,7 +277,7 @@ public class Result {
         this.error = t;
     }
 
-    public void setModifiers(Hashtable modifiers) {
+    public void setModifiers(LinkedHashMap modifiers) {
         this.modifiers = modifiers;
     }
 
@@ -297,7 +297,7 @@ public class Result {
         return ((long) getRepsPerRun()) * ((long) getUnitsPerRep());
     }
 
-    public Hashtable getModifiers() {
+    public LinkedHashMap getModifiers() {
         return modifiers;
     }
 
@@ -423,11 +423,11 @@ public class Result {
             System.out.println(test+" averaged "+getAverageString());
         }
         if (true) {
-            Enumeration enum_ = modifiers.keys();
+            Iterator iter_ = modifiers.keySet().iterator();
             System.out.print("    with");
             String sep = " ";
-            while (enum_.hasMoreElements()) {
-                Modifier mod = (Modifier) enum_.nextElement();
+            while (iter_.hasNext()) {
+                Modifier mod = (Modifier) iter_.next();
                 Object v = modifiers.get(mod);
                 System.out.print(sep);
                 System.out.print(mod.getAbbreviatedModifierDescription(v));
@@ -442,9 +442,9 @@ public class Result {
                    "num-reps=\""+getRepsPerRun()+"\" "+
                    "num-units=\""+getUnitsPerRep()+"\" "+
                    "name=\""+test.getTreeName()+"\">");
-        Enumeration enum_ = modifiers.keys();
-        while (enum_.hasMoreElements()) {
-            Modifier mod = (Modifier) enum_.nextElement();
+        Iterator iter_ = modifiers.keySet().iterator();
+        while (iter_.hasNext()) {
+            Modifier mod = (Modifier) iter_.next();
             Object v = modifiers.get(mod);
             String val = mod.getModifierValueName(v);
             pw.println("    <option "+

--- a/src/demo/share/java2d/J2DBench/src/j2dbench/TestEnvironment.java
+++ b/src/demo/share/java2d/J2DBench/src/j2dbench/TestEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,15 +40,15 @@
 
 package j2dbench;
 
+import java.awt.AlphaComposite;
 import java.awt.Canvas;
-import java.awt.Image;
+import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
-import java.awt.Dimension;
-import java.awt.AlphaComposite;
-import java.awt.Color;
+import java.awt.Image;
 import java.awt.Toolkit;
-import java.util.Hashtable;
+import java.util.LinkedHashMap;
 
 import j2dbench.tests.GraphicsTests;
 
@@ -105,12 +105,12 @@ public class TestEnvironment implements Node.Visitor {
     Image srcImage;
     boolean stopped;
     ResultSet results;
-    Hashtable modifiers;
+    LinkedHashMap modifiers;
     Timer timer;
 
     public TestEnvironment() {
         results = new ResultSet();
-        modifiers = new Hashtable();
+        modifiers = new LinkedHashMap();
         timer = Timer.getImpl();
     }
 
@@ -246,8 +246,8 @@ public class TestEnvironment implements Node.Visitor {
         modifiers.remove(o);
     }
 
-    public Hashtable getModifiers() {
-        return (Hashtable) modifiers.clone();
+    public LinkedHashMap getModifiers() {
+        return (LinkedHashMap) modifiers.clone();
     }
 
     public void record(Result result) {


### PR DESCRIPTION
Currently, the logging of the J2DBench differs from run to run. Each time the order of the parameters is random.

For example:
First run: `with to Default Frame, bounce, 1x1, SrcOver, ident, !extraalpha, !xormode, !clip, Default, from transvolimg translucent, !touchsrc, Nearest neighbor`
Next run: `with SrcOver, bounce, Nearest neighbor, ident, !touchsrc, to CompatImage(Opaque), Default, 1x1, !xormode, !clip, from bmcompatimg bitmask, !extraalpha
`
The root cause is that the options are stored in the Hashtable and printed in the "random" order. 

The fix replaces the usage of Hashtable by the LinkedHashMap. The code is tested on jdk1.7 and -source/-target 1.4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287761](https://bugs.openjdk.java.net/browse/JDK-8287761): Make the logging of J2DBench stable


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - Committer)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9008/head:pull/9008` \
`$ git checkout pull/9008`

Update a local copy of the PR: \
`$ git checkout pull/9008` \
`$ git pull https://git.openjdk.java.net/jdk pull/9008/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9008`

View PR using the GUI difftool: \
`$ git pr show -t 9008`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9008.diff">https://git.openjdk.java.net/jdk/pull/9008.diff</a>

</details>
