### PR TITLE
8287872: Disable concurrent execution of hotspot docker tests

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TEST.properties
+++ b/test/hotspot/jtreg/containers/docker/TEST.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+exclusiveAccess.dirs=.


### PR DESCRIPTION
Please review this quick fix.

Before the cause of [JDK-8287744](https://bugs.openjdk.org/browse/JDK-8287744) is known, let's disable concurrent execution of hotspot docker tests to avoid failures in CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287872](https://bugs.openjdk.org/browse/JDK-8287872): Disable concurrent execution of hotspot docker tests


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9047/head:pull/9047` \
`$ git checkout pull/9047`

Update a local copy of the PR: \
`$ git checkout pull/9047` \
`$ git pull https://git.openjdk.java.net/jdk pull/9047/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9047`

View PR using the GUI difftool: \
`$ git pr show -t 9047`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9047.diff">https://git.openjdk.java.net/jdk/pull/9047.diff</a>

</details>
