### PR TITLE
8288040: x86: Loom: Improve cont/monitor-count helper methods

### DIFF
--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -460,8 +460,7 @@ int LIR_Assembler::emit_unwind_handler() {
       __ unlock_object(rdi, rsi, rax, *stub->entry());
     }
     __ bind(*stub->continuation());
-    NOT_LP64(__ get_thread(thread);)
-    __ dec_held_monitor_count(thread);
+    __ dec_held_monitor_count();
   }
 
   if (compilation()->env()->dtrace_method_probes()) {
@@ -3516,32 +3515,12 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
     // will be skipped. Solution is
     // 1. Increase only in fastpath
     // 2. Runtime1::monitorenter increase count after locking
-#ifndef _LP64
-    Register thread = rsi;
-    __ push(thread);
-    __ get_thread(thread);
-#else
-    Register thread = r15_thread;
-#endif
-    __ inc_held_monitor_count(thread);
-#ifndef _LP64
-    __ pop(thread);
-#endif
+    __ inc_held_monitor_count();
   }
   __ bind(*op->stub()->continuation());
   if (op->code() == lir_unlock) {
     // unlock in slowpath is JRT_Leaf stub, no deoptimization can happen
-#ifndef _LP64
-    Register thread = rsi;
-    __ push(thread);
-    __ get_thread(thread);
-#else
-    Register thread = r15_thread;
-#endif
-    __ dec_held_monitor_count(thread);
-#ifndef _LP64
-    __ pop(thread);
-#endif
+    __ dec_held_monitor_count();
   }
 }
 

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1064,8 +1064,7 @@ void InterpreterMacroAssembler::remove_activation(
 
   bind(unlock);
   unlock_object(robj);
-  NOT_LP64(get_thread(rthread);)
-  dec_held_monitor_count(rthread);
+  dec_held_monitor_count();
 
   pop(state);
 
@@ -1111,8 +1110,7 @@ void InterpreterMacroAssembler::remove_activation(
       push(state);
       mov(robj, rmon);   // nop if robj and rmon are the same
       unlock_object(robj);
-      NOT_LP64(get_thread(rthread);)
-      dec_held_monitor_count(rthread);
+      dec_held_monitor_count();
       pop(state);
 
       if (install_monitor_exception) {
@@ -1173,7 +1171,7 @@ void InterpreterMacroAssembler::remove_activation(
   leave();                           // remove frame anchor
   pop(ret_addr);                     // get return address
   mov(rsp, rbx);                     // set sp to sender sp
-  pop_cont_fastpath(rthread);
+  pop_cont_fastpath();
 }
 
 void InterpreterMacroAssembler::get_method_counters(Register method,

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2833,36 +2833,120 @@ void MacroAssembler::push_IU_state() {
   pusha();
 }
 
-void MacroAssembler::push_cont_fastpath(Register java_thread) {
+void MacroAssembler::push_cont_fastpath() {
   if (!Continuations::enabled()) return;
+
+#ifndef _LP64
+  Register rthread = rax;
+  Register rrealsp = rbx;
+  push(rthread);
+  push(rrealsp);
+
+  get_thread(rthread);
+
+  // The code below wants the original RSP.
+  // Move it back after the pushes above.
+  movptr(rrealsp, rsp);
+  addptr(rrealsp, 2*wordSize);
+#else
+  Register rthread = r15_thread;
+  Register rrealsp = rsp;
+#endif
+
   Label done;
-  cmpptr(rsp, Address(java_thread, JavaThread::cont_fastpath_offset()));
+  cmpptr(rrealsp, Address(rthread, JavaThread::cont_fastpath_offset()));
   jccb(Assembler::belowEqual, done);
-  movptr(Address(java_thread, JavaThread::cont_fastpath_offset()), rsp);
+  movptr(Address(rthread, JavaThread::cont_fastpath_offset()), rrealsp);
   bind(done);
+
+#ifndef _LP64
+  pop(rrealsp);
+  pop(rthread);
+#endif
 }
 
-void MacroAssembler::pop_cont_fastpath(Register java_thread) {
+void MacroAssembler::pop_cont_fastpath() {
   if (!Continuations::enabled()) return;
+
+#ifndef _LP64
+  Register rthread = rax;
+  Register rrealsp = rbx;
+  push(rthread);
+  push(rrealsp);
+
+  get_thread(rthread);
+
+  // The code below wants the original RSP.
+  // Move it back after the pushes above.
+  movptr(rrealsp, rsp);
+  addptr(rrealsp, 2*wordSize);
+#else
+  Register rthread = r15_thread;
+  Register rrealsp = rsp;
+#endif
+
   Label done;
-  cmpptr(rsp, Address(java_thread, JavaThread::cont_fastpath_offset()));
+  cmpptr(rrealsp, Address(rthread, JavaThread::cont_fastpath_offset()));
   jccb(Assembler::below, done);
-  movptr(Address(java_thread, JavaThread::cont_fastpath_offset()), 0);
+  movptr(Address(rthread, JavaThread::cont_fastpath_offset()), 0);
   bind(done);
+
+#ifndef _LP64
+  pop(rrealsp);
+  pop(rthread);
+#endif
 }
 
-void MacroAssembler::inc_held_monitor_count(Register java_thread) {
+void MacroAssembler::inc_held_monitor_count() {
   if (!Continuations::enabled()) return;
-  incrementl(Address(java_thread, JavaThread::held_monitor_count_offset()));
+
+#ifndef _LP64
+  Register thread = rax;
+  push(thread);
+  get_thread(thread);
+#else
+  Register thread = r15_thread;
+#endif
+
+  incrementl(Address(thread, JavaThread::held_monitor_count_offset()));
+
+#ifndef _LP64
+  pop(thread);
+#endif
 }
 
-void MacroAssembler::dec_held_monitor_count(Register java_thread) {
+void MacroAssembler::dec_held_monitor_count() {
   if (!Continuations::enabled()) return;
-  decrementl(Address(java_thread, JavaThread::held_monitor_count_offset()));
+
+#ifndef _LP64
+  Register thread = rax;
+  push(thread);
+  get_thread(thread);
+#else
+  Register thread = r15_thread;
+#endif
+
+  decrementl(Address(thread, JavaThread::held_monitor_count_offset()));
+
+#ifndef _LP64
+  pop(thread);
+#endif
 }
 
-void MacroAssembler::reset_held_monitor_count(Register java_thread) {
-  movl(Address(java_thread, JavaThread::held_monitor_count_offset()), (int32_t)0);
+void MacroAssembler::reset_held_monitor_count() {
+#ifndef _LP64
+  Register thread = rax;
+  push(thread);
+  get_thread(thread);
+#else
+  Register thread = r15_thread;
+#endif
+
+  movl(Address(thread, JavaThread::held_monitor_count_offset()), (int32_t)0);
+
+#ifndef _LP64
+  pop(thread);
+#endif
 }
 
 #ifdef ASSERT

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2934,6 +2934,8 @@ void MacroAssembler::dec_held_monitor_count() {
 }
 
 void MacroAssembler::reset_held_monitor_count() {
+  if (!Continuations::enabled()) return;
+
 #ifndef _LP64
   Register thread = rax;
   push(thread);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -524,11 +524,11 @@ class MacroAssembler: public Assembler {
   void push_CPU_state();
   void pop_CPU_state();
 
-  void push_cont_fastpath(Register java_thread);
-  void pop_cont_fastpath(Register java_thread);
-  void inc_held_monitor_count(Register java_thread);
-  void dec_held_monitor_count(Register java_thread);
-  void reset_held_monitor_count(Register java_thread);
+  void push_cont_fastpath();
+  void pop_cont_fastpath();
+  void inc_held_monitor_count();
+  void dec_held_monitor_count();
+  void reset_held_monitor_count();
   DEBUG_ONLY(void stop_if_in_cont(Register cont_reg, const char* name);)
 
   // Round up to a power of two

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -941,7 +941,7 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm,
     }
   }
 
-  __ push_cont_fastpath(r15_thread); // Set JavaThread::_cont_fastpath to the sp of the oldest interpreted frame we know about
+  __ push_cont_fastpath(); // Set JavaThread::_cont_fastpath to the sp of the oldest interpreted frame we know about
 
   // 6243940 We might end up in handle_wrong_method if
   // the callee is deoptimized as we race thru here. If that

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -393,7 +393,7 @@ class StubGenerator: public StubCodeGenerator {
     }
 #endif
 
-    __ pop_cont_fastpath(r15_thread);
+    __ pop_cont_fastpath();
 
     // restore regs belonging to calling function
 #ifdef _WIN64
@@ -8338,7 +8338,7 @@ void fill_continuation_entry(MacroAssembler* masm, Register reg_cont_obj, Regist
   __ movl(Address(rsp, ContinuationEntry::parent_held_monitor_count_offset()), rax);
 
   __ movptr(Address(r15_thread, JavaThread::cont_fastpath_offset()), 0);
-  __ reset_held_monitor_count(r15_thread);
+  __ reset_held_monitor_count();
 }
 
 //---------------------------- continuation_enter_cleanup ---------------------------

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -2592,11 +2592,10 @@ void TemplateTable::_return(TosState state) {
 #endif
     __ jcc(Assembler::zero, no_safepoint);
     __ push(state);
-    __ push_cont_fastpath(NOT_LP64(thread) LP64_ONLY(r15_thread));
+    __ push_cont_fastpath();
     __ call_VM(noreg, CAST_FROM_FN_PTR(address,
                                        InterpreterRuntime::at_safepoint));
-    NOT_LP64(__ get_thread(thread);)
-    __ pop_cont_fastpath(NOT_LP64(thread) LP64_ONLY(r15_thread));
+    __ pop_cont_fastpath();
     __ pop(state);
     __ bind(no_safepoint);
   }
@@ -4365,9 +4364,7 @@ void TemplateTable::monitorenter() {
   __ lock_object(rmon);
 
   // The object is stored so counter should be increased even if stackoverflow is generated
-  Register rthread = LP64_ONLY(r15_thread) NOT_LP64(rbx);
-  NOT_LP64(__ get_thread(rthread);)
-  __ inc_held_monitor_count(rthread);
+  __ inc_held_monitor_count();
 
   // check to make sure this monitor doesn't cause stack overflow after locking
   __ save_bcp();  // in case of exception
@@ -4428,9 +4425,7 @@ void TemplateTable::monitorexit() {
   __ push_ptr(rax); // make sure object is on stack (contract with oopMaps)
   __ unlock_object(rtop);
 
-  Register rthread = LP64_ONLY(r15_thread) NOT_LP64(rax);
-  NOT_LP64(__ get_thread(rthread);)
-  __ dec_held_monitor_count(rthread);
+  __ dec_held_monitor_count();
 
   __ pop_ptr(rax); // discard object
 }

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -2170,13 +2170,10 @@ void ThawBase::finish_thaw(frame& f) {
   }
   assert(chunk->is_empty() == (chunk->max_thawing_size() == 0), "");
 
-#ifdef _LP64
   if ((intptr_t)f.sp() % frame::frame_alignment != 0) {
     assert(f.is_interpreted_frame(), "");
     f.set_sp(f.sp() - 1);
   }
-#endif
-
   push_return_frame(f);
   chunk->fix_thawed_frame(f, SmallRegisterMap::instance); // can only fix caller after push_return_frame (due to callee saved regs)
 
@@ -2242,9 +2239,7 @@ static inline intptr_t* thaw_internal(JavaThread* thread, const Continuation::th
 
   Thaw<ConfigT> thw(thread, cont);
   intptr_t* const sp = thw.thaw(kind);
-#ifdef _LP64
   assert(is_aligned(sp, frame::frame_alignment), "");
-#endif
 
   // All the frames have been thawed so we know they don't hold any monitors
   thread->reset_held_monitor_count();

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -2170,10 +2170,13 @@ void ThawBase::finish_thaw(frame& f) {
   }
   assert(chunk->is_empty() == (chunk->max_thawing_size() == 0), "");
 
+#ifdef _LP64
   if ((intptr_t)f.sp() % frame::frame_alignment != 0) {
     assert(f.is_interpreted_frame(), "");
     f.set_sp(f.sp() - 1);
   }
+#endif
+
   push_return_frame(f);
   chunk->fix_thawed_frame(f, SmallRegisterMap::instance); // can only fix caller after push_return_frame (due to callee saved regs)
 
@@ -2239,7 +2242,9 @@ static inline intptr_t* thaw_internal(JavaThread* thread, const Continuation::th
 
   Thaw<ConfigT> thw(thread, cont);
   intptr_t* const sp = thw.thaw(kind);
+#ifdef _LP64
   assert(is_aligned(sp, frame::frame_alignment), "");
+#endif
 
   // All the frames have been thawed so we know they don't hold any monitors
   thread->reset_held_monitor_count();


### PR DESCRIPTION
When doing x86_32 port, I realized that cont helper methods are sensitive to `rsp`, which makes the usual trick of using a scratch register for `thread` dangerous. We can just lift the entire thread-acquisition business into the methods themselves. Related to that, we can also do the same thing for monitor-count helper methods, thus fully isolating them from the caller code. It would be even better after [JDK-8286957](https://bugs.openjdk.org/browse/JDK-8286957).

This does the shared code change, so that x86_32 port can hopefully continue as late enhancement after RDP1.

Additional testing:
 - [x] Linux x86_64 fastdebug, `jdk_loom hotspot_loom`
 - [x] Linux x86_32 fastdebug, `jdk_loom hotspot_loom`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288040](https://bugs.openjdk.org/browse/JDK-8288040): x86: Loom: Improve cont/monitor-count helper methods


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9086/head:pull/9086` \
`$ git checkout pull/9086`

Update a local copy of the PR: \
`$ git checkout pull/9086` \
`$ git pull https://git.openjdk.java.net/jdk pull/9086/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9086`

View PR using the GUI difftool: \
`$ git pr show -t 9086`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9086.diff">https://git.openjdk.java.net/jdk/pull/9086.diff</a>

</details>
