### PR TITLE
8287743: javax/swing/text/CSSBorder/6796710/bug6796710.java failed

### DIFF
--- a/test/jdk/javax/swing/text/CSSBorder/6796710/bug6796710.java
+++ b/test/jdk/javax/swing/text/CSSBorder/6796710/bug6796710.java
@@ -73,7 +73,7 @@ public class bug6796710 {
     private static JFrame frame;
 
     private static JPanel pnBottom;
-    private static final int COLORTOLERANCE = 5;
+    private static final int COLOR_TOLERANCE = 5;
 
     public static void main(String[] args) throws Exception {
         robot = new Robot();
@@ -158,9 +158,9 @@ public class bug6796710 {
                 int blue2 = bufCol1.getBlue();
                 int green2 = bufCol1.getGreen();
 
-                if ((Math.abs(red1 - red2) > COLORTOLERANCE) ||
-                    (Math.abs(green1 - green2) > COLORTOLERANCE) ||
-                    (Math.abs(blue1 - blue2) > COLORTOLERANCE)) {
+                if ((Math.abs(red1 - red2) > COLOR_TOLERANCE) ||
+                    (Math.abs(green1 - green2) > COLOR_TOLERANCE) ||
+                    (Math.abs(blue1 - blue2) > COLOR_TOLERANCE)) {
                         System.out.println("x "+ x + " y " + y +
                             " rgb1: " + bufCol0 +
                             " rgb2: " + bufCol1);

--- a/test/jdk/javax/swing/text/CSSBorder/6796710/bug6796710.java
+++ b/test/jdk/javax/swing/text/CSSBorder/6796710/bug6796710.java
@@ -32,6 +32,7 @@
  */
 
 import java.awt.BorderLayout;
+import java.awt.Color;
 import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.image.BufferedImage;
@@ -126,13 +127,49 @@ public class bug6796710 {
         Thread.sleep(1000);
 
         BufferedImage pnBottomImage = getPnBottomImage();
-        if (!Util.compareBufferedImages(bufferedImage, pnBottomImage)) {
+        if (!compareBufferedImages(bufferedImage, pnBottomImage)) {
             ImageIO.write(bufferedImage, "png", new File("bufferedImage.png"));
             ImageIO.write(pnBottomImage, "png", new File("pnBottomImage.png"));
             throw new RuntimeException("The test failed");
         }
 
         System.out.println("The test bug6796710 passed.");
+    }
+
+    public static boolean compareBufferedImages(BufferedImage bufferedImage0, BufferedImage bufferedImage1) {
+        int width = bufferedImage0.getWidth();
+        int height = bufferedImage0.getHeight();
+        int colorTolerance = 5;
+
+        if (width != bufferedImage1.getWidth() || height != bufferedImage1.getHeight()) {
+            return false;
+        }
+
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                Color bufCol0 = new Color(bufferedImage0.getRGB(x, y));
+                Color bufCol1 = new Color(bufferedImage1.getRGB(x, y));
+
+                int red1 = bufCol0.getRed();
+                int blue1 = bufCol0.getBlue();
+                int green1 = bufCol0.getGreen();
+
+                int red2 = bufCol1.getRed();
+                int blue2 = bufCol1.getBlue();
+                int green2 = bufCol1.getGreen();
+
+                if ((Math.abs(red1 - red2) > colorTolerance) ||
+                    (Math.abs(green1 - green2) > colorTolerance) ||
+                    (Math.abs(blue1 - blue2) > colorTolerance)) {
+                        System.out.println("x "+ x + " y " + y +
+                            " rgb1: " + Integer.toHexString(bufferedImage0.getRGB(x, y)) +
+                            " rgb2: " + Integer.toHexString(bufferedImage1.getRGB(x, y)));
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     private static BufferedImage getPnBottomImage() {

--- a/test/jdk/javax/swing/text/CSSBorder/6796710/bug6796710.java
+++ b/test/jdk/javax/swing/text/CSSBorder/6796710/bug6796710.java
@@ -36,6 +36,7 @@ import java.awt.Color;
 import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.image.BufferedImage;
+import java.awt.image.MultiResolutionImage;
 import java.io.File;
 
 import javax.imageio.ImageIO;
@@ -127,7 +128,7 @@ public class bug6796710 {
         Thread.sleep(1000);
 
         BufferedImage pnBottomImage = getPnBottomImage();
-        if (!compareBufferedImages(bufferedImage, pnBottomImage)) {
+        if (!Util.compareBufferedImages(bufferedImage, pnBottomImage)) {
             ImageIO.write(bufferedImage, "png", new File("bufferedImage.png"));
             ImageIO.write(pnBottomImage, "png", new File("pnBottomImage.png"));
             throw new RuntimeException("The test failed");
@@ -136,47 +137,13 @@ public class bug6796710 {
         System.out.println("The test bug6796710 passed.");
     }
 
-    public static boolean compareBufferedImages(BufferedImage bufferedImage0, BufferedImage bufferedImage1) {
-        int width = bufferedImage0.getWidth();
-        int height = bufferedImage0.getHeight();
-        int colorTolerance = 5;
-
-        if (width != bufferedImage1.getWidth() || height != bufferedImage1.getHeight()) {
-            return false;
-        }
-
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                Color bufCol0 = new Color(bufferedImage0.getRGB(x, y));
-                Color bufCol1 = new Color(bufferedImage1.getRGB(x, y));
-
-                int red1 = bufCol0.getRed();
-                int blue1 = bufCol0.getBlue();
-                int green1 = bufCol0.getGreen();
-
-                int red2 = bufCol1.getRed();
-                int blue2 = bufCol1.getBlue();
-                int green2 = bufCol1.getGreen();
-
-                if ((Math.abs(red1 - red2) > colorTolerance) ||
-                    (Math.abs(green1 - green2) > colorTolerance) ||
-                    (Math.abs(blue1 - blue2) > colorTolerance)) {
-                        System.out.println("x "+ x + " y " + y +
-                            " rgb1: " + Integer.toHexString(bufferedImage0.getRGB(x, y)) +
-                            " rgb2: " + Integer.toHexString(bufferedImage1.getRGB(x, y)));
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    }
-
     private static BufferedImage getPnBottomImage() {
         Rectangle rect = pnBottom.getBounds();
 
         Util.convertRectToScreen(rect, pnBottom.getParent());
 
-        return robot.createScreenCapture(rect);
+        MultiResolutionImage img = robot.createMultiResolutionScreenCapture(rect);
+        return (BufferedImage)img.getResolutionVariant(rect.width, rect.height);
+        //return robot.createScreenCapture(rect);
     }
 }

--- a/test/jdk/javax/swing/text/CSSBorder/6796710/bug6796710.java
+++ b/test/jdk/javax/swing/text/CSSBorder/6796710/bug6796710.java
@@ -128,7 +128,7 @@ public class bug6796710 {
         Thread.sleep(1000);
 
         BufferedImage pnBottomImage = getPnBottomImage();
-        if (!Util.compareBufferedImages(bufferedImage, pnBottomImage)) {
+        if (!compareBufferedImages(bufferedImage, pnBottomImage)) {
             ImageIO.write(bufferedImage, "png", new File("bufferedImage.png"));
             ImageIO.write(pnBottomImage, "png", new File("pnBottomImage.png"));
             throw new RuntimeException("The test failed");
@@ -137,13 +137,48 @@ public class bug6796710 {
         System.out.println("The test bug6796710 passed.");
     }
 
+    public static boolean compareBufferedImages(BufferedImage bufferedImage0, BufferedImage bufferedImage1) {
+        int width = bufferedImage0.getWidth();
+        int height = bufferedImage0.getHeight();
+        int colorTolerance = 5;
+
+        if (width != bufferedImage1.getWidth() || height != bufferedImage1.getHeight()) {
+            return false;
+        }
+
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                Color bufCol0 = new Color(bufferedImage0.getRGB(x, y));
+                Color bufCol1 = new Color(bufferedImage1.getRGB(x, y));
+
+                int red1 = bufCol0.getRed();
+                int blue1 = bufCol0.getBlue();
+                int green1 = bufCol0.getGreen();
+
+                int red2 = bufCol1.getRed();
+                int blue2 = bufCol1.getBlue();
+                int green2 = bufCol1.getGreen();
+
+                if ((Math.abs(red1 - red2) > colorTolerance) ||
+                    (Math.abs(green1 - green2) > colorTolerance) ||
+                    (Math.abs(blue1 - blue2) > colorTolerance)) {
+                        System.out.println("x "+ x + " y " + y +
+                            " rgb1: " + Integer.toHexString(bufferedImage0.getRGB(x, y)) +
+                            " rgb2: " + Integer.toHexString(bufferedImage1.getRGB(x, y)));
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
     private static BufferedImage getPnBottomImage() {
         Rectangle rect = pnBottom.getBounds();
 
         Util.convertRectToScreen(rect, pnBottom.getParent());
 
-        MultiResolutionImage img = robot.createMultiResolutionScreenCapture(rect);
-        return (BufferedImage)img.getResolutionVariant(rect.width, rect.height);
-        //return robot.createScreenCapture(rect);
+        return robot.createScreenCapture(rect);
+
     }
 }

--- a/test/jdk/javax/swing/text/CSSBorder/6796710/bug6796710.java
+++ b/test/jdk/javax/swing/text/CSSBorder/6796710/bug6796710.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,6 +74,7 @@ public class bug6796710 {
     private static JFrame frame;
 
     private static JPanel pnBottom;
+    private static final int COLORTOLERANCE = 5;
 
     public static void main(String[] args) throws Exception {
         robot = new Robot();
@@ -140,7 +141,6 @@ public class bug6796710 {
     public static boolean compareBufferedImages(BufferedImage bufferedImage0, BufferedImage bufferedImage1) {
         int width = bufferedImage0.getWidth();
         int height = bufferedImage0.getHeight();
-        int colorTolerance = 5;
 
         if (width != bufferedImage1.getWidth() || height != bufferedImage1.getHeight()) {
             return false;
@@ -159,12 +159,12 @@ public class bug6796710 {
                 int blue2 = bufCol1.getBlue();
                 int green2 = bufCol1.getGreen();
 
-                if ((Math.abs(red1 - red2) > colorTolerance) ||
-                    (Math.abs(green1 - green2) > colorTolerance) ||
-                    (Math.abs(blue1 - blue2) > colorTolerance)) {
+                if ((Math.abs(red1 - red2) > COLORTOLERANCE) ||
+                    (Math.abs(green1 - green2) > COLORTOLERANCE) ||
+                    (Math.abs(blue1 - blue2) > COLORTOLERANCE)) {
                         System.out.println("x "+ x + " y " + y +
-                            " rgb1: " + Integer.toHexString(bufferedImage0.getRGB(x, y)) +
-                            " rgb2: " + Integer.toHexString(bufferedImage1.getRGB(x, y)));
+                            " rgb1: " + bufCol0 +
+                            " rgb2: " + bufCol1);
                     return false;
                 }
             }
@@ -179,6 +179,5 @@ public class bug6796710 {
         Util.convertRectToScreen(rect, pnBottom.getParent());
 
         return robot.createScreenCapture(rect);
-
     }
 }

--- a/test/jdk/javax/swing/text/CSSBorder/6796710/bug6796710.java
+++ b/test/jdk/javax/swing/text/CSSBorder/6796710/bug6796710.java
@@ -36,7 +36,6 @@ import java.awt.Color;
 import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.image.BufferedImage;
-import java.awt.image.MultiResolutionImage;
 import java.io.File;
 
 import javax.imageio.ImageIO;


### PR DESCRIPTION
Test is failing in iMac CI systems owing to color difference of 1

`x 0 y 0 rgb1: fff0f0f0 rgb2: fff0eff0`

Added minor color tolerance check. CI testing is green

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287743](https://bugs.openjdk.org/browse/JDK-8287743): javax/swing/text/CSSBorder/6796710/bug6796710.java failed


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9011/head:pull/9011` \
`$ git checkout pull/9011`

Update a local copy of the PR: \
`$ git checkout pull/9011` \
`$ git pull https://git.openjdk.org/jdk pull/9011/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9011`

View PR using the GUI difftool: \
`$ git pr show -t 9011`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9011.diff">https://git.openjdk.org/jdk/pull/9011.diff</a>

</details>
