### PR TITLE
8287828: Fix so that one can select jtreg test case by ID from make

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -354,45 +354,47 @@ ExpandJtregPath = \
 TestID = \
     $(subst .java,,$(subst .java,,$(suffix $(notdir $1))))
 
+# The test selector starting with a hash (#testid) will be stripped by all
+# evals in ParseJtregTestSelectionInner and will be reinserted by calling
+# TestID (if it is present).
+ParseJtregTestSelection = \
+    $(call IfAppend, $(call ParseJtregTestSelectionInner, $1), $(call TestID, $1))
+
 # Helper function to determine if a test specification is a Jtreg test
 #
 # It is a Jtreg test if it optionally begins with jtreg:, and then is either
 # an unspecified group name (possibly prefixed by :), or a group in a
 # specified test root, or a path to a test or test directory,
 # either absolute or relative to any of the TEST_BASEDIRS or test roots.
-define ParseJtregTestSelection
-  $(call IfAppend, \
-    $(eval TEST_NAME := $(strip $(patsubst jtreg:%, %, $1))) \
-    $(if $(or $(findstring :, $(TEST_NAME)), $(findstring /, $(TEST_NAME))), , \
-      $(eval TEST_NAME := :$(TEST_NAME)) \
-    ) \
-    $(if $(findstring :, $(TEST_NAME)), \
-      $(if $(filter :%, $(TEST_NAME)), \
-        $(eval TEST_GROUP := $(patsubst :%, %, $(TEST_NAME))) \
-        $(eval TEST_ROOTS := $(foreach test_root, $(JTREG_TESTROOTS), \
-            $(call CleanupJtregPath, $(test_root)))) \
-      , \
-        $(eval TEST_PATH := $(word 1, $(subst :, $(SPACE), $(TEST_NAME)))) \
-        $(eval TEST_GROUP := $(word 2, $(subst :, $(SPACE), $(TEST_NAME)))) \
-        $(eval TEST_ROOTS := $(call ExpandJtregRoot, $(TEST_PATH))) \
-      ) \
-      $(foreach test_root, $(TEST_ROOTS), \
-        $(if $(filter /%, $(test_root)), \
-          jtreg:$(test_root):$(TEST_GROUP) \
-        , \
-          $(if $(filter $(TEST_GROUP), $($(JTREG_TOPDIR)/$(test_root)_JTREG_TEST_GROUPS)), \
-            jtreg:$(test_root):$(TEST_GROUP) \
-          ) \
-        ) \
-      ) \
+define ParseJtregTestSelectionInner
+  $(eval TEST_NAME := $(strip $(patsubst jtreg:%, %, $1))) \
+  $(if $(or $(findstring :, $(TEST_NAME)), $(findstring /, $(TEST_NAME))), , \
+    $(eval TEST_NAME := :$(TEST_NAME)) \
+  ) \
+  $(if $(findstring :, $(TEST_NAME)), \
+    $(if $(filter :%, $(TEST_NAME)), \
+      $(eval TEST_GROUP := $(patsubst :%, %, $(TEST_NAME))) \
+      $(eval TEST_ROOTS := $(foreach test_root, $(JTREG_TESTROOTS), \
+          $(call CleanupJtregPath, $(test_root)))) \
     , \
-      $(eval TEST_PATHS := $(call ExpandJtregPath, $(TEST_NAME))) \
-      $(foreach test_path, $(TEST_PATHS), \
-        jtreg:$(test_path) \
+      $(eval TEST_PATH := $(word 1, $(subst :, $(SPACE), $(TEST_NAME)))) \
+      $(eval TEST_GROUP := $(word 2, $(subst :, $(SPACE), $(TEST_NAME)))) \
+      $(eval TEST_ROOTS := $(call ExpandJtregRoot, $(TEST_PATH))) \
+    ) \
+    $(foreach test_root, $(TEST_ROOTS), \
+      $(if $(filter /%, $(test_root)), \
+        jtreg:$(test_root):$(TEST_GROUP) \
+      , \
+        $(if $(filter $(TEST_GROUP), $($(JTREG_TOPDIR)/$(test_root)_JTREG_TEST_GROUPS)), \
+          jtreg:$(test_root):$(TEST_GROUP) \
+        ) \
       ) \
     ) \
   , \
-    $(call TestID, $1) \
+    $(eval TEST_PATHS := $(call ExpandJtregPath, $(TEST_NAME))) \
+    $(foreach test_path, $(TEST_PATHS), \
+      jtreg:$(test_path) \
+    ) \
   )
 endef
 

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -35,24 +35,6 @@ include FindTests.gmk
 ################################################################################
 # Parse global control variables
 ################################################################################
-
-HASH:=\#
-
-define IfAppend
-$(if $(strip $1),$(strip $1)$(strip $2),)
-endef
-
-define IfPrepend
-$(if $(strip $1),$(strip $2)$(strip $1),)
-endef
-
-define TestID
-$(subst .java,,$(subst .java$(HASH),,$(suffix $(notdir $1))))
-endef
-
-define HashTestID
-$(call IfPrepend,$(call TestID,$1),$(HASH))
-endef
 
 ifneq ($(TEST_VM_OPTS), )
   ifneq ($(TEST_OPTS), )
@@ -367,6 +349,11 @@ ExpandJtregPath = \
     )) \
   )
 
