### PR TITLE
8280472: Don't mix legacy logging with UL

### DIFF
--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -1494,7 +1494,7 @@ methodHandle Method::make_method_handle_intrinsic(vmIntrinsics::ID iid,
   if (iid == vmIntrinsics::_linkToNative) {
     m->set_interpreter_entry(m->adapter()->get_i2c_entry());
   }
-  if (log_is_enabled(Info, methodhandles) && (Verbose || WizardMode)) {
+  if (log_is_enabled(Debug, methodhandles)) {
     LogTarget(Info, methodhandles) lt;
     LogStream ls(lt);
     m->print_on(&ls);

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -1495,7 +1495,7 @@ methodHandle Method::make_method_handle_intrinsic(vmIntrinsics::ID iid,
     m->set_interpreter_entry(m->adapter()->get_i2c_entry());
   }
   if (log_is_enabled(Debug, methodhandles)) {
-    LogTarget(Info, methodhandles) lt;
+    LogTarget(Debug, methodhandles) lt;
     LogStream ls(lt);
     m->print_on(&ls);
   }


### PR DESCRIPTION
This PR remove extra conditions related to Unified Logging.

Those conditions have been left after the transition to Unified Logging. This is an only place that uses UL, Verbose and WizardMode flags together. This JBS issue suggests to remove those flags.

# Details
At present to output target log messages needs the debug build of OpenJDK and, Verbose or WizardMode option.
```
$ jdk/build/macosx-aarch64-server-fastdebug/jdk/bin/java -Xlog:methodhandles=info -XX:+Verbose -version
(Omitted)
[0.090s][info][methodhandles] make_method_handle_intrinsic MH.linkToStatic(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/invoke/MemberName;)Ljava/lang/Object;
[0.090s][info][methodhandles] {method}
[0.090s][info][methodhandles]  - this oop:          0x00000001303d6238
[0.090s][info][methodhandles]  - method holder:     public synchronized abstract 'java/lang/invoke/MethodHandle'
(Omitted)
[0.090s][info][methodhandles]  - signature handler: 0x0000000000000000
[0.090s][info][methodhandles] lookup_polymorphic_method => intrinsic {method}
[0.090s][info][methodhandles]  - this oop:          0x00000001303d6238
```
Target log messages are from `{method}` to `- signature handler`.

```
$ jdk/build/macosx-aarch64-server-fastdebug/jdk/bin/java -Xlog:methodhandles=info -version
(Omitted)
[0.134s][info][methodhandles] lookup_polymorphic_method linkToStatic (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/invoke/MemberName;)Ljava/lang/Object; => basic (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/invoke/MemberName;)Ljava/lang/Object;
[0.134s][info][methodhandles] make_method_handle_intrinsic MH.linkToStatic(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/invoke/MemberName;)Ljava/lang/Object;
[0.134s][info][methodhandles] lookup_polymorphic_method => intrinsic {method}
[0.134s][info][methodhandles]  - this oop:          0x000000012abd5e58
```
When those flags are off, UL doesn't output them. 

# Test
There is no test code for it. So I built and run OpenJDK to confirm log output by myself.

## Run with Log Level DEBUG After Applying This Patch
```
$ jdk/build/macosx-aarch64-server-fastdebug/jdk/bin/java -Xlog:methodhandles=debug -version
(Omitted)
[0.132s][info][methodhandles] make_method_handle_intrinsic MH.linkToStatic(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/invoke/MemberName;)Ljava/lang/Object;
[0.132s][debug][methodhandles] {method}
[0.132s][debug][methodhandles]  - this oop:          0x00000001217d6b98
(Omitted)
[0.132s][debug][methodhandles]  - signature handler: 0x0000000000000000
[0.132s][info ][methodhandles] lookup_polymorphic_method => intrinsic {method}
[0.132s][info ][methodhandles]  - this oop:          0x00000001217d6b98
```
UL outputted target log messages with the debug level. It was successful.

## Run with Log Level INFO After Applying This Patch
```
$ jdk/build/macosx-aarch64-server-fastdebug/jdk/bin/java -Xlog:methodhandles=info -version
(Omitted)
[0.086s][info][methodhandles] make_method_handle_intrinsic MH.linkToStatic(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/invoke/MemberName;)Ljava/lang/Object;
[0.086s][info][methodhandles] lookup_polymorphic_method => intrinsic {method}
[0.086s][info][methodhandles]  - this oop:          0x000000011f7d69f8
```
UL didn't output them. That was as I intended.

