### PR TITLE
8288051: Loom: Extend the compilation warning workaround in stack chunk copy

### DIFF
--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -316,6 +316,12 @@ inline void stackChunkOopDesc::copy_from_stack_to_chunk(intptr_t* from, intptr_t
   assert(to >= start_address(), "Chunk underflow");
   assert(to + size <= end_address(), "Chunk overflow");
 
+#if !defined(AMD64) || !defined(AARCH64) || defined(ZERO)
+  // Suppress compilation warning-as-error on unimplemented architectures
+  // that stub out arch-specific methods. Some compilers are smart enough
+  // to figure out the argument is always null.
+  if (to != nullptr)
+#endif
   memcpy(to, from, size << LogBytesPerWord);
 }
 
@@ -330,7 +336,9 @@ inline void stackChunkOopDesc::copy_from_chunk_to_stack(intptr_t* from, intptr_t
   assert(from + size <= end_address(), "");
 
 #if !defined(AMD64) || !defined(AARCH64) || defined(ZERO)
-  // Suppress compilation error from dummy function (somewhere).
+  // Suppress compilation warning-as-error on unimplemented architectures
+  // that stub out arch-specific methods. Some compilers are smart enough
+  // to figure out the argument is always null.
   if (to != nullptr)
 #endif
   memcpy(to, from, size << LogBytesPerWord);

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -319,7 +319,7 @@ inline void stackChunkOopDesc::copy_from_stack_to_chunk(intptr_t* from, intptr_t
 #if !defined(AMD64) || !defined(AARCH64) || defined(ZERO)
   // Suppress compilation warning-as-error on unimplemented architectures
   // that stub out arch-specific methods. Some compilers are smart enough
-  // to figure out the argument is always null.
+  // to figure out the argument is always null and then warn about it.
   if (to != nullptr)
 #endif
   memcpy(to, from, size << LogBytesPerWord);
@@ -338,7 +338,7 @@ inline void stackChunkOopDesc::copy_from_chunk_to_stack(intptr_t* from, intptr_t
 #if !defined(AMD64) || !defined(AARCH64) || defined(ZERO)
   // Suppress compilation warning-as-error on unimplemented architectures
   // that stub out arch-specific methods. Some compilers are smart enough
-  // to figure out the argument is always null.
+  // to figure out the argument is always null and then warn about it.
   if (to != nullptr)
 #endif
   memcpy(to, from, size << LogBytesPerWord);


### PR DESCRIPTION
Current builds fail on some newer GCCs and some arches. There is already a workaround in place in one copy method, we need the workaround in another one too. I took a brief look if we could dispense with this workaround altogether, but that does not seem to be straight-forward for JDK 19 timeframe.

```
* For target hotspot_variant-server_libjvm_objs_continuationFreezeThaw.o:
In file included from /home/buildbot/shipilev-jdk/src/hotspot/share/classfile/javaClasses.inline.hpp:36,
                 from /home/buildbot/shipilev-jdk/src/hotspot/share/runtime/continuationFreezeThaw.cpp:26:
In member function 'void stackChunkOopDesc::copy_from_stack_to_chunk(intptr_t*, intptr_t*, int)',
    inlined from 'void FreezeBase::copy_to_chunk(intptr_t*, intptr_t*, int)' at /home/buildbot/shipilev-jdk/src/hotspot/share/runtime/continuationFreezeThaw.cpp:499:34,
    inlined from 'freeze_result FreezeBase::recurse_freeze_stub_frame(frame&, frame&)' at /home/buildbot/shipilev-jdk/src/hotspot/share/runtime/continuationFreezeThaw.cpp:1168:16:
/home/buildbot/shipilev-jdk/src/hotspot/share/oops/stackChunkOop.inline.hpp:319:9: error: argument 1 null where non-null expected [-Werror=nonnull]
  319 |   memcpy(to, from, size << LogBytesPerWord);
      |   ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/buildbot/shipilev-jdk/src/hotspot/share/utilities/globalDefinitions_gcc.hpp:35,
                 from /home/buildbot/shipilev-jdk/src/hotspot/share/utilities/globalDefinitions.hpp:35,
                 from /home/buildbot/shipilev-jdk/src/hotspot/share/metaprogramming/primitiveConversions.hpp:30,
                 from /home/buildbot/shipilev-jdk/src/hotspot/share/utilities/enumIterator.hpp:32,
                 from /home/buildbot/shipilev-jdk/src/hotspot/share/classfile/vmClassID.hpp:29,
                 from /home/buildbot/shipilev-jdk/src/hotspot/share/classfile/vmClasses.hpp:28,
                 from /home/buildbot/shipilev-jdk/src/hotspot/share/classfile/javaClasses.hpp:28,
   ... (rest of output omitted)
```

Additional testing:
 - [x] Linux ARM32 release build with GCC 10, now passes
 - [x] Linux x86_64 fastdebug `jdk_loom hotspot_loom`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288051](https://bugs.openjdk.org/browse/JDK-8288051): Loom: Extend the compilation warning workaround in stack chunk copy


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9091/head:pull/9091` \
`$ git checkout pull/9091`

Update a local copy of the PR: \
`$ git checkout pull/9091` \
`$ git pull https://git.openjdk.java.net/jdk pull/9091/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9091`

View PR using the GUI difftool: \
`$ git pr show -t 9091`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9091.diff">https://git.openjdk.java.net/jdk/pull/9091.diff</a>

</details>
