### PR TITLE
JDK-8287671: Adjust ForceGC to invoke System::gc fewer times for negative case

### DIFF
--- a/test/lib/jdk/test/lib/util/ForceGC.java
+++ b/test/lib/jdk/test/lib/util/ForceGC.java
@@ -32,21 +32,24 @@ import java.util.function.BooleanSupplier;
  * Utility class to invoke System.gc()
  */
 public class ForceGC {
-    private final CountDownLatch cleanerInvoked = new CountDownLatch(1);
-    private final Cleaner cleaner = Cleaner.create();
+    private final static Cleaner cleaner = Cleaner.create();
+
+    private final CountDownLatch cleanerInvoked;
     private Object o;
+    private int gcCount = 0;
 
     public ForceGC() {
         this.o = new Object();
-        cleaner.register(o, () -> cleanerInvoked.countDown());
+        this.cleanerInvoked = new CountDownLatch(1);
+        cleaner.register(o, cleanerInvoked::countDown);
     }
 
     private void doit(int iter) {
         try {
             for (int i = 0; i < 10; i++) {
                 System.gc();
-                System.out.println("doit() iter: " + iter + ", gc " + i);
-                if (cleanerInvoked.await(1L, TimeUnit.SECONDS)) {
+                gcCount++;
+                if (cleanerInvoked.await(100L, TimeUnit.MILLISECONDS)) {
                     return;
                 }
             }
@@ -68,12 +71,20 @@ public class ForceGC {
         o = null; // Keep reference to Object until now, to ensure the Cleaner
                   // doesn't count down the latch before await() is called.
         for (int i = 0; i < 10; i++) {
-            if (s.getAsBoolean()) return true;
-            doit(i);
-            try { Thread.sleep(1000); } catch (InterruptedException e) {
+            if (s.getAsBoolean()) {
+                System.out.println("ForceGC condition met after System.gc() " + gcCount + " times");
+                return true;
+            }
+
+            doIt(i);
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
                 throw new AssertionError("unexpected interrupted sleep", e);
             }
         }
+
+        System.out.println("ForceGC condition not met after System.gc() " + gcCount + " times");
         return false;
     }
 }


### PR DESCRIPTION
This reapplies JDK-8287384 and adjust the number of GCs for negative case, i.e. the condition is never met that is used to verify a reference is not GC'ed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287671](https://bugs.openjdk.java.net/browse/JDK-8287671): Adjust ForceGC to invoke System::gc fewer times for negative case


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Brent Christian](https://openjdk.java.net/census#bchristi) (@bchristi-git - **Reviewer**)
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9021/head:pull/9021` \
`$ git checkout pull/9021`

Update a local copy of the PR: \
`$ git checkout pull/9021` \
`$ git pull https://git.openjdk.java.net/jdk pull/9021/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9021`

View PR using the GUI difftool: \
`$ git pr show -t 9021`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9021.diff">https://git.openjdk.java.net/jdk/pull/9021.diff</a>

</details>
