### PR TITLE
8289006: Cleanup from thread.hpp split

### DIFF
--- a/src/hotspot/cpu/zero/stack_zero.cpp
+++ b/src/hotspot/cpu/zero/stack_zero.cpp
@@ -28,7 +28,6 @@
 #include "interpreter/zero/bytecodeInterpreter.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/javaThread.inline.hpp"
-#include "stack_zero.hpp"
 #include "stack_zero.inline.hpp"
 #include "utilities/align.hpp"
 

--- a/src/hotspot/cpu/zero/stack_zero.cpp
+++ b/src/hotspot/cpu/zero/stack_zero.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2010 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -26,11 +26,10 @@
 #include "precompiled.hpp"
 #include "interpreter/interpreterRuntime.hpp"
 #include "interpreter/zero/bytecodeInterpreter.hpp"
-#include "runtime/javaThread.hpp"
-#include "stack_zero.hpp"
-#include "stack_zero.inline.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/javaThread.inline.hpp"
+#include "stack_zero.hpp"
+#include "stack_zero.inline.hpp"
 #include "utilities/align.hpp"
 
 // Inlined causes circular inclusion with thread.hpp

--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -36,7 +36,6 @@
 #include "runtime/os.hpp"
 #include "runtime/safepointMechanism.inline.hpp"
 #include "runtime/safepointVerifiers.hpp"
-#include "runtime/javaThread.inline.hpp"
 #include "runtime/threadWXSetters.inline.hpp"
 #include "runtime/vmOperations.hpp"
 #include "utilities/globalDefinitions.hpp"


### PR DESCRIPTION
Remove extra include directives.  Tested with GHA.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289006](https://bugs.openjdk.org/browse/JDK-8289006): Cleanup from thread.hpp split


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [f3e109c8](https://git.openjdk.org/jdk/pull/9252/files/f3e109c8f01b1b13f1bdc9859d5abfc41b21d6b1)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9252/head:pull/9252` \
`$ git checkout pull/9252`

Update a local copy of the PR: \
`$ git checkout pull/9252` \
`$ git pull https://git.openjdk.org/jdk pull/9252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9252`

View PR using the GUI difftool: \
`$ git pr show -t 9252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9252.diff">https://git.openjdk.org/jdk/pull/9252.diff</a>

</details>
