### PR TITLE
8288961: jpackage: test MSI installation fix

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
@@ -92,7 +92,7 @@ public class WindowsHelper {
         BiConsumer<JPackageCommand, Boolean> installMsi = (cmd, install) -> {
             cmd.verifyIsOfType(PackageType.WIN_MSI);
             runMsiexecWithRetries(Executor.of("msiexec", "/qn", "/norestart",
-                    install ? "/i" : "/x").addArgument(cmd.outputBundle()));
+                    install ? "/i" : "/x").addArgument(cmd.outputBundle().normalize()));
         };
 
         PackageHandlers msi = new PackageHandlers();


### PR DESCRIPTION
Please review this minor fix to the jpackage test suite.

When `INSTALL` and `UNINSTALL` actions are enabled for jpackage test suite runs (disabled by default), installation of `EXE` and `MSI` packages is performed. `EXE` package is invoked directly and `MSI` package is installed using `msiexec` utility. In both cases the path of the packages starts with a "." (current dir) symbol, it is processed correctly with EXE installation, but not with MSI, example:

```
[03:52:19.634] TRACE: assertTrue(): Check [.\\test.bcc14973\\output\\FileAssociationsTest-1.0.msi] path exists
[03:52:19.634] TRACE: assertTrue(): Check [.\\test.bcc14973\\output\\FileAssociationsTest-1.0.msi] is a file
[03:52:19.634] TRACE: exec: Execute [msiexec /qn /norestart /i .\\test.bcc14973\\output\\FileAssociationsTest-1.0.msi](5); discard I/O...
[03:52:19.790] TRACE: exec: Done. Exit code: 1619
[03:52:19.805] ERROR: Expected [0]. Actual [1619]: Check command [msiexec /qn /norestart /i .\\test.bcc14973\\output\\FileAssociationsTest-1.0.msi](5) exited with 0 code 
```

Is is proposed to normalize the path passed to `msiexec`, in this case installation will succeed:

```
[03:56:52.429] TRACE: assertTrue(): Check [.\\test.bcc14973\\output\\FileAssociationsTest-1.0.msi] path exists
[03:56:52.429] TRACE: assertTrue(): Check [.\\test.bcc14973\\output\\FileAssociationsTest-1.0.msi] is a file
[03:56:52.429] TRACE: exec: Execute [msiexec /qn /norestart /i test.bcc14973\\output\\FileAssociationsTest-1.0.msi](5); discard I/O...
[03:56:57.067] TRACE: exec: Done. Exit code: 0
[03:56:57.067] TRACE: assertEquals(0): Check command [msiexec /qn /norestart /i test.bcc14973\\output\\FileAssociationsTest-1.0.msi](5) exited with 0 code
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288961](https://bugs.openjdk.org/browse/JDK-8288961): jpackage: test MSI installation fix


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9236/head:pull/9236` \
`$ git checkout pull/9236`

Update a local copy of the PR: \
`$ git checkout pull/9236` \
`$ git pull https://git.openjdk.org/jdk pull/9236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9236`

View PR using the GUI difftool: \
`$ git pr show -t 9236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9236.diff">https://git.openjdk.org/jdk/pull/9236.diff</a>

</details>
