### PR TITLE
8288399: MacOS debug symbol files not always deterministic in reproducible builds

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -116,6 +116,18 @@ AC_DEFUN([FLAGS_SETUP_DEBUG_SYMBOLS],
     CFLAGS_DEBUG_SYMBOLS="-g"
     ASFLAGS_DEBUG_SYMBOLS="-g"
   elif test "x$TOOLCHAIN_TYPE" = xclang; then
+    if test "x$ALLOW_ABSOLUTE_PATHS_IN_OUTPUT" = "xfalse"; then
+      # Check if compiler supports -fdebug-prefix-map. If so, use that to make
+      # the debug symbol paths resolve to paths relative to the workspace root.
+      workspace_root_trailing_slash="${WORKSPACE_ROOT%/}/"
+      DEBUG_PREFIX_CFLAGS="-fdebug-prefix-map=${workspace_root_trailing_slash}="
+      FLAGS_COMPILER_CHECK_ARGUMENTS(ARGUMENT: [${DEBUG_PREFIX_CFLAGS}],
+        IF_FALSE: [
+            DEBUG_PREFIX_CFLAGS=
+        ]
+      )
+    fi
+
     CFLAGS_DEBUG_SYMBOLS="-g"
     ASFLAGS_DEBUG_SYMBOLS="-g"
   elif test "x$TOOLCHAIN_TYPE" = xxlc; then

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -359,9 +359,9 @@ define SetupCompileNativeFileBody
       $1_FLAGS := $(BASIC_ASFLAGS) $$($1_BASE_ASFLAGS)
       $1_COMPILER := $(AS)
 
-      # gcc assembly files must contain an appropriate relative .file
+      # gcc or clang assembly files must contain an appropriate relative .file
       # path for reproducible builds.
-      ifeq ($(TOOLCHAIN_TYPE), gcc)
+      ifneq ($(findstring $(TOOLCHAIN_TYPE), gcc clang), )
         # If no absolute paths allowed, work out relative source file path
         # for assembly .file substitution, otherwise use full file path
         ifeq ($(ALLOW_ABSOLUTE_PATHS_IN_OUTPUT), false)
@@ -403,8 +403,9 @@ define SetupCompileNativeFileBody
     $1_OBJ_DEPS := $$($1_SRC_FILE) $$($$($1_BASE)_COMPILE_VARDEPS_FILE) \
         $$($$($1_BASE)_EXTRA_DEPS) $$($1_VARDEPS_FILE)
     $1_COMPILE_OPTIONS := $$($1_FLAGS) $(CC_OUT_OPTION)$$($1_OBJ) $$($1_SRC_FILE)
-    # For reproducible builds with gcc ensure random symbol generation is seeded deterministically
-    ifeq ($(TOOLCHAIN_TYPE), gcc)
+    # For reproducible builds with gcc and clang ensure random symbol generation is
+    # seeded deterministically
+    ifneq ($(findstring $(TOOLCHAIN_TYPE), gcc clang), )
        ifeq ($$(ENABLE_REPRODUCIBLE_BUILD), true)
          $1_COMPILE_OPTIONS += -frandom-seed="$$($1_FILENAME)"
        endif


### PR DESCRIPTION
MacOS builds built with ENABLE_REPRODUCIBLE_BUILD enabled still contain full build paths in the
debug symbol information. Linux gcc reproducible builds already uses -fdebug-prefix-map to make these deterministic,
clang supports the same option, and testing with this for clang shows correct mapping.
Similiarly for reproducible builds assembly source file debug declarations need to be relative, as is for Linux gcc. 

The compiler generated unique function symbols contain a random generated part, which if not deterministically
seeded will be random. -frandom-seed provides a deterministic seed solution.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288399](https://bugs.openjdk.org/browse/JDK-8288399): MacOS debug symbol files not always deterministic in reproducible builds


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9166/head:pull/9166` \
`$ git checkout pull/9166`

Update a local copy of the PR: \
`$ git checkout pull/9166` \
`$ git pull https://git.openjdk.org/jdk pull/9166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9166`

View PR using the GUI difftool: \
`$ git pr show -t 9166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9166.diff">https://git.openjdk.org/jdk/pull/9166.diff</a>

</details>
