### PR TITLE
8288134: Super class names don't have envelopes

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -274,24 +274,16 @@ Klass* SystemDictionary::resolve_or_null(Symbol* class_name, Handle class_loader
   if (Signature::is_array(class_name)) {
     return resolve_array_class_or_null(class_name, class_loader, protection_domain, THREAD);
   } else {
-    return resolve_instance_class_or_null_helper(class_name, class_loader, protection_domain, THREAD);
-  }
-}
-
-// name may be in the form of "java/lang/Object" or "Ljava/lang/Object;"
-InstanceKlass* SystemDictionary::resolve_instance_class_or_null_helper(Symbol* class_name,
-                                                                       Handle class_loader,
-                                                                       Handle protection_domain,
-                                                                       TRAPS) {
-  assert(class_name != NULL && !Signature::is_array(class_name), "must be");
-  if (Signature::has_envelope(class_name)) {
-    ResourceMark rm(THREAD);
-    // Ignore wrapping L and ;.
-    TempNewSymbol name = SymbolTable::new_symbol(class_name->as_C_string() + 1,
-                                                 class_name->utf8_length() - 2);
-    return resolve_instance_class_or_null(name, class_loader, protection_domain, THREAD);
-  } else {
-    return resolve_instance_class_or_null(class_name, class_loader, protection_domain, THREAD);
+    assert(class_name != NULL && !Signature::is_array(class_name), "must be");
+    if (Signature::has_envelope(class_name)) {
+      ResourceMark rm(THREAD);
+      // Ignore wrapping L and ;.
+      TempNewSymbol name = SymbolTable::new_symbol(class_name->as_C_string() + 1,
+                                                   class_name->utf8_length() - 2);
+      return resolve_instance_class_or_null(name, class_loader, protection_domain, THREAD);
+    } else {
+      return resolve_instance_class_or_null(class_name, class_loader, protection_domain, THREAD);
+    }
   }
 }
 
@@ -424,10 +416,10 @@ InstanceKlass* SystemDictionary::resolve_super_or_fail(Symbol* class_name,
 
   // Resolve the superclass or superinterface, check results on return
   InstanceKlass* superk =
-    SystemDictionary::resolve_instance_class_or_null_helper(super_name,
-                                                            class_loader,
-                                                            protection_domain,
-                                                            THREAD);
+    SystemDictionary::resolve_instance_class_or_null(super_name,
+                                                     class_loader,
+                                                     protection_domain,
+                                                     THREAD);
 
   // Clean up placeholder entry.
   {

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -317,10 +317,6 @@ private:
 
 private:
   // Basic loading operations
-  static InstanceKlass* resolve_instance_class_or_null_helper(Symbol* name,
-                                                              Handle class_loader,
-                                                              Handle protection_domain,
-                                                              TRAPS);
   static InstanceKlass* resolve_instance_class_or_null(Symbol* class_name,
                                                        Handle class_loader,
                                                        Handle protection_domain, TRAPS);


### PR DESCRIPTION
SystemDictionary::resolve_super_or_null() calls resolve_instance_class_or_null_helper() which strips off the L; envelope for class names then calls resolve_instance_class_or_null().
Super class names come from the constant pool or an existing InstanceKlass in the CDS path, so is already verified by the format checker, if the name has L; and it will already get a class format error.

Removed this helper and call resolve_instance_class_or_null() directly, and inlined the helper function into resolve_or_null().

Tested by tier1-4 on Oracle supported platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288134](https://bugs.openjdk.org/browse/JDK-8288134): Super class names don't have envelopes


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9144/head:pull/9144` \
`$ git checkout pull/9144`

Update a local copy of the PR: \
`$ git checkout pull/9144` \
`$ git pull https://git.openjdk.org/jdk pull/9144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9144`

View PR using the GUI difftool: \
`$ git pr show -t 9144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9144.diff">https://git.openjdk.org/jdk/pull/9144.diff</a>

</details>
