### PR TITLE
JDK-8287867: Bad merge of jdk/test/lib/util/ForceGC.java causing test compilation error

### DIFF
--- a/test/lib/jdk/test/lib/util/ForceGC.java
+++ b/test/lib/jdk/test/lib/util/ForceGC.java
@@ -76,7 +76,7 @@ public class ForceGC {
                 return true;
             }
 
-            doIt(i);
+            doit(i);
             try {
                 Thread.sleep(100);
             } catch (InterruptedException e) {


### PR DESCRIPTION
A typo in ForceGC.java causes several test failing due to compilation error.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287867](https://bugs.openjdk.org/browse/JDK-8287867): Bad merge of jdk/test/lib/util/ForceGC.java causing test compilation error


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9043/head:pull/9043` \
`$ git checkout pull/9043`

Update a local copy of the PR: \
`$ git checkout pull/9043` \
`$ git pull https://git.openjdk.java.net/jdk pull/9043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9043`

View PR using the GUI difftool: \
`$ git pr show -t 9043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9043.diff">https://git.openjdk.java.net/jdk/pull/9043.diff</a>

</details>
