### PR TITLE
8288589: Files.readString ignores encoding errors for UTF-16

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -658,6 +658,8 @@ public final class String
 
             // decode using CharsetDecoder
             int en = scale(length, cd.maxCharsPerByte());
+            cd.onMalformedInput(CodingErrorAction.REPLACE)
+                    .onUnmappableCharacter(CodingErrorAction.REPLACE);
             char[] ca = new char[en];
             if (charset.getClass().getClassLoader0() != null &&
                     System.getSecurityManager() != null) {
@@ -665,7 +667,13 @@ public final class String
                 offset = 0;
             }
 
-            int caLen = decodeWithDecoder(cd, ca, bytes, offset, length);
+            int caLen;
+            try {
+                caLen = decodeWithDecoder(cd, ca, bytes, offset, length);
+            } catch (CharacterCodingException x) {
+                // Substitution is enabled, so this shouldn't happen
+                throw new Error(x);
+            }
             if (COMPACT_STRINGS) {
                 byte[] bs = StringUTF16.compress(ca, 0, caLen);
                 if (bs != null) {
@@ -791,7 +799,13 @@ public final class String
                 System.getSecurityManager() != null) {
             src = Arrays.copyOf(src, len);
         }
-        int caLen = decodeWithDecoder(cd, ca, src, 0, src.length);
+        int caLen;
+        try {
+            caLen = decodeWithDecoder(cd, ca, src, 0, src.length);
+        } catch (CharacterCodingException x) {
+            // throw via IAE
+            throw new IllegalArgumentException(x);
+        }
         if (COMPACT_STRINGS) {
             byte[] bs = StringUTF16.compress(ca, 0, caLen);
             if (bs != null) {
@@ -1199,23 +1213,16 @@ public final class String
         return dp;
     }
 
-    private static int decodeWithDecoder(CharsetDecoder cd, char[] dst, byte[] src, int offset, int length) {
+    private static int decodeWithDecoder(CharsetDecoder cd, char[] dst, byte[] src, int offset, int length)
+                                            throws CharacterCodingException {
         ByteBuffer bb = ByteBuffer.wrap(src, offset, length);
         CharBuffer cb = CharBuffer.wrap(dst, 0, dst.length);
-        cd.onMalformedInput(CodingErrorAction.REPLACE)
-            .onUnmappableCharacter(CodingErrorAction.REPLACE);
-        try {
-            CoderResult cr = cd.decode(bb, cb, true);
-            if (!cr.isUnderflow())
-                cr.throwException();
-            cr = cd.flush(cb);
-            if (!cr.isUnderflow())
-                cr.throwException();
-        } catch (CharacterCodingException x) {
-            // Substitution is always enabled,
-            // so this shouldn't happen
-            throw new Error(x);
-        }
+        CoderResult cr = cd.decode(bb, cb, true);
+        if (!cr.isUnderflow())
+            cr.throwException();
+        cr = cd.flush(cb);
+        if (!cr.isUnderflow())
+            cr.throwException();
         return cb.position();
     }
 

--- a/test/jdk/java/lang/String/NewStringNoRepl.java
+++ b/test/jdk/java/lang/String/NewStringNoRepl.java
@@ -23,11 +23,12 @@
 
 /*
  * @test
- * @bug 8286287
- * @summary Verifies newStringNoRepl() does not throw an Error.
+ * @bug 8286287 8288589
+ * @summary Verifies newStringNoRepl() throws a CharacterCodingException.
  */
 
 import java.io.IOException;
+import java.nio.charset.CharacterCodingException;
 import java.nio.file.Files;
 import java.util.HexFormat;
 import static java.nio.charset.StandardCharsets.UTF_16;
@@ -39,12 +40,16 @@ public class NewStringNoRepl {
         var f = Files.createTempFile(null, null);
         try (var fos = Files.newOutputStream(f)) {
             fos.write(MALFORMED_UTF16);
+            var read = Files.readString(f, UTF_16);
+            throw new RuntimeException("Exception should be thrown for a malformed input. Bytes read: " +
+                    HexFormat.of()
+                            .withPrefix("x")
+                            .withUpperCase()
+                            .formatHex(read.getBytes(UTF_16)));
+        } catch (CharacterCodingException cce) {
+            // success
+        } finally {
+            Files.delete(f);
         }
-        System.out.println("Returned bytes: " +
-            HexFormat.of()
-                .withPrefix("x")
-                .withUpperCase()
-                .formatHex(Files.readString(f, UTF_16).getBytes(UTF_16)));
-        Files.delete(f);
     }
 }


### PR DESCRIPTION
This is a regression caused by the fix to [JDK-8286287](https://bugs.openjdk.org/browse/JDK-8286287), which assumed the method `String.decodeWithDecoder()` was only invoked with cs.REPLACE mode based on the comment "should not happen". Possibly this refers to the `String(byte[], int, int, Charset)` constructor, which specifically mentions the `REPLACE` mode. However, the method is invoked with `String.newStringNoRepl()` and it should NOT replace the malformed input (duh!). The fix is to throw an `Error` for the former case as before the regression, and `CharacterCodingException` for the latter via an `IllegalArgumentException`.
In fact, `Files.readString()` stopped throwing a `MalformedInputException` since JDK17 with the fix to JDK-8259842, which started throwing an `Error`.