### PR TITLE
8288011: StringConcatFactory: Split application of stringifiers

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
@@ -485,12 +485,17 @@ public final class StringConcatFactory {
         MethodHandle[] doubleFilters = null;
         for (int i = 0; i < ptypes.length; i++) {
             Class<?> cl = ptypes[i];
-            MethodHandle filter = null;
+            // Use int as the logical type for subword integral types
+            // (byte and short). char and boolean require special
+            // handling so don't change the logical type of those
             if (cl == byte.class || cl == short.class) {
-                // use int for subword integral types; still need special mixers
-                // and prependers for char, boolean
                 ptypes[i] = int.class;
-            } else if (cl == Object.class) {
+            }
+            // Object, float and double will be eagerly transformed
+            // into a (non-null) String as a first step after invocation.
+            // Set up to use String as the logical type for such arguments
+            // internally.
+            else if (cl == Object.class) {
                 if (objFilters == null) {
                     objFilters = new MethodHandle[ptypes.length];
                 }

--- a/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
@@ -480,7 +480,9 @@ public final class StringConcatFactory {
         // The filtered argument type list is used all over in the combinators below.
 
         Class<?>[] ptypes = mt.erase().parameterArray();
-        MethodHandle[] filters = null;
+        MethodHandle[] objFilters = null;
+        MethodHandle[] floatFilters = null;
+        MethodHandle[] doubleFilters = null;
         for (int i = 0; i < ptypes.length; i++) {
             Class<?> cl = ptypes[i];
             MethodHandle filter = null;
@@ -489,17 +491,22 @@ public final class StringConcatFactory {
                 // and prependers for char, boolean
                 ptypes[i] = int.class;
             } else if (cl == Object.class) {
-                filter = objectStringifier();
-            } else if (cl == float.class) {
-                filter = floatStringifier();
-            } else if (cl == double.class) {
-                filter = doubleStringifier();
-            }
-            if (filter != null) {
-                if (filters == null) {
-                    filters = new MethodHandle[ptypes.length];
+                if (objFilters == null) {
+                    objFilters = new MethodHandle[ptypes.length];
                 }
-                filters[i] = filter;
+                objFilters[i] = objectStringifier();
+                ptypes[i] = String.class;
+            } else if (cl == float.class) {
+                if (floatFilters == null) {
+                    floatFilters = new MethodHandle[ptypes.length];
+                }
+                floatFilters[i] = floatStringifier();
+                ptypes[i] = String.class;
+            } else if (cl == double.class) {
+                if (doubleFilters == null) {
+                    doubleFilters = new MethodHandle[ptypes.length];
+                }
+                doubleFilters[i] = doubleStringifier();
                 ptypes[i] = String.class;
             }
         }
@@ -567,8 +574,14 @@ public final class StringConcatFactory {
         // The method handle shape here is (<args>).
 
         // Apply filters, converting the arguments:
-        if (filters != null) {
-            mh = MethodHandles.filterArguments(mh, 0, filters);
+        if (objFilters != null) {
+            mh = MethodHandles.filterArguments(mh, 0, objFilters);
+        }
+        if (floatFilters != null) {
+            mh = MethodHandles.filterArguments(mh, 0, floatFilters);
+        }
+        if (doubleFilters != null) {
+            mh = MethodHandles.filterArguments(mh, 0, doubleFilters);
         }
 
         return mh;


### PR DESCRIPTION
To take optimal advantage of the pre-existing optimization for repeated filters we could split the application of different types of stringifiers.

The resulting difference in order of evaluation is not observable by conventional means since all reference type share the same object stringifier, and the others are filtering primitives (floats and doubles) which have been passed by value already. 

This change neutral on many concatenation expression shapes, but for any complex expressions with interleaving float/double and reference parameters it brings a straightforward reduction in rebinds and underlying LFs generated. For example on the [MixedStringCombinations.java](https://gist.github.com/cl4es/08fb581dece3a73e89bfa52337bc4248) test there's a modest 2% reduction in total classes loaded with this change (from 16209 to 15872)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288011](https://bugs.openjdk.org/browse/JDK-8288011): StringConcatFactory: Split application of stringifiers


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - **Reviewer**) ⚠️ Review applies to [51c841e8](https://git.openjdk.org/jdk/pull/9082/files/51c841e81f36de4dea9786de8c471b3b9211d54b)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9082/head:pull/9082` \
`$ git checkout pull/9082`

Update a local copy of the PR: \
`$ git checkout pull/9082` \
`$ git pull https://git.openjdk.org/jdk pull/9082/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9082`

View PR using the GUI difftool: \
`$ git pr show -t 9082`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9082.diff">https://git.openjdk.org/jdk/pull/9082.diff</a>

</details>
