### PR TITLE
8288528: broken links in java.desktop

### DIFF
--- a/src/java.desktop/share/classes/java/awt/doc-files/AWTThreadIssues.html
+++ b/src/java.desktop/share/classes/java/awt/doc-files/AWTThreadIssues.html
@@ -121,7 +121,7 @@ Implementation-dependent behavior.
 Prior to 1.4, the helper threads were never terminated.
 <p>
 Starting with 1.4, the behavior has changed as a result of the fix for
-<a href="https://bugs.java.com/view_bug.do?bug_id=4030718">
+<a href="https://bugs.openjdk.org/browse/JDK-4030718">
 4030718</a>. With the current implementation, AWT terminates all its
 helper threads allowing the application to exit cleanly when the
 following three conditions are true:
@@ -154,11 +154,11 @@ will exit cleanly in all cases. Two examples:
 <ul>
   <li> Other packages can create displayable components for internal
        needs and never make them undisplayable. See
-<a href="https://bugs.java.com/view_bug.do?bug_id=4515058">
+<a href="https://bugs.openjdk.org/browse/JDK-4515058">
 4515058</a>,
-<a href="https://bugs.java.com/view_bug.do?bug_id=4671025">
+<a href="https://bugs.openjdk.org/browse/JDK-4671025">
 4671025</a>, and
-<a href="https://bugs.java.com/view_bug.do?bug_id=4465537">
+<a href="https://bugs.openjdk.org/browse/JDK-4465537">
 4465537</a>.
   <li> Both Microsoft Windows and X11 allow an application to send native
        events to windows that belong to another application. With this

--- a/src/java.desktop/share/classes/java/awt/doc-files/AWTThreadIssues.html
+++ b/src/java.desktop/share/classes/java/awt/doc-files/AWTThreadIssues.html
@@ -153,13 +153,7 @@ exit cleanly under normal conditions, it is not guaranteed that it
 will exit cleanly in all cases. Two examples:
 <ul>
   <li> Other packages can create displayable components for internal
-       needs and never make them undisplayable. See
-<a href="https://bugs.openjdk.org/browse/JDK-4515058">
-4515058</a>,
-<a href="https://bugs.openjdk.org/browse/JDK-4671025">
-4671025</a>, and
-<a href="https://bugs.openjdk.org/browse/JDK-4465537">
-4465537</a>.
+       needs and never make them undisplayable.
   <li> Both Microsoft Windows and X11 allow an application to send native
        events to windows that belong to another application. With this
        feature it is possible to write a malicious program that will

--- a/src/java.desktop/share/classes/javax/imageio/plugins/tiff/ExifTIFFTagSet.java
+++ b/src/java.desktop/share/classes/javax/imageio/plugins/tiff/ExifTIFFTagSet.java
@@ -32,8 +32,8 @@ import java.util.List;
  * A class representing the tags found in an Exif IFD.  Exif is a
  * standard for annotating images used by most digital camera
  * manufacturers.  The Exif specification may be found at
- * <a href="http://web.archive.org/web/20131018091152/http://exif.org/Exif2-2.PDF">
- * {@code http://web.archive.org/web/20131018091152/http://exif.org/Exif2-2.PDF}
+ * <a href="https://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf">
+ * {@code https://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf}
  * </a>.
  *
  * <p> The definitions of the data types referenced by the field

--- a/src/java.desktop/share/classes/javax/imageio/plugins/tiff/ExifTIFFTagSet.java
+++ b/src/java.desktop/share/classes/javax/imageio/plugins/tiff/ExifTIFFTagSet.java
@@ -32,8 +32,8 @@ import java.util.List;
  * A class representing the tags found in an Exif IFD.  Exif is a
  * standard for annotating images used by most digital camera
  * manufacturers.  The Exif specification may be found at
- * <a href="http://www.exif.org/Exif2-2.PDF">
- * {@code http://www.exif.org/Exif2-2.PDF}
+ * <a href="http://web.archive.org/web/20131018091152/http://exif.org/Exif2-2.PDF">
+ * {@code http://web.archive.org/web/20131018091152/http://exif.org/Exif2-2.PDF}
  * </a>.
  *
  * <p> The definitions of the data types referenced by the field

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
@@ -2139,7 +2139,7 @@ public class MetalLookAndFeel extends BasicLookAndFeel
 
 
     /**
-     * Returns a {@code LayoutStyle} implementing Java look and feel
+     * Returns a {@code LayoutStyle} implementing the Java look and feel
      * design guidelines.
      *
      * @return LayoutStyle implementing the Java look and feel design

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
@@ -2139,9 +2139,8 @@ public class MetalLookAndFeel extends BasicLookAndFeel
 
 
     /**
-     * Returns a {@code LayoutStyle} implementing the Java look and feel
-     * design guidelines as specified at
-     * <a href="http://www.oracle.com/technetwork/java/hig-136467.html">http://www.oracle.com/technetwork/java/hig-136467.html</a>.
+     * Returns a {@code LayoutStyle} implementing Java look and feel
+     * design guidelines.
      *
      * @return LayoutStyle implementing the Java look and feel design
      *         guidelines

--- a/src/java.desktop/share/classes/javax/swing/plaf/multi/doc-files/multi_tsc.html
+++ b/src/java.desktop/share/classes/javax/swing/plaf/multi/doc-files/multi_tsc.html
@@ -39,7 +39,7 @@
 <i>
 This document is based on an article
 originally published in
-<a href="http://www.oracle.com/technetwork/java/javase/tech/articles-jsp-139072.html"
+<a href="https://www.comp.nus.edu.sg/~cs3283/ftp/Java/swingConnect/archive/plaf_papers_arch/multi_update/multi_update.html"
    target="_top"><em>The Swing Connection</em></a>.
 </i>
 </p>

--- a/src/java.desktop/share/classes/javax/swing/plaf/multi/doc-files/multi_tsc.html
+++ b/src/java.desktop/share/classes/javax/swing/plaf/multi/doc-files/multi_tsc.html
@@ -33,19 +33,6 @@
 <main role="main">
 <h1>Using the Multiplexing Look and Feel</h1>
 
-<blockquote>
-<hr>
-<p>
-<i>
-This document is based on an article
-originally published in
-<a href="https://www.comp.nus.edu.sg/~cs3283/ftp/Java/swingConnect/archive/plaf_papers_arch/multi_update/multi_update.html"
-   target="_top"><em>The Swing Connection</em></a>.
-</i>
-</p>
-<hr>
-</blockquote>
-
 <p>
 The Multiplexing look and feel lets
 you supplement an ordinary look and feel


### PR DESCRIPTION
doccheck reports some broken links which are rectified

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288528](https://bugs.openjdk.org/browse/JDK-8288528): broken links in java.desktop


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**) ⚠️ Review applies to [83910eb0](https://git.openjdk.org/jdk/pull/9195/files/83910eb00a989deb98110e59b047cdd373c32de2)
 * @kristylee88 (no known github.com user name / role) ⚠️ Review applies to [83910eb0](https://git.openjdk.org/jdk/pull/9195/files/83910eb00a989deb98110e59b047cdd373c32de2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9195/head:pull/9195` \
`$ git checkout pull/9195`

Update a local copy of the PR: \
`$ git checkout pull/9195` \
`$ git pull https://git.openjdk.org/jdk pull/9195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9195`

View PR using the GUI difftool: \
`$ git pr show -t 9195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9195.diff">https://git.openjdk.org/jdk/pull/9195.diff</a>

</details>
