### PR TITLE
8289274: Cleanup unnecessary null comparison before instanceof check in security modules

### DIFF
--- a/src/java.base/macosx/classes/apple/security/KeychainStore.java
+++ b/src/java.base/macosx/classes/apple/security/KeychainStore.java
@@ -183,12 +183,12 @@ public final class KeychainStore extends KeyStoreSpi {
 
         Object entry = entries.get(alias.toLowerCase());
 
-        if (entry == null || !(entry instanceof KeyEntry)) {
+        if (!(entry instanceof KeyEntry keyEntry)) {
             return null;
         }
 
         // This call gives us a PKCS12 bag, with the key inside it.
-        byte[] exportedKeyInfo = _getEncodedKeyData(((KeyEntry)entry).keyRef, password);
+        byte[] exportedKeyInfo = _getEncodedKeyData(keyEntry.keyRef, password);
         if (exportedKeyInfo == null) {
             return null;
         }
@@ -273,11 +273,11 @@ public final class KeychainStore extends KeyStoreSpi {
 
         Object entry = entries.get(alias.toLowerCase());
 
-        if (entry != null && entry instanceof KeyEntry) {
-            if (((KeyEntry)entry).chain == null) {
+        if (entry instanceof KeyEntry keyEntry) {
+            if (keyEntry.chain == null) {
                 return null;
             } else {
-                return ((KeyEntry)entry).chain.clone();
+                return keyEntry.chain.clone();
             }
         } else {
             return null;
@@ -569,11 +569,7 @@ public final class KeychainStore extends KeyStoreSpi {
     public boolean engineIsKeyEntry(String alias) {
         permissionCheck();
         Object entry = entries.get(alias.toLowerCase());
-        if ((entry != null) && (entry instanceof KeyEntry)) {
-            return true;
-        } else {
-            return false;
-        }
+        return entry instanceof KeyEntry;
     }
 
     /**
@@ -586,11 +582,7 @@ public final class KeychainStore extends KeyStoreSpi {
     public boolean engineIsCertificateEntry(String alias) {
         permissionCheck();
         Object entry = entries.get(alias.toLowerCase());
-        if ((entry != null) && (entry instanceof TrustedCertEntry)) {
-            return true;
-        } else {
-            return false;
-        }
+        return entry instanceof TrustedCertEntry;
     }
 
     /**

--- a/src/java.base/share/classes/com/sun/crypto/provider/RC2Cipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/RC2Cipher.java
@@ -86,9 +86,8 @@ public sealed class RC2Cipher extends CipherSpi
     protected void engineInit(int opmode, Key key,
             AlgorithmParameterSpec params, SecureRandom random)
             throws InvalidKeyException, InvalidAlgorithmParameterException {
-        if (params != null && params instanceof RC2ParameterSpec) {
-            embeddedCipher.initEffectiveKeyBits
-                (((RC2ParameterSpec)params).getEffectiveKeyBits());
+        if (params instanceof RC2ParameterSpec rc2Spec) {
+            embeddedCipher.initEffectiveKeyBits(rc2Spec.getEffectiveKeyBits());
         } else {
             embeddedCipher.initEffectiveKeyBits(0);
         }

--- a/src/java.base/share/classes/javax/security/auth/PrivateCredentialPermission.java
+++ b/src/java.base/share/classes/javax/security/auth/PrivateCredentialPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -241,11 +241,8 @@ public final class PrivateCredentialPermission extends Permission {
      * the specified {@code Permission}, false if not.
      */
     public boolean implies(Permission p) {
-
-        if (p == null || !(p instanceof PrivateCredentialPermission))
+        if (!(p instanceof PrivateCredentialPermission that))
             return false;
-
-        PrivateCredentialPermission that = (PrivateCredentialPermission)p;
 
         if (!impliesCredentialClass(credentialClass, that.credentialClass))
             return false;
@@ -524,10 +521,8 @@ public final class PrivateCredentialPermission extends Permission {
         }
 
         public boolean implies(Object obj) {
-            if (obj == null || !(obj instanceof CredOwner))
+            if (!(obj instanceof CredOwner that))
                 return false;
-
-            CredOwner that = (CredOwner)obj;
 
             if (principalClass.equals("*") ||
                 principalClass.equals(that.principalClass)) {

--- a/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
+++ b/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
@@ -300,7 +300,7 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
         Entry entry = entries.get(alias.toLowerCase(Locale.ENGLISH));
         Key key = null;
 
-        if (entry == null || (!(entry instanceof KeyEntry))) {
+        if (!(entry instanceof KeyEntry)) {
             return null;
         }
 
@@ -471,18 +471,18 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
      */
     public Certificate[] engineGetCertificateChain(String alias) {
         Entry entry = entries.get(alias.toLowerCase(Locale.ENGLISH));
-        if (entry != null && entry instanceof PrivateKeyEntry) {
-            if (((PrivateKeyEntry) entry).chain == null) {
+        if (entry instanceof PrivateKeyEntry privateKeyEntry) {
+            if (privateKeyEntry.chain == null) {
                 return null;
             } else {
 
                 if (debug != null) {
                     debug.println("Retrieved a " +
-                        ((PrivateKeyEntry) entry).chain.length +
+                        privateKeyEntry.chain.length +
                         "-certificate chain at alias '" + alias + "'");
                 }
 
-                return ((PrivateKeyEntry) entry).chain.clone();
+                return privateKeyEntry.chain.clone();
             }
         } else {
             return null;
@@ -1012,7 +1012,7 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
         }
 
         Entry entry = entries.get(alias.toLowerCase(Locale.ENGLISH));
-        if (entry != null && entry instanceof KeyEntry) {
+        if (entry instanceof KeyEntry) {
             throw new KeyStoreException("Cannot overwrite own certificate");
         }
 
@@ -1095,11 +1095,7 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
      */
     public boolean engineIsKeyEntry(String alias) {
         Entry entry = entries.get(alias.toLowerCase(Locale.ENGLISH));
-        if (entry != null && entry instanceof KeyEntry) {
-            return true;
-        } else {
-            return false;
-        }
+        return entry instanceof KeyEntry;
     }
 
     /**
@@ -1111,8 +1107,8 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
      */
     public boolean engineIsCertificateEntry(String alias) {
         Entry entry = entries.get(alias.toLowerCase(Locale.ENGLISH));
-        if (entry != null && entry instanceof CertEntry &&
-            ((CertEntry) entry).trustedKeyUsage != null) {
+        if (entry instanceof CertEntry certEntry &&
+                certEntry.trustedKeyUsage != null) {
             return true;
         } else {
             return false;
@@ -1144,10 +1140,10 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
 
         Entry entry = entries.get(alias.toLowerCase(Locale.ENGLISH));
         if (entryClass == KeyStore.PrivateKeyEntry.class) {
-            return (entry != null && entry instanceof PrivateKeyEntry);
+            return (entry instanceof PrivateKeyEntry);
         }
         if (entryClass == KeyStore.SecretKeyEntry.class) {
-            return (entry != null && entry instanceof SecretKeyEntry);
+            return (entry instanceof SecretKeyEntry);
         }
         return false;
     }
@@ -1827,11 +1823,10 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
 
             String alias = e.nextElement();
             Entry entry = entries.get(alias);
-            if (entry == null || (!(entry instanceof KeyEntry))) {
+            if (!(entry instanceof KeyEntry keyEntry)) {
                 continue;
             }
             DerOutputStream safeBag = new DerOutputStream();
-            KeyEntry keyEntry = (KeyEntry) entry;
 
             // DER encode the private key
             if (keyEntry instanceof PrivateKeyEntry) {

--- a/src/java.base/share/classes/sun/security/provider/JavaKeyStore.java
+++ b/src/java.base/share/classes/sun/security/provider/JavaKeyStore.java
@@ -146,7 +146,7 @@ public abstract sealed class JavaKeyStore extends KeyStoreSpi {
     {
         Object entry = entries.get(convertAlias(alias));
 
-        if (entry == null || !(entry instanceof KeyEntry)) {
+        if (!(entry instanceof KeyEntry keyEntry)) {
             return null;
         }
         if (password == null) {
@@ -155,7 +155,7 @@ public abstract sealed class JavaKeyStore extends KeyStoreSpi {
 
         byte[] passwordBytes = convertToBytes(password);
         KeyProtector keyProtector = new KeyProtector(passwordBytes);
-        byte[] encrBytes = ((KeyEntry)entry).protectedPrivKey;
+        byte[] encrBytes = keyEntry.protectedPrivKey;
         EncryptedPrivateKeyInfo encrInfo;
         try {
             encrInfo = new EncryptedPrivateKeyInfo(encrBytes);
@@ -183,11 +183,11 @@ public abstract sealed class JavaKeyStore extends KeyStoreSpi {
     public Certificate[] engineGetCertificateChain(String alias) {
         Object entry = entries.get(convertAlias(alias));
 
-        if (entry != null && entry instanceof KeyEntry) {
-            if (((KeyEntry)entry).chain == null) {
+        if (entry instanceof KeyEntry keyEntry) {
+            if (keyEntry.chain == null) {
                 return null;
             } else {
-                return ((KeyEntry)entry).chain.clone();
+                return keyEntry.chain.clone();
             }
         } else {
             return null;
@@ -384,7 +384,7 @@ public abstract sealed class JavaKeyStore extends KeyStoreSpi {
         synchronized(entries) {
 
             Object entry = entries.get(convertAlias(alias));
-            if ((entry != null) && (entry instanceof KeyEntry)) {
+            if (entry instanceof KeyEntry) {
                 throw new KeyStoreException
                     ("Cannot overwrite own certificate");
             }
@@ -449,11 +449,7 @@ public abstract sealed class JavaKeyStore extends KeyStoreSpi {
      */
     public boolean engineIsKeyEntry(String alias) {
         Object entry = entries.get(convertAlias(alias));
-        if ((entry != null) && (entry instanceof KeyEntry)) {
-            return true;
-        } else {
-            return false;
-        }
+        return entry instanceof KeyEntry;
     }
 
     /**
@@ -465,11 +461,7 @@ public abstract sealed class JavaKeyStore extends KeyStoreSpi {
      */
     public boolean engineIsCertificateEntry(String alias) {
         Object entry = entries.get(convertAlias(alias));
-        if ((entry != null) && (entry instanceof TrustedCertEntry)) {
-            return true;
-        } else {
-            return false;
-        }
+        return entry instanceof TrustedCertEntry;
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/provider/PolicyFile.java
+++ b/src/java.base/share/classes/sun/security/provider/PolicyFile.java
@@ -1819,7 +1819,7 @@ public class PolicyFile extends java.security.Policy {
             return null;
         }
 
-        if (cert == null || !(cert instanceof X509Certificate)) {
+        if (!(cert instanceof X509Certificate x509Cert)) {
             if (debug != null) {
                 debug.println("  -- No certificate for '" +
                                 alias +
@@ -1827,8 +1827,6 @@ public class PolicyFile extends java.security.Policy {
             }
             return null;
         } else {
-            X509Certificate x509Cert = (X509Certificate)cert;
-
             // 4702543:  X500 names with an EmailAddress
             // were encoded incorrectly.  create new
             // X500Principal name with correct encoding

--- a/src/java.base/share/classes/sun/security/provider/SubjectCodeSource.java
+++ b/src/java.base/share/classes/sun/security/provider/SubjectCodeSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -164,16 +164,13 @@ class SubjectCodeSource extends CodeSource implements java.io.Serializable {
 
         LinkedList<PrincipalEntry> subjectList = null;
 
-        if (codesource == null ||
-            !(codesource instanceof SubjectCodeSource) ||
-            !(super.implies(codesource))) {
+        if (!(codesource instanceof SubjectCodeSource that) ||
+                !super.implies(codesource)) {
 
             if (debug != null)
                 debug.println("\tSubjectCodeSource.implies: FAILURE 1");
             return false;
         }
-
-        SubjectCodeSource that = (SubjectCodeSource)codesource;
 
         // if the principal list in the policy "implies"
         // the Subject associated with the current AccessControlContext,

--- a/src/java.base/share/classes/sun/security/provider/certpath/CertId.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/CertId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -202,11 +202,10 @@ public class CertId {
         if (this == other) {
             return true;
         }
-        if (other == null || (!(other instanceof CertId))) {
+        if (!(other instanceof CertId that)) {
             return false;
         }
 
-        CertId that = (CertId) other;
         if (hashAlgId.equals(that.getHashAlgorithm()) &&
             Arrays.equals(issuerNameHash, that.getIssuerNameHash()) &&
             Arrays.equals(issuerKeyHash, that.getIssuerKeyHash()) &&

--- a/src/java.base/share/classes/sun/security/provider/certpath/RevocationChecker.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/RevocationChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -488,10 +488,10 @@ class RevocationChecker extends PKIXRevocationChecker {
                 }
                 break;
             case "SSLServer":
-                result = (t != null && t instanceof IOException);
+                result = (t instanceof IOException);
                 break;
             case "URI":
-                result = (t != null && t instanceof IOException);
+                result = (t instanceof IOException);
                 break;
             default:
                 // we don't know about any other remote CertStore types

--- a/src/java.base/share/classes/sun/security/util/BitArray.java
+++ b/src/java.base/share/classes/sun/security/util/BitArray.java
@@ -170,9 +170,7 @@ public class BitArray {
 
     public boolean equals(Object obj) {
         if (obj == this) return true;
-        if (obj == null || !(obj instanceof BitArray)) return false;
-
-        BitArray ba = (BitArray) obj;
+        if (!(obj instanceof BitArray ba)) return false;
 
         if (ba.length != length) return false;
 

--- a/src/java.base/share/classes/sun/security/x509/AccessDescription.java
+++ b/src/java.base/share/classes/sun/security/x509/AccessDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,10 +87,9 @@ public final class AccessDescription {
     }
 
     public boolean equals(Object obj) {
-        if (obj == null || (!(obj instanceof AccessDescription))) {
+        if (!(obj instanceof AccessDescription that)) {
             return false;
         }
-        AccessDescription that = (AccessDescription)obj;
 
         if (this == that) {
             return true;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java
@@ -903,9 +903,8 @@ final class P11KeyStore extends KeyStoreSpi {
 
         token.ensureValid();
 
-        if (protParam != null &&
-            protParam instanceof KeyStore.PasswordProtection &&
-            ((KeyStore.PasswordProtection)protParam).getPassword() != null &&
+        if (protParam instanceof PasswordProtection pp &&
+            pp.getPassword() != null &&
             !token.config.getKeyStoreCompatibilityMode()) {
             throw new KeyStoreException("ProtectionParameter must be null");
         }
@@ -1006,9 +1005,8 @@ final class P11KeyStore extends KeyStoreSpi {
         token.ensureValid();
         checkWrite();
 
-        if (protParam != null &&
-            protParam instanceof KeyStore.PasswordProtection &&
-            ((KeyStore.PasswordProtection)protParam).getPassword() != null &&
+        if (protParam instanceof PasswordProtection pp &&
+            pp.getPassword() != null &&
             !token.config.getKeyStoreCompatibilityMode()) {
             throw new KeyStoreException(new UnsupportedOperationException
                                 ("ProtectionParameter must be null"));

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/module/KeyStoreLoginModule.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/module/KeyStoreLoginModule.java
@@ -662,16 +662,14 @@ public class KeyStoreLoginModule implements LoginModule {
             principal = certificate.getSubjectX500Principal();
 
             // if token, privateKeyPassword will be null
-            Key privateKey = keyStore.getKey(keyStoreAlias, privateKeyPassword);
-            if (privateKey == null
-                || !(privateKey instanceof PrivateKey))
-            {
+            Key key = keyStore.getKey(keyStoreAlias, privateKeyPassword);
+            if (!(key instanceof PrivateKey privateKey)) {
                 throw new FailedLoginException(
                     "Unable to recover key from keystore");
             }
 
             privateCredential = new X500PrivateCredential(
-                certificate, (PrivateKey) privateKey, keyStoreAlias);
+                certificate, privateKey, keyStoreAlias);
         } catch (KeyStoreException | NoSuchAlgorithmException e) {
             LoginException le = new LoginException("Error using keystore");
             le.initCause(e);

--- a/src/jdk.security.jgss/share/classes/com/sun/security/sasl/gsskerb/GssKrb5Client.java
+++ b/src/jdk.security.jgss/share/classes/com/sun/security/sasl/gsskerb/GssKrb5Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,8 +112,8 @@ final class GssKrb5Client extends GssKrb5Base implements SaslClient {
             GSSCredential credentials = null;
             if (props != null) {
                 Object prop = props.get(Sasl.CREDENTIALS);
-                if (prop != null && prop instanceof GSSCredential) {
-                    credentials = (GSSCredential) prop;
+                if (prop instanceof GSSCredential c) {
+                    credentials = c;
                     logger.log(Level.FINE,
                         "KRB5CLNT01:Using the credentials supplied in " +
                         "javax.security.sasl.credentials");


### PR DESCRIPTION
Update code checks both non-null and instance of a class in security classes.
The checks and explicit casts could also be replaced with pattern matching for the instanceof operator.

See similar cleanup in java.base - [JDK-8258422](https://bugs.openjdk.java.net/browse/JDK-8258422)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289274](https://bugs.openjdk.org/browse/JDK-8289274): Cleanup unnecessary null comparison before instanceof check in security modules


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9284/head:pull/9284` \
`$ git checkout pull/9284`

Update a local copy of the PR: \
`$ git checkout pull/9284` \
`$ git pull https://git.openjdk.org/jdk pull/9284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9284`

View PR using the GUI difftool: \
`$ git pr show -t 9284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9284.diff">https://git.openjdk.org/jdk/pull/9284.diff</a>

</details>
