### PR TITLE
8287541: Files.writeString fails to throw IOException for charset "windows-1252"

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -845,7 +845,8 @@ public final class String
         CharsetEncoder ce = cs.newEncoder();
         int len = val.length >> coder;  // assume LATIN1=0/UTF16=1;
         int en = scale(len, ce.maxBytesPerChar());
-        if (ce instanceof ArrayEncoder ae) {
+        // fastpath with ArrayEncoder implies `doReplace`.
+        if (ce instanceof ArrayEncoder ae && doReplace) {
             // fastpath for ascii compatible
             if (coder == LATIN1 &&
                     ae.isASCIICompatible() &&
@@ -855,10 +856,6 @@ public final class String
             byte[] ba = new byte[en];
             if (len == 0) {
                 return ba;
-            }
-            if (doReplace) {
-                ce.onMalformedInput(CodingErrorAction.REPLACE)
-                        .onUnmappableCharacter(CodingErrorAction.REPLACE);
             }
 
             int blen = (coder == LATIN1) ? ae.encodeFromLatin1(val, 0, len, ba)


### PR DESCRIPTION
The code path calls `String.getBytesNoRepl()`, but it blindly replaces unmappable characters with replacements if the encoder is an `ArrayEncoder`. Changed only to do so if `doReplace` is `true` in `String.encodeWithEncoder()`.