### PR TITLE
8288068: Javadoc contains spurious reference to CLinker

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -212,7 +212,7 @@ public sealed interface Linker permits AbstractLinker {
      *
      * @param symbol the address of the target function.
      * @param function the function descriptor of the target function.
-     * @return a downcall method handle. The method handle type is <a href="CLinker.html#downcall-method-handles"><em>inferred</em></a>
+     * @return a downcall method handle. The method handle type is <a href="Linker.html#downcall-method-handles"><em>inferred</em></a>
      * @throws IllegalArgumentException if the provided function descriptor is not supported by this linker.
      * or if the symbol is {@link MemoryAddress#NULL}
      */
@@ -235,7 +235,7 @@ public sealed interface Linker permits AbstractLinker {
      * associated with the {@link MemoryAddress#NULL} address, or a {@link NullPointerException} if that parameter is {@code null}.
      *
      * @param function the function descriptor of the target function.
-     * @return a downcall method handle. The method handle type is <a href="CLinker.html#downcall-method-handles"><em>inferred</em></a>
+     * @return a downcall method handle. The method handle type is <a href="Linker.html#downcall-method-handles"><em>inferred</em></a>
      * from the provided function descriptor.
      * @throws IllegalArgumentException if the provided function descriptor is not supported by this linker.
      */
@@ -261,7 +261,7 @@ public sealed interface Linker permits AbstractLinker {
      * @return a zero-length segment whose base address is the address of the upcall stub.
      * @throws IllegalArgumentException if the provided function descriptor is not supported by this linker.
      * @throws IllegalArgumentException if it is determined that the target method handle can throw an exception, or if the target method handle
-     * has a type that does not match the upcall stub <a href="CLinker.html#upcall-stubs"><em>inferred type</em></a>.
+     * has a type that does not match the upcall stub <a href="Linker.html#upcall-stubs"><em>inferred type</em></a>.
      * @throws IllegalStateException if {@code session} is not {@linkplain MemorySession#isAlive() alive}.
      * @throws WrongThreadException if this method is called from a thread other than the thread
      * {@linkplain MemorySession#ownerThread() owning} {@code session}.

--- a/src/java.base/share/classes/java/lang/foreign/package-info.java
+++ b/src/java.base/share/classes/java/lang/foreign/package-info.java
@@ -185,7 +185,7 @@
  * FunctionDescriptor intCompareDescriptor = FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS);
  * MethodHandle intCompareHandle = MethodHandles.lookup().findStatic(IntComparator.class,
  *                                                 "intCompare",
- *                                                 CLinker.upcallType(comparFunction));
+ *                                                 Linker.upcallType(comparFunction));
  * }
  *
  * As before, we need to create a {@link java.lang.foreign.FunctionDescriptor} instance, this time describing the signature
@@ -198,7 +198,7 @@
  *
  * {@snippet lang=java :
  * MemorySession session = ...
- * Addressable comparFunc = CLinker.nativeLinker().upcallStub(
+ * Addressable comparFunc = Linker.nativeLinker().upcallStub(
  *     intCompareHandle, intCompareDescriptor, session);
  * );
  * }


### PR DESCRIPTION
This simple patch fixes a bunch of references to "CLinker" and replaces them with "Linker", following the API name changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288068](https://bugs.openjdk.org/browse/JDK-8288068): Javadoc contains spurious reference to CLinker


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9094/head:pull/9094` \
`$ git checkout pull/9094`

Update a local copy of the PR: \
`$ git checkout pull/9094` \
`$ git pull https://git.openjdk.java.net/jdk pull/9094/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9094`

View PR using the GUI difftool: \
`$ git pr show -t 9094`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9094.diff">https://git.openjdk.java.net/jdk/pull/9094.diff</a>

</details>
