### PR TITLE
8288724: Prevent NullPointerException in serviceability/tmtools/jstack/DaemonThreadTest.java if jstack process fails

### DIFF
--- a/test/hotspot/jtreg/serviceability/tmtools/jstack/DaemonThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/tmtools/jstack/DaemonThreadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,7 +80,10 @@ public class DaemonThreadTest {
         // Run jstack tool and collect the output
         JstackTool jstackTool = new JstackTool(ProcessHandle.current().pid());
         ToolResults results = jstackTool.measure();
-
+        int exitCode = results.getExitCode();
+        if (exitCode != 0) {
+            throw new RuntimeException("jstack tool failed with an exit code " + exitCode);
+        }
         // Analyze the jstack output for the correct thread type
         JStack jstack = new DefaultFormat().parse(results.getStdoutString());
         ThreadStack ti = jstack.getThreadStack(thread.getName());


### PR DESCRIPTION
Can I please get a review of this test only change which updates the `DaemonThreadTest` to prevent a NPE when the `jstack` tool launched from the test fails with a non-zero exit code?
