### PR TITLE
8283724: Incorrect description for jtreg-failure-handler option

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -494,7 +494,7 @@ AC_DEFUN_ONCE([JDKOPT_ENABLE_DISABLE_FAILURE_HANDLER],
 [
   UTIL_ARG_ENABLE(NAME: jtreg-failure-handler, DEFAULT: auto,
       RESULT: BUILD_FAILURE_HANDLER,
-      DESC: [enable keeping of packaged modules in jdk image],
+      DESC: [enable building of the jtreg failure handler],
       DEFAULT_DESC: [enabled if jtreg is present],
       CHECKING_MSG: [if the jtreg failure handler should be built],
       CHECK_AVAILABLE: [


### PR DESCRIPTION
The description for the jtreg-failure-handler option is incorrect, so I fixed it to describe jtreg-failure-handler option.  
Would you please review this fix?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283724](https://bugs.openjdk.org/browse/JDK-8283724): Incorrect description for jtreg-failure-handler option


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9099/head:pull/9099` \
`$ git checkout pull/9099`

Update a local copy of the PR: \
`$ git checkout pull/9099` \
`$ git pull https://git.openjdk.org/jdk pull/9099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9099`

View PR using the GUI difftool: \
`$ git pr show -t 9099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9099.diff">https://git.openjdk.org/jdk/pull/9099.diff</a>

</details>
