### PR TITLE
JDK-8288094: cleanup old _MSC_VER handling

### DIFF
--- a/src/hotspot/os_cpu/windows_aarch64/unwind_windows_aarch64.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/unwind_windows_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * Copyright (c) 2020, 2022, Microsoft Corporation. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,15 +27,6 @@
 
 
 typedef unsigned char UBYTE;
-
-#if _MSC_VER < 1700
-
-/* Not needed for VS2012 compiler, comes from winnt.h. */
-#define UNW_FLAG_EHANDLER  0x01
-#define UNW_FLAG_UHANDLER  0x02
-#define UNW_FLAG_CHAININFO 0x04
-
-#endif
 
 // See https://docs.microsoft.com/en-us/cpp/build/arm64-exception-handling#xdata-records
 typedef struct _UNWIND_INFO_EH_ONLY {
@@ -69,34 +60,5 @@ typedef struct _RUNTIME_FUNCTION {
     } DUMMYUNIONNAME;
 } RUNTIME_FUNCTION, *PRUNTIME_FUNCTION;
 */
-
-#if _MSC_VER < 1700
-
-/* Not needed for VS2012 compiler, comes from winnt.h. */
-typedef struct _DISPATCHER_CONTEXT {
-    ULONG64 ControlPc;
-    ULONG64 ImageBase;
-    PRUNTIME_FUNCTION FunctionEntry;
-    ULONG64 EstablisherFrame;
-    ULONG64 TargetIp;
-    PCONTEXT ContextRecord;
-//    PEXCEPTION_ROUTINE LanguageHandler;
-    char * LanguageHandler; // double dependency problem
-    PVOID HandlerData;
-} DISPATCHER_CONTEXT, *PDISPATCHER_CONTEXT;
-
-#endif
-
-#if _MSC_VER < 1500
-
-/* Not needed for VS2008 compiler, comes from winnt.h. */
-typedef EXCEPTION_DISPOSITION (*PEXCEPTION_ROUTINE) (
-    IN PEXCEPTION_RECORD ExceptionRecord,
-    IN ULONG64 EstablisherFrame,
-    IN OUT PCONTEXT ContextRecord,
-    IN OUT PDISPATCHER_CONTEXT DispatcherContext
-);
-
-#endif
 
 #endif // OS_CPU_WINDOWS_AARCH64_UNWIND_WINDOWS_AARCH64_HPP

--- a/src/hotspot/os_cpu/windows_x86/unwind_windows_x86.hpp
+++ b/src/hotspot/os_cpu/windows_x86/unwind_windows_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,15 +29,6 @@
 #ifdef AMD64
 typedef unsigned char UBYTE;
 
-#if _MSC_VER < 1700
-
-/* Not needed for VS2012 compiler, comes from winnt.h. */
-#define UNW_FLAG_EHANDLER  0x01
-#define UNW_FLAG_UHANDLER  0x02
-#define UNW_FLAG_CHAININFO 0x04
-
-#endif
-
 // This structure is used to define an UNWIND_INFO that
 // only has an ExceptionHandler.  There are no UnwindCodes
 // declared.
@@ -55,7 +46,6 @@ typedef struct _UNWIND_INFO_EH_ONLY {
     OPTIONAL ULONG ExceptionData[1];
 } UNWIND_INFO_EH_ONLY, *PUNWIND_INFO_EH_ONLY;
 
-
 /*
 typedef struct _RUNTIME_FUNCTION {
     ULONG BeginAddress;
@@ -63,35 +53,6 @@ typedef struct _RUNTIME_FUNCTION {
     ULONG UnwindData;
 } RUNTIME_FUNCTION, *PRUNTIME_FUNCTION;
 */
-
-#if _MSC_VER < 1700
-
-/* Not needed for VS2012 compiler, comes from winnt.h. */
-typedef struct _DISPATCHER_CONTEXT {
-    ULONG64 ControlPc;
-    ULONG64 ImageBase;
-    PRUNTIME_FUNCTION FunctionEntry;
-    ULONG64 EstablisherFrame;
-    ULONG64 TargetIp;
-    PCONTEXT ContextRecord;
-//    PEXCEPTION_ROUTINE LanguageHandler;
-    char * LanguageHandler; // double dependency problem
-    PVOID HandlerData;
-} DISPATCHER_CONTEXT, *PDISPATCHER_CONTEXT;
-
-#endif
-
-#if _MSC_VER < 1500
-
-/* Not needed for VS2008 compiler, comes from winnt.h. */
-typedef EXCEPTION_DISPOSITION (*PEXCEPTION_ROUTINE) (
-    IN PEXCEPTION_RECORD ExceptionRecord,
-    IN ULONG64 EstablisherFrame,
-    IN OUT PCONTEXT ContextRecord,
-    IN OUT PDISPATCHER_CONTEXT DispatcherContext
-);
-
-#endif
 
 #endif // AMD64
 

--- a/src/hotspot/share/adlc/adlc.hpp
+++ b/src/hotspot/share/adlc/adlc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,13 +42,9 @@
 /* Make sure that we have the intptr_t and uintptr_t definitions */
 #ifdef _WIN32
 
