### PR TITLE
8288415: java/awt/PopupMenu/PopupMenuLocation.java is unstable in MacOS machines

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -450,7 +450,6 @@ java/awt/event/MouseEvent/ClickDuringKeypress/ClickDuringKeypress.java 8233568 m
 java/awt/event/KeyEvent/DeadKey/DeadKeyMacOSXInputText.java 8233568 macosx-all
 java/awt/event/KeyEvent/DeadKey/deadKeyMacOSX.java 8233568 macosx-all
 java/awt/TrayIcon/RightClickWhenBalloonDisplayed/RightClickWhenBalloonDisplayed.java 8238720 windows-all
-java/awt/PopupMenu/PopupMenuLocation.java 8238720 windows-all
 java/awt/GridLayout/ComponentPreferredSize/ComponentPreferredSize.java 8238720 windows-all
 java/awt/GridLayout/ChangeGridSize/ChangeGridSize.java   8238720 windows-all
 java/awt/event/MouseEvent/FrameMouseEventAbsoluteCoordsTest/FrameMouseEventAbsoluteCoordsTest.java

--- a/test/jdk/java/awt/PopupMenu/PopupMenuLocation.java
+++ b/test/jdk/java/awt/PopupMenu/PopupMenuLocation.java
@@ -66,7 +66,7 @@ public final class PopupMenuLocation {
         for (GraphicsDevice sd : sds) {
             GraphicsConfiguration gc = sd.getDefaultConfiguration();
             Rectangle bounds = gc.getBounds();
-            Point point = new Point(bounds.x + 20, bounds.y + 20);
+            Point point = new Point(bounds.x, bounds.y);
             Insets insets = Toolkit.getDefaultToolkit().getScreenInsets(gc);
             while (point.y < bounds.y + bounds.height - insets.bottom - SIZE) {
                 while (point.x <
@@ -116,12 +116,12 @@ public final class PopupMenuLocation {
 
     private static void openPopup(final Frame frame) throws Exception {
         robot.waitForIdle();
-        Point loc = frame.getLocationOnScreen();
-        robot.mouseMove(loc.x + frame.getWidth() / 2, loc.y + 50);
+        Point pt = frame.getLocationOnScreen();
+        robot.mouseMove(pt.x + frame.getWidth() / 2, pt.y + 50);
         robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
-        int x = loc.x + frame.getWidth() / 2;
-        int y = loc.y + 130;
+        int x = pt.x + frame.getWidth() / 2;
+        int y = pt.y + 130;
         robot.mouseMove(x, y);
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);


### PR DESCRIPTION
java/awt/PopupMenu/PopupMenuLocation.java seems to be unstable in MacOS machines, especially in MacOSX 12 machines. It seems to be a testbug as adding some stability improvements fix the issue. It intermittently fails in CI causing some noise. This test was already problem listed in windows due to an umbrella bug JDK-8238720. I have removed the problem listing and tested it in windows platform also, it works fine there.

Fix:
Some stability improvements have been done and the test has been run 100 times per platform in mach5 and got full PASS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288415](https://bugs.openjdk.org/browse/JDK-8288415): java/awt/PopupMenu/PopupMenuLocation.java is unstable in MacOS machines


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9187/head:pull/9187` \
`$ git checkout pull/9187`

Update a local copy of the PR: \
`$ git checkout pull/9187` \
`$ git pull https://git.openjdk.org/jdk pull/9187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9187`

View PR using the GUI difftool: \
`$ git pr show -t 9187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9187.diff">https://git.openjdk.org/jdk/pull/9187.diff</a>

</details>
