### PR TITLE
8288052: Small logging clarification during failed heap shrinkage

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1342,7 +1342,7 @@ void G1CollectedHeap::shrink_helper(size_t shrink_bytes) {
     log_debug(gc, heap)("Uncommittable regions after shrink: %u", num_regions_removed);
     policy()->record_new_heap_size(num_regions());
   } else {
-    log_debug(gc, ergo, heap)("Did not expand the heap (heap shrinking operation failed)");
+    log_debug(gc, ergo, heap)("Did not shrink the heap (heap shrinking operation failed)");
   }
 }
 


### PR DESCRIPTION
Hi all,

Could anyone review this trivial logging clarification in G1CollectedHeap::shrink_helper()? I'm sponsoring colleague Jonathan Joo for this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288052](https://bugs.openjdk.org/browse/JDK-8288052): Small logging clarification during failed heap shrinkage


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Contributors
 * Jonathan Joo `<jonathanjoo@google.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9092/head:pull/9092` \
`$ git checkout pull/9092`

Update a local copy of the PR: \
`$ git checkout pull/9092` \
`$ git pull https://git.openjdk.java.net/jdk pull/9092/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9092`

View PR using the GUI difftool: \
`$ git pr show -t 9092`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9092.diff">https://git.openjdk.java.net/jdk/pull/9092.diff</a>

</details>
