### PR TITLE
8288933: Improve the implementation of Double/Float.isInfinite

### DIFF
--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -765,7 +765,7 @@ public final class Double extends Number
      */
     @IntrinsicCandidate
     public static boolean isInfinite(double v) {
-        return (v == POSITIVE_INFINITY) || (v == NEGATIVE_INFINITY);
+        return Math.abs(v) > MAX_VALUE;
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Float.java
+++ b/src/java.base/share/classes/java/lang/Float.java
@@ -585,7 +585,7 @@ public final class Float extends Number
      */
     @IntrinsicCandidate
     public static boolean isInfinite(float v) {
-        return (v == POSITIVE_INFINITY) || (v == NEGATIVE_INFINITY);
+        return Math.abs(v) > MAX_VALUE;
     }
 
 


### PR DESCRIPTION
Improve the implementation of `Double/Float.isInfinite` to reduce branching. Using `>` comparison with `MAX_VALUE` instead of `==` with `POSITIVE_INFINITY` improves code emission on x86 and produces similar code for arm. This is also the way gcc implements `std::isinf` on x86 and arm (clang uses the pattern `Math.abs(v) == POSITIVE_INFINITY` on arm).

`test/micro/org/openjdk/bench/java/lang/FPComparison.java` has been added in #8525, the results are reshown here:

    Benchmark                      Mode  Cnt     Score     Error    Score     Error   Unit   Ratio
    FPComparison.isInfiniteDouble  avgt    5  1232.800 ±  31.677  621.185 ±  11.935  ns/op    1.98
    FPComparison.isInfiniteFloat   avgt    5  1234.708 ±  70.239  623.566 ±  15.206  ns/op    1.98

Thank you very much.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288933](https://bugs.openjdk.org/browse/JDK-8288933): Improve the implementation of Double/Float.isInfinite


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9238/head:pull/9238` \
`$ git checkout pull/9238`

Update a local copy of the PR: \
`$ git checkout pull/9238` \
`$ git pull https://git.openjdk.org/jdk pull/9238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9238`

View PR using the GUI difftool: \
`$ git pr show -t 9238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9238.diff">https://git.openjdk.org/jdk/pull/9238.diff</a>

</details>
