### PR TITLE
8265586: [windows] last button is not shown in AWT Frame with BorderLayout and MenuBar set.

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
@@ -1396,14 +1396,8 @@ BOOL AwtWindow::UpdateInsets(jobject insets)
     RECT inside;
     int extraBottomInsets = 0;
 
-    OSVERSIONINFOEX info;
-    ZeroMemory(&info, sizeof(OSVERSIONINFOEX));
-    info.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
-    GetVersionEx((LPOSVERSIONINFO) &info);
-
-    // add extra padded border only when Win OS version is 6+
-    int extraPaddedBorderInsets = info.dwMajorVersion >= 6 ?
-     ::GetSystemMetrics(SM_CXPADDEDBORDER) : 0;
+    // extra padded border for captioned windows
+    int extraPaddedBorderInsets = ::GetSystemMetrics(SM_CXPADDEDBORDER);
 
     ::GetClientRect(GetHWnd(), &inside);
     ::GetWindowRect(GetHWnd(), &outside);
@@ -1435,9 +1429,11 @@ BOOL AwtWindow::UpdateInsets(jobject insets)
                      extraPaddedBorderInsets;
             } else {
                 m_insets.left = m_insets.right =
-                    ::GetSystemMetrics(SM_CXDLGFRAME);
+                    ::GetSystemMetrics(SM_CXDLGFRAME) +
+                    extraPaddedBorderInsets;
                 m_insets.top = m_insets.bottom =
-                    ::GetSystemMetrics(SM_CYDLGFRAME);
+                    ::GetSystemMetrics(SM_CYDLGFRAME) +
+                    extraPaddedBorderInsets;
             }
             /* Add in title. */
             m_insets.top += ::GetSystemMetrics(SM_CYCAPTION);

--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,8 @@
  */
 
 #include "awt.h"
-
 #include <jlong.h>
+#include <windows.h>
 
 #include "awt_Component.h"
 #include "awt_Container.h"
@@ -1396,6 +1396,15 @@ BOOL AwtWindow::UpdateInsets(jobject insets)
     RECT inside;
     int extraBottomInsets = 0;
 
+    OSVERSIONINFOEX info;
+    ZeroMemory(&info, sizeof(OSVERSIONINFOEX));
+    info.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
+    GetVersionEx((LPOSVERSIONINFO) &info);
+
+    // add extra padded border only when Win OS version is 6+
+    int extraPaddedBorderInsets = info.dwMajorVersion >= 6 ?
+     ::GetSystemMetrics(SM_CXPADDEDBORDER) : 0;
+
     ::GetClientRect(GetHWnd(), &inside);
     ::GetWindowRect(GetHWnd(), &outside);
 
@@ -1419,17 +1428,17 @@ BOOL AwtWindow::UpdateInsets(jobject insets)
             LONG style = GetStyle();
             if (style & WS_THICKFRAME) {
                 m_insets.left = m_insets.right =
-                    ::GetSystemMetrics(SM_CXSIZEFRAME);
+                    ::GetSystemMetrics(SM_CXSIZEFRAME) +
+                     extraPaddedBorderInsets;
                 m_insets.top = m_insets.bottom =
-                    ::GetSystemMetrics(SM_CYSIZEFRAME);
+                    ::GetSystemMetrics(SM_CYSIZEFRAME) +
+                     extraPaddedBorderInsets;
             } else {
                 m_insets.left = m_insets.right =
                     ::GetSystemMetrics(SM_CXDLGFRAME);
                 m_insets.top = m_insets.bottom =
                     ::GetSystemMetrics(SM_CYDLGFRAME);
             }
-
-
             /* Add in title. */
             m_insets.top += ::GetSystemMetrics(SM_CYCAPTION);
         }

--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
@@ -25,7 +25,6 @@
 
 #include "awt.h"
 #include <jlong.h>
-#include <windows.h>
 
 #include "awt_Component.h"
 #include "awt_Container.h"
