### PR TITLE
8287903: Reduce runtime of java.math microbenchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/java/math/BigDecimals.java
+++ b/test/micro/org/openjdk/bench/java/math/BigDecimals.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.math;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OperationsPerInvocation;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.math.BigDecimal;
@@ -40,6 +43,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3)
 public class BigDecimals {
 
     /** Make sure TEST_SIZE is used to size the arrays. We need this constant to parametrize the operations count. */

--- a/test/micro/org/openjdk/bench/java/math/BigIntegers.java
+++ b/test/micro/org/openjdk/bench/java/math/BigIntegers.java
@@ -24,6 +24,8 @@ package org.openjdk.bench.java.math;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OperationsPerInvocation;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -31,6 +33,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.math.BigInteger;
@@ -40,15 +43,15 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3)
 public class BigIntegers {
 
-    private BigInteger[] hugeArray, largeArray, smallArray, shiftArray, smallShiftArray;
+    private BigInteger[] hugeArray, largeArray, smallArray, shiftArray;
     public String[] dummyStringArray;
     public Object[] dummyArr;
     private static final int TESTSIZE = 1000;
-
-    @Param({"32", "64", "96", "128", "160", "192", "224", "256"})
-    private int maxNumbits;
 
     @Setup
     public void setup() {
@@ -72,9 +75,6 @@ public class BigIntegers {
          * Each array entry is atmost 16k bits
          * in size
          */
-        smallShiftArray = new BigInteger[TESTSIZE]; /*
-        * Small numbers, bits count in range [maxNumbits - 31, maxNumbits]
-        */
 
         dummyStringArray = new String[TESTSIZE];
         dummyArr = new Object[TESTSIZE];
@@ -87,7 +87,6 @@ public class BigIntegers {
             largeArray[i] = new BigInteger("" + ((long) value + (long) Integer.MAX_VALUE));
             smallArray[i] = new BigInteger("" + ((long) value / 1000));
             shiftArray[i] = new BigInteger(numbits, r);
-            smallShiftArray[i] = new BigInteger(Math.max(maxNumbits - value % 32, 0), r);
         }
     }
 
@@ -182,32 +181,6 @@ public class BigIntegers {
         bh.consume(tmp);
     }
 
-    /** Invokes the shiftLeft method of small BigInteger with different values. */
-    @Benchmark
-    @OperationsPerInvocation(TESTSIZE)
-    public void testSmallLeftShift(Blackhole bh) {
-        Random rand = new Random();
-        int shift = rand.nextInt(30) + 1;
-        BigInteger tmp = null;
-        for (BigInteger s : smallShiftArray) {
-            tmp = s.shiftLeft(shift);
-            bh.consume(tmp);
-        }
-    }
-
-    /** Invokes the shiftRight method of small BigInteger with different values. */
-    @Benchmark
-    @OperationsPerInvocation(TESTSIZE)
-    public void testSmallRightShift(Blackhole bh) {
-        Random rand = new Random();
-        int shift = rand.nextInt(30) + 1;
-        BigInteger tmp = null;
-        for (BigInteger s : smallShiftArray) {
-            tmp = s.shiftRight(shift);
-            bh.consume(tmp);
-        }
-    }
-
     /** Invokes the gcd method of BigInteger with different values. */
     @Benchmark
     @OperationsPerInvocation(TESTSIZE)
@@ -216,6 +189,54 @@ public class BigIntegers {
             BigInteger i1 = shiftArray[TESTSIZE - i - 1];
             BigInteger i2 = shiftArray[i];
             bh.consume(i2.gcd(i1));
+        }
+    }
+
+    public static class SmallShifts {
+
+        @Param({"32", "64", "128", "192", "256"})
+        private int maxNumbits;
+
+        /*
+         * Small numbers, bits count in range [maxNumbits - 31, maxNumbits]
+         */
+        BigInteger[] smallShiftArray = new BigInteger[TESTSIZE];
+
+        @Setup
+        public void setup() {
+            Random r = new Random(1123);
+            int numbits = r.nextInt(16384);
+
+            for (int i = 0; i < TESTSIZE; i++) {
+                int value = Math.abs(r.nextInt());
+                smallShiftArray[i] = new BigInteger(Math.max(maxNumbits - value % 32, 0), r);
+            }
+        }
+
+        /** Invokes the shiftLeft method of small BigInteger with different values. */
+        @Benchmark
+        @OperationsPerInvocation(TESTSIZE)
+        public void testSmallLeftShift(Blackhole bh) {
+            Random rand = new Random();
+            int shift = rand.nextInt(30) + 1;
+            BigInteger tmp = null;
+            for (BigInteger s : smallShiftArray) {
+                tmp = s.shiftLeft(shift);
+                bh.consume(tmp);
+            }
+        }
+
+        /** Invokes the shiftRight method of small BigInteger with different values. */
+        @Benchmark
+        @OperationsPerInvocation(TESTSIZE)
+        public void testSmallRightShift(Blackhole bh) {
+            Random rand = new Random();
+            int shift = rand.nextInt(30) + 1;
+            BigInteger tmp = null;
+            for (BigInteger s : smallShiftArray) {
+                tmp = s.shiftRight(shift);
+                bh.consume(tmp);
+            }
         }
     }
 }

--- a/test/micro/org/openjdk/bench/java/math/BigIntegers.java
+++ b/test/micro/org/openjdk/bench/java/math/BigIntegers.java
@@ -193,6 +193,9 @@ public class BigIntegers {
     }
 
     @State(Scope.Thread)
