### PR TITLE
8288627: [AIX] Implement WatchService using system library

### DIFF
--- a/src/java.base/aix/classes/sun/nio/fs/AhafsPoller.java
+++ b/src/java.base/aix/classes/sun/nio/fs/AhafsPoller.java
@@ -1,0 +1,602 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, IBM Corp.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.nio.fs;
+
+import java.nio.file.*;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.io.IOException;
+import jdk.internal.misc.Unsafe;
+
+import static sun.nio.fs.UnixNativeDispatcher.*;
+import static sun.nio.fs.UnixConstants.*;
+
+/**
+ * AIX Poller Implementation
+ */
+public class AhafsPoller extends AbstractPoller
+{
+    private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+    // The mount point for ahafs. Can be mounted at any point, but setup instructions recommend /aha.
+    private static final String AHA_MOUNT_POINT = "/aha";
+    // The following timeout controls the maximum time a worker thread will remain blocked before
+    // picking up newly registered keys.
+    private static final int POLL_TIMEOUT = 100; // ms
+    // This affects the OPAQUE_BUFFER_SIZE.
+    private static final int MAX_FDS = 2048;
+    // See description of opaque buffer below.
+    private static final int OPAQUE_BUFFER_SIZE = MAX_FDS*nPollfdSize();
+    // Careful when changing the following buffer size. Keep in sync with the one in AixWatchService.c
+    private static final int EVENT_BUFFER_SIZE = 2048;
+
+    private static final int SP_LISTEN = 0;
+    private static final int SP_NOTIFY = 1;
+
+    private AixWatchService watcher;
+    private HashMap<Integer, AixWatchKey> wdToKey;
+    // A socket pair created by the native socket pair routine.
+    private int[] sp_signal;
+    // Native-memory buffer used by AIX Event Infrastructure (AHAFS)
+    // to store file descriptors and other info.
+    // Treated as an 'opaque memory store' on the JVM heap. Keeping it here allows the
+    // native procedures to be functional (as in the paradigm).
+    private NativeBuffer opaqueBuffer;
+    // Number of open fds by the system. Managed by the native methods,
+    // but stored here for the same reasons as above.
+    private int[] nfds;
+
+    public AhafsPoller (AixWatchService watchService)
+        throws AixWatchService.FatalException
+    {
+        this.watcher = watchService;
+        this.wdToKey = new HashMap<Integer, AixWatchKey>();
+        this.nfds = new int[1];
+        this.opaqueBuffer = new NativeBuffer(OPAQUE_BUFFER_SIZE);
+
+        this. sp_signal = new int[2];
+        try {
+            nSocketpair(sp_signal);
+        } catch (UnixException e) {
+            throw new AixWatchService.FatalException("Could not create socketpair for Poller", e);
+        }
+
+        nInit(opaqueBuffer.address(), OPAQUE_BUFFER_SIZE, nfds, sp_signal[SP_LISTEN]);
+    }
+
+    /**
+     * Wake up the Poller to process changes.
+     */
+    @Override
+    void wakeup()
+        throws IOException
+    {
+        // write to socketpair to wakeup polling thread
+        try (NativeBuffer buffer = new NativeBuffer(1)) {
+            write(sp_signal[SP_NOTIFY], buffer.address(), 1);
+        } catch (UnixException x) {
+            throw new IOException("Exception ocurred during poller wakeup " + x.errorString());
+        }
+    }
+
+    private Path buildAhafsDirMonitorPath(Path path) { return buildAhafsMonitorPath(path, "modDir.monFactory"); }
+
+    private Path buildAhafsFileMonitorPath(Path path) { return buildAhafsMonitorPath(path, "modFile.monFactory"); }
+
+    /**
+     *  AHAFS works by creating a specific path in the AHA File System to monitor a target file elsewhere in the system.
+     *  This method and it's two helpers, create the path to be used depending on which event producer is to be used.
+     *  - modDir watches the contents of a directory for file or sub-directory create or delete events.
+     *  - modFile watches the file for modify events.
+     *  */
+    private Path buildAhafsMonitorPath(Path path, String eventProducer)
+    {
+        // Create path AHA_MOUNT_POINT/fs/<event-producer>/<parent-dir-path>/<fname>.mon
+        return Path.of(AHA_MOUNT_POINT, "fs", eventProducer,
+                       path.getParent().toString(), path.getFileName().toString() + ".mon");
+    }
+
+    /**
+     * Create the resources required to monitor a new file, and add the system created
+     * file descriptor to the opaque buffer to be watched with poll.
+     *
+     * The file descriptor returned by the system is used as a unique identifier for this key.
+     */
+    private int createNewWatchDescriptor(UnixPath ahafsMonitorPath)
+        throws AixWatchService.FatalException
+    {
+        int wd = AixWatchKey.INVALID_WATCH_DESCRIPTOR;
+
+        // Create resources in AHAFS
+        try {
+            Files.createDirectories(ahafsMonitorPath.getParent());
+        } catch (FileAlreadyExistsException e) {
+            // Ignore. It's OK if the parent directory is already present in AHAFS.
+        } catch (IOException e) {
+            throw new AixWatchService.FatalException("Unable to create parent directory in AHAFS for " + ahafsMonitorPath, e);
+        }
+
+        try (NativeBuffer strBuff =
+             NativeBuffers.asNativeBuffer(ahafsMonitorPath.getByteArrayForSysCalls())) {
+            wd = nRegisterMonitorPath(opaqueBuffer.address(), nfds[0], strBuff.address());
+        } catch (UnixException e) {
+            throw new AixWatchService.FatalException("Invalid WatchDescriptor (" + wd + ") returned by native procedure while attempting to register " + ahafsMonitorPath);
+        }
+
+        assert(wd != AixWatchKey.INVALID_WATCH_DESCRIPTOR);
+
+        nfds[0] += 1;
+        return wd;
+    }
+
+    /**
+     * Create a new SubKey.
+     *
+     * SubKeys are used to monitor a top level directory for modify events. This is required because
+     * AHAFS only supports monitoring a directory for create and delete events directly.
+     */
+    private AixWatchKey.SubKey createSubKey(Path filePath, AixWatchKey.TopLevelKey topLevelKey)
+        throws AixWatchService.FatalException
+    {
+        UnixPath monitorPath = (UnixPath) buildAhafsFileMonitorPath(filePath.normalize().toAbsolutePath());
+
+        int wd = createNewWatchDescriptor(monitorPath);
+
+        AixWatchKey.SubKey k = new AixWatchKey.SubKey(filePath, wd, topLevelKey);
+        wdToKey.put(wd, k);
+        return k;
+    }
+
+    /** Create SubKeys from a given root and add them to a given TopLevelKey
+     */
+    private void createSubKeys(Path root, AixWatchKey.TopLevelKey topLevelKey)
+        throws AixWatchService.FatalException, IOException
+    {
+        HashSet<AixWatchKey.SubKey> subKeys = new HashSet<>();
+
+        for (Path filePath: Files.walk(root, 1)
+                                 .filter((Path p) -> Files.isRegularFile(p))
+                                 .collect(Collectors.toList())) {
+            subKeys.add(createSubKey(filePath, topLevelKey));
+        }
+
+        topLevelKey.addSubKeys(subKeys);
+    }
+
+    Optional<? extends Exception> checkRegisterArgs(Path watchPath,
+                                                    Set<? extends WatchEvent.Kind<?>> events,
+                                                    WatchEvent.Modifier... modifiers)
+    {
+        UnixPath watchUnixPath = (UnixPath) watchPath;
+        UnixFileAttributes attrs = null;
+
+        // Validate path
+        if (watchPath == null) {
+            return Optional.of(new NullPointerException("AixWatchSerice: Path was null"));
+        }
+        try {
+            attrs = UnixFileAttributes.get(watchUnixPath , true);
+        } catch (UnixException x) {
+            return Optional.of(x.asIOException(watchUnixPath));
+        }
+        if (!attrs.isDirectory()) {
+            return Optional.of(new NotDirectoryException(watchUnixPath.getPathForExceptionMessage()));
+        }
+
+        // Validate events
+        if (events == null) {
+            return Optional.of(new NullPointerException("AixWatchSerice: Watch events list was null"));
+        } else if (events.contains(null)) {
+            return Optional.of(new NullPointerException("AixWatchSerice: Watch events list contains a null element"));
+        } else if (!(events.contains(StandardWatchEventKinds.ENTRY_CREATE) ||
+                     events.contains(StandardWatchEventKinds.ENTRY_MODIFY) ||
+                     events.contains(StandardWatchEventKinds.ENTRY_DELETE))) {
+            return Optional.of(new UnsupportedOperationException("AixWatchService: No supported events in registration of " + watchPath));
+        }
+
+        // Validate modifiers
+        if (modifiers.length > 0) {
+            for (WatchEvent.Modifier modifier: modifiers) {
+                if (modifier == null)
+                    return Optional.of(new NullPointerException("AixWatchService: Modifier was null"));
+                if (!ExtendedOptions.SENSITIVITY_HIGH.matches(modifier) &&
+                    !ExtendedOptions.SENSITIVITY_MEDIUM.matches(modifier) &&
+                    !ExtendedOptions.SENSITIVITY_LOW.matches(modifier)) {
+                    return Optional.of(new UnsupportedOperationException("AixWatchService: Modifiers not supported"));
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Register a path with the Poller.
+     *
+     * @return [WatchKey | RuntimeException | IOException] the caller is expected to check
+     * if the retuned object is an instance of either exception and act accordingly.
+     */
+    @Override
+    Object implRegister(Path watchPath,
+                        Set<? extends WatchEvent.Kind<?>> events,
+                        WatchEvent.Modifier... modifiers)
+    {
+        Optional<? extends Exception> mError = checkRegisterArgs(watchPath, events, modifiers);
+        if (mError.isPresent()) {
+            return mError.get();
+        }
+
+        // Create resources
+        UnixPath ahafsMonitorPath = (UnixPath)buildAhafsDirMonitorPath(watchPath.toAbsolutePath());
+        int wd = AixWatchKey.INVALID_WATCH_DESCRIPTOR;
+        try {
+            wd = createNewWatchDescriptor(ahafsMonitorPath);
+        } catch (AixWatchService.FatalException e) {
+            return new IOException("Invalid watch descriptor returned for " + ahafsMonitorPath + " during registration of " + watchPath, e);
+        }
+
+        AixWatchKey.TopLevelKey wk = new AixWatchKey.TopLevelKey(watchPath, wd, events, this.watcher);
+        wdToKey.put(wd, wk);
+
+        // Directory modifications are not supported directly in AIX Event
+        // Infrastructure. So the modify event is detected by monitoring
+        // for changes to the individual files in the directory.
+        if (wk.isWatching(StandardWatchEventKinds.ENTRY_MODIFY)) {
+            try {
+                createSubKeys(watchPath, wk);
+            } catch (IOException e) {
+                // See note about returning exceptions below.
+                return new IOException("[AixWatchService] IO error reported during file registration", e);
+            } catch (AixWatchService.FatalException e) {
+                // AbstractPolller checks if return type is insanceof IOE or RuntimeException
+                // and then throws. To ensure client is informed of the error, we
+                // map our internal exception to one checked by the caller and return.
+                return new IOException("[AixWatchService] Error reported during file registration", e);
+            }
+        }
+
+        return wk;
+    }
+
+    /**
+     * Update an existing AixWatchKey registration.
+     * Replace the currently watched events with the new event set,
+     * and perform any necessary housekeeping.
+     */
+    WatchKey reRegister(AixWatchKey wk,
+                        Set<? extends WatchEvent.Kind<?>> newEvents,
+                        WatchEvent.Modifier... modifiers)
+        throws AixWatchService.FatalException
+    {
+        AixWatchKey.TopLevelKey tlk = wk.resolve();
+        if (newEvents.contains(StandardWatchEventKinds.ENTRY_MODIFY) &&
+            !wk.isWatching(StandardWatchEventKinds.ENTRY_MODIFY)) {
+            try {
+                createSubKeys(wk.watchable(), tlk);
+            } catch (IOException e) {
+                throw new AixWatchService.FatalException("[AixWatchService] Error reported during file registration", e);
+            }
+        }
+        if (wk.isWatching(StandardWatchEventKinds.ENTRY_MODIFY) &&
+            !newEvents.contains(StandardWatchEventKinds.ENTRY_MODIFY)) {
+            for (AixWatchKey.SubKey sk : tlk.subKeys()) {
+                tlk.removeSubKey(sk);
+                cleanKeyResources(sk);
+            }
+        }
+
+        tlk.replaceEvents(newEvents);
+        return tlk;
+    }
+
+    /**
+     * Cancel an AixWatchKey.
+     * This method performs two (slightly different) tasks:
+     *
+     * 1. Cancel the given primary key (provided by the client) and
+     *      any subkeys.
+     * 2. Cancel the given subkey (provided as an interal call). Do not
+     *      resolve to TopLevelKey or cancel SubKeys.
+     *
+     */
+    @Override
+    void implCancelKey(WatchKey wk)
+    {
+        // Only cancel AixWatchKeys given out by this WatchService
+        if (!(wk instanceof AixWatchKey))
+            return;
+
+        AixWatchKey awk = (AixWatchKey) wk;
+        awk.invalidate();
+
+        // If cancelling a TopLevelKey, also cancel any SubKeys
+        if(wk instanceof AixWatchKey.TopLevelKey) {
+            AixWatchKey.TopLevelKey tlk = awk.resolve();
+            for (AixWatchKey.SubKey sk: tlk.subKeys()) {
+                tlk.removeSubKey(sk);
+                cleanKeyResources(sk);
+            }
+        }
+
+        // Cancel _this_ key regardless of whether it is a TopLevelKey or SubKey.
+        cleanKeyResources(awk);
+    }
+
+    /**
+     * Clean up Resources accociated with a given AixWatchKey
+     */
+    void cleanKeyResources(AixWatchKey awk)
+    {
+        nCancelWatchDescriptor(opaqueBuffer.address(), nfds[0], awk.watchDescriptor());
+        try {
+            Path monitorPath;
+            if (awk instanceof AixWatchKey.TopLevelKey) {
+                monitorPath = buildAhafsDirMonitorPath(awk.watchable());
+            } else {
+                monitorPath = buildAhafsFileMonitorPath(awk.watchable());
+            }
+            Files.deleteIfExists(monitorPath);
+        } catch (IOException e) {
+            System.err.println("Warn: Unable to remove monitor path in AixWatchService for key with (actual) path "
+                               + awk.watchable());
+        }
+        wdToKey.remove(awk.watchDescriptor());
+    }
+
+    // Cancel all keys. Close poller
+    @Override
+    void implCloseAll()
+    {
+        List<AixWatchKey> topLevelKeys = wdToKey.values()
+            .stream()
+            .filter((AixWatchKey k) -> k instanceof AixWatchKey.TopLevelKey)
+            .collect(Collectors.toList());
+
+        topLevelKeys.forEach(k -> implCancelKey(k));
+
+        UnixNativeDispatcher.close(sp_signal[SP_LISTEN], e -> null);
+        UnixNativeDispatcher.close(sp_signal[SP_NOTIFY], e -> null);
+
+        nCloseAll(opaqueBuffer.address(), nfds[0]);
+
+        nfds[0] = 0;
+        opaqueBuffer.close();
+    }
+
+    private int parseWd(String wdLine)
+    {
+        // Expect: BEGIN_WD=<wd>
+        return Integer.parseInt(wdLine.substring(9));
+    }
+
+    private Optional<WatchEvent.Kind<?>> parseEventKind(String line, AixWatchKey key)
+    {
+        if (key instanceof AixWatchKey.TopLevelKey) {
+            return parseTopLevelEventKind(line);
+        } else {
+            return parseSubKeyEventKind(line);
+        }
+    }
+
+    private Optional<WatchEvent.Kind<?>> parseTopLevelEventKind(String line)
+    {
+        if (line.equals("RC_FROM_EVPROD=1000")) {
+            return Optional.of(StandardWatchEventKinds.ENTRY_CREATE);
+        } else if (line.equals("RC_FROM_EVPROD=1002")) {
+            return Optional.of(StandardWatchEventKinds.ENTRY_DELETE);
+        } else if (line.equals("RC_FROM_EVPROD=1003")) {
+            // Listed an 'unavailable' in the documentation, but seen in
+            // the wild. Indicates the monitored directory has been deleted.
+            return Optional.of(StandardWatchEventKinds.ENTRY_DELETE);
+        } else {
+            return Optional.of(AixWatchService.POLL_ERROR);
+        }
+    }
+
+    static final int RC_LOWER = 1000;
+    static final int RC_UPPER = 1007;
+    static final int RC_PRE_LENGTH = "RC_FROM_EVPROD=".length();
+
+    private Optional<WatchEvent.Kind<?>> parseSubKeyEventKind(String line)
+    {
+        if (line.startsWith("RC_FROM_EVPROD=")) {
+            // Files watched by the modFile event producer may generate
+            // an event when they are:
+            // - Written to
+            // - Mapped for writing by a process
+            // - Cleared (by fclear)
+            // - Truncated (by ftrunc)
+            //
+            // The actual event code is umimportant as long as the value is
+            // in the expected range since the above events become ENTRY_MODIFY
+            // in the context of the WatchService API.
+            int code = Integer.parseInt(line.substring(RC_PRE_LENGTH));
+            if (code >= RC_LOWER && code <= RC_UPPER) {
+                return Optional.of(StandardWatchEventKinds.ENTRY_MODIFY);
+            }
+        }
+        return Optional.of(AixWatchService.POLL_ERROR);
+    }
+
+    private Iterable<String> getLines(long cBuffer)
+    {
+        ArrayList<String> lines = new ArrayList<String>();
+
+        int start = 0;
+        int pos = start;
+        boolean atEnd = false;
+        while(!atEnd) {
+            byte b = UNSAFE.getByte(cBuffer + pos);
+
+            // Detect end of c-string
+            atEnd |= (b == 0);
+
+            // Process new line
+            if (b == '\n' || b == 0) {
+                byte[] bytes = new byte[pos - start];
+
+                for (int c = 0; c < pos - start; c++) {
+                    bytes[c] = UNSAFE.getByte(cBuffer + start + c);
+                }
+
+                String line = new String(bytes);
+                lines.add(line);
+
+                start = pos + 1;
+                pos = start;
+            }
+            // O.W. Advance cursor until line is complete
+            else {
+                pos++;
+                atEnd |= (pos >= EVENT_BUFFER_SIZE);
+            }
+        }
+        return lines;
+    }
+
+    private Iterable<AixWatchService.PollEvent> parsePollEvents(long eventBuffer, int expCount)
+    {
+        ArrayList<AixWatchService.PollEvent> events = new ArrayList<>();
+
+        if (expCount <= 0)
+            return events;
+
+        Optional<AixWatchKey> mKey = Optional.empty();
+        Optional<WatchEvent.Kind<?>> mKind = Optional.empty();
+        Optional<String> mFilename = Optional.empty();
+
+        Iterator<String> lines = getLines(eventBuffer).iterator();
+        while (lines.hasNext()) {
+            String line = lines.next();
+            // Start parsing event.
+            if (line.startsWith("BEGIN_WD")) {
+                int wd = parseWd(line);
+                mKey = Optional.ofNullable(wdToKey.get(wd));
+            }
+            // Detect buffer overflow
+            else if (line.equals("BUF_WRAP")) {
+                mKind = Optional.of(StandardWatchEventKinds.OVERFLOW);
+            }
+            // Parse return code
+            else if (mKey.isPresent() && line.startsWith("RC_FROM_EVPROD")) {
+                mKind = parseEventKind(line, mKey.get());
+            }
+            // Parse additional info from event producer
+            else if (line.startsWith("BEGIN_EVPROD_INFO") && lines.hasNext()) {
+                // Expect exactly:                     // BEGIN_EVPROD_INFO
+                mFilename = Optional.of(lines.next()); // <filename>
+                if (lines.hasNext()) lines.next();     // END_EVPROD_INFO
+            }
+            // Finish parsing event.
+            else if (line.startsWith("END_WD")) {
+                if (mKey.isPresent() && mKind.isPresent()) {
+                    events.add(new AixWatchService.PollEvent(mKey.get(), mKind.get(), mFilename));
+                }
+                mKey      = Optional.empty();
+                mKind     = Optional.empty();
+                mFilename = Optional.empty();
+            }
+        }
+
+        return events;
+    }
+
+    private void processPollEvent(AixWatchService.PollEvent e)
+        throws AixWatchService.FatalException
+    {
+        // Process all events via the parent event since this is the only
+        // event expected by the client.
+        AixWatchKey.TopLevelKey receiver = e.key().resolve();
+
+        // Notify client of changes.
+        if (e.key().isWatching(e.kind())) {
+            receiver.signalEvent(e.kind(),
+                                 e.mContext().isPresent() ?
+                                 Path.of(e.mContext().get()) : e.key().watchable().getFileName());
+        } else if (e.kind().equals(AixWatchService.POLL_ERROR)) {
+            implCancelKey(e.key());
+            e.key().signal();
+        }
+
+        // Clean up or create resources as required by key & event type.
+        if (e.kind() == StandardWatchEventKinds.ENTRY_CREATE &&
+            receiver.isWatching(StandardWatchEventKinds.ENTRY_MODIFY)) {
+            String context = e.mContext().get();
+            createSubKey(Path.of(receiver.watchable().toString(), context), receiver);
+        } else if (e.kind() == StandardWatchEventKinds.ENTRY_DELETE &&
+                   (e.key() instanceof AixWatchKey.SubKey)) {
+            receiver.removeSubKey(e.key());
+            implCancelKey(e.key());
+        } else if (e.kind() == StandardWatchEventKinds.ENTRY_DELETE &&
+                   (e.key() instanceof AixWatchKey.TopLevelKey)) {
+            // 'Auto-Cancel' key and SubKeys if the directory that the TopLevelKey
+            // is watching has been deleted. Detect this by checking whether the
+            // event context (filename) matches the directory of the TopLevelKey
+            if (Optional.of(e.key().watchable().getFileName().toString()).equals(e.mContext())) {
+                implCancelKey(e.key());
+            }
+        }
+    }
+
+    // Main poller loop
+    @Override
+    public void run()
+    {
+        while (!processRequests()) {
+            int evcnt = 0;
+
+            try (NativeBuffer evbuf = new NativeBuffer(EVENT_BUFFER_SIZE)) {
+                evcnt = nPoll(opaqueBuffer.address(), nfds[0], POLL_TIMEOUT, evbuf.address(), EVENT_BUFFER_SIZE);
+                for (AixWatchService.PollEvent e: parsePollEvents(evbuf.address(), evcnt)) {
+                    processPollEvent(e);
+                }
+            } catch (Throwable e) {
+                // Warn, but don't stop processing events on error. Throwing here will stop all processing for
+                // the poller.
+                System.err.println("[AixWatchService] Caught exception in poll loop: " + e);
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private static native int nPollfdSize();
+
+    private static native void nInit(long buffer, int buff_size, int[] nv, int socketfd);
+
+    private static native void nCloseAll(long buffer, int nfds);
+
+    private static native void nSocketpair(int[] sv) throws UnixException;
+
+    private static native int nRegisterMonitorPath(long buffer, int nxt_fd, long pathv) throws UnixException;
+
+    private static native int nCancelWatchDescriptor(long buffer, int nfds, int wd);
+
+    private static native int nPoll(long buffer, int nfds, int timeout, long evbuf, int evbuf_size) throws UnixException;
+
+    static {
+        jdk.internal.loader.BootLoader.loadLibrary("nio");
+    }
+}

--- a/src/java.base/aix/classes/sun/nio/fs/AixFileSystem.java
+++ b/src/java.base/aix/classes/sun/nio/fs/AixFileSystem.java
@@ -46,7 +46,7 @@ class AixFileSystem extends UnixFileSystem {
     public WatchService newWatchService()
         throws IOException
     {
-        return new PollingWatchService();
+        return new AixWatchService();
     }
 
     // lazy initialization of the list of supported attribute views

--- a/src/java.base/aix/classes/sun/nio/fs/AixWatchKey.java
+++ b/src/java.base/aix/classes/sun/nio/fs/AixWatchKey.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, IBM Corp.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.nio.fs;
+
+import java.nio.file.*;
+import java.util.*;
+import java.io.IOException;
+
+import static sun.nio.fs.UnixConstants.*;
+
+/**
+ * AIX WatchKey Implementation
+ */
+public abstract class AixWatchKey extends AbstractWatchKey
+{
+    public static final int INVALID_WATCH_DESCRIPTOR = -1;
+
+    protected int watchDescriptor;
+
+    AixWatchKey(Path p, AbstractWatchService ws) { super(p, ws); }
+
+    public static class TopLevelKey extends AixWatchKey
+    {
+        private Set<AixWatchKey.SubKey> subKeys;
+        private Set<WatchEvent.Kind<?>> watchEventKinds;
+
+        /**
+         * TopLevelKeys may contain SubKeys
+         */
+        public TopLevelKey(Path topLevelPath, int watchDescriptor, Set<? extends WatchEvent.Kind<?>> events, AixWatchService ws)
+        {
+            super(topLevelPath, ws);
+            this.watchDescriptor = watchDescriptor;
+            this.watchEventKinds = new HashSet<>(events);
+            this.subKeys = new HashSet<>();
+        }
+
+        public void replaceEvents(Set<? extends WatchEvent.Kind<?>> events)
+        {
+            this.watchEventKinds = new HashSet<>(events);
+        }
+
+        public Iterable<AixWatchKey.SubKey> subKeys()
+        {
+            return Set.copyOf(subKeys);
+        }
+
+        protected void addSubKeys(HashSet<AixWatchKey.SubKey> subKeys)
+        {
+            this.subKeys.addAll(subKeys);
+        }
+
+        protected void removeSubKey(AixWatchKey key)
+        {
+            subKeys.remove(key);
+        }
+
+        @Override
+        protected TopLevelKey resolve()
+        {
+            return this;
+        }
+
+        @Override
+        public boolean isWatching(WatchEvent.Kind<?> kind)
+        {
+            return this.watchEventKinds.contains(kind) ||
+                StandardWatchEventKinds.OVERFLOW.equals(kind);
+        }
+    }
+
+    public static class SubKey extends AixWatchKey
+    {
+        private TopLevelKey topLevelKey;
+
+        public SubKey(Path subKeyPath, int watchDescriptor, TopLevelKey topLevelKey)
+        {
+            super(subKeyPath, topLevelKey.watcher());
+            this.watchDescriptor = watchDescriptor;
+            this.topLevelKey = topLevelKey;
+        }
+
+        @Override
+        public TopLevelKey resolve()
+        {
+            return this.topLevelKey;
+        }
+
+        @Override
+        public boolean isWatching(WatchEvent.Kind<?> kind)
+        {
+            return topLevelKey.isWatching(kind);
+        }
+    }
+
+    protected abstract TopLevelKey resolve();
+
+    public abstract boolean isWatching(WatchEvent.Kind<?> kind);
+
+    public int watchDescriptor() { return Math.abs(this.watchDescriptor); }
+
+    @Override
+    public boolean isValid()
+    {
+        return this.watchDescriptor > 0;
+    }
+
+    public void invalidate()
+    {
+        this.watchDescriptor = -this.watchDescriptor;
+    }
+
+    @Override
+    public void cancel()
+    {
+        if (isValid()) {
+            ((AixWatchService)watcher()).poller.cancel(this);
+            invalidate();
+        }
+    }
+
+
+}

--- a/src/java.base/aix/classes/sun/nio/fs/AixWatchService.java
+++ b/src/java.base/aix/classes/sun/nio/fs/AixWatchService.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, IBM Corp.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.nio.fs;
+
+import java.nio.file.*;
+import java.util.*;
+import java.io.IOException;
+import jdk.internal.misc.Unsafe;
+
+import static sun.nio.fs.UnixNativeDispatcher.*;
+import static sun.nio.fs.UnixConstants.*;
+
+/**
+ * AIX WatchService Implementation
+ */
+public class AixWatchService extends AbstractWatchService
+{
+    private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+    Map<Path,AixWatchKey> registeredKeys;
+    AhafsPoller poller;
+
+    public static record PollEvent(AixWatchKey key, WatchEvent.Kind<?> kind, Optional<String> mContext) {}
+    public static final WatchEvent.Kind<Path> POLL_ERROR = new WatchEvent.Kind<>() {
+        @Override public String name() { return "POLL_ERROR"; }
+        @Override public Class<Path> type() { return Path.class; }
+        @Override public String toString() { return this.name(); }
+    };
+
+    public static class FatalException extends Exception
+    {
+        private static final long serialVersionUID = 1L;
+        FatalException(String msg) { super(msg); }
+        FatalException(String msg, Throwable e) { super(msg, e); }
+    }
+
+    public AixWatchService()
+        throws IOException
+    {
+        super();
+        this.registeredKeys = new HashMap<>();
+        try {
+            this.poller = new AhafsPoller(this);
+            this.poller.start();
+        } catch (FatalException e) {
+            // Re-Throw as IOE so the exception conforms to the expected type
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    WatchKey register(Path dir,
+                      WatchEvent.Kind<?>[] events,
+                      WatchEvent.Modifier... modifiers)
+         throws IOException
+    {
+        // If path is already registered with this WatchService, re-register existing key.
+        if (registeredKeys.containsKey(dir)) {
+            AixWatchKey existingKey = registeredKeys.get(dir);
+            if (existingKey.isValid()) {
+                try {
+                    return poller.reRegister(existingKey,
+                                             new HashSet<>(Arrays.asList(events)),
+                                             modifiers);
+                } catch (AixWatchService.FatalException e) {
+                    throw new IOException(e);
+                }
+            } else {
+                registeredKeys.remove(existingKey);
+            }
+        }
+
+        // O.W. create and register new key
+        AixWatchKey key = (AixWatchKey)poller.register(dir, events, modifiers);
+        registeredKeys.put(dir, key);
+        return key;
+    }
+
+    @Override
+    void implClose() throws IOException
+    { poller.close(); }
+
+ }

--- a/src/java.base/aix/native/libnio/fs/AhafsPoller.c
+++ b/src/java.base/aix/native/libnio/fs/AhafsPoller.c
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, IBM Corp.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "jni.h"
+#include "jni_util.h"
+#include "jvm.h"
+#include "jlong.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <poll.h>
+#include <string.h>
+#include <sys/ahafs_evProds.h>
+
+#include "sun_nio_fs_AhafsPoller.h"
+
+#define INVALID_WD -1
+#define EVENT_BUFFER_SIZE 2048 // Change in sync with below 'BUF_SIZE' parameter
+#define AHA_INIT_STR "CHANGED=YES WAIT_TYPE=WAIT_IN_SELECT BUF_SIZE=2048"
+#define SIZEOF_AHA_INIT_STR sizeof(AHA_INIT_STR)
+
+static void throwUnixException(JNIEnv* env, int errnum) {
+    jobject x = JNU_NewObjectByName(env, "sun/nio/fs/UnixException",
+        "(I)V", errnum);
+    if (x != NULL) {
+        (*env)->Throw(env, x);
+    }
+}
+
+JNIEXPORT jint JNICALL
+Java_sun_nio_fs_AhafsPoller_nPollfdSize(JNIEnv *env, jclass clazz)
+{
+    return (jint)sizeof(struct pollfd);
+}
+
+JNIEXPORT void JNICALL
+Java_sun_nio_fs_AhafsPoller_nInit(JNIEnv* env, jclass clazz, jlong buf, jint buf_size, jintArray nv, jint socketfd)
+{
+    struct pollfd* fds = (struct pollfd*)jlong_to_ptr(buf);
+
+    memset(fds, 0, buf_size);
+    fds[0].fd = (int)socketfd;
+    fds[0].events = POLLIN;
+
+    int nfds[] = { 1 };
+
+    (*env)->SetIntArrayRegion(env, nv, 0, 1, &nfds[0]);
+}
+
+JNIEXPORT void JNICALL
+Java_sun_nio_fs_AhafsPoller_nCloseAll(JNIEnv* env, jclass clazz, jlong buf, jint nfds)
+{
+    struct pollfd* fds = (struct pollfd*)jlong_to_ptr(buf);
+
+    // First fd is assumed to be the socketpair, which will be cancelled
+    // in Java. Skip it here.
+    for (struct pollfd* pfd = fds+1; pfd <= fds + nfds; pfd++) {
+        close(pfd->fd);
+        pfd->events  = 0;
+        pfd->revents = 0;
+        pfd->fd = INVALID_WD;
+    }
+}
+
+JNIEXPORT void JNICALL
+Java_sun_nio_fs_AhafsPoller_nSocketpair
+    (JNIEnv* env, jclass clazz, jintArray sv)
+{
+    int sp[2];
+    if (socketpair(PF_UNIX, SOCK_STREAM, 0, sp) == -1) {
+        perror("Socketpair error");
+        throwUnixException(env, errno);
+    } else {
+        jint res[2];
+        res[0] = (jint)sp[0];
+        res[1] = (jint)sp[1];
+        (*env)->SetIntArrayRegion(env, sv, 0, 2, &res[0]);
+    }
+}
+
+JNIEXPORT jint JNICALL
+Java_sun_nio_fs_AhafsPoller_nRegisterMonitorPath
+    (JNIEnv* env, jclass clazz, jlong buf, jint nxt_fd, jlong pathv)
+{
+    struct pollfd* fds = (struct pollfd*)jlong_to_ptr(buf);
+    char* path = (char*)jlong_to_ptr(pathv);
+
+    int fd = open(path, O_CREAT | O_RDWR);
+    if (fd < 0) {
+        fprintf(stderr,"[nRegisterMonitorPath] Fd invalid (%d) while opening %s\n", fd, path);
+        perror("Open error");
+        throwUnixException(env, errno);
+        return INVALID_WD;
+    }
+    // Write AIX Event Infrastructure monitor args
+    int wlen = write(fd, AHA_INIT_STR, SIZEOF_AHA_INIT_STR);
+    if (wlen <= 0) {
+        perror("Write error");
+        throwUnixException(env, errno);
+        return INVALID_WD;
+    }
+
+    fds[nxt_fd].fd = fd;
+    fds[nxt_fd].events = POLLIN; // TODO: Are other event types important?
+
+    return (jint)fd;
+}
+
+JNIEXPORT jint JNICALL
+Java_sun_nio_fs_AhafsPoller_nCancelWatchDescriptor
+    (JNIEnv* env, jclass clazz, jlong buf, jint nfds, jint wd)
+{
+    struct pollfd* fds = (struct pollfd*)jlong_to_ptr(buf);
+
+    for (struct pollfd* pfd = fds; pfd != fds + nfds; pfd += 1) {
+        if (pfd->fd == wd) {
+            if (close(pfd->fd) != 0) {
+                perror("Close error");
+                fprintf(stderr,"[nCancelWatchDescriptor] Close returned error while closing %d\n", wd);
+                throwUnixException(env, errno);
+                break;
+            }
+            pfd->fd = INVALID_WD;
+            pfd->events  = 0;
+            pfd->revents = 0;
+            return wd;
+        }
+    }
+
+    return (jint)INVALID_WD;
+}
+
+JNIEXPORT jint JNICALL
+Java_sun_nio_fs_AhafsPoller_nPoll
+    (JNIEnv* env, jclass clazz, jlong fdsv, jint nfds, jint timeout, jlong evbufv, jint evbuf_size)
+{
+    char tmpbuf[evbuf_size];
+    int evcnt;
+    struct pollfd* fds = (struct pollfd*)jlong_to_ptr(fdsv);
+    char*        evbuf = (char*)jlong_to_ptr(evbufv);
+
+    // Poll for changes
+    if ((evcnt = poll(fds, nfds, timeout)) < 0) {
+        perror("Poll error");
+        throwUnixException(env, errno);
+        return (jint) evcnt;
+    }
+
+    // The first fd in fds is assumed to be the socketpair. Detect
+    // when the event count has included a wakeup event and remove it here.
+    if (fds->revents != 0) {
+        fds->revents = 0;
+        evcnt--;
+    }
+
+    // Iterate over fds (skipping the socketpair)
+    for (struct pollfd* pfd = fds+1; pfd != fds + nfds; pfd += 1) {
+        if (pfd->revents & POLLIN) {
+            int rlen;
+            if ((rlen = read(pfd->fd, tmpbuf, evbuf_size)) >= 0) {
+                tmpbuf[rlen] = (char)NULL;
+                // Wrap and write event data to provided buffer
+                sprintf(evbuf, "BEGIN_WD=%d\n%sEND_WD=%d\n", pfd->fd, tmpbuf, pfd->fd);
+            } else {
+                perror("Read error");
+                fprintf(stderr,"[nPoll] Read returned error while reading fd: %d. Got %s\n", pfd->fd, tmpbuf);
+                throwUnixException(env, errno);
+                break;
+            }
+
+            // strip revent data to prevent re-read of an old update.
+            pfd->revents = 0;
+        }
+    }
+
+    return (jint) evcnt;
+}

--- a/test/jdk/java/nio/file/WatchService/Basic.java
+++ b/test/jdk/java/nio/file/WatchService/Basic.java
@@ -68,15 +68,10 @@ public class Basic {
         WatchEvent<?> event = events.iterator().next();
         System.out.format("got event: type=%s, count=%d, context=%s\n",
             event.kind(), event.count(), event.context());
-        if (event.kind() != expectedKind) {
-            throw new RuntimeException("unexpected event: " + event.kind() +
-                                       " (expected: " + expectedKind + ")");
-        }
-        if (!expectedContext.equals(event.context())) {
-            System.out.format("context: %s (%s) | expected: %s (%s)", event.context(), event.context().getClass(), expectedContext, expectedContext.getClass());
-            throw new RuntimeException("unexpected context: " + event.context() +
-                                       " (expected: " + expectedContext + ")");
-        }
+        if (event.kind() != expectedKind)
+            throw new RuntimeException("unexpected event");
+        if (!expectedContext.equals(event.context()))
+            throw new RuntimeException("unexpected context");
     }
 
     /**
@@ -130,7 +125,7 @@ public class Basic {
 
             System.out.println("reset key");
             if (!myKey.reset())
-                throw new RuntimeException("key has been cancelled");
+                throw new RuntimeException("key has been cancalled");
 
             System.out.println("OKAY");
 

--- a/test/jdk/java/nio/file/WatchService/Basic.java
+++ b/test/jdk/java/nio/file/WatchService/Basic.java
@@ -68,10 +68,15 @@ public class Basic {
         WatchEvent<?> event = events.iterator().next();
         System.out.format("got event: type=%s, count=%d, context=%s\n",
             event.kind(), event.count(), event.context());
-        if (event.kind() != expectedKind)
-            throw new RuntimeException("unexpected event");
-        if (!expectedContext.equals(event.context()))
-            throw new RuntimeException("unexpected context");
+        if (event.kind() != expectedKind) {
+            throw new RuntimeException("unexpected event: " + event.kind() +
+                                       " (expected: " + expectedKind + ")");
+        }
+        if (!expectedContext.equals(event.context())) {
+            System.out.format("context: %s (%s) | expected: %s (%s)", event.context(), event.context().getClass(), expectedContext, expectedContext.getClass());
+            throw new RuntimeException("unexpected context: " + event.context() +
+                                       " (expected: " + expectedContext + ")");
+        }
     }
 
     /**
@@ -125,7 +130,7 @@ public class Basic {
 
             System.out.println("reset key");
             if (!myKey.reset())
-                throw new RuntimeException("key has been cancalled");
+                throw new RuntimeException("key has been cancelled");
 
             System.out.println("OKAY");
 


### PR DESCRIPTION
This PR begins an effort to re-implement the WatchService API on AIX using 'AIX Event Infrastructure' (AHAFS). The initial motivation for doing so was to address errors found by some internal testing in the implementation based on PollingWatchService.java.

I am submitting these changes before they are fully complete because (1) it represents a fairly large change that mostly works well, and could easily be improved upon in the future; (2) to get some early feedback on the changes so the final review process is quicker. My expected plan is to merge these changes after review, add any remaining test failures to a problem list, and return to them soon.

### Testing
I am waiting for confirmation that this re-implementation passes the internal tests we saw failing. Initial results look promising. In addition, I see the following failing tests from `test/jdk/java/nio/file/WatchService`:

- Basic.java fails at testTwoWatchers. Having two WatchService instances registered with the same file, will require some additional work to be supported with AHAFS. This is currently a limitation of this implementation.
- DeleteInterference.java fails for the same reason as above.
- UpdateInterference.java fails for no good reason that I can deduce. Logging the test's progress shows that it doesn't seem to leave [the main loop](https://github.com/openjdk/jdk/blob/master/test/jdk/java/nio/file/WatchService/UpdateInterference.java#L97-L111), but that it makes is to within 1ms of doing so.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288627](https://bugs.openjdk.org/browse/JDK-8288627): [AIX] Implement WatchService using system library


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9281/head:pull/9281` \
`$ git checkout pull/9281`

Update a local copy of the PR: \
`$ git checkout pull/9281` \
`$ git pull https://git.openjdk.org/jdk pull/9281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9281`

View PR using the GUI difftool: \
`$ git pr show -t 9281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9281.diff">https://git.openjdk.org/jdk/pull/9281.diff</a>

</details>
