### PR TITLE
8288114: Update JIRA link in vcs.xml

### DIFF
--- a/make/ide/idea/jdk/template/vcs.xml
+++ b/make/ide/idea/jdk/template/vcs.xml
@@ -5,7 +5,7 @@
       <list>
         <IssueNavigationLink>
           <option name="issueRegexp" value="\d{7}" />
-          <option name="linkRegexp" value="https://bugs.openjdk.java.net/browse/JDK-$0" />
+          <option name="linkRegexp" value="https://bugs.openjdk.org/browse/JDK-$0" />
         </IssueNavigationLink>
       </list>
     </option>


### PR DESCRIPTION
Update the link to JBS in `vcs.xml` template to https://bugs.openjdk.org/

It will affect newly generated project files only.  
Edit `vcs.xml` manually or in UI to update in existing projects.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288114](https://bugs.openjdk.org/browse/JDK-8288114): Update JIRA link in vcs.xml ⚠️ Issue is not open.


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9130/head:pull/9130` \
`$ git checkout pull/9130`

Update a local copy of the PR: \
`$ git checkout pull/9130` \
`$ git pull https://git.openjdk.org/jdk pull/9130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9130`

View PR using the GUI difftool: \
`$ git pr show -t 9130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9130.diff">https://git.openjdk.org/jdk/pull/9130.diff</a>

</details>
