### PR TITLE
8289385: Cleanup redundant synchronization in Http2ClientImpl

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2ClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2ClientImpl.java
@@ -56,6 +56,8 @@ class Http2ClientImpl {
             Utils.getDebugLogger("Http2ClientImpl"::toString, Utils.DEBUG);
 
     private final HttpClientImpl client;
+
+    // only accessed from within synchronized blocks
     private boolean stopping;
 
     Http2ClientImpl(HttpClientImpl client) {
@@ -65,6 +67,7 @@ class Http2ClientImpl {
     /* Map key is "scheme:host:port" */
     private final Map<String,Http2Connection> connections = new ConcurrentHashMap<>();
 
+    // only accessed from within synchronized blocks
     private final Set<String> failures = new HashSet<>();
 
     /**

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2ClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2ClientImpl.java
@@ -31,7 +31,6 @@ import java.io.UncheckedIOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -57,7 +56,7 @@ class Http2ClientImpl {
             Utils.getDebugLogger("Http2ClientImpl"::toString, Utils.DEBUG);
 
     private final HttpClientImpl client;
-    private volatile boolean stopping;
+    private boolean stopping;
 
     Http2ClientImpl(HttpClientImpl client) {
         this.client = client;
@@ -66,7 +65,7 @@ class Http2ClientImpl {
     /* Map key is "scheme:host:port" */
     private final Map<String,Http2Connection> connections = new ConcurrentHashMap<>();
 
-    private final Set<String> failures = Collections.synchronizedSet(new HashSet<>());
+    private final Set<String> failures = new HashSet<>();
 
     /**
      * When HTTP/2 requested only. The following describes the aggregate behavior including the


### PR DESCRIPTION
Http2ClientImpl.stopping and Http2ClientImpl.failures are always accessed under synchronized(this).
So we can remove 'volatile' modifier from 'stopping'. And remove 'synchronizedSet' wrapper from 'failures'

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289385](https://bugs.openjdk.org/browse/JDK-8289385): Cleanup redundant synchronization in Http2ClientImpl


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9311/head:pull/9311` \
`$ git checkout pull/9311`

Update a local copy of the PR: \
`$ git checkout pull/9311` \
`$ git pull https://git.openjdk.org/jdk pull/9311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9311`

View PR using the GUI difftool: \
`$ git pr show -t 9311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9311.diff">https://git.openjdk.org/jdk/pull/9311.diff</a>

</details>
