### PR TITLE
8288360: CI: ciInstanceKlass::implementor() is not consistent for well-known classes

### DIFF
--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -619,8 +619,10 @@ bool ciInstanceKlass::is_leaf_type() {
 ciInstanceKlass* ciInstanceKlass::implementor() {
   ciInstanceKlass* impl = _implementor;
   if (impl == NULL) {
-    // Go into the VM to fetch the implementor.
-    {
+    if (is_shared()) {
+      impl = this; // assume a well-known interface never has a unique implementor
+    } else {
+      // Go into the VM to fetch the implementor.
       VM_ENTRY_MARK;
       MutexLocker ml(Compile_lock);
       Klass* k = get_instanceKlass()->implementor();
@@ -634,9 +636,7 @@ ciInstanceKlass* ciInstanceKlass::implementor() {
       }
     }
     // Memoize this result.
-    if (!is_shared()) {
-      _implementor = impl;
-    }
+    _implementor = impl;
   }
   return impl;
 }


### PR DESCRIPTION
ciInstanceKlass::implementor() doesn't cache the result for well-known interfaces (`is_shared() == true`). Due to concurrent class loading, compilers can observe a change in reported unique implementor (in the worst case: from having no implementors to having one, then to having many) thus introducing paradoxical situations during a compilation.

What makes it very hard/impossible to trigger the bug is there's only a single well-known interface (`java.util.Iterable`) present as of now, which gets multiple implementors loaded early during startup.

Testing: hs-tier1 - hs-tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288360](https://bugs.openjdk.org/browse/JDK-8288360): CI: ciInstanceKlass::implementor() is not consistent for well-known classes


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9147/head:pull/9147` \
`$ git checkout pull/9147`

Update a local copy of the PR: \
`$ git checkout pull/9147` \
`$ git pull https://git.openjdk.org/jdk pull/9147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9147`

View PR using the GUI difftool: \
`$ git pr show -t 9147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9147.diff">https://git.openjdk.org/jdk/pull/9147.diff</a>

</details>
