### PR TITLE
8288203: runtime/ClassUnload/UnloadTestWithVerifyDuringGC.java fails with release VMs

### DIFF
--- a/test/hotspot/jtreg/runtime/ClassUnload/UnloadTestWithVerifyDuringGC.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/UnloadTestWithVerifyDuringGC.java
@@ -33,7 +33,7 @@
  * @library classes
  * @build sun.hotspot.WhiteBox test.Empty
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -Xmn8m -XX:+UseG1GC -XX:+VerifyDuringGC -XX:+AlwaysTenure -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc,class+unload=debug UnloadTestWithVerifyDuringGC
+ * @run main/othervm -Xbootclasspath/a:. -Xmn8m -XX:+UseG1GC -XX:+UnlockDiagnosticVMOptions -XX:+VerifyDuringGC -XX:+AlwaysTenure -XX:+WhiteBoxAPI -Xlog:gc,class+unload=debug UnloadTestWithVerifyDuringGC
  */
 import sun.hotspot.WhiteBox;
 import jdk.test.lib.classloader.ClassUnloadCommon;


### PR DESCRIPTION
Hi all,

Please review this trivial patch.
runtime/ClassUnload/UnloadTestWithVerifyDuringGC.java fails with release VMs due to 'VerifyDuringGC' is diagnostic.
So let's move `-XX:+UnlockDiagnosticVMOptions` before 'VerifyDuringGC' to fix it.

Thanks.
Best regards, 
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288203](https://bugs.openjdk.org/browse/JDK-8288203): runtime/ClassUnload/UnloadTestWithVerifyDuringGC.java fails with release VMs


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9125/head:pull/9125` \
`$ git checkout pull/9125`

Update a local copy of the PR: \
`$ git checkout pull/9125` \
`$ git pull https://git.openjdk.org/jdk pull/9125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9125`

View PR using the GUI difftool: \
`$ git pr show -t 9125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9125.diff">https://git.openjdk.org/jdk/pull/9125.diff</a>

</details>
