### PR TITLE
JDK-8288003: log events for os::dll_unload

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1788,7 +1788,7 @@ void * os::Linux::dll_load_in_vmthread(const char *filename, char *ebuf,
 
 const char* os::Linux::dll_path(void* lib) {
   struct link_map *lmap;
-  const char* l_path = "<not available>";
+  const char* l_path = NULL;
   if (lib != NULL) {
     int res_dli = ::dlinfo(lib, RTLD_DI_LINKMAP, &lmap);
     if (res_dli == 0) {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1786,6 +1786,16 @@ void * os::Linux::dll_load_in_vmthread(const char *filename, char *ebuf,
   return result;
 }
 
+const char* os::Linux::dll_path(void* lib) {
+  struct link_map *lmap;
+  int res_dli = ::dlinfo(lib, RTLD_DI_LINKMAP, &lmap);
+  const char* l_path = "<none>";
+  if (res_dli == 0) {
+    l_path = lmap->l_name;
+  }
+  return l_path;
+}
+
 static bool _print_ascii_file(const char* filename, outputStream* st, const char* hdr = NULL) {
   int fd = ::open(filename, O_RDONLY);
   if (fd == -1) {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1789,11 +1789,11 @@ void * os::Linux::dll_load_in_vmthread(const char *filename, char *ebuf,
 const char* os::Linux::dll_path(void* lib) {
   struct link_map *lmap;
   const char* l_path = NULL;
-  if (lib != NULL) {
-    int res_dli = ::dlinfo(lib, RTLD_DI_LINKMAP, &lmap);
-    if (res_dli == 0) {
-      l_path = lmap->l_name;
-    }
+  assert(lib != NULL, "dll_path parameter must not be NULL");
+
+  int res_dli = ::dlinfo(lib, RTLD_DI_LINKMAP, &lmap);
+  if (res_dli == 0) {
+    l_path = lmap->l_name;
   }
   return l_path;
 }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1788,10 +1788,12 @@ void * os::Linux::dll_load_in_vmthread(const char *filename, char *ebuf,
 
 const char* os::Linux::dll_path(void* lib) {
   struct link_map *lmap;
-  int res_dli = ::dlinfo(lib, RTLD_DI_LINKMAP, &lmap);
-  const char* l_path = "<none>";
-  if (res_dli == 0) {
-    l_path = lmap->l_name;
+  const char* l_path = "<not available>";
+  if (lib != NULL) {
+    int res_dli = ::dlinfo(lib, RTLD_DI_LINKMAP, &lmap);
+    if (res_dli == 0) {
+      l_path = lmap->l_name;
+    }
   }
   return l_path;
 }

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,6 +120,7 @@ class Linux {
   static bool _stack_is_executable;
   static void *dlopen_helper(const char *name, char *ebuf, int ebuflen);
   static void *dll_load_in_vmthread(const char *name, char *ebuf, int ebuflen);
+  static const char *dll_path(void* lib); 
 
   static void init_thread_fpu_state();
   static int  get_fpu_control_word();

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -120,7 +120,7 @@ class Linux {
   static bool _stack_is_executable;
   static void *dlopen_helper(const char *name, char *ebuf, int ebuflen);
   static void *dll_load_in_vmthread(const char *name, char *ebuf, int ebuflen);
-  static const char *dll_path(void* lib); 
+  static const char *dll_path(void* lib);
 
   static void init_thread_fpu_state();
   static int  get_fpu_control_word();

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -708,6 +708,7 @@ void* os::dll_lookup(void* handle, const char* name) {
 void os::dll_unload(void *lib) {
   const char* l_path = LINUX_ONLY(os::Linux::dll_path(lib))
                        NOT_LINUX("<not available>");
+  if (l_path == NULL) l_path = "<not available>";
   int res = ::dlclose(lib);
 
   if (res == 0) {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1245,7 +1245,7 @@ void  os::dll_unload(void *lib) {
     log_info(os)("Unloaded dll \"%s\" [" INTPTR_FORMAT "]", name, p2i(lib));
   } else {
     const DWORD errcode = ::GetLastError();
-    Events::log_dll_message(NULL, "Attempt to unload dll %s [" INTPTR_FORMAT "] failed (error code %d)", name, p2i(lib), errcode);
+    Events::log_dll_message(NULL, "Attempt to unload dll \"%s\" [" INTPTR_FORMAT "] failed (error code %d)", name, p2i(lib), errcode);
     log_info(os)("Attempt to unload dll \"%s\" [" INTPTR_FORMAT "] failed (error code %d)", name, p2i(lib), errcode);
   }
 }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1236,7 +1236,18 @@ void os::die() {
 const char* os::dll_file_extension() { return ".dll"; }
 
 void  os::dll_unload(void *lib) {
-  ::FreeLibrary((HMODULE)lib);
+  char name[MAX_PATH];
+  if (::GetModuleFileName((HMODULE)lib, name, sizeof(name)) == 0) {
+    name[0] = '\0';
+  }
+  if (::FreeLibrary((HMODULE)lib)) {
+    Events::log_dll_message(NULL, "Unloaded dll \"%s\" [" INTPTR_FORMAT "]", name, p2i(lib));
+    log_info(os)("Unloaded dll \"%s\" [" INTPTR_FORMAT "]", name, p2i(lib));
+  } else {
+    const DWORD errcode = ::GetLastError();
+    Events::log_dll_message(NULL, "Attempt to unload dll %s [" INTPTR_FORMAT "] failed (error code %d)", name, p2i(lib), errcode);
+    log_info(os)("Attempt to unload dll \"%s\" [" INTPTR_FORMAT "] failed (error code %d)", name, p2i(lib), errcode);
+  }
 }
 
 void* os::dll_lookup(void *lib, const char *name) {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1238,7 +1238,7 @@ const char* os::dll_file_extension() { return ".dll"; }
 void  os::dll_unload(void *lib) {
   char name[MAX_PATH];
   if (::GetModuleFileName((HMODULE)lib, name, sizeof(name)) == 0) {
-    name[0] = '\0';
+    snprintf(name, MAX_PATH, "<not available>");
   }
   if (::FreeLibrary((HMODULE)lib)) {
     Events::log_dll_message(NULL, "Unloaded dll \"%s\" [" INTPTR_FORMAT "]", name, p2i(lib));


### PR DESCRIPTION
Currently we only log events for os::dll_load, but not for os::dll_unload, this patch adds it. On some platforms (Linux/Windows) we can use OS APIs (e.g. dlinfo on Linux) to log the path of the unloaded shared lib.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288003](https://bugs.openjdk.org/browse/JDK-8288003): log events for os::dll_unload


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [dbdca1ee](https://git.openjdk.org/jdk/pull/9101/files/dbdca1eef2465660320afae21bd76ed3f1b342f5)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [b255beb8](https://git.openjdk.org/jdk/pull/9101/files/b255beb84991e4c99b30a7ab098b922711d2d299)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9101/head:pull/9101` \
`$ git checkout pull/9101`

Update a local copy of the PR: \
`$ git checkout pull/9101` \
`$ git pull https://git.openjdk.org/jdk pull/9101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9101`

View PR using the GUI difftool: \
`$ git pr show -t 9101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9101.diff">https://git.openjdk.org/jdk/pull/9101.diff</a>

</details>
