### PR TITLE
8287902: UnreadableRB case in MissingResourceCauseTest is not working reliably on Windows

### DIFF
--- a/test/jdk/java/util/ResourceBundle/Control/MissingResourceCauseTest.java
+++ b/test/jdk/java/util/ResourceBundle/Control/MissingResourceCauseTest.java
@@ -45,6 +45,9 @@ public class MissingResourceCauseTest {
 
     private static void callGetBundle(String baseName, Locale locale,
                                       Class<? extends Throwable> expectedCause) {
+        if (baseName.equals("UnreadableRB") && System.getProperty("os.name").startsWith("Windows")) {
+            return;
+        }
         ResourceBundle rb;
         try {
             rb = ResourceBundle.getBundle(baseName, locale);


### PR DESCRIPTION
The test  `test/jdk/java/util/ResourceBundle/Control/MissingResourceCauseTest.java` verifies different failure modes of resource bundles. One of the failures is that the runner class, `MissingResourceCauseTestRun.java`, creates a file `UnreadableRB`, and runs `chmod 000` on it, to make it unreadable by the test. Then MissingResourceCauseTest is called, and the `UnreadableRB` file is removed.

This does not work reliably on Windows. On msys2, `chmod` is essentially a no-op, so the file is not made unreadable, and hence the test fails. In my personal cygwin test environment, the chmod command does have some effect, but it is still not enough to make the file unreadable, and so the test fails.

The test was originally a shell script test that got converted to Java in [JDK-4354216](https://bugs.openjdk.org/browse/JDK-8213127). The original shell script code explicitly excluded Windows from testing. This was changed in the rewrite, for reasons I cannot determine.

What suprises me, though, is the "how can this ever has worked???" factor. Apparently the test passes on the current Cygwin setup on GHA. I have failed to reproduce the working conditions that makes a file actually unreadable for the owner on Windows, neither on my GHA test repo, nor locally. I've searched the web to figure out how to properly set file permissions on Windows to make the file unreadable, using Windows native tools, to no avail. I've even asked a [Stack Overflow question](https://stackoverflow.com/questions/72528318/what-file-permissions-make-a-file-unreadable-by-owner-in-windows); which as of yet is still unanswered.

Since I feel I've spent far more time than reasonable trying to get this to work properly, I suggest we instead skip the unreadable test on Windows. It is clearly unstable and highly depending on the Windows environment, the test was never originally supported or intended for Windows, and at the of the day, testing file unreadability is not an important regression test for [JDK-4354216](https://bugs.openjdk.org/browse/JDK-4354216).