### PR TITLE
8288685 JFR: Use static methods for Active Recording and Active Setting events

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/events/ActiveRecordingEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/ActiveRecordingEvent.java
@@ -40,8 +40,8 @@ import jdk.jfr.internal.Type;
 @StackTrace(false)
 public final class ActiveRecordingEvent extends AbstractJDKEvent {
 
-    // To be accessed when holding recorder lock
-    public static final ActiveRecordingEvent EVENT = new ActiveRecordingEvent();
+    // The order of these fields must be the same as the parameters in
+    // commit(... , long, String, String, String, long, long, long, long, long)
 
     @Label("Id")
     public long id;
@@ -71,4 +71,14 @@ public final class ActiveRecordingEvent extends AbstractJDKEvent {
     @Label("Recording Duration")
     @Timespan(Timespan.MILLISECONDS)
     public long recordingDuration;
+
+    public static boolean enabled() {
+        return false; // Generated
+    }
+
+    public static void commit(long timestamp, long duration, long id, String name,
+                              String destination, long maxAge, long flushInterval,
+                              long maxSize, long recordingStart, long recordingDuration) {
+        // Generated
+    }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/events/ActiveSettingEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/ActiveSettingEvent.java
@@ -37,8 +37,6 @@ import jdk.jfr.internal.Type;
 @StackTrace(false)
 public final class ActiveSettingEvent extends AbstractJDKEvent {
 
-    public static final ActiveSettingEvent EVENT = new ActiveSettingEvent();
-
     // The order of these fields must be the same as the parameters in
     // commit(... , long, String, String)
 
@@ -53,5 +51,9 @@ public final class ActiveSettingEvent extends AbstractJDKEvent {
 
     public static void commit(long startTime, long duration, long id, String name, String value) {
         // Generated
+    }
+
+    public static boolean enabled() {
+        return false; // Generated
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventControl.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventControl.java
@@ -289,7 +289,7 @@ public final class EventControl {
                 if (value == null) {
                     value = nc.control.getDefaultValue();
                 }
-                if (ActiveSettingEvent.EVENT.isEnabled()) {
+                if (ActiveSettingEvent.enabled()) {
                     ActiveSettingEvent.commit(timestamp, 0L, type.getId(), nc.name(), value);
                 }
             }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -66,8 +66,6 @@ public final class PlatformRecorder {
     private static final List<SecureRecorderListener> changeListeners = new ArrayList<>();
     private final Repository repository;
     private static final JVM jvm = JVM.getJVM();
-    private final EventType activeRecordingEvent;
-    private final EventType activeSettingEvent;
     private final Thread shutdownHook;
 
     private Timer timer;
@@ -85,12 +83,9 @@ public final class PlatformRecorder {
         Logger.log(JFR_SYSTEM, INFO, "Registered JDK events");
         JDKEvents.addInstrumentation();
         startDiskMonitor();
-        activeRecordingEvent = EventType.getEventType(ActiveRecordingEvent.class);
-        activeSettingEvent = EventType.getEventType(ActiveSettingEvent.class);
         shutdownHook = SecuritySupport.createThreadWitNoPermissions("JFR Shutdown Hook", new ShutdownHook(this));
         SecuritySupport.setUncaughtExceptionHandler(shutdownHook, new ShutdownHook.ExceptionHandler());
         SecuritySupport.registerShutdownHook(shutdownHook);
-
     }
 
 
@@ -460,30 +455,32 @@ public final class PlatformRecorder {
     }
 
     private void writeMetaEvents() {
-        if (activeRecordingEvent.isEnabled()) {
-            ActiveRecordingEvent event = ActiveRecordingEvent.EVENT;
+        long timestamp = JVM.counterTime();
+        if (ActiveRecordingEvent.enabled()) {
             for (PlatformRecording r : getRecordings()) {
                 if (r.getState() == RecordingState.RUNNING && r.shouldWriteMetadataEvent()) {
-                    event.id = r.getId();
-                    event.name = r.getName();
-                    WriteableUserPath p = r.getDestination();
-                    event.destination = p == null ? null : p.getRealPathText();
-                    Duration d = r.getDuration();
-                    event.recordingDuration = d == null ? Long.MAX_VALUE : d.toMillis();
+                    WriteableUserPath path = r.getDestination();
                     Duration age = r.getMaxAge();
-                    event.maxAge = age == null ? Long.MAX_VALUE : age.toMillis();
+                    Duration flush = r.getFlushInterval();
                     Long size = r.getMaxSize();
-                    event.maxSize = size == null ? Long.MAX_VALUE : size;
-                    Instant start = r.getStartTime();
-                    event.recordingStart = start == null ? Long.MAX_VALUE : start.toEpochMilli();
-                    Duration fi = r.getFlushInterval();
-                    event.flushInterval = fi == null ? Long.MAX_VALUE : fi.toMillis();
-                    event.commit();
+                    Instant rStart = r.getStartTime();
+                    Duration rDuration = r.getDuration();
+                    ActiveRecordingEvent.commit(
+                        timestamp,
+                        0L,
+                        r.getId(),
+                        r.getName(),
+                        path == null ? null : path.getRealPathText(),
+                        age == null ? Long.MAX_VALUE : age.toMillis(),
+                        flush == null ? Long.MAX_VALUE : flush.toMillis(),
+                        size == null ? Long.MAX_VALUE : size,
+                        rStart == null ? Long.MAX_VALUE : rStart.toEpochMilli(),
+                        rDuration == null ? Long.MAX_VALUE : rDuration.toMillis()
+                    );
                 }
             }
         }
-        if (activeSettingEvent.isEnabled()) {
-            long timestamp = JVM.counterTime();
+        if (ActiveSettingEvent.enabled()) {
             for (EventControl ec : MetadataRepository.getInstance().getEventControls()) {
                 ec.writeActiveSettingEvent(timestamp);
             }


### PR DESCRIPTION
Could I have a review of PR that ensures that Active Recording and Active Setting events have the same timestamp.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288685](https://bugs.openjdk.org/browse/JDK-8288685): JFR: Use static methods for Active Recording and Active Setting events


### Reviewers
 * @kristylee88 (no known github.com user name / role)
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9206/head:pull/9206` \
`$ git checkout pull/9206`

Update a local copy of the PR: \
`$ git checkout pull/9206` \
`$ git pull https://git.openjdk.org/jdk pull/9206/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9206`

View PR using the GUI difftool: \
`$ git pr show -t 9206`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9206.diff">https://git.openjdk.org/jdk/pull/9206.diff</a>

</details>
