### PR TITLE
8289189: Configure fails on WSL1

### DIFF
--- a/make/autoconf/basic_windows.m4
+++ b/make/autoconf/basic_windows.m4
@@ -89,8 +89,8 @@ AC_DEFUN([BASIC_SETUP_PATHS_WINDOWS],
   WINENV_TEMP_DIR=$($PATHTOOL -u $($CMD /q /c echo %TEMP% 2> /dev/null) | $TR -d '\r\n')
   AC_MSG_RESULT([$WINENV_TEMP_DIR])
 
-  if test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.wsl2"; then
-    # Don't trust the current directory for WSL2, but change to an OK temp dir
+  if test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.wsl1" || test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.wsl2"; then
+    # Don't trust the current directory for WSL, but change to an OK temp dir
     cd "$WINENV_TEMP_DIR"
     # Bring along confdefs.h or autoconf gets all confused
     cp "$CONFIGURE_START_DIR/confdefs.h" "$WINENV_TEMP_DIR"
@@ -228,7 +228,7 @@ AC_DEFUN([BASIC_WINDOWS_FINALIZE_FIXPATH],
 # Platform-specific finalization
 AC_DEFUN([BASIC_WINDOWS_FINALIZE],
 [
-  if test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.wsl2"; then
+  if test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.wsl1" || test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.wsl2"; then
     # Change back from temp dir
     cd $CONFIGURE_START_DIR
   fi


### PR DESCRIPTION
Use temp directory for autoconf on both WSL1 and WSL2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289189](https://bugs.openjdk.org/browse/JDK-8289189): Configure fails on WSL1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9289/head:pull/9289` \
`$ git checkout pull/9289`

Update a local copy of the PR: \
`$ git checkout pull/9289` \
`$ git pull https://git.openjdk.org/jdk pull/9289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9289`

View PR using the GUI difftool: \
`$ git pr show -t 9289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9289.diff">https://git.openjdk.org/jdk/pull/9289.diff</a>

</details>
