### PR TITLE
8287854: Dangling reference in ClassVerifier::verify_class

### DIFF
--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -594,7 +594,7 @@ void ErrorContext::stackmap_details(outputStream* ss, const Method* method) cons
 
 ClassVerifier::ClassVerifier(JavaThread* current, InstanceKlass* klass)
     : _thread(current), _previous_symbol(NULL), _symbols(NULL), _exception_type(NULL),
-      _message(NULL), _method_signatures_table(NULL), _klass(klass) {
+      _message(NULL), _klass(klass) {
   _this_type = VerificationType::reference_type(klass->name());
 }
 
@@ -625,19 +625,12 @@ void ClassVerifier::verify_class(TRAPS) {
   // Either verifying both local and remote classes or just remote classes.
   assert(BytecodeVerificationRemote, "Should not be here");
 
-  // Create hash table containing method signatures.
-  method_signatures_table_type method_signatures_table;
-  set_method_signatures_table(&method_signatures_table);
-
   Array<Method*>* methods = _klass->methods();
   int num_methods = methods->length();
 
   for (int index = 0; index < num_methods; index++) {
     // Check for recursive re-verification before each method.
-    if (was_recursively_verified()) {
-      set_method_signatures_table(NULL); // clear stack allocated pointer.
-      return;
-    }
+    if (was_recursively_verified()) return;
 
     Method* m = methods->at(index);
     if (m->is_native() || m->is_abstract() || m->is_overpass()) {
@@ -654,7 +647,6 @@ void ClassVerifier::verify_class(TRAPS) {
     log_info(class, init)("Recursive verification detected for: %s",
                         _klass->external_name());
   }
-  set_method_signatures_table(NULL); // clear stack allocated pointer.
 }
 
 // Translate the signature entries into verification types and save them in

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -634,7 +634,10 @@ void ClassVerifier::verify_class(TRAPS) {
 
   for (int index = 0; index < num_methods; index++) {
     // Check for recursive re-verification before each method.
-    if (was_recursively_verified())  return;
+    if (was_recursively_verified()) {
+      set_method_signatures_table(NULL); // clear stack allocated pointer.
+      return;
+    }
 
     Method* m = methods->at(index);
     if (m->is_native() || m->is_abstract() || m->is_overpass()) {
@@ -651,6 +654,7 @@ void ClassVerifier::verify_class(TRAPS) {
     log_info(class, init)("Recursive verification detected for: %s",
                         _klass->external_name());
   }
+  set_method_signatures_table(NULL); // clear stack allocated pointer.
 }
 
 // Translate the signature entries into verification types and save them in

--- a/src/hotspot/share/classfile/verifier.hpp
+++ b/src/hotspot/share/classfile/verifier.hpp
@@ -285,7 +285,7 @@ class ClassVerifier : public StackObj {
   Symbol* _exception_type;
   char* _message;
 
-  method_signatures_table_type* _method_signatures_table;
+  method_signatures_table_type _method_signatures_table;
 
   ErrorContext _error_context;  // contains information about an error
 
@@ -437,12 +437,8 @@ class ClassVerifier : public StackObj {
 
   Klass* load_class(Symbol* name, TRAPS);
 
-  method_signatures_table_type* method_signatures_table() const {
-    return _method_signatures_table;
-  }
-
-  void set_method_signatures_table(method_signatures_table_type* method_signatures_table) {
-    _method_signatures_table = method_signatures_table;
+  method_signatures_table_type* method_signatures_table() {
+    return &_method_signatures_table;
   }
 
   int change_sig_to_verificationType(


### PR DESCRIPTION
Please review this small change to fix JDK_8287854.  The fix was tested with JCK lang and VM tests, Mach5 tiers 1 and 2 on Linux, Mac OS, and Windows (in progress), and Mach5 tiers 3-5 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287854](https://bugs.openjdk.org/browse/JDK-8287854): Dangling reference in ClassVerifier::verify_class


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9075/head:pull/9075` \
`$ git checkout pull/9075`

Update a local copy of the PR: \
`$ git checkout pull/9075` \
`$ git pull https://git.openjdk.java.net/jdk pull/9075/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9075`

View PR using the GUI difftool: \
`$ git pr show -t 9075`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9075.diff">https://git.openjdk.java.net/jdk/pull/9075.diff</a>

</details>
