### PR TITLE
8289044: ARM32: missing LIR_Assembler::cmove metadata type support

### DIFF
--- a/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
@@ -1478,6 +1478,9 @@ void LIR_Assembler::cmove(LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2, L
           __ mov_double(result->as_double_reg(), c->as_jdouble(), acond);
 #endif // __SOFTFP__
           break;
+        case T_METADATA:
+          __ mov_metadata(result->as_register(), c->as_metadata(), acond);
+          break;
         default:
           ShouldNotReachHere();
       }


### PR DESCRIPTION
Fixing ARM32 jtreg fails:
- compiler/floatingpoint/TestFloatJNIArgs.java
- runtime/logging/MonitorMismatchTest.java.MonitorMismatchTest

```
# A fatal error has been detected by the Java Runtime Environment:
#
# Internal Error (c1_LIRAssembler_arm.cpp:1482), pid=21156, tid=21171
# Error: ShouldNotReachHere() 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289044](https://bugs.openjdk.org/browse/JDK-8289044): ARM32: missing LIR_Assembler::cmove metadata type support


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9258/head:pull/9258` \
`$ git checkout pull/9258`

Update a local copy of the PR: \
`$ git checkout pull/9258` \
`$ git pull https://git.openjdk.org/jdk pull/9258/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9258`

View PR using the GUI difftool: \
`$ git pr show -t 9258`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9258.diff">https://git.openjdk.org/jdk/pull/9258.diff</a>

</details>
