### PR TITLE
8288140: Avoid redundant Hashtable.get call in Signal.handle

### DIFF
--- a/src/java.base/share/classes/jdk/internal/misc/Signal.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Signal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/misc/Signal.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Signal.java
@@ -174,8 +174,7 @@ public final class Signal {
         }
         signals.put(sig.number, sig);
         synchronized (handlers) {
-            Signal.Handler oldHandler = handlers.get(sig);
-            handlers.remove(sig);
+            Signal.Handler oldHandler = handlers.remove(sig);
             if (newH == 2) {
                 handlers.put(sig, handler);
             }

--- a/src/java.base/share/classes/jdk/internal/misc/Signal.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Signal.java
@@ -71,8 +71,8 @@ import java.util.Objects;
  * @since    9
  */
 public final class Signal {
-    private static Hashtable<Signal, Signal.Handler> handlers = new Hashtable<>(4);
-    private static Hashtable<Integer, Signal> signals = new Hashtable<>(4);
+    private static final Hashtable<Signal, Signal.Handler> handlers = new Hashtable<>(4);
+    private static final Hashtable<Integer, Signal> signals = new Hashtable<>(4);
 
     private int number;
     private String name;
@@ -161,7 +161,7 @@ public final class Signal {
      * @see jdk.internal.misc.Signal.Handler#SIG_IGN
      */
     public static synchronized Signal.Handler handle(Signal sig,
-                                                    Signal.Handler handler)
+                                                     Signal.Handler handler)
         throws IllegalArgumentException {
         Objects.requireNonNull(sig, "sig");
         Objects.requireNonNull(handler, "handler");
@@ -173,20 +173,20 @@ public final class Signal {
                 ("Signal already used by VM or OS: " + sig);
         }
         signals.put(sig.number, sig);
-        synchronized (handlers) {
-            Signal.Handler oldHandler = handlers.remove(sig);
-            if (newH == 2) {
-                handlers.put(sig, handler);
-            }
-            if (oldH == 0) {
-                return Signal.Handler.SIG_DFL;
-            } else if (oldH == 1) {
-                return Signal.Handler.SIG_IGN;
-            } else if (oldH == 2) {
-                return oldHandler;
-            } else {
-                return new NativeHandler(oldH);
-            }
+        Signal.Handler oldHandler;
+        if (newH == 2) {
+            oldHandler = handlers.put(sig, handler);
+        } else {
+            oldHandler = handlers.remove(sig);
+        }
+        if (oldH == 0) {
+            return Signal.Handler.SIG_DFL;
+        } else if (oldH == 1) {
+            return Signal.Handler.SIG_IGN;
+        } else if (oldH == 2) {
+            return oldHandler;
+        } else {
+            return new NativeHandler(oldH);
         }
     }
 


### PR DESCRIPTION
https://github.com/openjdk/jdk/blob/bc28baeba9360991e9b7575e1fbe178d873ccfc1/src/java.base/share/classes/jdk/internal/misc/Signal.java#L177-L178

Instead of separate Hashtable.get/remove calls we can just use value returned by `remove`,
It results in cleaner and a bit faster code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288140](https://bugs.openjdk.org/browse/JDK-8288140): Avoid redundant Hashtable.get call in Signal.handle


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9100/head:pull/9100` \
`$ git checkout pull/9100`

Update a local copy of the PR: \
`$ git checkout pull/9100` \
`$ git pull https://git.openjdk.org/jdk pull/9100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9100`

View PR using the GUI difftool: \
`$ git pr show -t 9100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9100.diff">https://git.openjdk.org/jdk/pull/9100.diff</a>

</details>
