### PR TITLE
8280235: Deprecated flag FlightRecorder missing from VMDeprecatedOptions test

### DIFF
--- a/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
@@ -68,7 +68,7 @@ public class VMDeprecatedOptions {
           }
         ));
         if (wb.isJFRIncluded()) {
-            deprecated.add(new String[] {"FlightRecorder",                  "false"});
+            deprecated.add(new String[] {"FlightRecorder", "false"});
         }
         DEPRECATED_OPTIONS = deprecated.toArray(new String[][]{});
     };

--- a/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
@@ -67,6 +67,9 @@ public class VMDeprecatedOptions {
             {"CreateMinidumpOnCrash", "false"}
           }
         ));
+        if (wb.isJFRIncluded()) {
+            deprecated.add(new String[] {"FlightRecorder",                  "false"});
+        }
         DEPRECATED_OPTIONS = deprecated.toArray(new String[][]{});
     };
 
@@ -89,16 +92,6 @@ public class VMDeprecatedOptions {
         output.shouldHaveExitValue(0);
         for (String[] deprecated : optionInfo) {
             String match = getDeprecationString(deprecated[0]);
-            output.shouldMatch(match);
-        }
-
-        Object jfr = wb.getVMFlag("FlightRecorder");
-        if (jfr != null) {
-            String jfrOptionNames[] =  { "FlightRecorder" };
-            String jfrEexpectedValues[] = { "false" };
-            output = CommandLineOptionTest.startVMWithOptions(jfrOptionNames, jfrEexpectedValues);
-            output.shouldHaveExitValue(0);
-            String match = getDeprecationString(jfrOptionNames[0]);
             output.shouldMatch(match);
         }
     }

--- a/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
@@ -57,6 +57,7 @@ public class VMDeprecatedOptions {
             {"TLABStats",                 "false"},
             {"AllowRedefinitionToAddDeleteMethods", "true"},
 
+            { "FlightRecorder",           "false"},
             // deprecated alias flags (see also aliased_jvm_flags):
             {"DefaultMaxRAMFraction", "4"},
             {"CreateMinidumpOnCrash", "false"}
@@ -68,6 +69,10 @@ public class VMDeprecatedOptions {
     static String getDeprecationString(String optionName) {
         return "Option " + optionName
             + " was deprecated in version [\\S]+ and will likely be removed in a future release";
+    }
+
+    static String getUnrecognizedOptionMessage(String optionName) {
+        return "Unrecognized VM option '" + optionName + "'";
     }
 
     static void testDeprecated(String[][] optionInfo) throws Throwable {
@@ -84,6 +89,22 @@ public class VMDeprecatedOptions {
         output.shouldHaveExitValue(0);
         for (String[] deprecated : optionInfo) {
             String match = getDeprecationString(deprecated[0]);
+            output.shouldMatch(match);
+        }
+
+        // Verify ExtendedDTraceProbes option for jdk19
+        // if DTRACE_ENABLED is defined, Deprecated VM option
+        // if not, Unrecognized VM option
+        String dtraceOptionNames[] =  { "ExtendedDTraceProbes" };
+        String dtraceEexpectedValues[] = { "false" };
+        output = CommandLineOptionTest.startVMWithOptions(dtraceOptionNames, dTraceEexpectedValues);
+        try {
+            output.shouldHaveExitValue(0);
+            String match = getDeprecationString(dtraceOptionNames[0]);
+            output.shouldMatch(match);
+        }
+        catch (RuntimeException e) {
+            String match = getUnrecognizedOptionMessage(dtraceOptionNames[0]);
             output.shouldMatch(match);
         }
     }


### PR DESCRIPTION
I would like to fix 8280235: Deprecated flag FlightRecorder missing from VMDeprecatedOptions test. 

FlightRecorder option has not been tested since JDK13.
I think we should test it, because FlightRecorder option has not been obsolete in the latest JDK.
Users would be in trouble if the option suddenly disappears without notice, 
so it's important to confirm the deprication message.

Also we should add a test of ExtendedDTraceProbes option.
The test was disabled in 8281675, because some jdk can't specify it.
I modified the test to be able to verify  ExtendedDTraceProbes in either case that DTRACE_ENABLED is enabled or not.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280235](https://bugs.openjdk.org/browse/JDK-8280235): Deprecated flag FlightRecorder missing from VMDeprecatedOptions test


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9123/head:pull/9123` \
`$ git checkout pull/9123`

Update a local copy of the PR: \
`$ git checkout pull/9123` \
`$ git pull https://git.openjdk.org/jdk pull/9123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9123`

View PR using the GUI difftool: \
`$ git pr show -t 9123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9123.diff">https://git.openjdk.org/jdk/pull/9123.diff</a>

</details>
