### PR TITLE
JDK-8289143: JDK-6980847 broke 32-bit builds

### DIFF
--- a/src/java.base/unix/native/libnio/fs/UnixCopyFile.c
+++ b/src/java.base/unix/native/libnio/fs/UnixCopyFile.c
@@ -80,7 +80,7 @@ Java_sun_nio_fs_UnixCopyFile_bufferedCopy0
 {
     volatile jint* cancel = (jint*)jlong_to_ptr(cancelAddress);
 
-    char* buf = (char*)address;
+    char* buf = (char*)jlong_to_ptr(address);
 
 #if defined(__linux__)
     int advice = POSIX_FADV_SEQUENTIAL | // sequential data access


### PR DESCRIPTION
Trivial fix to get 32-bit to build again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289143](https://bugs.openjdk.org/browse/JDK-8289143): JDK-6980847 broke 32-bit builds


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9275/head:pull/9275` \
`$ git checkout pull/9275`

Update a local copy of the PR: \
`$ git checkout pull/9275` \
`$ git pull https://git.openjdk.org/jdk pull/9275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9275`

View PR using the GUI difftool: \
`$ git pr show -t 9275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9275.diff">https://git.openjdk.org/jdk/pull/9275.diff</a>

</details>
