### PR TITLE
8288707: javax/swing/JToolBar/4529206/bug4529206.java: setFloating does not work correctly

### DIFF
--- a/test/jdk/javax/swing/JToolBar/4529206/bug4529206.java
+++ b/test/jdk/javax/swing/JToolBar/4529206/bug4529206.java
@@ -107,7 +107,7 @@ public class bug4529206 {
                     }
                 }
             });
-	} finally {
+        } finally {
             SwingUtilities.invokeAndWait(() -> {
                 if (frame != null) {
                     frame.dispose();

--- a/test/jdk/javax/swing/JToolBar/4529206/bug4529206.java
+++ b/test/jdk/javax/swing/JToolBar/4529206/bug4529206.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,27 +28,34 @@
  * @key headful
  * @bug     4529206
  * @summary JToolBar - setFloating does not work correctly
- * @author  Konstantin Eremin
  * @run     main bug4529206
  */
 
-import javax.swing.*;
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Robot;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
 
-public class bug4529206 extends JFrame {
+public class bug4529206 {
     static JFrame frame;
     static JToolBar jToolBar1;
-    public bug4529206() {
-        setDefaultCloseOperation(EXIT_ON_CLOSE);
-        JPanel jPanFrame = (JPanel) this.getContentPane();
+    static JButton jButton1;
+
+    private static void test() {
+        frame = new JFrame();
+        JPanel jPanFrame = (JPanel) frame.getContentPane();
         jPanFrame.setLayout(new BorderLayout());
-        this.setSize(new Dimension(200, 100));
-        this.setLocation(125, 75);
-        this.setTitle("Test Floating Toolbar");
+        frame.setSize(new Dimension(200, 100));
+        frame.setTitle("Test Floating Toolbar");
         jToolBar1 = new JToolBar();
-        JButton jButton1 = new JButton("Float");
+        jButton1 = new JButton("Float");
         jPanFrame.add(jToolBar1, BorderLayout.NORTH);
         JTextField tf = new JTextField("click here");
         jPanFrame.add(tf);
@@ -58,11 +65,13 @@ public class bug4529206 extends JFrame {
                 buttonPressed(e);
             }
         });
-        makeToolbarFloat();
-        setVisible(true);
+
+        frame.setUndecorated(true);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
     }
 
-    private void makeToolbarFloat() {
+    private static void makeToolbarFloat() {
         javax.swing.plaf.basic.BasicToolBarUI ui = (javax.swing.plaf.basic.BasicToolBarUI) jToolBar1.getUI();
         if (!ui.isFloating()) {
             ui.setFloatingLocation(100, 100);
@@ -70,24 +79,40 @@ public class bug4529206 extends JFrame {
         }
     }
 
-    private void buttonPressed(ActionEvent e) {
+    private static void buttonPressed(ActionEvent e) {
         makeToolbarFloat();
     }
 
     public static void main(String[] args) throws Exception {
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                frame = new bug4529206();
-            }
-        });
-        Robot robot = new Robot();
-        robot.waitForIdle();
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                if (frame.isFocused()) {
-                    throw (new RuntimeException("setFloating does not work correctly"));
+        try {
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    test();
                 }
-            }
-        });
+            });
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            SwingUtilities.invokeAndWait(() -> {
+                makeToolbarFloat();
+            });
+
+            robot.waitForIdle();
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    if (frame.isFocused()) {
+                        throw
+                          new RuntimeException("setFloating does not work correctly");
+                    }
+                }
+            });
+	} finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
Test was failing intermittently around 1 or 2 out of 30 runs. 
Fixed by adding stability code, wait for a sec after frame is visible, set frame to center.
Modified test has run at least 50 times in all platforms and 100 times in linux (where it is seen intermittently) without any issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288707](https://bugs.openjdk.org/browse/JDK-8288707): javax/swing/JToolBar/4529206/bug4529206.java: setFloating does not work correctly


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Author)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9269/head:pull/9269` \
`$ git checkout pull/9269`

Update a local copy of the PR: \
`$ git checkout pull/9269` \
`$ git pull https://git.openjdk.org/jdk pull/9269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9269`

View PR using the GUI difftool: \
`$ git pr show -t 9269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9269.diff">https://git.openjdk.org/jdk/pull/9269.diff</a>

</details>
