### PR TITLE
8289275: Remove incorrect __declspec(dllimport) attributes from pointers in jdk.crypto.cryptoki

### DIFF
--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11.h
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11.h
@@ -99,7 +99,7 @@ extern "C" {
  * functions in a Win32 Cryptoki .dll, in might be defined by:
  *
  * #define CK_DECLARE_FUNCTION_POINTER(returnType, name) \
- *   returnType __declspec(dllimport) (* name)
+ *   returnType (* name)
  *
  * In a UNIX environment, it might be defined by:
  *

--- a/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/j2secmod_md.h
+++ b/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/j2secmod_md.h
@@ -31,8 +31,8 @@
 //      const char *certPrefix, const char *keyPrefix,
 //      const char *secmodName, PRUint32 flags);
 
-typedef int __declspec(dllimport) (*FPTR_VersionCheck)(const char *importedVersion);
-typedef int __declspec(dllimport) (*FPTR_Initialize)(const char *configdir,
+typedef int (*FPTR_VersionCheck)(const char *importedVersion);
+typedef int (*FPTR_Initialize)(const char *configdir,
         const char *certPrefix, const char *keyPrefix,
         const char *secmodName, unsigned int flags);
 
@@ -42,6 +42,6 @@ typedef int __declspec(dllimport) (*FPTR_Initialize)(const char *configdir,
 //char **SECMOD_GetModuleSpecList(SECMODModule *module);
 //extern SECMODModuleList *SECMOD_GetDBModuleList(void);
 
-typedef void __declspec(dllimport) *(*FPTR_LoadModule)(char *moduleSpec, void *parent, int recurse);
-typedef char __declspec(dllimport) **(*FPTR_GetModuleSpecList)(void *module);
-typedef void __declspec(dllimport) *(*FPTR_GetDBModuleList)(void);
+typedef void *(*FPTR_LoadModule)(char *moduleSpec, void *parent, int recurse);
+typedef char **(*FPTR_GetModuleSpecList)(void *module);
+typedef void *(*FPTR_GetDBModuleList)(void);

--- a/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.h
+++ b/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.h
@@ -69,7 +69,7 @@
 #define CK_PTR *
 #define CK_DEFINE_FUNCTION(returnType, name) returnType __declspec(dllexport) name
 #define CK_DECLARE_FUNCTION(returnType, name) returnType __declspec(dllimport) name
-#define CK_DECLARE_FUNCTION_POINTER(returnType, name) returnType __declspec(dllimport) (* name)
+#define CK_DECLARE_FUNCTION_POINTER(returnType, name) returnType (* name)
 #define CK_CALLBACK_FUNCTION(returnType, name) returnType (* name)
 #ifndef NULL_PTR
 #define NULL_PTR 0


### PR DESCRIPTION
Several instances of function pointers in jdk.crypto.cryptoki are marked with the dllimport attribute, which should only be applied to symbol declarations, of which a typedef'd function pointer is not. This would only be useful if a function pointer defined in the linked dll is desired to be imported, not if the pointer itself is created locally and used to store a function address. In addition to being incorrect, at least on the versions of Visual C++ the JDK supports today, it is also redundant; Typically they are used to avoid an indirect stub that jumps to the proper entry in the import address table, but usage of these typedefs involves loading the address of a function and directly (Usually through GetProcAddress, even in other cases it would simply be set to the address of a function anyway) assigning it to the pointer before immediately dispatching when called, which bypasses this procedure entirely and makes the attribute pointless.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289275](https://bugs.openjdk.org/browse/JDK-8289275): Remove incorrect __declspec(dllimport) attributes from pointers in jdk.crypto.cryptoki


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9304/head:pull/9304` \
`$ git checkout pull/9304`

Update a local copy of the PR: \
`$ git checkout pull/9304` \
`$ git pull https://git.openjdk.org/jdk pull/9304/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9304`

View PR using the GUI difftool: \
`$ git pr show -t 9304`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9304.diff">https://git.openjdk.org/jdk/pull/9304.diff</a>

</details>
