### PR TITLE
8288628: Unnecessary Hashtable usage in ConditionalSpecialCasing

### DIFF
--- a/src/java.base/share/classes/java/lang/ConditionalSpecialCasing.java
+++ b/src/java.base/share/classes/java/lang/ConditionalSpecialCasing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,8 @@
 package java.lang;
 
 import java.text.BreakIterator;
+import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.Locale;
 import sun.text.Normalizer;
@@ -89,7 +89,7 @@ final class ConditionalSpecialCasing {
     };
 
     // A hash table that contains the above entries
-    static Hashtable<Integer, HashSet<Entry>> entryTable = new Hashtable<>();
+    private static final HashMap<Integer, HashSet<Entry>> entryTable = new HashMap<>();
     static {
         // create hashtable from the entry
         for (Entry cur : entry) {


### PR DESCRIPTION
If a thread-safe implementation is not needed, it is recommended to use HashMap in place of Hashtable.
`ConditionalSpecialCasing.entryTable` is read-only Map which is modified only in `static` block. It means we can safely replace it with HashMap.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288628](https://bugs.openjdk.org/browse/JDK-8288628): Unnecessary Hashtable usage in ConditionalSpecialCasing


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9172/head:pull/9172` \
`$ git checkout pull/9172`

Update a local copy of the PR: \
`$ git checkout pull/9172` \
`$ git pull https://git.openjdk.org/jdk pull/9172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9172`

View PR using the GUI difftool: \
`$ git pr show -t 9172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9172.diff">https://git.openjdk.org/jdk/pull/9172.diff</a>

</details>
