### PR TITLE
8287924: Avoid redundant HashMap.containsKey call in EnvHelp.mapToHashtable

### DIFF
--- a/src/java.management/share/classes/com/sun/jmx/remote/util/EnvHelp.java
+++ b/src/java.management/share/classes/com/sun/jmx/remote/util/EnvHelp.java
@@ -48,8 +48,6 @@ import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXConnectorServerFactory;
 import com.sun.jmx.mbeanserver.GetPropertyAction;
 import com.sun.jmx.remote.security.NotificationAccessController;
-import javax.management.remote.JMXConnector;
-import javax.management.remote.JMXConnectorServer;
 
 public class EnvHelp {
 
@@ -733,11 +731,11 @@ public class EnvHelp {
      * it removes all the 'null' values from the map.
      */
     public static <K, V> Hashtable<K, V> mapToHashtable(Map<K, V> map) {
-        HashMap<K, V> m = new HashMap<K, V>(map);
-        if (m.containsKey(null)) m.remove(null);
+        HashMap<K, V> m = new HashMap<>(map);
+        m.remove(null);
         for (Iterator<?> i = m.values().iterator(); i.hasNext(); )
             if (i.next() == null) i.remove();
-        return new Hashtable<K, V>(m);
+        return new Hashtable<>(m);
     }
 
     /**


### PR DESCRIPTION
No need to separately perform HashMap.containsKey before HashMap.remove call. If key is present - it will be removed anyway. If it's not present, nothing will be deleted.
https://github.com/openjdk/jdk/blob/a6fc485a22484b70daf170e981432c0856b9d93d/src/java.management/share/classes/com/sun/jmx/remote/util/EnvHelp.java#L735-L741

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287924](https://bugs.openjdk.org/browse/JDK-8287924): Avoid redundant HashMap.containsKey call in EnvHelp.mapToHashtable


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9031/head:pull/9031` \
`$ git checkout pull/9031`

Update a local copy of the PR: \
`$ git checkout pull/9031` \
`$ git pull https://git.openjdk.java.net/jdk pull/9031/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9031`

View PR using the GUI difftool: \
`$ git pr show -t 9031`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9031.diff">https://git.openjdk.java.net/jdk/pull/9031.diff</a>

</details>
