### PR TITLE
8288000: compiler/loopopts/TestOverUnrolling2.java fails with release VMs

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestOverUnrolling2.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestOverUnrolling2.java
@@ -26,8 +26,8 @@
  * @bug 8286625
  * @key stress
  * @summary C2 fails with assert(!n->is_Store() && !n->is_LoadStore()) failed: no node with a side effect
- * @run main/othervm -XX:-BackgroundCompilation -XX:+StressIGVN -XX:StressSeed=4232417824 TestOverUnrolling2
- * @run main/othervm -XX:-BackgroundCompilation -XX:+StressIGVN TestOverUnrolling2
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-BackgroundCompilation -XX:+StressIGVN -XX:StressSeed=4232417824 TestOverUnrolling2
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-BackgroundCompilation -XX:+StressIGVN TestOverUnrolling2
  */
 
 public class TestOverUnrolling2 {


### PR DESCRIPTION
Hi all,

Please review this trivial change which fixes the failure of compiler/loopopts/TestOverUnrolling2.java with release VMs.
Only `-XX:+UnlockDiagnosticVMOptions` is added.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288000](https://bugs.openjdk.org/browse/JDK-8288000): compiler/loopopts/TestOverUnrolling2.java fails with release VMs


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9080/head:pull/9080` \
`$ git checkout pull/9080`

Update a local copy of the PR: \
`$ git checkout pull/9080` \
`$ git pull https://git.openjdk.java.net/jdk pull/9080/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9080`

View PR using the GUI difftool: \
`$ git pr show -t 9080`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9080.diff">https://git.openjdk.java.net/jdk/pull/9080.diff</a>

</details>
