### PR TITLE
JDK-8289238: Refactoring changes to PassFailJFrame Test Framework

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/ImagePrinting/ClippedImages.java
+++ b/test/jdk/java/awt/print/PrinterJob/ImagePrinting/ClippedImages.java
@@ -125,8 +125,8 @@ public class ClippedImages {
         frame.pack();
         frame.setVisible(true);
 
-        PassFailJFrame.addTestFrame(frame);
-        PassFailJFrame.positionTestFrame(frame, PassFailJFrame.Position.HORIZONTAL);
+        PassFailJFrame.addTestWindow(frame);
+        PassFailJFrame.positionTestWindow(frame, PassFailJFrame.Position.HORIZONTAL);
     }
 
     private static void printOne() {

--- a/test/jdk/java/awt/print/PrinterJob/PrintGlyphVectorTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintGlyphVectorTest.java
@@ -152,10 +152,10 @@ public class PrintGlyphVectorTest extends Component implements Printable {
         f.setVisible(true);
 
         // add the test frame to dispose
-        PassFailJFrame.addTestFrame(f);
+        PassFailJFrame.addTestWindow(f);
 
         // Arrange the test instruction frame and test frame side by side
-        PassFailJFrame.positionTestFrame(f, PassFailJFrame.Position.HORIZONTAL);
+        PassFailJFrame.positionTestWindow(f, PassFailJFrame.Position.HORIZONTAL);
     }
 
     public static void main(String[] arg) throws Exception {

--- a/test/jdk/java/awt/print/PrinterJob/PrintLatinCJKTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintLatinCJKTest.java
@@ -78,10 +78,10 @@ public class PrintLatinCJKTest implements Printable {
             frame.setVisible(true);
 
             // add the test frame to dispose
-            PassFailJFrame.addTestFrame(frame);
+            PassFailJFrame.addTestWindow(frame);
 
             // Arrange the test instruction frame and test frame side by side
-            PassFailJFrame.positionTestFrame(frame,
+            PassFailJFrame.positionTestWindow(frame,
                     PassFailJFrame.Position.HORIZONTAL);
         });
     }

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -23,8 +23,8 @@
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.Frame;
 import java.awt.Toolkit;
+import java.awt.Window;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.lang.reflect.InvocationTargetException;
@@ -51,7 +51,7 @@ public class PassFailJFrame {
     private static final int ROWS = 10;
     private static final int COLUMNS = 40;
 
-    private static final List<Frame> frameList = new ArrayList<>();
+    private static final List<Window> windowList = new ArrayList<>();
     private static final Timer timer = new Timer(0, null);
     private static final CountDownLatch latch = new CountDownLatch(1);
 
@@ -172,7 +172,7 @@ public class PassFailJFrame {
         frame.pack();
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
-        frameList.add(frame);
+        windowList.add(frame);
     }
 
     private static String convertMillisToTimeStr(long millis) {
@@ -215,12 +215,12 @@ public class PassFailJFrame {
     }
 
     /**
-     * Dispose all the frame(s) i,e both the test instruction frame as
-     * well as the frame that is added via addTestFrame(Frame frame)
+     * Dispose all the windows(s) i,e both the test instruction frame and
+     * the testWindow that is added via addTestWindow(Window testWindow)
      */
     private static synchronized void disposeFrames() {
-        for (Frame f : frameList) {
-            f.dispose();
+        for (Window win : windowList) {
+            win.dispose();
         }
     }
 
@@ -257,42 +257,40 @@ public class PassFailJFrame {
     }
 
     /**
-     * Position the instruction frame with testFrame ( testcase created
-     * frame) by the specified position
+     * Position the instruction frame with testWindow (testcase created
+     * window) by the specified position
      * Note: This method should be invoked from the method that creates
-     * testFrame
-     *
-     * @param testFrame test frame that the test is created
+     * testWindow
+     *  @param testWindow test window that the test is created
      * @param position  position can be either HORIZONTAL (both test
-     *                  instruction frame and test frame as arranged side by
-     *                  side or VERTICAL ( both test instruction frame and
-     *                  test frame as arranged up and down)
+     *                  instruction frame and test window as arranged side by
+     *                  side or VERTICAL (both test instruction frame and
      */
-    public static void positionTestFrame(Frame testFrame, Position position) {
+    public static void positionTestWindow(Window testWindow, Position position) {
         Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
         if (position.equals(Position.HORIZONTAL)) {
             int newX = ((screenSize.width / 2) - frame.getWidth());
             frame.setLocation(newX, frame.getY());
 
-            testFrame.setLocation((frame.getLocation().x + frame.getWidth() + 5), frame.getY());
+            testWindow.setLocation((frame.getLocation().x + frame.getWidth() + 5), frame.getY());
         } else if (position.equals(Position.VERTICAL)) {
             int newY = ((screenSize.height / 2) - frame.getHeight());
             frame.setLocation(frame.getX(), newY);
 
-            testFrame.setLocation(frame.getX(),
+            testWindow.setLocation(frame.getX(),
                     (frame.getLocation().y + frame.getHeight() + 5));
         }
     }
 
     /**
-     * Add the testFrame to the frameList so that test instruction frame
-     * and testFrame and any other frame used in this test is disposed
-     * via disposeFrames()
+     * Add the testWindow to the windowList so that test instruction frame
+     * and testWindow and any other windows used in this test is disposed
+     * via disposeFrames().
      *
-     * @param testFrame testFrame that needs to be disposed
+     * @param testWindow testWindow that needs to be disposed
      */
-    public static synchronized void addTestFrame(Frame testFrame) {
-        frameList.add(testFrame);
+    public static synchronized void addTestWindow(Window testWindow) {
+        windowList.add(testWindow);
     }
 
     /**
@@ -315,6 +313,8 @@ public class PassFailJFrame {
      */
     public static void forceFail() {
         failed = true;
+        testFailedReason = "Failure Reason:\n" +
+                           "Test force failed";
         latch.countDown();
     }
 }

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -287,7 +287,7 @@ public class PassFailJFrame {
     /**
      * Add the testWindow to the windowList so that test instruction frame
      * and testWindow and any other windows used in this test is disposed
-     * via disposeFrames().
+     * via disposeWindows().
      *
      * @param testWindow testWindow that needs to be disposed
      */

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -201,7 +201,7 @@ public class PassFailJFrame {
             throw new IllegalStateException("awaitAndCheck() should not be called on EDT");
         }
         latch.await();
-        invokeAndWait(PassFailJFrame::disposeFrames);
+        invokeAndWait(PassFailJFrame::disposeWindows);
 
         if (timeout) {
             throw new RuntimeException(testFailedReason);
@@ -218,7 +218,7 @@ public class PassFailJFrame {
      * Dispose all the window(s) i,e both the test instruction frame and
      * the window(s) that is added via addTestWindow(Window testWindow)
      */
-    private static synchronized void disposeFrames() {
+    private static synchronized void disposeWindows() {
         for (Window win : windowList) {
             win.dispose();
         }
@@ -316,8 +316,7 @@ public class PassFailJFrame {
     public static void forceFail() {
         failed = true;
         testFailedReason = "Failure Reason:\n" +
-                           "Test force failed";
+                           "forceFail called";
         latch.countDown();
     }
 }
-

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -215,8 +215,8 @@ public class PassFailJFrame {
     }
 
     /**
-     * Dispose all the windows(s) i,e both the test instruction frame and
-     * the testWindow that is added via addTestWindow(Window testWindow)
+     * Dispose all the window(s) i,e both the test instruction frame and
+     * the window(s) that is added via addTestWindow(Window testWindow)
      */
     private static synchronized void disposeFrames() {
         for (Window win : windowList) {
@@ -258,13 +258,15 @@ public class PassFailJFrame {
 
     /**
      * Position the instruction frame with testWindow (testcase created
-     * window) by the specified position
+     * window) by the specified position.
      * Note: This method should be invoked from the method that creates
-     * testWindow
-     *  @param testWindow test window that the test is created
+     * testWindow.
+     *
+     * @param testWindow test window that the test is created
      * @param position  position can be either HORIZONTAL (both test
-     *                  instruction frame and test window as arranged side by
-     *                  side or VERTICAL (both test instruction frame and
+     *                  instruction frame and test window as arranged
+     *                  side by side) or VERTICAL (both test instruction
+     *                  frame and test window as arranged up and down)
      */
     public static void positionTestWindow(Window testWindow, Position position) {
         Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();

--- a/test/jdk/javax/swing/JRadioButton/bug4380543.java
+++ b/test/jdk/javax/swing/JRadioButton/bug4380543.java
@@ -68,8 +68,8 @@ public class bug4380543 {
                     passFailJFrame = new PassFailJFrame(instructions);
                     testObj = new TestFrame();
                     //Adding the Test Frame to handle dispose
-                    PassFailJFrame.addTestFrame(testObj);
-                    PassFailJFrame.positionTestFrame(testObj, PassFailJFrame.Position.HORIZONTAL);
+                    PassFailJFrame.addTestWindow(testObj);
+                    PassFailJFrame.positionTestWindow(testObj, PassFailJFrame.Position.HORIZONTAL);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/test/jdk/javax/swing/JTabbedPane/4209065/bug4209065.java
+++ b/test/jdk/javax/swing/JTabbedPane/4209065/bug4209065.java
@@ -67,8 +67,8 @@ public final class bug4209065 {
             frame.setVisible(true);
 
 
-            PassFailJFrame.addTestFrame(frame);
-            PassFailJFrame.positionTestFrame(frame,
+            PassFailJFrame.addTestWindow(frame);
+            PassFailJFrame.positionTestWindow(frame,
                     PassFailJFrame.Position.HORIZONTAL);
         });
     }

--- a/test/jdk/javax/swing/JTable/PrintAllPagesTest.java
+++ b/test/jdk/javax/swing/JTable/PrintAllPagesTest.java
@@ -68,10 +68,10 @@ public class PrintAllPagesTest {
         });
 
         // add the test frame to dispose
-        PassFailJFrame.addTestFrame(f);
+        PassFailJFrame.addTestWindow(f);
 
         // Arrange the test instruction frame and test frame side by side
-        PassFailJFrame.positionTestFrame(f, PassFailJFrame.Position.HORIZONTAL);
+        PassFailJFrame.positionTestWindow(f, PassFailJFrame.Position.HORIZONTAL);
 
         SwingUtilities.invokeAndWait(() -> {
             try {

--- a/test/jdk/javax/swing/text/html/HtmlScriptTagParserTest.java
+++ b/test/jdk/javax/swing/text/html/HtmlScriptTagParserTest.java
@@ -67,8 +67,8 @@ public class HtmlScriptTagParserTest {
             frame.pack();
             frame.setLocationRelativeTo(null);
 
-            PassFailJFrame.addTestFrame(frame);
-            PassFailJFrame.positionTestFrame(frame,
+            PassFailJFrame.addTestWindow(frame);
+            PassFailJFrame.positionTestWindow(frame,
                     PassFailJFrame.Position.HORIZONTAL);
         });
     }


### PR DESCRIPTION
Currently PassFailJFrame.positionTestFrame() and PassFailJFrame.addTestFrame() take Frame as input parameter, this has been changed to Window.

Refactored the above method names to reflect the functionality & input parameter type -
addTestWindow(), positionTestWindow()

Additionally added test fail reason to `forceFail()` to avoid NPE.

Benefits of the change -

- Since Window is a parent class, this would allow the test frame to be a Window/Frame/Dialog and not be restricted to a Frame.
- Code reusability - no need to have separate methods to manage Frame and Window
- Additionally it would allow proper clean-up of window and its container subclasses which are added to the PassFailJFrame.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289238](https://bugs.openjdk.org/browse/JDK-8289238): Refactoring changes to PassFailJFrame Test Framework


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9300/head:pull/9300` \
`$ git checkout pull/9300`

Update a local copy of the PR: \
`$ git checkout pull/9300` \
`$ git pull https://git.openjdk.org/jdk pull/9300/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9300`

View PR using the GUI difftool: \
`$ git pr show -t 9300`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9300.diff">https://git.openjdk.org/jdk/pull/9300.diff</a>

</details>
