### PR TITLE
JDK-8288058: Broken links on constant-values page

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlIds.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlIds.java
@@ -135,6 +135,19 @@ public class HtmlIds {
     }
 
     /**
+     * Returns an id for a package name.
+     *
+     * @param pkgName the package name
+     *
+     * @return the id
+     */
+    HtmlId forPackageName(String pkgName) {
+        return pkgName.isEmpty()
+                ? UNNAMED_PACKAGE_ANCHOR
+                : HtmlId.of(pkgName);
+    }
+
+    /**
      * Returns an id for a class or interface.
      *
      * @param element the class or interface

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/ConstantsSummaryWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/ConstantsSummaryWriter.java
@@ -55,13 +55,10 @@ public interface ConstantsSummaryWriter {
     /**
      * Adds the given package name link to the constant content list.
      *
-     * @param pkg                    the {@link PackageElement} to index.
-     * @param writtenPackageHeaders  the set of package headers that have already
-     *                               been indexed, we want to index utmost once.
-     * @param content                the content to which the link will be added
+     * @param abbrevPackageName the abbreviated package name
+     * @param content       the content to which the link will be added
      */
-    void addLinkToPackageContent(PackageElement pkg, Set<PackageElement> writtenPackageHeaders,
-                                 Content content);
+    void addLinkToPackageContent(String abbrevPackageName, Content content);
 
     /**
      * Add the content list to the documentation.
@@ -78,17 +75,12 @@ public interface ConstantsSummaryWriter {
     Content getConstantSummaries();
 
     /**
-     * Adds the given package name.
+     * Adds a header for the given abbreviated package name.
      *
-     * @param pkg  the parsed package name.  We only Write the
-     *                          first 2 directory levels of the package
-     *                          name. For example, java.lang.ref would be
-     *                          indexed as java.lang.*.
+     * @param abbrevPackageName  the abbreviated package name
      * @param toContent the summaries documentation
-     * @param first true if the first package is listed
-     *                    be written
      */
