### PR TITLE
P11TlsKeyMaterialGenerator works with ChaCha20-Poly1305

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
@@ -99,6 +99,9 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
 
     // returns direct lookup result of keyTypes using algorithm
     static long getKeyType(String algorithm) {
+        if ("ChaCha20-Poly1305".equals(algorithm)) {
+            algorithm = "ChaCha20";
+        }
         Long l = keyTypes.get(algorithm);
         if (l == null) {
             algorithm = algorithm.toUpperCase(Locale.ENGLISH);

--- a/test/jdk/sun/security/pkcs11/tls/TestKeyMaterialChaCha20.java
+++ b/test/jdk/sun/security/pkcs11/tls/TestKeyMaterialChaCha20.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test that KeyMaterial generator works with ChaCha20-Poly1305
+ * @author Zdenek Zambersky
+ * @library /test/lib ..
+ * @modules java.base/sun.security.internal.spec
+ *          jdk.crypto.cryptoki
+ * @run main/othervm TestKeyMaterialChaCha20
+ */
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import java.security.Provider;
+import java.security.NoSuchAlgorithmException;
+import sun.security.internal.spec.TlsRsaPremasterSecretParameterSpec;
+import sun.security.internal.spec.TlsMasterSecretParameterSpec;
+import sun.security.internal.spec.TlsKeyMaterialParameterSpec;
+
+
+public class TestKeyMaterialChaCha20 extends PKCS11Test {
+
+    public static void main(String[] args) throws Exception {
+        main(new TestKeyMaterialChaCha20(), args);
+    }
+
+    @Override
+    public void main(Provider provider) throws Exception {
+        try {
+            KeyGenerator.getInstance("ChaCha20", provider);
+        } catch (NoSuchAlgorithmException e) {
+            System.out.println("Skipping, ChaCha20 not supported");
+            return;
+        }
+
+        KeyGenerator kg1 = KeyGenerator.getInstance("SunTlsRsaPremasterSecret", provider);
+        kg1.init(new TlsRsaPremasterSecretParameterSpec(0x0303, 0x0303));
+        SecretKey preMasterSecret = kg1.generateKey();
+
+        TlsMasterSecretParameterSpec spec = new TlsMasterSecretParameterSpec(
+            preMasterSecret,
+            3, 3,
+            new byte[32],
+            new byte[32],
+            "SHA-256", 32, 64);
+        KeyGenerator kg2 = KeyGenerator.getInstance("SunTls12MasterSecret", provider);
+        kg2.init(spec);
+        SecretKey masterSecret = kg2.generateKey();
+
+        // https://github.com/openjdk/jdk/blob/ccec5d1e8529c8211cc678d8acc8d37fe461cb51/src/java.base/share/classes/sun/security/ssl/SSLTrafficKeyDerivation.java#L270
+        // https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/sun/security/ssl/CipherSuite.java#L93
+        TlsKeyMaterialParameterSpec params = new TlsKeyMaterialParameterSpec(
+            masterSecret, 3, 3,
+            new byte[32],
+            new byte[32],
+            "ChaCha20-Poly1305", 32, 32,
+            12, 0,
+            "SHA-256", 32, 64);
+        KeyGenerator kg3 = KeyGenerator.getInstance("SunTls12KeyMaterial", provider);
+        kg3.init(params);
+        kg3.generateKey();
+    }
+
+}


### PR DESCRIPTION
TLS `*_CHACHA20_POLY1305_*` cipher suites are currently broken when configuration with SunPKCS11 provider is used. I discovered this by my ssl-tests testsuite [1].

```
make TEST_PKCS11_FIPS=1 SSLTESTS_SSL_CONFIG_FILTER=SunJSSE,Default,TLSv1.2,TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256 SSLTESTS_CUSTOM_JAVA_PARAMS=-Djdk.tls.ephemeralDHKeySize=2048 ssl-tests
...
javax.net.ssl.SSLException: Unknown algorithm: ChaCha20-Poly1305
	at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:132)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:371)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:314)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:309)
	at java.base/sun.security.ssl.SSLSocketImpl.handleException(SSLSocketImpl.java:1712)
	at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:470)
	at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:426)
	at SSLSocketClient.test(SSLSocketClient.java:72)
	at SSLSocketTester.testConfiguration(SSLSocketTester.java:392)
	at SSLSocketTester.testConfigurations(SSLSocketTester.java:322)
	at SSLSocketTester.testProvider(SSLSocketTester.java:234)
	at SSLSocketTester.testProviders(SSLSocketTester.java:190)
	at Main.main(Main.java:30)
Caused by: java.security.ProviderException: Unknown algorithm: ChaCha20-Poly1305
	at jdk.crypto.cryptoki/sun.security.pkcs11.P11TlsKeyMaterialGenerator.engineGenerateKey(P11TlsKeyMaterialGenerator.java:168)
	at java.base/javax.crypto.KeyGenerator.generateKey(KeyGenerator.java:564)
	at java.base/sun.security.ssl.SSLTrafficKeyDerivation$LegacyTrafficKeyDerivation.<init>(SSLTrafficKeyDerivation.java:282)
	at java.base/sun.security.ssl.SSLTrafficKeyDerivation$T12TrafficKeyDerivationGenerator.createKeyDerivation(SSLTrafficKeyDerivation.java:117)
	at java.base/sun.security.ssl.SSLTrafficKeyDerivation.createKeyDerivation(SSLTrafficKeyDerivation.java:79)
	at java.base/sun.security.ssl.DHClientKeyExchange$DHClientKeyExchangeProducer.produce(DHClientKeyExchange.java:221)
	at java.base/sun.security.ssl.ClientKeyExchange$ClientKeyExchangeProducer.produce(ClientKeyExchange.java:65)
	at java.base/sun.security.ssl.SSLHandshake.produce(SSLHandshake.java:440)
	at java.base/sun.security.ssl.ServerHelloDone$ServerHelloDoneConsumer.consume(ServerHelloDone.java:182)
	at java.base/sun.security.ssl.SSLHandshake.consume(SSLHandshake.java:396)
	at java.base/sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:480)
	at java.base/sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:458)
	at java.base/sun.security.ssl.TransportContext.dispatch(TransportContext.java:201)
	at java.base/sun.security.ssl.SSLTransport.decode(SSLTransport.java:172)
	at java.base/sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1510)
	at java.base/sun.security.ssl.SSLSocketImpl.readHandshakeRecord(SSLSocketImpl.java:1425)
	at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:455)
	... 7 more

FAILED: SunJSSE/Default: TLSv1.2 + TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256
```

Problem:
Exception is thrown by P11TlsKeyMaterialGenerator.engineGenerateKey method [2], based on result of P11SecretKeyFactory.getKeyType method [3], which only "knows" "ChaCha20" key algorithm, but does not accept "ChaCha20-Poly1305" as algorithm. Algorithm value is passed from SSLTrafficKeyDerivation.LegacyTrafficKeyDerivation class [4], which leads to algorithm field in SSLCipher class [5]. Value of that field comes from cipher name in JsseJce class [6] (ending at first slash, if any).

Fix:
This fix basically modifies P11SecretKeyFactory.getKeyType method to accept "ChaCha20-Poly1305" as alias for "ChaCha20". 

Testing:
I ran jdk_security tests locally and they passed. Also failure in ssl-tests gets fixed.

[1] https://github.com/zzambers/ssl-tests
[2] https://github.com/openjdk/jdk/blob/b7a34f728d0653d55ef01da045c9aad4c0471143/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11TlsKeyMaterialGenerator.java#L168
[3] https://github.com/openjdk/jdk/blob/b7a34f728d0653d55ef01da045c9aad4c0471143/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java#L101
[4] https://github.com/openjdk/jdk/blob/b7a34f728d0653d55ef01da045c9aad4c0471143/src/java.base/share/classes/sun/security/ssl/SSLTrafficKeyDerivation.java#L270
[5] https://github.com/openjdk/jdk/blob/b7a34f728d0653d55ef01da045c9aad4c0471143/src/java.base/share/classes/sun/security/ssl/SSLCipher.java#L496
[6] https://github.com/openjdk/jdk/blob/b7a34f728d0653d55ef01da045c9aad4c0471143/src/java.base/share/classes/sun/security/ssl/JsseJce.java#L81