@@ -1422,18 +1421,14 @@ BOOL AwtWindow::UpdateInsets(jobject insets)
             LONG style = GetStyle();
             if (style & WS_THICKFRAME) {
                 m_insets.left = m_insets.right =
-                    ::GetSystemMetrics(SM_CXSIZEFRAME) +
-                     extraPaddedBorderInsets;
+                    ::GetSystemMetrics(SM_CXSIZEFRAME) + extraPaddedBorderInsets;
                 m_insets.top = m_insets.bottom =
-                    ::GetSystemMetrics(SM_CYSIZEFRAME) +
-                     extraPaddedBorderInsets;
+                    ::GetSystemMetrics(SM_CYSIZEFRAME) + extraPaddedBorderInsets;
             } else {
                 m_insets.left = m_insets.right =
-                    ::GetSystemMetrics(SM_CXDLGFRAME) +
-                    extraPaddedBorderInsets;
+                    ::GetSystemMetrics(SM_CXDLGFRAME) + extraPaddedBorderInsets;
                 m_insets.top = m_insets.bottom =
-                    ::GetSystemMetrics(SM_CYDLGFRAME) +
-                    extraPaddedBorderInsets;
+                    ::GetSystemMetrics(SM_CYDLGFRAME) + extraPaddedBorderInsets;
             }
             /* Add in title. */
             m_insets.top += ::GetSystemMetrics(SM_CYCAPTION);

--- a/test/jdk/java/awt/Frame/AwtFramePackTest.java
+++ b/test/jdk/java/awt/Frame/AwtFramePackTest.java
@@ -100,4 +100,3 @@ public class AwtFramePackTest {
         }
     }
 }
-

