### PR TITLE
8287905: Reduce runtime of java.nio microbenchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/java/nio/channels/SelectOne.java
+++ b/test/micro/org/openjdk/bench/java/nio/channels/SelectOne.java
@@ -25,6 +25,8 @@ package org.openjdk.bench.java.nio.channels;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
@@ -32,6 +34,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -52,6 +55,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3)
 public class SelectOne {
     private Selector sel;
     private List<SocketChannel> clients;

--- a/test/micro/org/openjdk/bench/java/nio/channels/SelectorWakeup.java
+++ b/test/micro/org/openjdk/bench/java/nio/channels/SelectorWakeup.java
@@ -24,10 +24,13 @@
 package org.openjdk.bench.java.nio.channels;
 
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.io.*;
 import java.net.*;
@@ -39,6 +42,9 @@ import java.nio.channels.*;
  * epoll(7)-based implementation on Linux.
  */
 @State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3)
 public class SelectorWakeup {
     private Selector sel;
 


### PR DESCRIPTION
Reduce runtime by reducing number of forks, iterations..

Most benchmarks in the java.nio packages already had sensible configuration, so this reduces estimated runtime by a small amount (~5h42m -> ~5s03m)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287905](https://bugs.openjdk.org/browse/JDK-8287905): Reduce runtime of java.nio microbenchmarks


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9183/head:pull/9183` \
`$ git checkout pull/9183`

Update a local copy of the PR: \
`$ git checkout pull/9183` \
`$ git pull https://git.openjdk.org/jdk pull/9183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9183`

View PR using the GUI difftool: \
`$ git pr show -t 9183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9183.diff">https://git.openjdk.org/jdk/pull/9183.diff</a>

</details>