+    @Warmup(iterations = 5, time = 1)
+    @Measurement(iterations = 5, time = 1)
+    @Fork(value = 3)
     public static class SmallShifts {
 
         @Param({"32", "64", "128", "192", "256"})

--- a/test/micro/org/openjdk/bench/java/math/BigIntegers.java
+++ b/test/micro/org/openjdk/bench/java/math/BigIntegers.java
@@ -192,6 +192,8 @@ public class BigIntegers {
         }
     }
 
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
     @State(Scope.Thread)
     @Warmup(iterations = 5, time = 1)
     @Measurement(iterations = 5, time = 1)

--- a/test/micro/org/openjdk/bench/java/math/BigIntegers.java
+++ b/test/micro/org/openjdk/bench/java/math/BigIntegers.java
@@ -192,6 +192,7 @@ public class BigIntegers {
         }
     }
 
+    @State(Scope.Thread)
     public static class SmallShifts {
 
         @Param({"32", "64", "128", "192", "256"})

--- a/test/micro/org/openjdk/bench/java/math/BigIntegers.java
+++ b/test/micro/org/openjdk/bench/java/math/BigIntegers.java
@@ -200,7 +200,7 @@ public class BigIntegers {
     @Fork(value = 3)
     public static class SmallShifts {
 
-        @Param({"32", "64", "128", "192", "256"})
+        @Param({"32", "128", "256"})
         private int maxNumbits;
 
         /*
@@ -211,8 +211,6 @@ public class BigIntegers {
         @Setup
         public void setup() {
             Random r = new Random(1123);
-            int numbits = r.nextInt(16384);
-
             for (int i = 0; i < TESTSIZE; i++) {
                 int value = Math.abs(r.nextInt());
                 smallShiftArray[i] = new BigInteger(Math.max(maxNumbits - value % 32, 0), r);
@@ -222,26 +220,22 @@ public class BigIntegers {
         /** Invokes the shiftLeft method of small BigInteger with different values. */
         @Benchmark
         @OperationsPerInvocation(TESTSIZE)
-        public void testSmallLeftShift(Blackhole bh) {
+        public void testLeftShift(Blackhole bh) {
             Random rand = new Random();
             int shift = rand.nextInt(30) + 1;
-            BigInteger tmp = null;
             for (BigInteger s : smallShiftArray) {
-                tmp = s.shiftLeft(shift);
-                bh.consume(tmp);
+                bh.consume(s.shiftLeft(shift));
             }
         }
 
         /** Invokes the shiftRight method of small BigInteger with different values. */
         @Benchmark
         @OperationsPerInvocation(TESTSIZE)
-        public void testSmallRightShift(Blackhole bh) {
+        public void testRightShift(Blackhole bh) {
             Random rand = new Random();
             int shift = rand.nextInt(30) + 1;
-            BigInteger tmp = null;
             for (BigInteger s : smallShiftArray) {
-                tmp = s.shiftRight(shift);
-                bh.consume(tmp);
+                bh.consume(s.shiftRight(shift));
             }
         }
     }

--- a/test/micro/org/openjdk/bench/java/math/FpRoundingBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/math/FpRoundingBenchmark.java
@@ -29,9 +29,12 @@ import org.openjdk.jmh.annotations.*;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3)
 public class FpRoundingBenchmark {
 
-  @Param({"1024", "2048"})
+  @Param({"2048"})
   public int TESTSIZE;
 
   public double[] DargV1;

--- a/test/micro/org/openjdk/bench/vm/compiler/VectorSignum.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/VectorSignum.java
@@ -31,6 +31,9 @@ import java.util.Random;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 2)
 public class VectorSignum {
     @Param({"256", "512", "1024", "2048"})
     private static int SIZE;
@@ -48,7 +51,7 @@ public class VectorSignum {
         floats = new float[SIZE];
         res_doubles = new double[SIZE];
         res_floats = new float[SIZE];
-        for (int i=0; i<SIZE; i++) {
+        for (int i = 0; i < SIZE; i++) {
             floats[i] = r.nextFloat();
             doubles[i] = r.nextDouble();
         }
@@ -56,14 +59,14 @@ public class VectorSignum {
 
     @Benchmark
     public void floatSignum() {
-        for(int i = 0; i < SIZE; i++) {
+        for (int i = 0; i < SIZE; i++) {
             res_floats[i] = Math.signum(floats[i]);
         }
     }
 
     @Benchmark
     public void doubleSignum() {
-        for(int i = 0; i < SIZE; i++) {
+        for (int i = 0; i < SIZE; i++) {
             res_doubles[i] = Math.signum(doubles[i]);
         }
     }


### PR DESCRIPTION
- Reduce runtime by running fewer forks, fewer iterations, less warmup. All micros tested in this group appear to stabilize very quickly.
- Refactor BigIntegers to avoid re-running some (most) micros over and over with parameter values that don't affect them.

Expected runtime down from 14 hours to 15 minutes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287903](https://bugs.openjdk.org/browse/JDK-8287903): Reduce runtime of java.math microbenchmarks


### Reviewers
 * [Eric Caspole](https://openjdk.java.net/census#ecaspole) (@ericcaspole - Committer)
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9062/head:pull/9062` \
`$ git checkout pull/9062`

Update a local copy of the PR: \
`$ git checkout pull/9062` \
`$ git pull https://git.openjdk.java.net/jdk pull/9062/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9062`

View PR using the GUI difftool: \
`$ git pr show -t 9062`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9062.diff">https://git.openjdk.java.net/jdk/pull/9062.diff</a>

</details>
