### PR TITLE
8287808: javac generates illegal class file for pattern matching switch with records

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -352,7 +352,7 @@ public class TransPatterns extends TreeTranslator {
                                              types.erasure(component.type),
                                              List.nil(),
                                              syms.methodClass);
-            MethodSymbol proxy = new MethodSymbol(Flags.STATIC | Flags.SYNTHETIC,
+            MethodSymbol proxy = new MethodSymbol(Flags.PRIVATE | Flags.STATIC | Flags.SYNTHETIC,
                                                   names.fromString("$proxy$" + component.name),
                                                   type,
                                                   currentClass);

--- a/test/langtools/tools/javac/annotations/typeAnnotations/classfile/Patterns.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/classfile/Patterns.java
@@ -245,9 +245,9 @@ public class Patterns {
                                       value=[@Patterns$DeconstructionPattern$A,@Patterns$DeconstructionPattern$A]
                                     )
 
-                            static java.lang.String $proxy$s(Patterns$DeconstructionPattern$R);
+                            private static java.lang.String $proxy$s(Patterns$DeconstructionPattern$R);
                               descriptor: (LPatterns$DeconstructionPattern$R;)Ljava/lang/String;
-                              flags: (0x1008) ACC_STATIC, ACC_SYNTHETIC
+                              flags: (0x100a) ACC_PRIVATE, ACC_STATIC, ACC_SYNTHETIC
 
                             static {};
                               descriptor: ()V

--- a/test/langtools/tools/javac/patterns/SimpleDeconstructionPattern.java
+++ b/test/langtools/tools/javac/patterns/SimpleDeconstructionPattern.java
@@ -112,6 +112,9 @@ public class SimpleDeconstructionPattern {
         if (!testGen3(new GenRecord1<>(3, ""))) {
             throw new IllegalStateException();
         }
+        if (!I.testInInterface(new P2(new P(0), ""))) {
+            throw new IllegalStateException();
+        }
     }
 
     private static void exp(Object o) throws Throwable {
@@ -188,6 +191,11 @@ public class SimpleDeconstructionPattern {
         return o instanceof GenRecord1<Integer, String>(var i, var s) && i.intValue() == 3 && s.length() == 0;
     }
 
+    interface I {
+        public static boolean testInInterface(Object o) {
+            return o instanceof P2(P(int i), var s) && i == 0;
+        }
+    }
     public record P(int i) {
     }
 

--- a/test/langtools/tools/javac/patterns/SimpleDeconstructionPatternNoPreview.out
+++ b/test/langtools/tools/javac/patterns/SimpleDeconstructionPatternNoPreview.out
@@ -1,2 +1,2 @@
-SimpleDeconstructionPattern.java:118:27: compiler.err.preview.feature.disabled.plural: (compiler.misc.feature.deconstruction.patterns)
+SimpleDeconstructionPattern.java:121:27: compiler.err.preview.feature.disabled.plural: (compiler.misc.feature.deconstruction.patterns)
 1 error


### PR DESCRIPTION
For record patterns, javac generates proxy methods for accessors, to properly wrap exceptions. These proxies are currently generated as package private, which is not valid for interfaces. Using private methods should be better.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287808](https://bugs.openjdk.org/browse/JDK-8287808): javac generates illegal class file for pattern matching switch with records


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9039/head:pull/9039` \
`$ git checkout pull/9039`

Update a local copy of the PR: \
`$ git checkout pull/9039` \
`$ git pull https://git.openjdk.java.net/jdk pull/9039/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9039`

View PR using the GUI difftool: \
`$ git pr show -t 9039`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9039.diff">https://git.openjdk.java.net/jdk/pull/9039.diff</a>

</details>
