### PR TITLE
JDK-8288573: Make Executable.getParameterCount() actually abstract

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -253,9 +253,7 @@ public abstract sealed class Executable extends AccessibleObject
      * @return The number of formal parameters for the executable this
      * object represents
      */
-    public int getParameterCount() {
-        throw new AbstractMethodError();
-    }
+    public abstract int getParameterCount();
 
     /**
      * Returns an array of {@code Type} objects that represent the


### PR DESCRIPTION
Whatever the motivation for how this method was coded when added in JDK 8, since Executable is now a sealed class with Constructor and Method the only allowed subclasses, getParameterCount can be coded as an normal abstract method. (The implementation of getParameterCount in Method and Constructor use fields private to each of those classes so the code cannot easily be shared in Executable).

Please also review the small accompanying CSR: https://bugs.openjdk.org/browse/JDK-8288630

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8288573](https://bugs.openjdk.org/browse/JDK-8288573): Make Executable.getParameterCount() actually abstract
 * [JDK-8288630](https://bugs.openjdk.org/browse/JDK-8288630): Make Executable.getParameterCount() actually abstract (**CSR**)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [f1a3116c](https://git.openjdk.org/jdk/pull/9192/files/f1a3116c6f76224ec2898f1fa9e611f366c68368)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [f1a3116c](https://git.openjdk.org/jdk/pull/9192/files/f1a3116c6f76224ec2898f1fa9e611f366c68368)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [f1a3116c](https://git.openjdk.org/jdk/pull/9192/files/f1a3116c6f76224ec2898f1fa9e611f366c68368)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9192/head:pull/9192` \
`$ git checkout pull/9192`

Update a local copy of the PR: \
`$ git checkout pull/9192` \
`$ git pull https://git.openjdk.org/jdk pull/9192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9192`

View PR using the GUI difftool: \
`$ git pr show -t 9192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9192.diff">https://git.openjdk.org/jdk/pull/9192.diff</a>

</details>