--- a/test/jdk/java/awt/Frame/AwtFramePackTest.java
+++ b/test/jdk/java/awt/Frame/AwtFramePackTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8265586
+ * @key headful
+ * @summary Tests the functionality of AWT frame.pack() on Windows.
+ * @run main AwtFramePackTest
+ * @requires (os.family == "windows")
+ */
+
+import java.awt.AWTException;
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.Panel;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import javax.imageio.ImageIO;
+
+public class AwtFramePackTest {
+
+    private static Frame frame;
+    private static Robot robot;
+
+    public static void main(String[] args) throws AWTException {
+        try {
+            robot = new Robot();
+            robot.setAutoDelay(300);
+            robot.waitForIdle();
+
+            frame = new Frame();
+            frame.setLayout(new BorderLayout());
+
+            Panel panel = new Panel();
+            panel.add(new Button("Panel Button B1"));
+            panel.add(new Button("Panel Button B2"));
+            frame.add(panel, BorderLayout.CENTER);
+
+            MenuBar mb = new MenuBar();
+            Menu m = new Menu("Menu");
+            mb.add(m);
+            frame.setMenuBar(mb);
+
+            frame.pack();
+            frame.setVisible(true);
+
+            Dimension actualFrameSize = frame.getSize();
+            Dimension expectedFrameSize = frame.getPreferredSize();
+
+            if (!actualFrameSize.equals(expectedFrameSize)) {
+                System.out.println("Expected frame size: "+ expectedFrameSize);
+                System.out.println("Actual frame size: "+ actualFrameSize);
+                saveScreenCapture();
+                throw new RuntimeException("Expected and Actual frame size" +
+                        " are different. frame.pack() does not work!!");
+           }
+        } finally {
+            frame.dispose();
+        }
+    }
+
+    // debugging purpose, saves screen capture when test fails
+    private static void saveScreenCapture() {
+        robot.delay(500);
+        robot.waitForIdle();
+        BufferedImage image = robot.createScreenCapture(
+                new Rectangle(0, 0, 500, 500));
+        try {
+            ImageIO.write(image, "png", new File("Frame"));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}
+

--- a/test/jdk/java/awt/Frame/AwtFramePackTest.java
+++ b/test/jdk/java/awt/Frame/AwtFramePackTest.java
@@ -21,15 +21,6 @@
  * questions.
  */
 
-/*
- * @test
- * @bug 8265586
- * @key headful
- * @summary Tests the functionality of AWT frame.pack() on Windows.
- * @run main AwtFramePackTest
- * @requires (os.family == "windows")
- */
-
 import java.awt.AWTException;
 import java.awt.BorderLayout;
 import java.awt.Button;
@@ -38,12 +29,21 @@ import java.awt.Frame;
 import java.awt.Menu;
 import java.awt.MenuBar;
 import java.awt.Panel;
-import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import javax.imageio.ImageIO;
+
+/*
+ * @test
+ * @bug 8265586
+ * @key headful
+ * @requires (os.family == "windows")
+ * @summary Tests whether insets are calculated correctly on Windows
+ * for AWT Frame by checking the actual and expected/preferred frame sizes.
+ * @run main/othervm -Dsun.java2d.uiScale=1 AwtFramePackTest
+ */
 
 public class AwtFramePackTest {
 
@@ -54,7 +54,6 @@ public class AwtFramePackTest {
         try {
             robot = new Robot();
             robot.setAutoDelay(300);
-            robot.waitForIdle();
 
             frame = new Frame();
             frame.setLayout(new BorderLayout());
@@ -72,6 +71,9 @@ public class AwtFramePackTest {
             frame.pack();
             frame.setVisible(true);
 
+            robot.delay(500);
+            robot.waitForIdle();
+
             Dimension actualFrameSize = frame.getSize();
             Dimension expectedFrameSize = frame.getPreferredSize();
 
@@ -81,20 +83,17 @@ public class AwtFramePackTest {
                 saveScreenCapture();
                 throw new RuntimeException("Expected and Actual frame size" +
                         " are different. frame.pack() does not work!!");
-           }
+            }
         } finally {
             frame.dispose();
         }
     }
 
-    // debugging purpose, saves screen capture when test fails
+    // for debugging purpose, saves screen capture when test fails.
     private static void saveScreenCapture() {
-        robot.delay(500);
-        robot.waitForIdle();
-        BufferedImage image = robot.createScreenCapture(
-                new Rectangle(0, 0, 500, 500));
+        BufferedImage image = robot.createScreenCapture(frame.getBounds());
         try {
-            ImageIO.write(image, "png", new File("Frame"));
+            ImageIO.write(image,"png", new File("Frame.png"));
         } catch (IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Due to incorrect AWT Frame inset values being returned from native code, few of the components in the frame were not being shown completely on Windows. With the proposed fix, correct insets are obtained which in turn sizes and displays the frame correctly.

The default insets obtained from the Win system was adding only `::GetSystemMetrics(SM_CXSIZEFRAME)` for **WS_THICKFRAME** and the insets were off by few pixels from the expected value. `::GetSystemMetrics(SM_CXPADDEDBORDER)` is additionally added to top, bottom, left and right insets to account for the 6px. [GetSystemMetric() Document](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getsystemmetrics)

A test case is added which checks if the actual frame size is equal to the expected frame size (frame.getSize() == frame.getPreferredSize()), thus checking if frame.pack() works as expected.

Following are before and after screenshots - 
![image](https://user-images.githubusercontent.com/95945681/172999272-981a0b07-2bd1-425c-b73d-f21f68922262.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8265586](https://bugs.openjdk.org/browse/JDK-8265586): [windows] last button is not shown in AWT Frame with BorderLayout and MenuBar set.


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Dmitry Markov](https://openjdk.java.net/census#dmarkov) (@dmarkov20 - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9118/head:pull/9118` \
`$ git checkout pull/9118`

Update a local copy of the PR: \
`$ git checkout pull/9118` \
`$ git pull https://git.openjdk.org/jdk pull/9118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9118`

View PR using the GUI difftool: \
`$ git pr show -t 9118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9118.diff">https://git.openjdk.org/jdk/pull/9118.diff</a>

</details>
