### PR TITLE
8287764: runtime/cds/serviceability/ReplaceCriticalClasses failed on localized Windows

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClasses.java
+++ b/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClasses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,7 +100,6 @@ public class ReplaceCriticalClasses {
             // classes even when CDS is enabled. Nothing bad should happen.
             "-notshared java/util/Locale",
             "-notshared sun/util/locale/BaseLocale",
-            "-notshared java/lang/Readable",
         };
         return tests;
     }


### PR DESCRIPTION
The ReplaceCriticalClasses verifies CDS behavior when replacing the Readable interface as an example of a class that is read after JVMTI_PHASE_PRIMORDIAL.
However, the order in which classes are loaded is affected by the language of the test environment, so the timing at which the Readable interface is loaded also changes on Windows with multibyte characters.
Therefore, the Readable interface is not suitable for this test and should be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287764](https://bugs.openjdk.java.net/browse/JDK-8287764): runtime/cds/serviceability/ReplaceCriticalClasses failed on localized Windows


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9009/head:pull/9009` \
`$ git checkout pull/9009`

Update a local copy of the PR: \
`$ git checkout pull/9009` \
`$ git pull https://git.openjdk.java.net/jdk pull/9009/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9009`

View PR using the GUI difftool: \
`$ git pr show -t 9009`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9009.diff">https://git.openjdk.java.net/jdk/pull/9009.diff</a>

</details>
