### PR TITLE
JDK-8288227: Refactor annotation implementation to use pattern matching for instanceof

### DIFF
--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotatedTypeFactory.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotatedTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,20 +69,20 @@ public final class AnnotatedTypeFactory {
                     actualTypeAnnos,
                     allOnSameTarget,
                     decl);
-        } else if (type instanceof TypeVariable) {
-            return new AnnotatedTypeVariableImpl((TypeVariable)type,
+        } else if (type instanceof TypeVariable<?> typeVariable) {
+            return new AnnotatedTypeVariableImpl(typeVariable,
                     currentLoc,
                     actualTypeAnnos,
                     allOnSameTarget,
                     decl);
-        } else if (type instanceof ParameterizedType) {
-            return new AnnotatedParameterizedTypeImpl((ParameterizedType)type,
+        } else if (type instanceof ParameterizedType paramType) {
+            return new AnnotatedParameterizedTypeImpl(paramType,
                     currentLoc,
                     actualTypeAnnos,
                     allOnSameTarget,
                     decl);
-        } else if (type instanceof WildcardType) {
-            return new AnnotatedWildcardTypeImpl((WildcardType) type,
+        } else if (type instanceof WildcardType wildType) {
+            return new AnnotatedWildcardTypeImpl(wildType,
                     currentLoc,
                     actualTypeAnnos,
                     allOnSameTarget,
@@ -94,15 +94,13 @@ public final class AnnotatedTypeFactory {
     public static LocationInfo nestingForType(Type type, LocationInfo addTo) {
         if (isArray(type))
             return addTo;
-        if (type instanceof Class) {
-            Class<?> clz = (Class)type;
+        if (type instanceof Class<?> clz) {
             if (clz.getEnclosingClass() == null)
                 return addTo;
             if (Modifier.isStatic(clz.getModifiers()))
                 return addTo;
             return nestingForType(clz.getEnclosingClass(), addTo.pushInner());
-        } else if (type instanceof ParameterizedType) {
-            ParameterizedType t = (ParameterizedType)type;
+        } else if (type instanceof ParameterizedType t) {
             if (t.getOwnerType() == null)
                 return addTo;
             if (t.getRawType() instanceof Class
@@ -114,8 +112,7 @@ public final class AnnotatedTypeFactory {
     }
 
     private static boolean isArray(Type t) {
-        if (t instanceof Class) {
-            Class<?> c = (Class)t;
+        if (t instanceof Class<?> c) {
             if (c.isArray())
                 return true;
         } else if (t instanceof GenericArrayType) {
@@ -317,8 +314,7 @@ public final class AnnotatedTypeFactory {
 
         private Type getComponentType() {
             Type t = getType();
-            if (t instanceof Class) {
-                Class<?> c = (Class)t;
+            if (t instanceof Class<?> c) {
                 return c.getComponentType();
             }
             return ((GenericArrayType)t).getGenericComponentType();
@@ -343,8 +339,7 @@ public final class AnnotatedTypeFactory {
             StringBuilder sb = new StringBuilder();
 
             AnnotatedType componentType = this;
-            while (componentType instanceof AnnotatedArrayType) {
-                AnnotatedArrayType annotatedArrayType = (AnnotatedArrayType) componentType;
+            while (componentType instanceof AnnotatedArrayType annotatedArrayType) {
                 sb.append(annotationsToString(annotatedArrayType.getAnnotations(), true) + "[]");
                 componentType = annotatedArrayType.getAnnotatedGenericComponentType();
             }
@@ -355,8 +350,7 @@ public final class AnnotatedTypeFactory {
 
         @Override
         public boolean equals(Object o) {
-            if (o instanceof AnnotatedArrayType) {
-                AnnotatedArrayType that = (AnnotatedArrayType) o;
+            if (o instanceof AnnotatedArrayType that) {
                 return equalsTypeAndAnnotations(that) &&
                     Objects.equals(getAnnotatedGenericComponentType(),
                                    that.getAnnotatedGenericComponentType());
@@ -401,8 +395,7 @@ public final class AnnotatedTypeFactory {
 
         @Override
         public boolean equals(Object o) {
-            if (o instanceof AnnotatedTypeVariable) {
-                AnnotatedTypeVariable that = (AnnotatedTypeVariable) o;
+            if (o instanceof AnnotatedTypeVariable that) {
                 return equalsTypeAndAnnotations(that);
             } else {
                 return false;
@@ -483,8 +476,7 @@ public final class AnnotatedTypeFactory {
 
         @Override
         public boolean equals(Object o) {
-            if (o instanceof AnnotatedParameterizedType) {
-                AnnotatedParameterizedType that = (AnnotatedParameterizedType) o;
+            if (o instanceof AnnotatedParameterizedType that) {
                 return equalsTypeAndAnnotations(that) &&
                     Arrays.equals(getAnnotatedActualTypeArguments(), that.getAnnotatedActualTypeArguments());
             } else {
@@ -598,8 +590,7 @@ public final class AnnotatedTypeFactory {
 
         @Override
         public boolean equals(Object o) {
-            if (o instanceof AnnotatedWildcardType) {
-                AnnotatedWildcardType that = (AnnotatedWildcardType) o;
+            if (o instanceof AnnotatedWildcardType that) {
                 return equalsTypeAndAnnotations(that) &&
                     // Treats ordering as significant
                     Arrays.equals(getAnnotatedLowerBounds(), that.getAnnotatedLowerBounds()) &&

--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotationInvocationHandler.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotationInvocationHandler.java
@@ -85,8 +85,8 @@ class AnnotationInvocationHandler implements InvocationHandler, Serializable {
         if (result == null)
             throw new IncompleteAnnotationException(type, member);
 
-        if (result instanceof ExceptionProxy)
-            throw ((ExceptionProxy) result).generateException();
+        if (result instanceof ExceptionProxy exceptProxy)
+            throw exceptProxy.generateException();
 
         if (result.getClass().isArray() && Array.getLength(result) != 0)
             result = cloneArray(result);
@@ -410,8 +410,8 @@ class AnnotationInvocationHandler implements InvocationHandler, Serializable {
     private AnnotationInvocationHandler asOneOfUs(Object o) {
         if (Proxy.isProxyClass(o.getClass())) {
             InvocationHandler handler = Proxy.getInvocationHandler(o);
-            if (handler instanceof AnnotationInvocationHandler)
-                return (AnnotationInvocationHandler) handler;
+            if (handler instanceof AnnotationInvocationHandler annotationHandler)
+                return annotationHandler;
         }
         return null;
     }

--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotationParser.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotationParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -280,9 +280,8 @@ public class AnnotationParser {
                 skipMemberValue(buf);
             } else {
                 Object value = parseMemberValue(memberType, buf, constPool, container);
-                if (value instanceof AnnotationTypeMismatchExceptionProxy)
-                    ((AnnotationTypeMismatchExceptionProxy) value).
-                        setMember(type.members().get(memberName));
+                if (value instanceof AnnotationTypeMismatchExceptionProxy exceptProxy)
+                    exceptProxy.setMember(type.members().get(memberName));
                 memberValues.put(memberName, value);
             }
         }
@@ -443,9 +442,8 @@ public class AnnotationParser {
         return toClass(result);
     }
     static Class<?> toClass(Type o) {
-        if (o instanceof GenericArrayType)
-            return Array.newInstance(toClass(((GenericArrayType)o).getGenericComponentType()),
-                                     0)
+        if (o instanceof GenericArrayType gat)
+            return Array.newInstance(toClass(gat.getGenericComponentType()), 0)
                 .getClass();
         return (Class)o;
     }
@@ -744,8 +742,9 @@ public class AnnotationParser {
             int tag = buf.get();
             if (tag == expectedTag) {
                 Object value = parseElement.get();
-                if (value instanceof ExceptionProxy) {
-                    if (exceptionProxy == null) exceptionProxy = (ExceptionProxy) value;
+                if (value instanceof ExceptionProxy proxyValue) {
+                    if (exceptionProxy == null)
+                        exceptionProxy = proxyValue;
                 } else {
                     result[i] = value;
                 }

--- a/src/java.base/share/classes/sun/reflect/annotation/TypeAnnotationParser.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/TypeAnnotationParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -127,8 +127,7 @@ public final class TypeAnnotationParser {
         // has no annotations and the annotations to parameter mapping
         // should be offset by 1.
         boolean offset = false;
-        if (decl instanceof Constructor) {
-            Constructor<?> ctor = (Constructor<?>) decl;
+        if (decl instanceof Constructor<?> ctor) {
             Class<?> declaringClass = ctor.getDeclaringClass();
             if (!declaringClass.isEnum() &&
                 (declaringClass.isMemberClass() &&
@@ -226,11 +225,11 @@ public final class TypeAnnotationParser {
             int typeVarIndex) {
         AnnotatedElement decl;
         TypeAnnotationTarget predicate;
-        if (genericDecl instanceof Class) {
-            decl = (Class<?>)genericDecl;
+        if (genericDecl instanceof Class<?> classDecl) {
+            decl = classDecl;
             predicate = TypeAnnotationTarget.CLASS_TYPE_PARAMETER;
-        } else if (genericDecl instanceof Executable) {
-            decl = (Executable)genericDecl;
+        } else if (genericDecl instanceof Executable execDecl) {
+            decl = execDecl;
             predicate = TypeAnnotationTarget.METHOD_TYPE_PARAMETER;
         } else {
             throw new AssertionError("Unknown GenericDeclaration " + genericDecl + "\nthis should not happen.");
@@ -279,13 +278,11 @@ public final class TypeAnnotationParser {
             // if applicable.
             if (bounds.length > 0) {
                 Type b0 = bounds[0];
-                if (b0 instanceof Class<?>) {
-                    Class<?> c = (Class<?>) b0;
+                if (b0 instanceof Class<?> c) {
                     if (c.isInterface()) {
                         startIndex = 1;
                     }
-                } else if (b0 instanceof ParameterizedType) {
-                    ParameterizedType p = (ParameterizedType) b0;
+                } else if (b0 instanceof ParameterizedType p) {
                     Class<?> c = (Class<?>) p.getRawType();
                     if (c.isInterface()) {
                         startIndex = 1;
@@ -316,9 +313,9 @@ public final class TypeAnnotationParser {
     private static <D extends GenericDeclaration> List<TypeAnnotation> fetchBounds(D decl) {
         AnnotatedElement boundsDecl;
         TypeAnnotationTarget target;
-        if (decl instanceof Class) {
+        if (decl instanceof Class<?> classDecl) {
             target = TypeAnnotationTarget.CLASS_TYPE_PARAMETER_BOUND;
-            boundsDecl = (Class)decl;
+            boundsDecl = classDecl;
         } else {
             target = TypeAnnotationTarget.METHOD_TYPE_PARAMETER_BOUND;
             boundsDecl = (Executable)decl;
@@ -337,12 +334,12 @@ public final class TypeAnnotationParser {
         Class<?> container;
         byte[] rawBytes;
         JavaLangAccess javaLangAccess = SharedSecrets.getJavaLangAccess();
-        if (decl instanceof Class) {
-            container = (Class<?>)decl;
+        if (decl instanceof Class<?> classDecl) {
+            container = classDecl;
             rawBytes = javaLangAccess.getRawClassTypeAnnotations(container);
-        } else if (decl instanceof Executable) {
-            container = ((Executable)decl).getDeclaringClass();
-            rawBytes = javaLangAccess.getRawExecutableTypeAnnotations((Executable)decl);
+        } else if (decl instanceof Executable execDecl) {
+            container = execDecl.getDeclaringClass();
+            rawBytes = javaLangAccess.getRawExecutableTypeAnnotations(execDecl);
         } else {
             // Should not reach here. Assert?
             return EMPTY_TYPE_ANNOTATION_ARRAY;


### PR DESCRIPTION
There are many instanceof checks in the sun.reflection.annotation code; these would be improved by using pattern matching for instanceof.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288227](https://bugs.openjdk.org/browse/JDK-8288227): Refactor annotation implementation to use pattern matching for instanceof


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9129/head:pull/9129` \
`$ git checkout pull/9129`

Update a local copy of the PR: \
`$ git checkout pull/9129` \
`$ git pull https://git.openjdk.org/jdk pull/9129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9129`

View PR using the GUI difftool: \
`$ git pr show -t 9129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9129.diff">https://git.openjdk.org/jdk/pull/9129.diff</a>

</details>
