### PR TITLE
8288594: Address possibly lossy conversions in java.base FloatToDecimal

### DIFF
--- a/src/java.base/share/classes/jdk/internal/math/FloatToDecimal.java
+++ b/src/java.base/share/classes/jdk/internal/math/FloatToDecimal.java
@@ -356,7 +356,7 @@ final public class FloatToDecimal {
          *     10^(H-1) <= f < 10^H
          *     fp 10^ep = f 10^(e-H) = 0.f 10^e
          */
-        f *= pow10(H - len);
+        f *= (int)pow10(H - len);
         e += len;
 
         /*


### PR DESCRIPTION
One new case of possibly lossy conversions recently appeared in jdk.internal.math.FloatToDecimal.
This patch avoids the warning by explicit cast from long to int.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288594](https://bugs.openjdk.org/browse/JDK-8288594): Address possibly lossy conversions in java.base FloatToDecimal


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9188/head:pull/9188` \
`$ git checkout pull/9188`

Update a local copy of the PR: \
`$ git checkout pull/9188` \
`$ git pull https://git.openjdk.org/jdk pull/9188/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9188`

View PR using the GUI difftool: \
`$ git pr show -t 9188`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9188.diff">https://git.openjdk.org/jdk/pull/9188.diff</a>

</details>
