### PR TITLE
8288195: Prepare build system for GHA changes

### DIFF
--- a/make/InitSupport.gmk
+++ b/make/InitSupport.gmk
@@ -436,21 +436,24 @@ else # $(HAS_SPEC)=true
 
   define PrintFailureReports
 	$(if $(filter none, $(LOG_REPORT)), , \
+	  $(RM) $(MAKESUPPORT_OUTPUTDIR)/failure-summary.log ; \
 	  $(if $(wildcard $(MAKESUPPORT_OUTPUTDIR)/failure-logs/*.log), \
-	    $(PRINTF) "\n=== Output from failing command(s) repeated here ===\n" $(NEWLINE) \
-	    $(foreach logfile, $(sort $(wildcard $(MAKESUPPORT_OUTPUTDIR)/failure-logs/*.log)), \
-	        $(PRINTF) "* For target $(notdir $(basename $(logfile))):\n" $(NEWLINE) \
-	        $(if $(filter all, $(LOG_REPORT)), \
-	          $(GREP) -v -e "^Note: including file:" <  $(logfile) || true $(NEWLINE) \
-	        , \
-	          ($(GREP) -v -e "^Note: including file:" <  $(logfile) || true) | $(HEAD) -n 15 $(NEWLINE) \
-	          if test `$(WC) -l < $(logfile)` -gt 15; then \
-	            $(ECHO) "   ... (rest of output omitted)" ; \
-	          fi $(NEWLINE) \
-	        ) \
-	    ) \
-	    $(PRINTF) "\n* All command lines available in $(MAKESUPPORT_OUTPUTDIR)/failure-logs.\n" $(NEWLINE) \
-	    $(PRINTF) "=== End of repeated output ===\n" \
+	    ( \
+	      $(PRINTF) "\n=== Output from failing command(s) repeated here ===\n" ;  \
+	      $(foreach logfile, $(sort $(wildcard $(MAKESUPPORT_OUTPUTDIR)/failure-logs/*.log)), \
+	          $(PRINTF) "* For target $(notdir $(basename $(logfile))):\n" ; \
+	          $(if $(filter all, $(LOG_REPORT)), \
+	            $(GREP) -v -e "^Note: including file:" <  $(logfile) || true ; \
+	          , \
+	            ($(GREP) -v -e "^Note: including file:" <  $(logfile) || true) | $(HEAD) -n 15 ; \
+	            if test `$(WC) -l < $(logfile)` -gt 15; then \
+	              $(ECHO) "   ... (rest of output omitted)" ; \
+	            fi ; \
+	          ) \
+	      ) \
+	      $(PRINTF) "\n* All command lines available in $(MAKESUPPORT_OUTPUTDIR)/failure-logs.\n" ; \
+	      $(PRINTF) "=== End of repeated output ===\n" ; \
+	    )  >> $(MAKESUPPORT_OUTPUTDIR)/failure-summary.log  \
 	  ) \
 	)
   endef
@@ -465,7 +468,8 @@ else # $(HAS_SPEC)=true
 	  else \
 	    $(PRINTF) "\nNo indication of failed target found.\n" ; \
 	    $(PRINTF) "HELP: Try searching the build log for '] Error'.\n" ; \
-	  fi \
+	  fi >> $(MAKESUPPORT_OUTPUTDIR)/failure-summary.log ; \
+	  $(CAT) $(MAKESUPPORT_OUTPUTDIR)/failure-summary.log \
 	)
   endef
 

--- a/make/autoconf/basic.m4
+++ b/make/autoconf/basic.m4
@@ -300,6 +300,8 @@ AC_DEFUN_ONCE([BASIC_SETUP_DEVKIT],
   # Prepend the extra path to the global path
   UTIL_PREPEND_TO_PATH([PATH],$EXTRA_PATH)
 
+  UTIL_FIXUP_PATH([SYSROOT])
+
   AC_MSG_CHECKING([for sysroot])
   AC_MSG_RESULT([$SYSROOT])
   AC_SUBST(SYSROOT)

--- a/make/autoconf/help.m4
+++ b/make/autoconf/help.m4
@@ -311,6 +311,13 @@ AC_DEFUN_ONCE([HELP_PRINT_SUMMARY_AND_WARNINGS],
   fi
   printf "* Boot JDK:       $BOOT_JDK_VERSION (at $BOOT_JDK)\n"
   printf "* Toolchain:      $TOOLCHAIN_TYPE ($TOOLCHAIN_DESCRIPTION)\n"
+  if test "x$DEVKIT_NAME" != x; then
+    printf "* Devkit:         $DEVKIT_NAME ($DEVKIT_ROOT)\n"
+  elif test "x$DEVKIT_ROOT" != x; then
+    printf "* Devkit:         $DEVKIT_ROOT\n"
+  elif test "x$SYSROOT" != x; then
+    printf "* Sysroot:        $SYSROOT\n"
+  fi
   printf "* C Compiler:     Version $CC_VERSION_NUMBER (at ${CC#"$FIXPATH "})\n"
   printf "* C++ Compiler:   Version $CXX_VERSION_NUMBER (at ${CXX#"$FIXPATH "})\n"
 


### PR DESCRIPTION
A few changes to the build system is needed for the GHA rewrite ([JDK-8287906](https://bugs.openjdk.org/browse/JDK-8287906)).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288195](https://bugs.openjdk.org/browse/JDK-8288195): Prepare build system for GHA changes


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9122/head:pull/9122` \
`$ git checkout pull/9122`

Update a local copy of the PR: \
`$ git checkout pull/9122` \
`$ git pull https://git.openjdk.org/jdk pull/9122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9122`

View PR using the GUI difftool: \
`$ git pr show -t 9122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9122.diff">https://git.openjdk.org/jdk/pull/9122.diff</a>

</details>
