### PR TITLE
8288480: IGV: toolbar action is not applied to the focused graph

### DIFF
--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorTopComponent.java
@@ -433,14 +433,7 @@ public final class EditorTopComponent extends TopComponent implements PropertyCh
     }
 
     public static EditorTopComponent getActive() {
-        Set<? extends Mode> modes = WindowManager.getDefault().getModes();
-        for (Mode m : modes) {
-            TopComponent tc = m.getSelectedTopComponent();
-            if (tc instanceof EditorTopComponent) {
-                return (EditorTopComponent) tc;
-            }
-        }
-        return null;
+        return (EditorTopComponent) EditorTopComponent.getRegistry().getActivated();
     }
 
     /** This method is called from within the constructor to


### PR DESCRIPTION
When multiple graphs are displayed simultaneously in split windows, the following toolbar actions are always applied to the same graph, regardless of which graph window is focused:

- search nodes and blocks
- extract node
- hide node
- show all nodes
- zoom in
- zoom out

This changeset ensures that each of the above actions is only applied within its corresponding graph window. This is achieved by applying the actions to the graph window that is currently activated (`EditorTopComponent.getRegistry().getActivated()`) instead of the first matching occurrence in `WindowManager.getDefault().getModes()`.

The changeset makes it practical, for example, to explore different views of the same graph simultaneously, as illustrated here:

![multi-view](https://user-images.githubusercontent.com/8792647/173841115-084c6396-3843-4d9b-9951-f93c932100c3.png)

Tested manually by triggering the above actions within multiple split graph windows and asserting that they are only applied to their corresponding graphs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288480](https://bugs.openjdk.org/browse/JDK-8288480): IGV: toolbar action is not applied to the focused graph


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9169/head:pull/9169` \
`$ git checkout pull/9169`

Update a local copy of the PR: \
`$ git checkout pull/9169` \
`$ git pull https://git.openjdk.org/jdk pull/9169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9169`

View PR using the GUI difftool: \
`$ git pr show -t 9169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9169.diff">https://git.openjdk.org/jdk/pull/9169.diff</a>

</details>
