### PR TITLE
8220732: setSeed(long) java api doc is missing warning about provided seed quality

### DIFF
--- a/src/java.base/share/classes/java/security/SecureRandom.java
+++ b/src/java.base/share/classes/java/security/SecureRandom.java
@@ -725,6 +725,11 @@ public class SecureRandom extends java.util.Random {
      * in the given {@code long seed}. The given seed supplements,
      * rather than replaces, the existing seed. Thus, repeated calls
      * are guaranteed never to reduce randomness.
+     * <p>
+     * A PRNG {@code SecureRandom} will not seed itself automatically if
+     * {@code setSeed} is called before any {@code nextBytes} or {@code reseed}
+     * calls. The caller should make sure that the {@code seed} argument
+     * contains enough entropy for the security of this {@code SecureRandom}.
      *
      * <p>This method is defined for compatibility with
      * {@code java.util.Random}.


### PR DESCRIPTION
Resolves [JDK-8220732](https://bugs.openjdk.org/browse/JDK-8220732?filter=42718). The additional guidance as been added to the javadoc for `setSeed(long)`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8220732](https://bugs.openjdk.org/browse/JDK-8220732): setSeed(long) java api doc is missing warning about provided seed quality
 * [JDK-8288435](https://bugs.openjdk.org/browse/JDK-8288435): setSeed(long) java api doc is missing warning about provided seed quality (**CSR**)


### Reviewers
 * [Bradford Wetmore](https://openjdk.org/census#wetmore) (@bradfordwetmore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9156/head:pull/9156` \
`$ git checkout pull/9156`

Update a local copy of the PR: \
`$ git checkout pull/9156` \
`$ git pull https://git.openjdk.org/jdk pull/9156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9156`

View PR using the GUI difftool: \
`$ git pr show -t 9156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9156.diff">https://git.openjdk.org/jdk/pull/9156.diff</a>

</details>
