### PR TITLE
8289095: (fs) UnixCopyFile build error on linux-x86

### DIFF
--- a/src/java.base/unix/native/libnio/fs/UnixCopyFile.c
+++ b/src/java.base/unix/native/libnio/fs/UnixCopyFile.c
@@ -80,7 +80,7 @@ Java_sun_nio_fs_UnixCopyFile_bufferedCopy0
 {
     volatile jint* cancel = (jint*)jlong_to_ptr(cancelAddress);
 
-    char* buf = (char*)address;
+    char* buf = (char*)jlong_to_ptr(address);
 
 #if defined(__linux__)
     int advice = POSIX_FADV_SEQUENTIAL | // sequential data access


### PR DESCRIPTION
Use `(char*)jlong_to_ptr(address)` instead of the straight cast `(char*)address`.