### PR TITLE
8283383: [macos] a11y : Screen magnifier shows extra characters (0) at the end JButton accessibility name

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ButtonAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ButtonAccessibility.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,17 @@
 - (id)accessibilityParent
 {
     return [super accessibilityParent];
+}
+
+- (id _Nullable)accessibilityValue
+{
+    if ([self accessibilityRole] == NSAccessibilityButtonRole) {
+        // Only do it for buttons, radio buttons and checkbox buttons
+        // have a meaningful value to return
+        return NULL;
+    } else {
+        return [super accessibilityValue];
+    }
 }
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,7 +126,7 @@ static jobject sAccessibilityClass = NULL;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:50];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:51];
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
@@ -159,6 +159,7 @@ static jobject sAccessibilityClass = NULL;
     [rolesMap setObject:@"MenuBarAccessibility" forKey:@"menubar"];
     [rolesMap setObject:@"MenuAccessibility" forKey:@"menu"];
     [rolesMap setObject:@"MenuAccessibility" forKey:@"popupmenu"];
+    [rolesMap setObject:@"MenuItemAccessibility" forKey:@"menuitem"];
     [rolesMap setObject:@"ProgressIndicatorAccessibility" forKey:@"progressbar"];
 
     /*

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ImageAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ImageAccessibility.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,11 @@
 - (id)accessibilityParent
 {
     return [super accessibilityParent];
+}
+
+- (id _Nullable)accessibilityValue
+{
+    return NULL;
 }
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuAccessibility.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,11 @@
 - (BOOL)isAccessibilityElement
 {
     return YES;
+}
+
+- (id _Nullable)accessibilityValue
+{
+    return NULL;
 }
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuItemAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuItemAccessibility.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@
 
 - (id _Nullable)accessibilityValue
 {
-    return [super accessibilityValue];
+    return NULL;
 }
 
 @end


### PR DESCRIPTION
Add the accessibilityValue implementation to the affected classes to return NULL value
Reverse the default initialization of MenuItemAccessibility if no parent is specified

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283383](https://bugs.openjdk.org/browse/JDK-8283383): [macos] a11y : Screen magnifier shows extra characters (0) at the end JButton accessibility name


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Dmitry Markov](https://openjdk.java.net/census#dmarkov) (@dmarkov20 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9044/head:pull/9044` \
`$ git checkout pull/9044`

Update a local copy of the PR: \
`$ git checkout pull/9044` \
`$ git pull https://git.openjdk.java.net/jdk pull/9044/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9044`

View PR using the GUI difftool: \
`$ git pr show -t 9044`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9044.diff">https://git.openjdk.java.net/jdk/pull/9044.diff</a>

</details>
