### PR TITLE
8288601: Consolidate static/dynamic archive tables

### DIFF
--- a/src/hotspot/share/cds/dumpTimeClassInfo.hpp
+++ b/src/hotspot/share/cds/dumpTimeClassInfo.hpp
@@ -24,7 +24,6 @@
 
 #ifndef SHARED_CDS_DUMPTIMESHAREDCLASSINFO_HPP
 #define SHARED_CDS_DUMPTIMESHAREDCLASSINFO_HPP
-
 #include "cds/archiveBuilder.hpp"
 #include "cds/archiveUtils.hpp"
 #include "cds/metaspaceShared.hpp"

--- a/src/hotspot/share/cds/dumpTimeClassInfo.hpp
+++ b/src/hotspot/share/cds/dumpTimeClassInfo.hpp
@@ -24,6 +24,7 @@
 
 #ifndef SHARED_CDS_DUMPTIMESHAREDCLASSINFO_HPP
 #define SHARED_CDS_DUMPTIMESHAREDCLASSINFO_HPP
+
 #include "cds/archiveBuilder.hpp"
 #include "cds/archiveUtils.hpp"
 #include "cds/metaspaceShared.hpp"

--- a/src/hotspot/share/cds/runTimeClassInfo.cpp
+++ b/src/hotspot/share/cds/runTimeClassInfo.cpp
@@ -24,7 +24,9 @@
 
 #include "precompiled.hpp"
 #include "cds/archiveBuilder.hpp"
+#include "cds/dumpTimeClassInfo.hpp"
 #include "cds/runTimeClassInfo.hpp"
+#include "classfile/systemDictionaryShared.hpp"
 
 void RunTimeClassInfo::init(DumpTimeClassInfo& info) {
   ArchiveBuilder* builder = ArchiveBuilder::current();

--- a/src/hotspot/share/cds/runTimeClassInfo.hpp
+++ b/src/hotspot/share/cds/runTimeClassInfo.hpp
@@ -24,9 +24,9 @@
 
 #ifndef SHARED_CDS_SHAREDCLASSINFO_HPP
 #define SHARED_CDS_SHAREDCLASSINFO_HPP
+
 #include "classfile/compactHashtable.hpp"
 #include "classfile/javaClasses.hpp"
-#include "classfile/systemDictionaryShared.hpp"
 #include "cds/archiveBuilder.hpp"
 #include "cds/archiveUtils.hpp"
 #include "cds/metaspaceShared.hpp"
@@ -36,6 +36,7 @@
 #include "utilities/growableArray.hpp"
 #include "utilities/resourceHash.hpp"
 
+class DumpTimeClassInfo;
 class Method;
 class Symbol;
 
@@ -46,7 +47,7 @@ public:
     int _clsfile_crc32;
   };
 
-  // This is different than  DumpTimeClassInfo::DTVerifierConstraint. We use
+  // This is different than DumpTimeClassInfo::DTVerifierConstraint. We use
   // u4 instead of Symbol* to save space on 64-bit CPU.
   struct RTVerifierConstraint {
     u4 _name;


### PR DESCRIPTION
Please review this small clean-up of almost identical code that handles the tables for the static and dynamic archives.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288601](https://bugs.openjdk.org/browse/JDK-8288601): Consolidate static/dynamic archive tables


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**) ⚠️ Review applies to [1d15341b](https://git.openjdk.org/jdk/pull/9190/files/1d15341bf0ec495df98d60dd33547476ed9b337d)
 * @kristylee88 (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9190/head:pull/9190` \
`$ git checkout pull/9190`

Update a local copy of the PR: \
`$ git checkout pull/9190` \
`$ git pull https://git.openjdk.org/jdk pull/9190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9190`

View PR using the GUI difftool: \
`$ git pr show -t 9190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9190.diff">https://git.openjdk.org/jdk/pull/9190.diff</a>

</details>
