### PR TITLE
8287745 jni/nullCaller/NullCallerTest.java fails with "exitValue = 1"

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -62,8 +62,9 @@ ifeq ($(call isTargetOs, windows), true)
   WIN_LIB_JLI := $(SUPPORT_OUTPUTDIR)/native/java.base/libjli/jli.lib
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeJliLaunchTest := $(WIN_LIB_JLI)
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeCallerAccessTest := jvm.lib
-  BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerTest := jvm.lib
+  BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerTest := $(LIBCXX) jvm.lib
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exerevokeall := advapi32.lib
+  BUILD_JDK_JTREG_EXECUTABLES_CFLAGS_exeNullCallerTest := /EHsc
   BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libAsyncStackWalk := /EHsc
   BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libAsyncInvokers := /EHsc
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerUnnamed := /EHsc
@@ -90,7 +91,7 @@ else
   endif
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeJliLaunchTest := -ljli
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeCallerAccessTest := -ljvm
-  BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerTest := -ljvm
+  BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerTest := $(LIBCXX) -ljvm
 endif
 
 ifeq ($(call isTargetOs, macosx), true)

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -494,7 +494,6 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java        8151492 generic-
 java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-x64
 java/lang/invoke/RicochetTest.java                              8251969 generic-all
-jni/nullCaller/NullCallerTest.java                              8287745 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Fixed JtregNativeJdk.gmk to include c++ libs for NullCallerTest

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287745](https://bugs.openjdk.java.net/browse/JDK-8287745): jni/nullCaller/NullCallerTest.java fails with "exitValue = 1"


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9010/head:pull/9010` \
`$ git checkout pull/9010`

Update a local copy of the PR: \
`$ git checkout pull/9010` \
`$ git pull https://git.openjdk.java.net/jdk pull/9010/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9010`

View PR using the GUI difftool: \
`$ git pr show -t 9010`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9010.diff">https://git.openjdk.java.net/jdk/pull/9010.diff</a>

</details>
