### PR TITLE
8283082: sun.security.x509.X509CertImpl.delete("x509.info.validity") nulls out info field

### DIFF
--- a/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
@@ -739,7 +739,7 @@ public class X509CertImpl extends X509Certificate implements DerEncoder {
         id = attr.getPrefix();
 
         if (id.equalsIgnoreCase(INFO)) {
-            if (attr.getSuffix() != null) {
+            if (!(attr.getSuffix() != null)) {
                 info = null;
             } else {
                 info.delete(attr.getSuffix());

--- a/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
@@ -739,7 +739,7 @@ public class X509CertImpl extends X509Certificate implements DerEncoder {
         id = attr.getPrefix();
 
         if (id.equalsIgnoreCase(INFO)) {
-            if ((attr.getSuffix() == null)) {
+            if (attr.getSuffix() == null) {
                 info = null;
             } else {
                 info.delete(attr.getSuffix());

--- a/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
@@ -739,7 +739,7 @@ public class X509CertImpl extends X509Certificate implements DerEncoder {
         id = attr.getPrefix();
 
         if (id.equalsIgnoreCase(INFO)) {
-            if (!(attr.getSuffix() != null)) {
+            if ((attr.getSuffix() == null)) {
                 info = null;
             } else {
                 info.delete(attr.getSuffix());

--- a/test/jdk/sun/security/x509/X509CertImpl/JDK8283082.java
+++ b/test/jdk/sun/security/x509/X509CertImpl/JDK8283082.java
@@ -1,3 +1,35 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8283082
+ * @modules java.base/sun.security.x509
+ * @summary This test is to confirm that 
+ * sun.security.x509.X509CertImpl.delete("x509.info.validity") doesn't 
+ * null out info field as reported by bug 8283082
+ */
+
 import sun.security.x509.X500Name;
 import sun.security.x509.X509CertImpl;
 import sun.security.x509.X509CertInfo;

--- a/test/jdk/sun/security/x509/X509CertImpl/JDK8283082.java
+++ b/test/jdk/sun/security/x509/X509CertImpl/JDK8283082.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/security/x509/X509CertImpl/JDK8283082.java
+++ b/test/jdk/sun/security/x509/X509CertImpl/JDK8283082.java
@@ -1,0 +1,13 @@
+import sun.security.x509.X500Name;
+import sun.security.x509.X509CertImpl;
+import sun.security.x509.X509CertInfo;
+
+public class JDK8283082{
+    public static void main(String[] args) throws Exception {
+        var c = new X509CertImpl();
+        c.set("x509.info", new X509CertInfo());
+        c.set("x509.info.issuer", new X500Name("CN=one"));
+        c.delete("x509.info.issuer");
+        c.set("x509.info.issuer", new X500Name("CN=two"));
+    }
+}

--- a/test/jdk/sun/security/x509/X509CertImpl/JDK8283082.java
+++ b/test/jdk/sun/security/x509/X509CertImpl/JDK8283082.java
@@ -25,8 +25,8 @@
  * @test
  * @bug 8283082
  * @modules java.base/sun.security.x509
- * @summary This test is to confirm that 
- * sun.security.x509.X509CertImpl.delete("x509.info.validity") doesn't 
+ * @summary This test is to confirm that
+ * sun.security.x509.X509CertImpl.delete("x509.info.validity") doesn't
  * null out info field as reported by bug 8283082
  */
 


### PR DESCRIPTION
Could you please review the changes?
This is to address the issue: https://bugs.openjdk.org/browse/JDK-8283082?jql=labels%20%3D%20starter-bug

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283082](https://bugs.openjdk.org/browse/JDK-8283082): sun.security.x509.X509CertImpl.delete("x509.info.validity") nulls out info field


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9306/head:pull/9306` \
`$ git checkout pull/9306`

Update a local copy of the PR: \
`$ git checkout pull/9306` \
`$ git pull https://git.openjdk.org/jdk pull/9306/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9306`

View PR using the GUI difftool: \
`$ git pr show -t 9306`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9306.diff">https://git.openjdk.org/jdk/pull/9306.diff</a>

</details>
