### PR TITLE
8288895: LdapContext doesn't honor set referrals limit

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/AbstractLdapNamingEnumeration.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/AbstractLdapNamingEnumeration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -310,10 +310,8 @@ abstract class AbstractLdapNamingEnumeration<T extends NameClassPair>
      */
     protected final boolean hasMoreReferrals() throws NamingException {
 
-        if ((refEx != null) &&
-            (refEx.hasMoreReferrals() ||
-             refEx.hasMoreReferralExceptions()
-                && !(errEx instanceof LimitExceededException))) {
+        if ((refEx != null) && !(errEx instanceof LimitExceededException) &&
+            (refEx.hasMoreReferrals() || refEx.hasMoreReferralExceptions())) {
 
             if (homeCtx.handleReferrals == LdapClient.LDAP_REF_THROW) {
                 throw (NamingException)(refEx.fillInStackTrace());
@@ -333,9 +331,13 @@ abstract class AbstractLdapNamingEnumeration<T extends NameClassPair>
 
                 } catch (LdapReferralException re) {
 
-                    // record a previous exception
-                    if (errEx == null) {
-                        errEx = re.getNamingException();
+                    // record a previous exception and quit if any limit is reached
+                    var namingException = re.getNamingException();
+                    if (namingException instanceof LimitExceededException) {
+                        errEx = namingException;
+                        break;
+                    } else if (errEx == null) {
+                        errEx = namingException;
                     }
                     refEx = re;
                     continue;
@@ -381,6 +383,10 @@ abstract class AbstractLdapNamingEnumeration<T extends NameClassPair>
         entries = ne.entries;
         refEx = ne.refEx;
         listArg = ne.listArg;
+        // record a previous exception and quit if any limit is reached
+        if (errEx == null || ne.errEx instanceof LimitExceededException) {
+            errEx = ne.errEx;
+        }
     }
 
     @SuppressWarnings("removal")

--- a/test/jdk/com/sun/jndi/ldap/ReferralLimitSearchTest.java
+++ b/test/jdk/com/sun/jndi/ldap/ReferralLimitSearchTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8288895
+ * @summary LdapContext doesn't honor set referrals limit
+ * @library lib /test/lib
+ */
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import javax.naming.NamingEnumeration;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.SearchControls;
+import java.nio.charset.StandardCharsets;
+import java.net.InetAddress;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.naming.Context;
+import javax.naming.LimitExceededException;
+import javax.naming.directory.InitialDirContext;
+import javax.naming.directory.SearchResult;
+import jdk.test.lib.net.URIBuilder;
+
+/**
+ * <p>Little test for referral limit. The ldap server is configured to
+ * always return a referral so LimitExceededException is expected when
+ * <em>java.naming.ldap.referral.limit</em> is reached.</p>
+ *
+ * @author rmartinc
+ */
+public class ReferralLimitSearchTest {
+
+    // number of refarral hops to test
+    private static final int MAX_REFERRAL_LIMIT = 4;
+
+    // position of the message-id inside the responses
+    private static final int MESSAGE_ID_IDX = 4;
+
+    // success bind response
+    private static final byte[] BIND_RESPONSE = {
+            0x30, 0x0C, 0x02, 0x01, 0x00, 0x61, 0x07, 0x0A,
+            0x01, 0x00, 0x04, 0x00, 0x04, 0x00
+    };
+
+    // search res done
+    private static final byte[] SEARCH_RESPONSE = {
+            0x30, 0x0C, 0x02, 0x01, 0x00, 0x65, 0x07, 0x0A,
+            0x01, 0x00, 0x04, 0x00, 0x04, 0x00
+    };
+
+    public static void main(String[] args) throws Exception {
+
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        // Start the LDAP server
+        BaseLdapServer ldapServer = new BaseLdapServer() {
+            AtomicInteger hops = new AtomicInteger(0);
+
+            @Override
+            protected void handleRequest(Socket socket, LdapMessage request,
+                    OutputStream out) throws IOException {
+                switch (request.getOperation()) {
+                    case BIND_REQUEST:
+                        byte[] bindResponse = BIND_RESPONSE.clone();
+                        bindResponse[MESSAGE_ID_IDX] = (byte) request.getMessageID();
+                        out.write(bindResponse);
+                        break;
+                    case SEARCH_REQUEST:
+                        if (hops.incrementAndGet() > MAX_REFERRAL_LIMIT + 1) {
+                            throw new IOException("Referral limit not enforced. Number of hops=" + hops);
+                        }
+                        byte[] referral = new StringBuilder("ldap://")
+                                .append(InetAddress.getLoopbackAddress().getHostAddress())
+                                .append(":")
+                                .append(getPort())
+                                .append("/ou=People??sub")
+                                .toString()
+                                .getBytes(StandardCharsets.UTF_8);
+                        out.write(0x30);
+                        out.write(referral.length + 7);
+                        out.write(new byte[] {0x02, 0x01});
+                        out.write(request.getMessageID());
+                        out.write(0x73);
+                        out.write(referral.length + 2);
+                        out.write(0x04);
+                        out.write(referral.length);
+                        out.write(referral);
+
+                        byte[] searchResponse = SEARCH_RESPONSE.clone();
+                        searchResponse[MESSAGE_ID_IDX] = (byte) request.getMessageID();
+                        out.write(searchResponse);
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            protected void beforeAcceptingConnections() {
+                latch.countDown();
+            }
+        }.start();
+
+        try (ldapServer) {
+
+            if (!latch.await(5, TimeUnit.SECONDS)) {
+                throw new RuntimeException("LdapServer not started in time");
+            }
+
+            // Setup JNDI parameters
+            Properties env = new Properties();
+            env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+            env.put(Context.REFERRAL, "follow");
+            env.put("java.naming.ldap.referral.limit", Integer.toString(MAX_REFERRAL_LIMIT));
+            env.put(Context.PROVIDER_URL, URIBuilder.newBuilder()
+                    .scheme("ldap")
+                    .loopback()
+                    .port(ldapServer.getPort())
+                    .build().toString());
+
+            System.out.println("Client: connecting...");
+            DirContext ctx = new InitialDirContext(env);
+            SearchControls sc = new SearchControls();
+            sc.setSearchScope(SearchControls.SUBTREE_SCOPE);
+            sc.setReturningAttributes(new String[]{"uid"});
+            System.out.println("Client: performing search...");
+            NamingEnumeration<SearchResult> ne = ctx.search("ou=People", "(uid=*)", sc);
+            while (ne.hasMore()) {
+                SearchResult sr = ne.next();
+                System.out.println("Client: Search result " + sr);
+            }
+            System.out.println("Client: search done...");
+            ctx.close();
+
+            // LimitExceededException expected throw error if this point is reached
+            throw new RuntimeException("LimitExceededException expected");
+
+        } catch (LimitExceededException e) {
+            System.out.println("Passed: caught the expected Exception - " + e);
+        } catch (Exception e) {
+            System.err.println("Failed: caught an unexpected Exception - " + e);
+            throw e;
+        }
+    }
+}

--- a/test/jdk/com/sun/jndi/ldap/ReferralLimitSearchTest.java
+++ b/test/jdk/com/sun/jndi/ldap/ReferralLimitSearchTest.java
@@ -55,7 +55,7 @@ import jdk.test.lib.net.URIBuilder;
  */
 public class ReferralLimitSearchTest {
 
-    // number of refarral hops to test
+    // number of referral hops to test
     private static final int MAX_REFERRAL_LIMIT = 4;
 
     // position of the message-id inside the responses


### PR DESCRIPTION
Fixes [JDK-8288895](https://bugs.openjdk.org/browse/JDK-8288895).

Any `LimitExceededException` now quits the referral loop.

Added class `ReferralLimitSearchTest`. It is a simple jtreg test which checks that `java.naming.ldap.referral.limit` is really enforced. The dummy ldap server always returns a referral for any search query. If the number of searches exceeds the limit, it throws an `IOException` and the test fails.

```
make test TEST=jtreg:jdk/com/sun/jndi/ldap/ReferralLimitSearchTest.java
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288895](https://bugs.openjdk.org/browse/JDK-8288895): LdapContext doesn't honor set referrals limit


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Aleksei Efimov](https://openjdk.org/census#aefimov) (@AlekseiEfimov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9256/head:pull/9256` \
`$ git checkout pull/9256`

Update a local copy of the PR: \
`$ git checkout pull/9256` \
`$ git pull https://git.openjdk.org/jdk pull/9256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9256`

View PR using the GUI difftool: \
`$ git pr show -t 9256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9256.diff">https://git.openjdk.org/jdk/pull/9256.diff</a>

</details>
