### PR TITLE
8288499: Restore cancel-in-progress in GHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
 


### PR DESCRIPTION
I accidentally changed the behavior in GHA wrt multiple runs from the same branch. The old solution used `cancel-in-progress: true` which means that an old batch was cancelled when a new commit was pushed to the branch.

I think this is a good behavior, since it minimizes wait times for GHA results, and wastes less GHA resources.

I changed this to `false` while developing the new GHA framework, and intended to change it back before pushing, but forgot about it. 