### PR TITLE
8288332: Tier1 validate-source fails after 8279614

### DIFF
--- a/test/jdk/javax/swing/border/EtchedBorder/ScaledEtchedBorderTest.java
+++ b/test/jdk/javax/swing/border/EtchedBorder/ScaledEtchedBorderTest.java
@@ -2,6 +2,10 @@
  * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License


### PR DESCRIPTION
A trivial fix to make validate-source happy again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288332](https://bugs.openjdk.org/browse/JDK-8288332): Tier1 validate-source fails after 8279614


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9146/head:pull/9146` \
`$ git checkout pull/9146`

Update a local copy of the PR: \
`$ git checkout pull/9146` \
`$ git pull https://git.openjdk.org/jdk pull/9146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9146`

View PR using the GUI difftool: \
`$ git pr show -t 9146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9146.diff">https://git.openjdk.org/jdk/pull/9146.diff</a>

</details>
