### PR TITLE
8289421: No-PCH build for Minimal VM was broken by JDK-8287001

### DIFF
--- a/src/hotspot/share/compiler/disassembler.cpp
+++ b/src/hotspot/share/compiler/disassembler.cpp
@@ -32,6 +32,7 @@
 #include "gc/shared/cardTable.hpp"
 #include "gc/shared/cardTableBarrierSet.hpp"
 #include "gc/shared/collectedHeap.hpp"
+#include "logging/log.hpp"
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
 #include "oops/oop.inline.hpp"


### PR DESCRIPTION
We see following error if we pass `--with-jvm-variants=minimal --disable-precompiled-headers` to configure script.

```
src/hotspot/share/compiler/disassembler.cpp:841:5: error: 'log_warning' was not declared in this scope; did you mean 'warning'?
[2022-06-29T01:25:45,429Z] 841 | log_warning(os)("Loading hsdis library failed");
[2022-06-29T01:25:45,429Z] | ^~~~~~~~~~~
[2022-06-29T01:25:45,429Z] | warning
```

Missing include of log.hpp

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289421](https://bugs.openjdk.org/browse/JDK-8289421): No-PCH build for Minimal VM was broken by JDK-8287001


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9323/head:pull/9323` \
`$ git checkout pull/9323`

Update a local copy of the PR: \
`$ git checkout pull/9323` \
`$ git pull https://git.openjdk.org/jdk pull/9323/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9323`

View PR using the GUI difftool: \
`$ git pr show -t 9323`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9323.diff">https://git.openjdk.org/jdk/pull/9323.diff</a>

</details>
