### PR TITLE
6980847: (fs) Files.copy needs to be "tuned"

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixCopyFile.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixCopyFile.java
@@ -280,8 +280,7 @@ class UnixCopyFile {
                     if (bss > 0 && bst > 0) {
                         transferSize = bss == bst ? bss : lcm(bss, bst);
                     }
-                } catch (IllegalArgumentException | SecurityException |
-                         UnixException | UnsupportedOperationException ignored) {
+                } catch (IllegalArgumentException | UnixException ignored) {
                 }
 
                 // transfer bytes to target file

--- a/src/java.base/unix/native/libnio/fs/UnixCopyFile.c
+++ b/src/java.base/unix/native/libnio/fs/UnixCopyFile.c
@@ -38,7 +38,7 @@
 #endif
 #include "sun_nio_fs_UnixCopyFile.h"
 
-#define DEFAULT_TRANSFER_SIZE 8192
+#define DEFAULT_TRANSFER_SIZE (sun_nio_fs_UnixCopyFile_TRANSFER_SIZE)
 
 #define RESTARTABLE(_cmd, _result) do { \
   do { \
@@ -121,16 +121,6 @@ void transfer(JNIEnv* env, jint dst, jint src, jlong transferSize,
 cleanup:
     if (buf != stackBuf)
         free(buf);
-}
-
-/**
- * Return the default transfer buffer size
- */
-JNIEXPORT jlong JNICALL
-Java_sun_nio_fs_UnixCopyFile_transferSize0
-    (JNIEnv* env, jclass this)
-{
-    return DEFAULT_TRANSFER_SIZE;
 }
 
 /**

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsConstants.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsConstants.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsConstants.java
@@ -132,6 +132,7 @@ class WindowsConstants {
     // copy flags
     public static final int COPY_FILE_FAIL_IF_EXISTS       = 0x00000001;
     public static final int COPY_FILE_COPY_SYMLINK         = 0x00000800;
+    public static final int COPY_FILE_NO_BUFFERING         = 0x00001000;
 
     // move flags
     public static final int MOVEFILE_REPLACE_EXISTING       = 0x00000001;

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsConstants.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java
@@ -25,8 +25,14 @@
 
 package sun.nio.fs;
 
-import java.nio.file.*;
 import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.CopyOption;
+import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.LinkOption;
+import java.nio.file.LinkPermission;
+import java.nio.file.StandardCopyOption;
 import java.util.concurrent.ExecutionException;
 
 import static sun.nio.fs.WindowsNativeDispatcher.*;
@@ -177,11 +183,6 @@ class WindowsFileCopy {
 
         // Use CopyFileEx if the file is not a directory or junction
         if (!sourceAttrs.isDirectory() && !sourceAttrs.isDirectoryLink()) {
-            long size = 0;
-            try {
-                size = Files.size(source);
-            } catch (IOException ignored) {
-            }
             final int flags = ((!followLinks) ? COPY_FILE_COPY_SYMLINK : 0) |
                               ((sourceAttrs.size() > UNBUFFERED_IO_THRESHOLD) ?
                                   COPY_FILE_NO_BUFFERING : 0);

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java
@@ -183,7 +183,8 @@ class WindowsFileCopy {
             } catch (IOException ignored) {
             }
             final int flags = ((!followLinks) ? COPY_FILE_COPY_SYMLINK : 0) |
-                ((size > UNBUFFERED_IO_THRESHOLD) ? COPY_FILE_NO_BUFFERING : 0);
+                              ((sourceAttrs.size() > UNBUFFERED_IO_THRESHOLD) ?
+                                  COPY_FILE_NO_BUFFERING : 0);
 
             if (interruptible) {
                 // interruptible copy

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java
@@ -183,9 +183,9 @@ class WindowsFileCopy {
 
         // Use CopyFileEx if the file is not a directory or junction
         if (!sourceAttrs.isDirectory() && !sourceAttrs.isDirectoryLink()) {
-            final int flags = ((!followLinks) ? COPY_FILE_COPY_SYMLINK : 0) |
-                              ((sourceAttrs.size() > UNBUFFERED_IO_THRESHOLD) ?
-                                  COPY_FILE_NO_BUFFERING : 0);
+            boolean isBuffering = sourceAttrs.size() <= UNBUFFERED_IO_THRESHOLD;
+            final int flags = (followLinks ? 0 : COPY_FILE_COPY_SYMLINK) |
+                              (isBuffering ? 0 : COPY_FILE_NO_BUFFERING);
 
             if (interruptible) {
                 // interruptible copy


### PR DESCRIPTION
Modify `UnixCopyFile.copyFile()` to set the transfer size to the least common multiple of the source and destination file block sizes if the block sizes are not equal. Modify `WindowsFileCopy.copy()` to set `COPY_FILE_NO_BUFFERING` in the flags passed to `CopyFileEx()` if the size of the transfer is greater than a threshold.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6980847](https://bugs.openjdk.org/browse/JDK-6980847): (fs) Files.copy needs to be "tuned"


### Reviewers
 * @kristylee88 (no known github.com user name / role) ⚠️ Review applies to [a6575484](https://git.openjdk.org/jdk/pull/9161/files/a657548422ef0be5edabe5a28c074204b59b8981)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9161/head:pull/9161` \
`$ git checkout pull/9161`

Update a local copy of the PR: \
`$ git checkout pull/9161` \
`$ git pull https://git.openjdk.org/jdk pull/9161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9161`

View PR using the GUI difftool: \
`$ git pr show -t 9161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9161.diff">https://git.openjdk.org/jdk/pull/9161.diff</a>

</details>
