### PR TITLE
8065097: [macosx] javax/swing/Popup/TaskbarPositionTest.java fails because Popup is one pixel off

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -669,7 +669,6 @@ javax/swing/text/DefaultCaret/HidingSelection/MultiSelectionTest.java 8213562 li
 javax/swing/JFileChooser/6798062/bug6798062.java 8146446 windows-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all
 javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-all
-javax/swing/Popup/TaskbarPositionTest.java 8065097 macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 
 # Several tests which fail on some hidpi systems/macosx12-aarch64 system

--- a/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
+++ b/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
@@ -103,7 +103,7 @@ public class TaskbarPositionTest implements ActionListener {
         fullScreenBounds = new Rectangle(new Point(), toolkit.getScreenSize());
         screenBounds = new Rectangle(new Point(), toolkit.getScreenSize());
 
-        // Place the frame near the bottom. This is a pretty wild guess.
+        // Place the frame near the bottom.
         frame.setLocation(0, screenBounds.y + screenBounds.height - frame.getHeight());
 
         // Reduce the screen bounds by the insets.

--- a/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
+++ b/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
@@ -103,8 +103,6 @@ public class TaskbarPositionTest implements ActionListener {
         fullScreenBounds = new Rectangle(new Point(), toolkit.getScreenSize());
         screenBounds = new Rectangle(new Point(), toolkit.getScreenSize());
 
-        // Place the frame near the bottom.
-        frame.setLocation(0, screenBounds.y + screenBounds.height - frame.getHeight());
 
         // Reduce the screen bounds by the insets.
         GraphicsConfiguration gc = frame.getGraphicsConfiguration();
@@ -117,6 +115,8 @@ public class TaskbarPositionTest implements ActionListener {
             screenBounds.y += screenInsets.top;
         }
 
+        // Place the frame near the bottom.
+        frame.setLocation(0, screenBounds.y + screenBounds.height - frame.getHeight());
         frame.setVisible(true);
     }
 

--- a/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
+++ b/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
@@ -54,7 +54,6 @@ import javax.swing.event.PopupMenuEvent;
  * @test
  * @bug 4245587 4474813 4425878 4767478 8015599
  * @key headful
- * @author Mark Davidson
  * @summary Tests the location of the heavy weight popup portion of JComboBox,
  * JMenu and JPopupMenu.
  * @library ../regtesthelpers
@@ -105,7 +104,7 @@ public class TaskbarPositionTest implements ActionListener {
         screenBounds = new Rectangle(new Point(), toolkit.getScreenSize());
 
         // Place the frame near the bottom. This is a pretty wild guess.
-        frame.setLocation(0, (int) screenBounds.getHeight() - 2 * frame.getHeight());
+        frame.setLocation(0, screenBounds.y + screenBounds.height - frame.getHeight());
 
         // Reduce the screen bounds by the insets.
         GraphicsConfiguration gc = frame.getGraphicsConfiguration();
@@ -118,7 +117,6 @@ public class TaskbarPositionTest implements ActionListener {
             screenBounds.y += screenInsets.top;
         }
 
-        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 
@@ -347,7 +345,7 @@ public class TaskbarPositionTest implements ActionListener {
             // Popup from a mouse click.
             Point pt = new Point(2, 2);
             SwingUtilities.convertPointToScreen(pt, panel);
-            robot.mouseMove((int) pt.getX(), (int) pt.getY());
+            robot.mouseMove(pt.x, pt.y);
             robot.mousePress(InputEvent.BUTTON3_MASK);
             robot.mouseRelease(InputEvent.BUTTON3_MASK);
 

--- a/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
+++ b/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
@@ -366,7 +366,7 @@ public class TaskbarPositionTest implements ActionListener {
             robot.keyRelease(KeyEvent.VK_ESCAPE);
 
             robot.waitForIdle();
-	} finally {
+        } finally {
             SwingUtilities.invokeAndWait(() -> {
                 if (frame != null) {
                     frame.dispose();

--- a/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
+++ b/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,10 +21,34 @@
  * questions.
  */
 
-import java.awt.*;
-import java.awt.event.*;
-import javax.swing.*;
-import javax.swing.event.*;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GraphicsConfiguration;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseAdapter;
+import javax.swing.AbstractAction;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JSeparator;
+import javax.swing.JTextField;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+import javax.swing.event.PopupMenuListener;
+import javax.swing.event.PopupMenuEvent;
 
 /**
  * @test
@@ -37,11 +61,12 @@ import javax.swing.event.*;
  * @build Util
  * @run main TaskbarPositionTest
  */
-public class TaskbarPositionTest extends JFrame implements ActionListener {
+public class TaskbarPositionTest implements ActionListener {
 
     private boolean done;
     private Throwable error;
     private static TaskbarPositionTest test;
+    private static JFrame frame;
     private static JPopupMenu popupMenu;
     private static JPanel panel;
     private static JComboBox<String> combo1;
@@ -63,27 +88,27 @@ public class TaskbarPositionTest extends JFrame implements ActionListener {
     };
 
     public TaskbarPositionTest() {
-        super("Use CTRL-down to show a JPopupMenu");
-        setContentPane(panel = createContentPane());
-        setJMenuBar(createMenuBar("1 - First Menu", true));
-        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame = new JFrame("Use CTRL-down to show a JPopupMenu");
+        frame.setContentPane(panel = createContentPane());
+        frame.setJMenuBar(createMenuBar("1 - First Menu", true));
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
         // CTRL-down will show the popup.
         panel.getInputMap().put(KeyStroke.getKeyStroke(
                 KeyEvent.VK_DOWN, InputEvent.CTRL_MASK), "OPEN_POPUP");
         panel.getActionMap().put("OPEN_POPUP", new PopupHandler());
 
-        pack();
+        frame.pack();
 
         Toolkit toolkit = Toolkit.getDefaultToolkit();
         fullScreenBounds = new Rectangle(new Point(), toolkit.getScreenSize());
         screenBounds = new Rectangle(new Point(), toolkit.getScreenSize());
 
         // Place the frame near the bottom. This is a pretty wild guess.
-        this.setLocation(0, (int) screenBounds.getHeight() - 2 * this.getHeight());
+        frame.setLocation(0, (int) screenBounds.getHeight() - 2 * frame.getHeight());
 
         // Reduce the screen bounds by the insets.
-        GraphicsConfiguration gc = this.getGraphicsConfiguration();
+        GraphicsConfiguration gc = frame.getGraphicsConfiguration();
         if (gc != null) {
             Insets screenInsets = toolkit.getScreenInsets(gc);
             screenBounds = gc.getBounds();
@@ -93,7 +118,8 @@ public class TaskbarPositionTest extends JFrame implements ActionListener {
             screenBounds.y += screenInsets.top;
         }
 
-        setVisible(true);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
     }
 
     public static class ComboPopupCheckListener implements PopupMenuListener {
@@ -113,7 +139,8 @@ public class TaskbarPositionTest extends JFrame implements ActionListener {
             if (pm != null) {
                 Point p = pm.getLocation();
                 SwingUtilities.convertPointToScreen(p, pm);
-                if (p.y < cpos.y) {
+                if (p.y+1 < cpos.y) {
+                    System.out.println("p.y " + p.y + " cpos.y " + cpos.y);
                     throw new RuntimeException("ComboBox popup is wrongly aligned");
                 }  // check that popup was opened down
             }
@@ -261,81 +288,90 @@ public class TaskbarPositionTest extends JFrame implements ActionListener {
 
     public static void main(String[] args) throws Throwable {
 
+        try {
+            // Use Robot to automate the test
+            Robot robot;
+            robot = new Robot();
+            robot.setAutoDelay(50);
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                test = new TaskbarPositionTest();
-            }
-        });
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    test = new TaskbarPositionTest();
+                }
+            });
 
-        // Use Robot to automate the test
-        Robot robot;
-        robot = new Robot();
-        robot.setAutoDelay(125);
+            robot.waitForIdle();
+            robot.delay(1000);
 
-        // 1 - menu
-        Util.hitMnemonics(robot, KeyEvent.VK_1);
+            // 1 - menu
+            Util.hitMnemonics(robot, KeyEvent.VK_1);
 
-        robot.waitForIdle();
-        isPopupOnScreen(menu1.getPopupMenu(), screenBounds);
+            robot.waitForIdle();
+            SwingUtilities.invokeAndWait(() -> isPopupOnScreen(menu1.getPopupMenu(), screenBounds));
 
-        // 2 menu with sub menu
-        robot.keyPress(KeyEvent.VK_RIGHT);
-        robot.keyRelease(KeyEvent.VK_RIGHT);
-        Util.hitMnemonics(robot, KeyEvent.VK_S);
+            // 2 menu with sub menu
+            robot.keyPress(KeyEvent.VK_RIGHT);
+            robot.keyRelease(KeyEvent.VK_RIGHT);
+            Util.hitMnemonics(robot, KeyEvent.VK_S);
 
-        robot.waitForIdle();
-        isPopupOnScreen(menu2.getPopupMenu(), screenBounds);
+            robot.waitForIdle();
+            SwingUtilities.invokeAndWait(() -> isPopupOnScreen(menu2.getPopupMenu(), screenBounds));
 
-        robot.keyPress(KeyEvent.VK_ENTER);
-        robot.keyRelease(KeyEvent.VK_ENTER);
+            robot.keyPress(KeyEvent.VK_ENTER);
+            robot.keyRelease(KeyEvent.VK_ENTER);
 
-        // Focus should go to non editable combo box
-        robot.waitForIdle();
-        Thread.sleep(500);
+            // Focus should go to non editable combo box
+            robot.waitForIdle();
+            robot.delay(500);
 
-        robot.keyPress(KeyEvent.VK_DOWN);
+            robot.keyPress(KeyEvent.VK_DOWN);
 
-        // How do we check combo boxes?
+            // How do we check combo boxes?
 
-        // Editable combo box
-        robot.keyPress(KeyEvent.VK_TAB);
-        robot.keyRelease(KeyEvent.VK_TAB);
-        robot.keyPress(KeyEvent.VK_DOWN);
-        robot.keyRelease(KeyEvent.VK_DOWN);
+            // Editable combo box
+            robot.keyPress(KeyEvent.VK_TAB);
+            robot.keyRelease(KeyEvent.VK_TAB);
+            robot.keyPress(KeyEvent.VK_DOWN);
+            robot.keyRelease(KeyEvent.VK_DOWN);
 
-        // combo1.getUI();
+            // combo1.getUI();
 
-        // Popup from Text field
-        robot.keyPress(KeyEvent.VK_TAB);
-        robot.keyRelease(KeyEvent.VK_TAB);
-        robot.keyPress(KeyEvent.VK_CONTROL);
-        robot.keyPress(KeyEvent.VK_DOWN);
-        robot.keyRelease(KeyEvent.VK_DOWN);
-        robot.keyRelease(KeyEvent.VK_CONTROL);
+            // Popup from Text field
+            robot.keyPress(KeyEvent.VK_TAB);
+            robot.keyRelease(KeyEvent.VK_TAB);
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.keyPress(KeyEvent.VK_DOWN);
+            robot.keyRelease(KeyEvent.VK_DOWN);
+            robot.keyRelease(KeyEvent.VK_CONTROL);
 
-        // Popup from a mouse click.
-        Point pt = new Point(2, 2);
-        SwingUtilities.convertPointToScreen(pt, panel);
-        robot.mouseMove((int) pt.getX(), (int) pt.getY());
-        robot.mousePress(InputEvent.BUTTON3_MASK);
-        robot.mouseRelease(InputEvent.BUTTON3_MASK);
+            // Popup from a mouse click.
+            Point pt = new Point(2, 2);
+            SwingUtilities.convertPointToScreen(pt, panel);
+            robot.mouseMove((int) pt.getX(), (int) pt.getY());
+            robot.mousePress(InputEvent.BUTTON3_MASK);
+            robot.mouseRelease(InputEvent.BUTTON3_MASK);
 
-        robot.waitForIdle();
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                test.setLocation(-30, 100);
-                combo1.addPopupMenuListener(new ComboPopupCheckListener());
-                combo1.requestFocus();
-            }
-        });
+            robot.waitForIdle();
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    frame.setLocation(-30, 100);
+                    combo1.addPopupMenuListener(new ComboPopupCheckListener());
+                    combo1.requestFocus();
+                }
+            });
 
-        robot.keyPress(KeyEvent.VK_DOWN);
-        robot.keyRelease(KeyEvent.VK_DOWN);
-        robot.keyPress(KeyEvent.VK_ESCAPE);
-        robot.keyRelease(KeyEvent.VK_ESCAPE);
+            robot.keyPress(KeyEvent.VK_DOWN);
+            robot.keyRelease(KeyEvent.VK_DOWN);
+            robot.keyPress(KeyEvent.VK_ESCAPE);
+            robot.keyRelease(KeyEvent.VK_ESCAPE);
 
-        robot.waitForIdle();
-        Thread.sleep(500);
+            robot.waitForIdle();
+	} finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
Test seems to fail in macOS citing popup location is 1 pixel off compared to combobox position ie
`p.y 154 cpos.y 155`

But in macOS, popup location, if 1st entry is selected, is 1 pixel higher than combobox so it's expected as can be seen below
<img width="661" alt="Screenshot 2022-06-29 at 1 53 42 PM" src="https://user-images.githubusercontent.com/43534309/176389227-4e568117-ffce-4b4a-92d7-ab5c78c4ce08.png">

so test is updated to add 1 pixel to popup location. 
It will not affect windows and linux as popup is placed below the combobox in those platforms so 1 pixel higher will not make any difference.
Also, added some stability fixes..Test passed for several iterations in all platforms in CI..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8065097](https://bugs.openjdk.org/browse/JDK-8065097): [macosx] javax/swing/Popup/TaskbarPositionTest.java fails because Popup is one pixel off


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**) ⚠️ Review applies to [2ad78ef0](https://git.openjdk.org/jdk/pull/9321/files/2ad78ef064db1c764411150cb89e21645fcd9e3e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9321/head:pull/9321` \
`$ git checkout pull/9321`

Update a local copy of the PR: \
`$ git checkout pull/9321` \
`$ git pull https://git.openjdk.org/jdk pull/9321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9321`

View PR using the GUI difftool: \
`$ git pr show -t 9321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9321.diff">https://git.openjdk.org/jdk/pull/9321.diff</a>

</details>
