### PR TITLE
8289301: P11Cipher should not throw out of bounds exception during padding

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
@@ -814,12 +814,10 @@ final class P11Cipher extends CipherSpi {
                 if (paddingObj != null) {
                     int startOff = 0;
                     if (reqBlockUpdates) {
-                        // padding is added to data in padBuffer
-                        // unless padBuffer is already full in which case
-                        // EncryptUpdate is performed and whole new padding
-                        // block is created
+                        // call C_EncryptUpdate first if the padBuffer is full
+                        // to make room for padding bytes
                         if (padBufferLen == padBuffer.length) {
-                            k += token.p11.C_EncryptUpdate(session.id(),
+                            k = token.p11.C_EncryptUpdate(session.id(),
                                 0, padBuffer, 0, padBufferLen,
                                 0, out, outOfs, outLen);
                         } else {
@@ -912,12 +910,10 @@ final class P11Cipher extends CipherSpi {
                 if (paddingObj != null) {
                     int startOff = 0;
                     if (reqBlockUpdates) {
-                        // padding is added to data in padBuffer
-                        // unless padBuffer is already full in which case
-                        // EncryptUpdate is performed and whole new padding
-                        // block is created
+                        // call C_EncryptUpdate first if the padBuffer is full
+                        // to make room for padding bytes
                         if (padBufferLen == padBuffer.length) {
-                            k += token.p11.C_EncryptUpdate(session.id(),
+                            k = token.p11.C_EncryptUpdate(session.id(),
                                 0, padBuffer, 0, padBufferLen,
                                 outAddr, outArray, outOfs, outLen);
                         } else {

--- a/test/jdk/sun/security/pkcs11/Cipher/TestPaddingOOB.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestPaddingOOB.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary P11Cipher should not throw OOB exception during padding
+ * @library /test/lib ..
+ * @run main/othervm TestPaddingOOB
+ */
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.security.Key;
+import java.security.Provider;
+
+public class TestPaddingOOB extends PKCS11Test {
+
+    public static void main(String[] args) throws Exception {
+        main(new TestPaddingOOB(), args);
+    }
+
+    @Override
+    public void main(Provider p) throws Exception {
+        KeyGenerator kg = KeyGenerator.getInstance("AES", p);
+        Key key = kg.generateKey();
+
+        Cipher c = Cipher.getInstance("AES/ECB/PKCS5Padding", p);
+        int bs = c.getBlockSize();
+
+        // Test with arrays
+        byte[] plainArr = new byte[bs];
+        Arrays.fill(plainArr, (byte) 'a');
+        c.init(Cipher.ENCRYPT_MODE, key);
+        byte[] encArr = new byte[c.getOutputSize(plainArr.length)];
+        int off = c.update(plainArr, 0, 1, encArr, 0);
+        off += c.doFinal(plainArr, 1, plainArr.length - 1, encArr, off);
+        if (off != 2 * bs) {
+            throw new Exception("Unexpected encrypted size (array)");
+        }
+        c.init(Cipher.DECRYPT_MODE, key);
+        byte[] plainArr2 = new byte[c.getOutputSize(encArr.length)];
+        off = c.doFinal(encArr, 0, encArr.length, plainArr2, 0);
+        if (off != bs) {
+            throw new Exception("Unexpected decrypted size (array)");
+        }
+        if (!Arrays.equals(plainArr, Arrays.copyOfRange(plainArr2, 0, off))) {
+            throw new Exception("Invalid decrypted data (array)");
+        }
+
+        // Test with buffers
+        ByteBuffer plainBuf = ByteBuffer.allocate(bs);
+        Arrays.fill(plainArr, (byte) 'b');
+        plainBuf.put(plainArr);
+        plainBuf.flip();
+        c.init(Cipher.ENCRYPT_MODE, key);
+        ByteBuffer encBuf = ByteBuffer.allocate(c.getOutputSize(plainBuf.limit()));
+        plainBuf.limit(1);
+        off = c.update(plainBuf, encBuf);
+        plainBuf.limit(bs);
+        off += c.doFinal(plainBuf, encBuf);
+        if (off != 2 * bs) {
+            throw new Exception("Unexpected encrypted size (buffer)");
+        }
+        encBuf.flip();
+        c.init(Cipher.DECRYPT_MODE, key);
+        ByteBuffer plainBuf2 = ByteBuffer.allocate(c.getOutputSize(encBuf.limit()));
+        off = c.doFinal(encBuf, plainBuf2);
+        if (off != bs) {
+            throw new Exception("Unexpected decrypted size (buffer)");
+        }
+        plainBuf2.flip();
+        plainBuf2.get(plainArr2, 0, off);
+        if (!Arrays.equals(plainArr, Arrays.copyOfRange(plainArr2, 0, off))) {
+            throw new Exception("Invalid decrypted data (buffer)");
+        }
+    }
+
+}

--- a/test/jdk/sun/security/pkcs11/Cipher/TestPaddingOOB.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestPaddingOOB.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8289301
- * @summary P11Cipher should not throw OOB exception during padding
+ * @summary P11Cipher should not throw OOB exception during padding when "reqBlockUpdates" == true
  * @library /test/lib ..
  * @run main/othervm TestPaddingOOB
  */
@@ -58,13 +58,13 @@ public class TestPaddingOOB extends PKCS11Test {
         int off = c.update(plainArr, 0, 1, encArr, 0);
         off += c.doFinal(plainArr, 1, plainArr.length - 1, encArr, off);
         if (off != 2 * bs) {
-            throw new Exception("Unexpected encrypted size (array)");
+            throw new Exception("Unexpected encrypted size (array): " + off);
         }
         c.init(Cipher.DECRYPT_MODE, key);
         byte[] plainArr2 = new byte[c.getOutputSize(encArr.length)];
         off = c.doFinal(encArr, 0, encArr.length, plainArr2, 0);
         if (off != bs) {
-            throw new Exception("Unexpected decrypted size (array)");
+            throw new Exception("Unexpected decrypted size (array): " + off);
         }
         if (!Arrays.equals(plainArr, Arrays.copyOfRange(plainArr2, 0, off))) {
             throw new Exception("Invalid decrypted data (array)");
@@ -82,14 +82,14 @@ public class TestPaddingOOB extends PKCS11Test {
         plainBuf.limit(bs);
         off += c.doFinal(plainBuf, encBuf);
         if (off != 2 * bs) {
-            throw new Exception("Unexpected encrypted size (buffer)");
+            throw new Exception("Unexpected encrypted size (buffer): " + off);
         }
         encBuf.flip();
         c.init(Cipher.DECRYPT_MODE, key);
         ByteBuffer plainBuf2 = ByteBuffer.allocate(c.getOutputSize(encBuf.limit()));
         off = c.doFinal(encBuf, plainBuf2);
         if (off != bs) {
-            throw new Exception("Unexpected decrypted size (buffer)");
+            throw new Exception("Unexpected decrypted size (buffer): " + off);
         }
         plainBuf2.flip();
         plainBuf2.get(plainArr2, 0, off);

--- a/test/jdk/sun/security/pkcs11/Cipher/TestPaddingOOB.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestPaddingOOB.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8289301
  * @summary P11Cipher should not throw OOB exception during padding
  * @library /test/lib ..
  * @run main/othervm TestPaddingOOB


### PR DESCRIPTION
SunPkcs11 provider throws out of bounds exception during encryption when specific conditions are met.

Exception:
```
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: Array index out of range: 32
	at java.base/java.util.Arrays.rangeCheck(Arrays.java:725)
	at java.base/java.util.Arrays.fill(Arrays.java:3308)
	at jdk.crypto.cryptoki/sun.security.pkcs11.P11Cipher$PKCS5Padding.setPaddingBytes(P11Cipher.java:96)
	at jdk.crypto.cryptoki/sun.security.pkcs11.P11Cipher.implDoFinal(P11Cipher.java:813)
	at jdk.crypto.cryptoki/sun.security.pkcs11.P11Cipher.engineDoFinal(P11Cipher.java:585)
	at java.base/javax.crypto.Cipher.doFinal(Cipher.java:2417)
...
```

Details:
This problems happens when reqBlockUpdates is true and implUpdate, which does not end on block boundary, is performed followed by final implUpdate, which ends exactly on block boundary. In that case final implUpdate fills padBuffer and then just returns. [1] Following implDoFinal then tries to add padding and throws OOB exception. Problem is, that in this case (input is multiple of block size) whole padding block should be added, but there is no space for it in padBuffer causing OOB exception.

Solution:
Solution is to detect this case (implDoFinal is called with full padBuffer) and to perform additional C_EncryptUpdate to free up padBuffer so that padBuffer can than be used to add whole new padding block.

[1] https://github.com/openjdk/jdk/blob/d4eeeb82cb2288973a6a247c54513f7e1c6b58f0/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java#L622

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289301](https://bugs.openjdk.org/browse/JDK-8289301): P11Cipher should not throw out of bounds exception during padding


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9310/head:pull/9310` \
`$ git checkout pull/9310`

Update a local copy of the PR: \
`$ git checkout pull/9310` \
`$ git pull https://git.openjdk.org/jdk pull/9310/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9310`

View PR using the GUI difftool: \
`$ git pr show -t 9310`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9310.diff">https://git.openjdk.org/jdk/pull/9310.diff</a>

</details>
