### PR TITLE
8289060: Undefined Behaviour in class VMReg

### DIFF
--- a/src/hotspot/share/code/vmreg.cpp
+++ b/src/hotspot/share/code/vmreg.cpp
@@ -26,10 +26,11 @@
 #include "asm/assembler.hpp"
 #include "code/vmreg.hpp"
 
-VMRegImpl all_VMRegs[ConcreteRegisterImpl::number_of_registers + 1];
-
-// First VMReg value that could refer to a stack slot
-VMReg VMRegImpl::stack0 = VMRegImpl::stack_0();
+// First VMReg value that could refer to a stack slot.  This is only
+// used by SA and jvmti, but it's a leaky abstraction: SA and jvmti
+// "know" that stack0 is an integer masquerading as a pointer. For the
+// sake of those clients, we preserve this interface.
+VMReg SharedInfo::stack0 = (VMReg)VMRegImpl::stack_0()->value();
 
 // VMRegs are 4 bytes wide on all platforms
 const int VMRegImpl::stack_slot_size = 4;
@@ -50,5 +51,7 @@ void VMRegImpl::print_on(outputStream* st) const {
     st->print("BAD!");
   }
 }
+
+VMRegImpl all_VMRegs[ConcreteRegisterImpl::number_of_registers + 1];
 
 void VMRegImpl::print() const { print_on(tty); }

--- a/src/hotspot/share/code/vmreg.cpp
+++ b/src/hotspot/share/code/vmreg.cpp
@@ -30,7 +30,7 @@
 // used by SA and jvmti, but it's a leaky abstraction: SA and jvmti
 // "know" that stack0 is an integer masquerading as a pointer. For the
 // sake of those clients, we preserve this interface.
-VMReg SharedInfo::stack0 = (VMReg)VMRegImpl::stack_0()->value();
+VMReg VMRegImpl::stack0 = (VMReg)VMRegImpl::stack_0()->value();
 
 // VMRegs are 4 bytes wide on all platforms
 const int VMRegImpl::stack_slot_size = 4;

--- a/src/hotspot/share/code/vmreg.cpp
+++ b/src/hotspot/share/code/vmreg.cpp
@@ -28,7 +28,8 @@
 
 VMRegImpl all_VMRegs[ConcreteRegisterImpl::number_of_registers + 1];
 
-VMReg VMRegImpl::stack0 = as_VMReg((ConcreteRegisterImpl::number_of_registers + 7) & ~7);
+// First VMReg value that could refer to a stack slot
+VMReg VMRegImpl::stack0 = VMRegImpl::stack_0();
 
 // VMRegs are 4 bytes wide on all platforms
 const int VMRegImpl::stack_slot_size = 4;

--- a/src/hotspot/share/code/vmreg.cpp
+++ b/src/hotspot/share/code/vmreg.cpp
@@ -26,8 +26,9 @@
 #include "asm/assembler.hpp"
 #include "code/vmreg.hpp"
 
-// First VMReg value that could refer to a stack slot
-VMReg VMRegImpl::stack0 = (VMReg)(intptr_t)((ConcreteRegisterImpl::number_of_registers + 7) & ~7);
+VMRegImpl all_VMRegs[ConcreteRegisterImpl::number_of_registers + 1];
+
+VMReg VMRegImpl::stack0 = as_VMReg((ConcreteRegisterImpl::number_of_registers + 7) & ~7);
 
 // VMRegs are 4 bytes wide on all platforms
 const int VMRegImpl::stack_slot_size = 4;

--- a/src/hotspot/share/code/vmreg.hpp
+++ b/src/hotspot/share/code/vmreg.hpp
@@ -37,7 +37,7 @@
 
 //------------------------------VMReg------------------------------------------
 // The VM uses 'unwarped' stack slots; the compiler uses 'warped' stack slots.
-// Register numbers below SharedInfo::stack0 are the same for both.  Register
+// Register numbers below VMRegImpl::stack0 are the same for both.  Register
 // numbers above stack0 are either warped (in the compiler) or unwarped
 // (in the VM).  Unwarped numbers represent stack indices, offsets from
 // the current stack pointer.  Warped numbers are required during compilation
@@ -160,7 +160,7 @@ inline constexpr VMReg VMRegImpl::first() { return all_VMRegs + 1; }
 //---------------------------VMRegPair-------------------------------------------
 // Pairs of 32-bit registers for arguments.
 // SharedRuntime::java_calling_convention will overwrite the structs with
