### PR TITLE
8287901: Loom: Failures with -XX:+VerifyStack

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -607,10 +607,19 @@ void frame::describe_pd(FrameValues& values, int frame_no) {
   }
 
   if (is_java_frame() || Continuation::is_continuation_enterSpecial(*this)) {
-    address ret_pc = *(address*)(real_fp() - return_addr_offset);
-    values.describe(frame_no, real_fp() - return_addr_offset,
+    intptr_t* ret_pc_loc;
+    intptr_t* fp_loc;
+    if (is_interpreted_frame()) {
+      ret_pc_loc = fp() + return_addr_offset;
+      fp_loc = fp();
+    } else {
+      ret_pc_loc = real_fp() - return_addr_offset;
+      fp_loc = real_fp() - sender_sp_offset;
+    }
+    address ret_pc = *(address*)ret_pc_loc;
+    values.describe(frame_no, ret_pc_loc,
       Continuation::is_return_barrier_entry(ret_pc) ? "return address (return barrier)" : "return address");
-    values.describe(-1, real_fp() - sender_sp_offset, "saved fp", 2); // "unowned" as value belongs to sender
+    values.describe(-1, fp_loc, "saved fp", 0); // "unowned" as value belongs to sender
   }
 }
 #endif

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -606,13 +606,12 @@ void frame::describe_pd(FrameValues& values, int frame_no) {
     DESCRIBE_FP_OFFSET(interpreter_frame_initial_sp);
   }
 
-  intptr_t* ret_pc_loc = sp() - return_addr_offset;
-  address ret_pc = *(address*)ret_pc_loc;
-  if (Continuation::is_return_barrier_entry(ret_pc))
-    values.describe(frame_no, ret_pc_loc, "return address (return barrier)");
-  else
-    values.describe(frame_no, ret_pc_loc, err_msg("return address for #%d", frame_no));
-  values.describe(frame_no, sp() - sender_sp_offset, err_msg("saved fp for #%d", frame_no), 0);
+  if (is_java_frame() || Continuation::is_continuation_enterSpecial(*this)) {
+    address ret_pc = *(address*)(real_fp() - return_addr_offset);
+    values.describe(frame_no, real_fp() - return_addr_offset,
+      Continuation::is_return_barrier_entry(ret_pc) ? "return address (return barrier)" : "return address");
+    values.describe(-1, real_fp() - sender_sp_offset, "saved fp", 2); // "unowned" as value belongs to sender
+  }
 }
 #endif
 

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -619,13 +619,12 @@ void frame::describe_pd(FrameValues& values, int frame_no) {
 #endif // AMD64
   }
 
-  intptr_t* ret_pc_loc = sp() - return_addr_offset;
-  address ret_pc = *(address*)ret_pc_loc;
-  if (Continuation::is_return_barrier_entry(ret_pc))
-    values.describe(frame_no, ret_pc_loc, "return address (return barrier)");
-  else
-    values.describe(frame_no, ret_pc_loc, err_msg("return address for #%d", frame_no));
-  values.describe(frame_no, sp() - sender_sp_offset, err_msg("saved fp for #%d", frame_no), 0);
+  if (is_java_frame() || Continuation::is_continuation_enterSpecial(*this)) {
+    address ret_pc = *(address*)(real_fp() - return_addr_offset);
+    values.describe(frame_no, real_fp() - return_addr_offset,
+      Continuation::is_return_barrier_entry(ret_pc) ? "return address (return barrier)" : "return address");
+    values.describe(-1, real_fp() - sender_sp_offset, "saved fp", 2); // "unowned" as value belongs to sender
+  }
 }
 
 #endif // !PRODUCT

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -620,10 +620,19 @@ void frame::describe_pd(FrameValues& values, int frame_no) {
   }
 
   if (is_java_frame() || Continuation::is_continuation_enterSpecial(*this)) {
-    address ret_pc = *(address*)(real_fp() - return_addr_offset);
-    values.describe(frame_no, real_fp() - return_addr_offset,
+    intptr_t* ret_pc_loc;
+    intptr_t* fp_loc;
+    if (is_interpreted_frame()) {
+      ret_pc_loc = fp() + return_addr_offset;
+      fp_loc = fp();
+    } else {
+      ret_pc_loc = real_fp() - return_addr_offset;
+      fp_loc = real_fp() - sender_sp_offset;
+    }
+    address ret_pc = *(address*)ret_pc_loc;
+    values.describe(frame_no, ret_pc_loc,
       Continuation::is_return_barrier_entry(ret_pc) ? "return address (return barrier)" : "return address");
-    values.describe(-1, real_fp() - sender_sp_offset, "saved fp", 2); // "unowned" as value belongs to sender
+    values.describe(-1, fp_loc, "saved fp", 0); // "unowned" as value belongs to sender
   }
 }
 

--- a/test/jdk/jdk/internal/vm/Continuation/Basic.java
+++ b/test/jdk/jdk/internal/vm/Continuation/Basic.java
@@ -37,7 +37,18 @@
 * @run testng/othervm --enable-preview -Xcomp -XX:-TieredCompilation -XX:CompileOnly=jdk/internal/vm/Continuation,Basic -XX:CompileCommand=exclude,Basic.manyArgsDriver Basic
 * @run testng/othervm --enable-preview -Xcomp -XX:-TieredCompilation -XX:CompileOnly=jdk/internal/vm/Continuation,Basic -XX:CompileCommand=exclude,jdk/internal/vm/Continuation.enter Basic
 * @run testng/othervm --enable-preview -Xcomp -XX:-TieredCompilation -XX:CompileOnly=jdk/internal/vm/Continuation,Basic -XX:CompileCommand=inline,jdk/internal/vm/Continuation.run Basic
+*/
+
+/**
+* @test
+* @requires vm.continuations
+* @requires vm.debug
+* @modules java.base/jdk.internal.vm
+* @build java.base/java.lang.StackWalkerHelper
 *
+* @run testng/othervm --enable-preview -XX:+VerifyStack -Xint Basic
+* @run testng/othervm --enable-preview -XX:+VerifyStack -Xcomp -XX:TieredStopAtLevel=3 -XX:CompileOnly=jdk/internal/vm/Continuation,Basic Basic
+* @run testng/othervm --enable-preview -XX:+VerifyStack -Xcomp -XX:-TieredCompilation -XX:CompileOnly=jdk/internal/vm/Continuation,Basic Basic
 */
 
 import jdk.internal.vm.Continuation;


### PR DESCRIPTION
Please review the following change.

Debugging information added to `frame::describe` (used by `JavaThread::print_frame_layout`) was inaccurate, but proved fatal with `VerifyStack`, which uses the same information for verification.

The location of a caller frame's return address and spilled fp, which are located in the callee, were recorded by the caller frame. In the case of the special frame `Continuation.enterSpecial`, those locations were recorded incorrectly. The fix is to record the information while describing the callee frame, rather than the caller.

Passes tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287901](https://bugs.openjdk.org/browse/JDK-8287901): Loom: Failures with -XX:+VerifyStack


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9066/head:pull/9066` \
`$ git checkout pull/9066`

Update a local copy of the PR: \
`$ git checkout pull/9066` \
`$ git pull https://git.openjdk.java.net/jdk pull/9066/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9066`

View PR using the GUI difftool: \
`$ git pr show -t 9066`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9066.diff">https://git.openjdk.java.net/jdk/pull/9066.diff</a>

</details>
