### PR TITLE
8286160: (fs) Files.exists returns unexpected results with C:\pagefile.sys because it's not readable

### DIFF
--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystemProvider.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -374,11 +374,25 @@ class WindowsFileSystemProvider
             }
         }
 
-        // special-case read access to avoid needing to determine effective
-        // access to file; default if modes not specified
         if (!w && !x) {
-            checkReadAccess(file);
-            return;
+            try {
+                // special-case read access to avoid needing to determine
+                // effective access to file
+                checkReadAccess(file);
+                return;
+            } catch (IOException ioe) {
+                if (!r) {
+                    // Modes not specified: existence check only.
+                    // Assume file exists if attributes can be read.
+                    try {
+                        WindowsFileAttributes.get(file, true);
+                        return;
+                    } catch (WindowsException e) {
+                        ioe.addSuppressed(e);
+                    }
+                }
+                throw ioe;
+            }
         }
 
         int mask = 0;

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystemProvider.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystemProvider.java
@@ -374,25 +374,22 @@ class WindowsFileSystemProvider
             }
         }
 
-        if (!w && !x) {
+        // check file exists only
+        if (!(r || w || x)) {
+            file.checkRead();
             try {
-                // special-case read access to avoid needing to determine
-                // effective access to file
-                checkReadAccess(file);
+                WindowsFileAttributes.get(file, true);
                 return;
-            } catch (IOException ioe) {
-                if (!r) {
-                    // Modes not specified: existence check only.
-                    // Assume file exists if attributes can be read.
-                    try {
-                        WindowsFileAttributes.get(file, true);
-                        return;
-                    } catch (WindowsException e) {
-                        ioe.addSuppressed(e);
-                    }
-                }
-                throw ioe;
+            } catch (WindowsException exc) {
+                exc.rethrowAsIOException(file);
             }
+        }
+
+        // special-case read access to avoid needing to determine effective
+        // access to file
+        if (!w && !x) {
+            checkReadAccess(file);
+            return;
         }
 
         int mask = 0;

--- a/test/jdk/java/nio/file/Files/Misc.java
+++ b/test/jdk/java/nio/file/Files/Misc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,17 +22,29 @@
  */
 
 /* @test
- * @bug 4313887 6838333 8005566 8032220 8215467 8255576
+ * @bug 4313887 6838333 8005566 8032220 8215467 8255576 8286160
  * @summary Unit test for miscellenous methods in java.nio.file.Files
- * @library ..
+ * @library .. /test/lib
+ * @build jdk.test.lib.Platform
+ * @run main Misc
  */
 
-import java.nio.file.*;
+import java.io.IOException;
+import java.io.File;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryPermission;
+import java.nio.file.attribute.AclEntryType;
+import java.nio.file.attribute.AclFileAttributeView;
+import java.nio.file.attribute.DosFileAttributeView;
+import java.nio.file.attribute.UserPrincipal;
+import java.util.List;
+import jdk.test.lib.Platform;
+
 import static java.nio.file.Files.*;
 import static java.nio.file.LinkOption.*;
-import java.nio.file.attribute.*;
-import java.io.IOException;
-import java.util.*;
 
 public class Misc {
 
@@ -78,7 +90,7 @@ public class Misc {
         } catch (IOException x) { }
 
         // the root directory always exists
-        Path root = Paths.get("/");
+        Path root = Path.of("/");
         Files.createDirectories(root);
         Files.createDirectories(root.toAbsolutePath());
     }
@@ -93,7 +105,7 @@ public class Misc {
         assertTrue(!isHidden(tmpdir));
 
         Path file = tmpdir.resolve(".foo");
-        if (System.getProperty("os.name").startsWith("Windows")) {
+        if (Platform.isWindows()) {
             createFile(file);
             try {
                 setAttribute(file, "dos:hidden", true);
@@ -286,6 +298,13 @@ public class Misc {
             assertTrue(exists(tmpdir));
             assertTrue(!notExists(tmpdir));
 
+            if (Platform.isWindows()) {
+                Path pageFile = Path.of("C:\\pagefile.sys");
+                if (pageFile.toFile().exists()) {
+                    System.out.printf("Check page file %s%n", pageFile);
+                    assertTrue(exists(pageFile));
+                }
+            }
 
             // sym link exists
             if (TestUtil.supportsLinks(tmpdir)) {
@@ -351,7 +370,7 @@ public class Misc {
             /**
              * Test: Windows DOS read-only attribute
              */
-            if (System.getProperty("os.name").startsWith("Windows")) {
+            if (Platform.isWindows()) {
                 setAttribute(file, "dos:readonly", true);
                 try {
                     assertTrue(!isWritable(file));
@@ -381,10 +400,10 @@ public class Misc {
     }
 
     private static boolean isRoot() {
-        if (System.getProperty("os.name").startsWith("Windows"))
+        if (Platform.isWindows())
             return false;
 
-        Path passwd = Paths.get("/etc/passwd");
+        Path passwd = Path.of("/etc/passwd");
         return Files.isWritable(passwd);
     }
 }


### PR DESCRIPTION
If in `WindosFileSystemProvider.checkAccess(Path obj, AccessMode... modes)` the sub-test `checkReadAccess(WindowsPath)` fails and no modes are specified, then try to determine file existence by reading the file's attributes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286160](https://bugs.openjdk.org/browse/JDK-8286160): (fs) Files.exists returns unexpected results with C:\pagefile.sys because it's not readable


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9045/head:pull/9045` \
`$ git checkout pull/9045`

Update a local copy of the PR: \
`$ git checkout pull/9045` \
`$ git pull https://git.openjdk.java.net/jdk pull/9045/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9045`

View PR using the GUI difftool: \
`$ git pr show -t 9045`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9045.diff">https://git.openjdk.java.net/jdk/pull/9045.diff</a>

</details>
