### PR TITLE
8287771: Remove useless G1 After GC summary refinement and sampling thread times

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2803,7 +2803,7 @@ bool G1CollectedHeap::do_collection_pause_at_safepoint(double target_pause_time_
 
 G1HeapPrinterMark::G1HeapPrinterMark(G1CollectedHeap* g1h) : _g1h(g1h), _heap_transition(g1h) {
   // This summary needs to be printed before incrementing total collections.
-  _g1h->rem_set()->print_periodic_summary_info("Before GC RS summary", _g1h->total_collections());
+  _g1h->rem_set()->print_periodic_summary_info("Before GC RS summary", _g1h->total_collections(), true);
   _g1h->print_heap_before_gc();
   _g1h->print_heap_regions();
 }
@@ -2812,7 +2812,7 @@ G1HeapPrinterMark::~G1HeapPrinterMark() {
   _g1h->policy()->print_age_table();
   _g1h->rem_set()->print_coarsen_stats();
   // We are at the end of the GC. Total collections has already been increased.
-  _g1h->rem_set()->print_periodic_summary_info("After GC RS summary", _g1h->total_collections() - 1);
+  _g1h->rem_set()->print_periodic_summary_info("After GC RS summary", _g1h->total_collections() - 1, false);
 
   _heap_transition.print();
   _g1h->print_heap_regions();

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2803,7 +2803,9 @@ bool G1CollectedHeap::do_collection_pause_at_safepoint(double target_pause_time_
 
 G1HeapPrinterMark::G1HeapPrinterMark(G1CollectedHeap* g1h) : _g1h(g1h), _heap_transition(g1h) {
   // This summary needs to be printed before incrementing total collections.
-  _g1h->rem_set()->print_periodic_summary_info("Before GC RS summary", _g1h->total_collections(), true);
+  _g1h->rem_set()->print_periodic_summary_info("Before GC RS summary",
+                                               _g1h->total_collections(),
+                                               true /* show_thread_times */);
   _g1h->print_heap_before_gc();
   _g1h->print_heap_regions();
 }
@@ -2812,7 +2814,9 @@ G1HeapPrinterMark::~G1HeapPrinterMark() {
   _g1h->policy()->print_age_table();
   _g1h->rem_set()->print_coarsen_stats();
   // We are at the end of the GC. Total collections has already been increased.
-  _g1h->rem_set()->print_periodic_summary_info("After GC RS summary", _g1h->total_collections() - 1, false);
+  _g1h->rem_set()->print_periodic_summary_info("After GC RS summary",
+                                               _g1h->total_collections() - 1,
+                                               false /* show_thread_times */);
 
   _heap_transition.print();
   _g1h->print_heap_regions();

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1763,7 +1763,7 @@ void G1RemSet::enqueue_for_reprocessing(CardValue* card_ptr) {
   dcqs.enqueue_completed_buffer(BufferNode::make_node_from_buffer(buffer, index));
 }
 
-void G1RemSet::print_periodic_summary_info(const char* header, uint period_count) {
+void G1RemSet::print_periodic_summary_info(const char* header, uint period_count, bool include_vtimes) {
   if ((G1SummarizeRSetStatsPeriod > 0) && log_is_enabled(Trace, gc, remset) &&
       (period_count % G1SummarizeRSetStatsPeriod == 0)) {
 
@@ -1774,7 +1774,7 @@ void G1RemSet::print_periodic_summary_info(const char* header, uint period_count
     log.trace("%s", header);
     ResourceMark rm;
     LogStream ls(log.trace());
-    _prev_period_summary.print_on(&ls);
+    _prev_period_summary.print_on(&ls, include_vtimes);
 
     _prev_period_summary.set(&current);
   }
@@ -1787,7 +1787,7 @@ void G1RemSet::print_summary_info() {
     G1RemSetSummary current;
     ResourceMark rm;
     LogStream ls(log.trace());
-    current.print_on(&ls);
+    current.print_on(&ls, true);
   }
 }
 

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1787,7 +1787,7 @@ void G1RemSet::print_summary_info() {
     G1RemSetSummary current;
     ResourceMark rm;
     LogStream ls(log.trace());
-    current.print_on(&ls, true);
+    current.print_on(&ls, true /* show_thread_times*/);
   }
 }
 

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1763,7 +1763,7 @@ void G1RemSet::enqueue_for_reprocessing(CardValue* card_ptr) {
   dcqs.enqueue_completed_buffer(BufferNode::make_node_from_buffer(buffer, index));
 }
 
-void G1RemSet::print_periodic_summary_info(const char* header, uint period_count, bool include_vtimes) {
+void G1RemSet::print_periodic_summary_info(const char* header, uint period_count, bool show_thread_times) {
   if ((G1SummarizeRSetStatsPeriod > 0) && log_is_enabled(Trace, gc, remset) &&
       (period_count % G1SummarizeRSetStatsPeriod == 0)) {
 
@@ -1774,7 +1774,7 @@ void G1RemSet::print_periodic_summary_info(const char* header, uint period_count
     log.trace("%s", header);
     ResourceMark rm;
     LogStream ls(log.trace());
-    _prev_period_summary.print_on(&ls, include_vtimes);
+    _prev_period_summary.print_on(&ls, show_thread_times);
 
     _prev_period_summary.set(&current);
   }

--- a/src/hotspot/share/gc/g1/g1RemSet.hpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.hpp
@@ -146,7 +146,7 @@ public:
   void print_summary_info();
 
   // Print accumulated summary info from the last time called.
-  void print_periodic_summary_info(const char* header, uint period_count);
+  void print_periodic_summary_info(const char* header, uint period_count, bool include_vtimes);
 
   // Rebuilds the remembered set by scanning from bottom to TARS for all regions
   // using the given workers.

--- a/src/hotspot/share/gc/g1/g1RemSet.hpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.hpp
@@ -146,7 +146,7 @@ public:
   void print_summary_info();
 
   // Print accumulated summary info from the last time called.
-  void print_periodic_summary_info(const char* header, uint period_count, bool include_vtimes);
+  void print_periodic_summary_info(const char* header, uint period_count, bool show_thread_times);
 
   // Rebuilds the remembered set by scanning from bottom to TARS for all regions
   // using the given workers.

--- a/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
@@ -321,15 +321,17 @@ public:
   }
 };
 
-void G1RemSetSummary::print_on(outputStream* out) {
-  out->print_cr("  Concurrent refinement threads times (s)");
-  out->print("     ");
-  for (uint i = 0; i < _num_vtimes; i++) {
-    out->print("    %5.2f", rs_thread_vtime(i));
+void G1RemSetSummary::print_on(outputStream* out, bool include_vtimes) {
+  if (include_vtimes) {
+    out->print_cr(" Concurrent refinement threads times (s)");
+    out->print("     ");
+    for (uint i = 0; i < _num_vtimes; i++) {
+      out->print("    %5.2f", rs_thread_vtime(i));
+    }
+    out->cr();
+    out->print_cr(" Sampling task time (ms)");
+    out->print_cr("         %5.3f", sampling_task_vtime() * MILLIUNITS);
   }
-  out->cr();
-  out->print_cr("  Sampling task time (ms)");
-  out->print_cr("         %5.3f", sampling_task_vtime() * MILLIUNITS);
 
   HRRSStatsIter blk;
   G1CollectedHeap::heap()->heap_region_iterate(&blk);

--- a/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
@@ -321,8 +321,8 @@ public:
   }
 };
 
-void G1RemSetSummary::print_on(outputStream* out, bool include_vtimes) {
-  if (include_vtimes) {
+void G1RemSetSummary::print_on(outputStream* out, bool show_thread_times) {
+  if (show_thread_times) {
     out->print_cr(" Concurrent refinement threads times (s)");
     out->print("     ");
     for (uint i = 0; i < _num_vtimes; i++) {

--- a/src/hotspot/share/gc/g1/g1RemSetSummary.hpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.hpp
@@ -57,7 +57,7 @@ public:
   // subtract all counters from the other summary, and set them in the current
   void subtract_from(G1RemSetSummary* other);
 
-  void print_on(outputStream* out);
+  void print_on(outputStream* out, bool include_vtimes);
 
   double rs_thread_vtime(uint thread) const;
 

--- a/src/hotspot/share/gc/g1/g1RemSetSummary.hpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.hpp
@@ -57,7 +57,7 @@ public:
   // subtract all counters from the other summary, and set them in the current
   void subtract_from(G1RemSetSummary* other);
 
-  void print_on(outputStream* out, bool include_vtimes);
+  void print_on(outputStream* out, bool show_thread_times);
 
   double rs_thread_vtime(uint thread) const;
 

--- a/test/hotspot/jtreg/gc/g1/TestRemsetLoggingTools.java
+++ b/test/hotspot/jtreg/gc/g1/TestRemsetLoggingTools.java
@@ -109,7 +109,7 @@ public class TestRemsetLoggingTools {
     }
 
     public static void expectRSetSummaries(String result, int expectedCumulative, int expectedPeriodic) throws Exception {
-        int actualTotal = result.split("Concurrent refinement threads times").length - 1;
+        int actualTotal = result.split("Current rem set statistics").length - 1;
         int actualCumulative = result.split("Cumulative RS summary").length - 1;
 
         if (expectedCumulative != actualCumulative) {


### PR DESCRIPTION
In the "After GC summary" printed by gc+remset=trace and G1RemsetStatsSummaryPeriod > 1 we print refinement and sampling thread times. However during GC neither thread types are active, so it always prints zeros.

Remove the printing of these unnecessary values in the after gc summary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287771](https://bugs.openjdk.org/browse/JDK-8287771): Remove useless G1 After GC summary refinement and sampling thread times


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to [a2c7dde2](https://git.openjdk.org/jdk/pull/9106/files/a2c7dde2d40adb53e957c7342247c3538fccb4a8)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9106/head:pull/9106` \
`$ git checkout pull/9106`

Update a local copy of the PR: \
`$ git checkout pull/9106` \
`$ git pull https://git.openjdk.org/jdk pull/9106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9106`

View PR using the GUI difftool: \
`$ git pr show -t 9106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9106.diff">https://git.openjdk.org/jdk/pull/9106.diff</a>

</details>
