### PR TITLE
8288181: AArch64: clean up out-of-date comments

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_FrameMap_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_FrameMap_aarch64.cpp
@@ -300,8 +300,6 @@ void FrameMap::initialize() {
 
 
 Address FrameMap::make_new_address(ByteSize sp_offset) const {
-  // for rbp, based address use this:
-  // return Address(rbp, in_bytes(sp_offset) - (framesize() - 2) * 4);
   return Address(sp, in_bytes(sp_offset));
 }
 

--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
@@ -313,7 +313,7 @@ void C1_MacroAssembler::verified_entry(bool breakAtEntry) {
 }
 
 void C1_MacroAssembler::load_parameter(int offset_in_words, Register reg) {
-  // rbp, + 0: link
+  // rfp, + 0: link
   //     + 1: return address
   //     + 2: argument with offset 0
   //     + 3: argument with offset 1

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -465,13 +465,11 @@ inline frame frame::sender_for_compiled_frame(RegisterMap* map) const {
 template <typename RegisterMapT>
 void frame::update_map_with_saved_link(RegisterMapT* map, intptr_t** link_addr) {
   // The interpreter and compiler(s) always save FP in a known
-  // location on entry. We must record where that location is
-  // so this if FP was live on callout from c2 we can find
-  // the saved copy no matter what it called.
+  // location on entry. C2-compiled code uses FP as an allocatable
+  // callee-saved register. We must record where that location is so
+  // that if FP was live on callout from c2 we can find the saved copy
+  // no matter what it called.
 
-  // Since the interpreter always saves FP, if we record where it is then
-  // we don't have to always save FP on entry and exit to c2 compiled
-  // code, on entry will be enough.
   map->set_location(rfp->as_VMReg(), (address) link_addr);
   // this is weird "H" ought to be at a higher address however the
   // oopMaps seems to have the "H" regs at the same address and the

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -444,7 +444,7 @@ inline frame frame::sender_for_compiled_frame(RegisterMap* map) const {
       assert(oop_map() == NULL || !oop_map()->has_any(OopMapValue::callee_saved_value), "callee-saved value in compiled frame");
     }
 
-    // Since the prolog does the save and restore of EBP there is no oopmap
+    // Since the prolog does the save and restore of FP there is no oopmap
     // for it so we must fill in its location as if there was an oopmap entry
     // since if our caller was compiled code there could be live jvm state in it.
     update_map_with_saved_link(map, saved_fp_addr);
@@ -464,13 +464,13 @@ inline frame frame::sender_for_compiled_frame(RegisterMap* map) const {
 
 template <typename RegisterMapT>
 void frame::update_map_with_saved_link(RegisterMapT* map, intptr_t** link_addr) {
-  // The interpreter and compiler(s) always save EBP/RBP in a known
+  // The interpreter and compiler(s) always save FP in a known
   // location on entry. We must record where that location is
-  // so this if EBP/RBP was live on callout from c2 we can find
+  // so this if FP was live on callout from c2 we can find
   // the saved copy no matter what it called.
 
-  // Since the interpreter always saves EBP/RBP if we record where it is then
-  // we don't have to always save EBP/RBP on entry and exit to c2 compiled
+  // Since the interpreter always saves FP, if we record where it is then
+  // we don't have to always save FP on entry and exit to c2 compiled
   // code, on entry will be enough.
   map->set_location(rfp->as_VMReg(), (address) link_addr);
   // this is weird "H" ought to be at a higher address however the

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -467,8 +467,7 @@ void frame::update_map_with_saved_link(RegisterMapT* map, intptr_t** link_addr) 
   // The interpreter and compiler(s) always save FP in a known
   // location on entry. C2-compiled code uses FP as an allocatable
   // callee-saved register. We must record where that location is so
-  // that if FP was live on callout from c2 we can find the saved copy
-  // no matter what it called.
+  // that if FP was live on callout from c2 we can find the saved copy.
 
   map->set_location(rfp->as_VMReg(), (address) link_addr);
   // this is weird "H" ought to be at a higher address however the

--- a/src/hotspot/cpu/aarch64/gc/g1/g1BarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/g1/g1BarrierSetAssembler_aarch64.cpp
@@ -162,7 +162,7 @@ void G1BarrierSetAssembler::g1_write_barrier_pre(MacroAssembler* masm,
   // that checks that the *(rfp+frame::interpreter_frame_last_sp) == NULL.
   //
   // If we care generating the pre-barrier without a frame (e.g. in the
-  // intrinsified Reference.get() routine) then ebp might be pointing to
+  // intrinsified Reference.get() routine) then rfp might be pointing to
   // the caller frame and so this check will most likely fail at runtime.
   //
   // Expanding the call directly bypasses the generation of the check.

--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -159,7 +159,7 @@ void ShenandoahBarrierSetAssembler::satb_write_barrier_pre(MacroAssembler* masm,
   // that checks that the *(rfp+frame::interpreter_frame_last_sp) == NULL.
   //
   // If we care generating the pre-barrier without a frame (e.g. in the
-  // intrinsified Reference.get() routine) then ebp might be pointing to
+  // intrinsified Reference.get() routine) then rfp might be pointing to
   // the caller frame and so this check will most likely fail at runtime.
   //
   // Expanding the call directly bypasses the generation of the check.

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -81,8 +81,8 @@ class SimpleRuntimeFrame {
     // so that it agrees with the frame sender code.
     // we don't expect any arg reg save area so aarch64 asserts that
     // frame::arg_reg_save_area_bytes == 0
-    rbp_off = 0,
-    rbp_off2,
+    rfp_off = 0,
+    rfp_off2,
     return_off, return_off2,
     framesize
   };
@@ -2756,7 +2756,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const cha
 }
 
 #ifdef COMPILER2
-// This is here instead of runtime_x86_64.cpp because it uses SimpleRuntimeFrame
+// This is here instead of runtime_aarch64_64.cpp because it uses SimpleRuntimeFrame
 //
 //------------------------------generate_exception_blob---------------------------
 // creates exception blob at the end

--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -3772,7 +3772,7 @@ void TemplateTable::athrow() {
 // [monitor entry]
 // [frame data   ] <--- monitor block bot
 // ...
-// [saved rbp    ] <--- rbp
+// [saved rfp    ] <--- rfp
 void TemplateTable::monitorenter()
 {
   transition(atos, vtos);


### PR DESCRIPTION
Some of the comments and enum constants in cpu/aarch64 date from the early days of the project and are no longer valid.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288181](https://bugs.openjdk.org/browse/JDK-8288181): AArch64: clean up out-of-date comments


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9124/head:pull/9124` \
`$ git checkout pull/9124`

Update a local copy of the PR: \
`$ git checkout pull/9124` \
`$ git pull https://git.openjdk.org/jdk pull/9124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9124`

View PR using the GUI difftool: \
`$ git pr show -t 9124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9124.diff">https://git.openjdk.org/jdk/pull/9124.diff</a>

</details>
