### PR TITLE
8288669: compiler/vectorapi/VectorFPtoIntCastTest.java still fails with "IRViolationException: There were one or multiple IR rule failures."

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/VectorFPtoIntCastTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorFPtoIntCastTest.java
@@ -49,19 +49,22 @@ public class VectorFPtoIntCastTest {
     private static final VectorSpecies<Byte> bspec128 = ByteVector.SPECIES_128;
     private static final VectorSpecies<Byte> bspec64  = ByteVector.SPECIES_64;
 
-    private float [] float_arr;
-    private double [] double_arr;
-    private long [] long_arr;
-    private int [] int_arr;
-    private short [] short_arr;
-    private byte [] byte_arr;
+    private float[] float_arr;
+    private double[] double_arr;
+    private long[] long_arr;
+    private int[] int_arr;
+    private short[] short_arr;
+    private byte[] byte_arr;
 
     private FloatVector fvec256;
     private FloatVector fvec512;
     private DoubleVector dvec512;
 
-    public static void main(String args[]) {
-        TestFramework.runWithFlags("--add-modules=jdk.incubator.vector");
+    public static void main(String[] args) {
+        TestFramework testFramework = new TestFramework();
+        testFramework.setDefaultWarmup(5000)
+                     .addFlags("--add-modules=jdk.incubator.vector")
+                     .start();
     }
 
     public VectorFPtoIntCastTest() {


### PR DESCRIPTION
IR matching fails when run with `-XX:-TieredCompilation` because we don't have enough profiling information. There is an RFE ([JDK-8276547](https://bugs.openjdk.org/browse/JDK-8276547)) that should change the fixed default warm-up into a compilation policy based warm-up to prevent such test failures in the future. The fix for this test is to just increase the default warm-up for now.

Testing:
- tier1-4 flags for VectorFPtoIntCastTest.java
- repeated runs with tier3 flags (includes `-XX:-TieredCompilation`)

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288669](https://bugs.openjdk.org/browse/JDK-8288669): compiler/vectorapi/VectorFPtoIntCastTest.java still fails with "IRViolationException: There were one or multiple IR rule failures."


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9259/head:pull/9259` \
`$ git checkout pull/9259`

Update a local copy of the PR: \
`$ git checkout pull/9259` \
`$ git pull https://git.openjdk.org/jdk pull/9259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9259`

View PR using the GUI difftool: \
`$ git pr show -t 9259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9259.diff">https://git.openjdk.org/jdk/pull/9259.diff</a>

</details>
