### PR TITLE
JDK-8288699: cleanup HTML tree in HtmlDocletWriter.commentTagsToContent

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
@@ -877,6 +877,32 @@ public class DocCommentParser {
                     }
                     nextChar();
                 }
+            } else {
+                String CDATA = "[CDATA[";  // full prefix is <![CDATA[
+                for (int i = 0; i < CDATA.length(); i++) {
+                    if (ch == CDATA.charAt(i)) {
+                        nextChar();
+                    } else {
+                        return erroneous("dc.invalid.html", p);
+                    }
+                }
+                // suffix is ]]>
+                while (bp < buflen) {
+                    if (ch == ']') {
+                        int n = 0;
+                        while (bp < buflen && ch == ']') {
+                            n++;
+                            nextChar();
+                        }
+                        if (n >= 2 && ch == '>') {
+                            nextChar();
+                            return m.at(p).newTextTree(newString(p, bp));
+                        }
+                    } else {
+                        nextChar();
+                    }
+                }
+                return erroneous("dc.invalid.html", p);
             }
         }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractOverviewIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractOverviewIndexWriter.java
@@ -125,7 +125,7 @@ public abstract class AbstractOverviewIndexWriter extends HtmlDocletWriter {
     protected void addConfigurationTitle(Content target) {
         String doctitle = configuration.getOptions().docTitle();
         if (!doctitle.isEmpty()) {
-            var title = new RawHtml(doctitle);
+            var title = RawHtml.of(doctitle);
             var heading = HtmlTree.HEADING(Headings.PAGE_TITLE_HEADING,
                     HtmlStyle.title, title);
             var div = HtmlTree.DIV(HtmlStyle.header, heading);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -500,7 +500,7 @@ public class HtmlDocletWriter {
      */
     protected HtmlTree getHeader(Navigation.PageMode pageMode, Element element) {
         return HtmlTree.HEADER()
-                .add(new RawHtml(replaceDocRootDir(options.top())))
+                .add(RawHtml.of(replaceDocRootDir(options.top())))
                 .add(getNavBar(pageMode, element).getContent());
     }
 
@@ -515,7 +515,7 @@ public class HtmlDocletWriter {
      */
     protected Navigation getNavBar(Navigation.PageMode pageMode, Element element) {
         return new Navigation(element, configuration, pageMode, path)
-                .setUserHeader(new RawHtml(replaceDocRootDir(options.header())));
+                .setUserHeader(RawHtml.of(replaceDocRootDir(options.header())));
     }
 
     /**
@@ -532,7 +532,7 @@ public class HtmlDocletWriter {
                     .add(new HtmlTree(TagName.HR))
                     .add(HtmlTree.P(HtmlStyle.legalCopy,
                             HtmlTree.SMALL(
-                                    new RawHtml(replaceDocRootDir(bottom)))));
+                                    RawHtml.of(replaceDocRootDir(bottom)))));
     }
 
     /**
@@ -994,7 +994,7 @@ public class HtmlDocletWriter {
                     }
                     case START_ELEMENT -> {
                         // @see <a href="...">...</a>
-                        return new RawHtml(replaceDocRootDir(removeTrailingSlash(seeText)));
+                        return RawHtml.of(replaceDocRootDir(removeTrailingSlash(seeText)));
                     }
                     case REFERENCE -> {
                         // @see reference label...
@@ -1473,7 +1473,6 @@ public class HtmlDocletWriter {
             }
         };
         CommentHelper ch = utils.getCommentHelper(element);
-        // Array of all possible inline tags for this javadoc run
         configuration.tagletManager.checkTags(element, trees, true);
         commentRemoved = false;
 
@@ -1500,103 +1499,110 @@ public class HtmlDocletWriter {
                 }
             }
 
-            boolean allDone = new SimpleDocTreeVisitor<Boolean, Content>() {
+            var docTreeVisitor = new SimpleDocTreeVisitor<Boolean, Content>() {
 
                 private boolean inAnAtag() {
-                    if (utils.isStartElement(tag)) {
-                        StartElementTree st = (StartElementTree)tag;
-                        Name name = st.getName();
-                        if (name != null) {
-                            HtmlTag htag = HtmlTag.get(name);
-                            return htag != null && htag.equals(HtmlTag.A);
-                        }
-                    }
-                    return false;
+                    return (tag instanceof StartElementTree st) && equalsIgnoreCase(st.getName(), "a");
+                }
+
+                private boolean equalsIgnoreCase(Name name, String s) {
+                    return name != null && name.toString().equalsIgnoreCase(s);
                 }
 
                 @Override
-                public Boolean visitAttribute(AttributeTree node, Content c) {
-                    StringBuilder sb = new StringBuilder(SPACER).append(node.getName().toString());
+                public Boolean visitAttribute(AttributeTree node, Content content) {
+                    if (!content.isEmpty()) {
+                        content.add(" ");
+                    }
+                    content.add(node.getName());
                     if (node.getValueKind() == ValueKind.EMPTY) {
-                        result.add(sb);
                         return false;
                     }
-                    sb.append("=");
+                    content.add("=");
                     String quote = switch (node.getValueKind()) {
                         case DOUBLE -> "\"";
                         case SINGLE -> "'";
                         default -> "";
                     };
-                    sb.append(quote);
-                    result.add(sb);
-                    Content docRootContent = new ContentBuilder();
+                    content.add(quote);
 
-                    boolean isHRef = inAnAtag() && node.getName().toString().equalsIgnoreCase("href");
+                    /* In the following code for an attribute value:
+                     * 1. {@docRoot} followed by text beginning "/.." is replaced by the value
+                     *    of the docrootParent option, followed by the remainder of the text
+                     * 2. in the value of an "href" attribute in a <a> tag, an initial text
+                     *    value will have a relative link redirected.
+                     * Note that, realistically, it only makes sense to ever use {@docRoot}
+                     * at the beginning of a URL in an attribute value, but this is not
+                     * required or enforced.
+                     */
+                    boolean isHRef = inAnAtag() && equalsIgnoreCase(node.getName(), "href");
+                    boolean first = true;
+                    DocRootTree pendingDocRoot = null;
                     for (DocTree dt : node.getValue()) {
-                        if (utils.isText(dt) && isHRef) {
-                            String text = ((TextTree) dt).getBody();
-                            if (text.startsWith("/..") && !options.docrootParent().isEmpty()) {
-                                result.add(options.docrootParent());
-                                docRootContent = new ContentBuilder();
-                                result.add(textCleanup(text.substring(3), isLastNode));
-                            } else {
-                                if (!docRootContent.isEmpty()) {
-                                    docRootContent = copyDocRootContent(docRootContent);
-                                } else {
-                                    text = redirectRelativeLinks(element, (TextTree) dt);
+                        if (pendingDocRoot != null) {
+                            if (dt instanceof TextTree tt) {
+                                String text = tt.getBody();
+                                if (text.startsWith("/..") && !options.docrootParent().isEmpty()) {
+                                    content.add(options.docrootParent());
+                                    content.add(textCleanup(text.substring(3), isLastNode));
+                                    pendingDocRoot = null;
+                                    first = false;
+                                    continue;
                                 }
-                                result.add(textCleanup(text, isLastNode));
                             }
-                        } else {
-                            docRootContent = copyDocRootContent(docRootContent);
-                            dt.accept(this, docRootContent);
+                            pendingDocRoot.accept(this, content);
+                            pendingDocRoot = null;
+                            first = false;
                         }
+
+                        if (dt instanceof TextTree tt){
+                            String text = tt.getBody();
+                            if (first && isHRef) {
+                                text = redirectRelativeLinks(element, (TextTree) dt);
+                            }
+                            content.add(textCleanup(text, isLastNode));
+                        } else if (dt instanceof DocRootTree drt) {
+                            // defer until we see what, if anything, follows this node
+                            pendingDocRoot = drt;
+                        } else {
+                            dt.accept(this, content);
+                        }
+                        first = false;
                     }
-                    copyDocRootContent(docRootContent);
-                    result.add(quote);
-                    return false;
-                }
-
-                @Override
-                public Boolean visitComment(CommentTree node, Content c) {
-                    result.add(new RawHtml(node.getBody()));
-                    return false;
-                }
-
-                private Content copyDocRootContent(Content content) {
-                    if (!content.isEmpty()) {
-                        result.add(content);
-                        return new ContentBuilder();
+                    if (pendingDocRoot != null) {
+                        pendingDocRoot.accept(this, content);
                     }
-                    return content;
-                }
 
-                @Override
-                public Boolean visitDocRoot(DocRootTree node, Content c) {
-                    Content docRootContent = getInlineTagOutput(element, node, context);
-                    if (c != null) {
-                        c.add(docRootContent);
-                    } else {
-                        result.add(docRootContent);
-                    }
+                    content.add(quote);
                     return false;
                 }
 
                 @Override
-                public Boolean visitEndElement(EndElementTree node, Content c) {
-                    RawHtml rawHtml = new RawHtml("</" + node.getName() + ">");
-                    result.add(rawHtml);
+                public Boolean visitComment(CommentTree node, Content content) {
+                    content.add(RawHtml.comment(node.getBody()));
                     return false;
                 }
 
                 @Override
-                public Boolean visitEntity(EntityTree node, Content c) {
-                    result.add(new RawHtml(node.toString()));
+                public Boolean visitDocRoot(DocRootTree node, Content content) {
+                    content.add(getInlineTagOutput(element, node, context));
                     return false;
                 }
 
                 @Override
-                public Boolean visitErroneous(ErroneousTree node, Content c) {
+                public Boolean visitEndElement(EndElementTree node, Content content) {
+                    content.add(RawHtml.endElement(node.getName()));
+                    return false;
+                }
+
+                @Override
+                public Boolean visitEntity(EntityTree node, Content content) {
+                    content.add(Entity.of(node.getName()));
+                    return false;
+                }
+
+                @Override
+                public Boolean visitErroneous(ErroneousTree node, Content content) {
                     DocTreePath dtp = ch.getDocTreePath(node);
                     if (dtp != null) {
                         String body = node.getBody();
@@ -1606,11 +1612,11 @@ public class HtmlDocletWriter {
                             if (!configuration.isDocLintSyntaxGroupEnabled()) {
                                 messages.warning(dtp, "doclet.tag.invalid_input", body);
                             }
-                            result.add(invalidTagOutput(resources.getText("doclet.tag.invalid_input", body),
+                            content.add(invalidTagOutput(resources.getText("doclet.tag.invalid_input", body),
                                     Optional.empty()));
                         } else {
                             messages.warning(dtp, "doclet.tag.invalid_usage", body);
-                            result.add(invalidTagOutput(resources.getText("doclet.tag.invalid", tagName),
+                            content.add(invalidTagOutput(resources.getText("doclet.tag.invalid", tagName),
                                     Optional.of(Text.of(body))));
                         }
                     }
@@ -1618,24 +1624,24 @@ public class HtmlDocletWriter {
                 }
 
                 @Override
-                public Boolean visitInheritDoc(InheritDocTree node, Content c) {
+                public Boolean visitInheritDoc(InheritDocTree node, Content content) {
                     Content output = getInlineTagOutput(element, node, context);
-                    result.add(output);
+                    content.add(output);
                     // if we obtained the first sentence successfully, nothing more to do
                     return (context.isFirstSentence && !output.isEmpty());
                 }
 
                 @Override
-                public Boolean visitIndex(IndexTree node, Content p) {
+                public Boolean visitIndex(IndexTree node, Content content) {
                     Content output = getInlineTagOutput(element, node, context);
                     if (output != null) {
-                        result.add(output);
+                        content.add(output);
                     }
                     return false;
                 }
 
                 @Override
-                public Boolean visitLink(LinkTree node, Content c) {
+                public Boolean visitLink(LinkTree node, Content content) {
                     var inTags = context.inTags;
                     if (inTags.contains(LINK) || inTags.contains(LINK_PLAIN) || inTags.contains(SEE)) {
                         DocTreePath dtp = ch.getDocTreePath(node);
@@ -1646,55 +1652,50 @@ public class HtmlDocletWriter {
                         if (label.isEmpty()) {
                             label = Text.of(node.getReference().getSignature());
                         }
-                        result.add(label);
+                        content.add(label);
                     } else {
-                        Content content = seeTagToContent(element, node, context.within(node));
-                        result.add(content);
+                        Content c = seeTagToContent(element, node, context.within(node));
+                        content.add(c);
                     }
                     return false;
                 }
 
                 @Override
-                public Boolean visitLiteral(LiteralTree node, Content c) {
+                public Boolean visitLiteral(LiteralTree node, Content content) {
                     String s = node.getBody().getBody();
-                    Content content = Text.of(utils.normalizeNewlines(s));
-                    if (node.getKind() == CODE)
-                        content = HtmlTree.CODE(content);
-                    result.add(content);
+                    Content t = Text.of(utils.normalizeNewlines(s));
+                    content.add(node.getKind() == CODE ? HtmlTree.CODE(t) : t);
                     return false;
                 }
 
                 @Override
-                public Boolean visitSee(SeeTree node, Content c) {
-                    result.add(seeTagToContent(element, node, context));
+                public Boolean visitSee(SeeTree node, Content content) {
+                    content.add(seeTagToContent(element, node, context));
                     return false;
                 }
 
                 @Override
-                public Boolean visitStartElement(StartElementTree node, Content c) {
-                    String text = "<" + node.getName();
-                    RawHtml rawHtml = new RawHtml(utils.normalizeNewlines(text));
-                    result.add(rawHtml);
-
+                public Boolean visitStartElement(StartElementTree node, Content content) {
+                    Content attrs = new ContentBuilder();
                     for (DocTree dt : node.getAttributes()) {
-                        dt.accept(this, null);
+                        dt.accept(this, attrs);
                     }
-                    result.add(new RawHtml(node.isSelfClosing() ? "/>" : ">"));
+                    content.add(RawHtml.startElement(node.getName(), attrs, node.isSelfClosing()));
                     return false;
                 }
 
                 @Override
-                public Boolean visitSummary(SummaryTree node, Content c) {
+                public Boolean visitSummary(SummaryTree node, Content content) {
                     Content output = getInlineTagOutput(element, node, context);
-                    result.add(output);
+                    content.add(output);
                     return false;
                 }
 
                 @Override
-                public Boolean visitSystemProperty(SystemPropertyTree node, Content p) {
+                public Boolean visitSystemProperty(SystemPropertyTree node, Content content) {
                     Content output = getInlineTagOutput(element, node, context);
                     if (output != null) {
-                        result.add(output);
+                        content.add(output);
                     }
                     return false;
                 }
@@ -1717,23 +1718,28 @@ public class HtmlDocletWriter {
                 }
 
                 @Override
-                public Boolean visitText(TextTree node, Content c) {
+                public Boolean visitText(TextTree node, Content content) {
                     String text = node.getBody();
-                    result.add(new RawHtml(textCleanup(text, isLastNode, commentRemoved)));
+                    result.add(text.startsWith("<![CDATA[")
+                            ? RawHtml.cdata(text)
+                            : Text.of(textCleanup(text, isLastNode, commentRemoved)));
                     return false;
                 }
 
                 @Override
-                protected Boolean defaultAction(DocTree node, Content c) {
+                protected Boolean defaultAction(DocTree node, Content content) {
                     Content output = getInlineTagOutput(element, node, context);
                     if (output != null) {
-                        result.add(output);
+                        content.add(output);
                     }
                     return false;
                 }
 
-            }.visit(tag, null);
+            };
+
+            boolean allDone = docTreeVisitor.visit(tag, result);
             commentRemoved = false;
+
             if (allDone)
                 break;
         }
@@ -1884,15 +1890,6 @@ public class HtmlDocletWriter {
             }
         }
         return text;
-    }
-
-    /**
-     * According to
-     * <cite>The Java Language Specification</cite>,
-     * all the outer classes and static nested classes are core classes.
-     */
-    public boolean isCoreClass(TypeElement typeElement) {
-        return utils.getEnclosingTypeElement(typeElement) == null || utils.isStatic(typeElement);
     }
 
     /**
@@ -2155,6 +2152,7 @@ public class HtmlDocletWriter {
                     }
                 }.visit(t);
             }
+
             @Override
             public Content visitAnnotation(AnnotationMirror a, Void p) {
                 List<Content> list = getAnnotations(List.of(a), false);
@@ -2164,10 +2162,12 @@ public class HtmlDocletWriter {
                 }
                 return buf;
             }
+
             @Override
             public Content visitEnumConstant(VariableElement c, Void p) {
                 return getDocLink(HtmlLinkInfo.Kind.ANNOTATION, c, c.getSimpleName());
             }
+
             @Override
             public Content visitArray(List<? extends AnnotationValue> vals, Void p) {
                 ContentBuilder buf = new ContentBuilder();
@@ -2179,6 +2179,7 @@ public class HtmlDocletWriter {
                 }
                 return buf;
             }
+
             @Override
             protected Content defaultAction(Object o, Void p) {
                 return Text.of(annotationValue.toString());
@@ -2261,10 +2262,6 @@ public class HtmlDocletWriter {
                 .replace("API", "Api");
         String page = kind.substring(0, 1).toLowerCase(Locale.US) + kind.substring(1) + "Page";
         return HtmlStyle.valueOf(page);
-    }
-
-    Script getMainBodyScript() {
-        return mainBodyScript;
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialFieldWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialFieldWriter.java
@@ -134,7 +134,7 @@ public class HtmlSerialFieldWriter extends FieldWriterImpl
         CommentHelper ch = utils.getCommentHelper(field);
         List<? extends DocTree> description = ch.getDescription(serialFieldTag);
         if (!description.isEmpty()) {
-            Content serialFieldContent = new RawHtml(ch.getText(description));
+            Content serialFieldContent = RawHtml.of(ch.getText(description)); // should interpret tags
             var div = HtmlTree.DIV(HtmlStyle.block, serialFieldContent);
             content.add(div);
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
@@ -52,6 +52,7 @@ import com.sun.source.doctree.ReturnTree;
 import com.sun.source.doctree.SeeTree;
 import com.sun.source.doctree.SnippetTree;
 import com.sun.source.doctree.SystemPropertyTree;
+import com.sun.source.doctree.TextTree;
 import com.sun.source.doctree.ThrowsTree;
 import com.sun.source.util.DocTreePath;
 import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
@@ -307,7 +308,7 @@ public class TagletWriterImpl extends TagletWriter {
     public Content returnTagOutput(Element element, ReturnTree returnTag, boolean inline) {
         CommentHelper ch = utils.getCommentHelper(element);
         List<? extends DocTree> desc = ch.getDescription(returnTag);
-        Content content = htmlWriter.commentTagsToContent(element, desc , context.within(returnTag));
+        Content content = htmlWriter.commentTagsToContent(element, desc, context.within(returnTag));
         return inline
                 ? new ContentBuilder(contents.getContent("doclet.Returns_0", content))
                 : new ContentBuilder(HtmlTree.DT(contents.returns), HtmlTree.DD(content));
@@ -371,7 +372,7 @@ public class TagletWriterImpl extends TagletWriter {
             many = true;
         }
         return new ContentBuilder(
-                HtmlTree.DT(new RawHtml(header)),
+                HtmlTree.DT(RawHtml.of(header)),
                 HtmlTree.DD(body));
     }
 
@@ -504,9 +505,9 @@ public class TagletWriterImpl extends TagletWriter {
            excName = htmlWriter.getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.MEMBER,
                    substituteType));
         } else if (exception == null) {
-            excName = new RawHtml(ch.getExceptionName(throwsTag).toString());
+            excName = Text.of(ch.getExceptionName(throwsTag).toString());
         } else if (exception.asType() == null) {
-            excName = new RawHtml(utils.getFullyQualifiedName(exception));
+            excName = Text.of(utils.getFullyQualifiedName(exception));
         } else {
             HtmlLinkInfo link = new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.MEMBER,
                                                  exception.asType());

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Entity.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Entity.java
@@ -41,6 +41,16 @@ public class Entity extends Content {
 
     public final String text;
 
+    /**
+     * Creates an entity with a given name or numeric value.
+     *
+     * @param name the name, or numeric value
+     * @return the entity
+     */
+    public static Entity of(CharSequence name) {
+        return new Entity("&" + name + ";");
+    }
+
     private Entity(String text) {
         this.text = text;
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/RawHtml.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/RawHtml.java
@@ -36,14 +36,91 @@ import jdk.javadoc.internal.doclets.toolkit.util.DocletConstants;
  */
 public class RawHtml extends Content {
 
-    private final String rawHtmlContent;
+    protected final String rawHtmlContent;
+
+    /**
+     * Creates HTML for an arbitrary string of HTML.
+     * The string is accepted as-is and is not validated in any way.
+     * It should be syntactically well-formed and contain matching {@code <} and {@code >},
+     * and matching quotes for attributes.
+     *
+     * @param rawHtml the string
+     * @return the HTML
+     */
+    public static RawHtml of(CharSequence rawHtml) {
+        return new RawHtml(rawHtml) {
+            @Override
+            public int charCount() {
+                return charCount(rawHtmlContent);
+            }
+        };
+    }
+
+    /**
+     * Creates HTML for the start of an element.
+     *
+     * @param name the name of the element
+     * @param attrs content containing any attributes
+     * @param selfClosing whether this is a self-closing element.
+     * @return the HTML
+     */
+    public static RawHtml startElement(CharSequence name, Content attrs, boolean selfClosing) {
+        StringBuilder sb = new StringBuilder("<" + name);
+        if (!attrs.isEmpty()) {
+            sb.append(" ");
+            sb.append(attrs);
+        }
+        sb.append(selfClosing ? "/>" : ">");
+        return new RawHtml(sb);
+    }
+
+    /**
+     * Creates HTML for the end of an element.
+     *
+     * @param name the name of the element
+     * @return the HTML
+     */
+    public static RawHtml endElement(CharSequence name) {
+        return new RawHtml("</" + name + ">");
+    }
+
+    /**
+     * Creates HTML for an HTML comment.
+     *
+     * The body will be enclosed in {@code <!--} and {@code -->} if it does not
+     * already begin and end with those sequences.
+     *
+     * @param body the body of the comment
+     *
+     * @return the HTML
+     */
+    public static RawHtml comment(String body) {
+        return section("<!--", body, "-->");
+    }
+    /**
+     * Creates HTML for an HTML CDATA section.
+     *
+     * The body will be enclosed in {@code <![CDATA]} and {@code ]]>} if it does not
+     * already begin and end with those sequences.
+     *
+     * @param body the body of the CDATA section
+     *
+     * @return the HTML
+     */
+    public static RawHtml cdata(String body) {
+        return section("<![CDATA[", body, "]]>");
+    }
+
+    private static RawHtml section(String prefix, String body, String suffix) {
+        return new RawHtml(body.startsWith(prefix) && body.endsWith(suffix) ? body : prefix + body + suffix);
+    }
 
     /**
      * Constructor to construct a RawHtml object.
      *
      * @param rawHtml raw HTML text to be added
      */
-    public RawHtml(CharSequence rawHtml) {
+    private RawHtml(CharSequence rawHtml) {
         rawHtmlContent = rawHtml.toString();
     }
 
@@ -59,12 +136,7 @@ public class RawHtml extends Content {
 
     private enum State { TEXT, ENTITY, TAG, STRING }
 
-    @Override
-    public int charCount() {
-        return charCount(rawHtmlContent);
-    }
-
-    static int charCount(CharSequence htmlText) {
+    protected static int charCount(CharSequence htmlText) {
         State state = State.TEXT;
         int count = 0;
         for (int i = 0; i < htmlText.length(); i++) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Text.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Text.java
@@ -33,6 +33,7 @@ import jdk.javadoc.internal.doclets.toolkit.util.DocletConstants;
 
 /**
  * Class for containing immutable string content for HTML tags of javadoc output.
+ * Any special HTML characters will be escaped if and when the content is written out.
  */
 public class Text extends Content {
     private final String string;
@@ -55,7 +56,7 @@ public class Text extends Content {
      * @param content content for the object
      */
     private Text(CharSequence content) {
-        string = Entity.escapeHtmlChars(content);
+        string = content.toString();
     }
 
     @Override
@@ -65,7 +66,7 @@ public class Text extends Content {
 
     @Override
     public int charCount() {
-        return RawHtml.charCount(string);
+        return string.length();
     }
 
     @Override
@@ -75,7 +76,7 @@ public class Text extends Content {
 
     @Override
     public boolean write(Writer out, boolean atNewline) throws IOException {
-        out.write(string);
+        out.write(Entity.escapeHtmlChars(string));
         return string.endsWith(DocletConstants.NL);
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/TextBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/TextBuilder.java
@@ -34,6 +34,7 @@ import jdk.javadoc.internal.doclets.toolkit.util.DocletConstants;
 /**
  * Class for generating string content for HTML tags of javadoc output.
  * The content is mutable to the extent that additional content may be added.
+ * Any special HTML characters will be escaped if and when the content is written out.
  */
 public class TextBuilder extends Content {
 
@@ -52,19 +53,17 @@ public class TextBuilder extends Content {
      * @param initialContent initial content for the object
      */
     public TextBuilder(CharSequence initialContent) {
-        stringBuilder = new StringBuilder();
-        Entity.escapeHtmlChars(initialContent, stringBuilder);
+        stringBuilder = new StringBuilder(initialContent);
     }
 
     /**
-     * Adds content for the StringContent object.  The method escapes
-     * HTML characters for the string content that is added.
+     * Adds content for the StringContent object.
      *
      * @param strContent string content to be added
      */
     @Override
     public TextBuilder add(CharSequence strContent) {
-        Entity.escapeHtmlChars(strContent, stringBuilder);
+        stringBuilder.append(strContent);
         return this;
     }
 
@@ -75,7 +74,7 @@ public class TextBuilder extends Content {
 
     @Override
     public int charCount() {
-        return RawHtml.charCount(stringBuilder.toString());
+        return stringBuilder.length();
     }
 
     @Override
@@ -85,7 +84,7 @@ public class TextBuilder extends Content {
 
     @Override
     public boolean write(Writer out, boolean atNewline) throws IOException {
-        String s = stringBuilder.toString();
+        String s = Entity.escapeHtmlChars(stringBuilder);
         out.write(s);
         return s.endsWith(DocletConstants.NL);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/Content.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/Content.java
@@ -133,9 +133,7 @@ public abstract class Content {
     }
 
     /**
-     * Return the number of characters of plain text content in this object
-     * (optional operation.)
-     * @return the number of characters of plain text content in this
+     * {@return the number of characters of plain text content in this object}
      */
     public int charCount() {
         return 0;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/UserTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/UserTaglet.java
@@ -107,7 +107,7 @@ public final class UserTaglet implements Taglet {
     @Override
     public Content getInlineTagOutput(Element element, DocTree tag, TagletWriter writer) {
         Content output = writer.getOutputInstance();
-        output.add(new RawHtml(userTaglet.toString(List.of(tag), element)));
+        output.add(RawHtml.of(userTaglet.toString(List.of(tag), element)));
         return output;
     }
 
@@ -119,7 +119,7 @@ public final class UserTaglet implements Taglet {
         if (!tags.isEmpty()) {
             String tagString = userTaglet.toString(tags, holder);
             if (tagString != null) {
-                output.add(new RawHtml(tagString));
+                output.add(RawHtml.of(tagString));
             }
         }
         return output;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
@@ -314,7 +314,7 @@ public class CommentHelper {
             public String visitSee(SeeTree node, Void p) {
                 Utils utils = configuration.utils;
                 return node.getReference().stream()
-                        .filter(utils::isText)
+                        .filter(dt -> dt.getKind() == DocTree.Kind.TEXT)
                         .map(dt -> ((TextTree) dt).getBody())
                         .collect(Collectors.joining());
             }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -2193,18 +2193,6 @@ public class Utils {
         return mdle.getQualifiedName().toString();
     }
 
-    public boolean isStartElement(DocTree doctree) {
-        return isKind(doctree, START_ELEMENT);
-    }
-
-    public boolean isText(DocTree doctree) {
-        return isKind(doctree, TEXT);
-    }
-
-    private boolean isKind(DocTree doctree, DocTree.Kind match) {
-        return  doctree.getKind() == match;
-    }
-
     private final CommentHelperCache commentHelperCache = new CommentHelperCache(this);
 
     public CommentHelper getCommentHelper(Element element) {


### PR DESCRIPTION
Please review a particularly satisfying review of a cleanup for
`HtmlDocletWriter.commentTagsToContent`, and the use of `RawHtml`.

The background for this is a separate cleanup for `CommentHelper.getText`,
during which it was observed that the code could be eliminated, with some
uses being replaced by `HtmlDocletWriter.commentTagsToContent`. That led
to more tags being processed, which in turn led to the observation that
`Content.charCount` was often giving incorrect results.

The primary root cause of the problem with `Content.charCount` was the
handling of `StartElementTree` in the visitor in `commentTagsToContent`.
The problem is that code there creates a sequence of text nodes for the
attributes, preceded by a `RawHtml` object containing `<TAGNAME` and followed
by another separate `RawHtml` node containing just `>`.  The net result
is that `charCount` is mistaken into including the size of the intervening
text nodes in the total, because it does not recognize the "unbalanced" `<`
and `>` in the surrounding nodes.

The general system fix for `commentTagsToContent` is to change the _visit..._
methods to always append to the `Content` object supplied as a parameter, instead
of to a fixed local variable (`result`) in the enclosing scope. This allows
`visitStartElement` to accumulate the attributes in a temporary buffer,
and then create a single `RawHtml` node as the translation of the
`StartElementTree`.  Changing the methodology of the visitors also
required disentangling the processing of `{@docRoot}`, which generally
always appears inside the `href` attribute, typically followed by
the rest of the URL. The complication there is that since forever there
has been special handling of `{@docRoot}/..` which can be replaced by
the value of the `--docrootparent` option. In reviewing that part of the code,
it may help to just ignore the old code and just review the new replacement
code.

Starting with the code in `commentTagsToContent`, it became worthwhile to
use factory methods on `RawHtml` for stylized uses of the class, for _start
element_, _end element_, and _comment_. These all have a `charCount` of zero,
so it only becomes necessary to compute the character count when given
arbitrary text.

Related, the `Text` and `TextBuilder` classes are changed so that they 
contain unescaped content, and only escape the HTML characters when they
are written out. This allows their `charCount` to simply return the `length()`
of the string content, instead of having to parse the content to account
of any entities that may be present.  This also means that newline characters
will be counted; previously, they were not.

Another noteworthy change. Somewhat usually, some resource strings for the
description of mandated methods, such as for enum and record classes, contain
simple HTML (`<i>...</i>`), which is modelled in a single `TextTree` and
subsequently converted to a non-standard use of `RawHtml`. To avoid
significantly changing the resource strings, the solution is to parse the
resources into a suitable `List<DocTree>`, using a relatively simple regular
expression. The goal is to _not_ extend the support any further than that
provided.

Finally, one more change/bug fix. We do not claim to support HTML CDATA
sections, but there is one in the JDK API docs (in `coll-index.html`). 
It "mostly worked" by accident, but dropped the leading `<`, which "broke"
the section in the generated output. I've put code into `DocCommentParser`
to handle CDATA sections, representing them (for now) as a `Text` node
containing just the section itself. This is then handled specially up in
`commentTagsToContent`, where it is translated to a new `RawHtml` node.

For reviewing, I suggest starting with `RawHtml` and then `HtmlDocletWriter`.
Many of the other changes are derivative changes, such as changing
`new RawHtml(...)` to `RawHtml.of(...)` and similar other changes.

All tests continue to pass without change.

There are minor changes to the generated docs, in two flavors.

1. There is one instance, in `Collectors.html`, where the fixes to `charCount`
   are enough to change the separator after the type parameters in a 
   method summary table from `&nbsp;` to `<br>`. 
   See `AbstractMemberWriter` line 207. The current threshold is 10, and
   some of the methods in `Collectors.html` were less and are now more.

2. A number of files use an unescaped `>` in doc comments. These are now
   translated to `&gt;` in the output.  The change in behavior is because of
   changing to use `html.Text` nodes instead of `html.RawHtml` nodes to represent
   user-provided text in `TextTree` nodes.
   Previously, the generated output was inconsistent in this area: most
   instances used `&gt;`, but user-provided `>` was passed through.
   Now, the output is consistent. 
   FWIW, `tidy` prefers the use of `&gt;` as well.
   
