### PR TITLE
8288687: (fc) Unix version ofFileChannelImpl.transferTo0() should should return IOS_UNSUPPORTED if not Linux, macOS, nor AIX

### DIFF
--- a/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
+++ b/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
@@ -255,7 +255,7 @@ Java_sun_nio_ch_FileChannelImpl_transferTo0(JNIEnv *env, jobject this,
 
     return IOS_UNSUPPORTED_CASE;
 #else
-    return IOS_UNSUPPORTED_CASE;
+    return IOS_UNSUPPORTED;
 #endif
 }
 


### PR DESCRIPTION
Return `IOS_UNSUPPORTED` from the `#else` conditional compilation branch of `Java_sun_nio_ch_FileChannelImpl_transferTo0`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288687](https://bugs.openjdk.org/browse/JDK-8288687): (fc) Unix version ofFileChannelImpl.transferTo0() should should return IOS_UNSUPPORTED if not Linux, macOS, nor AIX


### Reviewers
 * @kristylee88 (no known github.com user name / role)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9205/head:pull/9205` \
`$ git checkout pull/9205`

Update a local copy of the PR: \
`$ git checkout pull/9205` \
`$ git pull https://git.openjdk.org/jdk pull/9205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9205`

View PR using the GUI difftool: \
`$ git pr show -t 9205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9205.diff">https://git.openjdk.org/jdk/pull/9205.diff</a>

</details>
