### PR TITLE
8288667: Reduce runtime of java.text microbenchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/java/text/DefFormatterBench.java
+++ b/test/micro/org/openjdk/bench/java/text/DefFormatterBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,8 +32,8 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
@@ -43,20 +43,28 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Warmup(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
-@Fork(1)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(3)
 @State(Scope.Benchmark)
 public class DefFormatterBench {
 
-    @Param({"1.23", "1.49", "1.80", "1.7", "0.0", "-1.49", "-1.50", "9999.9123", "1.494", "1.495", "1.03", "25.996", "-25.996"})
-    public double value;
+    public double[] values;
 
-    private DefNumerFormat dnf = new DefNumerFormat();
+    @Setup
+    public void setup() {
+        values = new double[] {
+            1.23, 1.49, 1.80, 1.7, 0.0, -1.49, -1.50, 9999.9123, 1.494, 1.495, 1.03, 25.996, -25.996
+        };
+    }
+
+    private DefNumberFormat dnf = new DefNumberFormat();
 
     @Benchmark
     public void testDefNumberFormatter(final Blackhole blackhole) {
-        blackhole.consume(this.dnf.format(this.value));
+        for (double value : values) {
+            blackhole.consume(this.dnf.format(value));
+        }
     }
 
     public static void main(String... args) throws Exception {
@@ -64,11 +72,11 @@ public class DefFormatterBench {
         new Runner(opts).run();
     }
 
-    private static class DefNumerFormat {
+    private static class DefNumberFormat {
 
         private final NumberFormat n;
 
-        public DefNumerFormat() {
+        public DefNumberFormat() {
             this.n = NumberFormat.getInstance(Locale.ENGLISH);
             this.n.setMaximumFractionDigits(2);
             this.n.setMinimumFractionDigits(2);

--- a/test/micro/org/openjdk/bench/java/text/DefFormatterBench.java
+++ b/test/micro/org/openjdk/bench/java/text/DefFormatterBench.java
@@ -31,6 +31,7 @@ import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -61,6 +62,7 @@ public class DefFormatterBench {
     private DefNumberFormat dnf = new DefNumberFormat();
 
     @Benchmark
+    @OperationsPerInvocation(13)
     public void testDefNumberFormatter(final Blackhole blackhole) {
         for (double value : values) {
             blackhole.consume(this.dnf.format(value));


### PR DESCRIPTION
- Refactor micro using a range of parameters to a simpler benchmark that tests different values in one pass
- Reduce iterations and their runtimes, but add forks (important to be able to detect run-to-run variation anomalies)

Just one micro modified in this package, but reduces total runtime from 16 minutes to ~1 minute

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288667](https://bugs.openjdk.org/browse/JDK-8288667): Reduce runtime of java.text microbenchmarks


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**) ⚠️ Review applies to [28016417](https://git.openjdk.org/jdk/pull/9198/files/280164176b7c2e300147b4221ccf18f4106d1b46)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9198/head:pull/9198` \
`$ git checkout pull/9198`

Update a local copy of the PR: \
`$ git checkout pull/9198` \
`$ git pull https://git.openjdk.org/jdk pull/9198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9198`

View PR using the GUI difftool: \
`$ git pr show -t 9198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9198.diff">https://git.openjdk.org/jdk/pull/9198.diff</a>

</details>
