### PR TITLE
8288530: ProblemList serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java in -Xcomp mode

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -39,3 +39,5 @@ serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
 vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t002/TestDescription.java 8245680 windows-x64
 
 vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8265295 linux-x64,windows-x64
+
+serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java 8288430 generic-all


### PR DESCRIPTION
A trivial fix to ProblemList serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java in -Xcomp mode.

Humor note: The product bug ID and ProblemList bug ID differ by exactly 100.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288530](https://bugs.openjdk.org/browse/JDK-8288530): ProblemList serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java in -Xcomp mode


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9173/head:pull/9173` \
`$ git checkout pull/9173`

Update a local copy of the PR: \
`$ git checkout pull/9173` \
`$ git pull https://git.openjdk.org/jdk pull/9173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9173`

View PR using the GUI difftool: \
`$ git pr show -t 9173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9173.diff">https://git.openjdk.org/jdk/pull/9173.diff</a>

</details>
