### PR TITLE
8288568: Reduce runtime of java.security microbenchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/java/security/AlgorithmConstraintsPermits.java
+++ b/test/micro/org/openjdk/bench/java/security/AlgorithmConstraintsPermits.java
@@ -25,12 +25,14 @@ package org.openjdk.bench.java.security;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 import sun.security.util.DisabledAlgorithmConstraints;
 
 import java.security.AlgorithmConstraints;
@@ -43,8 +45,10 @@ import static sun.security.util.DisabledAlgorithmConstraints.PROPERTY_TLS_DISABL
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(jvmArgsAppend = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
+@Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
 @State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
 public class AlgorithmConstraintsPermits {
 
     AlgorithmConstraints tlsDisabledAlgConstraints;

--- a/test/micro/org/openjdk/bench/java/security/CacheBench.java
+++ b/test/micro/org/openjdk/bench/java/security/CacheBench.java
@@ -27,6 +27,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
@@ -38,11 +39,14 @@ import org.openjdk.jmh.annotations.TearDown;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
+import org.openjdk.jmh.annotations.Warmup;
 import sun.security.util.Cache;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(jvmArgsAppend = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED", "-Xmx1g"})
+@Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED", "-Xmx1g"})
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
 public class CacheBench {
 
     @State(Scope.Benchmark)

--- a/test/micro/org/openjdk/bench/java/security/CipherSuiteBench.java
+++ b/test/micro/org/openjdk/bench/java/security/CipherSuiteBench.java
@@ -30,10 +30,12 @@ import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
 
 
-@Fork(jvmArgsAppend = {"--add-exports", "java.base/sun.security.ssl=ALL-UNNAMED", "--add-opens", "java.base/sun.security.ssl=ALL-UNNAMED"})
+@Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/sun.security.ssl=ALL-UNNAMED", "--add-opens", "java.base/sun.security.ssl=ALL-UNNAMED"})
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
 public class CipherSuiteBench {
 
     Method nameOf;
@@ -53,6 +55,6 @@ public class CipherSuiteBench {
 
     @Benchmark
     public Object benchmarkCipherSuite() throws InvocationTargetException, IllegalAccessException {
-        return nameOf.invoke(null,cipherSuite);
+        return nameOf.invoke(null, cipherSuite);
     }
 }

--- a/test/micro/org/openjdk/bench/java/security/DoPrivileged.java
+++ b/test/micro/org/openjdk/bench/java/security/DoPrivileged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/security/DoPrivileged.java
+++ b/test/micro/org/openjdk/bench/java/security/DoPrivileged.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.security;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -40,6 +43,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3)
 public class DoPrivileged {
 
     private PrivilegedAction<Integer> privilegedAction;

--- a/test/micro/org/openjdk/bench/java/security/GetContext.java
+++ b/test/micro/org/openjdk/bench/java/security/GetContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/security/GetContext.java
+++ b/test/micro/org/openjdk/bench/java/security/GetContext.java
@@ -26,11 +26,14 @@ package org.openjdk.bench.java.security;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.security.AccessControlContext;
 import java.security.AccessController;
@@ -43,6 +46,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3)
 public abstract class GetContext {
 
     public static class Top extends GetContext {

--- a/test/micro/org/openjdk/bench/java/security/GetMessageDigest.java
+++ b/test/micro/org/openjdk/bench/java/security/GetMessageDigest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/security/GetMessageDigest.java
+++ b/test/micro/org/openjdk/bench/java/security/GetMessageDigest.java
@@ -47,7 +47,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 5, time = 1)
-@Measurement(iterations = 10, time = 1)
+@Measurement(iterations = 5, time = 1)
 @Fork(value = 3)
 public class GetMessageDigest {
 

--- a/test/micro/org/openjdk/bench/java/security/MessageDigests.java
+++ b/test/micro/org/openjdk/bench/java/security/MessageDigests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/security/MessageDigests.java
+++ b/test/micro/org/openjdk/bench/java/security/MessageDigests.java
@@ -45,18 +45,18 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @State(Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgsAppend = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 5)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(jvmArgsAppend = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 3)
 public class MessageDigests {
 
-    @Param({"64", "1024", "16384"})
+    @Param({"64", "16384"})
     private int length;
 
-    @Param({"md2", "md5", "SHA-1", "SHA-224", "SHA-256", "SHA-384", "SHA-512", "SHA3-224", "SHA3-256", "SHA3-384", "SHA3-512"})
+    @Param({"md5", "SHA-1", "SHA-224", "SHA-256", "SHA-384", "SHA-512", "SHA3-256", "SHA3-512"})
     private String digesterName;
 
-    @Param({"DEFAULT", "SUN"})
+    @Param({"DEFAULT"})
     protected String provider;
 
     private byte[] inputBytes;

--- a/test/micro/org/openjdk/bench/java/security/PKCS12KeyStores.java
+++ b/test/micro/org/openjdk/bench/java/security/PKCS12KeyStores.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/security/PKCS12KeyStores.java
+++ b/test/micro/org/openjdk/bench/java/security/PKCS12KeyStores.java
@@ -38,10 +38,10 @@ import org.openjdk.jmh.annotations.*;
  */
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Warmup(iterations = 2)
-@Measurement(iterations = 10)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
 @BenchmarkMode(Mode.AverageTime)
-@Fork(jvmArgsAppend = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 5)
+@Fork(jvmArgsAppend = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 3)
 public class PKCS12KeyStores {
 
     private static final char[] PASS = "changeit".toCharArray();

--- a/test/micro/org/openjdk/bench/java/security/PermissionsImplies.java
+++ b/test/micro/org/openjdk/bench/java/security/PermissionsImplies.java
@@ -42,8 +42,8 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
-@Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
 @Fork(3)
 @State(Scope.Thread)
 public class PermissionsImplies {

--- a/test/micro/org/openjdk/bench/java/security/SSLHandshake.java
+++ b/test/micro/org/openjdk/bench/java/security/SSLHandshake.java
@@ -51,6 +51,9 @@ import javax.net.ssl.TrustManagerFactory;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3)
 public class SSLHandshake {
 
     private SSLContext sslc;

--- a/test/micro/org/openjdk/bench/java/security/SSLHandshake.java
+++ b/test/micro/org/openjdk/bench/java/security/SSLHandshake.java
@@ -51,8 +51,8 @@ import javax.net.ssl.TrustManagerFactory;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
-@Warmup(iterations = 5, time = 1)
-@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 5, time = 5)
+@Measurement(iterations = 5, time = 5)
 @Fork(value = 3)
 public class SSLHandshake {
 
@@ -112,9 +112,6 @@ public class SSLHandshake {
      * The client and the server both operate on the same thread.
      */
     @Benchmark
-    @Warmup(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
-    @Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
-    @Fork(3)
     public SSLSession doHandshake() throws Exception {
 
         createSSLEngines();


### PR DESCRIPTION
- Reduce forks, iteration, runtime to reduce runtime while maintaining high data quality on typical benchmarking hosts.

Reduces runtime from estimated 10+ hours to 54 minutes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288568](https://bugs.openjdk.org/browse/JDK-8288568): Reduce runtime of java.security microbenchmarks


### Reviewers
 * [Eric Caspole](https://openjdk.org/census#ecaspole) (@ericcaspole - Committer) ⚠️ Review applies to [263c0ae3](https://git.openjdk.org/jdk/pull/9189/files/263c0ae3494b7f48cb372af6fa1f1bd13a29e35d)
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - Committer) ⚠️ Review applies to [8330c018](https://git.openjdk.org/jdk/pull/9189/files/8330c018479c66230a3a6a021e1f274ff27fed4b)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to [8330c018](https://git.openjdk.org/jdk/pull/9189/files/8330c018479c66230a3a6a021e1f274ff27fed4b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9189/head:pull/9189` \
`$ git checkout pull/9189`

Update a local copy of the PR: \
`$ git checkout pull/9189` \
`$ git pull https://git.openjdk.org/jdk pull/9189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9189`

View PR using the GUI difftool: \
`$ git pr show -t 9189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9189.diff">https://git.openjdk.org/jdk/pull/9189.diff</a>

</details>
