### PR TITLE
8263384: IGV: Outline should highlight the Graph that has focus

### DIFF
--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
@@ -130,6 +130,19 @@ public final class OutlineTopComponent extends TopComponent implements ExplorerM
         binaryServer = new Server(getDocument(), callback, true);
     }
 
+    // Fetch and select the latest active graph.
+    private void updateGraphSelection() {
+        final InputGraphProvider p = LookupHistory.getLast(InputGraphProvider.class);
+        if (p == null) {
+            return;
+        }
+        try {
+            manager.setSelectedNodes(new GraphNode[]{FolderNode.getGraphNode(p.getGraph())});
+        } catch (Exception e) {
+            Exceptions.printStackTrace(e);
+        }
+    }
+
     public void clear() {
         document.clear();
         FolderNode.clearGraphNodeMap();
@@ -184,6 +197,7 @@ public final class OutlineTopComponent extends TopComponent implements ExplorerM
         Lookup.Template<InputGraphProvider> tpl = new Lookup.Template<InputGraphProvider>(InputGraphProvider.class);
         result = Utilities.actionsGlobalContext().lookup(tpl);
         result.addLookupListener(this);
+        updateGraphSelection();
         this.requestActive();
     }
 
@@ -223,18 +237,7 @@ public final class OutlineTopComponent extends TopComponent implements ExplorerM
         }
         // Wait for LookupHistory to be updated with the last active graph
         // before selecting it.
-        Runnable updateSelectedGraph = () -> {
-            final InputGraphProvider p = LookupHistory.getLast(InputGraphProvider.class);
-            if (p == null) {
-                return;
-            }
-            try {
-                manager.setSelectedNodes(new GraphNode[]{FolderNode.getGraphNode(p.getGraph())});
-            } catch (Exception e) {
-                Exceptions.printStackTrace(e);
-            }
-        };
-        SwingUtilities.invokeLater(updateSelectedGraph);
+        SwingUtilities.invokeLater(() -> updateGraphSelection());
     }
 
     @Override

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
@@ -190,7 +190,6 @@ public final class OutlineTopComponent extends TopComponent implements ExplorerM
     @Override
     public void componentClosed() {
         result.removeLookupListener(this);
-        result = null;
     }
 
     @Override

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.border.Border;
 import org.openide.ErrorManager;
@@ -221,15 +222,20 @@ public final class OutlineTopComponent extends TopComponent implements ExplorerM
         if (result.allItems().isEmpty()) {
             return;
         }
-        final InputGraphProvider p = LookupHistory.getLast(InputGraphProvider.class);
-        if (p == null) {
-            return;
-        }
-        try {
-            manager.setSelectedNodes(new GraphNode[]{FolderNode.getGraphNode(p.getGraph())});
-        } catch (Exception e) {
-            Exceptions.printStackTrace(e);
-        }
+        // Wait for LookupHistory to be updated with the last active graph
+        // before selecting it.
+        Runnable updateSelectedGraph = () -> {
+            final InputGraphProvider p = LookupHistory.getLast(InputGraphProvider.class);
+            if (p == null) {
+                return;
+            }
+            try {
+                manager.setSelectedNodes(new GraphNode[]{FolderNode.getGraphNode(p.getGraph())});
+            } catch (Exception e) {
+                Exceptions.printStackTrace(e);
+            }
+        };
+        SwingUtilities.invokeLater(updateSelectedGraph);
     }
 
     @Override


### PR DESCRIPTION
This changeset eases navigation within and across graph groups by highlighting the focused graph in the Outline window. If the user changes the focus to another graph window, or moves to the previous or next graph within the same window, the newly focused graph is automatically highlighted in the Outline window. This is implemented by maintaining a static map from opened graphs to their corresponding [NetBeans nodes](https://netbeans.apache.org/tutorials/nbm-selection-2.html). The Outline window uses the map to select, on a graph focus change, the NetBeans node of the newly focused graph that should be highlighted.

Tested manually by opening simultaneously tens of graphs from different groups and switching the focus randomly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8263384](https://bugs.openjdk.org/browse/JDK-8263384): IGV: Outline should highlight the Graph that has focus


### Reviewers
 * [Xin Liu](https://openjdk.org/census#xliu) (@navyxliu - Committer)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9167/head:pull/9167` \
`$ git checkout pull/9167`

Update a local copy of the PR: \
`$ git checkout pull/9167` \
`$ git pull https://git.openjdk.org/jdk pull/9167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9167`

View PR using the GUI difftool: \
`$ git pr show -t 9167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9167.diff">https://git.openjdk.org/jdk/pull/9167.diff</a>

</details>