+# with selection: dir/Test.java#selection -> Test.java#selection -> .java#selection -> #selection
+# or without:     dir/Test.java           -> Test.java           -> .java           -> <<empty string>>
+TestID = \
+    $(subst .java,,$(subst .java,,$(suffix $(notdir $1))))
+
 # Helper function to determine if a test specification is a Jtreg test
 #
 # It is a Jtreg test if it optionally begins with jtreg:, and then is either
@@ -374,36 +361,39 @@ ExpandJtregPath = \
 # specified test root, or a path to a test or test directory,
 # either absolute or relative to any of the TEST_BASEDIRS or test roots.
 define ParseJtregTestSelection
-$(call IfAppend, \
-  $(eval TEST_NAME := $(strip $(patsubst jtreg:%, %, $1))) \
-  $(if $(or $(findstring :, $(TEST_NAME)), $(findstring /, $(TEST_NAME))), , \
-    $(eval TEST_NAME := :$(TEST_NAME)) \
-  ) \
-  $(if $(findstring :, $(TEST_NAME)), \
-    $(if $(filter :%, $(TEST_NAME)), \
-      $(eval TEST_GROUP := $(patsubst :%, %, $(TEST_NAME))) \
-      $(eval TEST_ROOTS := $(foreach test_root, $(JTREG_TESTROOTS), \
-          $(call CleanupJtregPath, $(test_root)))) \
-    , \
-      $(eval TEST_PATH := $(word 1, $(subst :, $(SPACE), $(TEST_NAME)))) \
-      $(eval TEST_GROUP := $(word 2, $(subst :, $(SPACE), $(TEST_NAME)))) \
-      $(eval TEST_ROOTS := $(call ExpandJtregRoot, $(TEST_PATH))) \
+  $(call IfAppend, \
+    $(eval TEST_NAME := $(strip $(patsubst jtreg:%, %, $1))) \
+    $(if $(or $(findstring :, $(TEST_NAME)), $(findstring /, $(TEST_NAME))), , \
+      $(eval TEST_NAME := :$(TEST_NAME)) \
     ) \
-    $(foreach test_root, $(TEST_ROOTS), \
-      $(if $(filter /%, $(test_root)), \
-        jtreg:$(test_root):$(TEST_GROUP) \
+    $(if $(findstring :, $(TEST_NAME)), \
+      $(if $(filter :%, $(TEST_NAME)), \
+        $(eval TEST_GROUP := $(patsubst :%, %, $(TEST_NAME))) \
+        $(eval TEST_ROOTS := $(foreach test_root, $(JTREG_TESTROOTS), \
+            $(call CleanupJtregPath, $(test_root)))) \
       , \
-        $(if $(filter $(TEST_GROUP), $($(JTREG_TOPDIR)/$(test_root)_JTREG_TEST_GROUPS)), \
+        $(eval TEST_PATH := $(word 1, $(subst :, $(SPACE), $(TEST_NAME)))) \
+        $(eval TEST_GROUP := $(word 2, $(subst :, $(SPACE), $(TEST_NAME)))) \
+        $(eval TEST_ROOTS := $(call ExpandJtregRoot, $(TEST_PATH))) \
+      ) \
+      $(foreach test_root, $(TEST_ROOTS), \
+        $(if $(filter /%, $(test_root)), \
           jtreg:$(test_root):$(TEST_GROUP) \
+        , \
+          $(if $(filter $(TEST_GROUP), $($(JTREG_TOPDIR)/$(test_root)_JTREG_TEST_GROUPS)), \
+            jtreg:$(test_root):$(TEST_GROUP) \
+          ) \
         ) \
+      ) \
+    , \
+      $(eval TEST_PATHS := $(call ExpandJtregPath, $(TEST_NAME))) \
+      $(foreach test_path, $(TEST_PATHS), \
+        jtreg:$(test_path) \
       ) \
     ) \
   , \
-    $(eval TEST_PATHS := $(call ExpandJtregPath, $(TEST_NAME))) \
-    $(foreach test_path, $(TEST_PATHS), \
-      jtreg:$(test_path) \
-    ) \
-  ),$(call HashTestID,$1))
+    $(call TestID, $1) \
+  )
 endef
 
 # Helper function to determine if a test specification is a special test
@@ -439,14 +429,19 @@ ifeq ($(TEST), )
 endif
 
 define ParseTestSelection
-$(strip $(foreach parser,ParseCustomTestSelection ParseGtestTestSelection ParseMicroTestSelection ParseJtregTestSelection ParseSpecialTestSelection \
- ,$(call $(parser),$1)))
+  $(strip $(or \
+    $(call ParseCustomTestSelection, $1) \
+    $(call ParseGtestTestSelection, $1) \
+    $(call ParseMicroTestSelection, $1) \
+    $(call ParseJtregTestSelection, $1) \
+    $(call ParseSpecialTestSelection, $1) \
+  ))
 endef
 
 # Now intelligently convert the test selection given by the user in TEST
 # into a list of fully qualified test descriptors of the tests to run.
-TESTS_TO_RUN:=$(strip $(foreach test,$(TEST),$(call ParseTestSelection,$(test))))
-UNKNOWN_TEST:=$(strip $(foreach test,$(TEST),$(if $(call ParseTestSelection,$(test)),,$(test))))
+TESTS_TO_RUN := $(strip $(foreach test, $(TEST), $(call ParseTestSelection, $(test))))
+UNKNOWN_TEST := $(strip $(foreach test, $(TEST), $(if $(call ParseTestSelection, $(test)), , $(test))))
 
 ifneq ($(UNKNOWN_TEST), )
   $(info Unknown test selection: '$(UNKNOWN_TEST)')

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -36,6 +36,24 @@ include FindTests.gmk
 # Parse global control variables
 ################################################################################
 
+HASH:=\#
+
+define IfAppend
+$(if $(strip $1),$(strip $1)$(strip $2),)
+endef
+
+define IfPrepend
+$(if $(strip $1),$(strip $2)$(strip $1),)
+endef
+
+define TestID
+$(subst .java,,$(subst .java$(HASH),,$(suffix $(notdir $1))))
+endef
+
+define HashTestID
+$(call IfPrepend,$(call TestID,$1),$(HASH))
+endef
+
 ifneq ($(TEST_VM_OPTS), )
   ifneq ($(TEST_OPTS), )
     TEST_OPTS := $(TEST_OPTS);VM_OPTIONS=$(TEST_VM_OPTS)
@@ -356,6 +374,7 @@ ExpandJtregPath = \
 # specified test root, or a path to a test or test directory,
 # either absolute or relative to any of the TEST_BASEDIRS or test roots.
 define ParseJtregTestSelection
+$(call IfAppend, \
   $(eval TEST_NAME := $(strip $(patsubst jtreg:%, %, $1))) \
   $(if $(or $(findstring :, $(TEST_NAME)), $(findstring /, $(TEST_NAME))), , \
     $(eval TEST_NAME := :$(TEST_NAME)) \
@@ -384,7 +403,7 @@ define ParseJtregTestSelection
     $(foreach test_path, $(TEST_PATHS), \
       jtreg:$(test_path) \
     ) \
-  )
+  ),$(call HashTestID,$1))
 endef
 
 # Helper function to determine if a test specification is a special test
@@ -419,37 +438,21 @@ ifeq ($(TEST), )
   $(error Cannot continue)
 endif
 
+define ParseTestSelection
+$(strip $(foreach parser,ParseCustomTestSelection ParseGtestTestSelection ParseMicroTestSelection ParseJtregTestSelection ParseSpecialTestSelection \
+ ,$(call $(parser),$1)))
+endef
+
 # Now intelligently convert the test selection given by the user in TEST
 # into a list of fully qualified test descriptors of the tests to run.
-TESTS_TO_RUN :=
-$(foreach test, $(TEST), \
-  $(eval PARSED_TESTS := $(call ParseCustomTestSelection, $(test))) \
-  $(if $(strip $(PARSED_TESTS)), , \
-    $(eval PARSED_TESTS += $(call ParseGtestTestSelection, $(test))) \
-  ) \
-  $(if $(strip $(PARSED_TESTS)), , \
-    $(eval PARSED_TESTS += $(call ParseMicroTestSelection, $(test))) \
-  ) \
-  $(if $(strip $(PARSED_TESTS)), , \
-    $(eval PARSED_TESTS += $(call ParseJtregTestSelection, $(test))) \
-  ) \
-  $(if $(strip $(PARSED_TESTS)), , \
-    $(eval PARSED_TESTS += $(call ParseSpecialTestSelection, $(test))) \
-  ) \
-  $(if $(strip $(PARSED_TESTS)), , \
-    $(eval UNKNOWN_TEST := $(test)) \
-  ) \
-  $(eval TESTS_TO_RUN += $(PARSED_TESTS)) \
-)
+TESTS_TO_RUN:=$(strip $(foreach test,$(TEST),$(call ParseTestSelection,$(test))))
+UNKNOWN_TEST:=$(strip $(foreach test,$(TEST),$(if $(call ParseTestSelection,$(test)),,$(test))))
 
 ifneq ($(UNKNOWN_TEST), )
   $(info Unknown test selection: '$(UNKNOWN_TEST)')
   $(info See doc/testing.[md|html] for help)
   $(error Cannot continue)
 endif
-
-TESTS_TO_RUN := $(strip $(TESTS_TO_RUN))
-
 
 # Present the result of our parsing to the user
 $(info Test selection '$(TEST)', will run:)

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -349,12 +349,12 @@ ExpandJtregPath = \
     )) \
   )
 
