### PR TITLE
8288067: Avoid redundant HashMap.containsKey call in Type1Font.expandAbbreviation

### DIFF
--- a/src/java.desktop/share/classes/sun/font/Type1Font.java
+++ b/src/java.desktop/share/classes/sun/font/Type1Font.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,8 +102,8 @@ public class Type1Font extends FileFont {
 
     private String psName = null;
 
-    private static HashMap<String, String> styleAbbreviationsMapping;
-    private static HashSet<String> styleNameTokes;
+    private static final HashMap<String, String> styleAbbreviationsMapping;
+    private static final HashSet<String> styleNameTokes;
 
     static {
         styleAbbreviationsMapping = new HashMap<>();
@@ -143,7 +143,7 @@ public class Type1Font extends FileFont {
         for(int i=0; i<styleTokens.length; i++) {
             styleNameTokes.add(styleTokens[i]);
         }
-        }
+    }
 
 
     /**
@@ -406,7 +406,7 @@ public class Type1Font extends FileFont {
                 }
             }
         } catch (Exception e) {
-                throw new FontFormatException(e.toString());
+            throw new FontFormatException(e.toString());
         }
 
         /* Ignore all fonts besides Type1 (e.g. Type3 fonts) */
@@ -414,24 +414,24 @@ public class Type1Font extends FileFont {
             throw new FontFormatException("Unsupported font type");
         }
 
-    if (psName == null) { //no explicit FontName
-                // Try to extract font name from the first text line.
-                // According to Type1 spec first line consist of
-                //  "%!FontType1-SpecVersion: FontName FontVersion"
-                // or
-                //  "%!PS-AdobeFont-1.0: FontName version"
-                bb.position(0);
-                if (bb.getShort() != 0x2521) { //if pfb (do not start with "%!")
-                    //skip segment header and "%!"
-                    bb.position(8);
-                    //NB: assume that first segment is ASCII one
-                    //  (is it possible to have valid Type1 font with first binary segment?)
-                }
-                String formatType = getSimpleToken(bb);
-                if (!formatType.startsWith("FontType1-") && !formatType.startsWith("PS-AdobeFont-")) {
-                        throw new FontFormatException("Unsupported font format [" + formatType + "]");
-                }
-                psName = getSimpleToken(bb);
+        if (psName == null) { //no explicit FontName
+            // Try to extract font name from the first text line.
+            // According to Type1 spec first line consist of
+            //  "%!FontType1-SpecVersion: FontName FontVersion"
+            // or
+            //  "%!PS-AdobeFont-1.0: FontName version"
+            bb.position(0);
+            if (bb.getShort() != 0x2521) { //if pfb (do not start with "%!")
+                //skip segment header and "%!"
+                bb.position(8);
+                //NB: assume that first segment is ASCII one
+                //  (is it possible to have valid Type1 font with first binary segment?)
+            }
+            String formatType = getSimpleToken(bb);
+            if (!formatType.startsWith("FontType1-") && !formatType.startsWith("PS-AdobeFont-")) {
+                throw new FontFormatException("Unsupported font format [" + formatType + "]");
+            }
+            psName = getSimpleToken(bb);
         }
 
     //if we got to the end of file then we did not find at least one of FullName or FamilyName
@@ -451,8 +451,7 @@ public class Type1Font extends FileFont {
     }
 
     private String fullName2FamilyName(String name) {
-        String res, token;
-        int len, start, end; //length of family name part
+        int start, end; //length of family name part
 
         //FamilyName is truncated version of FullName
         //Truncated tail must contain only style modifiers
@@ -465,19 +464,17 @@ public class Type1Font extends FileFont {
               start--;
             //as soon as we meet first non style token truncate
             // current tail and return
-                        if (!isStyleToken(name.substring(start+1, end))) {
-                                return name.substring(0, end);
+            if (!isStyleToken(name.substring(start+1, end))) {
+                return name.substring(0, end);
             }
-                        end = start;
+            end = start;
         }
 
-                return name; //should not happen
-        }
+        return name; //should not happen
+    }
 
     private String expandAbbreviation(String abbr) {
-        if (styleAbbreviationsMapping.containsKey(abbr))
-                        return styleAbbreviationsMapping.get(abbr);
-        return abbr;
+        return styleAbbreviationsMapping.getOrDefault(abbr, abbr);
     }
 
     private boolean isStyleToken(String token) {
@@ -550,7 +547,7 @@ public class Type1Font extends FileFont {
                 res.append(s.substring(start, end));
             }
             start = end;
-                }
+        }
 
         return res.toString();
     }


### PR DESCRIPTION
Instead of pair HashMap.containsKey/HashMap.get method calls, we can use single call HashMap.getOrDefault.
It's faster and clearer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288067](https://bugs.openjdk.org/browse/JDK-8288067): Avoid redundant HashMap.containsKey call in Type1Font.expandAbbreviation


### Reviewers
 * [Attila Szegedi](https://openjdk.org/census#attila) (@szegedi - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9089/head:pull/9089` \
`$ git checkout pull/9089`

Update a local copy of the PR: \
`$ git checkout pull/9089` \
`$ git pull https://git.openjdk.org/jdk pull/9089/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9089`

View PR using the GUI difftool: \
`$ git pr show -t 9089`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9089.diff">https://git.openjdk.org/jdk/pull/9089.diff</a>

</details>
