### PR TITLE
JDK-8288556: VM crashes if it gets sent SIGUSR2 from outside

### DIFF
--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -1602,8 +1602,8 @@ static void SR_handler(int sig, siginfo_t* siginfo, ucontext_t* context) {
   // accidentally. In that case the receiving thread may not be attached to the VM. We handle
   // that case by asserting (debug VM) resp. writing a diagnostic message to tty and
   // otherwise ignoring the stray signal (release VMs).
-  // We print the full siginfo as part of the diagnostic message, which will contain the
-  // sender pid and thus allow the user to investigate the signal sender.
+  // We print the siginfo as part of the diagnostics, which also contains the sender pid of
+  // the stray signal.
   if (thread == nullptr) {
     stringStream ss;
     ss.print_raw("Non-attached thread received stray SR signal (");
@@ -1611,11 +1611,8 @@ static void SR_handler(int sig, siginfo_t* siginfo, ucontext_t* context) {
     ss.print_raw(").");
     assert(thread != NULL, "%s.", ss.base());
     tty->print_cr("%s", ss.base());
-    tty->flush();
     return;
   }
-
-  assert(thread != NULL, "Missing current thread in SR_handler (signal was sent by ");
 
   // On some systems we have seen signal delivery get "stuck" until the signal
   // mask is changed as part of thread termination. Check that the current thread

--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -1610,7 +1610,7 @@ static void SR_handler(int sig, siginfo_t* siginfo, ucontext_t* context) {
     os::print_siginfo(&ss, siginfo);
     ss.print_raw(").");
     assert(thread != NULL, "%s.", ss.base());
-    tty->print_cr("%s", ss.base());
+    log_warning(os)("%s", ss.base());
     return;
   }
 


### PR DESCRIPTION
The VM uses SIGUSR2 (can be overridden via _JAVA_SR_SIGNUM) to implement suspend/resume on java threads. It sends, via pthread_kill, SIGUSR2 to targeted threads to interrupt them. It knows the target thread, and the target thread is always a VM-attached thread.

However, if SIGUSR2 gets sent from outside, any thread may receive the signal, and if the target thread is not attached to the VM (e.g. primordial), it is unable to handle it. The result is an assert (debug VM) or a crash (release VM). On my box, this can be reliably reproduced by sending SIGUSR2 to any VM.

This has been discussed here: https://mail.openjdk.org/pipermail/core-libs-dev/2022-June/091450.html

The proposed solutions range from "works as designed" (on the ground that sending arbitrary signals to the JVM is an error in itself, and we should rather crash hard and fast) to "lets catch and ignore the signal".

----

In this patch I opt for:

- Debug: keep asserting, but make the message more helpful by including signal info for the stray SR signal. Includes sender pid and signal number (in case SR signal had been overridden).

```
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/shared/projects/openjdk/jdk-jdk/source/src/hotspot/os/posix/signals_posix.cpp:1611), pid=139712, tid=139712
#  assert(thread != __null) failed: Non-attached thread received stray SR signal (siginfo: si_signo: 12 (SIGUSR2), si_code: 0 (SI_USER), si_pid: 6681, si_uid: 1027)..
```
- Release: write a message to tty about this signal, including sender pid and signal name. Otherwise, ignore the signal, dont crash. Repeated signals will generate repeated output:

```
thomas@starfish:/shared/projects/openjdk/jdk-jdk/output-release$ ./images/jdk/bin/java -cp $REPROS_JAR de.stuefe.repros.Simple
<press key>
Non-attached thread received stray SR signal (siginfo: si_signo: 12 (SIGUSR2), si_code: 0 (SI_USER), si_pid: 239773, si_uid: 1027).
Non-attached thread received stray SR signal (siginfo: si_signo: 12 (SIGUSR2), si_code: 0 (SI_USER), si_pid: 239774, si_uid: 1027).
Non-attached thread received stray SR signal (siginfo: si_signo: 12 (SIGUSR2), si_code: 0 (SI_USER), si_pid: 239775, si_uid: 1027).
```

Notes:
- In release builds, we also could quit the VM instead of continuing. I prefer gracefully ignoring the signal, because in our experience quitting - regardless of how good the diagnostic message is - often just leads to frustrated users complaining about VMs mysteriously vanishing. Same goes for crashes, it just pools into the general "java is unstable" notion. I'm open for discussing this.
- I use tty for the diagnostic  message, which goes to stdout. I really dislike that, error output should go to stderr. But since the rest of the VM handles diagnostic output the same way, I use tty here too.

Thanks, Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288556](https://bugs.openjdk.org/browse/JDK-8288556): VM crashes if it gets sent SIGUSR2 from outside


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9181/head:pull/9181` \
`$ git checkout pull/9181`

Update a local copy of the PR: \
`$ git checkout pull/9181` \
`$ git pull https://git.openjdk.org/jdk pull/9181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9181`

View PR using the GUI difftool: \
`$ git pr show -t 9181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9181.diff">https://git.openjdk.org/jdk/pull/9181.diff</a>

</details>
