### PR TITLE
8288443: Simplify vmClasses::resolve_all()

### DIFF
--- a/src/hotspot/share/classfile/vmClassMacros.hpp
+++ b/src/hotspot/share/classfile/vmClassMacros.hpp
@@ -105,8 +105,6 @@
   do_klass(Continuation_klass,                          jdk_internal_vm_Continuation                          ) \
   do_klass(StackChunk_klass,                            jdk_internal_vm_StackChunk                            ) \
                                                                                                                 \
-  /* NOTE: needed too early in bootstrapping process to have checks based on JDK version */                     \
-  /* It's okay if this turns out to be NULL in non-1.4 JDKs. */                                                 \
   do_klass(reflect_MagicAccessorImpl_klass,             reflect_MagicAccessorImpl                             ) \
   do_klass(reflect_MethodAccessorImpl_klass,            reflect_MethodAccessorImpl                            ) \
   do_klass(reflect_ConstructorAccessorImpl_klass,       reflect_ConstructorAccessorImpl                       ) \
@@ -116,7 +114,7 @@
   do_klass(reflect_CallerSensitive_klass,               reflect_CallerSensitive                               ) \
   do_klass(reflect_NativeConstructorAccessorImpl_klass, reflect_NativeConstructorAccessorImpl                 ) \
                                                                                                                 \
-  /* support for dynamic typing; it's OK if these are NULL in earlier JDKs */                                   \
+  /* support for dynamic typing */                                                                              \
   do_klass(DirectMethodHandle_klass,                    java_lang_invoke_DirectMethodHandle                   ) \
   do_klass(MethodHandle_klass,                          java_lang_invoke_MethodHandle                         ) \
   do_klass(VarHandle_klass,                             java_lang_invoke_VarHandle                            ) \
@@ -135,7 +133,6 @@
   do_klass(ConstantCallSite_klass,                      java_lang_invoke_ConstantCallSite                     ) \
   do_klass(MutableCallSite_klass,                       java_lang_invoke_MutableCallSite                      ) \
   do_klass(VolatileCallSite_klass,                      java_lang_invoke_VolatileCallSite                     ) \
-  /* Note: MethodHandle must be first, and VolatileCallSite last in group */                                    \
                                                                                                                 \
   do_klass(AssertionStatusDirectives_klass,             java_lang_AssertionStatusDirectives                   ) \
   do_klass(StringBuffer_klass,                          java_lang_StringBuffer                                ) \
@@ -160,7 +157,6 @@
                                                                                                                 \
   do_klass(StackTraceElement_klass,                     java_lang_StackTraceElement                           ) \
                                                                                                                 \
-  /* It's okay if this turns out to be NULL in non-1.4 JDKs. */                                                 \
   do_klass(nio_Buffer_klass,                            java_nio_Buffer                                       ) \
                                                                                                                 \
   /* Stack Walking */                                                                                           \

