### PR TITLE
False build warning-as-error with GCC 9 after JDK-8214976

### DIFF
--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -89,6 +89,6 @@
   __VA_ARGS__                                           \
   PRAGMA_DIAG_POP
 
-#endif // gcc9+ or clang14+
+#endif // gcc10+ or clang14+
 
 #endif // SHARE_UTILITIES_COMPILERWARNINGS_GCC_HPP

--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -69,7 +69,7 @@
 
 #endif // clang/gcc version check
 
-#if (__GNUC__ >= 9) || (defined(__clang_major__) && (__clang_major__ >= 14))
+#if (__GNUC__ >= 10) || (defined(__clang_major__) && (__clang_major__ >= 14))
 
 // Use "warning" attribute to detect uses of "forbidden" functions.
 //


### PR DESCRIPTION
The macros introduced in [8214976](https://bugs.openjdk.org/browse/JDK-8214976) don't work properly with gcc 9, leading to failures along the lines of call to 'exit' declared with attribute warning: use os::exit [-Werror=attribute-warning] mid build. The best option seems to be to disable these macros if gcc is not 10 or above