### PR TITLE
8287895: Some langtools tests fail on msys2

### DIFF
--- a/test/langtools/tools/javac/Paths/Util.sh
+++ b/test/langtools/tools/javac/Paths/Util.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
A bunch of langtools tests, which all rely on `test/langtools/tools/javac/Paths/Util.sh`, fails when run on Windows with msys2, since this environment is not properly detected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287895](https://bugs.openjdk.org/browse/JDK-8287895): Some langtools tests fail on msys2


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9056/head:pull/9056` \
`$ git checkout pull/9056`

Update a local copy of the PR: \
`$ git checkout pull/9056` \
`$ git pull https://git.openjdk.java.net/jdk pull/9056/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9056`

View PR using the GUI difftool: \
`$ git pr show -t 9056`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9056.diff">https://git.openjdk.java.net/jdk/pull/9056.diff</a>

</details>
