### PR TITLE
8289427: compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java failed with null setting

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -44,7 +44,6 @@
 # :hotspot_compiler
 
 compiler/ciReplay/TestSAServer.java 8029528 generic-all
-compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java 8225370 generic-all
 compiler/jvmci/compilerToVM/GetFlagValueTest.java 8204459 generic-all
 compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java 8262901 macosx-aarch64
 compiler/tiered/LevelTransitionTest.java 8067651 generic-all

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -44,6 +44,7 @@
 # :hotspot_compiler
 
 compiler/ciReplay/TestSAServer.java 8029528 generic-all
+compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java 8225370 generic-all
 compiler/jvmci/compilerToVM/GetFlagValueTest.java 8204459 generic-all
 compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java 8262901 macosx-aarch64
 compiler/tiered/LevelTransitionTest.java 8067651 generic-all

--- a/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/DirectiveBuilder.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/DirectiveBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -213,7 +213,7 @@ public class DirectiveBuilder implements StateBuilder<CompileCommand> {
                 dirFile.option(DirectiveWriter.Option.PRINT_ASSEMBLY, true);
                 break;
             case INTRINSIC:
-                dirFile.option(DirectiveWriter.Option.INTRINSIC, "\"" + cmd.argument + "\"");
+                dirFile.option(DirectiveWriter.Option.INTRINSIC, "\"" + (cmd.argument != null ? cmd.argument : "+_fabs") + "\"");
                 break;
             case NONEXISTENT:
                 dirFile.write(JSONFile.Element.PAIR, command.name);


### PR DESCRIPTION
The problem of JDK-8289427 is caused by using incorrect compiler settings when the auto generated INTRINSIC parameter is null.
I fixed it to use the appropriate value if the argument of cmd was null.
Please review this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289427](https://bugs.openjdk.org/browse/JDK-8289427): compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java failed with null setting


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9318/head:pull/9318` \
`$ git checkout pull/9318`

Update a local copy of the PR: \
`$ git checkout pull/9318` \
`$ git pull https://git.openjdk.org/jdk pull/9318/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9318`

View PR using the GUI difftool: \
`$ git pr show -t 9318`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9318.diff">https://git.openjdk.org/jdk/pull/9318.diff</a>

</details>
