### PR TITLE
[PATCH] Avoid redundant HashMap.get call in P11KeyStore.deleteEntry

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java
@@ -68,7 +68,7 @@ import sun.security.util.Debug;
 import sun.security.util.DerValue;
 import sun.security.util.ECUtil;
 
-import sun.security.pkcs11.Secmod.*;
+import sun.security.pkcs11.Secmod.ModuleType;
 import static sun.security.pkcs11.P11Util.*;
 
 import sun.security.pkcs11.wrapper.*;
@@ -538,11 +538,8 @@ final class P11KeyStore extends KeyStoreSpi {
      * XXX - not sure whether to keep this
      */
     private boolean deleteEntry(String alias) throws KeyStoreException {
-        AliasInfo aliasInfo = aliasMap.get(alias);
+        AliasInfo aliasInfo = aliasMap.remove(alias);
         if (aliasInfo != null) {
-
-            aliasMap.remove(alias);
-
             try {
                 if (aliasInfo.type == ATTR_CLASS_CERT) {
                     // trusted certificate entry


### PR DESCRIPTION
https://github.com/openjdk/jdk/blob/9dc9a64fa453d8afc90871e9663a0ccc46212f64/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java#L540-L544

Instead of separate `get`+`remove` calls, we can call `remove` first and reuse its return variable.
It results in cleaner and a bit faster code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9271/head:pull/9271` \
`$ git checkout pull/9271`

Update a local copy of the PR: \
`$ git checkout pull/9271` \
`$ git pull https://git.openjdk.org/jdk pull/9271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9271`

View PR using the GUI difftool: \
`$ git pr show -t 9271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9271.diff">https://git.openjdk.org/jdk/pull/9271.diff</a>

</details>
