### PR TITLE
8288082: Build failure due to __clang_major__ is not defined after JDK-8214976

### DIFF
--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -63,7 +63,7 @@
 
 #endif // clang/gcc version check
 
-#if (__GNUC__ >= 9) || (__clang_major__ >= 14)
+#if (__GNUC__ >= 9) || (defined(__clang_major__) && (__clang_major__ >= 14))
 
 // Use "warning" attribute to detect uses of "forbidden" functions.
 //


### PR DESCRIPTION
Hi all,

Build failure was observed when build on a machine without clang.
Please review this trivial patch which fixes the build failure due to `__clang_major__` is not defined.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288082](https://bugs.openjdk.org/browse/JDK-8288082): Build failure due to __clang_major__ is not defined after JDK-8214976


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/9096/head:pull/9096` \
`$ git checkout pull/9096`

Update a local copy of the PR: \
`$ git checkout pull/9096` \
`$ git pull https://git.openjdk.java.net/jdk pull/9096/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9096`

View PR using the GUI difftool: \
`$ git pr show -t 9096`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/9096.diff">https://git.openjdk.java.net/jdk/pull/9096.diff</a>

</details>
