### PR TITLE
8288377: [REDO] DST not applying properly with zone id offset set with TZ env variable

### DIFF
--- a/src/java.base/unix/native/libjava/TimeZone_md.c
+++ b/src/java.base/unix/native/libjava/TimeZone_md.c
@@ -583,8 +583,7 @@ getGMTOffsetID()
     }
 #endif
 
-    strftime(offset, 6, "%z", &localtm);
-    if (strlen(offset) != 5) {
+    if (strftime(offset, 6, "%z", &localtm) != 5) {
         return strdup("GMT");
     }
 

--- a/src/java.base/unix/native/libjava/TimeZone_md.c
+++ b/src/java.base/unix/native/libjava/TimeZone_md.c
@@ -566,9 +566,29 @@ getGMTOffsetID()
         return strdup("GMT");
     }
 
-    strftime(offset, 6, "%z", &localtm);
-    char gmt_offset[] = {offset[0], offset[1], offset[2], ':', offset[3], offset[4], '\0'};
+#if defined(MACOSX)
+    time_t gmt_offset;
+    gmt_offset = (time_t)localtm.tm_gmtoff;
+    if (gmt_offset == 0) {
+        return strdup("GMT");
+    }
+#else
+    struct tm gmt;
+    if (gmtime_r(&clock, &gmt) == NULL) {
+        return strdup("GMT");
+    }
 
-    sprintf(buf, (const char *)"GMT%s", gmt_offset);
+    if(localtm.tm_hour == gmt.tm_hour && localtm.tm_min == gmt.tm_min) {
+        return strdup("GMT");
+    }
+#endif
+
+    strftime(offset, 6, "%z", &localtm);
+    if (strlen(offset) != 5) {
+        return strdup("GMT");
+    }
+
+    sprintf(buf, (const char *)"GMT%c%c%c:%c%c", offset[0], offset[1], offset[2],
+        offset[3], offset[4]);
     return strdup(buf);
 }

--- a/test/jdk/java/util/TimeZone/CustomTzIDCheckDST.java
+++ b/test/jdk/java/util/TimeZone/CustomTzIDCheckDST.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8285838
+ * @library /test/lib
+ * @summary This test will ensure that daylight savings rules are followed
+ * appropriately when setting a custom timezone ID via the TZ env variable.
+ * @requires os.family != "windows"
+ * @run main/othervm CustomTzIDCheckDST
+ */
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.SimpleTimeZone;
+import java.time.DayOfWeek;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAdjusters;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+public class CustomTzIDCheckDST {
+    private static String CUSTOM_TZ = "MEZ-1MESZ,M3.5.0,M10.5.0";
+    public static void main(String args[]) throws Throwable {
+        if (args.length == 0) {
+            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(List.of("CustomTzIDCheckDST", "runTZTest"));
+            pb.environment().put("TZ", CUSTOM_TZ);
+            OutputAnalyzer output = ProcessTools.executeProcess(pb);
+            output.shouldHaveExitValue(0);
+        } else {
+            runTZTest();
+        }
+    }
+
+    /* TZ code will always be set to "MEZ-1MESZ,M3.5.0,M10.5.0".
+     * This ensures the transition periods for Daylights Savings should be at March's last
+     * Sunday and October's last Sunday.
+     */
+    private static void runTZTest() {
+        Date time = new Date();
+        if (new SimpleTimeZone(3600000, "MEZ-1MESZ", Calendar.MARCH, -1, Calendar.SUNDAY, 0,
+                Calendar.OCTOBER, -1, Calendar.SUNDAY, 0).inDaylightTime(time)) {
+            // We are in Daylight savings period.
+            if (time.toString().endsWith("GMT+02:00 " + Integer.toString(time.getYear() + 1900)))
+                return;
+        } else {
+            if (time.toString().endsWith("GMT+01:00 " + Integer.toString(time.getYear() + 1900)))
+                return;
+        }
+
+        // Reaching here means time zone did not match up as expected.
+        throw new RuntimeException("Got unexpected timezone information: " + time);
+    }
+
+    private static ZonedDateTime getLastSundayOfMonth(ZonedDateTime date) {
+        return date.with(TemporalAdjusters.lastInMonth(DayOfWeek.SUNDAY));
+    }
+}


### PR DESCRIPTION
This is a REDO of the Fix that was incompletely implemented earlier:
[8285838: Fix for TZ environment variable DST rules](https://github.com/openjdk/jdk/pull/8660)

Offset calculation now accounts all the way upto year in order to avoid cross-day miscalculations as well as to calculate always in the correct direction for offset. In situations where there may be multiple days, the excess days of offset will be shaved off by applying mod to `seconds_per_day` , which will remove the excessive days that might be included in the offset calculation for special scenarios like a leap year / February months and variances between 30 and 31 days.

I have tested this solution with the cases where this fix had failed last time as well, and confirmed it works:
_(where 7200 represents 7200 seconds -> +2 hour offset)_
Sample output:
![image](https://user-images.githubusercontent.com/6877595/176259828-07e27901-4a3f-4949-bd8d-2f88c979685a.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288377](https://bugs.openjdk.org/browse/JDK-8288377): [REDO] DST not applying properly with zone id offset set with TZ env variable


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9312/head:pull/9312` \
`$ git checkout pull/9312`

Update a local copy of the PR: \
`$ git checkout pull/9312` \
`$ git pull https://git.openjdk.org/jdk pull/9312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9312`

View PR using the GUI difftool: \
`$ git pr show -t 9312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9312.diff">https://git.openjdk.org/jdk/pull/9312.diff</a>

</details>
