### PR TITLE
8288330: Avoid redundant ConcurrentHashMap.get call in Http2ClientImpl.deleteConnection

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2ClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2ClientImpl.java
@@ -188,9 +188,7 @@ class Http2ClientImpl {
         if (debug.on())
             debug.log("removing from the connection pool: %s", c);
         synchronized (this) {
-            Http2Connection c1 = connections.get(c.key());
-            if (c1 != null && c1.equals(c)) {
-                connections.remove(c.key());
+            if (connections.remove(c.key(), c)) {
                 if (debug.on())
                     debug.log("removed from the connection pool: %s", c);
             }


### PR DESCRIPTION
https://github.com/openjdk/jdk/blob/900d967da52afca9b239d8a58aa81b48b9fe0a78/src/java.net.http/share/classes/jdk/internal/net/http/Http2ClientImpl.java#L191-L196

Method `Http2ClientImpl.deleteConnection` removes `Http2Connection` from `ConcurrentHashMap` if it's present in the map. It does it with 2 steps: first invoke `ConcurrentHashMap.get` and then check if result of `get` is equals to parameter.

We can do better: there is single method `ConcurrentHashMap.remove(Key, Value)` which does the same thing, but faster.

Testing: `test/jdk/java/net/httpclient` on Win x64 release.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288330](https://bugs.openjdk.org/browse/JDK-8288330): Avoid redundant ConcurrentHashMap.get call in Http2ClientImpl.deleteConnection


### Reviewers
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9114/head:pull/9114` \
`$ git checkout pull/9114`

Update a local copy of the PR: \
`$ git checkout pull/9114` \
`$ git pull https://git.openjdk.org/jdk pull/9114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9114`

View PR using the GUI difftool: \
`$ git pr show -t 9114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9114.diff">https://git.openjdk.org/jdk/pull/9114.diff</a>

</details>
