### PR TITLE
JDK-8271252: os::reserve_memory should not use mtOther as default NMT flag

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1684,12 +1684,8 @@ bool os::create_stack_guard_pages(char* addr, size_t bytes) {
 char* os::reserve_memory(size_t bytes, bool executable, MEMFLAGS flags) {
   char* result = pd_reserve_memory(bytes, executable);
   if (result != NULL) {
-    MemTracker::record_virtual_memory_reserve(result, bytes, CALLER_PC);
-    if (flags != mtOther) {
-      MemTracker::record_virtual_memory_type(result, flags);
-    }
+    MemTracker::record_virtual_memory_reserve(result, bytes, CALLER_PC, flags);
   }
-
   return result;
 }
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -354,7 +354,7 @@ class os: AllStatic {
   static int    vm_allocation_granularity();
 
   // Reserves virtual memory.
-  static char*  reserve_memory(size_t bytes, bool executable = false, MEMFLAGS flags = mtOther);
+  static char*  reserve_memory(size_t bytes, bool executable = false, MEMFLAGS flags = mtNone);
 
   // Reserves virtual memory that starts at an address that is aligned to 'alignment'.
   static char*  reserve_memory_aligned(size_t size, size_t alignment, bool executable = false);


### PR DESCRIPTION
Small cleanup.

We use mtOther as default NMT flag for os::reserve_memory():

`static char* reserve_memory(size_t bytes, bool executable = false, MEMFLAGS flags = mtOther);`

mtOther marks allocations coming from outside the VM. It is not a good default flag. Note that in the end mtOther then was ignored in os::reserve_memory() and it defaulted to mtNone anyway.

This trivial patch straightens the logic and uses `mtNone` as default. Note that since mtOther was ignored before, there is no behavioral change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271252](https://bugs.openjdk.org/browse/JDK-8271252): os::reserve_memory should not use mtOther as default NMT flag


### Reviewers
 * @eastig (no known github.com user name / role)
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9287/head:pull/9287` \
`$ git checkout pull/9287`

Update a local copy of the PR: \
`$ git checkout pull/9287` \
`$ git pull https://git.openjdk.org/jdk pull/9287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9287`

View PR using the GUI difftool: \
`$ git pr show -t 9287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9287.diff">https://git.openjdk.org/jdk/pull/9287.diff</a>

</details>
