### PR TITLE
JDK-8288746: HttpClient resources could be reclaimed more eagerly

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -232,7 +232,8 @@ module java.base {
         jdk.management,
         jdk.jfr;
     exports jdk.internal.ref to
-        java.desktop;
+        java.desktop,
+        java.net.http;
     exports jdk.internal.reflect to
         java.logging,
         java.sql,

--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -19,6 +19,7 @@ grant codeBase "jrt:/java.net.http" {
     permission java.lang.RuntimePermission "accessClassInPackage.sun.net.util";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.net.www";
     permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.misc";
+    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.ref";
     permission java.lang.RuntimePermission "modifyThread";
     permission java.net.SocketPermission "*","connect,resolve";
     // required if the HTTPClient is configured to use a local bind address

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientFacade.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package jdk.internal.net.http;
 
 import java.io.IOException;
+import java.lang.ref.Cleaner;
 import java.lang.ref.Reference;
 import java.net.Authenticator;
 import java.net.CookieHandler;
@@ -44,12 +45,19 @@ import java.net.http.HttpResponse.PushPromiseHandler;
 import java.net.http.WebSocket;
 import jdk.internal.net.http.common.OperationTrackers.Trackable;
 import jdk.internal.net.http.common.OperationTrackers.Tracker;
+import jdk.internal.ref.CleanerFactory;
 
 /**
  * An HttpClientFacade is a simple class that wraps an HttpClient implementation
  * and delegates everything to its implementation delegate.
+ * @implSpec
+ * Though the facade strongly reference its implementation, the
+ * implementation MUST NOT strongly reference the facade.
+ * It MAY use weak references if needed.
  */
 public final class HttpClientFacade extends HttpClient implements Trackable {
+
+    static final Cleaner cleaner = CleanerFactory.cleaner();
 
     final HttpClientImpl impl;
 
@@ -58,6 +66,8 @@ public final class HttpClientFacade extends HttpClient implements Trackable {
      */
     HttpClientFacade(HttpClientImpl impl) {
         this.impl = impl;
+        // wakeup the impl when the facade is gc'ed
+        cleaner.register(this, impl::facadeCleanup);
     }
 
     @Override // for tests

--- a/test/jdk/java/net/httpclient/DigestEchoClient.java
+++ b/test/jdk/java/net/httpclient/DigestEchoClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,8 @@
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
 import java.math.BigInteger;
 import java.net.ProxySelector;
 import java.net.URI;
@@ -32,7 +34,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublisher;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandler;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
@@ -54,6 +55,7 @@ import javax.net.ssl.SSLContext;
 import jdk.test.lib.net.SimpleSSLContext;
 import sun.net.NetProperties;
 import sun.net.www.HeaderParser;
+
 import static java.lang.System.out;
 import static java.lang.String.format;
 
@@ -392,6 +394,8 @@ public class DigestEchoClient {
                 server.getServerAddress(), "/foo/");
 
         HttpClient client = newHttpClient(server);
+        ReferenceQueue<HttpClient> queue = new ReferenceQueue<>();
+        WeakReference<HttpClient> ref = new WeakReference<>(client, queue);
         HttpResponse<String> r;
         CompletableFuture<HttpResponse<String>> cf1;
         String auth = null;
@@ -503,6 +507,14 @@ public class DigestEchoClient {
                 }
             }
         } finally {
+            client = null;
+            System.gc();
+            while (!ref.refersTo(null)) {
+                System.gc();
+                if (queue.remove(100) == ref) break;
+            }
+            var error = TRACKER.checkShutdown(500);
+            if (error != null) throw error;
         }
         System.out.println("OK");
     }

--- a/test/jdk/java/net/httpclient/ReferenceTracker.java
+++ b/test/jdk/java/net/httpclient/ReferenceTracker.java
@@ -179,13 +179,15 @@ public class ReferenceTracker {
                                 boolean printThreads) {
         AssertionError fail = null;
         graceDelayMs = Math.max(graceDelayMs, 100);
-        long delay = Math.min(graceDelayMs, 500);
+        long delay = Math.min(graceDelayMs, 10);
         var count = delay > 0 ? graceDelayMs / delay : 1;
         for (int i = 0; i < count; i++) {
             if (TRACKERS.stream().anyMatch(hasOutstanding)) {
                 System.gc();
                 try {
-                    System.out.println("Waiting for HTTP operations to terminate...");
+                    if (i == 0) {
+                        System.out.println("Waiting for HTTP operations to terminate...");
+                    }
                     Thread.sleep(Math.min(graceDelayMs, Math.max(delay, 1)));
                 } catch (InterruptedException x) {
                     // OK

--- a/test/jdk/java/net/httpclient/ResponseBodyBeforeError.java
+++ b/test/jdk/java/net/httpclient/ResponseBodyBeforeError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @summary Tests that all response body is delivered to the BodySubscriber
  *          before an abortive error terminates the flow
+ * @modules java.net.http/jdk.internal.net.http.common
  * @library /test/lib
  * @build jdk.test.lib.net.SimpleSSLContext
  * @run testng/othervm ResponseBodyBeforeError
@@ -59,6 +60,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLServerSocketFactory;
+
+import static java.lang.System.err;
 import static java.lang.System.out;
 import static java.net.http.HttpClient.Builder.NO_PROXY;
 import static java.net.http.HttpResponse.BodyHandlers.ofString;
@@ -177,6 +180,7 @@ public class ResponseBodyBeforeError {
     }
 
     static final int ITERATION_COUNT = 3;
+    static final ReferenceTracker TRACKER = ReferenceTracker.INSTANCE;
 
     @Test(dataProvider = "uris")
     void testSynchronousAllRequestBody(String url,
@@ -186,24 +190,34 @@ public class ResponseBodyBeforeError {
     {
         out.print("---\n");
         HttpClient client = null;
-        for (int i=0; i< ITERATION_COUNT; i++) {
-            if (!sameClient || client == null)
-                client = HttpClient.newBuilder()
-                        .proxy(NO_PROXY)
-                        .sslContext(sslContext)
-                        .build();
-            HttpRequest request = HttpRequest.newBuilder(URI.create(url)).build();
-            CustomBodySubscriber bs = new CustomBodySubscriber();
-            try {
-                HttpResponse<String> response = client.send(request, r -> bs);
-                String body = response.body();
-                out.println(response + ": " + body);
-                fail("UNEXPECTED RESPONSE: " + response);
-            } catch (IOException expected) {
-                String pm = bs.receivedAsString();
-                out.println("partial body received: " + pm);
-                assertEquals(pm, expectedPatrialBody);
+        try {
+            for (int i = 0; i < ITERATION_COUNT; i++) {
+                if (!sameClient || client == null) {
+                    client = HttpClient.newBuilder()
+                            .proxy(NO_PROXY)
+                            .sslContext(sslContext)
+                            .build();
+                    TRACKER.track(client);
+                    System.gc();
+                }
+                HttpRequest request = HttpRequest.newBuilder(URI.create(url)).build();
+                CustomBodySubscriber bs = new CustomBodySubscriber();
+                try {
+                    HttpResponse<String> response = client.send(request, r -> bs);
+                    String body = response.body();
+                    out.println(response + ": " + body);
+                    fail("UNEXPECTED RESPONSE: " + response);
+                } catch (IOException expected) {
+                    String pm = bs.receivedAsString();
+                    out.println("partial body received: " + pm);
+                    assertEquals(pm, expectedPatrialBody);
+                }
             }
+        } finally {
+            client = null;
+            System.gc();
+            var error = TRACKER.checkShutdown(1000);
+            if (error != null) throw error;
         }
     }
 
@@ -215,28 +229,38 @@ public class ResponseBodyBeforeError {
     {
         out.print("---\n");
         HttpClient client = null;
-        for (int i=0; i< ITERATION_COUNT; i++) {
-            if (!sameClient || client == null)
-                client = HttpClient.newBuilder()
-                        .proxy(NO_PROXY)
-                        .sslContext(sslContext)
-                        .build();
-            HttpRequest request = HttpRequest.newBuilder(URI.create(url)).build();
-            CustomBodySubscriber bs = new CustomBodySubscriber();
-            try {
-                HttpResponse<String> response = client.sendAsync(request, r -> bs).get();
-                String body = response.body();
-                out.println(response + ": " + body);
-                fail("UNEXPECTED RESPONSE: " + response);
-            } catch (ExecutionException ee) {
-                if (ee.getCause() instanceof IOException) {
-                    String pm = bs.receivedAsString();
-                    out.println("partial body received: " + pm);
-                    assertEquals(pm, expectedPatrialBody);
-                } else {
-                    throw ee;
+        try {
+            for (int i = 0; i < ITERATION_COUNT; i++) {
+                if (!sameClient || client == null) {
+                    client = HttpClient.newBuilder()
+                            .proxy(NO_PROXY)
+                            .sslContext(sslContext)
+                            .build();
+                    System.gc();
+                    TRACKER.track(client);
+                }
+                HttpRequest request = HttpRequest.newBuilder(URI.create(url)).build();
+                CustomBodySubscriber bs = new CustomBodySubscriber();
+                try {
+                    HttpResponse<String> response = client.sendAsync(request, r -> bs).get();
+                    String body = response.body();
+                    out.println(response + ": " + body);
+                    fail("UNEXPECTED RESPONSE: " + response);
+                } catch (ExecutionException ee) {
+                    if (ee.getCause() instanceof IOException) {
+                        String pm = bs.receivedAsString();
+                        out.println("partial body received: " + pm);
+                        assertEquals(pm, expectedPatrialBody);
+                    } else {
+                        throw ee;
+                    }
                 }
             }
+        } finally {
+            client = null;
+            System.gc();
+            var error = TRACKER.checkShutdown(1000);
+            if (error != null) throw error;
         }
     }
 


### PR DESCRIPTION
Hi,

Please find here a patch that should help the HttpClient's SelectorManager thread to terminate more timely, allowing the resources consumed by the client to be released earlier.

The idea is to use a Cleaner registered with the HttpClientFacade to wakeup the Selector when the facade is being gc'ed.
Some tests have been modified to wait for the selector manager thread to shutdown, and some of them have been observed to timeout when the fix is not in place.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288746](https://bugs.openjdk.org/browse/JDK-8288746): HttpClient resources could be reclaimed more eagerly


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9217/head:pull/9217` \
`$ git checkout pull/9217`

Update a local copy of the PR: \
`$ git checkout pull/9217` \
`$ git pull https://git.openjdk.org/jdk pull/9217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9217`

View PR using the GUI difftool: \
`$ git pr show -t 9217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9217.diff">https://git.openjdk.org/jdk/pull/9217.diff</a>

</details>