-// the calling convention's registers.  VMRegImpl::Bad is returned for any
+ // the calling convention's registers.  VMRegImpl::Bad is returned for any
 // unused 32-bit register.  This happens for the unused high half of Int
 // arguments, or for 32-bit pointers or for longs in the 32-bit sparc build
 // (which are passed to natives in low 32-bits of e.g. O0/O1 and the high

--- a/src/hotspot/share/code/vmreg.hpp
+++ b/src/hotspot/share/code/vmreg.hpp
@@ -37,7 +37,7 @@
 
 //------------------------------VMReg------------------------------------------
 // The VM uses 'unwarped' stack slots; the compiler uses 'warped' stack slots.
-// Register numbers below VMRegImpl::stack0 are the same for both.  Register
+// Register numbers below SharedInfo::stack0 are the same for both.  Register
 // numbers above stack0 are either warped (in the compiler) or unwarped
 // (in the VM).  Unwarped numbers represent stack indices, offsets from
 // the current stack pointer.  Warped numbers are required during compilation
@@ -57,7 +57,9 @@ private:
   };
 
   // Despite being private, this field is exported to the
-  // serviceability agent and our friends.
+  // serviceability agent and our friends. It's not really a pointer,
+  // but that's fine and dandy as long as no-one tries to dereference
+  // it.
   static VMReg stack0;
 
   static constexpr VMReg first();
@@ -65,11 +67,11 @@ private:
   static const char *regName[];
   static const int register_count;
 
+public:
+
   static constexpr VMReg stack_0() {
     return first() + ((ConcreteRegisterImpl::number_of_registers + 7) & ~7);
   }
-
-public:
 
   static VMReg  as_VMReg(int val, bool bad_ok = false) {
     assert(val > BAD_REG || bad_ok, "invalid");
@@ -107,15 +109,15 @@ public:
   // we don't try and get the VMReg number of a physical register that doesn't
   // have an expressible part. That would be pd specific code
   VMReg next() {
-    assert((is_reg() && value() < stack0->value() - 1) || is_stack(), "must be");
+    assert((is_reg() && this < stack_0() - 1) || is_stack(), "must be");
     return this + 1;
   }
   VMReg next(int i) {
-    assert((is_reg() && value() < stack0->value() - i) || is_stack(), "must be");
+    assert((is_reg() && this < stack_0() - i) || is_stack(), "must be");
     return this + i;
   }
   VMReg prev() {
-    assert((is_stack() && value() > stack0->value()) || (is_reg() && value() != 0), "must be");
+    assert((is_stack() && this > stack_0()) || (is_reg() && value() != 0), "must be");
     return this - 1;
   }
 

--- a/src/hotspot/share/code/vmreg.hpp
+++ b/src/hotspot/share/code/vmreg.hpp
@@ -57,16 +57,15 @@ private:
   };
 
 
-
   static VMReg stack0;
+  static constexpr VMReg first();
   // Names for registers
   static const char *regName[];
   static const int register_count;
 
-
 public:
 
-  static VMReg  as_VMReg(int val, bool bad_ok = false) { assert(val > BAD_REG || bad_ok, "invalid"); return (VMReg) (intptr_t) val; }
+  static VMReg  as_VMReg(int val, bool bad_ok = false) { assert(val > BAD_REG || bad_ok, "invalid"); return val + first(); }
 
   const char*  name() {
     if (is_reg()) {
@@ -78,9 +77,10 @@ public:
       return "STACKED REG";
     }
   }
-  static VMReg Bad() { return (VMReg) (intptr_t) BAD_REG; }
-  bool is_valid() const { return ((intptr_t) this) != BAD_REG; }
-  bool is_stack() const { return (intptr_t) this >= (intptr_t) stack0; }
+  int raw_encoding() const { return this - first(); }
+  static VMReg Bad() { return BAD_REG+first(); }
+  bool is_valid() const { return raw_encoding() != BAD_REG; }
+  bool is_stack() const { return this >= stack0; }
   bool is_reg()   const { return is_valid() && !is_stack(); }
 
   // A concrete register is a value that returns true for is_reg() and is
@@ -99,19 +99,19 @@ public:
   // have an expressible part. That would be pd specific code
   VMReg next() {
     assert((is_reg() && value() < stack0->value() - 1) || is_stack(), "must be");
-    return (VMReg)(intptr_t)(value() + 1);
+    return this + 1;
   }
   VMReg next(int i) {
     assert((is_reg() && value() < stack0->value() - i) || is_stack(), "must be");
-    return (VMReg)(intptr_t)(value() + i);
+    return this + i;
   }
   VMReg prev() {
     assert((is_stack() && value() > stack0->value()) || (is_reg() && value() != 0), "must be");
-    return (VMReg)(intptr_t)(value() - 1);
+    return this - 1;
   }
 
 
