### PR TITLE
8288495: [test] Make OutputAnalyzer exception more informative

### DIFF
--- a/test/lib-test/jdk/test/lib/process/OutputAnalyzerTest.java
+++ b/test/lib-test/jdk/test/lib/process/OutputAnalyzerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib-test/jdk/test/lib/process/OutputAnalyzerTest.java
+++ b/test/lib-test/jdk/test/lib/process/OutputAnalyzerTest.java
@@ -237,7 +237,7 @@ public class OutputAnalyzerTest {
                 out.shouldNotHaveExitValue(0);
                 throw new RuntimeException("'shouldNotHaveExitValue' should have thrown an exception");
             } catch (Throwable ex) {
-                if (!ex.getMessage().equals("Unexpected to get exit value of [0], exit value is: [0]")) {
+                if (!ex.getMessage().equals("Unexpected to get exit value of [0]")) {
                     throw new RuntimeException("Unexpected message: " + ex.getMessage());
                 }
             }

--- a/test/lib-test/jdk/test/lib/process/OutputAnalyzerTest.java
+++ b/test/lib-test/jdk/test/lib/process/OutputAnalyzerTest.java
@@ -24,12 +24,12 @@
 /*
  * @test
  * @summary Test the OutputAnalyzer utility class
- * @modules java.management
  * @library /test/lib
  * @run main OutputAnalyzerTest
  */
 
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 public class OutputAnalyzerTest {
 
@@ -214,6 +214,32 @@ public class OutputAnalyzerTest {
             String result = output.firstMatch(aa_grouped_aa, 1);
             if (!aa.equals(result)) {
                 throw new Exception("firstMatch(String, int) failed to match. Expected: " + aa + " got: " + result);
+            }
+        }
+
+        {
+            try {
+                // Verify the exception message
+                OutputAnalyzer out = ProcessTools.executeProcess("true");
+                out.shouldHaveExitValue(1);
+                throw new RuntimeException("'shouldHaveExitValue' should have thrown an exception");
+            } catch (Throwable ex) {
+                if (!ex.getMessage().equals("Expected to get exit value of [1], exit value is: [0]")) {
+                    throw new RuntimeException("Unexpected message: " + ex.getMessage());
+                }
+            }
+        }
+
+        {
+            try {
+                // Verify the exception message
+                OutputAnalyzer out = ProcessTools.executeProcess("true");
+                out.shouldNotHaveExitValue(0);
+                throw new RuntimeException("'shouldNotHaveExitValue' should have thrown an exception");
+            } catch (Throwable ex) {
+                if (!ex.getMessage().equals("Unexpected to get exit value of [0], exit value is: [0]")) {
+                    throw new RuntimeException("Unexpected message: " + ex.getMessage());
+                }
             }
         }
     }

--- a/test/lib/jdk/test/lib/process/OutputAnalyzer.java
+++ b/test/lib/jdk/test/lib/process/OutputAnalyzer.java
@@ -502,7 +502,7 @@ public final class OutputAnalyzer {
         if (getExitValue() == notExpectedExitValue) {
             reportDiagnosticSummary();
             throw new RuntimeException("Unexpected to get exit value of ["
-                    + notExpectedExitValue + "], exit value is: [" + getExitValue() + "]");
+                    + notExpectedExitValue + "]");
         }
         return this;
     }

--- a/test/lib/jdk/test/lib/process/OutputAnalyzer.java
+++ b/test/lib/jdk/test/lib/process/OutputAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -218,7 +218,7 @@ public final class OutputAnalyzer {
         String stderr = getStderr();
         if (!stdout.contains(expectedString) && !stderr.contains(expectedString)) {
             reportDiagnosticSummary();
-            throw new RuntimeException("'" + expectedString + "' missing from stdout/stderr \n");
+            throw new RuntimeException("'" + expectedString + "' missing from stdout/stderr");
         }
         return this;
     }
@@ -233,7 +233,7 @@ public final class OutputAnalyzer {
         String stdout = getStdout();
         if (!stdout.contains(expectedString)) {
             reportDiagnosticSummary();
-            throw new RuntimeException("'" + expectedString + "' missing from stdout \n");
+            throw new RuntimeException("'" + expectedString + "' missing from stdout");
         }
         return this;
     }
@@ -248,7 +248,7 @@ public final class OutputAnalyzer {
         String stderr = getStderr();
         if (!stderr.contains(expectedString)) {
             reportDiagnosticSummary();
-            throw new RuntimeException("'" + expectedString + "' missing from stderr \n");
+            throw new RuntimeException("'" + expectedString + "' missing from stderr");
         }
         return this;
     }
@@ -264,11 +264,11 @@ public final class OutputAnalyzer {
         String stderr = getStderr();
         if (stdout.contains(notExpectedString)) {
             reportDiagnosticSummary();
-            throw new RuntimeException("'" + notExpectedString + "' found in stdout \n");
+            throw new RuntimeException("'" + notExpectedString + "' found in stdout");
         }
         if (stderr.contains(notExpectedString)) {
             reportDiagnosticSummary();
-            throw new RuntimeException("'" + notExpectedString + "' found in stderr \n");
+            throw new RuntimeException("'" + notExpectedString + "' found in stderr");
         }
         return this;
     }
