### PR TITLE
8288744: Remove tools/jlink/plugins/CompressorPluginTest.java from problemlist

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -692,7 +692,6 @@ sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all
 
 # core_tools
 
-tools/jlink/plugins/CompressorPluginTest.java                   8247407 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Can I please get a review for this change which proposes to remove the `CompressorPluginTest` from the problemlist?

This test was problem listed since it had intermittently failed with odd exception in the past (https://bugs.openjdk.org/browse/JDK-8247407). Over the past several months I have attempted multiple runs of this test (with very high test repeats) both locally as well as a CI setup to see if this is still reproducible. So far, I haven't been able to reproduce it. Given the odd exception it was throwing originally, it's hard to say what the issue could have been (and whether it got fixed in recent times), but since it isn't reproducible now, I would like to remove this from the problemlist. If it does fail again, I'll go ahead and collect some additional details to help narrow this down.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288744](https://bugs.openjdk.org/browse/JDK-8288744): Remove tools/jlink/plugins/CompressorPluginTest.java from problemlist


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9221/head:pull/9221` \
`$ git checkout pull/9221`

Update a local copy of the PR: \
`$ git checkout pull/9221` \
`$ git pull https://git.openjdk.org/jdk pull/9221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9221`

View PR using the GUI difftool: \
`$ git pr show -t 9221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9221.diff">https://git.openjdk.org/jdk/pull/9221.diff</a>

</details>
