### PR TITLE
8287830: gtest fails to compile after JDK-8287661

### DIFF
--- a/test/hotspot/gtest/utilities/test_bitMap.cpp
+++ b/test/hotspot/gtest/utilities/test_bitMap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,7 +96,7 @@ class BitMapTest {
     EXPECT_TRUE(map.is_same(map2)) << "With init_size " << init_size;
   }
 
-#ifndef PRODUCT
+#ifdef ASSERT
 
   static void testPrintOn(BitMap::idx_t size) {
     ResourceMark rm;
@@ -165,7 +165,7 @@ TEST_VM(BitMap, reinitialize) {
   BitMapTest::testReinitialize(BitMapTest::BITMAP_SIZE);
 }
 
-#ifndef PRODUCT
+#ifdef ASSERT
 
 TEST_VM(BitMap, print_on) {
   BitMapTest::testPrintOn(0);


### PR DESCRIPTION
Hi all,

gtest fails to compile when configured with `--with-debug-level=optimized`.

This is because for `optimized` no `PRODUCT` is defined.
```
ifeq ($(DEBUG_LEVEL), release)
  # For hotspot, release builds differ internally between "optimized" and "product"
  # in that "optimize" does not define PRODUCT.
  ifneq ($(HOTSPOT_DEBUG_LEVEL), optimized)
    JVM_CFLAGS_DEBUGLEVEL := -DPRODUCT
  endif
```

And the `test` log tag is only defined for DEBUG versions.
```
  LOG_TAG(table) \
  LOG_TAG(task) \
  DEBUG_ONLY(LOG_TAG(test)) \
  LOG_TAG(thread) \
  LOG_TAG(throttle) \
```

So let's fix it.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287830](https://bugs.openjdk.java.net/browse/JDK-8287830): gtest fails to compile after JDK-8287661


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9029/head:pull/9029` \
`$ git checkout pull/9029`

Update a local copy of the PR: \
`$ git checkout pull/9029` \
`$ git pull https://git.openjdk.java.net/jdk pull/9029/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9029`

View PR using the GUI difftool: \
`$ git pr show -t 9029`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9029.diff">https://git.openjdk.java.net/jdk/pull/9029.diff</a>

</details>
