### PR TITLE
8286389: Address possibly lossy conversions in jdk.crypto.ec

### DIFF
--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/XDHPublicKeyImpl.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/XDHPublicKeyImpl.java
@@ -76,7 +76,7 @@ public final class XDHPublicKeyImpl extends X509Key implements XECPublicKey {
         // clear the extra bits
         int bitsMod8 = params.getBits() % 8;
         if (bitsMod8 != 0) {
-            int mask = (1 << bitsMod8) - 1;
+            byte mask = (byte) ((1 << bitsMod8) - 1);
             u_arr[0] &= mask;
         }
 

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAOperations.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAOperations.java
@@ -256,7 +256,7 @@ public class EdDSAOperations {
 
         // set the highest bit
         if (highBits == 0) {
-            k[lastByteIndex - 1] |= 0x80;
+            k[lastByteIndex - 1] |= (byte) 0x80;
         } else {
             byte msbMaskOn = (byte) (1 << (highBits - 1));
             k[lastByteIndex] |= msbMaskOn;
@@ -278,7 +278,7 @@ public class EdDSAOperations {
     private static byte[] encode(int length, AffinePoint p) {
         byte[] result = p.getY().asByteArray(length);
         int xLSB = p.getX().asByteArray(1)[0] & 0x01;
-        result[result.length - 1] |= (xLSB << 7);
+        result[result.length - 1] |= (byte) (xLSB << 7);
         return result;
     }
 }


### PR DESCRIPTION
Applied required casts in jdk.crypto.ec for the upcoming warning.
Verified by cherry-picking @asotona's patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286389](https://bugs.openjdk.org/browse/JDK-8286389): Address possibly lossy conversions in jdk.crypto.ec


### Reviewers
 * [Chris Hegarty](https://openjdk.org/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9203/head:pull/9203` \
`$ git checkout pull/9203`

Update a local copy of the PR: \
`$ git checkout pull/9203` \
`$ git pull https://git.openjdk.org/jdk pull/9203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9203`

View PR using the GUI difftool: \
`$ git pr show -t 9203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9203.diff">https://git.openjdk.org/jdk/pull/9203.diff</a>

</details>
