### PR TITLE
8287178: IntegerModuloP::multiplicativeInverse returns 0 for 0

### DIFF
--- a/src/java.base/share/classes/sun/security/util/math/IntegerModuloP.java
+++ b/src/java.base/share/classes/sun/security/util/math/IntegerModuloP.java
@@ -158,7 +158,7 @@ public interface IntegerModuloP {
     default ImmutableIntegerModuloP multiplicativeInverse() {
         // This method is used in 2 cases:
         // 1. To calculate the inverse of a number in ECDSAOperations,
-        //    this number must be non zero (modulus p).
+        //    this number must be non zero (modulo p).
         // 2. To flatten a 3D point to a 2D AffinePoint. This number
         //    might be zero (infinity). However, since the infinity
         //    is represented as (0, 0) in 2D, it’s OK returning 0 as

--- a/src/java.base/share/classes/sun/security/util/math/IntegerModuloP.java
+++ b/src/java.base/share/classes/sun/security/util/math/IntegerModuloP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -156,6 +156,13 @@ public interface IntegerModuloP {
      * @return the multiplicative inverse (1 / this)
      */
     default ImmutableIntegerModuloP multiplicativeInverse() {
+        // This method is used in 2 cases:
+        // 1. To calculate the inverse of a number in ECDSAOperations,
+        //    this number must be non zero (modulus p).
+        // 2. To flatten a 3D point to a 2D AffinePoint. This number
+        //    might be zero (infinity). However, since the infinity
+        //    is represented as (0, 0) in 2D, it’s OK returning 0 as
+        //    the inverse of 0, i.e. (1, 1, 0) == (1/0, 1/0) == (0, 0).
         return pow(getField().getSize().subtract(BigInteger.valueOf(2)));
     }
 


### PR DESCRIPTION
Add comment to the method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287178](https://bugs.openjdk.org/browse/JDK-8287178): IntegerModuloP::multiplicativeInverse returns 0 for 0


### Reviewers
 * [Jamil Nimeh](https://openjdk.java.net/census#jnimeh) (@jnimeh - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9115/head:pull/9115` \
`$ git checkout pull/9115`

Update a local copy of the PR: \
`$ git checkout pull/9115` \
`$ git pull https://git.openjdk.org/jdk pull/9115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9115`

View PR using the GUI difftool: \
`$ git pr show -t 9115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9115.diff">https://git.openjdk.org/jdk/pull/9115.diff</a>

</details>