-# with selection: dir/Test.java#selection -> Test.java#selection -> .java#selection -> #selection
-# or without:     dir/Test.java           -> Test.java           -> .java           -> <<empty string>>
+# with test id: dir/Test.java#selection -> Test.java#selection -> .java#selection -> #selection
+#      without: dir/Test.java           -> Test.java           -> .java           -> <<empty string>>
 TestID = \
     $(subst .java,,$(subst .java,,$(suffix $(notdir $1))))
 
-# The test selector starting with a hash (#testid) will be stripped by all
+# The test id starting with a hash (#testid) will be stripped by all
 # evals in ParseJtregTestSelectionInner and will be reinserted by calling
 # TestID (if it is present).
 ParseJtregTestSelection = \

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -428,15 +428,14 @@ ifeq ($(TEST), )
   $(error Cannot continue)
 endif
 
-define ParseTestSelection
-  $(strip $(or \
-    $(call ParseCustomTestSelection, $1) \
-    $(call ParseGtestTestSelection, $1) \
-    $(call ParseMicroTestSelection, $1) \
-    $(call ParseJtregTestSelection, $1) \
-    $(call ParseSpecialTestSelection, $1) \
-  ))
-endef
+ParseTestSelection = \
+    $(strip $(or \
+      $(call ParseCustomTestSelection, $1) \
+      $(call ParseGtestTestSelection, $1) \
+      $(call ParseMicroTestSelection, $1) \
+      $(call ParseJtregTestSelection, $1) \
+      $(call ParseSpecialTestSelection, $1) \
+    ))
 
 # Now intelligently convert the test selection given by the user in TEST
 # into a list of fully qualified test descriptors of the tests to run.

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -352,7 +352,7 @@ ExpandJtregPath = \
 # with test id: dir/Test.java#selection -> Test.java#selection -> .java#selection -> #selection
 #      without: dir/Test.java           -> Test.java           -> .java           -> <<empty string>>
 TestID = \
