### PR TITLE
JDK-8289146: containers/docker/TestMemoryWithCgroupV1.java fails on linux ppc64le machine with missing Memory and Swap Limit output

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
@@ -81,10 +81,17 @@ public class TestMemoryWithCgroupV1 {
         Common.addWhiteBoxOpts(opts);
 
         OutputAnalyzer out = Common.run(opts);
-        out.shouldContain("Memory and Swap Limit is: " + expectedReadLimit)
+        // in case of warnings like : "Your kernel does not support swap limit
+        // capabilities or the cgroup is not mounted. Memory limited without swap."
+        // we only have Memory and Swap Limit is: <huge integer> in the output
+        try {
+            out.shouldContain("Memory and Swap Limit is: " + expectedReadLimit)
                 .shouldContain(
                         "Memory and Swap Limit has been reset to " + expectedResetLimit + " because swappiness is 0")
                 .shouldContain("Memory & Swap Limit: " + expectedLimit);
+        } catch (RuntimeException ex) {
+            out.shouldMatch("Memory and Swap Limit is: [0-9]+");
+        }
     }
 
     private static void testOSBeanSwappinessMemory(String memoryAllocation, String swapAllocation,

--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
@@ -90,7 +90,9 @@ public class TestMemoryWithCgroupV1 {
                         "Memory and Swap Limit has been reset to " + expectedResetLimit + " because swappiness is 0")
                 .shouldContain("Memory & Swap Limit: " + expectedLimit);
         } catch (RuntimeException ex) {
-            out.shouldMatch("Memory and Swap Limit is: [0-9]+");
+            System.out.println("Expected Memory and Swap Limit output missing.");
+            System.out.println("Check the cgroup_enable=memory swapaccount setting of your system.");
+            throw ex;
         }
     }
 

--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
@@ -91,7 +91,7 @@ public class TestMemoryWithCgroupV1 {
                 .shouldContain("Memory & Swap Limit: " + expectedLimit);
         } catch (RuntimeException ex) {
             System.out.println("Expected Memory and Swap Limit output missing.");
-            System.out.println("Check the cgroup_enable=memory swapaccount setting of your system.");
+            System.out.println("You may need to add 'cgroup_enable=memory swapaccount=1' to the Linux kernel boot parameters.");
             throw ex;
         }
     }


### PR DESCRIPTION
On Linux ppc64le machines , the test fails with

 stderr: [WARNING: Your kernel does not support swap limit capabilities or the cgroup is not mounted. Memory limited without swap.
]
 exitValue = 0

java.lang.RuntimeException: 'Memory and Swap Limit is: 157286400' missing from stdout/stderr

at jdk.test.lib.process.OutputAnalyzer.shouldContain(OutputAnalyzer.java:221)
at TestMemoryWithCgroupV1.testMemoryLimitWithSwappiness(TestMemoryWithCgroupV1.java:84)
at TestMemoryWithCgroupV1.main(TestMemoryWithCgroupV1.java:61)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:578)
at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:312)
at java.base/java.lang.Thread.run(Thread.java:1596)

This is most likely related to "kernel does not support swap limit capabilities",
we've seen similar issues on other Linux ppc64 le machines in some tests before.
So there needs to be some special handling added to the test for the case without kernel swap limit capabilities.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289146](https://bugs.openjdk.org/browse/JDK-8289146): containers/docker/TestMemoryWithCgroupV1.java fails on linux ppc64le machine with missing Memory and Swap Limit output


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**) ⚠️ Review applies to [f81053b2](https://git.openjdk.org/jdk/pull/9319/files/f81053b21fa3af890b185093d8391eca033e26f3)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [f81053b2](https://git.openjdk.org/jdk/pull/9319/files/f81053b21fa3af890b185093d8391eca033e26f3)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9319/head:pull/9319` \
`$ git checkout pull/9319`

Update a local copy of the PR: \
`$ git checkout pull/9319` \
`$ git pull https://git.openjdk.org/jdk pull/9319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9319`

View PR using the GUI difftool: \
`$ git pr show -t 9319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9319.diff">https://git.openjdk.org/jdk/pull/9319.diff</a>

</details>
