### PR TITLE
8288282: Zero-release build is broken after JDK-8279047 due to UseHeavyMonitors is read-only

### DIFF
--- a/src/hotspot/cpu/zero/vm_version_zero.cpp
+++ b/src/hotspot/cpu/zero/vm_version_zero.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2009 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -45,9 +45,10 @@ void VM_Version::initialize() {
   }
   FLAG_SET_DEFAULT(AllocatePrefetchDistance, 0);
 
-  // If lock diagnostics is needed, always call to runtime
+  // Disable lock diagnostics for Zero
   if (DiagnoseSyncOnValueBasedClasses != 0) {
-    FLAG_SET_DEFAULT(UseHeavyMonitors, true);
+    warning("Lock diagnostics is not available for a Zero VM");
+    FLAG_SET_DEFAULT(DiagnoseSyncOnValueBasedClasses, 0);
   }
 
   if (UseAESIntrinsics) {


### PR DESCRIPTION
Hi all,

Zero-release build is broken after JDK-8279047.
After JDK-8279047, `UseHeavyMonitors` becomes read-only in PRODUCT VMs.

But for Zero, `UseHeavyMonitors` needs to be reset if `DiagnoseSyncOnValueBasedClasses != 0`.
```
  // If lock diagnostics is needed, always call to runtime
  if (DiagnoseSyncOnValueBasedClasses != 0) {
    FLAG_SET_DEFAULT(UseHeavyMonitors, true);
  }
```

I never hear that people would DiagnoseSyncOnValueBasedClasses with zero vms.
So in order to expire `UseHeavyMonitors` for all PRODUCT VMs, I suggest disabling lock diagnostics for zero vms.

Thanks.
Best regards,
Jie