### PR TITLE
8288732: Reduce runtime of java.util.concurrent microbenchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/java/util/concurrent/Atomic.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/Atomic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,13 +24,16 @@ package org.openjdk.bench.java.util.concurrent;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OperationsPerInvocation;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.util.concurrent.TimeUnit;
@@ -42,6 +45,9 @@ import java.util.concurrent.atomic.AtomicReference;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(3)
 public class Atomic {
 
     public AtomicInteger aInteger;

--- a/test/micro/org/openjdk/bench/java/util/concurrent/AtomicIntegerUpdateAndGet.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/AtomicIntegerUpdateAndGet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.util.concurrent;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -43,6 +46,9 @@ import java.util.function.IntUnaryOperator;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(3)
 public class AtomicIntegerUpdateAndGet {
 
     private PaddedAtomicInteger count;

--- a/test/micro/org/openjdk/bench/java/util/concurrent/ForkJoinPoolRawCallable.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/ForkJoinPoolRawCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,12 +23,15 @@
 package org.openjdk.bench.java.util.concurrent;
 
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,6 +51,9 @@ import java.util.concurrent.TimeUnit;
  */
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+@Fork(3)
 public class ForkJoinPoolRawCallable {
 
     /**

--- a/test/micro/org/openjdk/bench/java/util/concurrent/ForkJoinPoolThresholdAutoQueued.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/ForkJoinPoolThresholdAutoQueued.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/concurrent/ForkJoinPoolThresholdAutoQueued.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/ForkJoinPoolThresholdAutoQueued.java
@@ -23,12 +23,15 @@
 package org.openjdk.bench.java.util.concurrent;
 
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
  */
 @OutputTimeUnit(TimeUnit.MINUTES)
 @State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+@Fork(3)
 public class ForkJoinPoolThresholdAutoQueued {
 
     /**
@@ -54,31 +60,40 @@ public class ForkJoinPoolThresholdAutoQueued {
      * versus sequential version.
      */
 
-    @Param("0")
-    private int workers;
-
     @Param("10000000")
     private int size;
 
-    @Param({"1", "2", "3", "4", "5", "6", "7", "8"})
-    private int threshold;
+    /** Encapsulate all the state depended on only by actual test. This avoids running baselines for every parameter value. */
+    @State(Scope.Benchmark)
+    public static class TestState {
 
-    private ForkJoinPool fjp;
+        @Param("0")
+        private int workers;
+
+        @Param({"1", "2", "3", "4", "5", "6", "7", "8"})
+        private int threshold;
+
+        private ForkJoinPool fjp;
+
+        @Setup
+        public void setup() {
+            if (workers == 0) {
+                workers = Runtime.getRuntime().availableProcessors();
+            }
+            fjp = new ForkJoinPool(workers);
+        }
+
+        @TearDown
+        public void teardown() {
+            fjp.shutdownNow();
+        }
+    }
+
     private Problem problem;
 
     @Setup
     public void setup() {
-        if (workers == 0) {
-            workers = Runtime.getRuntime().availableProcessors();
-        }
-
         problem = new Problem(size);
-        fjp = new ForkJoinPool(workers);
-    }
-
-    @TearDown
-    public void teardown() {
-        fjp.shutdownNow();
     }
 
     @Benchmark
@@ -87,8 +102,8 @@ public class ForkJoinPoolThresholdAutoQueued {
     }
 
     @Benchmark
-    public Long test() throws ExecutionException, InterruptedException {
-        return fjp.invoke(new AutoQueuedTask(threshold, problem, 0, problem.size()));
+    public Long test(TestState state) throws ExecutionException, InterruptedException {
+        return state.fjp.invoke(new AutoQueuedTask(state.threshold, problem, 0, problem.size()));
     }
 
     private static class AutoQueuedTask extends RecursiveTask<Long> {

--- a/test/micro/org/openjdk/bench/java/util/concurrent/ForkJoinPoolThresholdAutoSurplus.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/ForkJoinPoolThresholdAutoSurplus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/concurrent/ForkJoinPoolThresholdAutoSurplus.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/ForkJoinPoolThresholdAutoSurplus.java
@@ -23,12 +23,15 @@
 package org.openjdk.bench.java.util.concurrent;
 
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
  */
 @OutputTimeUnit(TimeUnit.MINUTES)
 @State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+@Fork(3)
 public class ForkJoinPoolThresholdAutoSurplus {
 
     /**
@@ -54,31 +60,40 @@ public class ForkJoinPoolThresholdAutoSurplus {
      * versus sequential version.
      */
 
-    @Param("0")
-    private int workers;
-
     @Param("10000000")
     private int size;
 
-    @Param({"1", "2", "3", "4", "5", "6", "7", "8"})
-    private int threshold;
+    /** Encapsulate all the state depended on only by actual test. This avoids running baselines for every parameter value. */
+    @State(Scope.Benchmark)
+    public static class TestState {
 
-    private ForkJoinPool fjp;
+        @Param("0")
+        private int workers;
+
+        @Param({"1", "2", "3", "4", "5", "6", "7", "8"})
+        private int threshold;
+
+        private ForkJoinPool fjp;
+
+        @Setup
+        public void setup() {
+            if (workers == 0) {
+                workers = Runtime.getRuntime().availableProcessors();
+            }
+            fjp = new ForkJoinPool(workers);
+        }
+
+        @TearDown
+        public void teardown() {
+            fjp.shutdownNow();
+        }
+    }
+
     private Problem problem;
 
     @Setup
     public void setup() {
-        if (workers == 0) {
-            workers = Runtime.getRuntime().availableProcessors();
-        }
-
         problem = new Problem(size);
-        fjp = new ForkJoinPool(workers);
-    }
-
-    @TearDown
-    public void teardown() {
-        fjp.shutdownNow();
     }
 
     @Benchmark
@@ -87,8 +102,8 @@ public class ForkJoinPoolThresholdAutoSurplus {
     }
 
     @Benchmark
-    public Long test() throws ExecutionException, InterruptedException {
-        return fjp.invoke(new AutoQueuedTask(threshold, problem, 0, problem.size()));
+    public Long test(TestState state) throws ExecutionException, InterruptedException {
+        return state.fjp.invoke(new AutoQueuedTask(state.threshold, problem, 0, problem.size()));
     }
 
     private static class AutoQueuedTask extends RecursiveTask<Long> {
@@ -122,7 +137,4 @@ public class ForkJoinPoolThresholdAutoSurplus {
             return res;
         }
     }
-
-
-
 }

--- a/test/micro/org/openjdk/bench/java/util/concurrent/ForkJoinPoolThresholdStatic.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/ForkJoinPoolThresholdStatic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/concurrent/ForkJoinPoolThresholdStatic.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/ForkJoinPoolThresholdStatic.java
@@ -23,12 +23,15 @@
 package org.openjdk.bench.java.util.concurrent;
 
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
  */
 @OutputTimeUnit(TimeUnit.MINUTES)
 @State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+@Fork(3)
 public class ForkJoinPoolThresholdStatic {
 
     /**
@@ -56,31 +62,40 @@ public class ForkJoinPoolThresholdStatic {
      * versus sequential version.
      */
 
-    @Param("0")
-    private int workers;
-
     @Param("10000000")
     private int size;
 
-    @Param({"1", "5", "10", "50", "100", "500", "1000", "5000", "10000", "50000", "100000", "500000", "1000000", "5000000", "10000000"})
-    private int threshold;
+    /** Encapsulate all the state depended on only by actual test. This avoids running baselines for every parameter value. */
+    @State(Scope.Benchmark)
+    public static class TestState {
 
-    private ForkJoinPool fjp;
+        @Param("0")
+        private int workers;
+
+        @Param({"1", "5", "10", "100", "1000", "10000", "100000", "1000000", "10000000"})
+        private int threshold;
+
+        private ForkJoinPool fjp;
+
+        @Setup
+        public void setup() {
+            if (workers == 0) {
+                workers = Runtime.getRuntime().availableProcessors();
+            }
+            fjp = new ForkJoinPool(workers);
+        }
+
+        @TearDown
+        public void teardown() {
+            fjp.shutdownNow();
+        }
+    }
+
     private Problem problem;
 
     @Setup
     public void setup() {
-        if (workers == 0) {
-            workers = Runtime.getRuntime().availableProcessors();
-        }
-
         problem = new Problem(size);
-        fjp = new ForkJoinPool(workers);
-    }
-
-    @TearDown
-    public void teardown() {
-        fjp.shutdownNow();
     }
 
     @Benchmark
@@ -89,8 +104,8 @@ public class ForkJoinPoolThresholdStatic {
     }
 
     @Benchmark
-    public Long test() throws ExecutionException, InterruptedException {
-        return fjp.invoke(new AdjustableThreshTask(threshold, problem, 0, problem.size()));
+    public Long test(TestState state) throws ExecutionException, InterruptedException {
+        return state.fjp.invoke(new AdjustableThreshTask(state.threshold, problem, 0, problem.size()));
     }
 
     private static class AdjustableThreshTask extends RecursiveTask<Long> {

--- a/test/micro/org/openjdk/bench/java/util/concurrent/Locks.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/Locks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/concurrent/Locks.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/Locks.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.util.concurrent;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.io.IOException;
@@ -44,6 +47,9 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(3)
 public class Locks {
 
     private ReentrantLock reentrantLock;

--- a/test/micro/org/openjdk/bench/java/util/concurrent/Maps.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/Maps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/concurrent/Maps.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/Maps.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.concurrent;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -39,6 +42,9 @@ import java.util.concurrent.atomic.AtomicLong;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(3)
 public class Maps {
     private SimpleRandom rng;
     private Map<Integer, Integer> map;

--- a/test/micro/org/openjdk/bench/java/util/concurrent/ProducerConsumer.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/ProducerConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/concurrent/ProducerConsumer.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/ProducerConsumer.java
@@ -24,6 +24,8 @@ package org.openjdk.bench.java.util.concurrent;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
@@ -31,6 +33,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.util.concurrent.ArrayBlockingQueue;
@@ -47,6 +50,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(3)
 public class ProducerConsumer {
 
     @Param("100")

--- a/test/micro/org/openjdk/bench/java/util/concurrent/Queues.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/Queues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/concurrent/Queues.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/Queues.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.concurrent;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.util.concurrent.ArrayBlockingQueue;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(3)
 public class Queues {
 
     @Param("100")

--- a/test/micro/org/openjdk/bench/java/util/concurrent/ThreadLocalRandomNextInt.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/ThreadLocalRandomNextInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/concurrent/ThreadLocalRandomNextInt.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/ThreadLocalRandomNextInt.java
@@ -32,6 +32,9 @@ import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(3)
 public class ThreadLocalRandomNextInt {
 
     @State(Scope.Benchmark)


### PR DESCRIPTION
- Refactor so that various baseline micros are not run repeatedly with different parameter values that does not affect the baseline
- Tune iteration times, counts, forks..

Reduces runtime of java.util.concurrent micros from an estimated 14h43m to 1h21m

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288732](https://bugs.openjdk.org/browse/JDK-8288732): Reduce runtime of java.util.concurrent microbenchmarks


### Reviewers
 * [Eric Caspole](https://openjdk.org/census#ecaspole) (@ericcaspole - Committer)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9214/head:pull/9214` \
`$ git checkout pull/9214`

Update a local copy of the PR: \
`$ git checkout pull/9214` \
`$ git pull https://git.openjdk.org/jdk pull/9214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9214`

View PR using the GUI difftool: \
`$ git pr show -t 9214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9214.diff">https://git.openjdk.org/jdk/pull/9214.diff</a>

</details>
