### PR TITLE
JDK-8288824: [arm32] Display isetstate in register output

### DIFF
--- a/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
+++ b/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
@@ -444,7 +444,20 @@ void os::print_context(outputStream *st, const void *context) {
   }
 #define U64_FORMAT "0x%016llx"
   // now print flag register
-  st->print_cr("  %-4s = 0x%08lx", "cpsr",uc->uc_mcontext.arm_cpsr);
+  uint32_t cpsr = uc->uc_mcontext.arm_cpsr;
+  st->print_cr("  %-4s = 0x%08x", "cpsr", cpsr);
+  // print out instruction set state
+  st->print("isetstate: ");
+  const int isetstate =
+      ((cpsr & (1 << 5))  ? 1 : 0) | // T
+      ((cpsr & (1 << 24)) ? 2 : 0); // J
+  switch (isetstate) {
+  case 0: st->print_cr("ARM"); break;
+  case 1: st->print_cr("Thumb"); break;
+  case 2: st->print_cr("Jazelle"); break;
+  case 3: st->print_cr("ThumbEE"); break;
+  default: ShouldNotReachHere();
+  };
   st->cr();
 }
 


### PR DESCRIPTION
When analyzing [JDK-8288719](https://bugs.openjdk.org/browse/JDK-8288719), to know the current isetstate was useful. It would be nice if that were printed clearly in the register output to save some mental cycles parsing CPSR.

Looks like this:
```
Registers:
  r0  = 0x00000000
  r1  = 0xbe9e7fb8
  r2  = 0x00000000
  r3  = 0xb6f860ac
  r4  = 0xbe9e7fb8
  r5  = 0xb6f864e0
  r6  = 0xbe9e8060
  r7  = 0xbe9e7fb0
  r8  = 0xb6da8798
  r9  = 0x00000000
  r10 = 0x00000000
  fp  = 0x00000001
  r12 = 0xb6da87ec
  sp  = 0xbe9e7fb0
  lr  = 0xb6bc7dfb
  pc  = 0xb6bc7dfa
  cpsr = 0x800e0030
isetstate: Thumb

Registers:
  r0  = 0xb6be3664
  r1  = 0xbe947c70
  r2  = 0x00000058
  r3  = 0xb6f3e000
  r4  = 0xbe947c70
  r5  = 0xb6f3f510
  r6  = 0xb6c95bdc
  r7  = 0xbe947d18
  r8  = 0xbe947d98
  r9  = 0x00000000
  r10 = 0x00000000
  fp  = 0xbe947d14
  r12 = 0xb6c95f84
  sp  = 0xbe947c68
  lr  = 0xb6e97218
  pc  = 0xb6793f3c
  cpsr = 0x60000010
isetstate: ARM 
```

I refrained from parsing more information from the CPSR because I did not want to blow up the patch. ISETSTATE proved to be useful. More information can be added if needed.
