### PR TITLE
8289126: Cleanup unnecessary null comparison before instanceof check in jdk.hotspot.agent

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -581,8 +581,8 @@ public class CommandProcessor {
                     // dump replay data
 
                     CodeBlob cb = VM.getVM().getCodeCache().findBlob(a);
-                    if (cb != null && (cb instanceof NMethod)) {
-                        ((NMethod)cb).dumpReplayData(out);
+                    if (cb instanceof NMethod nMethod) {
+                        nMethod.dumpReplayData(out);
                         return;
                     }
                     // assume it is Metadata

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdThread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,11 +49,11 @@ class BsdThread implements ThreadProxy {
     }
 
     public boolean equals(Object obj) {
-        if ((obj == null) || !(obj instanceof BsdThread)) {
+        if (!(obj instanceof BsdThread other)) {
             return false;
         }
 
-        return (((BsdThread) obj).unique_thread_id == unique_thread_id);
+        return (other.unique_thread_id == unique_thread_id);
     }
 
     public int hashCode() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/LoadObjectComparator.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/LoadObjectComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,9 +38,6 @@ public class LoadObjectComparator implements Comparator<LoadObject> {
    }
 
    public boolean equals(Object o) {
-      if (o == null || !(o instanceof LoadObjectComparator)) {
-         return false;
-      }
-      return true;
+      return o instanceof LoadObjectComparator;
    }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxThread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,11 +55,11 @@ class LinuxThread implements ThreadProxy {
     }
 
     public boolean equals(Object obj) {
-        if ((obj == null) || !(obj instanceof LinuxThread)) {
+        if (!(obj instanceof LinuxThread other)) {
             return false;
         }
 
-        return (((LinuxThread) obj).lwp_id == lwp_id);
+        return (other.lwp_id == lwp_id);
     }
 
     public int hashCode() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/posix/DSO.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/posix/DSO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@ package sun.jvm.hotspot.debugger.posix;
 
 import sun.jvm.hotspot.debugger.*;
 import sun.jvm.hotspot.debugger.cdbg.*;
-import sun.jvm.hotspot.utilities.memo.*;
 
 /** Provides a simple wrapper around the ELF library which handles
     relocation. */
@@ -69,10 +68,9 @@ public abstract class DSO implements LoadObject {
     }
 
     public boolean equals(Object o) {
-        if (o == null || !(o instanceof DSO)) {
+        if (!(o instanceof DSO other)) {
            return false;
         }
-        DSO other = (DSO)o;
         return getBase().equals(other.getBase());
     }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/proc/aarch64/ProcAARCH64Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/proc/aarch64/ProcAARCH64Thread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -74,11 +74,11 @@ public class ProcAARCH64Thread implements ThreadProxy {
     }
 
     public boolean equals(Object obj) {
-        if ((obj == null) || !(obj instanceof ProcAARCH64Thread)) {
+        if (!(obj instanceof ProcAARCH64Thread other)) {
             return false;
         }
 
-        return (((ProcAARCH64Thread) obj).id == id);
+        return (other.id == id);
     }
 
     public int hashCode() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/proc/amd64/ProcAMD64Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/proc/amd64/ProcAMD64Thread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,11 +73,11 @@ public class ProcAMD64Thread implements ThreadProxy {
     }
 
     public boolean equals(Object obj) {
-        if ((obj == null) || !(obj instanceof ProcAMD64Thread)) {
+        if (!(obj instanceof ProcAMD64Thread other)) {
             return false;
         }
 
-        return (((ProcAMD64Thread) obj).id == id);
+        return (other.id == id);
     }
 
     public int hashCode() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/proc/ppc64/ProcPPC64Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/proc/ppc64/ProcPPC64Thread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,11 +73,11 @@ public class ProcPPC64Thread implements ThreadProxy {
   }
 
   public boolean equals(Object obj) {
-    if ((obj == null) || !(obj instanceof ProcPPC64Thread)) {
+    if (!(obj instanceof ProcPPC64Thread other)) {
       return false;
     }
 
-    return (((ProcPPC64Thread) obj).id == id);
+    return (other.id == id);
   }
 
   public int hashCode() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/proc/riscv64/ProcRISCV64Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/proc/riscv64/ProcRISCV64Thread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, Red Hat Inc.
  * Copyright (c) 2021, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -75,11 +75,11 @@ public class ProcRISCV64Thread implements ThreadProxy {
     }
 
     public boolean equals(Object obj) {
-        if ((obj == null) || !(obj instanceof ProcRISCV64Thread)) {
+        if (!(obj instanceof ProcRISCV64Thread other)) {
             return false;
         }
 
-        return (((ProcRISCV64Thread) obj).id == id);
+        return (other.id == id);
     }
 
     public int hashCode() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/proc/x86/ProcX86Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/proc/x86/ProcX86Thread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,11 +78,11 @@ public class ProcX86Thread implements ThreadProxy {
   }
 
   public boolean equals(Object obj) {
-    if ((obj == null) || !(obj instanceof ProcX86Thread)) {
+    if (!(obj instanceof ProcX86Thread other)) {
       return false;
     }
 
-    return (((ProcX86Thread) obj).id == id);
+    return (other.id == id);
   }
 
   public int hashCode() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/aarch64/WindbgAARCH64Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/aarch64/WindbgAARCH64Thread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -26,7 +26,6 @@
 package sun.jvm.hotspot.debugger.windbg.aarch64;
 
 import sun.jvm.hotspot.debugger.*;
-import sun.jvm.hotspot.debugger.aarch64.*;
 import sun.jvm.hotspot.debugger.windbg.*;
 
 class WindbgAARCH64Thread implements ThreadProxy {
@@ -67,11 +66,11 @@ class WindbgAARCH64Thread implements ThreadProxy {
   }
 
   public boolean equals(Object obj) {
-    if ((obj == null) || !(obj instanceof WindbgAARCH64Thread)) {
+    if (!(obj instanceof WindbgAARCH64Thread other)) {
       return false;
     }
 
-    return (((WindbgAARCH64Thread) obj).getThreadID() == getThreadID());
+    return (other.getThreadID() == getThreadID());
   }
 
   public int hashCode() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/amd64/WindbgAMD64Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/amd64/WindbgAMD64Thread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 package sun.jvm.hotspot.debugger.windbg.amd64;
 
 import sun.jvm.hotspot.debugger.*;
-import sun.jvm.hotspot.debugger.amd64.*;
 import sun.jvm.hotspot.debugger.windbg.*;
 
 class WindbgAMD64Thread implements ThreadProxy {
@@ -70,11 +69,11 @@ class WindbgAMD64Thread implements ThreadProxy {
   }
 
   public boolean equals(Object obj) {
-    if ((obj == null) || !(obj instanceof WindbgAMD64Thread)) {
+    if (!(obj instanceof WindbgAMD64Thread other)) {
       return false;
     }
 
-    return (((WindbgAMD64Thread) obj).getThreadID() == getThreadID());
+    return (other.getThreadID() == getThreadID());
   }
 
   public int hashCode() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/x86/WindbgX86Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/x86/WindbgX86Thread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 package sun.jvm.hotspot.debugger.windbg.x86;
 
 import sun.jvm.hotspot.debugger.*;
-import sun.jvm.hotspot.debugger.x86.*;
 import sun.jvm.hotspot.debugger.windbg.*;
 
 class WindbgX86Thread implements ThreadProxy {
@@ -66,11 +65,11 @@ class WindbgX86Thread implements ThreadProxy {
   }
 
   public boolean equals(Object obj) {
-    if ((obj == null) || !(obj instanceof WindbgX86Thread)) {
+    if (!(obj instanceof WindbgX86Thread other)) {
       return false;
     }
 
-    return (((WindbgX86Thread) obj).getThreadID() == getThreadID());
+    return (other.getThreadID() == getThreadID());
   }
 
   public int hashCode() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Oop.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Oop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
 package sun.jvm.hotspot.oops;
 
 import java.io.*;
-import java.util.*;
-import sun.jvm.hotspot.utilities.*;
 import sun.jvm.hotspot.debugger.*;
 import sun.jvm.hotspot.runtime.*;
 import sun.jvm.hotspot.types.*;
@@ -115,8 +113,8 @@ public class Oop {
   }
 
   public boolean equals(Object obj) {
-    if (obj != null && (obj instanceof Oop)) {
-      return getHandle().equals(((Oop) obj).getHandle());
+    if (obj instanceof Oop other) {
+      return getHandle().equals(other.getHandle());
     }
     return false;
  }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaVFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaVFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -198,13 +198,11 @@ public abstract class JavaVFrame extends VFrame {
   }
 
   public boolean equals(Object o) {
-      if (o == null || !(o instanceof JavaVFrame)) {
+      if (!(o instanceof JavaVFrame other)) {
           return false;
       }
 
-      JavaVFrame other = (JavaVFrame) o;
-
-      // Check static part
+    // Check static part
       if (!getMethod().equals(other.getMethod())) {
           return false;
       }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/Inspector.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/Inspector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -271,8 +271,8 @@ public class Inspector extends SAPanel {
           if(selRow != -1) {
             if (e.getClickCount() == 1 && (e.getModifiersEx() & InputEvent.SHIFT_DOWN_MASK) != 0) {
               Object node = tree.getLastSelectedPathComponent();
-              if (node != null && node instanceof SimpleTreeNode) {
-                showInspector((SimpleTreeNode)node);
+              if (node instanceof SimpleTreeNode simpleNode) {
+                showInspector(simpleNode);
               }
             }
           }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/AbstractHeapGraphWriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/AbstractHeapGraphWriter.java
@@ -27,7 +27,6 @@ package sun.jvm.hotspot.utilities;
 import java.io.*;
 import sun.jvm.hotspot.debugger.*;
 import sun.jvm.hotspot.gc.shared.OopStorage;
-import sun.jvm.hotspot.memory.*;
 import sun.jvm.hotspot.oops.*;
 import sun.jvm.hotspot.runtime.*;
 
@@ -437,8 +436,8 @@ public abstract class AbstractHeapGraphWriter implements HeapGraphWriter {
     protected void handleRuntimeException(RuntimeException re)
         throws IOException {
         Throwable cause = re.getCause();
-        if (cause != null && cause instanceof IOException) {
-            throw (IOException) cause;
+        if (cause instanceof IOException io) {
+            throw io;
         } else {
             // some other RuntimeException, just re-throw
             throw re;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/SystemDictionaryHelper.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/SystemDictionaryHelper.java
@@ -98,8 +98,8 @@ public class SystemDictionaryHelper {
 
       // check whether we have a class of given name
       Klass klass = cldg.find(className);
-      if (klass != null && klass instanceof InstanceKlass) {
-         return (InstanceKlass) klass;
+      if (klass instanceof InstanceKlass ik) {
+         return ik;
       } else {
         // no match ..
         return null;


### PR DESCRIPTION
Update code checks both non-null and instance of a class in jdk.hotspot.agent module classes.
The checks and explicit casts could also be replaced with pattern matching for the instanceof operator.

For example, the following code:

              Object node = tree.getLastSelectedPathComponent();
              if (node != null && node instanceof SimpleTreeNode) {
                showInspector((SimpleTreeNode)node);
              }

Can be simplified to:

              Object node = tree.getLastSelectedPathComponent();
              if (node instanceof SimpleTreeNode simpleNode) {
                showInspector(simpleNode);
              }


See similar cleanup in java.base - [JDK-8258422](https://bugs.openjdk.java.net/browse/JDK-8258422)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289126](https://bugs.openjdk.org/browse/JDK-8289126): Cleanup unnecessary null comparison before instanceof check in jdk.hotspot.agent


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9272/head:pull/9272` \
`$ git checkout pull/9272`

Update a local copy of the PR: \
`$ git checkout pull/9272` \
`$ git pull https://git.openjdk.org/jdk pull/9272/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9272`

View PR using the GUI difftool: \
`$ git pr show -t 9272`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9272.diff">https://git.openjdk.org/jdk/pull/9272.diff</a>

</details>
