### PR TITLE
8287860: Revise usage of volatile in j.u.Locale

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -50,6 +50,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.spi.LocaleNameProvider;
 import java.util.stream.Collectors;
 
+import jdk.internal.vm.annotation.Stable;
+
 import sun.security.action.GetPropertyAction;
 import sun.util.locale.BaseLocale;
 import sun.util.locale.InternalLocaleBuilder;
@@ -2260,7 +2262,7 @@ public final class Locale implements Cloneable, Serializable {
     /**
      * Calculated hashcode
      */
-    private transient int hashCodeValue;
+    private transient @Stable int hashCodeValue;
 
     private static volatile Locale defaultLocale = initDefault();
     private static volatile Locale defaultDisplayLocale;
@@ -3113,7 +3115,7 @@ public final class Locale implements Cloneable, Serializable {
         private final String range;
         private final double weight;
 
-        private int hash;
+        private @Stable int hash;
 
         /**
          * Constructs a {@code LanguageRange} using the given {@code range}.

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -1081,18 +1081,18 @@ public final class Locale implements Cloneable, Serializable {
     private static Locale initDefault(Locale.Category category) {
         Properties props = GetPropertyAction.privilegedGetProperties();
 
-        Locale defaultLocale = Locale.defaultLocale;
+        Locale locale = Locale.defaultLocale;
         return getInstance(
             props.getProperty(category.languageKey,
-                    defaultLocale.getLanguage()),
+                    locale.getLanguage()),
             props.getProperty(category.scriptKey,
-                    defaultLocale.getScript()),
+                    locale.getScript()),
             props.getProperty(category.countryKey,
-                    defaultLocale.getCountry()),
+                    locale.getCountry()),
             props.getProperty(category.variantKey,
-                    defaultLocale.getVariant()),
+                    locale.getVariant()),
             getDefaultExtensions(props.getProperty(category.extensionsKey, ""))
-                .orElse(defaultLocale.getLocaleExtensions()));
+                .orElse(locale.getLocaleExtensions()));
     }
 
     private static Optional<LocaleExtensions> getDefaultExtensions(String extensionsProp) {
@@ -1268,12 +1268,12 @@ public final class Locale implements Cloneable, Serializable {
      * @return An array of ISO 639 two-letter language codes.
      */
     public static String[] getISOLanguages() {
-        String[] isoLanguages = Locale.isoLanguages;
-        if (isoLanguages == null) {
-            Locale.isoLanguages = isoLanguages = getISO2Table(LocaleISOData.isoLanguageTable);
+        String[] languages = Locale.isoLanguages;
+        if (languages == null) {
+            Locale.isoLanguages = languages = getISO2Table(LocaleISOData.isoLanguageTable);
         }
-        String[] result = new String[isoLanguages.length];
-        System.arraycopy(isoLanguages, 0, result, 0, isoLanguages.length);
+        String[] result = new String[languages.length];
+        System.arraycopy(languages, 0, result, 0, languages.length);
         return result;
     }
 
@@ -1612,9 +1612,9 @@ public final class Locale implements Cloneable, Serializable {
      * @since 1.7
      */
     public String toLanguageTag() {
-        String languageTag = this.languageTag;
-        if (languageTag != null) {
-            return languageTag;
+        String lTag = this.languageTag;
+        if (lTag != null) {
+            return lTag;
         }
 
         LanguageTag tag = LanguageTag.parseLocale(baseLocale, localeExtensions);

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -681,7 +681,7 @@ public final class Locale implements Cloneable, Serializable {
         /**
          * Map to hold country codes for each ISO3166 part.
          */
-        private static Map<IsoCountryCode, Set<String>> iso3166CodesMap = new ConcurrentHashMap<>();
+        private static final Map<IsoCountryCode, Set<String>> iso3166CodesMap = new ConcurrentHashMap<>();
 
         /**
          * This method is called from Locale class to retrieve country code set
@@ -1079,6 +1079,7 @@ public final class Locale implements Cloneable, Serializable {
     private static Locale initDefault(Locale.Category category) {
         Properties props = GetPropertyAction.privilegedGetProperties();
 
+        Locale defaultLocale = Locale.defaultLocale;
         return getInstance(
             props.getProperty(category.languageKey,
                     defaultLocale.getLanguage()),
@@ -1265,8 +1266,9 @@ public final class Locale implements Cloneable, Serializable {
      * @return An array of ISO 639 two-letter language codes.
      */
     public static String[] getISOLanguages() {
+        String[] isoLanguages = Locale.isoLanguages;
         if (isoLanguages == null) {
-            isoLanguages = getISO2Table(LocaleISOData.isoLanguageTable);
+            Locale.isoLanguages = isoLanguages = getISO2Table(LocaleISOData.isoLanguageTable);
         }
         String[] result = new String[isoLanguages.length];
         System.arraycopy(isoLanguages, 0, result, 0, isoLanguages.length);
@@ -1608,6 +1610,7 @@ public final class Locale implements Cloneable, Serializable {
      * @since 1.7
      */
     public String toLanguageTag() {
+        String languageTag = this.languageTag;
         if (languageTag != null) {
             return languageTag;
         }
@@ -1657,11 +1660,11 @@ public final class Locale implements Cloneable, Serializable {
 
         String langTag = buf.toString();
         synchronized (this) {
-            if (languageTag == null) {
-                languageTag = langTag;
+            if (this.languageTag == null) {
+                this.languageTag = langTag;
             }
         }
-        return languageTag;
+        return langTag;
     }
 
     /**
@@ -2257,7 +2260,7 @@ public final class Locale implements Cloneable, Serializable {
     /**
      * Calculated hashcode
      */
-    private transient volatile int hashCodeValue;
+    private transient int hashCodeValue;
 
     private static volatile Locale defaultLocale = initDefault();
     private static volatile Locale defaultDisplayLocale;
@@ -3110,7 +3113,7 @@ public final class Locale implements Cloneable, Serializable {
         private final String range;
         private final double weight;
 
-        private volatile int hash;
+        private int hash;
 
         /**
          * Constructs a {@code LanguageRange} using the given {@code range}.

--- a/src/java.base/share/classes/sun/util/locale/BaseLocale.java
+++ b/src/java.base/share/classes/sun/util/locale/BaseLocale.java
@@ -97,7 +97,7 @@ public final class BaseLocale {
     private final String region;
     private final String variant;
 
-    private int hash;
+    private @Stable int hash;
 
     /**
      * Boolean for the old ISO language code compatibility.

--- a/src/java.base/share/classes/sun/util/locale/BaseLocale.java
+++ b/src/java.base/share/classes/sun/util/locale/BaseLocale.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,7 +97,7 @@ public final class BaseLocale {
     private final String region;
     private final String variant;
 
-    private volatile int hash;
+    private int hash;
 
     /**
      * Boolean for the old ISO language code compatibility.


### PR DESCRIPTION
- cached hash code of `Locale` and `Locale$LanguageRange` shouldn't be volatile, even in case of race in the worst case it is recalculated at most once per thread
- `defaultLocale` field is read multiple times in `initDefault()`
- `isoLanguages` is accessed multiple times in `getISOLanguages()`
- `languageTag` is read twice in `toLanguageTag()`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287860](https://bugs.openjdk.org/browse/JDK-8287860): Revise usage of volatile in j.u.Locale


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9041/head:pull/9041` \
`$ git checkout pull/9041`

Update a local copy of the PR: \
`$ git checkout pull/9041` \
`$ git pull https://git.openjdk.java.net/jdk pull/9041/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9041`

View PR using the GUI difftool: \
`$ git pr show -t 9041`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9041.diff">https://git.openjdk.java.net/jdk/pull/9041.diff</a>

</details>
