### PR TITLE
8287869: -XX:+AutoCreateSharedArchive doesn't work when JDK build is switched

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -209,11 +209,15 @@ void FileMapInfo::populate_header(size_t core_region_alignment) {
     // dynamic header including base archive name for non-default base archive
     c_header_size = sizeof(DynamicArchiveHeader);
     header_size = c_header_size;
-    if (!FLAG_IS_DEFAULT(SharedArchiveFile)) {
-      base_archive_name_size = strlen(Arguments::GetSharedArchivePath()) + 1;
+
+    const char* default_base_archive_name = Arguments::get_default_shared_archive_path();
+    const char* current_base_archive_name = Arguments::GetSharedArchivePath();
+    if (!os::same_files(current_base_archive_name, default_base_archive_name)) {
+      base_archive_name_size = strlen(current_base_archive_name) + 1;
       header_size += base_archive_name_size;
       base_archive_name_offset = c_header_size;
     }
+    FREE_C_HEAP_ARRAY(const char, default_base_archive_name);
   }
   _header = (FileMapHeader*)os::malloc(header_size, mtInternal);
   memset((void*)_header, 0, header_size);
@@ -301,7 +305,7 @@ void FileMapHeader::print(outputStream* st) {
 
   st->print_cr("- magic:                          0x%08x", magic());
   st->print_cr("- crc:                            0x%08x", crc());
-  st->print_cr("- version:                        %d", version());
+  st->print_cr("- version:                        0x%x", version());
   st->print_cr("- header_size:                    " UINT32_FORMAT, header_size());
   st->print_cr("- base_archive_name_offset:       " UINT32_FORMAT, base_archive_name_offset());
   st->print_cr("- base_archive_name_size:         " UINT32_FORMAT, base_archive_name_size());
@@ -1151,14 +1155,14 @@ public:
     }
 
     if (gen_header._version < CDS_GENERIC_HEADER_SUPPORTED_MIN_VERSION) {
-      FileMapInfo::fail_continue("Cannot handle shared archive file version %d. Must be at least %d",
+      FileMapInfo::fail_continue("Cannot handle shared archive file version 0x%x. Must be at least 0x%x.",
                                  gen_header._version, CDS_GENERIC_HEADER_SUPPORTED_MIN_VERSION);
       return false;
     }
 
     if (gen_header._version !=  CURRENT_CDS_ARCHIVE_VERSION) {
-      FileMapInfo::fail_continue("The shared archive file version %d does not match the required version %d",
-                                    gen_header._version, CURRENT_CDS_ARCHIVE_VERSION);
+      FileMapInfo::fail_continue("The shared archive file version 0x%x does not match the required version 0x%x.",
+                                 gen_header._version, CURRENT_CDS_ARCHIVE_VERSION);
     }
 
     size_t filelen = os::lseek(fd, 0, SEEK_END);
@@ -1332,8 +1336,8 @@ bool FileMapInfo::init_from_file(int fd) {
   }
 
   if (header()->version() != CURRENT_CDS_ARCHIVE_VERSION) {
-    log_info(cds)("_version expected: %d", CURRENT_CDS_ARCHIVE_VERSION);
-    log_info(cds)("           actual: %d", header()->version());
+    log_info(cds)("_version expected: 0x%x", CURRENT_CDS_ARCHIVE_VERSION);
+    log_info(cds)("           actual: 0x%x", header()->version());
     fail_continue("The shared archive file has the wrong version.");
     return false;
   }

--- a/src/hotspot/share/include/cds.h
+++ b/src/hotspot/share/include/cds.h
@@ -61,7 +61,7 @@ typedef struct CDSFileMapRegion {
 } CDSFileMapRegion;
 
 // This portion of the archive file header must remain unchanged for
-// _version >= CDS_GENERIC_HEADER_SUPPORTED_MIN_VERSION (12).
+// _version >= CDS_GENERIC_HEADER_SUPPORTED_MIN_VERSION (13).
 // This makes it possible to read important information from a CDS archive created by
 // a different version of HotSpot, so that we can automatically regenerate the archive as necessary.
 typedef struct GenericCDSFileMapHeader {

--- a/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
@@ -97,6 +97,10 @@ public class SharedArchiveConsistency {
         TestCommon.checkExec(output);
     }
 
+    private static String hex(int version) {
+        return String.format("0x%x", version); 
+    }
+
     // dump with hello.jsa, then
     // read the jsa file
     //   1) run normal
@@ -189,7 +193,7 @@ public class SharedArchiveConsistency {
         copiedJsa = CDSArchiveUtils.copyArchiveFile(orgJsaFile, modVersion);
         CDSArchiveUtils.modifyHeaderIntField(copiedJsa, CDSArchiveUtils.offsetVersion(), version);
         output = shareAuto ? TestCommon.execAuto(execArgs) : TestCommon.execCommon(execArgs);
-        output.shouldContain("The shared archive file version " + version + " does not match the required version " + currentCDSArchiveVersion);
+        output.shouldContain("The shared archive file version " + hex(version) + " does not match the required version " + hex(currentCDSArchiveVersion));
         if (shareAuto) {
             output.shouldContain(HELLO_WORLD);
         }
@@ -200,7 +204,7 @@ public class SharedArchiveConsistency {
         version = genericHeaderMinVersion - 1;
         CDSArchiveUtils.modifyHeaderIntField(copiedJsa, CDSArchiveUtils.offsetVersion(), version);
         output = shareAuto ? TestCommon.execAuto(execArgs) : TestCommon.execCommon(execArgs);
-        output.shouldContain("Cannot handle shared archive file version " + version + ". Must be at least " + genericHeaderMinVersion);
+        output.shouldContain("Cannot handle shared archive file version " + hex(version) + ". Must be at least " + hex(genericHeaderMinVersion));
         output.shouldNotContain("Checksum verification failed");
         if (shareAuto) {
             output.shouldContain(HELLO_WORLD);

--- a/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
@@ -98,7 +98,7 @@ public class SharedArchiveConsistency {
     }
 
     private static String hex(int version) {
-        return String.format("0x%x", version); 
+        return String.format("0x%x", version);
     }
 
     // dump with hello.jsa, then

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java
@@ -151,6 +151,10 @@ public class TestAutoCreateSharedArchive extends DynamicArchiveTestBase {
         System.out.println(message);
     }
 
+    private static String hex(int version) {
+        return String.format("0x%x", version); 
+    }
+
     private static void testAutoCreateSharedArchive() throws Exception {
         String appJar = ClassFileInstaller.getJarPath("hello.jar");
         boolean fileModified = false;
@@ -303,7 +307,7 @@ public class TestAutoCreateSharedArchive extends DynamicArchiveTestBase {
             .assertNormalExit(output -> {
                 output.shouldHaveExitValue(0)
                       .shouldContain(HELLO_WORLD)
-                      .shouldContain("Cannot handle shared archive file version " + version1 + ". Must be at least " + genericHeaderMinVersion)
+                      .shouldContain("Cannot handle shared archive file version " + hex(version1) + ". Must be at least " + hex(genericHeaderMinVersion))
                       .shouldContain("Unable to use shared archive: invalid archive")
                       .shouldNotContain("Dumping shared data to file");
             });
@@ -331,7 +335,7 @@ public class TestAutoCreateSharedArchive extends DynamicArchiveTestBase {
             .assertNormalExit(output -> {
                 output.shouldHaveExitValue(0)
                       .shouldContain(HELLO_WORLD)
-                      .shouldContain("The shared archive file version " + version2 + " does not match the required version " + currentCDSVersion)
+                      .shouldContain("The shared archive file version " + hex(version2) + " does not match the required version " + hex(currentCDSVersion))
                       .shouldContain("UseSharedSpaces: The shared archive file has the wrong version")
                       .shouldContain("UseSharedSpaces: Initialize dynamic archive failed")
                       .shouldContain("Dumping shared data to file");
@@ -523,7 +527,7 @@ public class TestAutoCreateSharedArchive extends DynamicArchiveTestBase {
              .assertNormalExit(output -> {
                  output.shouldHaveExitValue(0)
                        .shouldContain(HELLO_WORLD)
-                       .shouldContain("Cannot handle shared archive file version " + version1)
+                       .shouldContain("Cannot handle shared archive file version " + hex(version1))
                        .shouldContain(versionB)
                        .shouldContain("Dumping shared data to file:");
              });
@@ -548,7 +552,7 @@ public class TestAutoCreateSharedArchive extends DynamicArchiveTestBase {
              "-cp", appJar,
              mainAppClass)
              .assertNormalExit(output -> {
-                 output.shouldContain("The shared archive file version " + version2 + " does not match the required version " + currentCDSVersion)
+                 output.shouldContain("The shared archive file version " + hex(version2) + " does not match the required version " + hex(currentCDSVersion))
                        .shouldContain(HELLO_WORLD)
                        .shouldContain("Dumping shared data to file:");
              });

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java
@@ -152,7 +152,7 @@ public class TestAutoCreateSharedArchive extends DynamicArchiveTestBase {
     }
 
     private static String hex(int version) {
-        return String.format("0x%x", version); 
+        return String.format("0x%x", version);
     }
 
     private static void testAutoCreateSharedArchive() throws Exception {


### PR DESCRIPTION
When you switch to a different build of the JDK (to a different version, or from product to debug), `-XX:+AutoCreateSharedArchive` should automatically regenerate the dynamic CDS archive.

However, we have a bug where the information about the base archive is incorrectly stored in the dynamic archive. As a result, the new JDK will try to load the default base archive from the old JDK, causing CDS to be disabled, which means that the dynamic CDS archive cannot be generated at VM exit.

The fix is to correctly set `GenericCDSFileMapHeader::__base_archive_name_{offset,size}` to zero when the default base archive is used.

(Currently the fix can be validated only manually -- see JBS bug report. We are looking into a way to test this scenario automatically in the CI).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287869](https://bugs.openjdk.org/browse/JDK-8287869): -XX:+AutoCreateSharedArchive doesn't work when JDK build is switched


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9046/head:pull/9046` \
`$ git checkout pull/9046`

Update a local copy of the PR: \
`$ git checkout pull/9046` \
`$ git pull https://git.openjdk.java.net/jdk pull/9046/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9046`

View PR using the GUI difftool: \
`$ git pr show -t 9046`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9046.diff">https://git.openjdk.java.net/jdk/pull/9046.diff</a>

</details>
