### PR TITLE
8288567: [macOS] NPE at sun.lwawt.macosx.CPlatformComponent.setBounds

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformComponent.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformComponent.java
@@ -30,6 +30,7 @@ import java.awt.Insets;
 
 import sun.lwawt.PlatformComponent;
 import sun.lwawt.PlatformWindow;
+import sun.lwawt.LWWindowPeer;
 
 /**
  * On OSX {@code CPlatformComponent} stores pointer to the native CAlayer which
@@ -63,7 +64,8 @@ class CPlatformComponent extends CFRetainedResource
     public void setBounds(final int x, final int y, final int w, final int h) {
         // translates values from the coordinate system of the top-level window
         // to the coordinate system of the content view
-        final Insets insets = platformWindow.getPeer().getInsets();
+        final LWWindowPeer peer = platformWindow.getPeer();
+        final Insets insets = (peer != null) ? peer.getInsets() : new Insets(0, 0, 0, 0);
         execute(ptr->nativeSetBounds(ptr, x - insets.left, y - insets.top, w, h));
     }
 


### PR DESCRIPTION
Even though I have not been able to reproduce the crash by hand, the problem and the fix are fairly obvious: 
`CWarningWindow` doesn't have a peer, so `platformWindow.getPeer()` can be null in that case. The fix is to accomodate for that in `CPlatformComponent.setBounds()`. Similar provisions exist elsewhere in the vicinity (for ex. `CPlatformLWWindow.setBounds()`, `CPlatformWindow.maximize()`, etc).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288567](https://bugs.openjdk.org/browse/JDK-8288567): [macOS] NPE at sun.lwawt.macosx.CPlatformComponent.setBounds


### Reviewers
 * @kristylee88 (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9184/head:pull/9184` \
`$ git checkout pull/9184`

Update a local copy of the PR: \
`$ git checkout pull/9184` \
`$ git pull https://git.openjdk.org/jdk pull/9184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9184`

View PR using the GUI difftool: \
`$ git pr show -t 9184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9184.diff">https://git.openjdk.org/jdk/pull/9184.diff</a>

</details>
