### PR TITLE
8282036: Change java/util/zip/ZipFile/DeleteTempJar.java to stop HttpServer cleanly in case of exceptions

### DIFF
--- a/test/jdk/java/util/zip/ZipFile/DeleteTempJar.java
+++ b/test/jdk/java/util/zip/ZipFile/DeleteTempJar.java
@@ -72,16 +72,21 @@ public class DeleteTempJar
                     }
                 }
             });
-        server.start();
 
-        URL url = new URL("jar:http://localhost:"
+        try {
+            server.start();
+            URL url = new URL("jar:http://localhost:"
                           + new Integer(server.getAddress().getPort()).toString()
                           + "/deletetemp.jar!/");
-        JarURLConnection c = (JarURLConnection)url.openConnection();
-        JarFile f = c.getJarFile();
-        check(f.getEntry("entry") != null);
-        System.out.println(f.getName());
-        server.stop(0);
+            JarURLConnection c = (JarURLConnection)url.openConnection();
+            JarFile f = c.getJarFile();
+            check(f.getEntry("entry") != null);
+            System.out.println(f.getName());
+        } finally {
+            if (server != null) {
+                server.stop(0);
+            }
+        }
     }
 
     //--------------------- Infrastructure ---------------------------

--- a/test/jdk/java/util/zip/ZipFile/DeleteTempJar.java
+++ b/test/jdk/java/util/zip/ZipFile/DeleteTempJar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,8 +73,8 @@ public class DeleteTempJar
                 }
             });
 
+        server.start();
         try {
-            server.start();
             URL url = new URL("jar:http://localhost:"
                           + new Integer(server.getAddress().getPort()).toString()
                           + "/deletetemp.jar!/");

--- a/test/jdk/java/util/zip/ZipFile/DeleteTempJar.java
+++ b/test/jdk/java/util/zip/ZipFile/DeleteTempJar.java
@@ -83,9 +83,7 @@ public class DeleteTempJar
             check(f.getEntry("entry") != null);
             System.out.println(f.getName());
         } finally {
-            if (server != null) {
-                server.stop(0);
-            }
+            server.stop(0);
         }
     }
 


### PR DESCRIPTION
This is a simple change to add some protective code to java/util/zip/ZipFile/DeleteTempJar.java so that the clean-up is more complete in the event of encountering an any exceptions while running. In the present state, the server.stop() does not get executed in case of encountering a failure. As a result, the test may get hung until a timeout. This fix should address the scenario.

The test passes on all supported platforms post fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282036](https://bugs.openjdk.org/browse/JDK-8282036): Change java/util/zip/ZipFile/DeleteTempJar.java to stop HttpServer cleanly in case of exceptions


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9293/head:pull/9293` \
`$ git checkout pull/9293`

Update a local copy of the PR: \
`$ git checkout pull/9293` \
`$ git pull https://git.openjdk.org/jdk pull/9293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9293`

View PR using the GUI difftool: \
`$ git pr show -t 9293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9293.diff">https://git.openjdk.org/jdk/pull/9293.diff</a>

</details>
