### PR TITLE
8287760: --do-not-resolve-by-default gets overwritten if --warn-if-resolved flags is used

### DIFF
--- a/src/jdk.jartool/share/classes/sun/tools/jar/GNUStyleOptions.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/GNUStyleOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jartool/share/classes/sun/tools/jar/GNUStyleOptions.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/GNUStyleOptions.java
@@ -178,7 +178,7 @@ class GNUStyleOptions {
                 void process(Main jartool, String opt, String arg) throws BadArgs {
                     ModuleResolution mres = ModuleResolution.empty();
                     if (jartool.moduleResolution.doNotResolveByDefault()) {
-                        mres.withDoNotResolveByDefault();
+                        mres = mres.withDoNotResolveByDefault();
                     }
                     if (arg.equals("deprecated")) {
                         jartool.moduleResolution = mres.withDeprecated();

--- a/test/jdk/tools/jar/modularJar/Basic.java
+++ b/test/jdk/tools/jar/modularJar/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/tools/jar/modularJar/Basic.java
+++ b/test/jdk/tools/jar/modularJar/Basic.java
@@ -947,8 +947,8 @@ public class Basic {
         }
     }
 
-    @DataProvider(name = "resolutionNames")
-    public Object[][] resolutionNames() {
+    @DataProvider(name = "resolutionWarnings")
+    public Object[][] resolutionWarnings() {
         return new Object[][] {
             {"incubating", (Predicate<ModuleResolution>) ModuleResolution::hasIncubatingWarning},
             {"deprecated", (Predicate<ModuleResolution>) ModuleResolution::hasDeprecatedWarning},
@@ -961,7 +961,7 @@ public class Basic {
      * Validate that you can create a jar only specifying --warn-if-resolved
      * @throws IOException
      */
-    @Test(dataProvider = "resolutionNames")
+    @Test(dataProvider = "resolutionWarnings")
     public void shouldAddWarnIfResolved(String resolutionName,
                                         Predicate<ModuleResolution> hasWarning) throws IOException {
         Path mp = Paths.get("moduleWarnIfResolved-" + resolutionName);
@@ -1019,7 +1019,7 @@ public class Basic {
      * --do-not-resolve-by-default
      * @throws IOException
      */
-    @Test(dataProvider = "resolutionNames")
+    @Test(dataProvider = "resolutionWarnings")
     public void shouldAddWarnIfResolvedAndDoNotResolveByDefault(String resolutionName,
                                         Predicate<ModuleResolution> hasWarning) throws IOException {
         Path mp = Paths.get("moduleResolutionWarnThenNotResolve-" + resolutionName);
@@ -1051,7 +1051,7 @@ public class Basic {
      * --warn-if-resolved
      * @throws IOException
      */
-    @Test(dataProvider = "resolutionNames")
+    @Test(dataProvider = "resolutionWarnings")
     public void shouldAddResolutionDoNotResolveByDefaultAndWarnIfResolved(String resolutionName,
                                         Predicate<ModuleResolution> hasWarning) throws IOException {
         Path mp = Paths.get("moduleResolutionNotResolveThenWarn-" + resolutionName);

--- a/test/jdk/tools/jar/modularJar/Basic.java
+++ b/test/jdk/tools/jar/modularJar/Basic.java
@@ -24,8 +24,6 @@
 import java.io.*;
 import java.lang.module.ModuleDescriptor;
 import java.lang.module.ModuleFinder;
-import java.lang.module.ModuleReader;
-import java.lang.module.ModuleReference;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -42,7 +40,6 @@ import java.util.spi.ToolProvider;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import jdk.internal.module.ModuleInfo;
 import jdk.internal.module.ModuleReferenceImpl;
 import jdk.internal.module.ModuleResolution;
 import jdk.test.lib.util.FileUtils;
@@ -953,9 +950,10 @@ public class Basic {
     @DataProvider(name = "resolutionNames")
     public Object[][] resolutionNames() {
         return new Object[][] {
-            {"incubating", (Predicate<ModuleResolution>)ModuleResolution::hasIncubatingWarning},
-            {"deprecated", (Predicate<ModuleResolution>)ModuleResolution::hasDeprecatedWarning},
-            {"deprecated-for-removal", (Predicate<ModuleResolution>)ModuleResolution::hasDeprecatedForRemovalWarning}
+            {"incubating", (Predicate<ModuleResolution>) ModuleResolution::hasIncubatingWarning},
+            {"deprecated", (Predicate<ModuleResolution>) ModuleResolution::hasDeprecatedWarning},
+            {"deprecated-for-removal",
+                (Predicate<ModuleResolution>) ModuleResolution::hasDeprecatedForRemovalWarning}
         };
     }
 
@@ -964,8 +962,9 @@ public class Basic {
      * @throws IOException
      */
     @Test(dataProvider = "resolutionNames")
-    public void updateFooModuleResolutionWarnIfResolved(String resolutionName, Predicate<ModuleResolution> hasWarning) throws IOException {
-        Path mp = Paths.get("updateFooModuleResolutionWarnIfResolved-" + resolutionName);
+    public void shouldAddWarnIfResolved(String resolutionName,
+                                        Predicate<ModuleResolution> hasWarning) throws IOException {
+        Path mp = Paths.get("moduleWarnIfResolved-" + resolutionName);
         createTestDir(mp);
         Path modClasses = MODULE_CLASSES.resolve(FOO.moduleName);
         Path modularJar = mp.resolve(FOO.moduleName + ".jar");
@@ -978,7 +977,8 @@ public class Basic {
             "-C", modClasses.toString(), ".")
             .assertSuccess();
 
-        ModuleReferenceImpl moduleReference = ModuleFinder.of(modularJar).find(FOO.moduleName)
+        ModuleReferenceImpl moduleReference = ModuleFinder.of(modularJar)
+            .find(FOO.moduleName)
             .map(ModuleReferenceImpl.class::cast)
             .orElseThrow();
         ModuleResolution moduleResolution = moduleReference.moduleResolution();
@@ -991,8 +991,8 @@ public class Basic {
      * @throws IOException
      */
     @Test
-    public void updateFooModuleResolutionWarnIfResolved() throws IOException {
-        Path mp = Paths.get("updateFooModuleResolutionDoNotResolveByDefault");
+    public void shouldAddDoNotResolveByDefault() throws IOException {
+        Path mp = Paths.get("moduleDoNotResolveByDefault");
         createTestDir(mp);
         Path modClasses = MODULE_CLASSES.resolve(FOO.moduleName);
         Path modularJar = mp.resolve(FOO.moduleName + ".jar");
@@ -1005,7 +1005,8 @@ public class Basic {
             "-C", modClasses.toString(), ".")
             .assertSuccess();
 
-        ModuleReferenceImpl moduleReference = ModuleFinder.of(modularJar).find(FOO.moduleName)
+        ModuleReferenceImpl moduleReference = ModuleFinder.of(modularJar)
+            .find(FOO.moduleName)
             .map(ModuleReferenceImpl.class::cast)
             .orElseThrow();
         ModuleResolution moduleResolution = moduleReference.moduleResolution();
@@ -1014,12 +1015,14 @@ public class Basic {
     }
 
     /**
-     * Validate that you can create a jar specifying --warn-if-resolved and --do-not-resolve-by-default
+     * Validate that you can create a jar specifying --warn-if-resolved and
+     * --do-not-resolve-by-default
      * @throws IOException
      */
     @Test(dataProvider = "resolutionNames")
-    public void updateFooModuleResolutionWarnIfResolvedAndDoNotResolveByDefault(String resolutionName, Predicate<ModuleResolution> hasWarning) throws IOException {
-        Path mp = Paths.get("updateFooModuleResolutionWarnThenNotResolve-" + resolutionName);
+    public void shouldAddWarnIfResolvedAndDoNotResolveByDefault(String resolutionName,
+                                        Predicate<ModuleResolution> hasWarning) throws IOException {
+        Path mp = Paths.get("moduleResolutionWarnThenNotResolve-" + resolutionName);
         createTestDir(mp);
         Path modClasses = MODULE_CLASSES.resolve(FOO.moduleName);
         Path modularJar = mp.resolve(FOO.moduleName + ".jar");
@@ -1033,7 +1036,8 @@ public class Basic {
             "-C", modClasses.toString(), ".")
             .assertSuccess();
 
-        ModuleReferenceImpl moduleReference = ModuleFinder.of(modularJar).find(FOO.moduleName)
+        ModuleReferenceImpl moduleReference = ModuleFinder.of(modularJar)
+            .find(FOO.moduleName)
             .map(ModuleReferenceImpl.class::cast)
             .orElseThrow();
         ModuleResolution moduleResolution = moduleReference.moduleResolution();
@@ -1043,12 +1047,14 @@ public class Basic {
     }
 
     /**
-     * Validate that you can create a jar specifying --do-not-resolve-by-default and --warn-if-resolved
+     * Validate that you can create a jar specifying --do-not-resolve-by-default and
+     * --warn-if-resolved
      * @throws IOException
      */
     @Test(dataProvider = "resolutionNames")
-    public void updateFooModuleResolutionDoNotResolveByDefaultAndWarnIfResolved(String resolutionName, Predicate<ModuleResolution> hasWarning) throws IOException {
-        Path mp = Paths.get("updateFooModuleResolutionNotResolveThenWarn-" + resolutionName);
+    public void shouldAddResolutionDoNotResolveByDefaultAndWarnIfResolved(String resolutionName,
+                                        Predicate<ModuleResolution> hasWarning) throws IOException {
+        Path mp = Paths.get("moduleResolutionNotResolveThenWarn-" + resolutionName);
         createTestDir(mp);
         Path modClasses = MODULE_CLASSES.resolve(FOO.moduleName);
         Path modularJar = mp.resolve(FOO.moduleName + ".jar");
@@ -1062,7 +1068,8 @@ public class Basic {
             "-C", modClasses.toString(), ".")
             .assertSuccess();
 
-        ModuleReferenceImpl moduleReference = ModuleFinder.of(modularJar).find(FOO.moduleName)
+        ModuleReferenceImpl moduleReference = ModuleFinder.of(modularJar)
+            .find(FOO.moduleName)
             .map(ModuleReferenceImpl.class::cast)
             .orElseThrow();
         ModuleResolution moduleResolution = moduleReference.moduleResolution();

--- a/test/jdk/tools/jar/modularJar/Basic.java
+++ b/test/jdk/tools/jar/modularJar/Basic.java
@@ -960,7 +960,7 @@ public class Basic {
     }
 
     /**
-     * Validate that you can update a jar only specifying --warn-if-resolved
+     * Validate that you can create a jar only specifying --warn-if-resolved
      * @throws IOException
      */
     @Test(dataProvider = "resolutionNames")
@@ -987,7 +987,7 @@ public class Basic {
     }
 
     /**
-     * Validate that you can update a jar only specifying --do-not-resolve-by-default
+     * Validate that you can create a jar only specifying --do-not-resolve-by-default
      * @throws IOException
      */
     @Test
@@ -1014,7 +1014,7 @@ public class Basic {
     }
 
     /**
-     * Validate that you can update a jar specifying --warn-if-resolved and --do-not-resolve-by-default
+     * Validate that you can create a jar specifying --warn-if-resolved and --do-not-resolve-by-default
      * @throws IOException
      */
     @Test(dataProvider = "resolutionNames")
@@ -1043,7 +1043,7 @@ public class Basic {
     }
 
     /**
-     * Validate that you can update a jar specifying --do-not-resolve-by-default and --warn-if-resolved
+     * Validate that you can create a jar specifying --do-not-resolve-by-default and --warn-if-resolved
      * @throws IOException
      */
     @Test(dataProvider = "resolutionNames")


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287760](https://bugs.openjdk.org/browse/JDK-8287760): --do-not-resolve-by-default gets overwritten if --warn-if-resolved flags is used


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to [c88bc754](https://git.openjdk.org/jdk/pull/9049/files/c88bc75453547c8a991f352cb5df3df82e30f456)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9049/head:pull/9049` \
`$ git checkout pull/9049`

Update a local copy of the PR: \
`$ git checkout pull/9049` \
`$ git pull https://git.openjdk.org/jdk pull/9049/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9049`

View PR using the GUI difftool: \
`$ git pr show -t 9049`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9049.diff">https://git.openjdk.org/jdk/pull/9049.diff</a>

</details>
