### PR TITLE
8287840: Dead copy region node blocks IfNode's fold-compares

### DIFF
--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -1216,6 +1216,9 @@ bool Node::has_special_unique_user() const {
   } else if (is_If() && (n->is_IfFalse() || n->is_IfTrue())) {
     // See IfProjNode::Identity()
     return true;
+  } else if ((is_IfFalse() || is_IfTrue()) && n->is_If()) {
+    // see IfNode::fold_compares
+    return true;
   } else {
     return false;
   }

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1217,7 +1217,7 @@ bool Node::has_special_unique_user() const {
     // See IfProjNode::Identity()
     return true;
   } else if ((is_IfFalse() || is_IfTrue()) && n->is_If()) {
-    // see IfNode::fold_compares
+    // See IfNode::fold_compares
     return true;
   } else {
     return false;


### PR DESCRIPTION
IfNode::fold_compares() requires ctrl has a single output. I found some fold-compares case postpone to IterGVN2. The reason is that a dead region prevents IfNode::fold_compares() from transforming code.  The dead node is removed in IterGVN, but it's too late. 

This PR extends Node::has_special_unique_user() so `PhaseIterGVN::remove_globally_dead_node()` puts IfNode back to worklist. The following attempt will carry out fold-compares().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287840](https://bugs.openjdk.org/browse/JDK-8287840): Dead copy region node blocks IfNode's fold-compares


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9035/head:pull/9035` \
`$ git checkout pull/9035`

Update a local copy of the PR: \
`$ git checkout pull/9035` \
`$ git pull https://git.openjdk.java.net/jdk pull/9035/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9035`

View PR using the GUI difftool: \
`$ git pr show -t 9035`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9035.diff">https://git.openjdk.java.net/jdk/pull/9035.diff</a>

</details>
