### PR TITLE
8289260: BigDecimal movePointLeft() and movePointRight() do not follow their API spec

### DIFF
--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -2993,7 +2993,7 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
      * @throws ArithmeticException if scale overflows.
      */
     public BigDecimal movePointLeft(int n) {
-        if (n == 0) return this;
+        if (n == 0 && scale >= 0) return this;
 
         // Cannot use movePointRight(-n) in case of n==Integer.MIN_VALUE
         int newScale = checkScale((long)scale + n);
@@ -3017,7 +3017,7 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
      * @throws ArithmeticException if scale overflows.
      */
     public BigDecimal movePointRight(int n) {
-        if (n == 0) return this;
+        if (n == 0 && scale >= 0) return this;
 
         // Cannot use movePointLeft(-n) in case of n==Integer.MIN_VALUE
         int newScale = checkScale((long)scale - n);

--- a/test/jdk/java/math/BigDecimal/MovePointTests.java
+++ b/test/jdk/java/math/BigDecimal/MovePointTests.java
@@ -37,17 +37,49 @@ public class MovePointTests {
         checkNotIdentical(bd, bd.movePointLeft(0));
         checkNotIdentical(bd, bd.movePointRight(0));
 
+        bd = BigDecimal.valueOf(1, 0);
+        checkIdentical(bd, bd.movePointLeft(0));
+        checkIdentical(bd, bd.movePointRight(0));
+
         bd = BigDecimal.valueOf(1, 3);
         checkIdentical(bd, bd.movePointLeft(0));
         checkIdentical(bd, bd.movePointRight(0));
 
         bd = BigDecimal.valueOf(1, -3);
         checkNotEquals(bd, bd.movePointLeft(1));
+        checkNotEquals(bd, bd.movePointLeft(-1));
         checkNotEquals(bd, bd.movePointRight(1));
+        checkNotEquals(bd, bd.movePointRight(-1));
+
+        bd = BigDecimal.valueOf(1, 0);
+        checkNotEquals(bd, bd.movePointLeft(1));
+        checkNotEquals(bd, bd.movePointLeft(-1));
+        checkNotEquals(bd, bd.movePointRight(1));
+        checkNotEquals(bd, bd.movePointRight(-1));
+
+        bd = BigDecimal.valueOf(1, 3);
+        checkNotEquals(bd, bd.movePointLeft(1));
+        checkNotEquals(bd, bd.movePointLeft(-1));
+        checkNotEquals(bd, bd.movePointRight(1));
+        checkNotEquals(bd, bd.movePointRight(-1));
 
         bd = BigDecimal.valueOf(1, -3);
-        checkNotEquals(bd, bd.movePointLeft(-1));
-        checkNotEquals(bd, bd.movePointRight(-1));
+        checkNotEquals(bd, bd.movePointLeft(10));
+        checkNotEquals(bd, bd.movePointLeft(-10));
+        checkNotEquals(bd, bd.movePointRight(10));
+        checkNotEquals(bd, bd.movePointRight(-10));
+
+        bd = BigDecimal.valueOf(1, 0);
+        checkNotEquals(bd, bd.movePointLeft(10));
+        checkNotEquals(bd, bd.movePointLeft(-10));
+        checkNotEquals(bd, bd.movePointRight(10));
+        checkNotEquals(bd, bd.movePointRight(-10));
+
+        bd = BigDecimal.valueOf(1, 3);
+        checkNotEquals(bd, bd.movePointLeft(10));
+        checkNotEquals(bd, bd.movePointLeft(-10));
+        checkNotEquals(bd, bd.movePointRight(10));
+        checkNotEquals(bd, bd.movePointRight(-10));
     }
 
     private static void checkIdentical(BigDecimal bd, BigDecimal res) {

--- a/test/jdk/java/math/BigDecimal/MovePointTests.java
+++ b/test/jdk/java/math/BigDecimal/MovePointTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,32 +32,43 @@ public class MovePointTests {
 
     public static void main(String argv[]) {
         BigDecimal bd;
-        BigDecimal res;
 
         bd = BigDecimal.valueOf(1, -3);
-        res = bd.movePointLeft(0);
-        if (res == bd) {  // intentionally ==
-            throw new RuntimeException("Unexpected result " +
-                    bd + " == " + res);
-        }
-        res = bd.movePointRight(0);
-        if (res == bd) {  // intentionally ==
-            throw new RuntimeException("Unexpected result " +
-                    bd + " == " + res);
-        }
+        checkNotIdentical(bd, bd.movePointLeft(0));
+        checkNotIdentical(bd, bd.movePointRight(0));
 
         bd = BigDecimal.valueOf(1, 3);
-        res = bd.movePointLeft(0);
-        if (res != bd) {  // intentionally !=
-            throw new RuntimeException("Unexpected result " +
-                    bd + " != " + res);
-        }
-        res = bd.movePointRight(0);
-        if (res != bd) {  // intentionally !=
-            throw new RuntimeException("Unexpected result " +
-                    bd + " != " + res);
-        }
+        checkIdentical(bd, bd.movePointLeft(0));
+        checkIdentical(bd, bd.movePointRight(0));
 
+        bd = BigDecimal.valueOf(1, -3);
+        checkNotEquals(bd, bd.movePointLeft(1));
+        checkNotEquals(bd, bd.movePointRight(1));
+
+        bd = BigDecimal.valueOf(1, -3);
+        checkNotEquals(bd, bd.movePointLeft(-1));
+        checkNotEquals(bd, bd.movePointRight(-1));
+    }
+
+    private static void checkIdentical(BigDecimal bd, BigDecimal res) {
+        if (res != bd) {  // intentionally !=
+            throw new RuntimeException("Unexpected result " +
+                    bd + " != " + res);
+        }
+    }
+
+    private static void checkNotIdentical(BigDecimal bd, BigDecimal res) {
+        if (res == bd) {  // intentionally ==
+            throw new RuntimeException("Unexpected result " +
+                    bd + " == " + res);
+        }
+    }
+
+    private static void checkNotEquals(BigDecimal bd, BigDecimal res) {
+        if (res.equals(bd)) {
+            throw new RuntimeException("Unexpected result " +
+                    bd + ".equals(" + res + ")");
+        }
     }
 
 }

--- a/test/jdk/java/math/BigDecimal/MovePointTests.java
+++ b/test/jdk/java/math/BigDecimal/MovePointTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8289260
+ */
+
+import java.math.BigDecimal;
+
+public class MovePointTests {
+
+    public static void main(String argv[]) {
+        BigDecimal bd;
+        BigDecimal res;
+
+        bd = BigDecimal.valueOf(1, -3);
+        res = bd.movePointLeft(0);
+        if (res == bd) {  // intentionally ==
+            throw new RuntimeException("Unexpected result " +
+                    bd + " == " + res);
+        }
+        res = bd.movePointRight(0);
+        if (res == bd) {  // intentionally ==
+            throw new RuntimeException("Unexpected result " +
+                    bd + " == " + res);
+        }
+
+        bd = BigDecimal.valueOf(1, 3);
+        res = bd.movePointLeft(0);
+        if (res != bd) {  // intentionally !=
+            throw new RuntimeException("Unexpected result " +
+                    bd + " != " + res);
+        }
+        res = bd.movePointRight(0);
+        if (res != bd) {  // intentionally !=
+            throw new RuntimeException("Unexpected result " +
+                    bd + " != " + res);
+        }
+
+    }
+
+}


### PR DESCRIPTION
`BigDecimal.morePoint[Left|Right]()` should return the target `this` when the argument is 0 _and_ the scale is non-negative.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8289260](https://bugs.openjdk.org/browse/JDK-8289260): BigDecimal movePointLeft() and movePointRight() do not follow their API spec
 * [JDK-8289504](https://bugs.openjdk.org/browse/JDK-8289504): BigDecimal movePointLeft() and movePointRight() do not follow their API spec (**CSR**)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9307/head:pull/9307` \
`$ git checkout pull/9307`

Update a local copy of the PR: \
`$ git checkout pull/9307` \
`$ git pull https://git.openjdk.org/jdk pull/9307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9307`

View PR using the GUI difftool: \
`$ git pr show -t 9307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9307.diff">https://git.openjdk.org/jdk/pull/9307.diff</a>

</details>
