### PR TITLE
8287984: AArch64: [vector] Make all bits set vector sharable for match rules

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2713,11 +2713,17 @@ bool size_fits_all_mem_uses(AddPNode* addp, int shift) {
   return true;
 }
 
-bool can_combine_with_imm(Node* binary_node, Node* replicate_node) {
-  if (UseSVE == 0 || !VectorNode::is_invariant_vector(replicate_node)){
+// Binary src (Replicate con)
+bool is_valid_sve_arith_imm_pattern(Node* n, Node* m) {
+  if (n == NULL || m == NULL) {
     return false;
   }
-  Node* imm_node = replicate_node->in(1);
+
+  if (UseSVE == 0 || !VectorNode::is_invariant_vector(m)) {
+    return false;
+  }
+
+  Node* imm_node = m->in(1);
   if (!imm_node->is_Con()) {
     return false;
   }
@@ -2727,11 +2733,11 @@ bool can_combine_with_imm(Node* binary_node, Node* replicate_node) {
     return false;
   }
 
-  switch (binary_node->Opcode()) {
+  switch (n->Opcode()) {
   case Op_AndV:
   case Op_OrV:
   case Op_XorV: {
-    Assembler::SIMD_RegVariant T = Assembler::elemType_to_regVariant(Matcher::vector_element_basic_type(binary_node));
+    Assembler::SIMD_RegVariant T = Assembler::elemType_to_regVariant(Matcher::vector_element_basic_type(n));
     uint64_t value = t->isa_long() ? (uint64_t)imm_node->get_long() : (uint64_t)imm_node->get_int();
     return Assembler::operand_valid_for_sve_logical_immediate(Assembler::regVariant_to_elemBits(T), value);
   }
@@ -2747,22 +2753,24 @@ bool can_combine_with_imm(Node* binary_node, Node* replicate_node) {
   }
 }
 
-bool is_vector_arith_imm_pattern(Node* n, Node* m) {
+// (XorV src (Replicate m1))
+// (XorVMask src (MaskAll m1))
+bool is_vector_bitwise_not_pattern(Node* n, Node* m) {
   if (n != NULL && m != NULL) {
-    return can_combine_with_imm(n, m);
+    return (n->Opcode() == Op_XorV || n->Opcode() == Op_XorVMask) &&
+           VectorNode::is_all_ones_vector(m);
   }
   return false;
 }
 
 // Should the matcher clone input 'm' of node 'n'?
 bool Matcher::pd_clone_node(Node* n, Node* m, Matcher::MStack& mstack) {
-  // ShiftV src (ShiftCntV con)
-  // Binary src (Replicate con)
-  if (is_vshift_con_pattern(n, m) || is_vector_arith_imm_pattern(n, m)) {
+  if (is_vshift_con_pattern(n, m) ||
+      is_vector_bitwise_not_pattern(n, m) ||
+      is_valid_sve_arith_imm_pattern(n, m)) {
     mstack.push(m, Visit);
     return true;
   }
-
   return false;
 }
 

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -847,6 +847,7 @@ bool VectorNode::is_all_ones_vector(Node* n) {
   case Op_ReplicateS:
   case Op_ReplicateI:
   case Op_ReplicateL:
+  case Op_MaskAll:
     return is_con_M1(n->in(1));
   default:
     return false;

--- a/test/hotspot/jtreg/compiler/vectorapi/AllBitsSetVectorMatchRuleTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/AllBitsSetVectorMatchRuleTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import compiler.lib.ir_framework.*;
+
+import java.util.Random;
+
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.LongVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+
+/**
+ * @test
+ * @bug 8287984
+ * @key randomness
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @requires vm.cpu.features ~= ".*simd.*" | vm.cpu.features ~= ".*sve.*"
+ * @summary AArch64: [vector] Make all bits set vector sharable for match rules
+ * @modules jdk.incubator.vector
+ *
+ * @run driver compiler.vectorapi.AllBitsSetVectorMatchRuleTest
+ */
+
+public class AllBitsSetVectorMatchRuleTest {
+    private static final VectorSpecies<Integer> I_SPECIES = IntVector.SPECIES_MAX;
+    private static final VectorSpecies<Long> L_SPECIES = LongVector.SPECIES_MAX;
+
+    private static int LENGTH = 128;
+    private static final Random RD = Utils.getRandomInstance();
+
+    private static int[] ia;
+    private static int[] ib;
+    private static int[] ir;
+    private static boolean[] ma;
+    private static boolean[] mb;
+    private static boolean[] mc;
+    private static boolean[] mr;
+
+    static {
+        ia = new int[LENGTH];
+        ib = new int[LENGTH];
+        ir = new int[LENGTH];
+        ma = new boolean[LENGTH];
+        mb = new boolean[LENGTH];
+        mc = new boolean[LENGTH];
+        mr = new boolean[LENGTH];
+
+        for (int i = 0; i < LENGTH; i++) {
+            ia[i] = RD.nextInt(25);
+            ib[i] = RD.nextInt(25);
+            ma[i] = RD.nextBoolean();
+            mb[i] = RD.nextBoolean();
+            mc[i] = RD.nextBoolean();
+        }
+    }
+
+    @Test
+    @Warmup(10000)
+    @IR(counts = { "bic", " >= 1" })
+    public static void testAllBitsSetVector() {
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        av.not().lanewise(VectorOperators.AND_NOT, bv).intoArray(ir, 0);
+
+        // Verify results
+        for (int i = 0; i < I_SPECIES.length(); i++) {
+            Asserts.assertEquals((~ia[i]) & (~ib[i]), ir[i]);
+        }
+    }
+
+    @Test
+    @Warmup(10000)
+    @IR(counts = { "bic", " >= 1" })
+    public static void testAllBitsSetMask() {
+        VectorMask<Long> avm = VectorMask.fromArray(L_SPECIES, ma, 0);
+        VectorMask<Long> bvm = VectorMask.fromArray(L_SPECIES, mb, 0);
+        VectorMask<Long> cvm = VectorMask.fromArray(L_SPECIES, mc, 0);
+        avm.andNot(bvm).andNot(cvm).intoArray(mr, 0);
+
+        // Verify results
+        for (int i = 0; i < L_SPECIES.length(); i++) {
+            Asserts.assertEquals((ma[i] & (!mb[i])) & (!mc[i]), mr[i]);
+        }
+    }
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("--add-modules=jdk.incubator.vector");
+    }
+}


### PR DESCRIPTION
We have the optimized rules for vector not/and_not in NEON and SVE, like:

```
 match(Set dst (XorV src (ReplicateB m1)))              ; vector not
 match(Set dst (AndV src1 (XorV src2 (ReplicateB m1)))) ; vector and_not
```

where "`m1`" is a ConI node with value -1. And we also have the similar rules for vector mask in SVE like:

```
 match(Set pd (AndVMask pn (XorVMask pm (MaskAll m1)))) ; mask and_not
```

These rules are not easy to be matched since the "`Replicate`" or "`MaskAll`" node is usually not single used for the `not/and_not` operation. To make these rules be matched as expected, this patch adds the vector (mask) "`not`" pattern to `Matcher::pd_clone_node()` which makes the all bits set vector `(Replicate/MaskAll)` sharable during matching rules.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287984](https://bugs.openjdk.org/browse/JDK-8287984): AArch64: [vector] Make all bits set vector sharable for match rules


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Nick Gasson](https://openjdk.org/census#ngasson) (@nick-arm - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9292/head:pull/9292` \
`$ git checkout pull/9292`

Update a local copy of the PR: \
`$ git checkout pull/9292` \
`$ git pull https://git.openjdk.org/jdk pull/9292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9292`

View PR using the GUI difftool: \
`$ git pr show -t 9292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9292.diff">https://git.openjdk.org/jdk/pull/9292.diff</a>

</details>
