### PR TITLE
JDK-8288740: Change incorrect documentation for sjavac flag

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -810,7 +810,7 @@ ls build/linux-aarch64-server-release/</code></pre></li>
 <p><a href="http://github.com/icecc/icecream">icecc/icecream</a> is a simple way to setup a distributed compiler network. If you have multiple machines available for building the JDK, you can drastically cut individual build times by utilizing it.</p>
 <p>To use, setup an icecc network, and install icecc on the build machine. Then run <code>configure</code> using <code>--enable-icecc</code>.</p>
 <h3 id="using-sjavac">Using sjavac</h3>
-<p>To speed up Java compilation, especially incremental compilations, you can try the experimental sjavac compiler by using <code>--enable-sjavac</code>.</p>
+<p>To speed up compilation of Java code, especially during incremental compilations, the sjavac server is automatically enabled in the configuration step by default. To explicitly enable or disable sjavac, use either <code>--enable-javac-server</code> or <code>--disable-javac-server</code>.</p>
 <h3 id="building-the-right-target">Building the Right Target</h3>
 <p>Selecting the proper target to build can have dramatic impact on build time. For normal usage, <code>jdk</code> or the default target is just fine. You only need to build <code>images</code> for shipping, or if your tests require it.</p>
 <p>See also <a href="#using-fine-grained-make-targets">Using Fine-Grained Make Targets</a> on how to build an even smaller subset of the product.</p>

--- a/doc/building.md
+++ b/doc/building.md
@@ -1296,8 +1296,10 @@ run `configure` using `--enable-icecc`.
 
 ### Using sjavac
 
-To speed up Java compilation, especially incremental compilations, you can try
-the experimental sjavac compiler by using `--enable-sjavac`.
+To speed up compilation of Java code, especially during incremental compilations,
+the sjavac server is automatically enabled in the configuration step by default.
+To explicitly enable or disable sjavac, use either `--enable-javac-server`
+or `--disable-javac-server`.
 
 ### Building the Right Target
 


### PR DESCRIPTION
The documentation for build performance currently points to the non-existent --enable-sjavac flag to enable sjavac, the correct one is actually --enable-javac-server (Finally seem to have gotten pandoc working, hopefully the html is correct this time)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288740](https://bugs.openjdk.org/browse/JDK-8288740): Change incorrect documentation for sjavac flag


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9215/head:pull/9215` \
`$ git checkout pull/9215`

Update a local copy of the PR: \
`$ git checkout pull/9215` \
`$ git pull https://git.openjdk.org/jdk pull/9215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9215`

View PR using the GUI difftool: \
`$ git pr show -t 9215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9215.diff">https://git.openjdk.org/jdk/pull/9215.diff</a>

</details>
