### PR TITLE
8289434: x86_64: Improve comment on gen_continuation_enter()

### DIFF
--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -1314,11 +1314,11 @@ static void gen_continuation_enter(MacroAssembler* masm,
 
   Label L_thaw, L_exit;
 
-  // If continuation, call to thaw. Otherwise, resolve the call and exit.
+  // If isContinue, call to thaw. Otherwise, call Continuation.enter(Continuation c, boolean isContinue)
   __ testptr(reg_is_cont, reg_is_cont);
   __ jccb(Assembler::notZero, L_thaw);
 
-  // --- Resolve path
+  // --- call Continuation.enter(Continuation c, boolean isContinue)
 
   // Make sure the call is patchable
   __ align(BytesPerWord, __ offset() + NativeCall::displacement_offset);
@@ -1330,7 +1330,10 @@ static void gen_continuation_enter(MacroAssembler* masm,
     fatal("CodeCache is full at gen_continuation_enter");
   }
 
-  // Call the resolve stub
+  // The call needs to be resolved. There's a special case for this in
+  // SharedRuntime::find_callee_info_helper() which calls
+  // LinkResolver::resolve_continuation_enter() which resolves the call to
+  // Continuation.enter(Continuation c, boolean isContinue).
   AddressLiteral resolve(SharedRuntime::get_resolve_static_call_stub(),
                          relocInfo::static_call_type);
   __ call(resolve);


### PR DESCRIPTION
Change code comments for `gen_continuation_enter()` explaining that the generated code will call `Continuation.enter(Continuation c, boolean isContinue)` if the continuation give as first parameter is run for the first time.

Also mention the special case for resolving this call.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289434](https://bugs.openjdk.org/browse/JDK-8289434): x86_64: Improve comment on gen_continuation_enter()


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9320/head:pull/9320` \
`$ git checkout pull/9320`

Update a local copy of the PR: \
`$ git checkout pull/9320` \
`$ git pull https://git.openjdk.org/jdk pull/9320/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9320`

View PR using the GUI difftool: \
`$ git pr show -t 9320`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9320.diff">https://git.openjdk.org/jdk/pull/9320.diff</a>

</details>