-#if _MSC_VER >= 1300
 using namespace std;
-#endif
 
-#if _MSC_VER >= 1400
 #define strdup _strdup
-#endif
 
 #if _MSC_VER < 1900
 #define snprintf _snprintf

--- a/src/hotspot/share/adlc/main.cpp
+++ b/src/hotspot/share/adlc/main.cpp
@@ -489,7 +489,7 @@ int get_legal_text(FileBuff &fbuf, char **legal_text)
 }
 
 // VS2005 has its own definition, identical to this one.
-#if !defined(_WIN32) || defined(_WIN64) || _MSC_VER < 1400
+#if !defined(_WIN32) || defined(_WIN64)
 void *operator new( size_t size, int, const char *, int ) throw() {
   return ::operator new( size );
 }

--- a/src/hotspot/share/adlc/main.cpp
+++ b/src/hotspot/share/adlc/main.cpp
@@ -488,7 +488,6 @@ int get_legal_text(FileBuff &fbuf, char **legal_text)
   return (int) (legal_end - legal_start);
 }
 
-// VS2005 has its own definition, identical to this one.
 #if !defined(_WIN32) || defined(_WIN64)
 void *operator new( size_t size, int, const char *, int ) throw() {
   return ::operator new( size );

--- a/src/hotspot/share/interpreter/bytecodes.cpp
+++ b/src/hotspot/share/interpreter/bytecodes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,16 +28,6 @@
 #include "oops/method.hpp"
 #include "utilities/align.hpp"
 #include "utilities/bytes.hpp"
-
-
-#if defined(WIN32) && (defined(_MSC_VER) && (_MSC_VER < 1600))
-// Windows AMD64 Compiler Hangs compiling this file
-// unless optimization is off
-#ifdef _M_AMD64
-#pragma optimize ("", off)
-#endif
-#endif
-
 
 bool            Bytecodes::_is_initialized = false;
 const char*     Bytecodes::_name          [Bytecodes::number_of_codes];

--- a/src/java.base/share/native/launcher/main.c
+++ b/src/java.base/share/native/launcher/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,46 +33,6 @@
 #include "defines.h"
 #include "jli_util.h"
 #include "jni.h"
-
-#ifdef _MSC_VER
-#if _MSC_VER > 1400 && _MSC_VER < 1600
-
-/*
- * When building for Microsoft Windows, main has a dependency on msvcr??.dll.
- *
- * When using Visual Studio 2005 or 2008, that must be recorded in
- * the [java,javaw].exe.manifest file.
- *
- * As of VS2010 (ver=1600), the runtimes again no longer need manifests.
- *
- * Reference:
- *     C:/Program Files/Microsoft SDKs/Windows/v6.1/include/crtdefs.h
- */
-#include <crtassem.h>
-#ifdef _M_IX86
-
-#pragma comment(linker,"/manifestdependency:\"type='win32' "            \
-        "name='" __LIBRARIES_ASSEMBLY_NAME_PREFIX ".CRT' "              \
-        "version='" _CRT_ASSEMBLY_VERSION "' "                          \
-        "processorArchitecture='x86' "                                  \
-        "publicKeyToken='" _VC_ASSEMBLY_PUBLICKEYTOKEN "'\"")
-
-#endif /* _M_IX86 */
-
-//This may not be necessary yet for the Windows 64-bit build, but it
-//will be when that build environment is updated.  Need to test to see
-//if it is harmless:
-#ifdef _M_AMD64
-
-#pragma comment(linker,"/manifestdependency:\"type='win32' "            \
-        "name='" __LIBRARIES_ASSEMBLY_NAME_PREFIX ".CRT' "              \
-        "version='" _CRT_ASSEMBLY_VERSION "' "                          \
-        "processorArchitecture='amd64' "                                \
-        "publicKeyToken='" _VC_ASSEMBLY_PUBLICKEYTOKEN "'\"")
-
-#endif  /* _M_AMD64 */
-#endif  /* _MSC_VER > 1400 && _MSC_VER < 1600 */
-#endif  /* _MSC_VER */
 
 /*
  * Entry point.

--- a/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
@@ -32,12 +32,6 @@
 
 #include <uxtheme.h>
 
-#if defined(_MSC_VER)
-#  define ROUND_TO_INT(num)    ((int) round(num))
-#else
-#  define ROUND_TO_INT(num)    ((int) floor((num) + 0.5))
-#endif
-
 #define ALPHA_MASK 0xff000000
 #define RED_MASK 0xff0000
 #define GREEN_MASK 0xff00
@@ -732,11 +726,11 @@ void rescale(SIZE *size) {
 
     if (dpiX !=0 && dpiX != 96) {
         float invScaleX = 96.0f / dpiX;
-        size->cx = ROUND_TO_INT(size->cx * invScaleX);
+        size->cx = (int) round(size->cx * invScaleX);
     }
     if (dpiY != 0 && dpiY != 96) {
         float invScaleY = 96.0f / dpiY;
-        size->cy = ROUND_TO_INT(size->cy * invScaleY);
+        size->cy = (int) round(size->cy * invScaleY);
     }
 }
 

--- a/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
 
 #include <uxtheme.h>
 
-#if defined(_MSC_VER) && _MSC_VER >= 1800
+#if defined(_MSC_VER)
 #  define ROUND_TO_INT(num)    ((int) round(num))
 #else
 #  define ROUND_TO_INT(num)    ((int) floor((num) + 0.5))

--- a/src/java.desktop/windows/native/libawt/windows/awt_DesktopProperties.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DesktopProperties.cpp
@@ -37,12 +37,6 @@
 
 #include "math.h"
 
-#if defined(_MSC_VER)
-#  define ROUND_TO_INT(num)    ((int) round(num))
-#else
-#  define ROUND_TO_INT(num)    ((int) floor((num) + 0.5))
-#endif
-
 // WDesktopProperties fields
 jfieldID AwtDesktopProperties::pDataID = 0;
 jmethodID AwtDesktopProperties::setBooleanPropertyID = 0;
@@ -103,7 +97,7 @@ void getInvScale(float &invScaleX, float &invScaleY) {
 }
 
 int rescale(int value, float invScale){
-    return invScale == 1.0f ? value : ROUND_TO_INT(value * invScale);
+    return invScale == 1.0f ? value : (int) round(value * invScale);
 }
 
 void AwtDesktopProperties::GetSystemProperties() {

--- a/src/java.desktop/windows/native/libawt/windows/awt_DesktopProperties.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DesktopProperties.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@
 
 #include "math.h"
 
-#if defined(_MSC_VER) && _MSC_VER >= 1800
+#if defined(_MSC_VER)
 #  define ROUND_TO_INT(num)    ((int) round(num))
 #else
 #  define ROUND_TO_INT(num)    ((int) floor((num) + 0.5))
@@ -286,7 +286,7 @@ void AwtDesktopProperties::GetNonClientParameters() {
     // when running on XP. However this can't be referenced at compile time
     // with the older SDK, so there use 'lfMessageFont' plus its size.
     if (!IS_WINVISTA) {
-#if defined(_MSC_VER) && (_MSC_VER >= 1600)
+#if defined(_MSC_VER)
         ncmetrics.cbSize = offsetof(NONCLIENTMETRICS, iPaddedBorderWidth);
 #else
         ncmetrics.cbSize = offsetof(NONCLIENTMETRICS,lfMessageFont) + sizeof(LOGFONT);

--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@
 typedef __int32 LONG_PTR;
 #endif // __int3264
 
-#if defined(_MSC_VER) && _MSC_VER >= 1800
+#if defined(_MSC_VER)
 #  define ROUND_TO_INT(num)    ((int) round(num))
 #else
 #  define ROUND_TO_INT(num)    ((int) floor((num) + 0.5))

--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
@@ -51,11 +51,6 @@
 typedef __int32 LONG_PTR;
 #endif // __int3264
 
-#if defined(_MSC_VER)
-#  define ROUND_TO_INT(num)    ((int) round(num))
-#else
-#  define ROUND_TO_INT(num)    ((int) floor((num) + 0.5))
-#endif
 // Used for Swing's Menu/Tooltip animation Support
 const int UNSPECIFIED = 0;
 const int TOOLTIP = 1;
@@ -3654,7 +3649,7 @@ int getSystemMetricValue(int msgType) {
     }
     if(dpi != 0 && dpi != 96) {
         float invScaleX = 96.0f / dpi;
-        value = (int) ROUND_TO_INT(value * invScaleX);
+        value = (int) round(value * invScaleX);
     }
     return value;
 }


### PR DESCRIPTION
We still handle at a number of places ancient historic _MSC_VER versions of Visual Studio releases e.g. pre VS2013 (VS2013 has _MSC_VER 1800).
This should be cleaned up, as long as it is not 3rd party code that we don't want to adjust.

Currently still supported ("valid") VS version are 2017+, see https://github.com/openjdk/jdk/blob/master/make/autoconf/toolchain_microsoft.m4 .
VALID_VS_VERSIONS="2019 2017 2022"
Even with adjusted toolchain m4 files, something older than VS2013 (also probably older than VS2015) would not be able to build jdk anymore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288094](https://bugs.openjdk.org/browse/JDK-8288094): cleanup old _MSC_VER handling


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [e97c8329](https://git.openjdk.org/jdk/pull/9105/files/e97c83291a13151f472ae0e6e20cc6689ded3d17)
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**) ⚠️ Review applies to [ee8dc996](https://git.openjdk.org/jdk/pull/9105/files/ee8dc996cd8b769a5a30ab58f60ac9d43391542e)
 * [Andrey Turbanov](https://openjdk.java.net/census#aturbanov) (@turbanoff - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9105/head:pull/9105` \
`$ git checkout pull/9105`

Update a local copy of the PR: \
`$ git checkout pull/9105` \
`$ git pull https://git.openjdk.org/jdk pull/9105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9105`

View PR using the GUI difftool: \
`$ git pr show -t 9105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9105.diff">https://git.openjdk.org/jdk/pull/9105.diff</a>

</details>
