### PR TITLE
8288838: jpackage: file association additional arguments

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Arguments.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Arguments.java
@@ -64,6 +64,7 @@ public class Arguments {
     private static final String FA_CONTENT_TYPE = "mime-type";
     private static final String FA_DESCRIPTION = "description";
     private static final String FA_ICON = "icon";
+    private static final String FA_PASS_ALL_ARGUMENTS = "pass-all-args";
 
     // Mac specific file association keys
     // String
@@ -234,6 +235,9 @@ public class Arguments {
 
             putUnlessNull(args, StandardBundlerParam.FA_ICON.getID(),
                     initialMap.get(FA_ICON));
+
+            putUnlessNull(args, StandardBundlerParam.FA_PASS_ALL_ARGUMENTS.getID(),
+                    initialMap.get(FA_PASS_ALL_ARGUMENTS));
 
             // Mac extended file association arguments
             putUnlessNull(args, MAC_CFBUNDLETYPEROLE,

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/FileAssociation.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/FileAssociation.java
@@ -39,6 +39,7 @@ import static jdk.jpackage.internal.StandardBundlerParam.FA_EXTENSIONS;
 import static jdk.jpackage.internal.StandardBundlerParam.FA_CONTENT_TYPE;
 import static jdk.jpackage.internal.StandardBundlerParam.FA_ICON;
 import static jdk.jpackage.internal.StandardBundlerParam.FA_DESCRIPTION;
+import static jdk.jpackage.internal.StandardBundlerParam.FA_PASS_ALL_ARGUMENTS;
 
 final class FileAssociation {
     void verify() {
@@ -94,6 +95,10 @@ final class FileAssociation {
                         assoc.iconPath = icon;
                     }
 
+                    assoc.passAllArguments = Optional.ofNullable(
+                    FA_PASS_ALL_ARGUMENTS.fetchFrom(fa))
+                    .orElse(false);
+
                     return assoc;
                 }).toList();
     }
@@ -103,4 +108,5 @@ final class FileAssociation {
     List<String> mimeTypes;
     List<String> extensions;
     String description;
+    boolean passAllArguments;
 }

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/StandardBundlerParam.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/StandardBundlerParam.java
@@ -417,6 +417,14 @@ class StandardBundlerParam<T> extends BundlerParamInfo<T> {
                     (s, p) -> Path.of(s)
             );
 
+    static final StandardBundlerParam<Boolean> FA_PASS_ALL_ARGUMENTS =
+            new StandardBundlerParam<>(
+                    "fileAssociation.passAllArguments",
+                    Boolean.class,
+                    params -> false,
+                    (s, p) -> Boolean.valueOf(s)
+            );
+
     @SuppressWarnings("unchecked")
     static final BundlerParamInfo<List<String>> DMG_CONTENT =
             new StandardBundlerParam<>(

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixAppImageFragmentBuilder.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixAppImageFragmentBuilder.java
@@ -529,7 +529,11 @@ class WixAppImageFragmentBuilder extends WixFragmentBuilder {
                 xml.writeStartElement("Verb");
                 xml.writeAttribute("Id", "open");
                 xml.writeAttribute("Command", "Open");
-                xml.writeAttribute("Argument", "\"%1\"");
+                if (fa.passAllArguments) {
+                    xml.writeAttribute("Argument", "\"%1\" %*");
+                } else {
+                    xml.writeAttribute("Argument", "\"%1\"");
+                }
                 xml.writeAttribute("TargetFile", Id.File.of(fa.launcherPath));
                 xml.writeEndElement(); // <Verb>
 

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/FileAssociations.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/FileAssociations.java
@@ -50,6 +50,9 @@ final public class FileAssociations {
                 entries.put("icon", icon.toString());
             }
         }
+        if (passAllArguments) {
+            entries.put("pass-all-args", "true");
+        }
         TKit.createPropertiesFile(file, entries);
     }
 
@@ -65,6 +68,11 @@ final public class FileAssociations {
 
     public FileAssociations setIcon(Path v) {
         icon = v;
+        return this;
+    }
+
+    public FileAssociations setPassAllArguments() {
+        passAllArguments = true;
         return this;
     }
 
@@ -101,4 +109,5 @@ final public class FileAssociations {
     final private String suffixName;
     private String description;
     private Path icon;
+    boolean passAllArguments;
 }

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
@@ -268,14 +268,21 @@ public final class PackageTest extends RunnablePackageTest {
                         .resolve(HelloApp.OUTPUT_FILENAME);
                 Files.deleteIfExists(appOutput);
 
-                TKit.trace(String.format("Use desktop to open [%s] file",
-                        testFile));
-                Desktop.getDesktop().open(testFile.toFile());
-                TKit.waitForFileCreated(appOutput, 7);
-
                 List<String> expectedArgs = new ArrayList<>(List.of(
                         faLauncherDefaultArgs));
                 expectedArgs.add(testFile.toString());
+
+                if (fa.passAllArguments) {
+                    TKit.trace(String.format("Use cmd.exe to open [%s] file with arguments",
+                            testFile));
+                    Executor.of("cmd", "/c", testFile.toString(), "foo", "bar", "baz").execute();
+                    expectedArgs.addAll(List.of("foo", "bar", "baz"));
+                } else {
+                    TKit.trace(String.format("Use desktop to open [%s] file",
+                            testFile));
+                    Desktop.getDesktop().open(testFile.toFile());
+                }
+                TKit.waitForFileCreated(appOutput, 7);
 
                 // Wait a little bit after file has been created to
                 // make sure there are no pending writes into it.

--- a/test/jdk/tools/jpackage/share/FileAssociationsTest.java
+++ b/test/jdk/tools/jpackage/share/FileAssociationsTest.java
@@ -24,10 +24,8 @@
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.List;
-import jdk.jpackage.test.TKit;
-import jdk.jpackage.test.PackageTest;
-import jdk.jpackage.test.PackageType;
-import jdk.jpackage.test.FileAssociations;
+
+import jdk.jpackage.test.*;
 import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.Annotations.Parameter;
 
@@ -86,6 +84,7 @@ public class FileAssociationsTest {
     @Parameter("false")
     public static void test(boolean includeDescription) {
         PackageTest packageTest = new PackageTest();
+        packageTest.forTypes(PackageType.WIN_EXE);
 
         // Not supported
         packageTest.excludeTypes(PackageType.MAC_DMG);
@@ -93,6 +92,8 @@ public class FileAssociationsTest {
         FileAssociations fa = new FileAssociations("jptest1");
         if (!includeDescription) {
             fa.setDescription(null);
+        } else {
+            fa.setPassAllArguments();
         }
         fa.applyTo(packageTest);
 
@@ -106,7 +107,8 @@ public class FileAssociationsTest {
                 .setIcon(icon)
                 .applyTo(packageTest);
 
-        packageTest.run();
+        packageTest.run(RunnablePackageTest.Action.CREATE, RunnablePackageTest.Action.INSTALL,
+                RunnablePackageTest.Action.VERIFY_INSTALL, RunnablePackageTest.Action.UNINSTALL);
     }
 
     @Test


### PR DESCRIPTION
jpackage implementation of file association on Windows currently passes a selected filename as an only argument to associated executable.

It is proposed to introduce additional option in file association property file to allow optionally support additional arguments using `%*` batch wildcard.

Note, current implementation, while fully functional, is only a **DRAFT** one, it is not ready for integration in this form. I would appreciate any guidance on the following points:

 - option naming inside a properties file, currently `pass-all-args` is used
 - option naming in a bundler parameter implementation, it is not clear if it should introduce a new group of "file association windows specific options" next to the existing "file association mac specific options" group
 - test organization to cover the new option: currently it is included inside `FileAssociationTest` and piggybacks on the existing (and unrelated) `includeDescription` parameter; it is not clear whether it should be done in a separate test and whether to include runs for every parameter combination
 - test run implementation: currently arguments are checked when a file with associated extension is invoked from command line; it is not clear whether it would be more appropriate instead to create a desktop shortcut with the same command as a target and to invoke it with `java.aws.Desktop`

Also please note, that full install/uninstall run is currently enabled in `FileAssociationTest`, it is intended to be used only in a draft code during the development and to be removed (to use the same "install or unpack" logic as other tests) in a final version.

Testing:
 
- [x] test to cover new logic is included
- [x] ran jtreg:jdk/tools/jpackage with no new failures