### PR TITLE
8286395: Address possibly lossy conversions in java.security.jgss

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/Des.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/Des.java
@@ -272,7 +272,7 @@ public final class Des {
         key = set_parity(key);
         if (bad_key(key)) {
             byte [] temp = long2octet(key);
-            temp[7] ^= 0xf0;
+            temp[7] ^= (byte) 0xf0;
             key = octet2long(temp);
         }
 
@@ -280,7 +280,7 @@ public final class Des {
         key = octet2long(set_parity(newkey));
         if (bad_key(key)) {
             byte [] temp = long2octet(key);
-            temp[7] ^= 0xf0;
+            temp[7] ^= (byte) 0xf0;
             key = octet2long(temp);
         }
 

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/dk/Des3DkCrypto.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/dk/Des3DkCrypto.java
@@ -157,7 +157,7 @@ public class Des3DkCrypto extends DkCrypto {
             }
             ++posn;
             if (bit != 0) {
-                last |= (bit<<posn);
+                last |= (byte) (bit<<posn);
             }
         }
 


### PR DESCRIPTION
Applied required casts in java.security.jgss for the upcoming warning.
Verified by cherry-picking @asotona's patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286395](https://bugs.openjdk.org/browse/JDK-8286395): Address possibly lossy conversions in java.security.jgss


### Reviewers
 * [Chris Hegarty](https://openjdk.org/census#chegar) (@ChrisHegarty - **Reviewer**)
 * @kristylee88 (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9204/head:pull/9204` \
`$ git checkout pull/9204`

Update a local copy of the PR: \
`$ git checkout pull/9204` \
`$ git pull https://git.openjdk.org/jdk pull/9204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9204`

View PR using the GUI difftool: \
`$ git pr show -t 9204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9204.diff">https://git.openjdk.org/jdk/pull/9204.diff</a>

</details>