-  intptr_t value() const         {return (intptr_t) this; }
+  intptr_t value() const         {return raw_encoding(); }
 
   void print_on(outputStream* st) const;
   void print() const;
@@ -131,12 +131,12 @@ public:
 
   // Convert register numbers to stack slots and vice versa
   static VMReg stack2reg( int idx ) {
-    return (VMReg) (intptr_t) (stack0->value() + idx);
+    return stack0 + idx;
   }
 
   uintptr_t reg2stack() {
     assert( is_stack(), "Not a stack-based register" );
-    return value() - stack0->value();
+    return this - stack0;
   }
 
   static void set_regName();
@@ -144,6 +144,9 @@ public:
 #include CPU_HEADER(vmreg)
 
 };
+
+extern VMRegImpl all_VMRegs[ConcreteRegisterImpl::number_of_registers + 1] INTERNAL_VISIBILITY;
+inline constexpr VMReg VMRegImpl::first() { return all_VMRegs + 1; }
 
 //---------------------------VMRegPair-------------------------------------------
 // Pairs of 32-bit registers for arguments.

--- a/src/hotspot/share/code/vmreg.hpp
+++ b/src/hotspot/share/code/vmreg.hpp
@@ -160,7 +160,7 @@ inline constexpr VMReg VMRegImpl::first() { return all_VMRegs + 1; }
 //---------------------------VMRegPair-------------------------------------------
 // Pairs of 32-bit registers for arguments.
 // SharedRuntime::java_calling_convention will overwrite the structs with
- // the calling convention's registers.  VMRegImpl::Bad is returned for any
+// the calling convention's registers.  VMRegImpl::Bad is returned for any
 // unused 32-bit register.  This happens for the unused high half of Int
 // arguments, or for 32-bit pointers or for longs in the 32-bit sparc build
 // (which are passed to natives in low 32-bits of e.g. O0/O1 and the high

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -279,7 +279,7 @@ void Matcher::match( ) {
       continue;
     }
     // calling_convention returns stack arguments as a count of
-    // slots beyond OptoReg::stack0()/SharedInfo::stack0.  We need to convert this to
+    // slots beyond OptoReg::stack0()/VMRegImpl::stack0.  We need to convert this to
     // the allocators point of view, taking into account all the
     // preserve area, locks & pad2.
 

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -279,7 +279,7 @@ void Matcher::match( ) {
       continue;
     }
     // calling_convention returns stack arguments as a count of
-    // slots beyond OptoReg::stack0()/VMRegImpl::stack0.  We need to convert this to
+    // slots beyond OptoReg::stack0()/SharedInfo::stack0.  We need to convert this to
     // the allocators point of view, taking into account all the
     // preserve area, locks & pad2.
 

--- a/src/hotspot/share/opto/optoreg.hpp
+++ b/src/hotspot/share/opto/optoreg.hpp
@@ -152,7 +152,7 @@ class OptoReg {
   }
 
   static OptoReg::Name stack0() {
-    return VMRegImpl::stack0->value();
+    return VMRegImpl::stack_0()->value();
   }
 
   static const char* regname(OptoReg::Name n) {


### PR DESCRIPTION
Like class `Register`, class `VMReg` exhibits undefined behaviour, in particular null pointer dereferences.

The right way to fix this is simple: make instances of `VMReg` point to reified instances of `VMRegImpl`. We do this by creating a static array of `VMRegImpl`, and making all `VMReg` instances point into it, making the code well defined.

However, while `VMReg` instances are no longer null, and so do not generate compile warnings or errors, there is still a problem in that higher-numbered `VMReg` instances point outside the static array of `VMRegImpl`. This is hard to avoid, given that (as far as I can tell) there is no upper limit on the number of stack slots that can be allocated as `VMReg` instances. While this is in theory UB, it's not likely to cause problems. We could fix this by creating a much larger static array of `VMRegImpl`, up to the largest plausible size of stack offsets.

We could instead make `VMReg` instances objects with a single numeric field rather than pointers, but some C++ compilers pass all such objects by reference, so I don't think we should.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289060](https://bugs.openjdk.org/browse/JDK-8289060): Undefined Behaviour in class VMReg


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9276/head:pull/9276` \
`$ git checkout pull/9276`

Update a local copy of the PR: \
`$ git checkout pull/9276` \
`$ git pull https://git.openjdk.org/jdk pull/9276/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9276`

View PR using the GUI difftool: \
`$ git pr show -t 9276`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9276.diff">https://git.openjdk.org/jdk/pull/9276.diff</a>

</details>
