### PR TITLE
8288651: CDS test HelloUnload.java should not use literal string as ClassLoader name

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,7 @@ public class HelloUnload {
         }
 
         URLClassLoader urlClassLoader =
-            new URLClassLoader("HelloClassLoader", urls, null);
+            new URLClassLoader("HelloClassLoader" + System.currentTimeMillis(), urls, null);
         Class c = Class.forName(className, true, urlClassLoader);
         if (keepAlive) {
             keptC = c;


### PR DESCRIPTION
A simple test fix for changing the class loader name to a non-literal string so that the symbol refcount could be decremented upon unloading of the class loader.

Passed tiers 1 and 2 testing. Inspected the .jtr file to check the symbol refcount was decremented.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288651](https://bugs.openjdk.org/browse/JDK-8288651): CDS test HelloUnload.java should not use literal string as ClassLoader name


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9297/head:pull/9297` \
`$ git checkout pull/9297`

Update a local copy of the PR: \
`$ git checkout pull/9297` \
`$ git pull https://git.openjdk.org/jdk pull/9297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9297`

View PR using the GUI difftool: \
`$ git pr show -t 9297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9297.diff">https://git.openjdk.org/jdk/pull/9297.diff</a>

</details>
