### PR TITLE
8288173: JDK-8202449 fix causes conformance test failure : api/java_util/Random/RandomGenerator/NextFloat.html

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
@@ -733,7 +733,7 @@ public class RandomSupport {
                 r = (r * (0.5f * bound - halfOrigin) + halfOrigin) * 2.0f;
             }
             if (r >= bound) // may need to correct a rounding problem
-                r = Math.nextDown(r);
+                r = Math.nextDown(bound);
         }
         return r;
     }
@@ -765,7 +765,7 @@ public class RandomSupport {
         float r = rng.nextFloat();
         r = r * bound;
         if (r >= bound) // may need to correct a rounding problem
-            r = Math.nextDown(r);
+            r = Math.nextDown(bound);
         return r;
     }
 


### PR DESCRIPTION
This fixes a bug introduced with JDK-8202449.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288173](https://bugs.openjdk.org/browse/JDK-8288173): JDK-8202449 fix causes conformance test failure : api/java_util/Random/RandomGenerator/NextFloat.html


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9120/head:pull/9120` \
`$ git checkout pull/9120`

Update a local copy of the PR: \
`$ git checkout pull/9120` \
`$ git pull https://git.openjdk.org/jdk pull/9120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9120`

View PR using the GUI difftool: \
`$ git pr show -t 9120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9120.diff">https://git.openjdk.org/jdk/pull/9120.diff</a>

</details>
