### PR TITLE
8282038: CipherSpi.bufferCrypt leaves plaintext copy on the heap

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/GCTR.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/GCTR.java
@@ -228,15 +228,19 @@ final class GCTR extends CounterMode implements GCM {
         len = src.remaining() - (src.remaining() % blockSize);
         int processed = len;
         byte[] in = new byte[Math.min(MAX_LEN, len)];
-        while (processed > MAX_LEN) {
-            src.get(in, 0, MAX_LEN);
-            encrypt(in, 0, MAX_LEN, in, 0);
-            dst.put(in, 0, MAX_LEN);
-            processed -= MAX_LEN;
+        try {
+            while (processed > MAX_LEN) {
+                src.get(in, 0, MAX_LEN);
+                encrypt(in, 0, MAX_LEN, in, 0);
+                dst.put(in, 0, MAX_LEN);
+                processed -= MAX_LEN;
+            }
+            src.get(in, 0, processed);
+            encrypt(in, 0, processed, in, 0);
+            dst.put(in, 0, processed);
+        } finally {
+            Arrays.fill(in, (byte)0);
         }
-        src.get(in, 0, processed);
-        encrypt(in, 0, processed, in, 0);
-        dst.put(in, 0, processed);
         return len;
     }
 

--- a/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
@@ -1011,6 +1011,7 @@ abstract class GaloisCounterMode extends CipherSpi {
 
             dst.flip();
             originalDst.put(dst);
+            dst.clear().put(new byte[dst.capacity()]);
             originalDst = null;
         }
 


### PR DESCRIPTION
Clearing buffers and temporary arrays to avoid data leaks in cipher operations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282038](https://bugs.openjdk.org/browse/JDK-8282038): CipherSpi.bufferCrypt leaves plaintext copy on the heap


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9158/head:pull/9158` \
`$ git checkout pull/9158`

Update a local copy of the PR: \
`$ git checkout pull/9158` \
`$ git pull https://git.openjdk.org/jdk pull/9158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9158`

View PR using the GUI difftool: \
`$ git pr show -t 9158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9158.diff">https://git.openjdk.org/jdk/pull/9158.diff</a>

</details>
