### PR TITLE
JDK-8288719: [arm32] SafeFetch32 thumb interleaving causes random crashes

### DIFF
--- a/src/hotspot/os_cpu/linux_arm/safefetch_linux_arm.S
+++ b/src/hotspot/os_cpu/linux_arm/safefetch_linux_arm.S
@@ -26,6 +26,7 @@
     .globl SafeFetch32_impl
     .globl _SafeFetch32_fault
     .globl _SafeFetch32_continuation
+    .type SafeFetch32_impl, %function
 
     # Support for int SafeFetch32(int* address, int defaultval);
     #

--- a/src/hotspot/share/runtime/safefetch.hpp
+++ b/src/hotspot/share/runtime/safefetch.hpp
@@ -34,11 +34,10 @@
 #ifdef _WIN32
   // Windows uses Structured Exception Handling
   #include "safefetch_windows.hpp"
-#elif defined(ZERO) || defined (_AIX) || defined (ARM32)
+#elif defined(ZERO) || defined (_AIX)
   // These platforms implement safefetch via Posix sigsetjmp/longjmp.
   // This is slower than the other methods and uses more thread stack,
   // but its safe and portable.
-  // (arm32 uses sigsetjmp/longjmp as long as JDK-8284997 is not solved)
   #include "safefetch_sigjmp.hpp"
   #define SAFEFETCH_METHOD_SIGSETJMP
 #else


### PR DESCRIPTION
After [JDK-8284997](https://bugs.openjdk.org/browse/JDK-8284997) delivered just a bandaid, this is hopefully the real fix.

JDK-8283326 re-implemented SafeFetch as static assembler functions. This broke arm: the VM would crash at random points, usually in Atomic::add(), usually right at startup. In most cases the VM could not even be built correctly, see JDK-8284997.

This was only reproducible if the VM was built natively, on a Raspberry Pi, inside an Ubuntu18-derived container. Buiding natively on Raspberry Pi OS was fine. Cross-building was fine too. The difference is the default instruction set the toolchain uses. We don't explicitly specify `-mthumb` or `-marm`, so we use the toolchain's default. That default seems to depend on how GCC itself was built. Ubuntu ships a GCC that has been built in thumb mode, thus defaulting to `-mthumb`, whereas Raspberry Pi OS and Fedora ship GCCs that default to `-marm`.

So, the VM proper is compiled either to arm or thumb code. The `SafeFetch32` assembly function itself uses arm code always. Why this is I don't know for sure, I assume if I wanted thumb I need to specify `.thumb_func` in the assembly. 

If the VM uses thumb, it needs to call SafeFetch32 with a switching branch instruction (BX). But the compiler-generated BL. The instruction set was not switched upon entering SafeFetch32 and garbage thumb code was executed. VM crashes soon after.

This seems to be a common problem when writing arm assembly by hand, the solution is specify `.type function`. See also [1]: "As of GCC 4.7, the .type directive is pretty much required for functions. Or, rather, it is required if you want ARM and Thumb interworking to work."

A remaining question is whether we should specify the instruction set explicitly when building on arm32, to prevent surprises like this. Preferably with a configure option.

----

Testing:
- GHAs are green, but that does not say much: they just do the usual cross building without running the executables. Even if they would run, they would be compiled with -marm and not show the default
- Both @marchof and me tested the fix with a native build on Raspberry Pi. I confirmed that the patch fixes the problem. I ran gtests, which also tests SafeFetch

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8288719](https://bugs.openjdk.org/browse/JDK-8288719): [arm32] SafeFetch32 thumb interleaving causes random crashes
 * [JDK-8284997](https://bugs.openjdk.org/browse/JDK-8284997): arm32 build crashes since JDK-8283326


### Reviewers
 * [Sergey Nazarkin](https://openjdk.org/census#snazarki) (@snazarkin - no project role)
 * [Xin Liu](https://openjdk.org/census#xliu) (@navyxliu - Committer)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9213/head:pull/9213` \
`$ git checkout pull/9213`

Update a local copy of the PR: \
`$ git checkout pull/9213` \
`$ git pull https://git.openjdk.org/jdk pull/9213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9213`

View PR using the GUI difftool: \
`$ git pr show -t 9213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9213.diff">https://git.openjdk.org/jdk/pull/9213.diff</a>

</details>
