### PR TITLE
8288080: (fc) FileChannel::map for MemorySegments should state it always throws UOE

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -997,6 +997,10 @@ public abstract class FileChannel
      *           of mapped memory associated with the returned mapped memory
      *           segment is unspecified and should not be relied upon.
      *
+     * @implSpec The {@code map(MapMode, long, long, MemorySession)} method of
+     *           {@code FileChannel} always throws an
+     *           {@code UnsupportedOperationException}.
+     *
      * @param   mode
      *          The file mapping mode, see
      *          {@link FileChannel#map(FileChannel.MapMode, long, long)};

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -997,8 +997,7 @@ public abstract class FileChannel
      *           of mapped memory associated with the returned mapped memory
      *           segment is unspecified and should not be relied upon.
      *
-     * @implSpec The {@code map(MapMode, long, long, MemorySession)} method of
-     *           {@code FileChannel} always throws an
+     * @implSpec The default implementation of this method throws
      *           {@code UnsupportedOperationException}.
      *
      * @param   mode


### PR DESCRIPTION
Add an `@implSpec` annotation to the `java.nio.channels.FileChannel::map` method for mapped memory segments indicating that it always throws an `UnsupportedOperationException`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8288080](https://bugs.openjdk.org/browse/JDK-8288080): (fc) FileChannel::map for MemorySegments should state it always throws UOE
 * [JDK-8288081](https://bugs.openjdk.org/browse/JDK-8288081): (fc) FileChannel::map for MemorySegments should state it always throws UOE (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [2b93620e](https://git.openjdk.org/jdk/pull/9095/files/2b93620e4891706ad802418ed5c94521805ead02)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9095/head:pull/9095` \
`$ git checkout pull/9095`

Update a local copy of the PR: \
`$ git checkout pull/9095` \
`$ git pull https://git.openjdk.org/jdk pull/9095/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9095`

View PR using the GUI difftool: \
`$ git pr show -t 9095`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9095.diff">https://git.openjdk.org/jdk/pull/9095.diff</a>

</details>
