### PR TITLE
8287811: JFR: jfr configure error message should not print stack trace

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Configure.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Configure.java
@@ -228,7 +228,6 @@ final class Configure extends Command {
         } catch (IOException ioe) {
             throw new UserDataException("i/o error: " + ioe.getMessage());
         } catch (ParseException pe) {
-            pe.printStackTrace();
             throw new UserDataException("parsing error: " + pe.getMessage());
         }
     }


### PR DESCRIPTION
Could I have a review of PR that removes a printStackTrace() for the jfr tool. 

Testing: jdk/jfr/tool

Thanks
Erik

