### PR TITLE
8287824: The MTPerLineTransformValidation tests has a typo in the @run tag

### DIFF
--- a/test/jdk/sun/java2d/cmm/ColorConvertOp/MTPerLineTransformValidation.java
+++ b/test/jdk/sun/java2d/cmm/ColorConvertOp/MTPerLineTransformValidation.java
@@ -29,7 +29,7 @@ import java.awt.image.ColorConvertOp;
  * @test
  * @bug 8273972
  * @summary Verifies that ColorConvertOp works fine if shared between threads
- * @run main/othervm/timeout=600 MTTransformValidation
+ * @run main/othervm/timeout=600 MTPerLineTransformValidation
  */
 public final class MTPerLineTransformValidation {
 


### PR DESCRIPTION
The typo in the  `@run` tag is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287824](https://bugs.openjdk.java.net/browse/JDK-8287824): The MTPerLineTransformValidation tests has a typo in the @run tag


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9030/head:pull/9030` \
`$ git checkout pull/9030`

Update a local copy of the PR: \
`$ git checkout pull/9030` \
`$ git pull https://git.openjdk.java.net/jdk pull/9030/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9030`

View PR using the GUI difftool: \
`$ git pr show -t 9030`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9030.diff">https://git.openjdk.java.net/jdk/pull/9030.diff</a>

</details>
