### PR TITLE
8287799: JFR: Less noisy platform threads with jfr print

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
@@ -540,7 +540,8 @@ public final class PrettyWriter extends EventPrintWriter {
     private void printThread(RecordedThread thread, String postFix) {
         long javaThreadId = thread.getJavaThreadId();
         if (javaThreadId > 0) {
-            println("\"" + thread.getJavaName() + "\" (javaThreadId = " + thread.getJavaThreadId() + ", virtual = " + thread.isVirtual() + ")" + postFix);
+            String virtualText = thread.isVirtual() ? ", virtual" : "";
+            println("\"" + thread.getJavaName() + "\" (javaThreadId = " + javaThreadId + virtualText + ")" + postFix);
         } else {
             println("\"" + thread.getOSName() + "\" (osThreadId = " + thread.getOSThreadId() + ")" + postFix);
         }


### PR DESCRIPTION
Could I have review of a PR that removes "virtual = false" from 'jfr print' if the thread is a platform thread. In case of a virtual thread, it should be sufficient to have "virtual" after the thread ID.

Testing: jdk/jdk/jfr + manual check of output for virtual and platform threads

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287799](https://bugs.openjdk.java.net/browse/JDK-8287799): JFR: Less noisy platform threads with jfr print


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9014/head:pull/9014` \
`$ git checkout pull/9014`

Update a local copy of the PR: \
`$ git checkout pull/9014` \
`$ git pull https://git.openjdk.java.net/jdk pull/9014/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9014`

View PR using the GUI difftool: \
`$ git pr show -t 9014`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9014.diff">https://git.openjdk.java.net/jdk/pull/9014.diff</a>

</details>
