### PR TITLE
8289659: Refactor I/O stream copying to use InputStream.readAllBytes in X509CertPath

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/certpath/X509CertPath.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/X509CertPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.provider.certpath;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.cert.CertificateEncodingException;
@@ -185,7 +184,7 @@ public class X509CertPath extends CertPath {
         }
 
         try {
-            DerInputStream dis = new DerInputStream(readAllBytes(is));
+            DerInputStream dis = new DerInputStream(is.readAllBytes());
             DerValue[] seq = dis.getSequence(3);
             if (seq.length == 0) {
                 return Collections.<X509Certificate>emptyList();
@@ -228,7 +227,7 @@ public class X509CertPath extends CertPath {
             if (is.markSupported() == false) {
                 // Copy the entire input stream into an InputStream that does
                 // support mark
-                is = new ByteArrayInputStream(readAllBytes(is));
+                is = new ByteArrayInputStream(is.readAllBytes());
             }
             PKCS7 pkcs7 = new PKCS7(is);
 
@@ -249,22 +248,6 @@ public class X509CertPath extends CertPath {
         // and the methods in the Sun JDK 1.4 implementation of ArrayList that
         // allow read-only access are thread-safe.
         return Collections.unmodifiableList(certList);
-    }
-
-    /*
-     * Reads the entire contents of an InputStream into a byte array.
-     *
-     * @param is the InputStream to read from
-     * @return the bytes read from the InputStream
-     */
-    private static byte[] readAllBytes(InputStream is) throws IOException {
-        byte[] buffer = new byte[8192];
-        ByteArrayOutputStream baos = new ByteArrayOutputStream(2048);
-        int n;
-        while ((n = is.read(buffer)) != -1) {
-            baos.write(buffer, 0, n);
-        }
-        return baos.toByteArray();
     }
 
     /**


### PR DESCRIPTION
Use `InputStream.readAllBytes` instead of manually written method.

Skipped this method in [JDK-8080272](https://bugs.openjdk.org/browse/JDK-8080272)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289659](https://bugs.openjdk.org/browse/JDK-8289659): Refactor I/O stream copying to use InputStream.readAllBytes in X509CertPath


### Reviewers
 * [Attila Szegedi](https://openjdk.org/census#attila) (@szegedi - **Reviewer**)
 * @stsypanov (no known github.com user name / role)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9263/head:pull/9263` \
`$ git checkout pull/9263`

Update a local copy of the PR: \
`$ git checkout pull/9263` \
`$ git pull https://git.openjdk.org/jdk pull/9263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9263`

View PR using the GUI difftool: \
`$ git pr show -t 9263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9263.diff">https://git.openjdk.org/jdk/pull/9263.diff</a>

</details>
