### PR TITLE
8288741: JFR: Change package of snippet files

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/snippet-files/Snippets.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/snippet-files/Snippets.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package example2;
+package jdk.jfr.snippets.consumer;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/src/jdk.jfr/share/classes/jdk/jfr/snippet-files/Snippets.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/snippet-files/Snippets.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package example1;
+package jdk.jfr.snippets;
 
 import jdk.jfr.AnnotationElement;
 import jdk.jfr.ValueDescriptor;


### PR DESCRIPTION
Could I have a review of PR that changes package names of the JFR snippet files. Today they are named "example1" and "example2" in the default package. It looks strange to see them on top and before jdk.jfr when browsing classes in jrt-fs.jar, for example in Eclipse.

Testing: build docs + tier1 + tier2

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288741](https://bugs.openjdk.org/browse/JDK-8288741): JFR: Change package of snippet files


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9216/head:pull/9216` \
`$ git checkout pull/9216`

Update a local copy of the PR: \
`$ git checkout pull/9216` \
`$ git pull https://git.openjdk.org/jdk pull/9216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9216`

View PR using the GUI difftool: \
`$ git pr show -t 9216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9216.diff">https://git.openjdk.org/jdk/pull/9216.diff</a>

</details>
