### PR TITLE
8288904: Incorrect memory ordering in UL

### DIFF
--- a/src/hotspot/share/logging/logOutputList.cpp
+++ b/src/hotspot/share/logging/logOutputList.cpp
@@ -46,6 +46,8 @@ void LogOutputList::wait_until_no_readers() const {
   while (Atomic::load(&_active_readers) != 0) {
     // Busy wait
   }
+  // Prevent mutations to the output list to float above the active reader check.
+  // Such a reordering would lead to readers loading faulty data.
   OrderAccess::loadstore();
 }
 

--- a/src/hotspot/share/logging/logOutputList.cpp
+++ b/src/hotspot/share/logging/logOutputList.cpp
@@ -43,9 +43,10 @@ jint LogOutputList::decrease_readers() {
 
 void LogOutputList::wait_until_no_readers() const {
   OrderAccess::storeload();
-  while (_active_readers != 0) {
+  while (Atomic::load(&_active_readers) != 0) {
     // Busy wait
   }
+  OrderAccess::loadstore();
 }
 
 void LogOutputList::set_output_level(LogOutput* output, LogLevelType level) {


### PR DESCRIPTION
Please review this fix for JDK-8288904, thank you.

Passed tier1-tier3 tests, excluding faulty tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288904](https://bugs.openjdk.org/browse/JDK-8288904): Incorrect memory ordering in UL


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9225/head:pull/9225` \
`$ git checkout pull/9225`

Update a local copy of the PR: \
`$ git checkout pull/9225` \
`$ git pull https://git.openjdk.org/jdk pull/9225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9225`

View PR using the GUI difftool: \
`$ git pr show -t 9225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9225.diff">https://git.openjdk.org/jdk/pull/9225.diff</a>

</details>
