### PR TITLE
8289138: G1: Remove redundant is-marking-active checks in C1 barrier

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/g1/g1BarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/g1/g1BarrierSetAssembler_aarch64.cpp
@@ -381,15 +381,6 @@ void G1BarrierSetAssembler::generate_c1_pre_barrier_runtime_stub(StubAssembler* 
   Label done;
   Label runtime;
 
-  // Is marking still active?
-  if (in_bytes(SATBMarkQueue::byte_width_of_active()) == 4) {
-    __ ldrw(tmp, in_progress);
-  } else {
-    assert(in_bytes(SATBMarkQueue::byte_width_of_active()) == 1, "Assumption");
-    __ ldrb(tmp, in_progress);
-  }
-  __ cbzw(tmp, done);
-
   // Can we store original value in the thread's buffer?
   __ ldr(tmp, queue_index);
   __ cbz(tmp, runtime);

--- a/src/hotspot/cpu/arm/gc/g1/g1BarrierSetAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/gc/g1/g1BarrierSetAssembler_arm.cpp
@@ -382,11 +382,6 @@ void G1BarrierSetAssembler::generate_c1_pre_barrier_runtime_stub(StubAssembler* 
   Label done;
   Label runtime;
 
-  // Is marking still active?
-  assert(in_bytes(SATBMarkQueue::byte_width_of_active()) == 1, "Assumption");
-  __ ldrb(R1, queue_active);
-  __ cbz(R1, done);
-
   __ ldr(r_index_1, queue_index);
   __ ldr(r_pre_val_0, Address(SP, nb_saved_regs*wordSize));
   __ ldr(r_buffer_2, buffer);

--- a/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.cpp
@@ -469,16 +469,6 @@ void G1BarrierSetAssembler::generate_c1_pre_barrier_runtime_stub(StubAssembler* 
   __ std(tmp, -16, R1_SP);
   __ std(tmp2, -24, R1_SP);
 
-  // Is marking still active?
-  if (in_bytes(SATBMarkQueue::byte_width_of_active()) == 4) {
-    __ lwz(tmp, satb_q_active_byte_offset, R16_thread);
-  } else {
-    assert(in_bytes(SATBMarkQueue::byte_width_of_active()) == 1, "Assumption");
-    __ lbz(tmp, satb_q_active_byte_offset, R16_thread);
-  }
-  __ cmpdi(CCR0, tmp, 0);
-  __ beq(CCR0, marking_not_active);
-
   __ bind(restart);
   // Load the index into the SATB buffer. SATBMarkQueue::_index is a
   // size_t so ld_ptr is appropriate.

--- a/src/hotspot/cpu/riscv/gc/g1/g1BarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/g1/g1BarrierSetAssembler_riscv.cpp
@@ -379,15 +379,6 @@ void G1BarrierSetAssembler::generate_c1_pre_barrier_runtime_stub(StubAssembler* 
   Label done;
   Label runtime;
 
-  // Is marking still active?
-  if (in_bytes(SATBMarkQueue::byte_width_of_active()) == 4) {  // 4-byte width
-    __ lwu(tmp, in_progress);
-  } else {
-    assert(in_bytes(SATBMarkQueue::byte_width_of_active()) == 1, "Assumption");
-    __ lbu(tmp, in_progress);
-  }
-  __ beqz(tmp, done);
-
   // Can we store original value in the thread's buffer?
   __ ld(tmp, queue_index);
   __ beqz(tmp, runtime);

--- a/src/hotspot/cpu/s390/gc/g1/g1BarrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/g1/g1BarrierSetAssembler_s390.cpp
@@ -488,15 +488,6 @@ void G1BarrierSetAssembler::generate_c1_pre_barrier_runtime_stub(StubAssembler* 
   __ z_stg(tmp,  0*BytesPerWord + FrameMap::first_available_sp_in_frame, Z_SP);
   __ z_stg(tmp2, 1*BytesPerWord + FrameMap::first_available_sp_in_frame, Z_SP);
 
-  // Is marking still active?
-  if (in_bytes(SATBMarkQueue::byte_width_of_active()) == 4) {
-    __ load_and_test_int(tmp, Address(Z_thread, satb_q_active_byte_offset));
-  } else {
-    assert(in_bytes(SATBMarkQueue::byte_width_of_active()) == 1, "Assumption");
-    __ load_and_test_byte(tmp, Address(Z_thread, satb_q_active_byte_offset));
-  }
-  __ z_bre(marking_not_active); // Activity indicator is zero, so there is no marking going on currently.
-
   __ bind(restart);
   // Load the index into the SATB buffer. SATBMarkQueue::_index is a
   // size_t so ld_ptr is appropriate.

--- a/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp
@@ -468,15 +468,6 @@ void G1BarrierSetAssembler::generate_c1_pre_barrier_runtime_stub(StubAssembler* 
   Label done;
   Label runtime;
 
-  // Is marking still active?
-  if (in_bytes(SATBMarkQueue::byte_width_of_active()) == 4) {
-    __ cmpl(queue_active, 0);
-  } else {
-    assert(in_bytes(SATBMarkQueue::byte_width_of_active()) == 1, "Assumption");
-    __ cmpb(queue_active, 0);
-  }
-  __ jcc(Assembler::equal, done);
-
   // Can we store original value in the thread's buffer?
 
   __ movptr(tmp, queue_index);


### PR DESCRIPTION
Simple change of removing a redundant check in C1 barrier code.

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289138](https://bugs.openjdk.org/browse/JDK-8289138): G1: Remove redundant is-marking-active checks in C1 barrier


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Erik Helin](https://openjdk.org/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9274/head:pull/9274` \
`$ git checkout pull/9274`

Update a local copy of the PR: \
`$ git checkout pull/9274` \
`$ git pull https://git.openjdk.org/jdk pull/9274/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9274`

View PR using the GUI difftool: \
`$ git pr show -t 9274`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9274.diff">https://git.openjdk.org/jdk/pull/9274.diff</a>

</details>
