### PR TITLE
8287798: Reduce runtime of java.lang.reflect/runtime microbenchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/reflect/Clazz.java
+++ b/test/micro/org/openjdk/bench/java/lang/reflect/Clazz.java
@@ -28,11 +28,17 @@ import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class Clazz {
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/reflect/ClazzWithSecurityManager.java
+++ b/test/micro/org/openjdk/bench/java/lang/reflect/ClazzWithSecurityManager.java
@@ -32,17 +32,22 @@ import java.net.URISyntaxException;
 import java.security.NoSuchAlgorithmException;
 import java.security.Policy;
 import java.security.URIParameter;
+import java.util.concurrent.TimeUnit;
 
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 /**
  * Reflection benchmark
- *
- * @author sfriberg
  */
 @State(Scope.Benchmark)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class ClazzWithSecurityManager extends Clazz {
 
     @SuppressWarnings("removal")

--- a/test/micro/org/openjdk/bench/java/lang/reflect/MethodInvoke.java
+++ b/test/micro/org/openjdk/bench/java/lang/reflect/MethodInvoke.java
@@ -25,11 +25,14 @@ package org.openjdk.bench.java.lang.reflect;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -43,6 +46,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class MethodInvoke {
 
     private Method staticMeth_0;

--- a/test/micro/org/openjdk/bench/java/lang/runtime/ObjectMethods.java
+++ b/test/micro/org/openjdk/bench/java/lang/runtime/ObjectMethods.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.runtime;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class ObjectMethods {
     record R0() {}
     record R1(int i) {}


### PR DESCRIPTION
Add explicit run configurations to java.lang.reflect and .runtime micros, aiming to reduce runtime while maintaining a decently high confidence that there's enough warmup to produce good enough data.

Roughly halves runtime of running `java.lang.reflect\|java.lang.runtime` from 159 to 78 minutes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287798](https://bugs.openjdk.java.net/browse/JDK-8287798): Reduce runtime of java.lang.reflect/runtime microbenchmarks


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9013/head:pull/9013` \
`$ git checkout pull/9013`

Update a local copy of the PR: \
`$ git checkout pull/9013` \
`$ git pull https://git.openjdk.java.net/jdk pull/9013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9013`

View PR using the GUI difftool: \
`$ git pr show -t 9013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9013.diff">https://git.openjdk.java.net/jdk/pull/9013.diff</a>

</details>
