### PR TITLE
8289098: clean up ported serviceability/jvmti tests

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/AddModuleExportsAndOpens/MyPackage/AddModuleExportsAndOpensTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/AddModuleExportsAndOpens/MyPackage/AddModuleExportsAndOpensTest.java
@@ -31,6 +31,8 @@ package MyPackage;
  * @run main/othervm/native -agentlib:AddModuleExportsAndOpensTest MyPackage.AddModuleExportsAndOpensTest
  */
 
+import java.io.PrintStream;
+
 public class AddModuleExportsAndOpensTest {
 
     static {

--- a/test/hotspot/jtreg/serviceability/jvmti/AddModuleExportsAndOpens/MyPackage/AddModuleExportsAndOpensTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/AddModuleExportsAndOpens/MyPackage/AddModuleExportsAndOpensTest.java
@@ -31,8 +31,6 @@ package MyPackage;
  * @run main/othervm/native -agentlib:AddModuleExportsAndOpensTest MyPackage.AddModuleExportsAndOpensTest
  */
 
-import java.io.PrintStream;
-
 public class AddModuleExportsAndOpensTest {
 
     static {

--- a/test/hotspot/jtreg/serviceability/jvmti/events/Breakpoint/breakpoint01/breakpoint01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/Breakpoint/breakpoint01/breakpoint01.java
@@ -57,14 +57,7 @@ import java.io.*;
  */
 public class breakpoint01 {
     static {
-        try {
-            System.loadLibrary("breakpoint01");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load \"breakpoint01\" library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("breakpoint01");
     }
 
     native int check();

--- a/test/hotspot/jtreg/serviceability/jvmti/events/Breakpoint/breakpoint01/libbreakpoint01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/Breakpoint/breakpoint01/libbreakpoint01.cpp
@@ -55,7 +55,7 @@ static volatile jint result = PASSED;
 static jvmtiEnv *jvmti = NULL;
 static jvmtiEventCallbacks callbacks;
 
-static volatile int callbacksEnabled = NSK_TRUE;
+static volatile int callbacksEnabled = JNI_TRUE;
 static jrawMonitorID agent_lock;
 
 static void initCounters() {
@@ -196,13 +196,13 @@ Breakpoint(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread, jmethodID method, jloca
 void JNICALL
 VMStart(jvmtiEnv *jvmti, JNIEnv *jni) {
   RawMonitorLocker rml(jvmti, jni, agent_lock);
-  callbacksEnabled = NSK_TRUE;
+  callbacksEnabled = JNI_TRUE;
 }
 
 void JNICALL
 VMDeath(jvmtiEnv *jvmti, JNIEnv *jni) {
   RawMonitorLocker rml(jvmti, jni, agent_lock);
-  callbacksEnabled = NSK_FALSE;
+  callbacksEnabled = JNI_FALSE;
 }
 
 JNIEXPORT jint JNICALL

--- a/test/hotspot/jtreg/serviceability/jvmti/events/ClassLoad/classload01/classload01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/ClassLoad/classload01/classload01.java
@@ -61,14 +61,7 @@ import java.io.*;
  */
 public class classload01 {
     static {
-        try {
-            System.loadLibrary("classload01");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load \"classload01\" library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("classload01");
     }
 
     native int check();

--- a/test/hotspot/jtreg/serviceability/jvmti/events/ClassPrepare/classprep01/classprep01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/ClassPrepare/classprep01/classprep01.java
@@ -21,9 +21,6 @@
  * questions.
  */
 
-import java.io.PrintStream;
-
-
 /*
  * @test
  *

--- a/test/hotspot/jtreg/serviceability/jvmti/events/ClassPrepare/classprep01/classprep01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/ClassPrepare/classprep01/classprep01.java
@@ -46,14 +46,7 @@
 public class classprep01 {
 
     static {
-        try {
-            System.loadLibrary("classprep01");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load classprep01 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("classprep01");
     }
 
     native static void getReady();

--- a/test/hotspot/jtreg/serviceability/jvmti/events/Exception/exception01/exception01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/Exception/exception01/exception01.java
@@ -21,8 +21,6 @@
  * questions.
  */
 
-import java.io.PrintStream;
-
 /*
  * @test
  *

--- a/test/hotspot/jtreg/serviceability/jvmti/events/Exception/exception01/exception01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/Exception/exception01/exception01.java
@@ -49,14 +49,7 @@
 public class exception01 {
 
     static {
-        try {
-            System.loadLibrary("exception01");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load exception01 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("exception01");
     }
 
     static volatile int result;

--- a/test/hotspot/jtreg/serviceability/jvmti/events/ExceptionCatch/excatch01/excatch01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/ExceptionCatch/excatch01/excatch01.java
@@ -49,14 +49,7 @@
 public class excatch01 {
 
     static {
-        try {
-            System.loadLibrary("excatch01");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load excatch01 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("excatch01");
     }
 
     static volatile int result;

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc01/fieldacc01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc01/fieldacc01.java
@@ -46,8 +46,6 @@
 
 public class fieldacc01 {
 
-    final static int JCK_STATUS_BASE = 95;
-
     static {
         try {
             System.loadLibrary("fieldacc01");

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc01/fieldacc01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc01/fieldacc01.java
@@ -47,14 +47,7 @@
 public class fieldacc01 {
 
     static {
-        try {
-            System.loadLibrary("fieldacc01");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load fieldacc01 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("fieldacc01");
     }
 
     static volatile int result;

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc02/fieldacc02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc02/fieldacc02.java
@@ -47,8 +47,6 @@ import java.io.PrintStream;
 
 public class fieldacc02 {
 
-    final static int JCK_STATUS_BASE = 95;
-
     static {
         try {
             System.loadLibrary("fieldacc02");

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc02/fieldacc02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc02/fieldacc02.java
@@ -46,14 +46,7 @@
 public class fieldacc02 {
 
     static {
-        try {
-            System.loadLibrary("fieldacc02");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load fieldacc02 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("fieldacc02");
     }
 
     static volatile int result;

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc02/fieldacc02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc02/fieldacc02.java
@@ -21,8 +21,6 @@
  * questions.
  */
 
-import java.io.PrintStream;
-
 /*
  * @test
  *

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc03/fieldacc03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc03/fieldacc03.java
@@ -21,8 +21,6 @@
  * questions.
  */
 
-import java.io.PrintStream;
-
 /*
  * @test
  *

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc03/fieldacc03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc03/fieldacc03.java
@@ -47,14 +47,7 @@
 public class fieldacc03 {
 
     static {
-        try {
-            System.loadLibrary("fieldacc03");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load fieldacc03 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("fieldacc03");
     }
 
     static volatile int result;

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc03/fieldacc03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc03/fieldacc03.java
@@ -48,8 +48,6 @@ import java.io.PrintStream;
 
 public class fieldacc03 {
 
-    final static int JCK_STATUS_BASE = 95;
-
     static {
         try {
             System.loadLibrary("fieldacc03");

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc04/fieldacc04.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc04/fieldacc04.java
@@ -46,14 +46,7 @@
 public class fieldacc04 {
 
     static {
-        try {
-            System.loadLibrary("fieldacc04");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load fieldacc04 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("fieldacc04");
     }
 
     static volatile int result;

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc04/fieldacc04.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc04/fieldacc04.java
@@ -46,8 +46,6 @@ import java.io.PrintStream;
 
 public class fieldacc04 {
 
-    final static int JCK_STATUS_BASE = 95;
-
     static {
         try {
             System.loadLibrary("fieldacc04");

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc04/fieldacc04.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc04/fieldacc04.java
@@ -20,7 +20,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-import java.io.PrintStream;
 
 /*
  * @test

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldModification/fieldmod01/fieldmod01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldModification/fieldmod01/fieldmod01.java
@@ -21,8 +21,6 @@
  * questions.
  */
 
-import java.io.PrintStream;
-
 /*
  * @test
  *

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldModification/fieldmod01/fieldmod01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldModification/fieldmod01/fieldmod01.java
@@ -46,14 +46,7 @@
 public class fieldmod01 {
 
     static {
-        try {
-            System.loadLibrary("fieldmod01");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load fieldmod01 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("fieldmod01");
     }
 
     static volatile int result;

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldModification/fieldmod01/fieldmod01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldModification/fieldmod01/fieldmod01.java
@@ -47,8 +47,6 @@ import java.io.PrintStream;
 
 public class fieldmod01 {
 
-    final static int JCK_STATUS_BASE = 95;
-
     static {
         try {
             System.loadLibrary("fieldmod01");

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldModification/fieldmod02/fieldmod02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldModification/fieldmod02/fieldmod02.java
@@ -21,9 +21,6 @@
  * questions.
  */
 
-import java.io.PrintStream;
-
-
 /*
  * @test
  *

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldModification/fieldmod02/fieldmod02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldModification/fieldmod02/fieldmod02.java
@@ -45,14 +45,7 @@
 public class fieldmod02 {
 
     static {
-        try {
-            System.loadLibrary("fieldmod02");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load fieldmod02 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("fieldmod02");
     }
 
     static volatile int result;

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FramePop/framepop01/framepop01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FramePop/framepop01/framepop01.java
@@ -47,14 +47,7 @@
 public class framepop01 {
 
     static {
-        try {
-            System.loadLibrary("framepop01");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load framepop01 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("framepop01");
     }
 
     static volatile int result;

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FramePop/framepop02/libframepop02.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FramePop/framepop02/libframepop02.cpp
@@ -57,7 +57,7 @@ static int thr_count = 0;
 static int max_depth = 0;
 static thr threads[MAX_THREADS];
 
-static volatile int callbacksEnabled = NSK_FALSE;
+static volatile int callbacksEnabled = JNI_FALSE;
 static jrawMonitorID agent_lock;
 
 void print_current_time() {
@@ -200,13 +200,13 @@ void JNICALL MethodEntry(jvmtiEnv *jvmti, JNIEnv *jni,
 
 void JNICALL VMStart(jvmtiEnv *jvmti, JNIEnv* jni) {
   RawMonitorLocker rml(jvmti, jni, agent_lock);
-  callbacksEnabled = NSK_TRUE;
+  callbacksEnabled = JNI_TRUE;
 }
 
 
 void JNICALL VMDeath(jvmtiEnv *jvmti, JNIEnv* jni) {
   RawMonitorLocker rml(jvmti, jni, agent_lock);
-  callbacksEnabled = NSK_FALSE;
+  callbacksEnabled = JNI_FALSE;
 }
 
 void JNICALL FramePop(jvmtiEnv *jvmti, JNIEnv *jni,

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MethodEntry/mentry01/mentry01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MethodEntry/mentry01/mentry01.java
@@ -21,8 +21,6 @@
  * questions.
  */
 
-import java.io.PrintStream;
-
 /*
  * @test
  *

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MethodEntry/mentry01/mentry01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MethodEntry/mentry01/mentry01.java
@@ -50,14 +50,7 @@
 public class mentry01 {
 
     static {
-        try {
-            System.loadLibrary("mentry01");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load mentry01 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("mentry01");
     }
 
     static volatile int result;

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MethodEntry/mentry02/mentry02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MethodEntry/mentry02/mentry02.java
@@ -21,8 +21,6 @@
  * questions.
  */
 
-import java.io.PrintStream;
-
 /*
  * @test
  *

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MethodEntry/mentry02/mentry02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MethodEntry/mentry02/mentry02.java
@@ -48,7 +48,6 @@ import java.io.PrintStream;
 
 public class mentry02 {
 
-    final static int JCK_STATUS_BASE = 95;
     final static int MAX_LOOP = 100;
 
     static {

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MethodEntry/mentry02/mentry02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MethodEntry/mentry02/mentry02.java
@@ -49,14 +49,7 @@ public class mentry02 {
     final static int MAX_LOOP = 100;
 
     static {
-        try {
-            System.loadLibrary("mentry02");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load mentry02 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("mentry02");
     }
 
     static volatile int result;

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MethodExit/mexit01/mexit01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MethodExit/mexit01/mexit01.java
@@ -21,9 +21,6 @@
  * questions.
  */
 
-import java.io.PrintStream;
-
-
 /*
  * @test
  *

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MethodExit/mexit01/mexit01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MethodExit/mexit01/mexit01.java
@@ -49,14 +49,7 @@
 public class mexit01 {
 
     static {
-        try {
-            System.loadLibrary("mexit01");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load mexit01 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("mexit01");
     }
 
     static volatile int result;

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MethodExit/mexit01/mexit01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MethodExit/mexit01/mexit01.java
@@ -51,8 +51,6 @@ import java.io.PrintStream;
 
 public class mexit01 {
 
-    final static int JCK_STATUS_BASE = 95;
-
     static {
         try {
             System.loadLibrary("mexit01");

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MethodExit/mexit02/mexit02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MethodExit/mexit02/mexit02.java
@@ -54,14 +54,7 @@
 public class mexit02 {
 
     static {
-        try {
-            System.loadLibrary("mexit02");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load mexit02 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("mexit02");
     }
 
     static volatile int result;

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MethodExit/mexit02/mexit02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MethodExit/mexit02/mexit02.java
@@ -21,7 +21,6 @@
  * questions.
  */
 
-import java.io.PrintStream;
 /*
  * @test
  *

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorContendedEnter/mcontenter01/libmcontenter01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorContendedEnter/mcontenter01/libmcontenter01.cpp
@@ -76,7 +76,7 @@ static int prepare() {
   if (err != JVMTI_ERROR_NONE) {
     jni->FatalError("Error enabling JVMTI_EVENT_MONITOR_CONTENDED_ENTER.");
   }
-  return NSK_TRUE;
+  return JNI_TRUE;
 }
 
 static int clean() {
@@ -86,7 +86,7 @@ static int clean() {
   if (err != JVMTI_ERROR_NONE) {
     set_agent_fail_status();
   }
-  return NSK_TRUE;
+  return JNI_TRUE;
 }
 
 /* agent algorithm
@@ -109,7 +109,7 @@ agentProc(jvmtiEnv *jvmti, JNIEnv *agentJNI, void *arg) {
   eventsCount = 0;
 
   /* resume debugee to catch MonitorContendedEnter event */
-  if (!((agent_resume_sync() == NSK_TRUE) && (agent_wait_for_sync(timeout) == NSK_TRUE))) {
+  if (!((agent_resume_sync() == JNI_TRUE) && (agent_wait_for_sync(timeout) == JNI_TRUE))) {
     return;
   }
   LOG("Number of MonitorContendedEnter events: %d\n", eventsCount);

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorContendedEntered/mcontentered01/libmcontentered01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorContendedEntered/mcontentered01/libmcontentered01.cpp
@@ -100,17 +100,17 @@ static int prepare() {
   err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, NULL);
   if (err != JVMTI_ERROR_NONE) {
     LOG("Prepare: 11\n");
-    return NSK_FALSE;
+    return JNI_FALSE;
   }
 
   /* enable MonitorContendedEnter event */
   err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL);
   if (err != JVMTI_ERROR_NONE) {
     LOG("Prepare: 11\n");
-    return NSK_FALSE;
+    return JNI_FALSE;
   }
 
-  return NSK_TRUE;
+  return JNI_TRUE;
 }
 
 static int clean() {
@@ -120,7 +120,7 @@ static int clean() {
   if (err != JVMTI_ERROR_NONE) {
     set_agent_fail_status();
   }
-  return NSK_TRUE;
+  return JNI_TRUE;
 }
 
 /* agent algorithm
@@ -142,7 +142,7 @@ agentProc(jvmtiEnv *jvmti, JNIEnv *agentJNI, void *arg) {
   eventsCount = 0;
 
   /* resume debugee to catch MonitorContendedEntered event */
-  if (!((agent_resume_sync() == NSK_TRUE) && (agent_wait_for_sync(timeout) == NSK_TRUE))) {
+  if (!((agent_resume_sync() == JNI_TRUE) && (agent_wait_for_sync(timeout) == JNI_TRUE))) {
     return;
   }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorContendedEntered/mcontentered01/mcontentered01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorContendedEntered/mcontentered01/mcontentered01.java
@@ -23,8 +23,6 @@
 
 import jdk.test.lib.jvmti.DebugeeClass;
 
-import java.io.PrintStream;
-
 /*
  * @test
  *

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWait/monitorwait01/libmonitorwait01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWait/monitorwait01/libmonitorwait01.cpp
@@ -73,9 +73,9 @@ static int prepare() {
   jvmtiError err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_WAIT, NULL);
   if (err != JVMTI_ERROR_NONE) {
     LOG("Prepare: 11\n");
-    return NSK_FALSE;
+    return JNI_FALSE;
   }
-  return NSK_TRUE;
+  return JNI_TRUE;
 }
 
 static int clean() {
@@ -84,7 +84,7 @@ static int clean() {
   if (err != JVMTI_ERROR_NONE) {
     set_agent_fail_status();
   }
-  return NSK_TRUE;
+  return JNI_TRUE;
 }
 
 static void JNICALL
@@ -104,7 +104,7 @@ agentProc(jvmtiEnv *jvmti, JNIEnv *agentJNI, void *arg) {
   eventsCount = 0;
 
   /* resume debugee to catch MonitorWait event */
-  if (!((agent_resume_sync() == NSK_TRUE) && (agent_wait_for_sync(timeout) == NSK_TRUE))) {
+  if (!((agent_resume_sync() == JNI_TRUE) && (agent_wait_for_sync(timeout) == JNI_TRUE))) {
     return;
   }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWait/monitorwait01/monitorwait01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWait/monitorwait01/monitorwait01.java
@@ -21,8 +21,6 @@
  * questions.
  */
 
-import java.io.PrintStream;
-
 import jdk.test.lib.jvmti.DebugeeClass;
 
 /*

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWaited/monitorwaited01/libmonitorwaited01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWaited/monitorwaited01/libmonitorwaited01.cpp
@@ -74,9 +74,9 @@ static int prepare() {
   jvmtiError err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_WAITED, NULL);
   if (err != JVMTI_ERROR_NONE) {
     LOG("Prepare: 11\n");
-    return NSK_FALSE;
+    return JNI_FALSE;
   }
-  return NSK_TRUE;
+  return JNI_TRUE;
 }
 
 static int clean() {
@@ -85,7 +85,7 @@ static int clean() {
   if (err != JVMTI_ERROR_NONE) {
     set_agent_fail_status();
   }
-  return NSK_TRUE;
+  return JNI_TRUE;
 }
 
 static void JNICALL
@@ -105,7 +105,7 @@ agentProc(jvmtiEnv *jvmti, JNIEnv *agentJNI, void *arg) {
   eventsCount = 0;
 
   /* resume debugee to catch MonitorWaited event */
-  if (!((agent_resume_sync() == NSK_TRUE) && (agent_wait_for_sync(timeout) == NSK_TRUE))) {
+  if (!((agent_resume_sync() == JNI_TRUE) && (agent_wait_for_sync(timeout) == JNI_TRUE))) {
     return;
   }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWaited/monitorwaited01/monitorwaited01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWaited/monitorwaited01/monitorwaited01.java
@@ -23,9 +23,6 @@
 
 import jdk.test.lib.jvmti.DebugeeClass;
 
-import java.io.PrintStream;
-
-
 /*
  * @test
  *

--- a/test/hotspot/jtreg/serviceability/jvmti/events/NativeMethodBind/nativemethbind01/nativemethbind01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/NativeMethodBind/nativemethbind01/nativemethbind01.java
@@ -52,13 +52,7 @@ import java.io.*;
 
 public class nativemethbind01 {
     static {
-        try {
-            System.loadLibrary("nativemethbind01");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load \"nativemethbind01\" library");
-            System.err.println("java.library.path:" + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("nativemethbind01");
     }
 
     native void nativeMethod(boolean registerNative);

--- a/test/hotspot/jtreg/serviceability/jvmti/events/NativeMethodBind/nativemethbind02/nativemethbind02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/NativeMethodBind/nativemethbind02/nativemethbind02.java
@@ -48,14 +48,7 @@ import java.io.*;
 
 public class nativemethbind02 {
     static {
-        try {
-            System.loadLibrary("nativemethbind02");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load \"nativemethbind02\" library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("nativemethbind02");
     }
 
     native int nativeMethod();

--- a/test/hotspot/jtreg/serviceability/jvmti/events/NativeMethodBind/nativemethbind03/nativemethbind03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/NativeMethodBind/nativemethbind03/nativemethbind03.java
@@ -53,14 +53,7 @@ import java.io.*;
 
 public class nativemethbind03 {
     static {
-        try {
-            System.loadLibrary("nativemethbind03");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load \"nativemethbind03\" library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("nativemethbind03");
     }
 
     native void registerNative();

--- a/test/hotspot/jtreg/serviceability/jvmti/events/NativeMethodBind/nativemethbind04/nativemethbind04.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/NativeMethodBind/nativemethbind04/nativemethbind04.java
@@ -52,14 +52,7 @@ import java.io.*;
 
 public class nativemethbind04 {
     static {
-        try {
-            System.loadLibrary("nativemethbind04");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load \"nativemethbind04\" library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("nativemethbind04");
     }
 
     native void nativeMethod();

--- a/test/hotspot/jtreg/serviceability/jvmti/events/SingleStep/singlestep01/libsinglestep01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/SingleStep/singlestep01/libsinglestep01.cpp
@@ -54,7 +54,7 @@ static jvmtiEnv *jvmti = NULL;
 
 static volatile jboolean isVirtualExpected = JNI_FALSE;
 
-static volatile int callbacksEnabled = NSK_FALSE;
+static volatile int callbacksEnabled = JNI_FALSE;
 static jrawMonitorID agent_lock;
 
 static void setBP(jvmtiEnv *jvmti, JNIEnv *jni, jclass klass) {
@@ -215,13 +215,13 @@ SingleStep(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread, jmethodID method, jloca
 void JNICALL
 VMStart(jvmtiEnv *jvmti, JNIEnv *jni) {
   RawMonitorLocker rml(jvmti, jni, agent_lock);
-  callbacksEnabled = NSK_TRUE;
+  callbacksEnabled = JNI_TRUE;
 }
 
 void JNICALL
 VMDeath(jvmtiEnv *jvmti, JNIEnv *jni) {
   RawMonitorLocker rml(jvmti, jni, agent_lock);
-  callbacksEnabled = NSK_FALSE;
+  callbacksEnabled = JNI_FALSE;
 }
 
 JNIEXPORT jint JNICALL

--- a/test/hotspot/jtreg/serviceability/jvmti/events/SingleStep/singlestep01/singlestep01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/SingleStep/singlestep01/singlestep01.java
@@ -52,14 +52,7 @@ import java.io.*;
 
 public class singlestep01 {
     static {
-        try {
-            System.loadLibrary("singlestep01");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load \"singlestep01\" library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("singlestep01");
     }
 
     static volatile int result;

--- a/test/hotspot/jtreg/serviceability/jvmti/events/SingleStep/singlestep02/singlestep02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/SingleStep/singlestep02/singlestep02.java
@@ -46,14 +46,7 @@ import java.io.*;
 public class singlestep02 {
 
     static {
-        try {
-            System.loadLibrary("singlestep02");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load \"singlestep02\" library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("singlestep02");
     }
 
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/serviceability/jvmti/events/SingleStep/singlestep03/libsinglestep03.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/SingleStep/singlestep03/libsinglestep03.cpp
@@ -56,7 +56,7 @@ static volatile jint result = PASSED;
 static jvmtiEnv *jvmti = NULL;
 static jvmtiEventCallbacks callbacks;
 
-static volatile int callbacksEnabled = NSK_FALSE;
+static volatile int callbacksEnabled = JNI_FALSE;
 static jrawMonitorID agent_lock;
 
 static void setBP(jvmtiEnv *jvmti, JNIEnv *jni, jclass klass) {
@@ -101,13 +101,13 @@ ClassLoad(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread, jclass klass) {
 void JNICALL
 VMStart(jvmtiEnv *jvmti, JNIEnv *jni) {
   RawMonitorLocker rml(jvmti, jni, agent_lock);
-  callbacksEnabled = NSK_TRUE;
+  callbacksEnabled = JNI_TRUE;
 }
 
 void JNICALL
 VMDeath(jvmtiEnv *jvmti, JNIEnv *jni) {
   RawMonitorLocker rml(jvmti, jni, agent_lock);
-  callbacksEnabled = NSK_FALSE;
+  callbacksEnabled = JNI_FALSE;
 }
 
 void JNICALL

--- a/test/hotspot/jtreg/serviceability/jvmti/events/SingleStep/singlestep03/singlestep03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/SingleStep/singlestep03/singlestep03.java
@@ -52,14 +52,7 @@ import java.io.*;
 
 public class singlestep03 {
     static {
-        try {
-            System.loadLibrary("singlestep03");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load \"singlestep03\" library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("singlestep03");
     }
 
     static volatile int result;

--- a/test/hotspot/jtreg/serviceability/jvmti/events/ThreadEnd/threadend01/threadend01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/ThreadEnd/threadend01/threadend01.java
@@ -45,14 +45,7 @@ public class threadend01 {
     final static String NAME_PREFIX = "threadend01-";
 
     static {
-        try {
-            System.loadLibrary("threadend01");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load threadend01 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("threadend01");
     }
 
     native static void getReady(int i, String name);

--- a/test/hotspot/jtreg/serviceability/jvmti/events/ThreadEnd/threadend01/threadend01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/ThreadEnd/threadend01/threadend01.java
@@ -21,8 +21,6 @@
  * questions.
  */
 
-import java.io.PrintStream;
-
 /*
  * @test
  *
@@ -63,13 +61,6 @@ public class threadend01 {
     static volatile int thrCount = THREADS_LIMIT;
 
     public static void main(String args[]) {
-        int result = run(args, System.out);
-        if (result != 0) {
-            throw new RuntimeException("Unexpected status: " + result);
-        }
-    }
-
-    public static int run(String args[], PrintStream out) {
         Thread t = new TestThread(NAME_PREFIX + thrCount);
         getReady(THREADS_LIMIT, NAME_PREFIX);
         t.start();
@@ -78,7 +69,10 @@ public class threadend01 {
         } catch (InterruptedException e) {
             throw new Error("Unexpected: " + e);
         }
-        return check();
+        int result = check();
+        if (result != 0) {
+            throw new RuntimeException("Unexpected status: " + result);
+        }
     }
 
     static class TestThread extends Thread {

--- a/test/hotspot/jtreg/serviceability/jvmti/events/ThreadEnd/threadend02/libthreadend02.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/ThreadEnd/threadend02/libthreadend02.cpp
@@ -55,23 +55,23 @@ enableEvent(jvmtiEventMode enable, jvmtiEvent event) {
   err = jvmti->SetEventNotificationMode(enable, event, NULL);
   if (err != JVMTI_ERROR_NONE) {
     set_agent_fail_status();
-    return NSK_FALSE;
+    return JNI_FALSE;
   }
 
-  return NSK_TRUE;
+  return JNI_TRUE;
 }
 
 /* ============================================================================= */
 
 int checkEvents() {
 
-  int result = NSK_TRUE;
+  int result = JNI_TRUE;
 
   if (eventCount == 0) {
     set_agent_fail_status();
     COMPLAIN("Number of THREAD_END events must be greater than 0\n");
     set_agent_fail_status();
-    result = NSK_FALSE;
+    result = JNI_FALSE;
   }
 
   return result;
@@ -89,10 +89,10 @@ setCallBacks() {
 
   err = jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks));
   if (err != JVMTI_ERROR_NONE) {
-    return NSK_FALSE;
+    return JNI_FALSE;
   }
 
-  return NSK_TRUE;
+  return JNI_TRUE;
 }
 
 /* ============================================================================= */

--- a/test/hotspot/jtreg/serviceability/jvmti/events/ThreadEnd/threadend02/threadend02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/ThreadEnd/threadend02/threadend02.java
@@ -22,7 +22,6 @@
  */
 
 import jdk.test.lib.jvmti.DebugeeClass;
-import java.io.PrintStream;
 
 /*
  * @test
@@ -44,18 +43,14 @@ public class threadend02 extends DebugeeClass {
 
     // run test from command line
     public static void main(String argv[]) {
-        int result = run(argv, System.out);
+        int result = new threadend02().runIt();
         if (result != 0) {
             throw new RuntimeException("Unexpected status: " + result);
         }
     }
 
-    public static int run(String argv[], PrintStream out) {
-        return new threadend02().runIt(argv, out);
-    }
-
     // run debuggee
-    public int runIt(String argv[], PrintStream out) {
+    public int runIt() {
 
         int status = threadend02.checkStatus(DebugeeClass.TEST_PASSED);
 

--- a/test/hotspot/jtreg/serviceability/jvmti/events/ThreadStart/threadstart01/threadstart01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/ThreadStart/threadstart01/threadstart01.java
@@ -21,8 +21,6 @@
  * questions.
  */
 
-import java.io.PrintStream;
-
 /*
  * @test
  *
@@ -63,13 +61,6 @@ public class threadstart01 {
     static volatile int thrCount = 0;
 
     public static void main(String args[]) {
-        int result = run(args, System.out);
-        if (result != 0) {
-            throw new RuntimeException("Unexpected status: " + result);
-        }
-    }
-
-    public static int run(String args[], PrintStream out) {
         TestThread t = new TestThread(NAME_PREFIX + thrCount);
         getReady(THREADS_LIMIT, NAME_PREFIX);
         t.start();
@@ -78,7 +69,10 @@ public class threadstart01 {
         } catch (InterruptedException e) {
             throw new Error("Unexpected: " + e);
         }
-        return check();
+        int result = check();
+        if (result != 0) {
+            throw new RuntimeException("Unexpected status: " + result);
+        }
     }
 
     static class TestThread extends Thread {

--- a/test/hotspot/jtreg/serviceability/jvmti/events/ThreadStart/threadstart01/threadstart01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/ThreadStart/threadstart01/threadstart01.java
@@ -45,14 +45,7 @@ public class threadstart01 {
     final static String NAME_PREFIX = "threadstart01-";
 
     static {
-        try {
-            System.loadLibrary("threadstart01");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load threadstart01 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("threadstart01");
     }
 
     native static void getReady(int i, String name);

--- a/test/hotspot/jtreg/serviceability/jvmti/events/ThreadStart/threadstart02/threadstart02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/ThreadStart/threadstart02/threadstart02.java
@@ -64,14 +64,7 @@
 public class threadstart02 {
 
     static {
-        try {
-            System.loadLibrary("threadstart02");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load threadstart02 library");
-            System.err.println("java.library.path:"
-                    + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("threadstart02");
     }
 
     native static int check();

--- a/test/hotspot/jtreg/serviceability/jvmti/events/ThreadStart/threadstart02/threadstart02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/ThreadStart/threadstart02/threadstart02.java
@@ -21,8 +21,6 @@
  * questions.
  */
 
-import java.io.PrintStream;
-
 /*
  * @test
  *
@@ -60,7 +58,7 @@ import java.io.PrintStream;
  *     Fixed according to 6221885 test bug.
  *
  * @library /test/lib
- * @run main/othervm/native -agentlib:threadstart02 threadstart02 5
+ * @run main/othervm/native -agentlib:threadstart02 threadstart02
  */
 
 public class threadstart02 {
@@ -78,26 +76,9 @@ public class threadstart02 {
 
     native static int check();
 
-    public static int waitTime = 2;
+    public static int waitTime = 5;
 
     public static void main(String args[]) {
-        int result = run(args, System.out);
-        if (result != 0) {
-            throw new RuntimeException("Unexpected status: " + result);
-        }
-    }
-
-    public static int run(String args[], PrintStream out) {
-        if (args.length > 0) {
-            try {
-                int i  = Integer.parseInt(args[0]);
-                waitTime = i;
-            } catch (NumberFormatException ex) {
-                out.println("# Wrong argument \"" + args[0] + "\", the default value is used");
-            }
-        }
-        out.println("# Waiting time = " + waitTime + " mins");
-
         TestThread t = new TestThread("TestThread_1");
         t.start();
 
@@ -107,7 +88,10 @@ public class threadstart02 {
             throw new Error("Unexpected: " + e);
         }
 
-        return check();
+        int result = check();
+        if (result != 0) {
+            throw new RuntimeException("Unexpected status: " + result);
+        }
     }
 
     static class TestThread extends Thread {

--- a/test/hotspot/jtreg/serviceability/jvmti/events/ThreadStart/threadstart03/threadstart03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/ThreadStart/threadstart03/threadstart03.java
@@ -21,8 +21,6 @@
  * questions.
  */
 
-import java.io.PrintStream;
-
 /*
  * @test
  *
@@ -62,13 +60,10 @@ public class threadstart03 {
     native static int check(Thread thr, String name);
 
     public static void main(String args[]) {
-        int result = run(args, System.out);
+        int result = check(new Thread(ThreadName), ThreadName);
         if (result != 0) {
             throw new RuntimeException("Unexpected status: " + result);
         }
     }
 
-    public static int run(String args[], PrintStream out) {
-        return check(new Thread(ThreadName), ThreadName);
-    }
 }

--- a/test/hotspot/jtreg/serviceability/jvmti/events/ThreadStart/threadstart03/threadstart03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/ThreadStart/threadstart03/threadstart03.java
@@ -46,7 +46,6 @@ import java.io.PrintStream;
 
 public class threadstart03 {
 
-    final static int JCK_STATUS_BASE = 95;
     final static String ThreadName = "testedThread";
 
     static {

--- a/test/hotspot/jtreg/serviceability/jvmti/events/ThreadStart/threadstart03/threadstart03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/ThreadStart/threadstart03/threadstart03.java
@@ -47,14 +47,7 @@ public class threadstart03 {
     final static String ThreadName = "testedThread";
 
     static {
-        try {
-            System.loadLibrary("threadstart03");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load threadstart03 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("threadstart03");
     }
 
     native static int check(Thread thr, String name);

--- a/test/hotspot/jtreg/serviceability/jvmti/events/VMObjectAlloc/vmobjalloc01/libvmobjalloc01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/VMObjectAlloc/vmobjalloc01/libvmobjalloc01.cpp
@@ -45,7 +45,7 @@ static int checkVMObjectAllocEvents() {
     LOG("#    (VM might not allocate such objects at all)\n");
   }
 
-  return NSK_TRUE;
+  return JNI_TRUE;
 }
 
 /* ========================================================================== */

--- a/test/hotspot/jtreg/serviceability/jvmti/events/VMObjectAlloc/vmobjalloc01/vmobjalloc01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/VMObjectAlloc/vmobjalloc01/vmobjalloc01.java
@@ -21,8 +21,6 @@
  * questions.
  */
 
-import java.io.PrintStream;
-
 import jdk.test.lib.jvmti.DebugeeClass;
 
 /*

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/GetAllThreadsNullTest/GetAllThreadsNullTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/GetAllThreadsNullTest/GetAllThreadsNullTest.java
@@ -42,14 +42,7 @@
 public class GetAllThreadsNullTest {
 
     static {
-        try {
-            System.loadLibrary("GetAllThreadsNullTest");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load GetAllThreadsNullTest library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("GetAllThreadsNullTest");
     }
 
     native static boolean check();

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/framecnt02/framecnt02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/framecnt02/framecnt02.java
@@ -60,23 +60,18 @@ public class framecnt02 {
         }
     }
 
-    final static int JCK_STATUS_BASE = 95;
-
     static int flag = 0;
 
     public static void main(String args[]) {
 
-
-        // produce JCK-like exit status.
-        System.exit(run(args, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream ref) {
         Thread currThread = Thread.currentThread();
         framecnt02a tested_thread_thr1 = new framecnt02a();
         checkFrames(tested_thread_thr1, 1);
         checkFrames(currThread, 0);
-        return getRes();
+        int result = getRes();
+        if (result != 0) {
+            throw new RuntimeException("check failed with result " + result);
+        }
     }
 }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/framecnt02/framecnt02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/framecnt02/framecnt02.java
@@ -42,8 +42,6 @@
  * @run main/othervm/native -agentlib:framecnt02 framecnt02
  */
 
-import java.io.PrintStream;
-
 public class framecnt02 {
 
     native static void checkFrames(Thread thr, int thr_num);

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/framecnt02/framecnt02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/framecnt02/framecnt02.java
@@ -48,14 +48,7 @@ public class framecnt02 {
     native static int getRes();
 
     static {
-        try {
-            System.loadLibrary("framecnt02");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load framecnt02 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("framecnt02");
     }
 
     static int flag = 0;

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/framecnt03/framecnt03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/framecnt03/framecnt03.java
@@ -41,14 +41,7 @@
 public class framecnt03 {
 
     static {
-        try {
-            System.loadLibrary("framecnt03");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load framecnt03 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("framecnt03");
     }
 
     native static int check();

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/framecnt03/framecnt03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/framecnt03/framecnt03.java
@@ -38,8 +38,6 @@
  * @run main/othervm/native -agentlib:framecnt03 framecnt03
  */
 
-import java.io.PrintStream;
-
 public class framecnt03 {
 
     static {

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/framecnt03/framecnt03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/framecnt03/framecnt03.java
@@ -42,8 +42,6 @@ import java.io.PrintStream;
 
 public class framecnt03 {
 
-    final static int JCK_STATUS_BASE = 95;
-
     static {
         try {
             System.loadLibrary("framecnt03");
@@ -58,13 +56,9 @@ public class framecnt03 {
     native static int check();
 
     public static void main(String args[]) {
-
-
-        // produce JCK-like exit status.
-        System.exit(run(args, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String args[], PrintStream out) {
-        return check();
+        int result = check();
+        if (result != 0) {
+            throw new RuntimeException("check failed with result " + result);
+        }
     }
 }

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/frameloc03/frameloc03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/frameloc03/frameloc03.java
@@ -41,8 +41,6 @@
  * @run main/othervm/native -agentlib:frameloc03 frameloc03
  */
 
-import java.io.PrintStream;
-
 public class frameloc03 {
 
     static {

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/frameloc03/frameloc03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/frameloc03/frameloc03.java
@@ -44,14 +44,7 @@
 public class frameloc03 {
 
     static {
-        try {
-            System.loadLibrary("frameloc03");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load frameloc03 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("frameloc03");
     }
 
     public static Object lockStart = new Object();

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/frameloc03/frameloc03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/frameloc03/frameloc03.java
@@ -45,8 +45,6 @@ import java.io.PrintStream;
 
 public class frameloc03 {
 
-    final static int JCK_STATUS_BASE = 95;
-
     static {
         try {
             System.loadLibrary("frameloc03");
@@ -58,19 +56,12 @@ public class frameloc03 {
         }
     }
 
-    native static int check(Thread thread);
-
-    public static void main(String args[]) {
-
-
-        // produce JCK-like exit status.
-        System.exit(run(args, System.out) + JCK_STATUS_BASE);
-    }
-
     public static Object lockStart = new Object();
     public static Object lockFinish = new Object();
 
-    public static int run(String args[], PrintStream out) {
+    native static int check(Thread thread);
+
+    public static void main(String args[]) {
         TestThread t = new TestThread();
 
         synchronized (lockStart) {
@@ -83,7 +74,7 @@ public class frameloc03 {
 
         }
 
-        int res = check(t);
+        int result = check(t);
 
         synchronized (lockFinish) {
             lockFinish.notify();
@@ -94,7 +85,9 @@ public class frameloc03 {
             throw new Error("Unexpected: " + e);
         }
 
-        return res;
+        if (result != 0) {
+            throw new RuntimeException("check failed with result " + result);
+        }
     }
 
     static class TestThread extends Thread {

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/getstacktr02/getstacktr02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/getstacktr02/getstacktr02.java
@@ -41,7 +41,6 @@
  * @library /test/lib
  * @run main/othervm/native -agentlib:getstacktr02 getstacktr02
  */
-import java.io.PrintStream;
 
 public class getstacktr02 {
 

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/getstacktr02/getstacktr02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/getstacktr02/getstacktr02.java
@@ -45,8 +45,6 @@ import java.io.PrintStream;
 
 public class getstacktr02 {
 
-    final static int JCK_STATUS_BASE = 95;
-
     static {
         try {
             System.loadLibrary("getstacktr02");
@@ -61,13 +59,9 @@ public class getstacktr02 {
     native static int check(Thread thread);
 
     public static void main(String args[]) {
-
-
-        // produce JCK-like exit status.
-        System.exit(run(args, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String args[], PrintStream out) {
-        return check(Thread.currentThread());
+        int result = check(Thread.currentThread());
+        if (result != 0) {
+            throw new RuntimeException("check failed with result " + result);
+        }
     }
 }

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/getstacktr02/getstacktr02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/getstacktr02/getstacktr02.java
@@ -45,14 +45,7 @@
 public class getstacktr02 {
 
     static {
-        try {
-            System.loadLibrary("getstacktr02");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load getstacktr02 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("getstacktr02");
     }
 
     native static int check(Thread thread);

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/getstacktr09/getstacktr09.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/getstacktr09/getstacktr09.java
@@ -40,9 +40,6 @@
  * @run main/othervm/native -agentlib:getstacktr09 getstacktr09
  */
 
-
-import java.io.PrintStream;
-
 public class getstacktr09 {
 
     final static int FAILED = 2;

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/getstacktr09/getstacktr09.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/getstacktr09/getstacktr09.java
@@ -45,14 +45,7 @@ public class getstacktr09 {
     final static int FAILED = 2;
 
     static {
-        try {
-            System.loadLibrary("getstacktr09");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load getstacktr09 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("getstacktr09");
     }
 
     native static int check(Thread thread1, Thread thread2);

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/getstacktr09/getstacktr09.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/getstacktr09/getstacktr09.java
@@ -45,7 +45,6 @@ import java.io.PrintStream;
 
 public class getstacktr09 {
 
-    final static int JCK_STATUS_BASE = 95;
     final static int FAILED = 2;
 
     static {
@@ -62,13 +61,6 @@ public class getstacktr09 {
     native static int check(Thread thread1, Thread thread2);
 
     public static void main(String args[]) {
-
-
-        // produce JCK-like exit status.
-        System.exit(run(args, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String args[], PrintStream out) {
         TestThread tested_thread_thr1 = new TestThread();
         TestThread thr2 = new TestThread();
 
@@ -76,11 +68,13 @@ public class getstacktr09 {
         try {
             thr2.join();
         } catch (InterruptedException ex) {
-            out.println("# Unexpected " + ex);
-            return FAILED;
+            throw new RuntimeException(ex);
         }
 
-        return check(tested_thread_thr1, thr2);
+        int result = check(tested_thread_thr1, thr2);
+        if (result != 0) {
+            throw new RuntimeException("check failed with result " + result);
+        }
     }
 
     static class TestThread extends Thread {

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/thrinfo02/thrinfo02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/thrinfo02/thrinfo02.java
@@ -43,8 +43,6 @@ import java.io.PrintStream;
 
 public class thrinfo02 {
 
-    final static int JCK_STATUS_BASE = 95;
-
     static {
         try {
             System.loadLibrary("thrinfo02");
@@ -60,11 +58,9 @@ public class thrinfo02 {
 
     public static void main(String args[]) {
         Thread.currentThread().setName("main");
-        // produce JCK-like exit status.
-        System.exit(run(args, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String args[], PrintStream out) {
-        return check(Thread.currentThread(), Thread.currentThread().getThreadGroup());
+        int result = check(Thread.currentThread(), Thread.currentThread().getThreadGroup());
+        if (result != 0) {
+            throw new RuntimeException("check failed with result " + result);
+        }
     }
 }

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/thrinfo02/thrinfo02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/thrinfo02/thrinfo02.java
@@ -39,8 +39,6 @@
  * @run main/othervm/native -agentlib:thrinfo02 thrinfo02
  */
 
-import java.io.PrintStream;
-
 public class thrinfo02 {
 
     static {

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/thrinfo02/thrinfo02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/thrinfo02/thrinfo02.java
@@ -42,14 +42,7 @@
 public class thrinfo02 {
 
     static {
-        try {
-            System.loadLibrary("thrinfo02");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load thrinfo02 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("thrinfo02");
     }
 
     native static int check(Thread thr, ThreadGroup group);

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/thrstat04/thrstat04.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/thrstat04/thrstat04.java
@@ -47,18 +47,12 @@ import java.io.PrintStream;
 
 public class thrstat04 {
 
-    final static int JCK_STATUS_BASE = 95;
-
     native static int check(Thread thr);
 
     public static void main(String args[]) {
-
-
-        // produce JCK-like exit status.
-        System.exit(run(args, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String args[], PrintStream out) {
-        return check(Thread.currentThread());
+        int result = check(Thread.currentThread());
+        if (result != 0) {
+            throw new RuntimeException("check failed with result " + result);
+        }
     }
 }

--- a/test/hotspot/jtreg/serviceability/jvmti/negative/thrstat04/thrstat04.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/negative/thrstat04/thrstat04.java
@@ -42,9 +42,6 @@
  * @run main/othervm/native -agentlib:thrstat04 thrstat04
  */
 
-
-import java.io.PrintStream;
-
 public class thrstat04 {
 
     native static int check(Thread thr);

--- a/test/hotspot/jtreg/serviceability/jvmti/stress/StackTrace/NotSuspended/libGetStackTraceNotSuspendedStress.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/stress/StackTrace/NotSuspended/libGetStackTraceNotSuspendedStress.cpp
@@ -132,7 +132,7 @@ extern JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM *jvm, char *options, void *res
     return JNI_ERR;
   }
 
-  if (set_agent_proc(agentProc, NULL) != NSK_TRUE) {
+  if (set_agent_proc(agentProc, NULL) != JNI_TRUE) {
     return JNI_ERR;
   }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/stress/StackTrace/Suspended/libGetStackTraceSuspendedStress.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/stress/StackTrace/Suspended/libGetStackTraceSuspendedStress.cpp
@@ -256,7 +256,7 @@ Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
     return JNI_ERR;
   }
 
-  if (set_agent_proc(agentProc, NULL) != NSK_TRUE) {
+  if (set_agent_proc(agentProc, NULL) != JNI_TRUE) {
     return JNI_ERR;
   }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/stress/ThreadLocalStorage/SetGetThreadLocalStorageStressTest/libSetGetThreadLocalStorageStress.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/stress/ThreadLocalStorage/SetGetThreadLocalStorageStressTest/libSetGetThreadLocalStorageStress.cpp
@@ -262,7 +262,7 @@ Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
     return JNI_ERR;
   }
 
-  if (set_agent_proc(agentProc, NULL) != NSK_TRUE) {
+  if (set_agent_proc(agentProc, NULL) != JNI_TRUE) {
     return JNI_ERR;
   }
   return JNI_OK;

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetAllThreads/allthr01/allthr01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetAllThreads/allthr01/allthr01.java
@@ -47,14 +47,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class allthr01 {
 
     static {
-        try {
-            System.loadLibrary("allthr01");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load allthr001 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("allthr01");
     }
 
     // Sync with native code

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameCount/framecnt01/framecnt01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameCount/framecnt01/framecnt01.java
@@ -52,14 +52,7 @@ public class framecnt01 {
     }
 
     static {
-        try {
-            System.loadLibrary("framecnt01");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load framecnt01 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("framecnt01");
     }
     static volatile boolean vThread1Started = false;
     static volatile boolean pThread1Started = false;

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameLocation/frameloc01/frameloc01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameLocation/frameloc01/frameloc01.java
@@ -50,14 +50,7 @@
 public class frameloc01 {
 
     static {
-        try {
-            System.loadLibrary("frameloc01");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load frameloc01 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("frameloc01");
     }
 
     native static void getReady(Class cls);

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameLocation/frameloc01/frameloc01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameLocation/frameloc01/frameloc01.java
@@ -47,8 +47,6 @@
  * @run main/othervm/native -agentlib:frameloc01 frameloc01
  */
 
-import java.io.PrintStream;
-
 public class frameloc01 {
 
     static {

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameLocation/frameloc01/frameloc01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameLocation/frameloc01/frameloc01.java
@@ -51,8 +51,6 @@ import java.io.PrintStream;
 
 public class frameloc01 {
 
-    final static int JCK_STATUS_BASE = 95;
-
     static {
         try {
             System.loadLibrary("frameloc01");
@@ -73,13 +71,6 @@ public class frameloc01 {
     static Object lock2 = new Object();
 
     public static void main(String args[]) {
-
-
-        // produce JCK-like exit status.
-        System.exit(run(args, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream ref) {
         frameloc01a thr = new frameloc01a();
 
         getReady(frameloc01a.class);
@@ -98,7 +89,10 @@ public class frameloc01 {
             checkFrame01(thr, frameloc01a.class, true);
         }
 
-        return getRes();
+        int result = getRes();
+        if (result != 0) {
+            throw new RuntimeException("check failed with result " + result);
+        }
     }
 
     private static void waitForChildThread(frameloc01a thr) {

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameLocation/frameloc02/frameloc02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameLocation/frameloc02/frameloc02.java
@@ -40,8 +40,6 @@
  * @run main/othervm/native -agentlib:frameloc02 frameloc02
  */
 
-import java.io.PrintStream;
-
 public class frameloc02 {
 
     static {

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameLocation/frameloc02/frameloc02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameLocation/frameloc02/frameloc02.java
@@ -44,8 +44,6 @@ import java.io.PrintStream;
 
 public class frameloc02 {
 
-    final static int JCK_STATUS_BASE = 95;
-
     static {
         try {
             System.loadLibrary("frameloc02");
@@ -60,11 +58,9 @@ public class frameloc02 {
     native static int check(Thread thr);
 
     public static void main(String args[]) {
-        // produce JCK-like exit status.
-        System.exit(run(args, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String args[], PrintStream out) {
-        return check(Thread.currentThread());
+        int result = check(Thread.currentThread());
+        if (result != 0) {
+            throw new RuntimeException("check failed with result " + result);
+        }
     }
 }

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameLocation/frameloc02/frameloc02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameLocation/frameloc02/frameloc02.java
@@ -43,14 +43,7 @@
 public class frameloc02 {
 
     static {
-        try {
-            System.loadLibrary("frameloc02");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load frameloc02 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("frameloc02");
     }
 
     native static int check(Thread thr);

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr06/getstacktr06.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr06/getstacktr06.java
@@ -43,8 +43,6 @@
  * @run main/othervm/native --enable-preview -agentlib:getstacktr06 getstacktr06
  */
 
-import java.io.PrintStream;
-
 public class getstacktr06 {
 
     static {

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadInfo/thrinfo01/thrinfo01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadInfo/thrinfo01/thrinfo01.java
@@ -51,14 +51,7 @@
 public class thrinfo01 {
 
     static {
-        try {
-            System.loadLibrary("thrinfo01");
-        } catch (UnsatisfiedLinkError ule) {
-            System.err.println("Could not load thrinfo01 library");
-            System.err.println("java.library.path:"
-                + System.getProperty("java.library.path"));
-            throw ule;
-        }
+        System.loadLibrary("thrinfo01");
     }
 
     native static boolean checkInfo0(Thread thread, ThreadGroup threadGroup, int ind);

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadState/thrstat02/thrstat02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadState/thrstat02/thrstat02.java
@@ -59,7 +59,6 @@
  * @run main/othervm/native -agentlib:thrstat02 thrstat02 5
  */
 
-import java.io.PrintStream;
 import java.util.concurrent.CountDownLatch;
 
 public class thrstat02 {

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadState/thrstat03/thrstat03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadState/thrstat03/thrstat03.java
@@ -43,8 +43,6 @@
  * @run main/othervm/native --enable-preview  -agentlib:thrstat03 thrstat03 5
  */
 
-import java.io.PrintStream;
-
 public class thrstat03 {
 
     static final int NOT_STARTED = 0;

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThread/resumethrd02/resumethrd02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThread/resumethrd02/resumethrd02.java
@@ -39,8 +39,6 @@
 
 import jdk.test.lib.jvmti.DebugeeClass;
 
-import java.io.PrintStream;
-
 public class resumethrd02 extends DebugeeClass {
 
     // load native library if required

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThreadList/resumethrdlst01/libresumethrdlst01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThreadList/resumethrdlst01/libresumethrdlst01.cpp
@@ -176,7 +176,7 @@ static int find_threads_by_name(jvmtiEnv* jvmti, JNIEnv* jni,
                   "#   expected: %d\n",
                   name, found, foundCount);
     set_agent_fail_status();
-    return NSK_FALSE;
+    return JNI_FALSE;
   }
 
   LOG("Make global references for threads: %d threads\n", foundCount);
@@ -184,12 +184,12 @@ static int find_threads_by_name(jvmtiEnv* jvmti, JNIEnv* jni,
     foundThreads[i] = (jthread) jni->NewGlobalRef(foundThreads[i]);
     if ( foundThreads[i] == NULL) {
       set_agent_fail_status();
-      return NSK_FALSE;
+      return JNI_FALSE;
     }
     LOG("  ... thread #%d: %p\n", i, foundThreads[i]);
   }
 
-  return NSK_TRUE;
+  return JNI_TRUE;
 }
 
 JNIEXPORT jint JNICALL

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThreadList/resumethrdlst01/resumethrdlst01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThreadList/resumethrdlst01/resumethrdlst01.java
@@ -41,8 +41,6 @@
 
 import jdk.test.lib.jvmti.DebugeeClass;
 
-import java.io.PrintStream;
-
 public class resumethrdlst01 extends DebugeeClass {
 
     // load native library if required

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThreadList/resumethrdlst01/resumethrdlst01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThreadList/resumethrdlst01/resumethrdlst01.java
@@ -52,12 +52,10 @@ public class resumethrdlst01 extends DebugeeClass {
 
     // run test from command line
     public static void main(String argv[]) {
-        System.exit(run(argv, System.out) + 95);
-    }
-
-    // run test from JCK-compatible environment
-    public static int run(String argv[], PrintStream out) {
-        return new resumethrdlst01().runIt(argv, out);
+        int result = new resumethrdlst01().runIt();
+        if (result != 0) {
+            throw new RuntimeException("check failed with result " + result);
+        }
     }
 
     /* =================================================================== */
@@ -72,7 +70,7 @@ public class resumethrdlst01 extends DebugeeClass {
     resumethrdlst01Thread threads[] = null;
 
     // run debuggee
-    public int runIt(String argv[], PrintStream out) {
+    public int runIt() {
         timeout =  60 * 1000;
 
         // create tested threads

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThreadList/resumethrdlst02/libresumethrdlst02.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThreadList/resumethrdlst02/libresumethrdlst02.cpp
@@ -197,7 +197,7 @@ static int find_threads_by_name(jvmtiEnv* jvmti, JNIEnv* jni,
                   "#   expected: %d\n",
                   name, found, foundCount);
     set_agent_fail_status();
-    return NSK_FALSE;
+    return JNI_FALSE;
   }
 
   LOG("Make global references for threads: %d threads\n", foundCount);
@@ -205,12 +205,12 @@ static int find_threads_by_name(jvmtiEnv* jvmti, JNIEnv* jni,
     foundThreads[i] = (jthread) jni->NewGlobalRef(foundThreads[i]);
     if ( foundThreads[i] == NULL) {
       set_agent_fail_status();
-      return NSK_FALSE;
+      return JNI_FALSE;
     }
       LOG("  ... thread #%d: %p\n", i, foundThreads[i]);
   }
 
-  return NSK_TRUE;
+  return JNI_TRUE;
 }
 
 /** THREAD_END callback. */

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThreadList/resumethrdlst02/resumethrdlst02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThreadList/resumethrdlst02/resumethrdlst02.java
@@ -48,14 +48,11 @@ public class resumethrdlst02 extends DebugeeClass {
         System.loadLibrary("resumethrdlst02");
     }
 
-    // run test from command line
     public static void main(String argv[]) {
-        System.exit(run(argv, System.out) + 95);
-    }
-
-    // run test from JCK-compatible environment
-    public static int run(String argv[], PrintStream out) {
-        return new resumethrdlst02().runIt(argv, out);
+        int result = new resumethrdlst02().runIt();
+        if (result != 0) {
+            throw new RuntimeException("check failed with result " + result);
+        }
     }
 
     /* =================================================================== */
@@ -71,7 +68,7 @@ public class resumethrdlst02 extends DebugeeClass {
     int threads_count = 0;
 
     // run debuggee
-    public int runIt(String argv[], PrintStream out) {
+    public int runIt() {
         timeout = 60 * 1000; // milliseconds
 
         // create tested threads

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThreadList/resumethrdlst02/resumethrdlst02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/ResumeThreadList/resumethrdlst02/resumethrdlst02.java
@@ -39,8 +39,6 @@
 
 import jdk.test.lib.jvmti.DebugeeClass;
 
-import java.io.PrintStream;
-
 public class resumethrdlst02 extends DebugeeClass {
 
     // load native library if required

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThread/suspendthrd01/suspendthrd01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThread/suspendthrd01/suspendthrd01.java
@@ -41,8 +41,6 @@
 
 import jdk.test.lib.jvmti.DebugeeClass;
 
-import java.io.PrintStream;
-
 public class suspendthrd01 extends DebugeeClass {
 
     // load native library if required

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThread/suspendthrd02/suspendthrd02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThread/suspendthrd02/suspendthrd02.java
@@ -39,8 +39,6 @@
 
 import jdk.test.lib.jvmti.DebugeeClass;
 
-import java.io.PrintStream;
-
 public class suspendthrd02 extends DebugeeClass {
 
     // load native library if required

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThread/suspendthrd02/suspendthrd02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThread/suspendthrd02/suspendthrd02.java
@@ -48,15 +48,11 @@ public class suspendthrd02 extends DebugeeClass {
         System.loadLibrary("suspendthrd02");
     }
 
-    // run test from command line
     public static void main(String argv[]) {
-        // JCK-compatible exit
-        System.exit(run(argv, System.out) + 95);
-    }
-
-    // run test from JCK-compatible environment
-    public static int run(String argv[], PrintStream out) {
-        return new suspendthrd02().runIt(argv, out);
+        int result = new suspendthrd02().runIt();
+        if (result != 0) {
+            throw new RuntimeException("check failed with result " + result);
+        }
     }
 
     /* =================================================================== */
@@ -68,7 +64,7 @@ public class suspendthrd02 extends DebugeeClass {
     suspendthrd02Thread thread = null;
 
     // run debuggee
-    public int runIt(String argv[], PrintStream out) {
+    public int runIt() {
         timeout = 60 * 1000; // milliseconds
 
         // create tested thread

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThread/suspendthrd03/suspendthrd03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThread/suspendthrd03/suspendthrd03.java
@@ -187,14 +187,11 @@ public class suspendthrd03 extends DebugeeClass {
         System.loadLibrary("suspendthrd03");
     }
 
-    // run test from command line
     public static void main(String argv[]) {
-        System.exit(run(argv, System.out) + 95);
-    }
-
-    // run test from JCK-compatible environment
-    public static int run(String argv[], PrintStream out) {
-        return new suspendthrd03().runIt(argv, out);
+        int result =  new suspendthrd03().runIt();
+        if (result != 0) {
+            throw new RuntimeException("check failed with result " + result);
+        }
     }
 
     /* =================================================================== */
@@ -205,7 +202,7 @@ public class suspendthrd03 extends DebugeeClass {
     suspendthrd03Thread thread = null;
 
     // run debuggee
-    public int runIt(String argv[], PrintStream out) {
+    public int runIt() {
         timeout = 60 * 1000; // milliseconds
 
         for (int i = 0; i < N_THREADS; i++) {

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThread/suspendthrd03/suspendthrd03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThread/suspendthrd03/suspendthrd03.java
@@ -176,8 +176,6 @@
 
 import jdk.test.lib.jvmti.DebugeeClass;
 
-import java.io.PrintStream;
-
 public class suspendthrd03 extends DebugeeClass {
 
     final static int N_THREADS = 10;

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThreadList/suspendthrdlst01/libsuspendthrdlst01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThreadList/suspendthrdlst01/libsuspendthrdlst01.cpp
@@ -176,7 +176,7 @@ static int find_threads_by_name(jvmtiEnv *jvmti, JNIEnv *jni, const char *name, 
         "#   expected: %d",
         name, found, found_count);
     set_agent_fail_status();
-    return NSK_FALSE;
+    return JNI_FALSE;
   }
 
   LOG("Make global references for threads: %d threads\n", found_count);
@@ -184,12 +184,12 @@ static int find_threads_by_name(jvmtiEnv *jvmti, JNIEnv *jni, const char *name, 
     found_threads[i] = (jthread) jni->NewGlobalRef(found_threads[i]);
     if (found_threads[i] == NULL) {
       set_agent_fail_status();
-      return NSK_FALSE;
+      return JNI_FALSE;
     }
     LOG("  ... thread #%d: %p\n", i, found_threads[i]);
   }
 
-  return NSK_TRUE;
+  return JNI_TRUE;
 }
 
 JNIEXPORT jint JNICALL

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThreadList/suspendthrdlst01/suspendthrdlst01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThreadList/suspendthrdlst01/suspendthrdlst01.java
@@ -49,15 +49,11 @@ public class suspendthrdlst01 extends DebugeeClass {
         System.loadLibrary("suspendthrdlst01");
     }
 
-    // run test from command line
     public static void main(String argv[]) {
-        // JCK-compatible exit
-        System.exit(run(argv, System.out) + 95);
-    }
-
-    // run test from JCK-compatible environment
-    public static int run(String argv[], PrintStream out) {
-        return new suspendthrdlst01().runIt(argv, out);
+        int result = new suspendthrdlst01().runIt();
+        if (result != 0) {
+            throw new RuntimeException("check failed with result " + result);
+        }
     }
 
     /* =================================================================== */
@@ -71,7 +67,7 @@ public class suspendthrdlst01 extends DebugeeClass {
     suspendthrdlst01Thread threads[] = null;
 
     // run debuggee
-    public int runIt(String argv[], PrintStream out) {
+    public int runIt() {
         timeout = 60 * 1000; // milliseconds
 
         // create tested threads

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThreadList/suspendthrdlst01/suspendthrdlst01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThreadList/suspendthrdlst01/suspendthrdlst01.java
@@ -40,7 +40,7 @@
  */
 
 import jdk.test.lib.jvmti.DebugeeClass;
-import java.io.PrintStream;
+
 
 public class suspendthrdlst01 extends DebugeeClass {
 

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThreadList/suspendthrdlst02/libsuspendthrdlst02.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThreadList/suspendthrdlst02/libsuspendthrdlst02.cpp
@@ -192,7 +192,7 @@ static int find_threads_by_name(jvmtiEnv* jvmti, JNIEnv* jni,
              "#   expected: %d\n",
              name, found, foundCount);
     set_agent_fail_status();
-    return NSK_FALSE;
+    return JNI_FALSE;
   }
 
   LOG("Make global references for threads: %d threads\n", foundCount);
@@ -200,12 +200,12 @@ static int find_threads_by_name(jvmtiEnv* jvmti, JNIEnv* jni,
     foundThreads[i] = (jthread) jni->NewGlobalRef(foundThreads[i]);
     if (foundThreads[i] == NULL) {
       set_agent_fail_status();
-      return NSK_FALSE;
+      return JNI_FALSE;
     }
     LOG("  ... thread #%d: %p\n", i, foundThreads[i]);
   }
 
-  return NSK_TRUE;
+  return JNI_TRUE;
 }
 
 /** THREAD_END callback. */

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThreadList/suspendthrdlst02/suspendthrdlst02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThreadList/suspendthrdlst02/suspendthrdlst02.java
@@ -39,11 +39,6 @@
 
 import jdk.test.lib.jvmti.DebugeeClass;
 
-import java.io.PrintStream;
-
-
-
-
 public class suspendthrdlst02 extends DebugeeClass {
 
     // load native library if required

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThreadList/suspendthrdlst02/suspendthrdlst02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/SuspendThreadList/suspendthrdlst02/suspendthrdlst02.java
@@ -51,15 +51,11 @@ public class suspendthrdlst02 extends DebugeeClass {
         System.loadLibrary("suspendthrdlst02");
     }
 
-    // run test from command line
     public static void main(String argv[]) {
-        // JCK-compatible exit
-        System.exit(run(argv, System.out) + 95);
-    }
-
-    // run test from JCK-compatible environment
-    public static int run(String argv[], PrintStream out) {
-        return new suspendthrdlst02().runIt(argv, out);
+        int result = new suspendthrdlst02().runIt();
+        if (result != 0) {
+            throw new RuntimeException("check failed with result " + result);
+        }
     }
 
     /* =================================================================== */
@@ -74,7 +70,7 @@ public class suspendthrdlst02 extends DebugeeClass {
     suspendthrdlst02Thread threads[] = null;
 
     // run debuggee
-    public int runIt(String argv[], PrintStream out) {
+    public int runIt() {
         timeout = 60 * 1000; // milliseconds
 
         // create tested threads

--- a/test/lib/jdk/test/lib/jvmti/jvmti_common.h
+++ b/test/lib/jdk/test/lib/jvmti/jvmti_common.h
@@ -36,9 +36,6 @@
 #include <unistd.h>
 #endif
 
-#define NSK_TRUE 1
-#define NSK_FALSE 0
-
 #define LOG(...) \
   { \
     printf(__VA_ARGS__); \
@@ -834,7 +831,7 @@ enable_events_notifications(jvmtiEnv* jvmti, JNIEnv* jni, jvmtiEventMode enable,
   for (int i = 0; i < size; i++) {
     check_jvmti_status(jni, jvmti->SetEventNotificationMode(enable, list[i], thread), "");
   }
-  return NSK_TRUE;
+  return JNI_TRUE;
 }
 
 void

--- a/test/lib/jdk/test/lib/jvmti/jvmti_thread.h
+++ b/test/lib/jdk/test/lib/jvmti/jvmti_thread.h
@@ -83,7 +83,7 @@ typedef struct agent_data_t {
 int set_agent_proc(jvmtiStartFunction proc, void* arg) {
   agent_thread_proc = proc;
   agent_thread_arg = arg;
-  return NSK_TRUE;
+  return JNI_TRUE;
 }
 
 static agent_data_t agent_data;
@@ -107,7 +107,7 @@ int agent_wait_for_sync(jlong timeout) {
   static const int inc_timeout = 1000;
 
   jlong t = 0;
-  int result = NSK_TRUE;
+  int result = JNI_TRUE;
 
   RawMonitorLocker monitor_locker(agent_jvmti_env, agent_jni_env, agent_data.monitor);
 
@@ -132,7 +132,7 @@ int agent_wait_for_sync(jlong timeout) {
   if (agent_data.thread_state == WAITING) {
       COMPLAIN("No status sync occured for timeout: %" LL "d ms\n", timeout);
     set_agent_fail_status();
-    result = NSK_FALSE;
+    result = JNI_FALSE;
   }
 
   return result;
@@ -144,7 +144,7 @@ int agent_resume_sync() {
   RawMonitorLocker monitor_locker(agent_jvmti_env, agent_jni_env, agent_data.monitor);
 
   if (agent_data.thread_state == SUSPENDED) {
-    result = NSK_TRUE;
+    result = JNI_TRUE;
     agent_data.thread_state = RUNNABLE;
     /* SP5.2-n - notify suspend done */
     /* SP7.2-n - notify agent end */
@@ -153,10 +153,10 @@ int agent_resume_sync() {
   else {
     COMPLAIN("Debuggee was not suspended on status sync\n");
     set_agent_fail_status();
-    result = NSK_FALSE;
+    result = JNI_FALSE;
   }
 
-  return NSK_TRUE;
+  return JNI_TRUE;
 }
 
 /* ============================================================================= */


### PR DESCRIPTION
The fix remove JCK-like run, NSK variables and LoadLibrary exception handling. The test behavior should remain the same.

The fix is split into several commits, which might be easier for review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289098](https://bugs.openjdk.org/browse/JDK-8289098): clean up ported serviceability/jvmti tests


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9267/head:pull/9267` \
`$ git checkout pull/9267`

Update a local copy of the PR: \
`$ git checkout pull/9267` \
`$ git pull https://git.openjdk.org/jdk pull/9267/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9267`

View PR using the GUI difftool: \
`$ git pr show -t 9267`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9267.diff">https://git.openjdk.org/jdk/pull/9267.diff</a>

</details>
