### PR TITLE
8288515: (ch) Unnecessary use of Math.addExact() in java.nio.channels.FileLock.overlaps()

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/FileLock.java
+++ b/src/java.base/share/classes/java/nio/channels/FileLock.java
@@ -277,13 +277,10 @@ public abstract class FileLock implements AutoCloseable {
         if (size < 0)
             return false;
 
-        // Test whether this is below that
-        try {
-            if (Math.addExact(this.position, this.size) <= position)
-                return false;
-        } catch (ArithmeticException ignored) {
-            // the sum of this.position and this.size overflows the range of
-            // long hence their mathematical sum is greater than position
+        // Test whether this is below that. The sum cannot overflow as the
+        // size and position are immutable and were checked at construction.
+        if (this.position + this.size <= position) {
+            return false;
         }
 
         // if size == 0 then the specified lock range is unbounded and


### PR DESCRIPTION
`FileLock` checks the immutable `position` and `size` parameters in its constructor hence using `Math.addExact()` on these instance variables in `overlaps()` is needless.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288515](https://bugs.openjdk.org/browse/JDK-8288515): (ch) Unnecessary use of Math.addExact() in java.nio.channels.FileLock.overlaps()


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9229/head:pull/9229` \
`$ git checkout pull/9229`

Update a local copy of the PR: \
`$ git checkout pull/9229` \
`$ git pull https://git.openjdk.org/jdk pull/9229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9229`

View PR using the GUI difftool: \
`$ git pr show -t 9229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9229.diff">https://git.openjdk.org/jdk/pull/9229.diff</a>

</details>
