### PR TITLE
JDK-8286610: Add additional diagnostic output to java/net/DatagramSocket/InterruptibleDatagramSocket.java

### DIFF
--- a/test/jdk/java/net/DatagramSocket/InterruptibleDatagramSocket.java
+++ b/test/jdk/java/net/DatagramSocket/InterruptibleDatagramSocket.java
@@ -28,6 +28,7 @@ import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.DatagramChannel;
+import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 
 import static java.lang.Thread.sleep;
@@ -60,6 +61,8 @@ public class InterruptibleDatagramSocket {
         latch.countDown();
         try {
             s.receive(p);
+            System.out.println("Received data " + Arrays.toString(p.getData())
+                    + " from " + p.getSocketAddress());
         } finally {
             try {
                 coordinator.join();
@@ -95,12 +98,17 @@ public class InterruptibleDatagramSocket {
 
     public static void main(String[] args) throws Exception {
         try (DatagramSocket s = new DatagramSocket()) {
+            System.out.println("Established uninterruptible datagram socket "
+                    + s.getLocalSocketAddress());
             test(s, false);
         }
         try (DatagramSocket s = new MulticastSocket()) {
+            System.out.println("Established uninterruptible multicast socket "
+                    + s.getLocalSocketAddress());
             test(s, false);
         }
         try (DatagramSocket s = DatagramChannel.open().socket()) {
+            System.out.println("Established interruptible datagram socket");
             test(s, true);
         }
     }


### PR DESCRIPTION
Failure was observed on java/net/DatagramSocket/InterruptibleDatagramSocket.java where data was received unexpectedly ( [JDK-8286607](https://bugs.openjdk.org/browse/JDK-8286607)). This failure could be caused by interference from other ongoing tests. The fix here is to output the unexpected received data and the sender's address for a further investigation ([JDK-8286610](https://bugs.openjdk.org/browse/JDK-8286610)).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8286610](https://bugs.openjdk.org/browse/JDK-8286610): Add additional diagnostic output to java/net/DatagramSocket/InterruptibleDatagramSocket.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9253/head:pull/9253` \
`$ git checkout pull/9253`

Update a local copy of the PR: \
`$ git checkout pull/9253` \
`$ git pull https://git.openjdk.org/jdk pull/9253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9253`

View PR using the GUI difftool: \
`$ git pr show -t 9253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9253.diff">https://git.openjdk.org/jdk/pull/9253.diff</a>

</details>
