### PR TITLE
8288673: Reduce runtime of java.time microbenchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/java/time/GetYearBench.java
+++ b/test/micro/org/openjdk/bench/java/time/GetYearBench.java
@@ -55,8 +55,8 @@ import org.openjdk.jmh.infra.Blackhole;
  */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
 @Fork(3)
 @State(Scope.Benchmark)
 public class GetYearBench {

--- a/test/micro/org/openjdk/bench/java/time/InstantBench.java
+++ b/test/micro/org/openjdk/bench/java/time/InstantBench.java
@@ -47,8 +47,8 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
 @Fork(3)
 @State(Scope.Benchmark)
 public class InstantBench {

--- a/test/micro/org/openjdk/bench/java/time/format/DateTimeFormatterBench.java
+++ b/test/micro/org/openjdk/bench/java/time/format/DateTimeFormatterBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,8 +50,8 @@ import org.openjdk.jmh.infra.Blackhole;
 
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Warmup(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
 @Fork(3)
 @State(Scope.Benchmark)
 public class DateTimeFormatterBench {


### PR DESCRIPTION
Minor adjustment to iteration times, reducing runtime from 25 minutes to 6.5 minutes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288673](https://bugs.openjdk.org/browse/JDK-8288673): Reduce runtime of java.time microbenchmarks


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9200/head:pull/9200` \
`$ git checkout pull/9200`

Update a local copy of the PR: \
`$ git checkout pull/9200` \
`$ git pull https://git.openjdk.org/jdk pull/9200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9200`

View PR using the GUI difftool: \
`$ git pr show -t 9200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9200.diff">https://git.openjdk.org/jdk/pull/9200.diff</a>

</details>
