### PR TITLE
8288723: Avoid redundant ConcurrentHashMap.get call in java.time

### DIFF
--- a/src/java.base/share/classes/java/time/ZoneOffset.java
+++ b/src/java.base/share/classes/java/time/ZoneOffset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -428,8 +428,10 @@ public final class ZoneOffset
             ZoneOffset result = SECONDS_CACHE.get(totalSecs);
             if (result == null) {
                 result = new ZoneOffset(totalSeconds);
-                SECONDS_CACHE.putIfAbsent(totalSecs, result);
-                result = SECONDS_CACHE.get(totalSecs);
+                ZoneOffset prev = SECONDS_CACHE.putIfAbsent(totalSecs, result);
+                if (prev != null) {
+                    result = prev;
+                }
                 ID_CACHE.putIfAbsent(result.getId(), result);
             }
             return result;

--- a/src/java.base/share/classes/java/time/ZoneOffset.java
+++ b/src/java.base/share/classes/java/time/ZoneOffset.java
@@ -424,17 +424,11 @@ public final class ZoneOffset
             throw new DateTimeException("Zone offset not in valid range: -18:00 to +18:00");
         }
         if (totalSeconds % (15 * SECONDS_PER_MINUTE) == 0) {
-            Integer totalSecs = totalSeconds;
-            ZoneOffset result = SECONDS_CACHE.get(totalSecs);
-            if (result == null) {
-                result = new ZoneOffset(totalSeconds);
-                ZoneOffset prev = SECONDS_CACHE.putIfAbsent(totalSecs, result);
-                if (prev != null) {
-                    result = prev;
-                }
+            return SECONDS_CACHE.computeIfAbsent(totalSeconds, totalSecs -> {
+                ZoneOffset result = new ZoneOffset(totalSecs);
                 ID_CACHE.putIfAbsent(result.getId(), result);
-            }
-            return result;
+                return result;
+            });
         } else {
             return new ZoneOffset(totalSeconds);
         }

