### PR TITLE
8288300: AArch64: Remove the assertion in fmovs/fmovd(FloatRegister, FloatRegister)

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -1930,31 +1930,17 @@ void mvnw(Register Rd, Register Rm,
     data_processing(op31, type, opcode, Vd, Vn);        \
   }
 
-private:
-  INSN(i_fmovs, 0b000, 0b00, 0b000000);
-public:
-  INSN(fabss, 0b000, 0b00, 0b000001);
-  INSN(fnegs, 0b000, 0b00, 0b000010);
+  INSN(fmovs,  0b000, 0b00, 0b000000);
+  INSN(fabss,  0b000, 0b00, 0b000001);
+  INSN(fnegs,  0b000, 0b00, 0b000010);
   INSN(fsqrts, 0b000, 0b00, 0b000011);
-  INSN(fcvts, 0b000, 0b00, 0b000101);   // Single-precision to double-precision
+  INSN(fcvts,  0b000, 0b00, 0b000101);   // Single-precision to double-precision
 
-private:
-  INSN(i_fmovd, 0b000, 0b01, 0b000000);
-public:
-  INSN(fabsd, 0b000, 0b01, 0b000001);
-  INSN(fnegd, 0b000, 0b01, 0b000010);
+  INSN(fmovd,  0b000, 0b01, 0b000000);
+  INSN(fabsd,  0b000, 0b01, 0b000001);
+  INSN(fnegd,  0b000, 0b01, 0b000010);
   INSN(fsqrtd, 0b000, 0b01, 0b000011);
-  INSN(fcvtd, 0b000, 0b01, 0b000100);   // Double-precision to single-precision
-
-  void fmovd(FloatRegister Vd, FloatRegister Vn) {
-    assert(Vd != Vn, "should be");
-    i_fmovd(Vd, Vn);
-  }
-
-  void fmovs(FloatRegister Vd, FloatRegister Vn) {
-    assert(Vd != Vn, "should be");
-    i_fmovs(Vd, Vn);
-  }
+  INSN(fcvtd,  0b000, 0b01, 0b000100);   // Double-precision to single-precision
 
 private:
   void _fcvt_narrow_extend(FloatRegister Vd, SIMD_Arrangement Ta,

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -1930,17 +1930,17 @@ void mvnw(Register Rd, Register Rm,
     data_processing(op31, type, opcode, Vd, Vn);        \
   }
 
-  INSN(fmovs,  0b000, 0b00, 0b000000);
-  INSN(fabss,  0b000, 0b00, 0b000001);
-  INSN(fnegs,  0b000, 0b00, 0b000010);
+  INSN(fmovs, 0b000, 0b00, 0b000000);
+  INSN(fabss, 0b000, 0b00, 0b000001);
+  INSN(fnegs, 0b000, 0b00, 0b000010);
   INSN(fsqrts, 0b000, 0b00, 0b000011);
-  INSN(fcvts,  0b000, 0b00, 0b000101);   // Single-precision to double-precision
+  INSN(fcvts, 0b000, 0b00, 0b000101);   // Single-precision to double-precision
 
-  INSN(fmovd,  0b000, 0b01, 0b000000);
-  INSN(fabsd,  0b000, 0b01, 0b000001);
-  INSN(fnegd,  0b000, 0b01, 0b000010);
+  INSN(fmovd, 0b000, 0b01, 0b000000);
+  INSN(fabsd, 0b000, 0b01, 0b000001);
+  INSN(fnegd, 0b000, 0b01, 0b000010);
   INSN(fsqrtd, 0b000, 0b01, 0b000011);
-  INSN(fcvtd,  0b000, 0b01, 0b000100);   // Double-precision to single-precision
+  INSN(fcvtd, 0b000, 0b01, 0b000100);   // Double-precision to single-precision
 
 private:
   void _fcvt_narrow_extend(FloatRegister Vd, SIMD_Arrangement Ta,


### PR DESCRIPTION
The assertion, i.e. src and dst must be different registers, was
introduced years ago. But I don't think it's needed.

This limitation was added in [1]. Frankly speaking, I don't know the
reason. But I guess the assertion is probably used for debugging,
raising one warning of fmovs/fmovd usage in the scenario of moving
element at index zero from one **vector** register, to one float-point
scalar register. If the "src" vector register and the "dst" float-point
scalar register are the same one, it introduces a side-effect, i.e. the
higher bits are cleared to zeros[2].

If so, I argue that
1) the assembler should align with the ISA.
2) compiler developers should be aware of the side-effect when they want
to use fmovs/fmovd, and they should guarantee "dst != src" if they like
to higher bits untouched, e.g., [3].

Hence, I think we can remove this unnecessary assertion.

[1] http://hg.openjdk.java.net/aarch64-port/jdk8/hotspot/rev/9baee4e65ac5
[2] https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/FMOV--register---Floating-point-Move-register-without-conversion-?lang=en
[3] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/aarch64/aarch64_sve.ad#L4899

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288300](https://bugs.openjdk.org/browse/JDK-8288300): AArch64: Remove the assertion in fmovs/fmovd(FloatRegister, FloatRegister)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Nick Gasson](https://openjdk.org/census#ngasson) (@nick-arm - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9163/head:pull/9163` \
`$ git checkout pull/9163`

Update a local copy of the PR: \
`$ git checkout pull/9163` \
`$ git pull https://git.openjdk.org/jdk pull/9163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9163`

View PR using the GUI difftool: \
`$ git pr show -t 9163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9163.diff">https://git.openjdk.org/jdk/pull/9163.diff</a>

</details>
