### PR TITLE
8287980: Build is broken due to SuperWordMaxVectorSize when C2 is disabled after JDK-8287697

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1295,6 +1295,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(MaxVectorSize, max_vector_size);
   }
 
+#if defined(COMPILER2)
   if (FLAG_IS_DEFAULT(SuperWordMaxVectorSize)) {
     if (FLAG_IS_DEFAULT(UseAVX) && UseAVX > 2 &&
         is_intel_skylake() && _stepping >= 5) {
@@ -1313,6 +1314,7 @@ void VM_Version::get_processor_features() {
       FLAG_SET_DEFAULT(SuperWordMaxVectorSize, MaxVectorSize);
     }
   }
+#endif
 
 #if defined(COMPILER2) && defined(ASSERT)
   if (MaxVectorSize > 0) {


### PR DESCRIPTION
Hi all,

Please review this trivial patch which fixes the build broken when C2 is disabled due to `SuperWordMaxVectorSize`.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287980](https://bugs.openjdk.org/browse/JDK-8287980): Build is broken due to SuperWordMaxVectorSize when C2 is disabled after JDK-8287697


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9078/head:pull/9078` \
`$ git checkout pull/9078`

Update a local copy of the PR: \
`$ git checkout pull/9078` \
`$ git pull https://git.openjdk.java.net/jdk pull/9078/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9078`

View PR using the GUI difftool: \
`$ git pr show -t 9078`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9078.diff">https://git.openjdk.java.net/jdk/pull/9078.diff</a>

</details>
