### PR TITLE
8289436: Make the redefine timer statistics more accurate

### DIFF
--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -237,6 +237,10 @@ bool VM_RedefineClasses::doit_prologue() {
 void VM_RedefineClasses::doit() {
   Thread* current = Thread::current();
 
+  if (log_is_enabled(Info, redefine, class, timer)) {
+    _timer_vm_op_doit.start();
+  }
+
 #if INCLUDE_CDS
   if (UseSharedSpaces) {
     // Sharing is enabled so we remap the shared readonly space to
@@ -246,6 +250,7 @@ void VM_RedefineClasses::doit() {
     if (!MetaspaceShared::remap_shared_readonly_as_readwrite()) {
       log_info(redefine, class, load)("failed to remap shared readonly space to readwrite, private");
       _res = JVMTI_ERROR_INTERNAL;
+      _timer_vm_op_doit.stop();
       return;
     }
   }
@@ -295,6 +300,8 @@ void VM_RedefineClasses::doit() {
 
   // Clean up any metadata now unreferenced while MetadataOnStackMark is set.
   ClassLoaderDataGraph::clean_deallocate_lists(false);
+
+  _timer_vm_op_doit.stop();
 }
 
 void VM_RedefineClasses::doit_epilogue() {
@@ -309,8 +316,7 @@ void VM_RedefineClasses::doit_epilogue() {
   if (log_is_enabled(Info, redefine, class, timer)) {
     // Used to have separate timers for "doit" and "all", but the timer
     // overhead skewed the measurements.
-    julong doit_time = _timer_rsc_phase1.milliseconds() +
-                       _timer_rsc_phase2.milliseconds();
+    julong doit_time = _timer_vm_op_doit.milliseconds();
     julong all_time = _timer_vm_op_prologue.milliseconds() + doit_time;
 
     log_info(redefine, class, timer)

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
@@ -383,6 +383,7 @@ class VM_RedefineClasses: public VM_Operation {
   // the heavy lifting.
   elapsedTimer  _timer_rsc_phase1;
   elapsedTimer  _timer_rsc_phase2;
+  elapsedTimer  _timer_vm_op_doit;
   elapsedTimer  _timer_vm_op_prologue;
 
   // Redefinition id used by JFR


### PR DESCRIPTION
Make the redefine timer statistics more accurate

After some significant performance improvements of the class redefinition, like: 
https://bugs.openjdk.org/browse/JDK-8139551
https://bugs.openjdk.org/browse/JDK-8078725

Some time-consumption operation were moved out the "redefine_single_class"
So the time added by  phase 1 and phase 2 cannot be accurately represented to the time of "vmop_doit"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289436](https://bugs.openjdk.org/browse/JDK-8289436): Make the redefine timer statistics more accurate


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9322/head:pull/9322` \
`$ git checkout pull/9322`

Update a local copy of the PR: \
`$ git checkout pull/9322` \
`$ git pull https://git.openjdk.org/jdk pull/9322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9322`

View PR using the GUI difftool: \
`$ git pr show -t 9322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9322.diff">https://git.openjdk.org/jdk/pull/9322.diff</a>

</details>
