### PR TITLE
8288013: jpackage: test utility Windows registry enhancement

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
@@ -373,9 +373,26 @@ public class WindowsHelper {
         }
 
         String value = status.assertExitCodeIsZero().getOutput().stream().skip(2).findFirst().orElseThrow();
-        // Extract the last field from the following line:
-        //     Common Desktop    REG_SZ    C:\Users\Public\Desktop
-        value = value.split("    REG_SZ    ")[1];
+        // Extract the last field from the following lines:
+        //    (Default)    REG_SZ    test1
+        //    string_val    REG_SZ    test2
+        //    string_val_empty    REG_SZ
+        //    bin_val    REG_BINARY    4242
+        //    bin_val_empty    REG_BINARY
+        //    dword_val    REG_DWORD    0x2a
+        //    qword_val    REG_QWORD    0x2a
+        //    multi_string_val    REG_MULTI_SZ    test3\0test4
+        //    multi_string_val_empty    REG_MULTI_SZ
+        //    expand_string_val    REG_EXPAND_SZ    test5
+        //    expand_string_val_empty    REG_EXPAND_SZ
+        String[] parts = value.split(" {4}REG_[A-Z_]+ {4}");
+        if (parts.length == 1) {
+            value = "";
+        } else if (parts.length == 2) {
+            value = parts[1];
+        } else {
+            throw new RuntimeException(String.format("Failed to extract registry value from string [%s]", value));
+        }
 
         TKit.trace(String.format("Registry value [%s] at [%s] path is [%s]",
                 valueName, keyPath, value));


### PR DESCRIPTION
In jpackage test suite there is a test utility WindowsHelper.queryRegistryValue . It is used to verify changes to Windows registry that can be done by installer packages. It spawns `reg.exe query` process and parses its output. This patch adds support for quering empty values and additional REG_* datatypes.

Correctness was verified manually with the following registry values:

```
        //    (Default)    REG_SZ    test1
        //    string_val    REG_SZ    test2
        //    string_val_empty    REG_SZ
        //    bin_val    REG_BINARY    4242
        //    bin_val_empty    REG_BINARY
        //    dword_val    REG_DWORD    0x2a
        //    qword_val    REG_QWORD    0x2a
        //    multi_string_val    REG_MULTI_SZ    test3\0test4
        //    multi_string_val_empty    REG_MULTI_SZ
        //    expand_string_val    REG_EXPAND_SZ    test5
        //    expand_string_val_empty    REG_EXPAND_SZ
```

Corresponding utility output:

```
[04:36:38.190] TRACE: Registry value [] at [...] path is [test1]
[04:36:38.220] TRACE: Registry value [string_val] at [...] path is [test2]
[04:36:38.251] TRACE: Registry value [string_val_empty] at [...] path is []
[04:36:38.282] TRACE: Registry value [bin_val] at [...] path is [4242]
[04:36:38.315] TRACE: Registry value [bin_val_empty] at [...] path is []
[04:36:38.347] TRACE: Registry value [dword_val] at [...] path is [0x2a]
[04:36:38.378] TRACE: Registry value [qword_val] at [...] path is [0x2a]
[04:36:38.410] TRACE: Registry value [multi_string_val] at [...] path is [test3\\0test4]
[04:36:38.441] TRACE: Registry value [multi_string_val_empty] at [...] path is []
[04:36:38.473] TRACE: Registry value [expand_string_val] at [...] path is [test5]
[04:36:38.506] TRACE: Registry value [expand_string_val_empty] at [...] path is []
```

Testing:

 - [x] ran "jtreg:jdk/tools/jpackage/windows" before and after the patch

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288013](https://bugs.openjdk.org/browse/JDK-8288013): jpackage: test utility Windows registry enhancement


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9083/head:pull/9083` \
`$ git checkout pull/9083`

Update a local copy of the PR: \
`$ git checkout pull/9083` \
`$ git pull https://git.openjdk.org/jdk pull/9083/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9083`

View PR using the GUI difftool: \
`$ git pr show -t 9083`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9083.diff">https://git.openjdk.org/jdk/pull/9083.diff</a>

</details>
