### PR TITLE
8290973: In AffineTransform, equals(Object) is inconsistent with hashCode()

### DIFF
--- a/src/java.desktop/share/classes/java/awt/geom/AffineTransform.java
+++ b/src/java.desktop/share/classes/java/awt/geom/AffineTransform.java
@@ -3913,7 +3913,7 @@ public class AffineTransform implements Cloneable, java.io.Serializable {
 
     /**
      * Returns a hash code for the given value, with negative zero
-     * collapsed into to the single positive zero.
+     * collapsed to the single positive zero.
      */
     private static long hash(double m) {
         long h = Double.doubleToLongBits(m);

--- a/src/java.desktop/share/classes/java/awt/geom/AffineTransform.java
+++ b/src/java.desktop/share/classes/java/awt/geom/AffineTransform.java
@@ -3902,13 +3902,23 @@ public class AffineTransform implements Cloneable, java.io.Serializable {
      * @since 1.2
      */
     public int hashCode() {
-        long bits = Double.doubleToLongBits(m00);
-        bits = bits * 31 + Double.doubleToLongBits(m01);
-        bits = bits * 31 + Double.doubleToLongBits(m02);
-        bits = bits * 31 + Double.doubleToLongBits(m10);
-        bits = bits * 31 + Double.doubleToLongBits(m11);
-        bits = bits * 31 + Double.doubleToLongBits(m12);
+        long bits = hash(m00);
+        bits = bits * 31 + hash(m01);
+        bits = bits * 31 + hash(m02);
+        bits = bits * 31 + hash(m10);
+        bits = bits * 31 + hash(m11);
+        bits = bits * 31 + hash(m12);
         return (((int) bits) ^ ((int) (bits >> 32)));
+    }
+
+    /**
+     * Returns a hash code for the given value, with negative zero
+     * collapsed into to the single positive zero.
+     */
+    private static long hash(double m) {
+        long h = Double.doubleToLongBits(m);
+        if (h == 0x8000000000000000L) h = 0;    // Replace -0 by +0.
+        return h;
     }
 
     /**
@@ -3928,8 +3938,17 @@ public class AffineTransform implements Cloneable, java.io.Serializable {
 
         AffineTransform a = (AffineTransform)obj;
 
-        return ((m00 == a.m00) && (m01 == a.m01) && (m02 == a.m02) &&
-                (m10 == a.m10) && (m11 == a.m11) && (m12 == a.m12));
+        return equals(m00, a.m00) && equals(m01, a.m01) &&
+               equals(m02, a.m02) && equals(m10, a.m10) &&
+               equals(m11, a.m11) && equals(m12, a.m12);
+    }
+
+    /**
+     * Compares the given floating point values, with negative zero
+     * considered equals to positive zero.
+     */
+    private static boolean equals(double a, double b) {
+        return (a == b) || (Double.isNaN(a) && Double.isNaN(b));
     }
 
     /* Serialization support.  A readObject method is neccessary because

--- a/test/jdk/java/awt/geom/AffineTransform/EqualsAndHashCode.java
+++ b/test/jdk/java/awt/geom/AffineTransform/EqualsAndHashCode.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Tests that equals(Object) is consistent with hashCode(),
+ *          in particular regarding negative versus positive zeros and
+ *          NaN values.
+ */
+
+import java.awt.geom.AffineTransform;
+
+public class EqualsAndHashCode {
+    private static boolean failed;
+
+    public static void main(String arg[]) {
+        checkReflexiveEquals();
+        checkZeros();
+        checkNotEqual();
+        if (failed) {
+            throw new RuntimeException("Some tests failed.");
+        }
+    }
+
+    private static void checkReflexiveEquals() {
+        AffineTransform t = new AffineTransform(1, 0, 0, 1, Double.NaN, 0);
+        if (!t.equals(t)) {
+            System.err.println("Transform should be equal to itself.");
+            failed = true;
+        }
+        if (!t.equals(t.clone())) {
+            System.err.println("Transform should be equal to its clone.");
+            failed = true;
+        }
+    }
+
+    private static void checkZeros() {
+        AffineTransform positive = new AffineTransform(2, 0, 0, 3, 0, +0.0);
+        AffineTransform negative = new AffineTransform(2, 0, 0, 3, 0, -0.0);
+        if (!positive.equals(negative)) {
+            System.err.println("Transforms should be equal despite the sign difference in zero values.");
+            failed = true;
+        } else if (positive.hashCode() != negative.hashCode()) {
+            System.err.println("Equal transforms should have the same hash code value.");
+            failed = true;
+        }
+    }
+
+    private static void checkNotEqual() {
+        AffineTransform t1 = new AffineTransform(2, 0, 0, 3, 2, 0);
+        AffineTransform t2 = new AffineTransform(2, 0, 0, 3, 2, 4);
+        if (t1.equals(t2)) {
+            System.err.println("Expected non-equal transforms.");
+            failed = true;
+        }
+        if (t1.hashCode() == t2.hashCode()) {
+            System.err.println("Expected different hash codes.");
+            failed = true;
+        }
+    }
+}


### PR DESCRIPTION
`AffineTransform.equals(Object)` and `hashCode()` break two contracts:

* `A.equals(A)` returns `false` if at least one affine transform coefficient is NaN.
* `A.equals(B)` should imply `A.hashCode() == B.hashCode()`, but it is not the case if a coefficient is zero with an opposite sign in A and B.

This patch preserves the current behaviour regarding 0 (i.e. -0 is considered equal to +0) for backward compatibility reason. Instead the `hashCode()` method is updated for being consistent with `equals(Object)` behaviour.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290973](https://bugs.openjdk.org/browse/JDK-8290973): In AffineTransform, equals(Object) is inconsistent with hashCode()


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [12abfde7](https://git.openjdk.org/jdk/pull/9121/files/12abfde795032429c6018b66d60f301779159193)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9121/head:pull/9121` \
`$ git checkout pull/9121`

Update a local copy of the PR: \
`$ git checkout pull/9121` \
`$ git pull https://git.openjdk.org/jdk pull/9121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9121`

View PR using the GUI difftool: \
`$ git pr show -t 9121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9121.diff">https://git.openjdk.org/jdk/pull/9121.diff</a>

</details>
