### PR TITLE
8287325: AArch64: fix virtual threads with -XX:UseBranchProtection=pac-ret

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -152,7 +152,10 @@ inline frame::frame(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, address
   setup(pc);
 }
 
-inline frame::frame(intptr_t* sp) : frame(sp, sp, *(intptr_t**)(sp - frame::sender_sp_offset), *(address*)(sp - 1)) {}
+inline frame::frame(intptr_t* sp)
+  : frame(sp, sp, *(intptr_t**)(sp - frame::sender_sp_offset),
+          pauth_strip_verifiable(*(address*)(sp - frame::return_addr_offset),
+                                 *(address*)(sp - frame::sender_sp_offset))) {}
 
 inline frame::frame(intptr_t* sp, intptr_t* fp) {
   intptr_t a = intptr_t(sp);

--- a/src/hotspot/cpu/aarch64/pauth_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/pauth_aarch64.hpp
@@ -85,4 +85,11 @@ inline address pauth_strip_verifiable(address ret_addr, address modifier) {
   return ret_addr;
 }
 
+// Authenticate then sign a return value using different sp values.
+//
+inline void pauth_resign_return_address(address *ret_addr, address old_sp, address new_sp) {
+  address orig_ret_pc = pauth_authenticate_return_address(*ret_addr, old_sp);
+  *ret_addr = pauth_sign_return_address(orig_ret_pc, new_sp);
+}
+
 #endif // CPU_AARCH64_PAUTH_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/stackChunkFrameStream_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/stackChunkFrameStream_aarch64.inline.hpp
@@ -26,6 +26,7 @@
 #define CPU_AARCH64_STACKCHUNKFRAMESTREAM_AARCH64_INLINE_HPP
 
 #include "interpreter/oopMapCache.hpp"
+#include "pauth_aarch64.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/registerMap.hpp"
 
@@ -52,7 +53,7 @@ inline frame StackChunkFrameStream<frame_kind>::to_frame() const {
 template <ChunkFrames frame_kind>
 inline address StackChunkFrameStream<frame_kind>::get_pc() const {
   assert(!is_done(), "");
-  return *(address*)(_sp - 1);
+  return pauth_strip_pointer(*(address*)(_sp - 1));
 }
 
 template <ChunkFrames frame_kind>

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -6743,6 +6743,7 @@ class StubGenerator: public StubCodeGenerator {
 
     if (return_barrier_exception) {
       __ ldr(c_rarg1, Address(rfp, wordSize)); // return address
+      __ authenticate_return_address(c_rarg1, rscratch1);
       __ verify_oop(r0);
       __ mov(r19, r0); // save return value contaning the exception oop in callee-saved R19
 
@@ -6754,7 +6755,7 @@ class StubGenerator: public StubCodeGenerator {
       // see OptoRuntime::generate_exception_blob: r0 -- exception oop, r3 -- exception pc
 
       __ mov(r1, r0); // the exception handler
-      __ mov(r0, r19); // restore return value contaning the exception oop
+      __ mov(r0, r19); // restore return value containing the exception oop
       __ verify_oop(r0);
 
       __ leave();

--- a/src/hotspot/cpu/arm/continuationHelper_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/continuationHelper_arm.inline.hpp
@@ -58,6 +58,10 @@ inline void ContinuationHelper::push_pd(const frame& f) {
   Unimplemented();
 }
 
+inline address ContinuationHelper::return_pc_at(intptr_t *sp) {
+  return *(address*)sp;
+}
+
 inline void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
   Unimplemented();
 }

--- a/src/hotspot/cpu/ppc/continuationHelper_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/continuationHelper_ppc.inline.hpp
@@ -56,6 +56,9 @@ inline void ContinuationHelper::push_pd(const frame& f) {
   Unimplemented();
 }
 
+inline address ContinuationHelper::return_pc_at(intptr_t *sp) {
+  return *(address*)sp;
+}
 
 inline void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
   Unimplemented();

--- a/src/hotspot/cpu/riscv/continuationHelper_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/continuationHelper_riscv.inline.hpp
@@ -56,6 +56,9 @@ inline void ContinuationHelper::push_pd(const frame& f) {
   Unimplemented();
 }
 
+inline address ContinuationHelper::return_pc_at(intptr_t *sp) {
+  return *(address*)sp;
+}
 
 inline void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
   Unimplemented();

--- a/src/hotspot/cpu/s390/continuationHelper_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/continuationHelper_s390.inline.hpp
@@ -58,6 +58,10 @@ inline void ContinuationHelper::push_pd(const frame& f) {
   Unimplemented();
 }
 
+inline address ContinuationHelper::return_pc_at(intptr_t *sp) {
+  return *(address*)sp;
+}
+
 inline void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
   Unimplemented();
 }

--- a/src/hotspot/cpu/x86/continuationHelper_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/continuationHelper_x86.inline.hpp
@@ -68,6 +68,10 @@ inline void ContinuationHelper::push_pd(const frame& f) {
   *(intptr_t**)(f.sp() - frame::sender_sp_offset) = f.fp();
 }
 
+inline address ContinuationHelper::return_pc_at(intptr_t *sp) {
+  return *(address*)sp;
+}
+
 inline void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* entry) {
   anchor->set_last_Java_fp(entry->entry_fp());
 }

--- a/src/hotspot/cpu/zero/continuationHelper_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/continuationHelper_zero.inline.hpp
@@ -56,6 +56,10 @@ inline void ContinuationHelper::push_pd(const frame& f) {
   Unimplemented();
 }
 
+inline address ContinuationHelper::return_pc_at(intptr_t *sp) {
+  return *(address*)sp;
+}
+
 inline void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
   Unimplemented();
 }

--- a/src/hotspot/share/runtime/continuationEntry.cpp
+++ b/src/hotspot/share/runtime/continuationEntry.cpp
@@ -26,6 +26,7 @@
 #include "code/nmethod.hpp"
 #include "runtime/continuation.hpp"
 #include "runtime/continuationEntry.inline.hpp"
+#include "runtime/continuationHelper.inline.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/stackFrameStream.inline.hpp"
 #include "runtime/stackWatermarkSet.inline.hpp"
@@ -98,7 +99,7 @@ bool ContinuationEntry::assert_entry_frame_laid_out(JavaThread* thread) {
 
   assert(sp != nullptr, "");
   assert(sp <= entry->entry_sp(), "");
-  address pc = *(address*)(sp - frame::sender_sp_ret_address_offset());
+  address pc = ContinuationHelper::return_pc_at(sp - frame::sender_sp_ret_address_offset());
 
   if (pc != StubRoutines::cont_returnBarrier()) {
     CodeBlob* cb = pc != nullptr ? CodeCache::find_blob(pc) : nullptr;

--- a/src/hotspot/share/runtime/continuationHelper.hpp
+++ b/src/hotspot/share/runtime/continuationHelper.hpp
@@ -44,6 +44,8 @@ public:
 
   static inline void push_pd(const frame& f);
 
+  static inline address return_pc_at(intptr_t *sp);
+
   static inline int frame_align_words(int size);
   static inline intptr_t* frame_align_pointer(intptr_t* sp);
 
@@ -68,7 +70,7 @@ public:
   static inline address real_pc(const frame& f);
   static inline void patch_pc(const frame& f, address pc);
   static address* return_pc_address(const frame& f);
-  static address return_pc(const frame& f) { return *return_pc_address(f); }
+  static address return_pc(const frame& f);
   static bool is_stub(CodeBlob* cb);
 
 #ifdef ASSERT

--- a/src/hotspot/share/runtime/continuationHelper.inline.hpp
+++ b/src/hotspot/share/runtime/continuationHelper.inline.hpp
@@ -48,6 +48,10 @@ inline Method* ContinuationHelper::Frame::frame_method(const frame& f) {
   return f.is_interpreted_frame() ? f.interpreter_frame_method() : f.cb()->as_compiled_method()->method();
 }
 
+inline address ContinuationHelper::Frame::return_pc(const frame& f) {
+  return return_pc_at((intptr_t *)return_pc_address(f));
+}
+
 #ifdef ASSERT
 inline intptr_t* ContinuationHelper::Frame::frame_top(const frame &f) {
   if (f.is_interpreted_frame()) {
@@ -89,7 +93,7 @@ inline bool ContinuationHelper::InterpretedFrame::is_instance(const frame& f) {
 }
 
 inline address ContinuationHelper::InterpretedFrame::return_pc(const frame& f) {
-  return *return_pc_address(f);
+  return return_pc_at((intptr_t *)return_pc_address(f));
 }
 
 inline int ContinuationHelper::InterpretedFrame::size(const frame&f) {


### PR DESCRIPTION
The continuation free/thaw mechanism relies on being able to move thread stacks around in memory.  However when PAC is enabled on supported AArch64 CPUs, the saved LR on the stack contains a "pointer authentication code" signed with the stack pointer at the time the frame was created.  When a stack frame is relocated we need to re-sign the LR with the new stack pointer to ensure it authenticates successfully when the method returns.

Introduced `ContinuationHelper::return_pc_at()` to avoid directly reading the saved PC from the stack in shared code.  On AArch64 with PAC it enabled it strips the PAC from the address after reading it, on all other platforms it just loads the PC from the stack as before.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287325](https://bugs.openjdk.org/browse/JDK-8287325): AArch64: fix virtual threads with -XX:UseBranchProtection=pac-ret


### Contributors
 * Alan Hayward `<ahayward@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9067/head:pull/9067` \
`$ git checkout pull/9067`

Update a local copy of the PR: \
`$ git checkout pull/9067` \
`$ git pull https://git.openjdk.java.net/jdk pull/9067/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9067`

View PR using the GUI difftool: \
`$ git pr show -t 9067`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9067.diff">https://git.openjdk.java.net/jdk/pull/9067.diff</a>

</details>
