### PR TITLE
8288982: JFR: Log event streaming actions

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
@@ -85,6 +85,9 @@ public abstract class AbstractEventStream implements EventStream {
             synchronized (streamConfiguration) {
                 dispatcher = new Dispatcher(streamConfiguration);
                 streamConfiguration.setChanged(false);
+                if (Logger.shouldLog(LogTag.JFR_SYSTEM_STREAMING, LogLevel.DEBUG)) {
+                    Logger.log(LogTag.JFR_SYSTEM_STREAMING, LogLevel.DEBUG, dispatcher.toString());
+                }
             }
         }
         return dispatcher;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/Dispatcher.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/Dispatcher.java
@@ -209,4 +209,15 @@ final class Dispatcher {
     public boolean hasMetadataHandler() {
         return metadataActions.length > 0;
     }
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Error actions: " + errorActions.length + "\n");
+        sb.append("Meta actions: " + metadataActions.length + "\n");
+        sb.append("Flush actions: " + flushActions.length + "\n");
+        sb.append("Close actions: " + closeActions.length+ "\n");
+        sb.append("Event dispatchers :" + dispatchers.length+ "\n" );
+        sb.append("Dispatch lookup size:" + dispatcherLookup.size());
+        return sb.toString();
+    }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/Dispatcher.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/Dispatcher.java
@@ -216,8 +216,8 @@ final class Dispatcher {
         sb.append("Meta actions: " + metadataActions.length + "\n");
         sb.append("Flush actions: " + flushActions.length + "\n");
         sb.append("Close actions: " + closeActions.length+ "\n");
-        sb.append("Event dispatchers :" + dispatchers.length+ "\n" );
-        sb.append("Dispatch lookup size:" + dispatcherLookup.size());
+        sb.append("Event dispatchers: " + dispatchers.length+ "\n" );
+        sb.append("Dispatch lookup size: " + dispatcherLookup.size());
         return sb.toString();
     }
 }

--- a/test/jdk/jdk/jfr/api/consumer/recordingstream/TestOnEvent.java
+++ b/test/jdk/jdk/jfr/api/consumer/recordingstream/TestOnEvent.java
@@ -35,7 +35,7 @@ import jdk.jfr.consumer.RecordingStream;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
- * @run main/othervm jdk.jfr.api.consumer.recordingstream.TestOnEvent
+ * @run main/othervm -Xlog:jfr+system+streaming=debug jdk.jfr.api.consumer.recordingstream.TestOnEvent
  */
 public class TestOnEvent {
 
@@ -154,12 +154,14 @@ public class TestOnEvent {
             EventProducer p = new EventProducer();
             p.start();
             Thread addHandler = new Thread(() ->  {
+                log("About to add handler");
                 r.onEvent(e -> {
                     // Got event, close stream
                     log("Executing onEvent");
                     r.close();
                     log("RecordingStream closed");
                 });
+                log("Handler added");
             });
             r.onFlush(() ->  {
                 // Only add handler once


### PR DESCRIPTION
Could I have a review of a change that log event actions for an EventStream. Purpose is to find cause of intermittent failure of TestOnEvent. See https://bugs.openjdk.org/browse/JDK-8255404

Testing:  test/jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288982](https://bugs.openjdk.org/browse/JDK-8288982): JFR: Log event streaming actions


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9244/head:pull/9244` \
`$ git checkout pull/9244`

Update a local copy of the PR: \
`$ git checkout pull/9244` \
`$ git pull https://git.openjdk.org/jdk pull/9244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9244`

View PR using the GUI difftool: \
`$ git pr show -t 9244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9244.diff">https://git.openjdk.org/jdk/pull/9244.diff</a>

</details>