--- a/src/java.base/share/classes/java/time/format/DateTimeTextProvider.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeTextProvider.java
@@ -309,15 +309,7 @@ class DateTimeTextProvider {
 
     private Object findStore(TemporalField field, Locale locale) {
         Entry<TemporalField, Locale> key = createEntry(field, locale);
-        Object store = CACHE.get(key);
-        if (store == null) {
-            store = createStore(field, locale);
-            Object prev = CACHE.putIfAbsent(key, store);
-            if (prev != null) {
-                store = prev;
-            }
-        }
-        return store;
+        return CACHE.computeIfAbsent(key, e -> createStore(e.getKey(), e.getValue()));
     }
 
     private static int toWeekDay(int calWeekDay) {

--- a/src/java.base/share/classes/java/time/format/DateTimeTextProvider.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeTextProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -312,8 +312,10 @@ class DateTimeTextProvider {
         Object store = CACHE.get(key);
         if (store == null) {
             store = createStore(field, locale);
-            CACHE.putIfAbsent(key, store);
-            store = CACHE.get(key);
+            Object prev = CACHE.putIfAbsent(key, store);
+            if (prev != null) {
+                store = prev;
+            }
         }
         return store;
     }

--- a/src/java.base/share/classes/java/time/format/DecimalStyle.java
+++ b/src/java.base/share/classes/java/time/format/DecimalStyle.java
@@ -160,7 +160,7 @@ public final class DecimalStyle {
      */
     public static DecimalStyle of(Locale locale) {
         Objects.requireNonNull(locale, "locale");
-        return CACHE.computeIfAbsent(locale, l -> create(l));
+        return CACHE.computeIfAbsent(locale, DecimalStyle::create);
     }
 
     private static DecimalStyle create(Locale locale) {

--- a/src/java.base/share/classes/java/time/format/DecimalStyle.java
+++ b/src/java.base/share/classes/java/time/format/DecimalStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -163,8 +163,10 @@ public final class DecimalStyle {
         DecimalStyle info = CACHE.get(locale);
         if (info == null) {
             info = create(locale);
-            CACHE.putIfAbsent(locale, info);
-            info = CACHE.get(locale);
+            DecimalStyle prev = CACHE.putIfAbsent(locale, info);
+            if (prev != null) {
+                info = prev;
+            }
         }
         return info;
     }

--- a/src/java.base/share/classes/java/time/format/DecimalStyle.java
+++ b/src/java.base/share/classes/java/time/format/DecimalStyle.java
@@ -160,15 +160,7 @@ public final class DecimalStyle {
      */
     public static DecimalStyle of(Locale locale) {
         Objects.requireNonNull(locale, "locale");
-        DecimalStyle info = CACHE.get(locale);
-        if (info == null) {
-            info = create(locale);
-            DecimalStyle prev = CACHE.putIfAbsent(locale, info);
-            if (prev != null) {
-                info = prev;
-            }
-        }
-        return info;
+        return CACHE.computeIfAbsent(locale, l -> create(l));
     }
 
     private static DecimalStyle create(Locale locale) {

--- a/src/java.base/share/classes/java/time/temporal/WeekFields.java
+++ b/src/java.base/share/classes/java/time/temporal/WeekFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -330,8 +330,10 @@ public final class WeekFields implements Serializable {
         WeekFields rules = CACHE.get(key);
         if (rules == null) {
             rules = new WeekFields(firstDayOfWeek, minimalDaysInFirstWeek);
-            CACHE.putIfAbsent(key, rules);
-            rules = CACHE.get(key);
+            WeekFields prev = CACHE.putIfAbsent(key, rules);
+            if (prev != null) {
+                rules = prev;
+            }
         }
         return rules;
     }

--- a/src/java.base/share/classes/java/time/temporal/WeekFields.java
+++ b/src/java.base/share/classes/java/time/temporal/WeekFields.java
@@ -196,7 +196,7 @@ public final class WeekFields implements Serializable {
      * The cache of rules by firstDayOfWeek plus minimalDays.
      * Initialized first to be available for definition of ISO, etc.
      */
-    private static final ConcurrentMap<WeekFieldsKey, WeekFields> CACHE = new ConcurrentHashMap<>(4, 0.75f, 2);
+    private static final ConcurrentMap<String, WeekFields> CACHE = new ConcurrentHashMap<>(4, 0.75f, 2);
 
     /**
      * The ISO-8601 definition, where a week starts on Monday and the first week
@@ -326,11 +326,16 @@ public final class WeekFields implements Serializable {
      *      or greater than 7
      */
     public static WeekFields of(DayOfWeek firstDayOfWeek, int minimalDaysInFirstWeek) {
-        WeekFieldsKey key = new WeekFieldsKey(firstDayOfWeek, minimalDaysInFirstWeek);
-        return CACHE.computeIfAbsent(key, k -> new WeekFields(k.firstDayOfWeek, k.minimalDaysInFirstWeek));
-    }
-
-    private record WeekFieldsKey(DayOfWeek firstDayOfWeek, int minimalDaysInFirstWeek) {
+        String key = firstDayOfWeek.toString() + minimalDaysInFirstWeek;
+        WeekFields rules = CACHE.get(key);
+        if (rules == null) {
+            rules = new WeekFields(firstDayOfWeek, minimalDaysInFirstWeek);
+            WeekFields prev = CACHE.putIfAbsent(key, rules);
+            if (prev != null) {
+                rules = prev;
+            }
+        }
+        return rules;
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/temporal/WeekFields.java
+++ b/src/java.base/share/classes/java/time/temporal/WeekFields.java
@@ -196,7 +196,7 @@ public final class WeekFields implements Serializable {
      * The cache of rules by firstDayOfWeek plus minimalDays.
      * Initialized first to be available for definition of ISO, etc.
      */
-    private static final ConcurrentMap<String, WeekFields> CACHE = new ConcurrentHashMap<>(4, 0.75f, 2);
+    private static final ConcurrentMap<WeekFieldsKey, WeekFields> CACHE = new ConcurrentHashMap<>(4, 0.75f, 2);
 
     /**
      * The ISO-8601 definition, where a week starts on Monday and the first week
@@ -326,16 +326,11 @@ public final class WeekFields implements Serializable {
      *      or greater than 7
      */
     public static WeekFields of(DayOfWeek firstDayOfWeek, int minimalDaysInFirstWeek) {
-        String key = firstDayOfWeek.toString() + minimalDaysInFirstWeek;
-        WeekFields rules = CACHE.get(key);
-        if (rules == null) {
-            rules = new WeekFields(firstDayOfWeek, minimalDaysInFirstWeek);
-            WeekFields prev = CACHE.putIfAbsent(key, rules);
-            if (prev != null) {
-                rules = prev;
-            }
-        }
-        return rules;
+        WeekFieldsKey key = new WeekFieldsKey(firstDayOfWeek, minimalDaysInFirstWeek);
+        return CACHE.computeIfAbsent(key, k -> new WeekFields(k.firstDayOfWeek, k.minimalDaysInFirstWeek));
+    }
+
+    private record WeekFieldsKey(DayOfWeek firstDayOfWeek, int minimalDaysInFirstWeek) {
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
Instead of separate ConcurrentHashMap.get call, we can use result of previous putIfAbsent call.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288723](https://bugs.openjdk.org/browse/JDK-8288723): Avoid redundant ConcurrentHashMap.get call in java.time


### Reviewers
 * [Attila Szegedi](https://openjdk.org/census#attila) (@szegedi - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9208/head:pull/9208` \
`$ git checkout pull/9208`

Update a local copy of the PR: \
`$ git checkout pull/9208` \
`$ git pull https://git.openjdk.org/jdk pull/9208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9208`

View PR using the GUI difftool: \
`$ git pr show -t 9208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9208.diff">https://git.openjdk.org/jdk/pull/9208.diff</a>

</details>
