### PR TITLE
8289258: ProblemList some failing custom loader tests with ZGC

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -27,6 +27,9 @@
 #
 #############################################################################
 
+runtime/cds/appcds/customLoader/HelloCustom.java              8289257   generic-all
+runtime/cds/appcds/customLoader/HelloCustom_JFR.java          8289257   generic-all
+runtime/cds/appcds/dynamicArchive/HelloDynamicCustomUnload.java 8289257   generic-all
 resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java 8276539   generic-all
 serviceability/sa/CDSJMapClstats.java                         8276539   generic-all
 serviceability/sa/ClhsdbJhisto.java                           8276539   generic-all


### PR DESCRIPTION
Problem listing the following tests in ProblemList-zgc.txt since they only failed with ZGC. See [JDK-8289257](https://bugs.openjdk.org/browse/JDK-8289257) for details.

- runtime/cds/appcds/customLoader/HelloCustom.java 
- runtime/cds/appcds/customLoader/HelloCustom_JFR.java 
- runtime/cds/appcds/dynamicArchive/HelloDynamicCustomUnload.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289258](https://bugs.openjdk.org/browse/JDK-8289258): ProblemList some failing custom loader tests with ZGC


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9301/head:pull/9301` \
`$ git checkout pull/9301`

Update a local copy of the PR: \
`$ git checkout pull/9301` \
`$ git pull https://git.openjdk.org/jdk pull/9301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9301`

View PR using the GUI difftool: \
`$ git pr show -t 9301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9301.diff">https://git.openjdk.org/jdk/pull/9301.diff</a>

</details>