-    void addPackageName(PackageElement pkg, Content toContent, boolean first);
+    void addPackageGroup(String abbrevPackageName, Content toContent);
 
     /**
      * Get the class summary header for the constants summary.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/WorkArounds.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/WorkArounds.java
@@ -500,22 +500,6 @@ public class WorkArounds {
         }
     }
 
-    // TODO: we need to eliminate this, as it is hacky.
-    /**
-     * Returns a representation of the package truncated to two levels.
-     * For instance if the given package represents foo.bar.baz will return
-     * a representation of foo.bar
-     * @param pkg the PackageElement
-     * @return an abbreviated PackageElement
-     */
-    public PackageElement getAbbreviatedPackageElement(PackageElement pkg) {
-        String parsedPackageName = utils.parsePackageName(pkg);
-        ModuleElement encl = (ModuleElement) pkg.getEnclosingElement();
-        return encl == null
-                ? utils.elementUtils.getPackageElement(parsedPackageName)
-                : ((JavacElements) utils.elementUtils).getPackageElement(encl, parsedPackageName);
-    }
-
     public boolean isPreviewAPI(Element el) {
         Symbol sym = (Symbol) el;
         return (sym.flags() & Flags.PREVIEW_API) != 0;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -124,7 +124,6 @@ import static javax.lang.model.element.ElementKind.*;
 import static javax.lang.model.type.TypeKind.*;
 
 import static com.sun.source.doctree.DocTree.Kind.*;
-import static jdk.javadoc.internal.doclets.toolkit.builders.ConstantsSummaryBuilder.MAX_CONSTANT_VALUE_INDEX_LENGTH;
 
 /**
  * Utilities Class for Doclets.
@@ -903,22 +902,6 @@ public class Utils {
                     : configuration.workArounds.searchClass(encl, className);
         }
         return searchResult;
-    }
-
-    /**
-     * Parse the package name.  We only want to display package name up to
-     * 2 levels.
-     */
-    public String parsePackageName(PackageElement p) {
-        String pkgname = p.isUnnamed() ? "" : getPackageName(p);
-        int index = -1;
-        for (int j = 0; j < MAX_CONSTANT_VALUE_INDEX_LENGTH; j++) {
-            index = pkgname.indexOf(".", index + 1);
-        }
-        if (index != -1) {
-            pkgname = pkgname.substring(0, index);
-        }
-        return pkgname;
     }
 
     /**

--- a/test/langtools/jdk/javadoc/doclet/testConstantValuesPage/TestConstantValuesPage.java
+++ b/test/langtools/jdk/javadoc/doclet/testConstantValuesPage/TestConstantValuesPage.java
@@ -23,16 +23,18 @@
 
 /*
  * @test
- * @bug 4681599
- * @summary Test to make sure that constant values page does not get
- * generated when doclet has nothing to document.
- * @library ../../lib
+ * @bug 4681599 8288058
+ * @summary Tests for the Constant Values page.
+ * @library /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
- * @build javadoc.tester.*
+ * @build toolbox.ToolBox javadoc.tester.*
  * @run main TestConstantValuesPage
  */
 
+import java.nio.file.Path;
+
 import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
 
 public class TestConstantValuesPage extends JavadocTester {
 
@@ -41,8 +43,14 @@ public class TestConstantValuesPage extends JavadocTester {
         tester.runTests();
     }
 
+    ToolBox tb = new ToolBox();
+
+    /**
+     * Test to make sure that constant values page does not get
+     * generated when doclet has nothing to document.
+     */
     @Test
-    public void test() {
+    public void testNoPage() {
         javadoc("-d", "out",
                 "-sourcepath", testSrc,
                 "foo");
@@ -50,5 +58,200 @@ public class TestConstantValuesPage extends JavadocTester {
 
         checkOutput(Output.OUT, false,
                 "constant-values.html...");
+        checkFiles(false, "constant-values.html");
+    }
+
+    /**
+     * Tests the "contents" list for a group of named packages in the unnamed module.
+     */
+    @Test
+    public void testIndexNamed(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                    package p1.p2a.p3a;
+                    public class CA {
+                        public static final int ia = 1;
+                        public static final String sa = "string";
+                    }
+                    """,
+                """
+                    package p1.p2a.p3b;
+                    public class CB {
+                        public static final int ib = 1;
+                        public static final String sb = "string";
+                    }
+                    """,
+                """
+                    package p1.p2b.p3c;
+                    public class CC {
+                        public static final int ic = 1;
+                        public static final String sc = "string";
+                    }
+                    """,
+                """
+                    package p2;
+                    public class CD {
+                        public static final int id = 1;
+                        public static final String sd = "string";
+                    }
+                    """);
+
+        setAutomaticCheckLinks(true); // ensure link-checking enabled for this test
+
+        javadoc("-d", base.resolve("api").toString(),
+                "-Xdoclint:none",
+                "-sourcepath", src.toString(),
+                "p1.p2a.p3a", "p1.p2a.p3b", "p1.p2b.p3c");
+        checkExit(Exit.OK);
+
+        checkOutput("constant-values.html", true,
+                """
+                    <section class="packages">
+                    <h2 title="Contents">Contents</h2>
+                    <ul>
+                    <li><a href="#p1.p2a">p1.p2a.*</a></li>
+                    <li><a href="#p1.p2b">p1.p2b.*</a></li>
+                    </ul>
+                    </section>""");
+    }
+
+    /**
+     * Tests the "contents" list for the unnamed package in the unnamed module.
+     */
+    @Test
+    public void testIndexUnnamed(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                    public class C {
+                        public static final int ia = 1;
+                        public static final String sa = "string";
+                    }
+                    """);
+
+        setAutomaticCheckLinks(true); // ensure link-checking enabled for this test
+
+        javadoc("-d", base.resolve("api").toString(),
+                "-Xdoclint:none",
+                "-sourcepath", src.toString(),
+                src.resolve("C.java").toString());
+        checkExit(Exit.OK);
+
+        checkOutput("constant-values.html", true,
+                """
+                    <section class="packages">
+                    <h2 title="Contents">Contents</h2>
+                    <ul>
+                    <li><a href="#unnamed-package">Unnamed Package</a></li>
+                    </ul>
+                    </section>""");
+    }
+
+    /**
+     * Tests the "contents" list for a group of named and unnamed packages in the unnamed module.
+     */
+    @Test
+    public void testMixed(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                    package p1.p2a.p3a;
+                    public class CA {
+                        public static final int ia = 1;
+                        public static final String sa = "string";
+                    }
+                    """,
+                """
+                    public class C {
+                        public static final int ia = 1;
+                        public static final String sa = "string";
+                    }
+                    """);
+
+        setAutomaticCheckLinks(true); // ensure link-checking enabled for this test
+
+        javadoc("-d", base.resolve("api").toString(),
+                "-Xdoclint:none",
+                "-sourcepath", src.toString(),
+                "p1.p2a.p3a", src.resolve("C.java").toString());
+        checkExit(Exit.OK);
+
+        checkOutput("constant-values.html", true,
+                """
+                    <section class="packages">
+                    <h2 title="Contents">Contents</h2>
+                    <ul>
+                    <li><a href="#unnamed-package">Unnamed Package</a></li>
+                    <li><a href="#p1.p2a">p1.p2a.*</a></li>
+                    </ul>
+                    </section>""");
+    }
+
+    /**
+     * Tests the "contents" list for a group of named packages in named modules.
+     */
+    @Test
+    public void testModules(Path base) throws Exception {
+        Path src = base.resolve("src");
+        Path src_mA = src.resolve("mA");
+        tb.writeJavaFiles(src_mA,
+                """
+                    module mA {
+                        exports p.a;
+                        exports p.q.r1;
+                    }
+                    """,
+                """
+                    package p.a;
+                    public class CA {
+                        public static final int iA = 1;
+                    }
+                    """,
+                """
+                    package p.q.r1;
+                    public class C1 {
+                        public static final int i1 = 1;
+                    }
+                    """);
+        Path src_mB = src.resolve("mB");
+        tb.writeJavaFiles(src_mB,
+                """
+                    module mB {
+                        exports p.b;
+                        exports p.q.r2;
+                    }
+                    """,
+                """
+                    package p.b;
+                    public class CB {
+                        public static final int iB = 1;
+                    }
+                    """,
+                """
+                    package p.q.r2;
+                    public class C2 {
+                        public static final int i2 = 1;
+                    }
+                    """);
+
+        setAutomaticCheckLinks(true); // ensure link-checking enabled for this test
+
+        javadoc("-d", base.resolve("api").toString(),
+                "-Xdoclint:none",
+                "--module-source-path", src.toString(),
+                "--module", "mA,mB");
+        checkExit(Exit.OK);
+
+        checkOutput("constant-values.html", true,
+                """
+                    <section class="packages">
+                    <h2 title="Contents">Contents</h2>
+                    <ul>
+                    <li><a href="#p.a">p.a.*</a></li>
+                    <li><a href="#p.b">p.b.*</a></li>
+                    <li><a href="#p.q">p.q.*</a></li>
+                    </ul>
+                    </section>""");
     }
 }


### PR DESCRIPTION
JDK 19: 

Please review a medium-simple fix for some broken links on the constant-values page, from the "contents" index at the top of the page to the summary tables lower down on the page.

There are two root causes:

1. The packages are grouped into "groups" with headings based on abbreviated package names, meaning "at most two leading components of each package name". At one point there is a probable typo, when a full package name is used instead of the abbreviated name, thus causing the wrong "id" to be generated, thus causing broken links.  The fix for this is obvious: use the correct name.

2. More seriously, the abbreviated package name is modeled using a `PackageElement`.   While seemingly a good idea, the construction of these elements inherits the module element of the originating package.  Then, the package elements are used to build a `Set` of headings, based on these package elements.  The problem is that when the subpackages are found in different modules, they give rise to distinct "abbreviated package elements" _in different modules_ and thus cause repeated instances of like-named headers in the output.  This is easily visible as repeated headers for `com.sun.*` in (for example) the [JDK 18 API](https://docs.oracle.com/en/java/javase/18/docs/api/constant-values.html).  The fix is to use a `Set<String>` to model the set of headers and associated links, instead of `Set<PackageElement>`.

Along with the two fixes described above, there is minor code cleanup, including the removal of some ill-considered code in both `Workarounds` and `Utils`. Apart from those classes, the changes are confined to the "constant summary" builder and writers.  The use of a member called "first" and related shenanigans is a holdover from the days when the page was generated literally top-to-bottom with `print` statements. It is easily removed.

The only existing test for the constant values page was laughably insufficient, and was effectively just a regression test for a minor issue in JDK 1.4.2. The test is enhanced with a bunch of new test cases, that exercise different scenarios for the list of contents at the top of the page, and the links to the corresponding sections lower down. The new test cases leverage the implicit support for checking links in the generated output, although they do forcibly enable that support, just to make sure it is active.

When comparing the new JDK API docs against recent JDK API docs, the only changes are the expected changes in the links and headings on the constant-values.html page.

There is more cleanup that could be done to this page ... such as suppressing the "contents:" list when it is just a single entry ... but that is an enhancement that is out of scope for this bug fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288058](https://bugs.openjdk.org/browse/JDK-8288058): Broken links on constant-values page


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9162/head:pull/9162` \
`$ git checkout pull/9162`

Update a local copy of the PR: \
`$ git checkout pull/9162` \
`$ git pull https://git.openjdk.org/jdk pull/9162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9162`

View PR using the GUI difftool: \
`$ git pr show -t 9162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9162.diff">https://git.openjdk.org/jdk/pull/9162.diff</a>

</details>
