### PR TITLE
8287700: C2 Crash running eclipse benchmark from Dacapo

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -2641,7 +2641,7 @@ bool ConnectionGraph::split_AddP(Node *addp, Node *base) {
   // this code branch will go away.
   //
   if (!t->is_known_instance() &&
-      !t->maybe_java_subtype_of(base_t)) {
+      !base_t->maybe_java_subtype_of(t)) {
      return false; // bail out
   }
   const TypeOopPtr *tinst = base_t->add_offset(t->offset())->is_oopptr();
@@ -3325,7 +3325,7 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
         } else {
           tn_t = tn_type->isa_oopptr();
         }
-        if (tn_t != NULL && tn_t->maybe_java_subtype_of(tinst)) {
+        if (tn_t != NULL && tinst->maybe_java_subtype_of(tn_t)) {
           if (tn_type->isa_narrowoop()) {
             tn_type = tinst->make_narrowoop();
           } else {
@@ -3338,7 +3338,7 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
           record_for_optimizer(n);
         } else {
           assert(tn_type == TypePtr::NULL_PTR ||
-                 tn_t != NULL && !tinst->is_java_subtype_of(tn_t),
+                 tn_t != NULL && !tinst->maybe_java_subtype_of(tn_t),
                  "unexpected type");
           continue; // Skip dead path with different type
         }

--- a/test/hotspot/jtreg/compiler/types/TestEACheckCastPP.java
+++ b/test/hotspot/jtreg/compiler/types/TestEACheckCastPP.java
@@ -45,6 +45,7 @@ public class TestEACheckCastPP {
 
     private static void test_helper2(I i, boolean flag) {
         if (flag) {
+            // branch never taken when called from test()
             A a = (A)i;
             C c = new C();
             c.a = a;

--- a/test/hotspot/jtreg/compiler/types/TestEACheckCastPP.java
+++ b/test/hotspot/jtreg/compiler/types/TestEACheckCastPP.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8287700
+ * @summary C2 Crash running eclipse benchmark from Dacapo
+ *
+ * @run main/othervm -XX:-BackgroundCompilation TestEACheckCastPP
+ *
+ */
+
+public class TestEACheckCastPP {
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test(false);
+            test_helper2(new A(), true);
+        }
+    }
+
+    private static void test(boolean flag) {
+        I i = test_helper();
+        test_helper2(i, flag);
+    }
+
+    private static void test_helper2(I i, boolean flag) {
+        if (flag) {
+            A a = (A)i;
+            C c = new C();
+            c.a = a;
+        }
+    }
+
+    private static I test_helper() {
+        B b = new B();
+        return b;
+    }
+
+    interface I {
+
+    }
+
+    private static class A implements I {
+
+    }
+    private static class B extends A {
+    }
+
+    private static class C {
+        public A a;
+    }
+}


### PR DESCRIPTION
With 8275201 (C2: hide klass() accessor from TypeOopPtr and typeKlassPtr subclasses), I made the following change to escape.cpp:

```
@@ -2628,7 +2632,7 @@ bool ConnectionGraph::split_AddP(Node *addp, Node *base) {
   // this code branch will go away.
   //
   if (!t->is_known_instance() &&
-      !base_t->klass()->is_subtype_of(t->klass())) {
+      !t->maybe_java_subtype_of(base_t)) {
      return false; // bail out
   }
   const TypeOopPtr *tinst = base_t->add_offset(t->offset())->is_oopptr();
@@ -3312,7 +3316,7 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
         } else {
           tn_t = tn_type->isa_oopptr();
         }
-        if (tn_t != NULL && tinst->klasgs()->is_subtype_of(tn_t->klass())) {
+        if (tn_t != NULL && tn_t->maybe_java_subtype_of(tinst)) {
           if (tn_type->isa_narrowoop()) {
             tn_type = tinst->make_narrowoop();
           } else {
@@ -3325,7 +3329,7 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
           record_for_optimizer(n);
         } else {
           assert(tn_type == TypePtr::NULL_PTR ||
-                 tn_t != NULL && !tinst->klass()->is_subtype_of(tn_t->klass()),
+                 tn_t != NULL && !tinst->is_java_subtype_of(tn_t),
                  "unexpected type");
           continue; // Skip dead path with different type
         }
```

Where I inverted the subtype and supertype in a subtype check (that is `tn_t->maybe_java_subtype_of(tinst)` when it was `tinst->klasgs()->is_subtype_of(tn_t->klass())`) in 2 places for no good reason AFAICT now. The assert used to also test the same condition as the if above but I changed that by mistake. This fixes addresses both issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287700](https://bugs.openjdk.org/browse/JDK-8287700): C2 Crash running eclipse benchmark from Dacapo


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Xin Liu](https://openjdk.java.net/census#xliu) (@navyxliu - Committer)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9054/head:pull/9054` \
`$ git checkout pull/9054`

Update a local copy of the PR: \
`$ git checkout pull/9054` \
`$ git pull https://git.openjdk.java.net/jdk pull/9054/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9054`

View PR using the GUI difftool: \
`$ git pr show -t 9054`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9054.diff">https://git.openjdk.java.net/jdk/pull/9054.diff</a>

</details>