-    $(subst .java,,$(subst .java,,$(suffix $(notdir $1))))
+    $(subst .java,,$(suffix $(notdir $1)))
 
 # The test id starting with a hash (#testid) will be stripped by all
 # evals in ParseJtregTestSelectionInner and will be reinserted by calling

--- a/make/common/Utils.gmk
+++ b/make/common/Utils.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -67,6 +67,15 @@ _sequence-do = \
       $(eval SEQUENCE_COUNT += .) \
       $(words $(SEQUENCE_COUNT)) \
       $(call _sequence-do,$1))
+
+################################################################################
+# Strip both arguments. Concat (append or prepend) the first argument to the
+# second argument. If the first argument is empty, return the empty string.
+IfAppend = \
+    $(if $(strip $1),$(strip $1)$(strip $2),)
+
+IfPrepend = \
+    $(if $(strip $1),$(strip $2)$(strip $1),)
 
 ################################################################################
 # Replace question marks with space in string. This macro needs to be called on

--- a/make/common/Utils.gmk
+++ b/make/common/Utils.gmk
@@ -69,13 +69,10 @@ _sequence-do = \
       $(call _sequence-do,$1))
 
 ################################################################################
-# Strip both arguments. Concat (append or prepend) the first argument to the
-# second argument. If the first argument is empty, return the empty string.
+# Strip both arguments. Append the first argument to the second argument. If the
+# first argument is empty, return the empty string.
 IfAppend = \
     $(if $(strip $1),$(strip $1)$(strip $2),)
