### PR TITLE
8289401: Add dump output to TestRawRSACipher.java

### DIFF
--- a/test/jdk/sun/security/pkcs11/Cipher/TestRawRSACipher.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestRawRSACipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6994008
+ * @bug 6994008 8289401
  * @summary basic test for RSA/ECB/NoPadding cipher
  * @author Valerie Peng
  * @library /test/lib ..
@@ -71,6 +71,17 @@ public class TestRawRSACipher extends PKCS11Test {
         cipherText = c1.doFinal(plainText);
         recoveredText = c2.doFinal(cipherText);
         if (!Arrays.equals(plainText, recoveredText)) {
+            System.out.println("*** E/D Test -- plainText:");
+            for (int i = 0; i < plainText.length ; i++) {
+                System.out.printf(String.format("%02x ", plainText[i]));
+            }
+            System.out.print("\n");
+            System.out.println("*** E/D Test -- recoveredText:");
+            for (int i = 0; i < recoveredText.length ; i++) {
+                System.out.printf(String.format("%02x ", recoveredText[i]));
+            }
+            System.out.print("\n");
+
             throw new RuntimeException("E/D Test against SunJCE Failed!");
         }
 
@@ -79,6 +90,17 @@ public class TestRawRSACipher extends PKCS11Test {
         cipherText = c2.doFinal(plainText);
         recoveredText = c1.doFinal(cipherText);
         if (!Arrays.equals(plainText, recoveredText)) {
+            System.out.println("*** D/E Test -- plainText:");
+            for (int i = 0; i < plainText.length ; i++) {
+                System.out.printf(String.format("%02x ", plainText[i]));
+            }
+            System.out.print("\n");
+            System.out.println("*** D/E Test -- recoveredText:");
+            for (int i = 0; i < recoveredText.length ; i++) {
+                System.out.printf(String.format("%02x ", recoveredText[i]));
+            }
+            System.out.print("\n");
+
             throw new RuntimeException("D/E Test against SunJCE Failed!");
         }
 

--- a/test/jdk/sun/security/pkcs11/Cipher/TestRawRSACipher.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestRawRSACipher.java
@@ -38,6 +38,7 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.Provider;
 import java.util.Arrays;
+import java.util.HexFormat;
 import java.util.Random;
 import javax.crypto.Cipher;
 
@@ -71,17 +72,9 @@ public class TestRawRSACipher extends PKCS11Test {
         cipherText = c1.doFinal(plainText);
         recoveredText = c2.doFinal(cipherText);
         if (!Arrays.equals(plainText, recoveredText)) {
-            System.out.println("*** E/D Test -- plainText:");
-            for (int i = 0; i < plainText.length ; i++) {
-                System.out.printf(String.format("%02x ", plainText[i]));
-            }
-            System.out.print("\n");
-            System.out.println("*** E/D Test -- recoveredText:");
-            for (int i = 0; i < recoveredText.length ; i++) {
-                System.out.printf(String.format("%02x ", recoveredText[i]));
-            }
-            System.out.print("\n");
-
+            System.out.println("*** E/D Test:");
+            System.out.println("\tplainText = " + HexFormat.of().formatHex(plainText));
+            System.out.println("\trecoveredText = " + HexFormat.of().formatHex(recoveredText));
             throw new RuntimeException("E/D Test against SunJCE Failed!");
         }
 
@@ -90,17 +83,9 @@ public class TestRawRSACipher extends PKCS11Test {
         cipherText = c2.doFinal(plainText);
         recoveredText = c1.doFinal(cipherText);
         if (!Arrays.equals(plainText, recoveredText)) {
-            System.out.println("*** D/E Test -- plainText:");
-            for (int i = 0; i < plainText.length ; i++) {
-                System.out.printf(String.format("%02x ", plainText[i]));
-            }
-            System.out.print("\n");
-            System.out.println("*** D/E Test -- recoveredText:");
-            for (int i = 0; i < recoveredText.length ; i++) {
-                System.out.printf(String.format("%02x ", recoveredText[i]));
-            }
-            System.out.print("\n");
-
+            System.out.println("*** D/E Test:");
+            System.out.println("\tplainText = " + HexFormat.of().formatHex(plainText));
+            System.out.println("\trecoveredText = " + HexFormat.of().formatHex(recoveredText));
             throw new RuntimeException("D/E Test against SunJCE Failed!");
         }
 


### PR DESCRIPTION
Test TestRawRSACipher.java may fail intermittently. Please review changes to dump out the input and output when it fails.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289401](https://bugs.openjdk.org/browse/JDK-8289401): Add dump output to TestRawRSACipher.java


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9316/head:pull/9316` \
`$ git checkout pull/9316`

Update a local copy of the PR: \
`$ git checkout pull/9316` \
`$ git pull https://git.openjdk.org/jdk pull/9316/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9316`

View PR using the GUI difftool: \
`$ git pr show -t 9316`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9316.diff">https://git.openjdk.org/jdk/pull/9316.diff</a>

</details>
