### PR TITLE
8286030: Support sharing of /tmp across Linux containers

### DIFF
--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -85,6 +85,9 @@
   product(bool, UseCpuAllocPath, false, DIAGNOSTIC,                     \
           "Use CPU_ALLOC code path in os::active_processor_count ")     \
                                                                         \
+  product(bool, UseRandomAttachID, false, DIAGNOSTIC,                   \
+          "Always use a random ID for hsperfdata file")                 \
+                                                                        \
   product(bool, DumpPerfMapAtExit, false, DIAGNOSTIC,                   \
           "Write map file for Linux perf tool at exit")
 

--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -781,7 +781,7 @@ static void cleanup_sharedmem_resources(int vmid, const char* dirname) {
     }
 
     // we now have a file name that converts to a valid integer
-    // that could represent a process id . 
+    // that could represent a process id .
     unlink_sharedmem_file_if_stale(vmid, pid, dirname, entry->d_name);
   }
 
@@ -971,7 +971,7 @@ static int open_sharedmem_file(const char* filename, int oflags, TRAPS) {
 
 static int open_sharedmem_file_from_proc_maps(int vmid, int oflags, TRAPS) {
   char buffer[512];
-  jio_snprintf(buffer, sizeof(buffer), "/proc/%d/maps", vmid); // FIXME: assert return 
+  jio_snprintf(buffer, sizeof(buffer), "/proc/%d/maps", vmid); // FIXME: assert return
 
   FILE* f = os::fopen(buffer, "r");
   int num_found = 0;

--- a/src/hotspot/share/runtime/perfMemory.cpp
+++ b/src/hotspot/share/runtime/perfMemory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,8 @@ size_t                   PerfMemory::_capacity = 0;
 int                      PerfMemory::_initialized = false;
 PerfDataPrologue*        PerfMemory::_prologue = NULL;
 bool                     PerfMemory::_destroyed = false;
+int                      PerfMemory::_attach_id = 0;
+bool                     PerfMemory::_attach_id_initialized = false;
 
 void perfMemory_init() {
 

--- a/src/hotspot/share/runtime/perfMemory.hpp
+++ b/src/hotspot/share/runtime/perfMemory.hpp
@@ -123,6 +123,8 @@ class PerfMemory : AllStatic {
     static PerfDataPrologue*  _prologue;
     static int    _initialized;
     static bool   _destroyed;
+    static int    _attach_id;
+    static bool   _attach_id_initialized;
 
     static void create_memory_region(size_t sizep);
     static void delete_memory_region();
@@ -157,6 +159,14 @@ class PerfMemory : AllStatic {
     // returns the complete file path of hsperfdata.
     // the caller is expected to free the allocated memory.
     static char* get_perfdata_file_path();
+
+    // Used/Implemented only by posix
+    static int attach_id();
+
+    static void set_attach_id(int i) {
+      _attach_id_initialized = true;
+      _attach_id = i;
+    }
 };
 
 void perfMemory_init();

--- a/src/jdk.internal.jvmstat/share/classes/module-info.java
+++ b/src/jdk.internal.jvmstat/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@
  * @since 9
  */
 module jdk.internal.jvmstat {
+    exports sun.jvmstat to
+        jdk.attach;
     exports sun.jvmstat.monitor to
         jdk.attach,
         jdk.jcmd,

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/PlatformSupport.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/PlatformSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package sun.jvmstat;
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.util.List;
+import java.util.Set;
 import jdk.internal.vm.VMSupport;
 
 /*
@@ -102,12 +103,11 @@ public class PlatformSupport {
         return Integer.parseInt(file.getName());
     }
 
+    public Set<Integer> activeVms() {
+        return null;
+    }
 
-    /*
-     * Return the inner most namespaced PID if there is one,
-     * otherwise return the original PID.
-     */
-    public int getNamespaceVmId(int pid) {
-        return pid;
+    public Integer getAttachID(int pid) {
+        return null;
     }
 }

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/LocalVmManager.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/LocalVmManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package sun.jvmstat.perfdata.monitor.protocol.local;
 import java.util.*;
 import java.util.regex.*;
 import java.io.*;
+import sun.jvmstat.PlatformSupport;
 
 /**
  * Class for managing the LocalMonitoredVm instances on the local system.
@@ -85,12 +86,16 @@ public class LocalVmManager {
      * @return Set - the Set of monitorable Java Virtual Machines
      */
     public synchronized Set<Integer> activeVms() {
+        Set<Integer> jvmSet = PlatformSupport.getInstance().activeVms();
+        if (jvmSet != null) {
+            return jvmSet;
+        }
         /*
          * TODO: this method was synchronized due to its thread-unsafe use of the regexp
          * Matcher objects. That is not the case anymore, but I am too afraid to change
          * it now. Maybe fix this later in a separate RFE.
          */
-        Set<Integer> jvmSet = new HashSet<Integer>();
+        jvmSet = new HashSet<Integer>();
         List<String> tmpdirs = PerfDataFile.getTempDirectories(0);
 
         for (String dir : tmpdirs) {

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/PerfDataFile.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/PerfDataFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ public class PerfDataFile {
      * <p>
      * This prefix must be kept in sync with the prefix used by the JVM.
      */
-    public static final String dirNamePrefix = "hsperfdata_";
+    public static final String dirNamePrefix = "hsperfdata_"; // FIXME -- use this
 
     /**
      * The directory name pattern for the user directories.


### PR DESCRIPTION
There are some Kubernetes setups that share the same `/tmp` directory across multiple containers. Such a scenario is currently not supported by the JDK and crashes may happen.

### Goals

+ Allow JVM processes in different containers to share the `/tmp` directory
+ Serviceability tools such as `jps` and `jcmd` should be able to access all such processes.

### Non-goals

+ The `/tmp` directory can be shared only by updated JVMs with this patch. We do not support such sharing with older JVMs.
+ When using a shared `/tmp` directory, you must use the updated versions of `jps`, `jcmd`, etc, that contains this patch. Tools from older JDKs don't work.

### Compatibility

+ When the `/tmp` directory is NOT shared across containers, the behavior of the updated JVM is exactly the same as before. The updated JVM can co-exist with older JVMs, and can be accessed by tools like `jps`, `jcmd`, etc, from older JDKs.
+ The updated `jps`, `jcmd`, etc, tools in the updated JDK can work with JVMs from older JDKs.

### Design

AttachID -- this is the number used for `/tmp/hsperfdata_$USER/<n>` and `/tmp/.java_pid<n>`

When a JVM starts, it chooses its AttachID by this pseudo code:

```
    for (id = os::current_process_id(); ; id = random_id()) {
      if ((flock(/tmp/hsperfdata_$USER/$id) == SUCCESS) {
        break;
      }
    }
```

Note that `random_id()` always returns a negative integer, so we will not step on the `pid` of another valid process.

- See the LINUX version of `mmap_create_shared()` in this patch.

### Cleaning up unused perfdata files

See `unlink_sharedmem_file_if_stale()` in the patch. We use both `flock()` and `kill(pid, 0)` to check to liveness. This is a little complicated because we need to co-exist with older JVMs.

Note that if the `pid` is positive, it could be from an older JVM, which doesn't do `flock()`. Therefore, for such positive `pids`, we also use `kill(pid, 0)`, which is racy, but this is no worse than before.

### Discovering JVMs

+ See `LocalVmManager.activeVms()` -> `PlatformSupport.activeVms()`.
+ See `PlatformSupport.getAttachID()`.

The Linux version no longer scans `/tmp` directories. Instead, it scans for `hsperfdata` files in the `/proc/*/maps` files. This way, it can detect the AttachID of each JVM process. The AttachID may be randomized so it may be different than the JVM's host `pid` and `nspid`.

### Testing

I've done some quick manual testing and it seems to work when several containers are sharing the same `/tmp` directory. My command-line is this (`/tmp` inside the container is mapped from `/tmp/dockertmp` on the host file system):

```
docker run -it --tty=true --rm \
     -v /tmp/dockertmp:/tmp my-java-container \
     java -cp / -Xlog:perf+memops=debug -Xlog:attach=trace Wait
```

I'll try to write a jtreg test case. Since we can't run as root, I'll try to use podman and run the tests in rootless mode.

### About `-XX:+PerfDisableSharedMem`

With my patch, if you share `/tmp` across two containers and run `java -XX:+PerfDisableSharedMem ...` in both containers:

+ `jps` will not list either JVM process
+ `jcmd $HOSTPID` works for the first process that you connect to, but will fail with the second process. This is because the processes will try to use the same socket file, e.g., `/tmp/.java_pid1`

Both of the above issues are the same as before, so there's no regression. To avoid making this patch more complicated, I plan to fix this problem in a future bug by mapping an empty `/tmp/hsperfdata_$USER/$id` when `-XX:+PerfDisableSharedMem` is specified.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286030](https://bugs.openjdk.org/browse/JDK-8286030): Support sharing of /tmp across Linux containers


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9226/head:pull/9226` \
`$ git checkout pull/9226`

Update a local copy of the PR: \
`$ git checkout pull/9226` \
`$ git pull https://git.openjdk.org/jdk pull/9226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9226`

View PR using the GUI difftool: \
`$ git pr show -t 9226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9226.diff">https://git.openjdk.org/jdk/pull/9226.diff</a>

</details>
