### PR TITLE
8287927: ProblemList java/awt/GraphicsDevice/DisplayModes/UnknownRefrshRateTest.java on macosx-aarch64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -468,6 +468,7 @@ java/awt/Window/GetScreenLocation/GetScreenLocationTest.java 8225787 linux-x64
 java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java 8266243 macosx-aarch64
 java/awt/dnd/BadSerializationTest/BadSerializationTest.java 8277817 linux-x64,windows-x64
 java/awt/GraphicsDevice/CheckDisplayModes.java 8266242 macosx-aarch64
+java/awt/GraphicsDevice/DisplayModes/UnknownRefrshRateTest.java 8286436 macosx-aarch64
 
 ############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList java/awt/GraphicsDevice/DisplayModes/UnknownRefrshRateTest.java on macosx-aarch64.

What I'd really like to is to ProblemList this test 
on Mac_OS_X_12.4 and Mac_OS_X_12.5, but two digit release values 
(M.N) did not work when I tried them a month or so ago.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287927](https://bugs.openjdk.org/browse/JDK-8287927): ProblemList java/awt/GraphicsDevice/DisplayModes/UnknownRefrshRateTest.java on macosx-aarch64


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9071/head:pull/9071` \
`$ git checkout pull/9071`

Update a local copy of the PR: \
`$ git checkout pull/9071` \
`$ git pull https://git.openjdk.java.net/jdk pull/9071/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9071`

View PR using the GUI difftool: \
`$ git pr show -t 9071`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9071.diff">https://git.openjdk.java.net/jdk/pull/9071.diff</a>

</details>
