### PR TITLE
8287876: The recently de-problemlisted TestTitledBorderLeak test is unstable

### DIFF
--- a/test/jdk/javax/swing/border/TestTitledBorderLeak.java
+++ b/test/jdk/javax/swing/border/TestTitledBorderLeak.java
@@ -24,7 +24,6 @@
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 
-import javax.swing.UIManager;
 import javax.swing.border.TitledBorder;
 
 /**
@@ -38,24 +37,11 @@ import javax.swing.border.TitledBorder;
 public final class TestTitledBorderLeak {
 
     public static void main(String[] args) throws Exception {
-        int ul = UIManager.getPropertyChangeListeners().length;
-        int dl = UIManager.getDefaults().getPropertyChangeListeners().length;
-
         Reference<TitledBorder> border = getTitleBorder();
         int attempt = 0;
         while (border.get() != null) {
             Util.generateOOME();
             System.out.println("Not freed, attempt: " + attempt++);
-        }
-        check(ul, UIManager.getPropertyChangeListeners().length);
-        check(dl, UIManager.getDefaults().getPropertyChangeListeners().length);
-    }
-
-    private static void check(int expected, int actual) {
-        if (expected != actual) {
-            System.err.println("Expected: " + expected);
-            System.err.println("Actual: " + actual);
-            throw new RuntimeException("Wrong number of listeners");
         }
     }
 

--- a/test/jdk/javax/swing/border/TestTitledBorderLeak.java
+++ b/test/jdk/javax/swing/border/TestTitledBorderLeak.java
@@ -42,7 +42,6 @@ public final class TestTitledBorderLeak {
         int dl = UIManager.getDefaults().getPropertyChangeListeners().length;
 
         Reference<TitledBorder> border = getTitleBorder();
-        Thread.sleep(3000);
         int attempt = 0;
         while (border.get() != null) {
             Util.generateOOME();


### PR DESCRIPTION
This is an update of the test which was de-problemlisted [here](https://github.com/openjdk/jdk/pull/8450).

Looks like the initial root cause of the issue was related to the last disposed frame which for some reason was not deleted from the memory, for that issue, the [next](https://bugs.openjdk.org/browse/JDK-8287707) bug was reported.
But that change also replaced the usage of weak references by the Runtime.getRuntime().freeMemory() which is not stable enough to verify the leak - its return values vary a lot.

This change returns the usage of weak references and tests only one instance of TitledBorder which is enough to verify the old [bug](https://bugs.openjdk.org/browse/JDK-8204963).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287876](https://bugs.openjdk.org/browse/JDK-8287876): The recently de-problemlisted TestTitledBorderLeak test is unstable


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**) ⚠️ Review applies to [da1a82c9](https://git.openjdk.java.net/jdk/pull/9051/files/da1a82c99d981a869f28c935684ab599448e8de1)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9051/head:pull/9051` \
`$ git checkout pull/9051`

Update a local copy of the PR: \
`$ git checkout pull/9051` \
`$ git pull https://git.openjdk.java.net/jdk pull/9051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9051`

View PR using the GUI difftool: \
`$ git pr show -t 9051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9051.diff">https://git.openjdk.java.net/jdk/pull/9051.diff</a>

</details>
