### PR TITLE
JDK-8287838: Update Float and Double to use snippets

### DIFF
--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -679,9 +679,10 @@ public final class Double extends Number
      *        ")[pP][+-]?" + Digits + "))" +
      *       "[fFdD]?))" +
      *       "[\\x00-\\x20]*");// Optional trailing "whitespace"
-     *
-     *  if (Pattern.matches(fpRegex, myString)) // @link substring="Pattern.matches" target ="java.util.regex.Pattern#matches"
+     *  // @link region substring="Pattern.matches" target ="java.util.regex.Pattern#matches"
+     *  if (Pattern.matches(fpRegex, myString))
      *      Double.valueOf(myString); // Will not throw NumberFormatException
+     * // @end
      *  else {
      *      // Perform suitable alternative action
      *  }

--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -640,7 +640,7 @@ public final class Double extends Number
      * a {@code NumberFormatException} be thrown, the regular
      * expression below can be used to screen the input string:
      *
-     * <pre>{@code
+     *  {@snippet lang="java" :
      *  final String Digits     = "(\\p{Digit}+)";
      *  final String HexDigits  = "(\\p{XDigit}+)";
      *  // an exponent is 'e' or 'E' followed by an optionally
@@ -685,7 +685,7 @@ public final class Double extends Number
      *  else {
      *      // Perform suitable alternative action
      *  }
-     * }</pre>
+     * }
      *
      * @param      s   the string to be parsed.
      * @return     a {@code Double} object holding the value
@@ -1099,13 +1099,13 @@ public final class Double extends Number
      * <p>In all other cases, let <i>s</i>, <i>e</i>, and <i>m</i> be three
      * values that can be computed from the argument:
      *
-     * <blockquote><pre>{@code
+     * {@snippet lang="java" :
      * int s = ((bits >> 63) == 0) ? 1 : -1;
      * int e = (int)((bits >> 52) & 0x7ffL);
      * long m = (e == 0) ?
      *                 (bits & 0xfffffffffffffL) << 1 :
      *                 (bits & 0xfffffffffffffL) | 0x10000000000000L;
-     * }</pre></blockquote>
+     * }
      *
      * Then the floating-point result equals the value of the mathematical
      * expression <i>s</i>&middot;<i>m</i>&middot;2<sup><i>e</i>-1075</sup>.

--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -640,7 +640,7 @@ public final class Double extends Number
      * a {@code NumberFormatException} be thrown, the regular
      * expression below can be used to screen the input string:
      *
-     *  {@snippet lang="java" :
+     * {@snippet lang="java" :
      *  final String Digits     = "(\\p{Digit}+)";
      *  final String HexDigits  = "(\\p{XDigit}+)";
      *  // an exponent is 'e' or 'E' followed by an optionally
@@ -680,7 +680,7 @@ public final class Double extends Number
      *       "[fFdD]?))" +
      *       "[\\x00-\\x20]*");// Optional trailing "whitespace"
      *
-     *  if (Pattern.matches(fpRegex, myString))
+     *  if (Pattern.matches(fpRegex, myString)) // @link substring="Pattern.matches" target ="java.util.regex.Pattern#matches"
      *      Double.valueOf(myString); // Will not throw NumberFormatException
      *  else {
      *      // Perform suitable alternative action

--- a/src/java.base/share/classes/java/lang/Float.java
+++ b/src/java.base/share/classes/java/lang/Float.java
@@ -922,13 +922,13 @@ public final class Float extends Number
      * <p>In all other cases, let <i>s</i>, <i>e</i>, and <i>m</i> be three
      * values that can be computed from the argument:
      *
-     * <blockquote><pre>{@code
+     * {@snippet lang="java" :
      * int s = ((bits >> 31) == 0) ? 1 : -1;
      * int e = ((bits >> 23) & 0xff);
      * int m = (e == 0) ?
      *                 (bits & 0x7fffff) << 1 :
      *                 (bits & 0x7fffff) | 0x800000;
-     * }</pre></blockquote>
+     * }
      *
      * Then the floating-point result equals the value of the mathematical
      * expression <i>s</i>&middot;<i>m</i>&middot;2<sup><i>e</i>-150</sup>.


### PR DESCRIPTION
Various code blocks in Float and Double would be better as snippets.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287838](https://bugs.openjdk.org/browse/JDK-8287838): Update Float and Double to use snippets


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [255fbb15](https://git.openjdk.java.net/jdk/pull/9034/files/255fbb15bc52045f0ad42180ba027de27c575114)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9034/head:pull/9034` \
`$ git checkout pull/9034`

Update a local copy of the PR: \
`$ git checkout pull/9034` \
`$ git pull https://git.openjdk.java.net/jdk pull/9034/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9034`

View PR using the GUI difftool: \
`$ git pr show -t 9034`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9034.diff">https://git.openjdk.java.net/jdk/pull/9034.diff</a>

</details>
