### PR TITLE
8288968: C2: remove use of covariant returns in type.[ch]pp

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -6614,7 +6614,7 @@ bool LibraryCallKit::inline_cipherBlockChaining_AESCrypt(vmIntrinsics::ID id) {
 
   ciInstanceKlass* instklass_AESCrypt = klass_AESCrypt->as_instance_klass();
   const TypeKlassPtr* aklass = TypeKlassPtr::make(instklass_AESCrypt);
-  const TypeOopPtr* xtype = aklass->as_instance_type()->cast_to_ptr_type(TypePtr::NotNull);
+  const TypeOopPtr* xtype = aklass->as_instance_type()->cast_to_ptr_type(TypePtr::NotNull)->is_oopptr();
   Node* aescrypt_object = new CheckCastPPNode(control(), embeddedCipherObj, xtype);
   aescrypt_object = _gvn.transform(aescrypt_object);
 
@@ -6702,7 +6702,7 @@ bool LibraryCallKit::inline_electronicCodeBook_AESCrypt(vmIntrinsics::ID id) {
 
   ciInstanceKlass* instklass_AESCrypt = klass_AESCrypt->as_instance_klass();
   const TypeKlassPtr* aklass = TypeKlassPtr::make(instklass_AESCrypt);
-  const TypeOopPtr* xtype = aklass->as_instance_type()->cast_to_ptr_type(TypePtr::NotNull);
+  const TypeOopPtr* xtype = aklass->as_instance_type()->cast_to_ptr_type(TypePtr::NotNull)->is_oopptr();
   Node* aescrypt_object = new CheckCastPPNode(control(), embeddedCipherObj, xtype);
   aescrypt_object = _gvn.transform(aescrypt_object);
 
@@ -6773,7 +6773,7 @@ bool LibraryCallKit::inline_counterMode_AESCrypt(vmIntrinsics::ID id) {
   assert(klass_AESCrypt->is_loaded(), "predicate checks that this class is loaded");
   ciInstanceKlass* instklass_AESCrypt = klass_AESCrypt->as_instance_klass();
   const TypeKlassPtr* aklass = TypeKlassPtr::make(instklass_AESCrypt);
-  const TypeOopPtr* xtype = aklass->as_instance_type()->cast_to_ptr_type(TypePtr::NotNull);
+  const TypeOopPtr* xtype = aklass->as_instance_type()->cast_to_ptr_type(TypePtr::NotNull)->is_oopptr();
   Node* aescrypt_object = new CheckCastPPNode(control(), embeddedCipherObj, xtype);
   aescrypt_object = _gvn.transform(aescrypt_object);
   // we need to get the start of the aescrypt_object's expanded key array
@@ -7291,7 +7291,7 @@ bool LibraryCallKit::inline_digestBase_implCompressMB(Node* digestBase_obj, ciIn
                                                       BasicType elem_type, address stubAddr, const char *stubName,
                                                       Node* src_start, Node* ofs, Node* limit) {
   const TypeKlassPtr* aklass = TypeKlassPtr::make(instklass_digestBase);
-  const TypeOopPtr* xtype = aklass->as_instance_type()->cast_to_ptr_type(TypePtr::NotNull);
+  const TypeOopPtr* xtype = aklass->as_instance_type()->cast_to_ptr_type(TypePtr::NotNull)->is_oopptr();
   Node* digest_obj = new CheckCastPPNode(control(), digestBase_obj, xtype);
   digest_obj = _gvn.transform(digest_obj);
 

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -2276,7 +2276,7 @@ int TypeAry::hash(void) const {
 /**
  * Return same type without a speculative part in the element
  */
-const TypeAry* TypeAry::remove_speculative() const {
+const Type* TypeAry::remove_speculative() const {
   return make(_elem->remove_speculative(), _size, _stable);
 }
 
@@ -2708,7 +2708,7 @@ int TypePtr::hash(void) const {
 /**
  * Return same type without a speculative part
  */
-const TypePtr* TypePtr::remove_speculative() const {
+const Type* TypePtr::remove_speculative() const {
   if (_speculative == NULL) {
     return this;
   }
@@ -3030,7 +3030,7 @@ const TypeRawPtr *TypeRawPtr::make( address bits ) {
 }
 
 //------------------------------cast_to_ptr_type-------------------------------
-const TypeRawPtr* TypeRawPtr::cast_to_ptr_type(PTR ptr) const {
+const TypePtr* TypeRawPtr::cast_to_ptr_type(PTR ptr) const {
   assert( ptr != Constant, "what is the constant?" );
   assert( ptr != Null, "Use TypePtr for NULL" );
   assert( _bits==0, "Why cast a constant address?");
@@ -3242,7 +3242,7 @@ const TypeOopPtr *TypeOopPtr::make(PTR ptr, int offset, int instance_id,
 
 
 //------------------------------cast_to_ptr_type-------------------------------
-const TypeOopPtr* TypeOopPtr::cast_to_ptr_type(PTR ptr) const {
+const TypePtr* TypeOopPtr::cast_to_ptr_type(PTR ptr) const {
   assert(_base == OopPtr, "subclass must override cast_to_ptr_type");
   if( ptr == _ptr ) return this;
   return make(ptr, _offset, _instance_id, _speculative, _inline_depth);
@@ -3581,14 +3581,14 @@ const TypePtr *TypeOopPtr::add_offset(intptr_t offset) const {
   return make(_ptr, xadd_offset(offset), _instance_id, add_offset_speculative(offset), _inline_depth);
 }
 
-const TypeOopPtr* TypeOopPtr::with_offset(intptr_t offset) const {
+const TypePtr* TypeOopPtr::with_offset(intptr_t offset) const {
   return make(_ptr, offset, _instance_id, with_offset_speculative(offset), _inline_depth);
 }
 
 /**
  * Return same type without a speculative part
  */
-const TypeOopPtr* TypeOopPtr::remove_speculative() const {
+const Type* TypeOopPtr::remove_speculative() const {
   if (_speculative == NULL) {
     return this;
   }
@@ -3738,7 +3738,7 @@ const Type* TypeInstPtr::get_const_boxed_value() const {
 }
 
 //------------------------------cast_to_ptr_type-------------------------------
-const TypeInstPtr* TypeInstPtr::cast_to_ptr_type(PTR ptr) const {
+const TypePtr* TypeInstPtr::cast_to_ptr_type(PTR ptr) const {
   if( ptr == _ptr ) return this;
   // Reconstruct _sig info here since not a problem with later lazy
   // construction, _sig will show up on demand.
@@ -3747,7 +3747,7 @@ const TypeInstPtr* TypeInstPtr::cast_to_ptr_type(PTR ptr) const {
 
 
 //-----------------------------cast_to_exactness-------------------------------
-const TypeInstPtr* TypeInstPtr::cast_to_exactness(bool klass_is_exact) const {
+const TypeOopPtr* TypeInstPtr::cast_to_exactness(bool klass_is_exact) const {
   if( klass_is_exact == _klass_is_exact ) return this;
   if (!_klass->is_loaded())  return this;
   ciInstanceKlass* ik = _klass->as_instance_klass();
@@ -3757,7 +3757,7 @@ const TypeInstPtr* TypeInstPtr::cast_to_exactness(bool klass_is_exact) const {
 }
 
 //-----------------------------cast_to_instance_id----------------------------
-const TypeInstPtr* TypeInstPtr::cast_to_instance_id(int instance_id) const {
+const TypeOopPtr* TypeInstPtr::cast_to_instance_id(int instance_id) const {
   if( instance_id == _instance_id ) return this;
   return make(_ptr, klass(), _klass_is_exact, const_oop(), _offset, instance_id, _speculative, _inline_depth);
 }
@@ -4278,12 +4278,12 @@ const TypePtr* TypeInstPtr::add_offset(intptr_t offset) const {
               _instance_id, add_offset_speculative(offset), _inline_depth);
 }
 
-const TypeInstPtr* TypeInstPtr::with_offset(intptr_t offset) const {
+const TypePtr* TypeInstPtr::with_offset(intptr_t offset) const {
   return make(_ptr, klass(), klass_is_exact(), const_oop(), offset,
               _instance_id, with_offset_speculative(offset), _inline_depth);
 }
 
-const TypeInstPtr* TypeInstPtr::remove_speculative() const {
+const Type* TypeInstPtr::remove_speculative() const {
   if (_speculative == NULL) {
     return this;
   }
@@ -4352,21 +4352,21 @@ const TypeAryPtr *TypeAryPtr::make(PTR ptr, ciObject* o, const TypeAry *ary, ciK
 }
 
 //------------------------------cast_to_ptr_type-------------------------------
-const TypeAryPtr* TypeAryPtr::cast_to_ptr_type(PTR ptr) const {
+const TypePtr* TypeAryPtr::cast_to_ptr_type(PTR ptr) const {
   if( ptr == _ptr ) return this;
   return make(ptr, ptr == Constant ? const_oop() : NULL, _ary, klass(), klass_is_exact(), _offset, _instance_id, _speculative, _inline_depth);
 }
 
 
 //-----------------------------cast_to_exactness-------------------------------
-const TypeAryPtr* TypeAryPtr::cast_to_exactness(bool klass_is_exact) const {
+const TypeOopPtr* TypeAryPtr::cast_to_exactness(bool klass_is_exact) const {
   if( klass_is_exact == _klass_is_exact ) return this;
   if (_ary->ary_must_be_exact())  return this;  // cannot clear xk
   return make(ptr(), const_oop(), _ary, klass(), klass_is_exact, _offset, _instance_id, _speculative, _inline_depth);
 }
 
 //-----------------------------cast_to_instance_id----------------------------
-const TypeAryPtr* TypeAryPtr::cast_to_instance_id(int instance_id) const {
+const TypeOopPtr* TypeAryPtr::cast_to_instance_id(int instance_id) const {
   if( instance_id == _instance_id ) return this;
   return make(_ptr, const_oop(), _ary, klass(), _klass_is_exact, _offset, instance_id, _speculative, _inline_depth);
 }
@@ -4870,7 +4870,7 @@ const TypePtr *TypeAryPtr::add_offset(intptr_t offset) const {
   return make(_ptr, _const_oop, _ary, _klass, _klass_is_exact, xadd_offset(offset), _instance_id, add_offset_speculative(offset), _inline_depth);
 }
 
-const TypeAryPtr* TypeAryPtr::with_offset(intptr_t offset) const {
+const TypePtr* TypeAryPtr::with_offset(intptr_t offset) const {
   return make(_ptr, _const_oop, _ary, _klass, _klass_is_exact, offset, _instance_id, with_offset_speculative(offset), _inline_depth);
 }
 
@@ -4878,7 +4878,7 @@ const TypeAryPtr* TypeAryPtr::with_ary(const TypeAry* ary) const {
   return make(_ptr, _const_oop, ary, _klass, _klass_is_exact, _offset, _instance_id, _speculative, _inline_depth);
 }
 
-const TypeAryPtr* TypeAryPtr::remove_speculative() const {
+const Type* TypeAryPtr::remove_speculative() const {
   if (_speculative == NULL) {
     return this;
   }
@@ -5018,7 +5018,7 @@ const TypeNarrowOop* TypeNarrowOop::make(const TypePtr* type) {
   return (const TypeNarrowOop*)(new TypeNarrowOop(type))->hashcons();
 }
 
-const TypeNarrowOop* TypeNarrowOop::remove_speculative() const {
+const Type* TypeNarrowOop::remove_speculative() const {
   return make(_ptrtype->remove_speculative()->is_ptr());
 }
 
@@ -5112,7 +5112,7 @@ intptr_t TypeMetadataPtr::get_con() const {
 }
 
 //------------------------------cast_to_ptr_type-------------------------------
-const TypeMetadataPtr* TypeMetadataPtr::cast_to_ptr_type(PTR ptr) const {
+const TypePtr* TypeMetadataPtr::cast_to_ptr_type(PTR ptr) const {
   if( ptr == _ptr ) return this;
   return make(ptr, metadata(), _offset);
 }
@@ -5417,12 +5417,12 @@ const TypePtr *TypeInstKlassPtr::add_offset( intptr_t offset ) const {
   return make( _ptr, klass(), xadd_offset(offset) );
 }
 
-const TypeInstKlassPtr* TypeInstKlassPtr::with_offset(intptr_t offset) const {
+const TypePtr* TypeInstKlassPtr::with_offset(intptr_t offset) const {
   return make(_ptr, klass(), offset);
 }
 
 //------------------------------cast_to_ptr_type-------------------------------
-const TypeInstKlassPtr* TypeInstKlassPtr::cast_to_ptr_type(PTR ptr) const {
+const TypePtr* TypeInstKlassPtr::cast_to_ptr_type(PTR ptr) const {
   assert(_base == InstKlassPtr, "subclass must override cast_to_ptr_type");
   if( ptr == _ptr ) return this;
   return make(ptr, _klass, _offset);
@@ -5692,7 +5692,7 @@ const TypeAryKlassPtr *TypeAryKlassPtr::make(PTR ptr, ciKlass* klass, int offset
   if (klass->is_obj_array_klass()) {
     // Element is an object array. Recursively call ourself.
     ciKlass* eklass = klass->as_obj_array_klass()->element_klass();
-    const TypeKlassPtr *etype = TypeKlassPtr::make(eklass)->cast_to_exactness(false);
+    const TypeKlassPtr *etype = TypeKlassPtr::make(eklass)->cast_to_exactness(false)->is_klassptr();
     return TypeAryKlassPtr::make(ptr, etype, NULL, offset);
   } else if (klass->is_type_array_klass()) {
     // Element is an typeArray
@@ -5840,12 +5840,12 @@ const TypePtr *TypeAryKlassPtr::add_offset(intptr_t offset) const {
   return make(_ptr, elem(), klass(), xadd_offset(offset));
 }
 
-const TypeAryKlassPtr* TypeAryKlassPtr::with_offset(intptr_t offset) const {
+const TypePtr* TypeAryKlassPtr::with_offset(intptr_t offset) const {
   return make(_ptr, elem(), klass(), offset);
 }
 
 //------------------------------cast_to_ptr_type-------------------------------
-const TypeAryKlassPtr* TypeAryKlassPtr::cast_to_ptr_type(PTR ptr) const {
+const TypePtr* TypeAryKlassPtr::cast_to_ptr_type(PTR ptr) const {
   assert(_base == AryKlassPtr, "subclass must override cast_to_ptr_type");
   if (ptr == _ptr) return this;
   return make(ptr, elem(), _klass, _offset);
@@ -5861,7 +5861,7 @@ bool TypeAryKlassPtr::must_be_exact() const {
 
 
 //-----------------------------cast_to_exactness-------------------------------
-const TypeKlassPtr *TypeAryKlassPtr::cast_to_exactness(bool klass_is_exact) const {
+const TypeKlassPtr* TypeAryKlassPtr::cast_to_exactness(bool klass_is_exact) const {
   if (must_be_exact()) return this;  // cannot clear xk
   ciKlass* k = _klass;
   const Type* elem = this->elem();

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -774,7 +774,7 @@ public:
   virtual const Type *xmeet( const Type *t ) const;
   virtual const Type *xdual() const;    // Compute dual right now.
   bool ary_must_be_exact() const;  // true if arrays of such are never generic
-  virtual const TypeAry* remove_speculative() const;
+  virtual const Type* remove_speculative() const;
   virtual const Type* cleanup_speculative() const;
 #ifdef ASSERT
   // One type is interface, the other is oop
@@ -996,7 +996,7 @@ public:
   virtual ciKlass* speculative_type_not_null() const;
   virtual bool speculative_maybe_null() const;
   virtual bool speculative_always_null() const;
-  virtual const TypePtr* remove_speculative() const;
+  virtual const Type* remove_speculative() const;
   virtual const Type* cleanup_speculative() const;
   virtual bool would_improve_type(ciKlass* exact_kls, int inline_depth) const;
   virtual bool would_improve_ptr(ProfilePtrKind maybe_null) const;
@@ -1032,12 +1032,12 @@ public:
   static const TypeRawPtr *make( address bits );
 
   // Return a 'ptr' version of this type
-  virtual const TypeRawPtr* cast_to_ptr_type(PTR ptr) const;
+  virtual const TypePtr* cast_to_ptr_type(PTR ptr) const;
 
   virtual intptr_t get_con() const;
 
   virtual const TypePtr* add_offset(intptr_t offset) const;
-  virtual const TypeRawPtr* with_offset(intptr_t offset) const { ShouldNotReachHere(); return NULL;}
+  virtual const TypePtr* with_offset(intptr_t offset) const { ShouldNotReachHere(); return NULL;}
 
   virtual const Type *xmeet( const Type *t ) const;
   virtual const Type *xdual() const;    // Compute dual right now.
@@ -1155,7 +1155,7 @@ public:
 
   virtual intptr_t get_con() const;
 
-  virtual const TypeOopPtr* cast_to_ptr_type(PTR ptr) const;
+  virtual const TypePtr* cast_to_ptr_type(PTR ptr) const;
 
   virtual const TypeOopPtr* cast_to_exactness(bool klass_is_exact) const;
 
@@ -1164,11 +1164,11 @@ public:
   // corresponding pointer to klass, for a given instance
   virtual const TypeKlassPtr* as_klass_type(bool try_for_exact = false) const;
 
-  virtual const TypeOopPtr* with_offset(intptr_t offset) const;
+  virtual const TypePtr* with_offset(intptr_t offset) const;
   virtual const TypePtr* add_offset(intptr_t offset) const;
 
   // Speculative type helper methods.
-  virtual const TypeOopPtr* remove_speculative() const;
+  virtual const Type* remove_speculative() const;
   virtual const Type* cleanup_speculative() const;
   virtual bool would_improve_type(ciKlass* exact_kls, int inline_depth) const;
   virtual const TypePtr* with_inline_depth(int depth) const;
@@ -1249,17 +1249,17 @@ public:
   // be a TypeInstPtr, but may also be a TypeInt::INT for int.class, etc.
   ciType* java_mirror_type() const;
 
-  virtual const TypeInstPtr* cast_to_ptr_type(PTR ptr) const;
+  virtual const TypePtr* cast_to_ptr_type(PTR ptr) const;
 
-  virtual const TypeInstPtr* cast_to_exactness(bool klass_is_exact) const;
+  virtual const TypeOopPtr* cast_to_exactness(bool klass_is_exact) const;
 
-  virtual const TypeInstPtr* cast_to_instance_id(int instance_id) const;
+  virtual const TypeOopPtr* cast_to_instance_id(int instance_id) const;
 
   virtual const TypePtr* add_offset(intptr_t offset) const;
-  virtual const TypeInstPtr* with_offset(intptr_t offset) const;
+  virtual const TypePtr* with_offset(intptr_t offset) const;
 
   // Speculative type helper methods.
-  virtual const TypeInstPtr* remove_speculative() const;
+  virtual const Type* remove_speculative() const;
   virtual const TypePtr* with_inline_depth(int depth) const;
   virtual const TypePtr* with_instance_id(int instance_id) const;
 
@@ -1350,22 +1350,22 @@ public:
                                 int inline_depth = InlineDepthBottom, bool is_autobox_cache = false);
 
   // Return a 'ptr' version of this type
-  virtual const TypeAryPtr* cast_to_ptr_type(PTR ptr) const;
+  virtual const TypePtr* cast_to_ptr_type(PTR ptr) const;
 
-  virtual const TypeAryPtr* cast_to_exactness(bool klass_is_exact) const;
+  virtual const TypeOopPtr* cast_to_exactness(bool klass_is_exact) const;
 
-  virtual const TypeAryPtr* cast_to_instance_id(int instance_id) const;
+  virtual const TypeOopPtr* cast_to_instance_id(int instance_id) const;
 
   virtual const TypeAryPtr* cast_to_size(const TypeInt* size) const;
   virtual const TypeInt* narrow_size_type(const TypeInt* size) const;
 
   virtual bool empty(void) const;        // TRUE if type is vacuous
   virtual const TypePtr *add_offset( intptr_t offset ) const;
-  virtual const TypeAryPtr *with_offset( intptr_t offset ) const;
+  virtual const TypePtr *with_offset( intptr_t offset ) const;
   const TypeAryPtr* with_ary(const TypeAry* ary) const;
 
   // Speculative type helper methods.
-  virtual const TypeAryPtr* remove_speculative() const;
+  virtual const Type* remove_speculative() const;
   virtual const TypePtr* with_inline_depth(int depth) const;
   virtual const TypePtr* with_instance_id(int instance_id) const;
 
@@ -1431,7 +1431,7 @@ public:
 
   ciMetadata* metadata() const { return _metadata; }
 
-  virtual const TypeMetadataPtr* cast_to_ptr_type(PTR ptr) const;
+  virtual const TypePtr* cast_to_ptr_type(PTR ptr) const;
 
   virtual const TypePtr *add_offset( intptr_t offset ) const;
 
@@ -1493,9 +1493,9 @@ public:
 
   virtual bool  is_loaded() const { return _klass->is_loaded(); }
 
-  virtual const TypeKlassPtr* cast_to_ptr_type(PTR ptr) const { ShouldNotReachHere(); return NULL; }
+  virtual const TypePtr* cast_to_ptr_type(PTR ptr) const { ShouldNotReachHere(); return NULL; }
 
-  virtual const TypeKlassPtr *cast_to_exactness(bool klass_is_exact) const { ShouldNotReachHere(); return NULL; }
+  virtual const TypeKlassPtr* cast_to_exactness(bool klass_is_exact) const { ShouldNotReachHere(); return NULL; }
 
   // corresponding pointer to instance, for a given class
   virtual const TypeOopPtr* as_instance_type(bool klass_change = true) const { ShouldNotReachHere(); return NULL; }
@@ -1506,7 +1506,7 @@ public:
 
   virtual intptr_t get_con() const;
 
-  virtual const TypeKlassPtr* with_offset(intptr_t offset) const { ShouldNotReachHere(); return NULL; }
+  virtual const TypePtr* with_offset(intptr_t offset) const { ShouldNotReachHere(); return NULL; }
 
 #ifndef PRODUCT
   virtual void dump2( Dict &d, uint depth, outputStream *st ) const; // Specialized per-Type dumping
@@ -1540,9 +1540,9 @@ public:
   }
   static const TypeInstKlassPtr *make(PTR ptr, ciKlass* k, int offset);
 
-  virtual const TypeInstKlassPtr* cast_to_ptr_type(PTR ptr) const;
+  virtual const TypePtr* cast_to_ptr_type(PTR ptr) const;
 
-  virtual const TypeKlassPtr *cast_to_exactness(bool klass_is_exact) const;
+  virtual const TypeKlassPtr* cast_to_exactness(bool klass_is_exact) const;
 
   // corresponding pointer to instance, for a given class
   virtual const TypeOopPtr* as_instance_type(bool klass_change = true) const;
@@ -1552,7 +1552,7 @@ public:
   virtual const TypePtr *add_offset( intptr_t offset ) const;
   virtual const Type    *xmeet( const Type *t ) const;
   virtual const Type    *xdual() const;
-  virtual const TypeInstKlassPtr* with_offset(intptr_t offset) const;
+  virtual const TypePtr* with_offset(intptr_t offset) const;
 
   bool is_interface() const { return klass()->is_interface(); }
 
@@ -1596,7 +1596,7 @@ public:
   virtual bool eq(const Type *t) const;
   virtual int hash() const;             // Type specific hashing
 
-  virtual const TypeAryKlassPtr* cast_to_ptr_type(PTR ptr) const;
+  virtual const TypePtr* cast_to_ptr_type(PTR ptr) const;
 
   virtual const TypeKlassPtr *cast_to_exactness(bool klass_is_exact) const;
 
@@ -1607,7 +1607,7 @@ public:
   virtual const Type    *xmeet( const Type *t ) const;
   virtual const Type    *xdual() const;      // Compute dual right now.
 
-  virtual const TypeAryKlassPtr* with_offset(intptr_t offset) const;
+  virtual const TypePtr* with_offset(intptr_t offset) const;
 
   virtual bool empty(void) const {
     return TypeKlassPtr::empty() || _elem->empty();
@@ -1699,7 +1699,7 @@ public:
   static const TypeNarrowOop *BOTTOM;
   static const TypeNarrowOop *NULL_PTR;
 
-  virtual const TypeNarrowOop* remove_speculative() const;
+  virtual const Type* remove_speculative() const;
   virtual const Type* cleanup_speculative() const;
 
 #ifndef PRODUCT


### PR DESCRIPTION
This removes some use of covariant returns that I added with 8275201
(C2: hide klass() accessor from TypeOopPtr and typeKlassPtr
subclasses).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288968](https://bugs.openjdk.org/browse/JDK-8288968): C2: remove use of covariant returns in type.[ch]pp


### Reviewers
 * [Xin Liu](https://openjdk.org/census#xliu) (@navyxliu - Committer)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9237/head:pull/9237` \
`$ git checkout pull/9237`

Update a local copy of the PR: \
`$ git checkout pull/9237` \
`$ git pull https://git.openjdk.org/jdk pull/9237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9237`

View PR using the GUI difftool: \
`$ git pr show -t 9237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9237.diff">https://git.openjdk.org/jdk/pull/9237.diff</a>

</details>
