### PR TITLE
8287785: Reduce runtime of java.lang.invoke microbenchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/invoke/CallSiteSetTarget.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/CallSiteSetTarget.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.CallSite;
 import java.lang.invoke.MethodHandle;
@@ -46,6 +49,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class CallSiteSetTarget {
 
     /*

--- a/test/micro/org/openjdk/bench/java/lang/invoke/CallSiteSetTargetSelf.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/CallSiteSetTargetSelf.java
@@ -24,10 +24,13 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.CallSite;
 import java.lang.invoke.MethodHandle;
@@ -43,6 +46,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class CallSiteSetTargetSelf {
 
     /*

--- a/test/micro/org/openjdk/bench/java/lang/invoke/CallSiteStable.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/CallSiteStable.java
@@ -24,10 +24,13 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.ConstantCallSite;
 import java.lang.invoke.MethodHandle;
@@ -43,6 +46,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class CallSiteStable {
 
     /*

--- a/test/micro/org/openjdk/bench/java/lang/invoke/LookupAcquire.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/LookupAcquire.java
@@ -48,17 +48,6 @@ import java.util.concurrent.TimeUnit;
 @Fork(3)
 public class LookupAcquire {
 
-    /*
-       This test assesses acquiring lookup object only
-     */
-
-    public static MethodHandles.Lookup cached;
-
-    @Setup
-    public void setup() {
-        cached = MethodHandles.lookup();
-    }
-
     @Benchmark
     public MethodHandles.Lookup testPublicLookup() throws Exception {
         return MethodHandles.publicLookup();

--- a/test/micro/org/openjdk/bench/java/lang/invoke/LookupAcquire.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/LookupAcquire.java
@@ -25,11 +25,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandles;
 import java.util.concurrent.TimeUnit;
@@ -40,14 +43,13 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class LookupAcquire {
 
     /*
-        Implementation notes:
-            - this test assesses acquiring lookup object only
-            - baseline includes returning cached lookup object, i.e. measures infra overheads
-            - additional baseline includes allocating object to understand Lookup instantiation costs
-            - cached instance is static, because that provides (unbeatably) best performance
+       This test assesses acquiring lookup object only
      */
 
     public static MethodHandles.Lookup cached;
@@ -58,16 +60,6 @@ public class LookupAcquire {
     }
 
     @Benchmark
-    public MethodHandles.Lookup baselineCached() throws Exception {
-        return cached;
-    }
-
-    @Benchmark
-    public MyLookup baselineNew() throws Exception {
-        return new MyLookup(Object.class, 1);
-    }
-
-    @Benchmark
     public MethodHandles.Lookup testPublicLookup() throws Exception {
         return MethodHandles.publicLookup();
     }
@@ -75,20 +67,5 @@ public class LookupAcquire {
     @Benchmark
     public MethodHandles.Lookup testLookup() throws Exception {
         return MethodHandles.lookup();
-    }
-
-    /**
-     * Dummy Lookup-looking class.
-     * Lookup is final, and all constructors are private.
-     * This class mocks the hotpath.
-     */
-    private static class MyLookup {
-        private final Class<?> klass;
-        private final int mode;
-
-        public MyLookup(Class<?> klass, int i) {
-            this.klass = klass;
-            this.mode = i;
-        }
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/invoke/LookupDefaultFind.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/LookupDefaultFind.java
@@ -25,10 +25,13 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class LookupDefaultFind {
 
     /*

--- a/test/micro/org/openjdk/bench/java/lang/invoke/LookupPublicFind.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/LookupPublicFind.java
@@ -25,10 +25,13 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class LookupPublicFind {
 
     /*

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleAsCollector.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleAsCollector.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandleAsCollector {
 
     /*
@@ -61,7 +67,7 @@ public class MethodHandleAsCollector {
     public void setup() throws IllegalAccessException, NoSuchMethodException {
         mh = MethodHandles.lookup().findVirtual(MethodHandleAsCollector.class, "doWork", MethodType.methodType(void.class, int[].class));
         collectorMH = mh.asCollector(int[].class, 5);
-        cachedArgs = new int[]{1, 2, 3, 4, 5};
+        cachedArgs = new int[]{ 1, 2, 3, 4, 5 };
     }
 
     @Benchmark
@@ -76,7 +82,7 @@ public class MethodHandleAsCollector {
 
     @Benchmark
     public void baselineRaw() throws Throwable {
-        doWork(new int[] { 1, 2, 3, 4, 5});
+        doWork(1, 2, 3, 4, 5);
     }
 
     @Benchmark
@@ -94,7 +100,7 @@ public class MethodHandleAsCollector {
         collectorMH.invokeExact(this, 1, 2, 3, 4, 5);
     }
 
-    public void doWork(int[] args) {
+    public void doWork(int... args) {
         for (int a : args) {
             i += a;
         }

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleAsSpreader.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleAsSpreader.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -41,15 +44,15 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandleAsSpreader {
 
     /*
     * Implementation notes:
-    *   - simple array-parameter method is being called
-    *   - baselineRaw calls method directly with dynamically instantiating the array
-    *   - baselineCached calls method directly with pre-cached array
-    *   - additional testCreate() test harnesses the collector acquisition performance
-    *   - testCollector() can be faster than both baselines: it can wrapping array at all
+    *   - simple five parameter method is being called using MH.asSpreader
+    *   - baselineMH invokes method directly without going through spreader
     */
 
     public int i;
@@ -67,11 +70,6 @@ public class MethodHandleAsSpreader {
     @Benchmark
     public void baselineMH() throws Throwable {
         mh.invokeExact(this, 1, 2, 3, 4, 5);
-    }
-
-    @Benchmark
-    public void baselineRaw() throws Throwable {
-        doWork(1, 2, 3, 4, 5);
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleAsVarargsCollector.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleAsVarargsCollector.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -41,15 +44,16 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandleAsVarargsCollector {
 
     /*
     * Implementation notes:
-    *   - simple array-parameter method is being called
-    *   - baselineRaw calls method directly with dynamically instantiating the array
-    *   - baselineCached calls method directly with pre-cached array
+    *   - simple array-parameter method is being called using MH.asVarargsCollector
     *   - additional testCreate() test harnesses the collector acquisition performance
-    *   - testCollector() can be faster than both baselines: it can wrapping array at all
+    *   - testCollector() can be faster than both baselines: it can elide wrapping array at all
     */
 
     public int i;
@@ -72,16 +76,6 @@ public class MethodHandleAsVarargsCollector {
     @Benchmark
     public void baselineMHCached() throws Throwable {
         mh.invoke(this, cachedArgs);
-    }
-
-    @Benchmark
-    public void baselineRaw() throws Throwable {
-        doWork(1, 2, 3, 4, 5);
-    }
-
-    @Benchmark
-    public void baselineRawCached() throws Throwable {
-        doWork(cachedArgs);
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleBasicInvoke.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleBasicInvoke.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -42,13 +45,14 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandleBasicInvoke {
 
     /*
      * Implementation notes:
      *   - this is a very basic test, does not do any parameter conversion (in fact, no parameters at all)
-     *   - baselines include calling method directly, and doing the same via reflection
-     *   - baselineRaw is known to be super-fast with good inlining
      */
 
     private int i;
@@ -64,11 +68,6 @@ public class MethodHandleBasicInvoke {
         ref.setAccessible(true);
 
         mhUnreflect = MethodHandles.lookup().unreflect(ref);
-    }
-
-    @Benchmark
-    public int baselineRaw() throws Throwable {
-        return doWork();
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleBindToBinding.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleBindToBinding.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandleBindToBinding {
 
     /*
@@ -58,11 +64,6 @@ public class MethodHandleBindToBinding {
     public void setup() throws Throwable {
         mhOrig = MethodHandles.lookup().findStatic(MethodHandleBindToBinding.class, "doWork",
                 MethodType.methodType(Integer.class, Integer.class, Integer.class, Integer.class));
-    }
-
-    @Benchmark
-    public Object baselineRaw() {
-        return mhOrig;
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleBindToCurry.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleBindToCurry.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandleBindToCurry {
 
     /*

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleConvertBoxing.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleConvertBoxing.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -42,6 +45,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandleConvertBoxing {
 
     /*

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleConvertCast.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleConvertCast.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -42,6 +45,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandleConvertCast {
 
     /*

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleConvertReturnPrimitive.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleConvertReturnPrimitive.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -42,6 +45,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandleConvertReturnPrimitive {
 
     /*

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleConvertReturnReference.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleConvertReturnReference.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -42,6 +45,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandleConvertReturnReference {
 
     /*

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleConvertReturnVoid.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleConvertReturnVoid.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -42,6 +45,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandleConvertReturnVoid {
 
     /*

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleConvertUnboxing.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleConvertUnboxing.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -42,6 +45,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandleConvertUnboxing {
 
     /*

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleConvertWidening.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleConvertWidening.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -42,6 +45,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandleConvertWidening {
 
     /*

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleInvokeWithArgs.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleInvokeWithArgs.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandleInvokeWithArgs {
 
     /*

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleProxiesAsIFInstance.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleProxiesAsIFInstance.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandleProxies;
@@ -42,6 +45,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandleProxiesAsIFInstance {
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleProxiesSuppl.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandleProxiesSuppl.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandleProxies;
@@ -44,6 +47,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandleProxiesSuppl {
 
     /*
@@ -57,11 +63,6 @@ public class MethodHandleProxiesSuppl {
     public void setup() throws Throwable {
         MethodHandle target = MethodHandles.lookup().findStatic(MethodHandleProxiesSuppl.class, "doWork", MethodType.methodType(int.class, int.class));
         instance = MethodHandleProxies.asInterfaceInstance(Doable.class, target);
-    }
-
-    @Benchmark
-    public Object baselineReturn() {
-        return instance;
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesArrayElementGetter.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesArrayElementGetter.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -42,6 +45,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandlesArrayElementGetter {
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesArrayElementSetter.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesArrayElementSetter.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -42,6 +45,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandlesArrayElementSetter {
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesCatchException.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesCatchException.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandlesCatchException {
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesConstant.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -40,30 +43,21 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandlesConstant {
 
     private MethodHandle mh;
-    private Integer cachedInt;
 
     @Setup
     public void setup() {
-        cachedInt = 42;
         mh = MethodHandles.constant(Integer.class, 42);
-    }
-
-    @Benchmark
-    public Integer baselineReturn() {
-        return cachedInt;
     }
 
     @Benchmark
     public MethodHandle interCreate() throws Throwable {
         return MethodHandles.constant(Integer.class, 42);
-    }
-
-    @Benchmark
-    public MethodHandle interCreateCached() throws Throwable {
-        return MethodHandles.constant(Integer.class, cachedInt);
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesDropArguments.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesDropArguments.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandlesDropArguments {
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesExactInvoker.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesExactInvoker.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandlesExactInvoker {
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesFilterArgs.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesFilterArgs.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandlesFilterArgs {
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesFilterReturn.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesFilterReturn.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandlesFilterReturn {
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesFoldArguments.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesFoldArguments.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandlesFoldArguments {
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesGuardWithTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesGuardWithTest.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandlesGuardWithTest {
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesIdentity.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesIdentity.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -40,6 +43,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandlesIdentity {
 
     private MethodHandle mh;
@@ -49,16 +55,6 @@ public class MethodHandlesIdentity {
     public void setup() {
         cachedArg = new Object();
         mh = MethodHandles.identity(Object.class);
-    }
-
-    @Benchmark
-    public Object baselineRaw() throws Throwable {
-        return new Object();
-    }
-
-    @Benchmark
-    public Object baselineRawCached() throws Throwable {
-        return cachedArg;
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesInsertArguments.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesInsertArguments.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandlesInsertArguments {
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesInvoker.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesInvoker.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandlesInvoker {
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesPermuteArguments.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesPermuteArguments.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandlesPermuteArguments {
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesSpreadInvoker.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesSpreadInvoker.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandlesSpreadInvoker {
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesThrowException.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesThrowException.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -40,6 +43,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodHandlesThrowException {
 
     /**
@@ -61,16 +67,7 @@ public class MethodHandlesThrowException {
     }
 
     @Benchmark
-    public int baselineRaw() {
-        try {
-            throw new MyException();
-        } catch (MyException my) {
-            return my.getFlag();
-        }
-    }
-
-    @Benchmark
-    public int baselineRawCached() {
+    public int baselineThrow() {
         try {
             throw cachedException;
         } catch (MyException my) {
@@ -80,16 +77,6 @@ public class MethodHandlesThrowException {
 
     @Benchmark
     public int testInvoke() throws Throwable {
-        try {
-            mh.invoke(new MyException());
-            throw new IllegalStateException("Should throw exception");
-        } catch (MyException my) {
-            return my.getFlag();
-        }
-    }
-
-    @Benchmark
-    public int testInvokeCached() throws Throwable {
         try {
             mh.invoke(cachedException);
             throw new IllegalStateException("Should throw exception");

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeAcquire.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeAcquire.java
@@ -42,8 +42,8 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
-@Warmup(iterations = 10, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
-@Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(3)
 public class MethodTypeAcquire {
 
@@ -55,11 +55,6 @@ public class MethodTypeAcquire {
     @Setup
     public void setup() {
         pTypes = MethodType.methodType(A.class, B.class);
-    }
-
-    @Benchmark
-    public MethodType baselineRaw() {
-        return pTypes;
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeAppendParams.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeAppendParams.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodType;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +42,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodTypeAppendParams {
 
     /**
@@ -52,11 +58,6 @@ public class MethodTypeAppendParams {
     @Setup
     public void setup() {
         mt = MethodType.methodType(void.class, int.class);
-    }
-
-    @Benchmark
-    public MethodType baselineRaw() {
-        return mt;
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeChangeParam.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeChangeParam.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodType;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +42,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodTypeChangeParam {
 
     private MethodType mt;
@@ -46,11 +52,6 @@ public class MethodTypeChangeParam {
     @Setup
     public void setup() {
         mt = MethodType.methodType(void.class, int.class, int.class);
-    }
-
-    @Benchmark
-    public MethodType baselineRaw() {
-        return mt;
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeChangeReturn.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeChangeReturn.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodType;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +42,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodTypeChangeReturn {
 
     private MethodType mt;
@@ -46,11 +52,6 @@ public class MethodTypeChangeReturn {
     @Setup
     public void setup() {
         mt = MethodType.methodType(void.class, int.class, int.class);
-    }
-
-    @Benchmark
-    public MethodType baselineRaw() {
-        return mt;
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeDropParams.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeDropParams.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodType;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +42,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodTypeDropParams {
 
     private MethodType mt;
@@ -46,11 +52,6 @@ public class MethodTypeDropParams {
     @Setup
     public void setup() {
         mt = MethodType.methodType(void.class, int.class, int.class, int.class);
-    }
-
-    @Benchmark
-    public MethodType baselineRaw() {
-        return mt;
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeGenerify.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeGenerify.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodType;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +42,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodTypeGenerify {
 
     private MethodType mt;
@@ -46,11 +52,6 @@ public class MethodTypeGenerify {
     @Setup
     public void setup() {
         mt = MethodType.methodType(void.class, int.class, Integer.class);
-    }
-
-    @Benchmark
-    public MethodType baselineRaw() {
-        return mt;
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeInsertParams.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeInsertParams.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodType;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +42,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodTypeInsertParams {
 
     private MethodType mt;
@@ -46,11 +52,6 @@ public class MethodTypeInsertParams {
     @Setup
     public void setup() {
         mt = MethodType.methodType(void.class, int.class);
-    }
-
-    @Benchmark
-    public MethodType baselineRaw() {
-        return mt;
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/invoke/SwitchPointAdhoc.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/SwitchPointAdhoc.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.CallSite;
 import java.lang.invoke.MethodHandle;
@@ -44,6 +47,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class SwitchPointAdhoc {
 
     /*

--- a/test/micro/org/openjdk/bench/java/lang/invoke/SwitchPointGuard.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/SwitchPointGuard.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.*;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +42,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class SwitchPointGuard {
 
     /*


### PR DESCRIPTION
- Add explicit run configurations to java.lang.invoke micros, aiming to reduce runtime while maintaining a decently high confidence that there's enough warmup to produce good enough data.

- Remove several trivial baseline micros, mainly those that only return a static object: It's reasonable to have baseline microbenchmarks when the baseline op is complex and you're mostly interested in checking the overhead of doing the same thing via some MH API, but blackhole operations are now shortcutting very quickly and timings doesn't differ from one type of object to another, so we don't need a multitude of such baseline tests.

Estimated runtime of `make test TEST=micro:java.lang.micro` (excluding build) drops from just above 28 to just above 3 hours.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287785](https://bugs.openjdk.java.net/browse/JDK-8287785): Reduce runtime of java.lang.invoke microbenchmarks


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9012/head:pull/9012` \
`$ git checkout pull/9012`

Update a local copy of the PR: \
`$ git checkout pull/9012` \
`$ git pull https://git.openjdk.java.net/jdk pull/9012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9012`

View PR using the GUI difftool: \
`$ git pr show -t 9012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9012.diff">https://git.openjdk.java.net/jdk/pull/9012.diff</a>

</details>
