### PR TITLE
JDK-8288993: Make AwtFramePackTest generic by removing @requires tag

### DIFF
--- a/test/jdk/java/awt/Frame/AwtFramePackTest.java
+++ b/test/jdk/java/awt/Frame/AwtFramePackTest.java
@@ -41,7 +41,7 @@ import javax.imageio.ImageIO;
  * @key headful
  * @summary Tests whether insets are calculated correctly on Windows
  * for AWT Frame by checking the actual and expected/preferred frame sizes.
- * @run main/othervm -Dsun.java2d.uiScale=1 AwtFramePackTest
+ * @run main AwtFramePackTest
  */
 
 public class AwtFramePackTest {

--- a/test/jdk/java/awt/Frame/AwtFramePackTest.java
+++ b/test/jdk/java/awt/Frame/AwtFramePackTest.java
@@ -39,7 +39,6 @@ import javax.imageio.ImageIO;
  * @test
  * @bug 8265586
  * @key headful
- * @requires (os.family == "windows")
  * @summary Tests whether insets are calculated correctly on Windows
  * for AWT Frame by checking the actual and expected/preferred frame sizes.
  * @run main/othervm -Dsun.java2d.uiScale=1 AwtFramePackTest


### PR DESCRIPTION
The following test was changed to generic based on this [Review Comment](https://github.com/openjdk/jdk/pull/9118#discussion_r897553780) and as the condition `frame.getSize() == frame.getPreferredSize() ` should hold on all platforms when frame.pack() is used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288993](https://bugs.openjdk.org/browse/JDK-8288993): Make AwtFramePackTest generic by removing @requires tag


### Reviewers
 * [Dmitry Markov](https://openjdk.org/census#dmarkov) (@dmarkov20 - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9248/head:pull/9248` \
`$ git checkout pull/9248`

Update a local copy of the PR: \
`$ git checkout pull/9248` \
`$ git pull https://git.openjdk.org/jdk pull/9248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9248`

View PR using the GUI difftool: \
`$ git pr show -t 9248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9248.diff">https://git.openjdk.org/jdk/pull/9248.diff</a>

</details>
