### PR TITLE
7124313: [macosx] Swing Popups should overlap taskbar

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -659,7 +659,6 @@ javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
 javax/swing/JTree/4633594/JTreeFocusTest.java 8173125 macosx-all
 javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8198003 generic-all
-javax/swing/JPopupMenu/6580930/bug6580930.java 7124313 macosx-all
 javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all
 javax/swing/JTabbedPane/8007563/Test8007563.java 8051591 generic-all
 javax/swing/JTabbedPane/4624207/bug4624207.java 8064922 macosx-all

--- a/test/jdk/javax/swing/JPopupMenu/6580930/bug6580930.java
+++ b/test/jdk/javax/swing/JPopupMenu/6580930/bug6580930.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,17 +24,26 @@
  * @test
  * @key headful
  * @bug 6580930 7184956
+ * @requires (os.family != "mac")
  * @summary Swing Popups should overlap taskbar
- * @author Alexander Potochkin
  * @library /lib/client
  * @build ExtendedRobot
  * @run main bug6580930
  */
 
-import javax.swing.*;
-import java.awt.*;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Insets;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.Window;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import javax.swing.JFrame;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
 
 public class bug6580930 {
     private static ExtendedRobot robot;


### PR DESCRIPTION
In macos, popups does not overlap taskbar unlike windows, as can be seen here  in "Settings"
so we can omit this test from macOS run.

![image](https://user-images.githubusercontent.com/43534309/175878607-6435da8c-ae32-4512-9cbc-0b449637e93f.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7124313](https://bugs.openjdk.org/browse/JDK-7124313): [macosx] Swing Popups should overlap taskbar


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Dmitry Markov](https://openjdk.org/census#dmarkov) (@dmarkov20 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9294/head:pull/9294` \
`$ git checkout pull/9294`

Update a local copy of the PR: \
`$ git checkout pull/9294` \
`$ git pull https://git.openjdk.org/jdk pull/9294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9294`

View PR using the GUI difftool: \
`$ git pr show -t 9294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9294.diff">https://git.openjdk.org/jdk/pull/9294.diff</a>

</details>
