### PR TITLE
8288128: S390X: Fix crashes after JDK-8284161 (Virtual Threads)

### DIFF
--- a/src/hotspot/cpu/s390/frame_s390.cpp
+++ b/src/hotspot/cpu/s390/frame_s390.cpp
@@ -240,20 +240,39 @@ address* frame::compiled_sender_pc_addr(CodeBlob* cb) const {
 
 void frame::patch_pc(Thread* thread, address pc) {
   assert(_cb == CodeCache::find_blob(pc), "unexpected pc");
+  address* pc_addr = (address*)&(own_abi()->return_pc); // TODO: This won't be lr on s390. Correct.
+
   if (TracePcPatching) {
     tty->print_cr("patch_pc at address  " PTR_FORMAT " [" PTR_FORMAT " -> " PTR_FORMAT "] ",
                   p2i(&((address*) _sp)[-1]), p2i(((address*) _sp)[-1]), p2i(pc));
   }
+  assert(!Continuation::is_return_barrier_entry(*pc_addr), "return barrier");
+  assert(_pc == *pc_addr || pc == *pc_addr || 0 == *pc_addr,
+         "must be (pc: " INTPTR_FORMAT " _pc: " INTPTR_FORMAT " pc_addr: " INTPTR_FORMAT
+         " *pc_addr: " INTPTR_FORMAT  " sp: " INTPTR_FORMAT ")",
+         p2i(pc), p2i(_pc), p2i(pc_addr), p2i(*pc_addr), p2i(sp()));
+  DEBUG_ONLY(address old_pc = _pc;)
   own_abi()->return_pc = (uint64_t)pc;
+  _pc = pc; // must be set before call to get_deopt_original_pc
   address original_pc = CompiledMethod::get_deopt_original_pc(this);
   if (original_pc != NULL) {
     assert(original_pc == _pc, "expected original to be stored before patching");
     _deopt_state = is_deoptimized;
-    // Leave _pc as is.
+    _pc = original_pc;
   } else {
     _deopt_state = not_deoptimized;
-    _pc = pc;
   }
+  assert(!is_compiled_frame() || !_cb->as_compiled_method()->is_deopt_entry(_pc), "must be");
+
+  #ifdef ASSERT
+  {
+    frame f(this->sp(), pc, this->unextended_sp());
+    assert(f.is_deoptimized_frame() == this->is_deoptimized_frame() && f.pc() == this->pc() && f.raw_pc() == this->raw_pc(),
+           "must be (f.is_deoptimized_frame(): %d this->is_deoptimized_frame(): %d "
+           "f.pc(): " INTPTR_FORMAT " this->pc(): " INTPTR_FORMAT " f.raw_pc(): " INTPTR_FORMAT " this->raw_pc(): " INTPTR_FORMAT ")",
+           f.is_deoptimized_frame(), this->is_deoptimized_frame(), p2i(f.pc()), p2i(this->pc()), p2i(f.raw_pc()), p2i(this->raw_pc()));
+  }
+  #endif
 }
 
 bool frame::is_interpreted_frame_valid(JavaThread* thread) const {

--- a/src/hotspot/cpu/s390/frame_s390.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.hpp
@@ -460,7 +460,8 @@
 
  private:
 
-  inline void find_codeblob_and_set_pc_and_deopt_state(address pc);
+  // Initialize frame members (_pc and _sp must be given)
+  inline void setup();
   const ImmutableOopMap* get_oop_map() const;
 
  // Constructors
@@ -468,7 +469,7 @@
  public:
   // To be used, if sp was not extended to match callee's calling convention.
   inline frame(intptr_t* sp, address pc);
-  inline frame(intptr_t* sp, address pc, intptr_t* unextended_sp);
+  inline frame(intptr_t* sp, address pc, intptr_t* unextended_sp, intptr_t* fp = nullptr, CodeBlob* cb = nullptr);
 
   // Access frame via stack pointer.
   inline intptr_t* sp_addr_at(int index) const  { return &sp()[index]; }

--- a/src/hotspot/cpu/s390/frame_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.inline.hpp
@@ -28,71 +28,70 @@
 
 #include "code/codeCache.hpp"
 #include "code/vmreg.inline.hpp"
+#include "runtime/sharedRuntime.hpp"
 #include "utilities/align.hpp"
 
 // Inline functions for z/Architecture frames:
 
-inline void frame::find_codeblob_and_set_pc_and_deopt_state(address pc) {
-  assert(pc != NULL, "precondition: must have PC");
+// Initialize frame members (_pc and _sp must be given)
+inline void frame::setup() {
+  assert(_pc != nullptr, "precondition: must have PC");
 
-  _cb = CodeCache::find_blob(pc);
-  _pc = pc;   // Must be set for get_deopt_original_pc().
+  if (_cb == nullptr) {
+    _cb = CodeCache::find_blob(_pc);
+  }
 
-  _fp = (intptr_t *) own_abi()->callers_sp;
+  if (_fp == nullptr) {
+    _fp = (intptr_t*)own_abi()->callers_sp;
+  }
+
+  // When thawing continuation frames the _unextended_sp passed to the constructor is not aligend
+  assert(_on_heap || (is_aligned(_sp, alignment_in_bytes) && is_aligned(_fp, alignment_in_bytes)),
+         "invalid alignment sp:" PTR_FORMAT " unextended_sp:" PTR_FORMAT " fp:" PTR_FORMAT, p2i(_sp), p2i(_unextended_sp), p2i(_fp));
 
   address original_pc = CompiledMethod::get_deopt_original_pc(this);
-  if (original_pc != NULL) {
+  if (original_pc != nullptr) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;
+    assert(_cb == nullptr || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
+           "original PC must be in the main code section of the the compiled method (or must be immediately following it)");
   } else {
     _deopt_state = not_deoptimized;
   }
 
-  assert(((uint64_t)_sp & 0x7) == 0, "SP must be 8-byte aligned");
+  assert(_on_heap || is_aligned(_sp, frame::frame_alignment), "SP must be 8-byte aligned");
 }
 
 // Constructors
 
 // Initialize all fields, _unextended_sp will be adjusted in find_codeblob_and_set_pc_and_deopt_state.
-inline frame::frame() : _sp(NULL), _pc(NULL), _cb(NULL), _deopt_state(unknown), _on_heap(false),
-#ifdef ASSERT
-                        _frame_index(-1),
-#endif
-                        _unextended_sp(NULL), _fp(NULL) {}
+inline frame::frame() : _sp(nullptr), _pc(nullptr), _cb(nullptr), _oop_map(nullptr), _deopt_state(unknown),
+                        _on_heap(false), DEBUG_ONLY(_frame_index(-1) COMMA) _unextended_sp(nullptr), _fp(nullptr) {}
 
-inline frame::frame(intptr_t* sp) : _sp(sp), _on_heap(false),
-#ifdef ASSERT
-                        _frame_index(-1),
-#endif
-                        _unextended_sp(sp) {
-  find_codeblob_and_set_pc_and_deopt_state((address)own_abi()->return_pc);
+inline frame::frame(intptr_t* sp)
+  : _sp(sp), _pc((address)own_abi()->return_pc), _cb(nullptr), _oop_map(nullptr),
+    _on_heap(false), DEBUG_ONLY(_frame_index(-1) COMMA) _unextended_sp(sp), _fp(nullptr) {
+  setup();
 }
 
-inline frame::frame(intptr_t* sp, address pc) : _sp(sp), _on_heap(false),
-#ifdef ASSERT
-                        _frame_index(-1),
-#endif
-                        _unextended_sp(sp) {
-  find_codeblob_and_set_pc_and_deopt_state(pc); // Also sets _fp and adjusts _unextended_sp.
+inline frame::frame(intptr_t* sp, address pc)
+  : _sp(sp), _pc(pc), _cb(nullptr), _oop_map(nullptr),
+    _on_heap(false), DEBUG_ONLY(_frame_index(-1) COMMA) _unextended_sp(sp), _fp(nullptr) {
+  setup();
 }
 
-inline frame::frame(intptr_t* sp, address pc, intptr_t* unextended_sp) : _sp(sp), _on_heap(false),
-#ifdef ASSERT
-                                                                         _frame_index(-1),
-#endif
-                                                                         _unextended_sp(unextended_sp) {
-  find_codeblob_and_set_pc_and_deopt_state(pc); // Also sets _fp and adjusts _unextended_sp.
+inline frame::frame(intptr_t* sp, address pc, intptr_t* unextended_sp, intptr_t* fp, CodeBlob* cb)
+  : _sp(sp), _pc(pc), _cb(nullptr), _oop_map(nullptr),
+    _on_heap(false), DEBUG_ONLY(_frame_index(-1) COMMA) _unextended_sp(unextended_sp), _fp(fp) {
+  setup();
 }
 
 // Generic constructor. Used by pns() in debug.cpp only
 #ifndef PRODUCT
-inline frame::frame(void* sp, void* pc, void* unextended_sp) :
-  _sp((intptr_t*)sp), _pc(NULL), _cb(NULL), _on_heap(false),
-#ifdef ASSERT
-  _frame_index(-1),
-#endif
-  _unextended_sp((intptr_t*)unextended_sp) {
-  find_codeblob_and_set_pc_and_deopt_state((address)pc); // Also sets _fp and adjusts _unextended_sp.
+inline frame::frame(void* sp, void* pc, void* unextended_sp)
+  : _sp((intptr_t*)sp), _pc((address)pc), _cb(nullptr), _oop_map(nullptr),
+    _on_heap(false), DEBUG_ONLY(_frame_index(-1) COMMA) _unextended_sp((intptr_t*)unextended_sp) {
+  setup();
 }
 #endif
 
@@ -304,7 +303,16 @@ inline intptr_t* frame::real_fp() const {
 }
 
 inline const ImmutableOopMap* frame::get_oop_map() const {
-  Unimplemented();
+  if (_cb == NULL) return NULL;
+  if (_cb->oop_maps() != NULL) {
+    NativePostCallNop* nop = nativePostCallNop_at(_pc);
+    if (nop != NULL && nop->displacement() != 0) {
+      int slot = ((nop->displacement() >> 24) & 0xff);
+      return _cb->oop_map_for_slot(slot, _pc);
+    }
+    const ImmutableOopMap* oop_map = OopMapSet::find_map(this);
+    return oop_map;
+  }
   return NULL;
 }
 

--- a/src/hotspot/cpu/s390/frame_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.inline.hpp
@@ -59,7 +59,7 @@ inline void frame::setup() {
     _deopt_state = not_deoptimized;
   }
 
-  assert(_on_heap || is_aligned(_sp, frame::frame_alignment), "SP must be 8-byte aligned");
+  // assert(_on_heap || is_aligned(_sp, frame::frame_alignment), "SP must be 8-byte aligned");
 }
 
 // Constructors

--- a/src/hotspot/cpu/s390/frame_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.inline.hpp
@@ -56,7 +56,11 @@ inline void frame::setup() {
     assert(_cb == nullptr || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
            "original PC must be in the main code section of the the compiled method (or must be immediately following it)");
   } else {
-    _deopt_state = not_deoptimized;
+    if (_cb == SharedRuntime::deopt_blob()) {
+      _deopt_state = is_deoptimized;
+    } else {
+      _deopt_state = not_deoptimized;
+    }
   }
 
   // assert(_on_heap || is_aligned(_sp, frame::frame_alignment), "SP must be 8-byte aligned");

--- a/src/hotspot/cpu/s390/nativeInst_s390.hpp
+++ b/src/hotspot/cpu/s390/nativeInst_s390.hpp
@@ -657,13 +657,13 @@ class NativeGeneralJump: public NativeInstruction {
 class NativePostCallNop: public NativeInstruction {
 public:
   bool check() const { Unimplemented(); return false; }
-  int displacement() const { Unimplemented(); return 0; }
+  int displacement() const { return 0; }
   void patch(jint diff) { Unimplemented(); }
   void make_deopt() { Unimplemented(); }
 };
 
 inline NativePostCallNop* nativePostCallNop_at(address address) {
-  Unimplemented();
+  // Unimplemented();
   return NULL;
 }
 
@@ -675,7 +675,7 @@ public:
   void  verify() { Unimplemented(); }
 
   static bool is_deopt_at(address instr) {
-    Unimplemented();
+    // Unimplemented();
     return false;
   }
 

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2857,6 +2857,44 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
+  RuntimeStub* generate_cont_doYield() {
+    if (!Continuations::enabled()) return nullptr;
+    Unimplemented();
+    return nullptr;
+  }
+
+  address generate_cont_thaw(bool return_barrier, bool exception) {
+    if (!Continuations::enabled()) return nullptr;
+    Unimplemented();
+    return nullptr;
+  }
+
+  address generate_cont_thaw() {
+    if (!Continuations::enabled()) return nullptr;
+    Unimplemented();
+    return nullptr;
+  }
+
+  address generate_cont_returnBarrier() {
+    if (!Continuations::enabled()) return nullptr;
+    Unimplemented();
+    return nullptr;
+  }
+
+  address generate_cont_returnBarrier_exception() {
+    if (!Continuations::enabled()) return nullptr;
+    Unimplemented();
+    return nullptr;
+  }
+
+  #if INCLUDE_JFR
+  RuntimeStub* generate_jfr_write_checkpoint() {
+    if (!Continuations::enabled()) return nullptr;
+    Unimplemented();
+    return nullptr;
+  }
+  #endif // INCLUD_JFR
+
   void generate_initial() {
     // Generates all stubs and initializes the entry points.
 
@@ -2895,6 +2933,18 @@ class StubGenerator: public StubCodeGenerator {
     StubRoutines::zarch::_trot_table_addr = (address)StubRoutines::zarch::_trot_table;
   }
 
+  void generate_phase1() {
+    // Continuation stubs:
+    StubRoutines::_cont_thaw          = generate_cont_thaw();
+    StubRoutines::_cont_returnBarrier = generate_cont_returnBarrier();
+    StubRoutines::_cont_returnBarrierExc = generate_cont_returnBarrier_exception();
+    StubRoutines::_cont_doYield_stub  = generate_cont_doYield();
+    StubRoutines::_cont_doYield       = StubRoutines::_cont_doYield_stub == nullptr ? nullptr
+                                      : StubRoutines::_cont_doYield_stub->entry_point();
+
+    JFR_ONLY(StubRoutines::_jfr_write_checkpoint_stub = generate_jfr_write_checkpoint();)
+    JFR_ONLY(StubRoutines::_jfr_write_checkpoint = StubRoutines::_jfr_write_checkpoint_stub->entry_point();)
+  }
 
   void generate_all() {
     // Generates all stubs and initializes the entry points.
@@ -2971,12 +3021,14 @@ class StubGenerator: public StubCodeGenerator {
   }
 
  public:
-  StubGenerator(CodeBuffer* code, bool all) : StubCodeGenerator(code) {
+  StubGenerator(CodeBuffer* code, int phase) : StubCodeGenerator(code) {
     _stub_count = !all ? 0x100 : 0x200;
-    if (all) {
-      generate_all();
-    } else {
+    if (phase == 0) {
       generate_initial();
+    } else if (phase == 1) {
+      generate_phase1(); // stubs that must be available for the interpreter
+    } else {
+      generate_all();
     }
   }
 

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -3022,7 +3022,7 @@ class StubGenerator: public StubCodeGenerator {
 
  public:
   StubGenerator(CodeBuffer* code, int phase) : StubCodeGenerator(code) {
-    _stub_count = !all ? 0x100 : 0x200;
+    _stub_count = (phase == 0) ? 0x100 : 0x200;
     if (phase == 0) {
       generate_initial();
     } else if (phase == 1) {

--- a/src/hotspot/cpu/s390/templateInterpreterGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/templateInterpreterGenerator_s390.cpp
@@ -483,6 +483,7 @@ address TemplateInterpreterGenerator::generate_abstract_entry(void) {
 }
 
 address TemplateInterpreterGenerator::generate_Continuation_doYield_entry(void) {
+  if (!Continuations::enabled()) return nullptr;
   Unimplemented();
   return NULL;
 }

--- a/src/hotspot/share/runtime/signature.cpp
+++ b/src/hotspot/share/runtime/signature.cpp
@@ -235,14 +235,14 @@ void Fingerprinter::do_type_calling_convention(BasicType type) {
   case T_BYTE:
   case T_SHORT:
   case T_INT:
-#if defined(PPC64)
+#if defined(PPC64) || defined(S390)
     if (_int_args < Argument::n_int_register_parameters_j) {
       _int_args++;
     } else {
       _stack_arg_slots += 1;
     }
     break;
-#endif // defined(PPC64)
+#endif // defined(PPC64) || defined(S390)
   case T_LONG:
   case T_OBJECT:
   case T_ARRAY:
@@ -251,23 +251,25 @@ void Fingerprinter::do_type_calling_convention(BasicType type) {
       _int_args++;
     } else {
       PPC64_ONLY(_stack_arg_slots = align_up(_stack_arg_slots, 2));
+      S390_ONLY(_stack_arg_slots = align_up(_stack_arg_slots, 2));
       _stack_arg_slots += 2;
     }
     break;
   case T_FLOAT:
-#if defined(PPC64)
+#if defined(PPC64) || defined(S390)
     if (_fp_args < Argument::n_float_register_parameters_j) {
       _fp_args++;
     } else {
       _stack_arg_slots += 1;
     }
     break;
-#endif // defined(PPC64)
+#endif // defined(PPC64) || defined(S390)
   case T_DOUBLE:
     if (_fp_args < Argument::n_float_register_parameters_j) {
       _fp_args++;
     } else {
       PPC64_ONLY(_stack_arg_slots = align_up(_stack_arg_slots, 2));
+      S390_ONLY(_stack_arg_slots = align_up(_stack_arg_slots, 2));
       _stack_arg_slots += 2;
     }
     break;


### PR DESCRIPTION
This PR is a WIP attempt to make the s390x port build-able again before a full implementation of JEP-425. I am following the changes made [to restore the ppc port](https://github.com/openjdk/jdk/commit/87f3d2b870a1534183c4a70db4526532bc858d04#diff-11b22e013dd60a5c34cb26362705099f0911c50922717182dd63620e3d013eb4).

Comments are welcome :-)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288128](https://bugs.openjdk.org/browse/JDK-8288128): S390X: Fix crashes after JDK-8284161 (Virtual Threads)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9313/head:pull/9313` \
`$ git checkout pull/9313`

Update a local copy of the PR: \
`$ git checkout pull/9313` \
`$ git pull https://git.openjdk.org/jdk pull/9313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9313`

View PR using the GUI difftool: \
`$ git pr show -t 9313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9313.diff">https://git.openjdk.org/jdk/pull/9313.diff</a>

</details>
