### PR TITLE
JDK-8284977: MetricsTesterCgroupV2.getLongValueEntryFromFile fails when named value doesn't exist

### DIFF
--- a/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV2.java
+++ b/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV2.java
@@ -121,6 +121,11 @@ public class MetricsTesterCgroupV2 implements CgroupMetricsTester {
         Path filePath = Paths.get(UNIFIED.getPath(), file);
         try {
             String strVal = Files.lines(filePath).filter(l -> l.startsWith(metric)).collect(Collectors.joining());
+            if (strVal.isEmpty()) {
+                // sometimes the match for the metric does not exist, e.g. cpu.stat's nr_periods iff the controller
+                // is not enabled
+                return UNLIMITED;
+            }
             String[] keyValues = strVal.split("\\s+");
             String value = keyValues[1];
             return convertStringToLong(value);


### PR DESCRIPTION
When running test/jdk/jdk/internal/platform/cgroup/TestCgroupMetrics.java on ubuntu 21.10 or 22 , this test looks for a named value "nr_periods" in the file /sys/fs/cgroup/..../cpu.stat . However this metric is not always present, which leads to an AIOOB exception.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284977](https://bugs.openjdk.org/browse/JDK-8284977): MetricsTesterCgroupV2.getLongValueEntryFromFile fails when named value doesn't exist


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9153/head:pull/9153` \
`$ git checkout pull/9153`

Update a local copy of the PR: \
`$ git checkout pull/9153` \
`$ git pull https://git.openjdk.org/jdk pull/9153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9153`

View PR using the GUI difftool: \
`$ git pr show -t 9153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9153.diff">https://git.openjdk.org/jdk/pull/9153.diff</a>

</details>
