### PR TITLE
JDK-8287967: Update golden test files after JDK-8287886

### DIFF
--- a/test/langtools/tools/javac/processing/warnings/au_8.out
+++ b/test/langtools/tools/javac/processing/warnings/au_8.out
@@ -1,4 +1,4 @@
-- compiler.warn.proc.messager: Duplicate annotation type ``Baz'' for processor TestRepeatedSupportedItems in its @SupportedAnnotationTypesannotation.
-- compiler.warn.proc.messager: Duplicate annotation type ``Baz'' for processor TestRepeatedSupportedItems in its @SupportedAnnotationTypesannotation.
+- compiler.warn.proc.messager: Duplicate annotation interface ``Baz'' for processor TestRepeatedSupportedItems in its @SupportedAnnotationTypesannotation.
+- compiler.warn.proc.messager: Duplicate annotation interface ``Baz'' for processor TestRepeatedSupportedItems in its @SupportedAnnotationTypesannotation.
 - compiler.warn.proc.messager: Duplicate option value ``Foo'' for processor TestRepeatedSupportedItems in its @SupportedOptionsannotation.
 3 warnings

--- a/test/langtools/tools/javac/processing/warnings/au_current.out
+++ b/test/langtools/tools/javac/processing/warnings/au_current.out
@@ -1,4 +1,4 @@
-- compiler.warn.proc.messager: Duplicate annotation type ``foo/Baz'' for processor TestRepeatedSupportedItems in its @SupportedAnnotationTypesannotation.
-- compiler.warn.proc.messager: Duplicate annotation type ``Baz'' for processor TestRepeatedSupportedItems in its @SupportedAnnotationTypesannotation.
+- compiler.warn.proc.messager: Duplicate annotation interface ``foo/Baz'' for processor TestRepeatedSupportedItems in its @SupportedAnnotationTypesannotation.
+- compiler.warn.proc.messager: Duplicate annotation interface ``Baz'' for processor TestRepeatedSupportedItems in its @SupportedAnnotationTypesannotation.
 - compiler.warn.proc.messager: Duplicate option value ``Foo'' for processor TestRepeatedSupportedItems in its @SupportedOptionsannotation.
 3 warnings


### PR DESCRIPTION
The terminology changes made to an exception message in [JDK-8287886](https://bugs.openjdk.org/browse/JDK-8287886) require updates to two golden files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287967](https://bugs.openjdk.org/browse/JDK-8287967): Update golden test files after JDK-8287886


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9076/head:pull/9076` \
`$ git checkout pull/9076`

Update a local copy of the PR: \
`$ git checkout pull/9076` \
`$ git pull https://git.openjdk.java.net/jdk pull/9076/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9076`

View PR using the GUI difftool: \
`$ git pr show -t 9076`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9076.diff">https://git.openjdk.java.net/jdk/pull/9076.diff</a>

</details>
