### PR TITLE
8276798: HttpURLConnection sends invalid HTTP request

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
@@ -630,7 +630,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
             final int requestLineIndex = requests.getKey(requestLine);
             if (requestLineIndex != 0) {
                 // we expect the request line to be at index 0. we set it here
-                // if we don't fine the request line at that index.
+                // if we don't find the request line at that index.
                 checkURLFile();
                 requests.prepend(requestLine, null);
             }

--- a/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
@@ -626,10 +626,13 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
              * to last and last, respectively, in the case of a POST
              * request.
              */
-            if (!failedOnce) {
+            final String requestLine = method + " " + getRequestURI()+ " " + httpVersion;
+            final int requestLineIndex = requests.getKey(requestLine);
+            if (requestLineIndex != 0) {
+                // we expect the request line to be at index 0. we set it here
+                // if we don't fine the request line at that index.
                 checkURLFile();
-                requests.prepend(method + " " + getRequestURI()+" "  +
-                                 httpVersion, null);
+                requests.prepend(requestLine, null);
             }
             if (!getUseCaches()) {
                 requests.setIfNotSet ("Cache-Control", "no-cache");
@@ -656,8 +659,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
              * or if keep alive is disabled via a system property
              */
 
-            // Try keep-alive only on first attempt
-            if (!failedOnce && http.getHttpKeepAliveSet()) {
+            if (http.getHttpKeepAliveSet()) {
                 if (http.usingProxy && tunnelState() != TunnelState.TUNNELING) {
                     requests.setIfNotSet("Proxy-Connection", "keep-alive");
                 } else {


### PR DESCRIPTION
Can I please get a review of this change which proposes to fix https://bugs.openjdk.java.net/browse/JDK-8276798?

`sun.net.www.protocol.http.HttpURLConnection` has a (private) `writeRequests` method. This method is responsible for creating the standard HTTP request headers (include the request line) and then writing it out to the `OutputStream` which communicates with the HTTP server. While writing out these request headers, if there's an IOException, then `HttpURLConnection` marks a `failedOnce` flag to `true` and attempts to write these again afresh (after creating new connection to the server). This re-attempt is done just once.

As noted in the linked JBS issue, specifically this comment https://bugs.openjdk.java.net/browse/JDK-8276798?focusedCommentId=14500074&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14500074, there's a specific case where creating and writing out these request headers ends up skipping the request line, which causes the server to respond back with a "Bad Request" response code.

The commit in this PR removes the use of `failedOnce` flag that was being used to decide whether or not to write the request line. The existing code doesn't have any specific comments on why this check was there in first place, nor does the commit history show anything about this check. However, reading through that code, my guess is that, it was there to avoid writing the request line twice when the same `requests` object gets reused during the re-attempt. I think a better check would be the see if the `requests` already has  the request line and if not add it afresh.
While in this code, I also removed the check where the `failedOnce` flag was being used to check if the `Connection: Keep-Alive`/`Proxy-Connection: Keep-alive` header needs to be set. This part of the code already has a call to `setIfNotSet`, so I don't think we need the `failedOnce` check here.

tier1, tier2 and tier3 tests have passed without issues. However, given the nature of this code, I'm not too confident that we have tests which can catch this issue (and adding one isn't easy), so I would like inputs on whether this change is good enough or whether it has the potential to cause any non-obvious regressions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276798](https://bugs.openjdk.org/browse/JDK-8276798): HttpURLConnection sends invalid HTTP request


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9038/head:pull/9038` \
`$ git checkout pull/9038`

Update a local copy of the PR: \
`$ git checkout pull/9038` \
`$ git pull https://git.openjdk.org/jdk pull/9038/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9038`

View PR using the GUI difftool: \
`$ git pr show -t 9038`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9038.diff">https://git.openjdk.org/jdk/pull/9038.diff</a>

</details>
