### PR TITLE
8286259: Password cleanup after KeyStore.PasswordProtection in P11KeyStore

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java
@@ -57,6 +57,7 @@ import java.security.spec.*;
 import javax.crypto.SecretKey;
 import javax.crypto.interfaces.*;
 
+import javax.security.auth.DestroyFailedException;
 import javax.security.auth.x500.X500Principal;
 import javax.security.auth.login.LoginException;
 import javax.security.auth.callback.Callback;
@@ -454,7 +455,18 @@ final class P11KeyStore extends KeyStoreSpi {
         } catch (NullPointerException | IllegalArgumentException e) {
             throw new KeyStoreException(e);
         }
-        engineSetEntry(alias, entry, new KeyStore.PasswordProtection(password));
+
+        KeyStore.PasswordProtection passwordProtection =
+                new KeyStore.PasswordProtection(password);
+        try {
+            engineSetEntry(alias, entry, passwordProtection);
+        } finally {
+            try {
+                passwordProtection.destroy();
+            } catch (DestroyFailedException dfe) {
+                // ignore
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Please review the small update for JDK-8286259.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286259](https://bugs.openjdk.org/browse/JDK-8286259): Password cleanup after KeyStore.PasswordProtection in P11KeyStore


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9254/head:pull/9254` \
`$ git checkout pull/9254`

Update a local copy of the PR: \
`$ git checkout pull/9254` \
`$ git pull https://git.openjdk.org/jdk pull/9254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9254`

View PR using the GUI difftool: \
`$ git pr show -t 9254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9254.diff">https://git.openjdk.org/jdk/pull/9254.diff</a>

</details>
