### PR TITLE
8287896: PropertiesTest.sh fail on msys2

### DIFF
--- a/test/jdk/java/util/Currency/PropertiesTest.sh
+++ b/test/jdk/java/util/Currency/PropertiesTest.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ case "$OS" in
     PS=";"
     FS="/"
     ;;
-  CYGWIN* )
+  CYGWIN*|MSYS*|MINGW* )
     PS=";"
     FS="/"
     TESTJAVA=`cygpath -u ${TESTJAVA}`


### PR DESCRIPTION
The test `test/jdk/java/util/Currency/PropertiesTest.sh` fails on msys2, since it does not properly detect this environment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287896](https://bugs.openjdk.org/browse/JDK-8287896): PropertiesTest.sh fail on msys2


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9057/head:pull/9057` \
`$ git checkout pull/9057`

Update a local copy of the PR: \
`$ git checkout pull/9057` \
`$ git pull https://git.openjdk.java.net/jdk pull/9057/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9057`

View PR using the GUI difftool: \
`$ git pr show -t 9057`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9057.diff">https://git.openjdk.java.net/jdk/pull/9057.diff</a>

</details>
