### PR TITLE
8288281: compiler/vectorapi/VectorFPtoIntCastTest.java failed with "IRViolationException: There were one or multiple IR rule failures."

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/VectorFPtoIntCastTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorFPtoIntCastTest.java
@@ -84,7 +84,7 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {"F2X", ">= 1"})
+    @IR(counts = {"VectorCastF2X", "> 0"})
     public void float2int() {
         var cvec = (IntVector)fvec512.convertShape(VectorOperators.F2I, ispec512, 0);
         cvec.intoArray(int_arr, 0);
@@ -101,7 +101,7 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {"F2X", ">= 1"})
+    @IR(counts = {"VectorCastF2X", "> 0"})
     public void float2long() {
         var cvec = (LongVector)fvec512.convertShape(VectorOperators.F2L, lspec512, 0);
         cvec.intoArray(long_arr, 0);
@@ -118,7 +118,7 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {"F2X", ">= 1"})
+    @IR(counts = {"VectorCastF2X", "> 0"})
     public void float2short() {
         var cvec = (ShortVector)fvec512.convertShape(VectorOperators.F2S, sspec256, 0);
         cvec.intoArray(short_arr, 0);
@@ -135,7 +135,7 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {"F2X", ">= 1"})
+    @IR(counts = {"VectorCastF2X", "> 0"})
     public void float2byte() {
         var cvec = (ByteVector)fvec512.convertShape(VectorOperators.F2B, bspec128, 0);
         cvec.intoArray(byte_arr, 0);
@@ -152,7 +152,7 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {"D2X", ">= 1"})
+    @IR(counts = {"VectorCastD2X", "> 0"})
     public void double2int() {
         var cvec = (IntVector)dvec512.convertShape(VectorOperators.D2I, ispec256, 0);
         cvec.intoArray(int_arr, 0);
@@ -169,7 +169,7 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {"D2X", ">= 1"})
+    @IR(counts = {"VectorCastD2X", "> 0"})
     public void double2long() {
         var cvec = (LongVector)dvec512.convertShape(VectorOperators.D2L, lspec512, 0);
         cvec.intoArray(long_arr, 0);
@@ -186,7 +186,7 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {"D2X", ">= 1"})
+    @IR(counts = {"VectorCastD2X", "> 0"})
     public void double2short() {
         var cvec = (ShortVector)dvec512.convertShape(VectorOperators.D2S, sspec128, 0);
         cvec.intoArray(short_arr, 0);
@@ -203,7 +203,7 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {"D2X", ">= 1"})
+    @IR(counts = {"VectorCastD2X", "> 0"})
     public void double2byte() {
         var cvec = (ByteVector)dvec512.convertShape(VectorOperators.D2B, bspec64, 0);
         cvec.intoArray(byte_arr, 0);

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorFPtoIntCastTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorFPtoIntCastTest.java
@@ -84,7 +84,7 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {"VectorCastF2X", "> 0"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2X, "> 0"})
     public void float2int() {
         var cvec = (IntVector)fvec512.convertShape(VectorOperators.F2I, ispec512, 0);
         cvec.intoArray(int_arr, 0);
@@ -101,7 +101,7 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {"VectorCastF2X", "> 0"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2X, "> 0"})
     public void float2long() {
         var cvec = (LongVector)fvec512.convertShape(VectorOperators.F2L, lspec512, 0);
         cvec.intoArray(long_arr, 0);
@@ -118,7 +118,7 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {"VectorCastF2X", "> 0"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2X, "> 0"})
     public void float2short() {
         var cvec = (ShortVector)fvec512.convertShape(VectorOperators.F2S, sspec256, 0);
         cvec.intoArray(short_arr, 0);
@@ -135,7 +135,7 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {"VectorCastF2X", "> 0"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2X, "> 0"})
     public void float2byte() {
         var cvec = (ByteVector)fvec512.convertShape(VectorOperators.F2B, bspec128, 0);
         cvec.intoArray(byte_arr, 0);
@@ -152,7 +152,7 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {"VectorCastD2X", "> 0"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2X, "> 0"})
     public void double2int() {
         var cvec = (IntVector)dvec512.convertShape(VectorOperators.D2I, ispec256, 0);
         cvec.intoArray(int_arr, 0);
@@ -169,7 +169,7 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {"VectorCastD2X", "> 0"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2X, "> 0"})
     public void double2long() {
         var cvec = (LongVector)dvec512.convertShape(VectorOperators.D2L, lspec512, 0);
         cvec.intoArray(long_arr, 0);
@@ -186,7 +186,7 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {"VectorCastD2X", "> 0"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2X, "> 0"})
     public void double2short() {
         var cvec = (ShortVector)dvec512.convertShape(VectorOperators.D2S, sspec128, 0);
         cvec.intoArray(short_arr, 0);
@@ -203,7 +203,7 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {"VectorCastD2X", "> 0"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2X, "> 0"})
     public void double2byte() {
         var cvec = (ByteVector)dvec512.convertShape(VectorOperators.D2B, bspec64, 0);
         cvec.intoArray(byte_arr, 0);


### PR DESCRIPTION
The IR Framework test was failing due to incorrect node name. 
Corrected the IR node name check.

Please review.

Best Regards,
Sandhya

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288281](https://bugs.openjdk.org/browse/JDK-8288281): compiler/vectorapi/VectorFPtoIntCastTest.java failed with "IRViolationException: There were one or multiple IR rule failures."


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [5baf4623](https://git.openjdk.org/jdk/pull/9177/files/5baf4623ccf079b212b9477d62c0e775b9b33818)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9177/head:pull/9177` \
`$ git checkout pull/9177`

Update a local copy of the PR: \
`$ git checkout pull/9177` \
`$ git pull https://git.openjdk.org/jdk pull/9177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9177`

View PR using the GUI difftool: \
`$ git pr show -t 9177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9177.diff">https://git.openjdk.org/jdk/pull/9177.diff</a>

</details>