-
-IfPrepend = \
-    $(if $(strip $1),$(strip $2)$(strip $1),)
 
 ################################################################################
 # Replace question marks with space in string. This macro needs to be called on


### PR DESCRIPTION
One can select a testcase by ID when running a jtreg test case directly from jtreg (using the testcase.java#testID syntax). However, this has not been possible to do when launching jtreg indirectly from make.

This fix attempts to address this issue. I have not tested this thoroughly yet, I wanted to show the code to get feedback first. The idea is to *not* emulated destructive imperative assignments through the use of eval. I instead try to handle it in a functional style without reassigning variables. I have tried to make the change as small as possible.

I am not used to change the build system, so I would appreciate thorough review.

`IfAppend` and `IfPrepend` are general purpose functions. If similar functions exists elsewhere inside the code base or in make itself I should probably use those instead. If they do not exist, they might be useful elsewhere and maybe should be placed in a common make file instead of the RunTests.gmk file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287828](https://bugs.openjdk.org/browse/JDK-8287828): Fix so that one can select jtreg test case by ID from make


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [a6d51c2a](https://git.openjdk.org/jdk/pull/9028/files/a6d51c2a473b570ceb0a2474be7184e842dac7ae)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to [ac9631e2](https://git.openjdk.org/jdk/pull/9028/files/ac9631e2aa93e0a7afd5c0389faab68077e5808a)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9028/head:pull/9028` \
`$ git checkout pull/9028`

Update a local copy of the PR: \
`$ git checkout pull/9028` \
`$ git pull https://git.openjdk.org/jdk pull/9028/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9028`

View PR using the GUI difftool: \
`$ git pr show -t 9028`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9028.diff">https://git.openjdk.org/jdk/pull/9028.diff</a>

</details>
