### PR TITLE
8287432: C2: assert(tn->in(0) != __null) failed: must have live top node

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3662,7 +3662,7 @@ void Compile::final_graph_reshaping_main_switch(Node* n, Final_Reshape_Counts& f
       n->set_req(MemBarNode::Precedent, top());
       while (wq.size() > 0) {
         Node* m = wq.pop();
-        if (m->outcnt() == 0) {
+        if (m->outcnt() == 0 && m != top()) {
           for (uint j = 0; j < m->req(); j++) {
             Node* in = m->in(j);
             if (in != NULL) {

--- a/test/hotspot/jtreg/compiler/c2/TestRemoveMemBarPrecEdge.java
+++ b/test/hotspot/jtreg/compiler/c2/TestRemoveMemBarPrecEdge.java
@@ -42,7 +42,7 @@ public class TestRemoveMemBarPrecEdge {
     }
 
     public static void test() {
-        // currentThread() is intrisified and C2 emits a special AddP node with a base that is top.
+        // currentThread() is intrinsified and C2 emits a special AddP node with a base that is top.
         Thread t = Thread.currentThread();
         // getName() returns the volatile _name field. The method is inlined and we just emit a LoadN + DecodeN which
         // is a precedence edge input into both MemBarAcquire nodes below for the volatile field _name.

--- a/test/hotspot/jtreg/compiler/c2/TestRemoveMemBarPrecEdge.java
+++ b/test/hotspot/jtreg/compiler/c2/TestRemoveMemBarPrecEdge.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8287432
+ * @summary Test removal of precedence edge of MemBarAcquire together with other now dead input nodes which visits a
+ *          top node. This resulted in a crash before as it disconnected top from the graph which is unexpected.
+ *
+ * @run main/othervm -Xbatch compiler.c2.TestRemoveMemBarPrecEdge
+ */
+package compiler.c2;
+
+public class TestRemoveMemBarPrecEdge {
+    static boolean flag = false;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10000; i++) {
+            test();
+            flag = !flag;
+        }
+    }
+
+    public static void test() {
+        // currentThread() is intrisified and C2 emits a special AddP node with a base that is top.
+        Thread t = Thread.currentThread();
+        // getName() returns the volatile _name field. The method is inlined and we just emit a LoadN + DecodeN which
+        // is a precedence edge input into both MemBarAcquire nodes below for the volatile field _name.
+        if (flag) {
+            t.getName();
+        } else {
+            t.getName();
+        }
+    }
+}


### PR DESCRIPTION
When intrisifying `java.lang.Thread::currentThread()`, we are creating an `AddP` node that has the `top` node as base to indicate that we do not have an oop (using `NULL` instead leads to crashes as it does not seem to be expected to have a `NULL` base):
https://github.com/openjdk/jdk/blob/6ff2d89ea11934bb13c8a419e7bad4fd40f76759/src/hotspot/share/opto/library_call.cpp#L904

This node is used on a chain of data nodes into two `MemBarAcquire` nodes as precedence edge in the test case:
![Screenshot from 2022-06-07 11-12-38](https://user-images.githubusercontent.com/17833009/172344751-5338b72f-baa5-4e9e-a44c-6d970798d9f2.png)

Later, in `final_graph_reshaping_impl()`, we are removing the precedence edge of both `MemBarAcquire` nodes and clean up all now dead nodes as a result of the removal:
https://github.com/openjdk/jdk/blob/6ff2d89ea11934bb13c8a419e7bad4fd40f76759/src/hotspot/share/opto/compile.cpp#L3655-L3679

We iteratively call `disconnect_inputs()` for all nodes that have no output anymore (i.e. dead nodes). This code, however, also treats the `top` node as dead since `outcnt()` of `top` is always zero:
https://github.com/openjdk/jdk/blob/6ff2d89ea11934bb13c8a419e7bad4fd40f76759/src/hotspot/share/opto/node.hpp#L495-L500

And we end up disconnecting `top` which results in the assertion failure.

The code misses a check for `top()`. I suggest to add this check before processing a node for which `outcnt()` is zero. This is a pattern which can also be found in other places in the code. I've checked all other usages of `oucnt() == 0` and could not find a case where this additional `top()` check is missing. Maybe we should refactor these two checks into a single method at some point to not need to worry about `top` anymore in the future when checking if a node is dead based on the outputs.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287432](https://bugs.openjdk.org/browse/JDK-8287432): C2: assert(tn->in(0) != __null) failed: must have live top node


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [3f351d40](https://git.openjdk.java.net/jdk/pull/9060/files/3f351d4014fc169fa28dede36642ac227f8c7eb0)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [3f351d40](https://git.openjdk.java.net/jdk/pull/9060/files/3f351d4014fc169fa28dede36642ac227f8c7eb0)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9060/head:pull/9060` \
`$ git checkout pull/9060`

Update a local copy of the PR: \
`$ git checkout pull/9060` \
`$ git pull https://git.openjdk.java.net/jdk pull/9060/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9060`

View PR using the GUI difftool: \
`$ git pr show -t 9060`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9060.diff">https://git.openjdk.java.net/jdk/pull/9060.diff</a>

</details>
