### PR TITLE
8288005: HotSpot build with disabled PCH fails for Windows AArch64

### DIFF
--- a/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "logging/log.hpp"
 #include "runtime/os.hpp"
 #include "runtime/vm_version.hpp"
 


### PR DESCRIPTION
Added a header file include that fixes HotSpot build with disabled PCH for Windows AArch64.
Build successfully tested on Windows 10 x86_64 machine:
* with Visual Studio 2019 for AArch64 cross-compile,
* with Visual Studio 2017 & 2019 for x86_64 build.

Running tests on Windows and other platforms showed no regression after this patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288005](https://bugs.openjdk.org/browse/JDK-8288005): HotSpot build with disabled PCH fails for Windows AArch64


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9178/head:pull/9178` \
`$ git checkout pull/9178`

Update a local copy of the PR: \
`$ git checkout pull/9178` \
`$ git pull https://git.openjdk.org/jdk pull/9178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9178`

View PR using the GUI difftool: \
`$ git pr show -t 9178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9178.diff">https://git.openjdk.org/jdk/pull/9178.diff</a>

</details>
