### PR TITLE
8288022: c2: Transform (CastLL (AddL into (AddL (CastLL when possible

### DIFF
--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -31,6 +31,7 @@
 #include "opto/phaseX.hpp"
 #include "opto/subnode.hpp"
 #include "opto/type.hpp"
+#include "castnode.hpp"
 
 //=============================================================================
 // If input is already higher or equal to cast type, then this is an identity.
@@ -128,13 +129,13 @@ Node* ConstraintCastNode::make_cast(int opcode, Node* c, Node *n, const Type *t,
   return NULL;
 }
 
-Node* ConstraintCastNode::make(Node* c, Node *n, const Type *t, BasicType bt) {
+Node* ConstraintCastNode::make(Node* c, Node *n, const Type *t, DependencyType dependency, BasicType bt) {
   switch(bt) {
   case T_INT: {
-    return make_cast(Op_CastII, c, n, t, RegularDependency);
+    return make_cast(Op_CastII, c, n, t, dependency);
   }
   case T_LONG: {
-    return make_cast(Op_CastLL, c, n, t, RegularDependency);
+    return make_cast(Op_CastLL, c, n, t, dependency);
   }
   default:
     fatal("Bad basic type %s", type2name(bt));
@@ -205,28 +206,8 @@ const Type* CastIINode::Value(PhaseGVN* phase) const {
   // Do not narrow the type of range check dependent CastIINodes to
   // avoid corruption of the graph if a CastII is replaced by TOP but
   // the corresponding range check is not removed.
-  if (!_range_check_dependency && phase->C->post_loop_opts_phase()) {
-    const TypeInt* this_type = res->is_int();
-    const TypeInt* in_type = phase->type(in(1))->isa_int();
-    if (in_type != NULL &&
-        (in_type->_lo != this_type->_lo ||
-         in_type->_hi != this_type->_hi)) {
-      jint lo1 = this_type->_lo;
-      jint hi1 = this_type->_hi;
-      int w1 = this_type->_widen;
-      if (lo1 >= 0) {
-        // Keep a range assertion of >=0.
-        lo1 = 0;        hi1 = max_jint;
-      } else if (hi1 < 0) {
-        // Keep a range assertion of <0.
-        lo1 = min_jint; hi1 = -1;
-      } else {
-        lo1 = min_jint; hi1 = max_jint;
-      }
-      res = TypeInt::make(MAX2(in_type->_lo, lo1),
-                          MIN2(in_type->_hi, hi1),
-                          MAX2((int)in_type->_widen, w1));
-    }
+  if (!_range_check_dependency) {
+    res = widen_type(phase, res, T_INT);
   }
 
   // Try to improve the type of the CastII if we recognize a CmpI/If
@@ -291,9 +272,8 @@ const Type* CastIINode::Value(PhaseGVN* phase) const {
   return res;
 }
 
-static Node* find_or_make_CastII(PhaseIterGVN* igvn, Node* parent, Node* control, const TypeInt* type, ConstraintCastNode::DependencyType dependency) {
-  Node* n = new CastIINode(parent, type, dependency);
-  n->set_req(0, control);
+static Node* find_or_make_integer_cast(PhaseIterGVN* igvn, Node* parent, Node* control, const TypeInteger* type, ConstraintCastNode::DependencyType dependency, BasicType bt) {
+  Node* n = ConstraintCastNode::make(control, parent, type, dependency, bt);
   Node* existing = igvn->hash_find_insert(n);
   if (existing != NULL) {
     n->destruct(igvn);
@@ -311,30 +291,8 @@ Node *CastIINode::Ideal(PhaseGVN *phase, bool can_reshape) {
     // makes sure we run ::Value to potentially remove type assertion after loop opts
     phase->C->record_for_post_loop_opts_igvn(this);
   }
-  PhaseIterGVN* igvn = phase->is_IterGVN();
-  const TypeInt* this_type = this->type()->is_int();
-  Node* z = in(1);
-  const TypeInteger* rx = NULL;
-  const TypeInteger* ry = NULL;
-  // Similar to ConvI2LNode::Ideal() for the same reasons
-  if (!_range_check_dependency && Compile::push_thru_add(phase, z, this_type, rx, ry, T_INT)) {
-    if (igvn == NULL) {
-      // Postpone this optimization to iterative GVN, where we can handle deep
-      // AddI chains without an exponential number of recursive Ideal() calls.
-      phase->record_for_igvn(this);
-      return NULL;
-    }
-    int op = z->Opcode();
-    Node* x = z->in(1);
-    Node* y = z->in(2);
-
-    Node* cx = find_or_make_CastII(igvn, x, in(0), rx->is_int(), _dependency);
-    Node* cy = find_or_make_CastII(igvn, y, in(0), ry->is_int(), _dependency);
-    switch (op) {
-      case Op_AddI:  return new AddINode(cx, cy);
-      case Op_SubI:  return new SubINode(cx, cy);
-      default:       ShouldNotReachHere();
-    }
+  if (!_range_check_dependency) {
+    return optimize_integer_cast(phase, T_INT);
   }
   return NULL;
 }
@@ -371,10 +329,24 @@ void CastIINode::dump_spec(outputStream* st) const {
 }
 #endif
 
+const Type* CastLLNode::Value(PhaseGVN* phase) const {
+  const Type* res = ConstraintCastNode::Value(phase);
+  if (res == Type::TOP) {
+    return Type::TOP;
+  }
+  assert(res->isa_long(), "res must be long");
+
+  return widen_type(phase, res, T_LONG);
+}
+
 Node* CastLLNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   Node* progress = ConstraintCastNode::Ideal(phase, can_reshape);
   if (progress != NULL) {
     return progress;
+  }
+  if (can_reshape && !phase->C->post_loop_opts_phase()) {
+    // makes sure we run ::Value to potentially remove type assertion after loop opts
+    phase->C->record_for_post_loop_opts_igvn(this);
   }
   // transform (CastLL (ConvI2L ..)) into (ConvI2L (CastII ..)) if the type of the CastLL is narrower than the type of
   // the ConvI2L.
@@ -396,7 +368,7 @@ Node* CastLLNode::Ideal(PhaseGVN* phase, bool can_reshape) {
       }
     }
   }
-  return NULL;
+  return optimize_integer_cast(phase, T_LONG);
 }
 
 //=============================================================================
@@ -619,4 +591,63 @@ Node* ConstraintCastNode::make_cast_for_type(Node* c, Node* in, const Type* type
     cast = make_cast(Op_CastPP, c, in, type, dependency);
   }
   return cast;
+}
+
+Node* ConstraintCastNode::optimize_integer_cast(PhaseGVN* phase, BasicType bt) {
+  PhaseIterGVN *igvn = phase->is_IterGVN();
+  const TypeInteger* this_type = this->type()->is_integer(bt);
+  Node* z = in(1);
+  const TypeInteger* rx = NULL;
+  const TypeInteger* ry = NULL;
+  // Similar to ConvI2LNode::Ideal() for the same reasons
+  if (Compile::push_thru_add(phase, z, this_type, rx, ry, bt, bt)) {
+    if (igvn == NULL) {
+      // Postpone this optimization to iterative GVN, where we can handle deep
+      // AddI chains without an exponential number of recursive Ideal() calls.
+      phase->record_for_igvn(this);
+      return NULL;
+    }
+    int op = z->Opcode();
+    Node* x = z->in(1);
+    Node* y = z->in(2);
+
+    Node* cx = find_or_make_integer_cast(igvn, x, in(0), rx, _dependency, bt);
+    Node* cy = find_or_make_integer_cast(igvn, y, in(0), ry, _dependency, bt);
+    if (op == Op_Add(bt)) {
+      return AddNode::make(cx, cy, bt);
+    } else {
+      assert(op == Op_Sub(bt), "");
+      return SubNode::make(cx, cy, bt);
+    }
+    return NULL;
+  }
+  return NULL;
+}
+
+const Type* ConstraintCastNode::widen_type(const PhaseGVN* phase, const Type* res, BasicType bt) const {
+  if (!phase->C->post_loop_opts_phase()) {
+    return res;
+  }
+  const TypeInteger* this_type = res->is_integer(bt);
+  const TypeInteger* in_type = phase->type(in(1))->isa_integer(bt);
+  if (in_type != NULL &&
+      (in_type->lo_as_long() != this_type->lo_as_long() ||
+       in_type->hi_as_long() != this_type->hi_as_long())) {
+    jlong lo1 = this_type->lo_as_long();
+    jlong hi1 = this_type->hi_as_long();
+    int w1 = this_type->_widen;
+    if (lo1 >= 0) {
+      // Keep a range assertion of >=0.
+      lo1 = 0;        hi1 = max_signed_integer(bt);
+    } else if (hi1 < 0) {
+      // Keep a range assertion of <0.
+      lo1 = min_signed_integer(bt); hi1 = -1;
+    } else {
+      lo1 = min_signed_integer(bt); hi1 = max_signed_integer(bt);
+    }
+    return TypeInteger::make(MAX2(in_type->lo_as_long(), lo1),
+                             MIN2(in_type->hi_as_long(), hi1),
+                             MAX2((int)in_type->_widen, w1), bt);
+  }
+  return res;
 }

--- a/src/hotspot/share/opto/castnode.hpp
+++ b/src/hotspot/share/opto/castnode.hpp
@@ -43,6 +43,7 @@ public:
   const DependencyType _dependency;
   virtual bool cmp( const Node &n ) const;
   virtual uint size_of() const;
+  const Type* widen_type(const PhaseGVN* phase, const Type* res, BasicType bt) const;
 
   public:
   ConstraintCastNode(Node *n, const Type *t, DependencyType dependency)
@@ -59,13 +60,15 @@ public:
   bool carry_dependency() const { return _dependency != RegularDependency; }
   TypeNode* dominating_cast(PhaseGVN* gvn, PhaseTransform* pt) const;
   static Node* make_cast(int opcode, Node* c, Node *n, const Type *t, DependencyType dependency);
-  static Node* make(Node* c, Node *n, const Type *t, BasicType bt);
+  static Node* make(Node* c, Node *n, const Type *t, DependencyType dependency, BasicType bt);
 
 #ifndef PRODUCT
   virtual void dump_spec(outputStream *st) const;
 #endif
 
   static Node* make_cast_for_type(Node* c, Node* in, const Type* type, DependencyType dependency);
+
+  Node* optimize_integer_cast(PhaseGVN* phase, BasicType bt);
 };
 
 //------------------------------CastIINode-------------------------------------
@@ -118,6 +121,7 @@ public:
     init_class_id(Class_CastLL);
   }
 
+  virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
   virtual int Opcode() const;
   virtual uint ideal_reg() const { return Op_RegL; }

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -1211,7 +1211,7 @@ class Compile : public Phase {
 #endif
 
   static bool push_thru_add(PhaseGVN* phase, Node* z, const TypeInteger* tz, const TypeInteger*& rx, const TypeInteger*& ry,
-                            BasicType bt);
+                            BasicType out_bt, BasicType in_bt);
 
   static Node* narrow_value(BasicType bt, Node* value, const Type* type, PhaseGVN* phase, bool transform_res);
 };

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1103,7 +1103,7 @@ bool LibraryCallKit::inline_preconditions_checkIndex(BasicType bt) {
 
   // length is now known positive, add a cast node to make this explicit
   jlong upper_bound = _gvn.type(length)->is_integer(bt)->hi_as_long();
-  Node* casted_length = ConstraintCastNode::make(control(), length, TypeInteger::make(0, upper_bound, Type::WidenMax, bt), bt);
+  Node* casted_length = ConstraintCastNode::make(control(), length, TypeInteger::make(0, upper_bound, Type::WidenMax, bt), ConstraintCastNode::RegularDependency, bt);
   casted_length = _gvn.transform(casted_length);
   replace_in_map(length, casted_length);
   length = casted_length;
@@ -1131,7 +1131,7 @@ bool LibraryCallKit::inline_preconditions_checkIndex(BasicType bt) {
   }
 
   // index is now known to be >= 0 and < length, cast it
-  Node* result = ConstraintCastNode::make(control(), index, TypeInteger::make(0, upper_bound, Type::WidenMax, bt), bt);
+  Node* result = ConstraintCastNode::make(control(), index, TypeInteger::make(0, upper_bound, Type::WidenMax, bt), ConstraintCastNode::RegularDependency, bt);
   result = _gvn.transform(result);
   set_result(result);
   replace_in_map(index, result);

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -1462,7 +1462,7 @@ const TypeInt *TypeInt::SYMINT; // symmetric range [-max_jint..max_jint]
 const TypeInt *TypeInt::TYPE_DOMAIN; // alias for TypeInt::INT
 
 //------------------------------TypeInt----------------------------------------
-TypeInt::TypeInt( jint lo, jint hi, int w ) : TypeInteger(Int), _lo(lo), _hi(hi), _widen(w) {
+TypeInt::TypeInt( jint lo, jint hi, int w ) : TypeInteger(Int, w), _lo(lo), _hi(hi) {
 }
 
 //------------------------------make-------------------------------------------
@@ -1724,7 +1724,7 @@ const TypeLong *TypeLong::UINT; // 32-bit unsigned subrange
 const TypeLong *TypeLong::TYPE_DOMAIN; // alias for TypeLong::LONG
 
 //------------------------------TypeLong---------------------------------------
-TypeLong::TypeLong(jlong lo, jlong hi, int w) : TypeInteger(Long), _lo(lo), _hi(hi), _widen(w) {
+TypeLong::TypeLong(jlong lo, jlong hi, int w) : TypeInteger(Long, w), _lo(lo), _hi(hi) {
 }
 
 //------------------------------make-------------------------------------------

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -552,13 +552,16 @@ public:
 
 class TypeInteger : public Type {
 protected:
-  TypeInteger(TYPES t) : Type(t) {}
+  TypeInteger(TYPES t, int w) : Type(t), _widen(w) {}
 
 public:
+  const short _widen;           // Limit on times we widen this sucker
+
   virtual jlong hi_as_long() const = 0;
   virtual jlong lo_as_long() const = 0;
   jlong get_con_as_long(BasicType bt) const;
   bool is_con() const { return lo_as_long() == hi_as_long(); }
+  virtual short widen_limit() const { return _widen; }
 
   static const TypeInteger* make(jlong lo, jlong hi, int w, BasicType bt);
 
@@ -585,7 +588,6 @@ public:
   virtual bool singleton(void) const;    // TRUE if type is a singleton
   virtual bool empty(void) const;        // TRUE if type is vacuous
   const jint _lo, _hi;          // Lower bound, upper bound
-  const short _widen;           // Limit on times we widen this sucker
 
   static const TypeInt *make(jint lo);
   // must always specify w
@@ -653,7 +655,6 @@ public:
   virtual bool empty(void) const;        // TRUE if type is vacuous
 public:
   const jlong _lo, _hi;         // Lower bound, upper bound
-  const short _widen;           // Limit on times we widen this sucker
 
   static const TypeLong *make(jlong lo);
   // must always specify w

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestPushAddThruCast.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestPushAddThruCast.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+import jdk.test.lib.Utils;
+import java.util.Random;
+import java.util.Objects;
+
+/*
+ * @test
+ * @bug 8288022
+ * @key randomness
+ * @summary c2: Transform (CastLL (AddL into (AddL (CastLL when possible
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.TestPushAddThruCast
+ */
+
+public class TestPushAddThruCast {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    final static int length = RANDOM.nextInt(Integer.MAX_VALUE);
+    final static long llength = RANDOM.nextInt(Integer.MAX_VALUE);
+    static int i;
+    static long l;
+    
+    @Test
+    @IR(counts = { IRNode.CAST_II, "1" })
+    public static int test1() {
+        int j = Objects.checkIndex(i, length);
+        int k = Objects.checkIndex(i + 1, length);
+        return j + k;
+    }
+
+    @Run(test = "test1")
+    public static void test1_runner() {
+        i = RANDOM.nextInt(length-1);
+        int res = test1();
+        if (res != i * 2 + 1) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+
+    }
+
+    @Test
+    @IR(counts = { IRNode.CAST_LL, "1" })
+    public static long test2() {
+        long j = Objects.checkIndex(l, llength);
+        long k = Objects.checkIndex(l + 1, llength);
+        return j + k;
+    }
+
+    @Run(test = "test2")
+    public static void test2_runner() {
+        l = RANDOM.nextInt(((int)llength)-1);
+        long res = test2();
+        if (res != l * 2 + 1) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+}


### PR DESCRIPTION
This implements a transformation that already exists for CastII and
ConvI2L and helps code generation. The tricky part is that:

(CastII (AddI into (AddI (CastII

is performed by first computing the bounds of the type of the AddI. To
protect against overflow, jlong variables are used. With CastLL/AddL
nodes there's no larger integer type to promote the bounds to. As a
consequence the logic in the patch explicitly tests for overflow. That
logic is shared by the int and long cases. The previous logic for the
int cases that promotes values to long is used as verification.

This patch also widens the type of CastLL nodes after loop opts the
way it's done for CastII/ConvI2L to allow commoning of nodes.

This was observed to help with Memory Segment micro benchmarks.

