### PR TITLE
8287970: riscv: jdk/incubator/vector/*VectorTests failing

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -783,18 +783,6 @@ instruct vnegD(vReg dst, vReg src) %{
   ins_pipe(pipe_slow);
 %}
 
-// popcount vector
-
-instruct vpopcountI(iRegINoSp dst, vReg src) %{
-  match(Set dst (PopCountVI src));
-  format %{ "vpopc.m $dst, $src\t#@vpopcountI" %}
-  ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
-    __ vpopc_m(as_Register($dst$$reg), as_VectorRegister($src$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
 // vector add reduction
 
 instruct reduce_addB(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -85,6 +85,8 @@ source %{
       case Op_VectorReinterpret:
       case Op_VectorStoreMask:
       case Op_VectorTest:
+      case Op_PopCountVI:
+      case Op_PopCountVL:
         return false;
       default:
         return UseRVV;


### PR DESCRIPTION
[JDK-8284960](https://bugs.openjdk.org/browse/JDK-8284960) added a new vector operation VectorOperations.BIT_COUNT, which needs the support of PopCountV*. The following tests failed when enabling `UseRVV`:

jdk/incubator/vector/Byte256VectorTests.java
jdk/incubator/vector/ByteMaxVectorTests.java
jdk/incubator/vector/Int256VectorTests.java
jdk/incubator/vector/IntMaxVectorTests.java
jdk/incubator/vector/Short256VectorTests.java
jdk/incubator/vector/ShortMaxVectorTests.java

Tests are failing with "assert(n_type->isa_vect() == __null || lrg._is_vector || ireg == Op_RegD || ireg == Op_RegL || ireg == Op_RegVectMask) failed: vector must be in vector registers" because C2 instruct "vpopcountI" stores the result into a general-purpose register (GPR) instead of a vector register.

Currently, riscv vector extension `vpopc.m` instruction counts the number of mask elements of the active elements of the vector source mask register that has the value 1 and writes the result to a scalar x register. \[1] `PopCountV*` needs to write back the pop counting results to vector registers, there is no single instruction in rvv that can satisfy the requirement.  So we decide to remove the vpopcountI instruct for now.

\[1]: https://github.com/riscv/riscv-v-spec/releases/download/v1.0/riscv-v-spec-1.0.pdf

Additional Tests:
- [x] jdk/incubator/vector (release with UseRVV on QEMU)
- [x] hotspot:tier1 (release with UseRVV on QEMU without new failure)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287970](https://bugs.openjdk.org/browse/JDK-8287970): riscv: jdk/incubator/vector/*VectorTests failing


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [6a05b12c](https://git.openjdk.java.net/jdk/pull/9079/files/6a05b12cda5022dceb5552533f0c3bfc03e3065c)
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [6a05b12c](https://git.openjdk.java.net/jdk/pull/9079/files/6a05b12cda5022dceb5552533f0c3bfc03e3065c)
 * [Yadong Wang](https://openjdk.java.net/census#yadongwang) (@yadongw - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9079/head:pull/9079` \
`$ git checkout pull/9079`

Update a local copy of the PR: \
`$ git checkout pull/9079` \
`$ git pull https://git.openjdk.java.net/jdk pull/9079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9079`

View PR using the GUI difftool: \
`$ git pr show -t 9079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9079.diff">https://git.openjdk.java.net/jdk/pull/9079.diff</a>

</details>