@@ -302,7 +302,7 @@ public final class OutputAnalyzer {
         String stdout = getStdout();
         if (stdout.contains(notExpectedString)) {
             reportDiagnosticSummary();
-            throw new RuntimeException("'" + notExpectedString + "' found in stdout \n");
+            throw new RuntimeException("'" + notExpectedString + "' found in stdout");
         }
         return this;
     }
@@ -317,7 +317,7 @@ public final class OutputAnalyzer {
         String stderr = getStderr();
         if (stderr.contains(notExpectedString)) {
             reportDiagnosticSummary();
-            throw new RuntimeException("'" + notExpectedString + "' found in stderr \n");
+            throw new RuntimeException("'" + notExpectedString + "' found in stderr");
         }
         return this;
     }
@@ -338,7 +338,7 @@ public final class OutputAnalyzer {
         if (!stdoutMatcher.find() && !stderrMatcher.find()) {
             reportDiagnosticSummary();
             throw new RuntimeException("'" + regexp
-                  + "' missing from stdout/stderr \n");
+                  + "' missing from stdout/stderr");
         }
         return this;
     }
@@ -356,7 +356,7 @@ public final class OutputAnalyzer {
         if (!matcher.find()) {
             reportDiagnosticSummary();
             throw new RuntimeException("'" + regexp
-                  + "' missing from stdout \n");
+                  + "' missing from stdout");
         }
         return this;
     }
@@ -374,7 +374,7 @@ public final class OutputAnalyzer {
         if (!matcher.find()) {
             reportDiagnosticSummary();
             throw new RuntimeException("'" + pattern
-                  + "' missing from stderr \n");
+                  + "' missing from stderr");
         }
         return this;
     }
@@ -393,7 +393,7 @@ public final class OutputAnalyzer {
         if (matcher.find()) {
             reportDiagnosticSummary();
             throw new RuntimeException("'" + regexp
-                    + "' found in stdout: '" + matcher.group() + "' \n");
+                    + "' found in stdout: '" + matcher.group() + "'");
         }
 
         String stderr = getStderr();
@@ -401,7 +401,7 @@ public final class OutputAnalyzer {
         if (matcher.find()) {
             reportDiagnosticSummary();
             throw new RuntimeException("'" + regexp
-                    + "' found in stderr: '" + matcher.group() + "' \n");
+                    + "' found in stderr: '" + matcher.group() + "'");
         }
 
         return this;
@@ -420,7 +420,7 @@ public final class OutputAnalyzer {
         if (matcher.find()) {
             reportDiagnosticSummary();
             throw new RuntimeException("'" + regexp
-                    + "' found in stdout \n");
+                    + "' found in stdout");
         }
         return this;
     }
@@ -438,7 +438,7 @@ public final class OutputAnalyzer {
         if (matcher.find()) {
             reportDiagnosticSummary();
             throw new RuntimeException("'" + regexp
-                    + "' found in stderr \n");
+                    + "' found in stderr");
         }
         return this;
     }
@@ -487,7 +487,7 @@ public final class OutputAnalyzer {
         if (getExitValue() != expectedExitValue) {
             reportDiagnosticSummary();
             throw new RuntimeException("Expected to get exit value of ["
-                    + expectedExitValue + "]\n");
+                    + expectedExitValue + "], exit value is: [" + getExitValue() + "]");
         }
         return this;
     }
@@ -502,7 +502,7 @@ public final class OutputAnalyzer {
         if (getExitValue() == notExpectedExitValue) {
             reportDiagnosticSummary();
             throw new RuntimeException("Unexpected to get exit value of ["
-                    + notExpectedExitValue + "]\n");
+                    + notExpectedExitValue + "], exit value is: [" + getExitValue() + "]");
         }
         return this;
     }
@@ -637,7 +637,7 @@ public final class OutputAnalyzer {
         if (!matcher.find()) {
             reportDiagnosticSummary();
             throw new RuntimeException("'" + pattern
-                  + "' missing from stderr \n");
+                  + "' missing from stderr");
         }
         return this;
     }


### PR DESCRIPTION
The RuntimeException from OutputAnalyzer for expected and unexpected exit values should include both the actual and expected values.
The method `shouldHaveExitvalue` and `shouldNotHaveExitValue` include the value expected and the value not expected instead of the actual value returned. The values provided in the exception are already known quantities in the code, what is not known is the actual value.  
The actual value is printed to stderr but not the expected value and in the logs, the exception report is frequently to stdout and therefor separated in the log from the output of stderr.  Including both expected and actual values in the exception makes it easier to understand.

Exception messages should not include newlines.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288495](https://bugs.openjdk.org/browse/JDK-8288495): [test] Make OutputAnalyzer exception more informative


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) ⚠️ Review applies to [e73bf2bd](https://git.openjdk.org/jdk/pull/9247/files/e73bf2bd026022ce332be1f845750a8787b0a231)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [e73bf2bd](https://git.openjdk.org/jdk/pull/9247/files/e73bf2bd026022ce332be1f845750a8787b0a231)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9247/head:pull/9247` \
`$ git checkout pull/9247`

Update a local copy of the PR: \
`$ git checkout pull/9247` \
`$ git pull https://git.openjdk.org/jdk pull/9247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9247`

View PR using the GUI difftool: \
`$ git pr show -t 9247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9247.diff">https://git.openjdk.org/jdk/pull/9247.diff</a>

</details>
