### PR TITLE
8288468: Avoid redundant HashMap.get call in NegotiateAuthentication.firstToken

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/http/NegotiateAuthentication.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/NegotiateAuthentication.java
@@ -216,12 +216,9 @@ class NegotiateAuthentication extends AuthenticationInfo {
      */
     private byte[] firstToken() throws IOException {
         negotiator = null;
-        HashMap <String, Negotiator> cachedMap = getCache();
+        HashMap<String, Negotiator> cachedMap = getCache();
         if (cachedMap != null) {
-            negotiator = cachedMap.get(getHost());
-            if (negotiator != null) {
-                cachedMap.remove(getHost()); // so that it is only used once
-            }
+            negotiator = cachedMap.remove(getHost()); // so that it is only used once
         }
         if (negotiator == null) {
             negotiator = Negotiator.getNegotiator(hci);


### PR DESCRIPTION
Instead of separate `HashMap.get`+`remove` call, we can use single `HashMap.remove` call and use its return value.
https://github.com/openjdk/jdk/blob/53a0acee06eb32fba700967c9a34d37ea42f7a99/src/java.base/share/classes/sun/net/www/protocol/http/NegotiateAuthentication.java#L219-L225
It makes code a bit cleaner and faster.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288468](https://bugs.openjdk.org/browse/JDK-8288468): Avoid redundant HashMap.get call in NegotiateAuthentication.firstToken


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9145/head:pull/9145` \
`$ git checkout pull/9145`

Update a local copy of the PR: \
`$ git checkout pull/9145` \
`$ git pull https://git.openjdk.org/jdk pull/9145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9145`

View PR using the GUI difftool: \
`$ git pr show -t 9145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9145.diff">https://git.openjdk.org/jdk/pull/9145.diff</a>

</details>
