### PR TITLE
JDK-8288207: Enhance MalformedURLException in Uri.parseCompat

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/toolkit/url/Uri.java
+++ b/src/java.naming/share/classes/com/sun/jndi/toolkit/url/Uri.java
@@ -364,7 +364,7 @@ public class Uri {
                             + (port == -1?"":(":" + port));
                     if (!auth.equals(hostport)) {
                         // throw if we have user info or regname
-                        throw new MalformedURLException("unsupported authority: " + auth);
+                        throw new MalformedURLException("unsupported authority: " + auth + ", host:port of URI:" + host + ":" + port);
                     }
                 } catch (URISyntaxException e) {
                     var mue = new MalformedURLException(e.getMessage());

--- a/src/java.naming/share/classes/com/sun/jndi/toolkit/url/Uri.java
+++ b/src/java.naming/share/classes/com/sun/jndi/toolkit/url/Uri.java
@@ -356,7 +356,7 @@ public class Uri {
                     }
                     if (q != null) {
                         throw new MalformedURLException("invalid trailing characters in authority: ?" + q);
-                    } user info.
+                    }
                     if (f != null) {
                         throw new MalformedURLException("invalid trailing characters in authority: #" + f);
                     }

--- a/src/java.naming/share/classes/com/sun/jndi/toolkit/url/Uri.java
+++ b/src/java.naming/share/classes/com/sun/jndi/toolkit/url/Uri.java
@@ -364,7 +364,8 @@ public class Uri {
                             + (port == -1?"":(":" + port));
                     if (!auth.equals(hostport)) {
                         // throw if we have user info or regname
-                        throw new MalformedURLException("Authority component is not server-based, or contains user info. Unsupported authority: " + auth);
+                        throw new MalformedURLException("Authority component is not server-based, " +
+                                              "or contains user info. Unsupported authority: " + auth);
                     }
                 } catch (URISyntaxException e) {
                     var mue = new MalformedURLException(e.getMessage());

--- a/src/java.naming/share/classes/com/sun/jndi/toolkit/url/Uri.java
+++ b/src/java.naming/share/classes/com/sun/jndi/toolkit/url/Uri.java
@@ -356,7 +356,7 @@ public class Uri {
                     }
                     if (q != null) {
                         throw new MalformedURLException("invalid trailing characters in authority: ?" + q);
-                    }
+                    } user info.
                     if (f != null) {
                         throw new MalformedURLException("invalid trailing characters in authority: #" + f);
                     }
@@ -364,7 +364,7 @@ public class Uri {
                             + (port == -1?"":(":" + port));
                     if (!auth.equals(hostport)) {
                         // throw if we have user info or regname
-                        throw new MalformedURLException("unsupported authority: " + auth + ", host:port of URI:" + host + ":" + port);
+                        throw new MalformedURLException("Authority component is not server-based, or contains user info. Unsupported authority: " + auth);
                     }
                 } catch (URISyntaxException e) {
                     var mue = new MalformedURLException(e.getMessage());


### PR DESCRIPTION
When trying to construct an LdapURL object with a bad input string (in this example the _ in ad_jbs is causing issues), and not using
the backward compatibility flag -Dcom.sun.jndi.ldapURLParsing="legacy" we run into the exception below :

import com.sun.jndi.ldap.LdapURL;
 ....
String url = "ldap://ad_jbs.ttt.net:389/xyz"; // bad input string containing _
LdapURL ldapUrl = new LdapURL(url);


java --add-opens java.naming/com.sun.jndi.ldap=ALL-UNNAMED LdapParseUrlTest
Exception in thread "main" javax.naming.NamingException: Cannot parse url: ldap://ad_jbs.ttt.net:389/xyz [Root exception is java.net.MalformedURLException: unsupported authority: ad_jbs.ttt.net:389]
at java.naming/com.sun.jndi.ldap.LdapURL.<init>(LdapURL.java:115)
at LdapParseUrlTest.main(LdapParseUrlTest.java:9)
Caused by: java.net.MalformedURLException: unsupported authority: ad_jbs.ttt.net:389
at java.naming/com.sun.jndi.toolkit.url.Uri.parseCompat(Uri.java:367)
at java.naming/com.sun.jndi.toolkit.url.Uri.parse(Uri.java:230)
at java.naming/com.sun.jndi.toolkit.url.Uri.init(Uri.java:174)
at java.naming/com.sun.jndi.ldap.LdapURL.<init>(LdapURL.java:105)

I would like to add the host and port info to the exception (in the example it is host:port of URI:null:-1] ) so that it is directly visible that the input caused the construction of a URI
with "special"/problematic host and port values.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288207](https://bugs.openjdk.org/browse/JDK-8288207): Enhance MalformedURLException in Uri.parseCompat


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9126/head:pull/9126` \
`$ git checkout pull/9126`

Update a local copy of the PR: \
`$ git checkout pull/9126` \
`$ git pull https://git.openjdk.org/jdk pull/9126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9126`

View PR using the GUI difftool: \
`$ git pr show -t 9126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9126.diff">https://git.openjdk.org/jdk/pull/9126.diff</a>

</details>
