### PR TITLE
8288001: SOURCE_DATE_EPOCH should not be set by default

### DIFF
--- a/make/InitSupport.gmk
+++ b/make/InitSupport.gmk
@@ -311,7 +311,7 @@ else # $(HAS_SPEC)=true
   define SetupReproducibleBuild
     ifeq ($$(SOURCE_DATE), updated)
       # For static values of SOURCE_DATE (not "updated"), these are set in spec.gmk
-      export SOURCE_DATE_EPOCH := $$(shell $$(DATE) +"%s")
+      SOURCE_DATE_EPOCH := $$(shell $$(DATE) +"%s")
       export SOURCE_DATE_ISO_8601 := $$(call EpochToISO8601, $$(SOURCE_DATE_EPOCH))
     endif
   endef

--- a/make/modules/jdk.compiler/Gendata.gmk
+++ b/make/modules/jdk.compiler/Gendata.gmk
@@ -63,6 +63,11 @@ $(eval $(call SetupJavaCompilation, COMPILE_CREATE_SYMBOLS, \
         $(COMPILECREATESYMBOLS_ADD_EXPORTS), \
 ))
 
+ifndef SOURCE_DATE_EPOCH
+    SOURCE_DATE_EPOCH := $(shell $(DATE) +"%s")
+endif
+
+
 $(SUPPORT_OUTPUTDIR)/symbols/ct.sym: \
     $(COMPILE_CREATE_SYMBOLS) \
     $(wildcard $(MODULE_SRC)/share/data/symbols/*) \

--- a/make/modules/jdk.compiler/Gendata.gmk
+++ b/make/modules/jdk.compiler/Gendata.gmk
@@ -67,7 +67,6 @@ ifndef SOURCE_DATE_EPOCH
     SOURCE_DATE_EPOCH := $(shell $(DATE) +"%s")
 endif
 
-
 $(SUPPORT_OUTPUTDIR)/symbols/ct.sym: \
     $(COMPILE_CREATE_SYMBOLS) \
     $(wildcard $(MODULE_SRC)/share/data/symbols/*) \


### PR DESCRIPTION
At default configuration, SOURCE_DATE_EPOCH is exported as environment variable in SetupReproducibleBuild. Then, gcc is affected of SOURCE_DATE_EPOCH environment variable. This value is used only to set SOURCE_DATE_ISO_8601 (except below), so I removed "export" for SOURCE_DATE_EPOCH in SetupReproducibleBuild. And, at building ct.sym, SOURCE_DATE_EPOCH environment variable is needed. So I added setting routine if SOURCE_DATE_EPOCH is not set.

This fix works fine. With default configuration shows -Xinternalversion output same as Windows, and with --with-source-date configuration shows -Xinternalversion output specified timestamp. Would you please review this fix?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288001](https://bugs.openjdk.org/browse/JDK-8288001): SOURCE_DATE_EPOCH should not be set by default


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9081/head:pull/9081` \
`$ git checkout pull/9081`

Update a local copy of the PR: \
`$ git checkout pull/9081` \
`$ git pull https://git.openjdk.java.net/jdk pull/9081/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9081`

View PR using the GUI difftool: \
`$ git pr show -t 9081`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9081.diff">https://git.openjdk.java.net/jdk/pull/9081.diff</a>

</details>
