### PR TITLE
8287917: System.loadLibrary does not work on Big Sur if JDK is built with macOS SDK 10.15 and earlier

### DIFF
--- a/src/java.base/macosx/classes/jdk/internal/loader/ClassLoaderHelper.java
+++ b/src/java.base/macosx/classes/jdk/internal/loader/ClassLoaderHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,8 @@ class ClassLoaderHelper {
         try {
             major = Integer.parseInt(i < 0 ? osVersion : osVersion.substring(0, i));
         } catch (NumberFormatException e) {}
-        hasDynamicLoaderCache = major >= 11;
+        // SDK 10.15 and earlier always reports 10.16 instead of 11.x.x
+        hasDynamicLoaderCache = major >= 11 || osVersion.equals("10.16");
     }
 
     private ClassLoaderHelper() {}

--- a/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/LibraryFromCache.java
+++ b/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/LibraryFromCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/LibraryFromCache.java
+++ b/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/LibraryFromCache.java
@@ -43,7 +43,7 @@ import java.nio.file.Paths;
 public class LibraryFromCache {
     public static void main(String[] args) throws IOException {
         System.out.println("os.version = " + System.getProperty("os.version"));
-        
+
         String libname = args[0];
         if (!systemHasLibrary(libname)) {
             System.out.println("Test skipped. Library " + libname + " not found");

--- a/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/LibraryFromCache.java
+++ b/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/LibraryFromCache.java
@@ -48,6 +48,7 @@ public class LibraryFromCache {
             return;
         }
 
+        System.out.println("os.version = " + System.getProperty("os.version"));
         System.loadLibrary(libname);
     }
 

--- a/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/LibraryFromCache.java
+++ b/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/LibraryFromCache.java
@@ -42,13 +42,14 @@ import java.nio.file.Paths;
 
 public class LibraryFromCache {
     public static void main(String[] args) throws IOException {
+        System.out.println("os.version = " + System.getProperty("os.version"));
+        
         String libname = args[0];
         if (!systemHasLibrary(libname)) {
             System.out.println("Test skipped. Library " + libname + " not found");
             return;
         }
 
-        System.out.println("os.version = " + System.getProperty("os.version"));
         System.loadLibrary(libname);
     }
 


### PR DESCRIPTION
Please review this PR.
SDK 10.15 and earlier reports os.version as 10.16 on Big Sur.  This fix will check if dynamic linker support, which is supported from Big Sur, is available or not on the OS even if os.version is reported as 10.16 instead of 11.  The os.version 10.16 doesn't include the update version like y of 10.x.y.  Hence the change only see if it is 10.16 or not.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287917](https://bugs.openjdk.org/browse/JDK-8287917): System.loadLibrary does not work on Big Sur if JDK is built with macOS SDK 10.15 and earlier


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to [a9b95965](https://git.openjdk.org/jdk/pull/9077/files/a9b959659e3a7e16e307145c2e5a0da19cb83d30)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9077/head:pull/9077` \
`$ git checkout pull/9077`

Update a local copy of the PR: \
`$ git checkout pull/9077` \
`$ git pull https://git.openjdk.org/jdk pull/9077/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9077`

View PR using the GUI difftool: \
`$ git pr show -t 9077`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9077.diff">https://git.openjdk.org/jdk/pull/9077.diff</a>

</details>