--- a/src/hotspot/share/classfile/vmClasses.cpp
+++ b/src/hotspot/share/classfile/vmClasses.cpp
@@ -158,7 +158,7 @@ void vmClasses::resolve_all(TRAPS) {
   java_lang_Object::register_natives(CHECK);
 
   // Calculate offsets for String and Class classes since they are loaded and
-  // can be used after this point.
+  // can be used after this point. These are no-op when CDS is enabled.
   java_lang_String::compute_offsets();
   java_lang_Class::compute_offsets();
 
@@ -166,31 +166,36 @@ void vmClasses::resolve_all(TRAPS) {
   Universe::initialize_basic_type_mirrors(CHECK);
   Universe::fixup_mirrors(CHECK);
 
-  // do a bunch more:
-  resolve_through(VM_CLASS_ID(Reference_klass), scan, CHECK);
+  if (UseSharedSpaces) {
+    // These should already have been initialized during CDS dump.
+    assert(vmClasses::Reference_klass()->reference_type() == REF_OTHER, "sanity");
+    assert(vmClasses::SoftReference_klass()->reference_type() == REF_SOFT, "sanity");
+    assert(vmClasses::WeakReference_klass()->reference_type() == REF_WEAK, "sanity");
+    assert(vmClasses::FinalReference_klass()->reference_type() == REF_FINAL, "sanity");
+    assert(vmClasses::PhantomReference_klass()->reference_type() == REF_PHANTOM, "sanity");
+  } else {
+    // If CDS is not enabled, the references classes must be initialized in
+    // this order before the rest of the vmClasses can be resolved.
+    resolve_through(VM_CLASS_ID(Reference_klass), scan, CHECK);
 
-  // The offsets for jlr.Reference must be computed before
-  // InstanceRefKlass::update_nonstatic_oop_maps is called. That function uses
-  // the offsets to remove the referent and discovered fields from the oop maps,
-  // as they are treated in a special way by the GC. Removing these oops from the
-  // oop maps must be done before the usual subclasses of jlr.Reference are loaded.
-  java_lang_ref_Reference::compute_offsets();
+    // The offsets for jlr.Reference must be computed before
+    // InstanceRefKlass::update_nonstatic_oop_maps is called. That function uses
+    // the offsets to remove the referent and discovered fields from the oop maps,
+    // as they are treated in a special way by the GC. Removing these oops from the
+    // oop maps must be done before the usual subclasses of jlr.Reference are loaded.
+    java_lang_ref_Reference::compute_offsets();
 
-  // Preload ref klasses and set reference types
-  vmClasses::Reference_klass()->set_reference_type(REF_OTHER);
-  InstanceRefKlass::update_nonstatic_oop_maps(vmClasses::Reference_klass());
+    // Preload ref klasses and set reference types
+    vmClasses::Reference_klass()->set_reference_type(REF_OTHER);
+    InstanceRefKlass::update_nonstatic_oop_maps(vmClasses::Reference_klass());
 
-  resolve_through(VM_CLASS_ID(PhantomReference_klass), scan, CHECK);
-  vmClasses::SoftReference_klass()->set_reference_type(REF_SOFT);
-  vmClasses::WeakReference_klass()->set_reference_type(REF_WEAK);
-  vmClasses::FinalReference_klass()->set_reference_type(REF_FINAL);
-  vmClasses::PhantomReference_klass()->set_reference_type(REF_PHANTOM);
+    resolve_through(VM_CLASS_ID(PhantomReference_klass), scan, CHECK);
+    vmClasses::SoftReference_klass()->set_reference_type(REF_SOFT);
+    vmClasses::WeakReference_klass()->set_reference_type(REF_WEAK);
+    vmClasses::FinalReference_klass()->set_reference_type(REF_FINAL);
+    vmClasses::PhantomReference_klass()->set_reference_type(REF_PHANTOM);
+  }
 
-  // JSR 292 classes
-  vmClassID jsr292_group_start = VM_CLASS_ID(MethodHandle_klass);
-  vmClassID jsr292_group_end   = VM_CLASS_ID(VolatileCallSite_klass);
-  resolve_until(jsr292_group_start, scan, CHECK);
-  resolve_through(jsr292_group_end, scan, CHECK);
   resolve_until(vmClassID::LIMIT, scan, CHECK);
 
   CollectedHeap::set_filler_object_klass(vmClasses::FillerObject_klass());


### PR DESCRIPTION
Please review this simple clean up:

- There's no need to initialize the JSR 292 classes separately (the `-XX:+EnableInvokeDynamic` option has been removed long time ago).
- Separate initialization of the reference classes is not necessary when CDS is enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288443](https://bugs.openjdk.org/browse/JDK-8288443): Simplify vmClasses::resolve_all()


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**) ⚠️ Review applies to [e802861c](https://git.openjdk.org/jdk/pull/9157/files/e802861cfa26763f0be9f625aa706a06c7a29847)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [e802861c](https://git.openjdk.org/jdk/pull/9157/files/e802861cfa26763f0be9f625aa706a06c7a29847)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9157/head:pull/9157` \
`$ git checkout pull/9157`

Update a local copy of the PR: \
`$ git checkout pull/9157` \
`$ git pull https://git.openjdk.org/jdk pull/9157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9157`

View PR using the GUI difftool: \
`$ git pr show -t 9157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9157.diff">https://git.openjdk.org/jdk/pull/9157.diff</a>

</details>
