### PR TITLE
8288754: GCC 12 fails to build zReferenceProcessor.cpp

### DIFF
--- a/src/hotspot/share/gc/z/zReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/z/zReferenceProcessor.cpp
@@ -59,7 +59,7 @@ static const char* reference_type_name(ReferenceType type) {
 
   default:
     ShouldNotReachHere();
-    return NULL;
+    return "ERROR";
   }
 }
 


### PR DESCRIPTION
When compiling with GCC 12.1.1 (current in Fedora rawhide), the following warning-as-error is produced and breaks the build by default:

```
/home/test/shipilev-jdk/src/hotspot/share/gc/z/zReferenceProcessor.cpp: In member function 'oopDesc* ZReferenceProcessor::drop(oop, ReferenceType)':
/home/test/shipilev-jdk/src/hotspot/share/gc/z/zReferenceProcessor.cpp:270:22: error: '%s' directive argument is null [-Werror=format-overflow=]
  270 | log_trace(gc, ref)("Dropped Reference: " PTR_FORMAT " (%s)", p2i(reference), reference_type_name(type));
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The problem is over-zealous compiler seeing `NULL` from `ShouldNotReachHere()` block, and complaining about it. In this particular case, we can dodge this by returning a more reasonable constant on failure path.

(This thing should be more reasonably handled when `ShouldNotReachHere()` is somehow `nonreturn`-ed, but Hotspot style doc is still undecided on this).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288754](https://bugs.openjdk.org/browse/JDK-8288754): GCC 12 fails to build zReferenceProcessor.cpp


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9219/head:pull/9219` \
`$ git checkout pull/9219`

Update a local copy of the PR: \
`$ git checkout pull/9219` \
`$ git pull https://git.openjdk.org/jdk pull/9219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9219`

View PR using the GUI difftool: \
`$ git pr show -t 9219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9219.diff">https://git.openjdk.org/jdk/pull/9219.diff</a>

</details>
