### PR TITLE
8289291: HttpServer sets incorrect value for "max" parameter in Keep-Alive header value

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -670,12 +670,11 @@ class ServerImpl implements TimeSource {
                     if (chdr == null) {
                         tx.close = true;
                         rheaders.set ("Connection", "close");
-                    } else if (chdr.equalsIgnoreCase ("keep-alive")) {
-                        rheaders.set ("Connection", "keep-alive");
-                        int idle=(int)(ServerConfig.getIdleInterval()/1000);
-                        int max=ServerConfig.getMaxIdleConnections();
-                        String val = "timeout="+idle+", max="+max;
-                        rheaders.set ("Keep-Alive", val);
+                    } else if (chdr.equalsIgnoreCase("keep-alive")) {
+                        rheaders.set("Connection", "keep-alive");
+                        int timeoutSeconds = (int) (ServerConfig.getIdleInterval() / 1000);
+                        String val = "timeout=" + timeoutSeconds;
+                        rheaders.set("Keep-Alive", val);
                     }
                 }
 

--- a/test/jdk/com/sun/net/httpserver/Http10KeepAliveMaxParamTest.java
+++ b/test/jdk/com/sun/net/httpserver/Http10KeepAliveMaxParamTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import com.sun.net.httpserver.HttpServer;
+import jdk.test.lib.net.HttpHeaderParser;
+
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Locale;
+
+/*
+ * @test
+ * @bug 8289291
+ * @summary Verifies that the HttpServer doesn't add the "max" parameter to the Keep-Alive header
+ * that it sets in the response
+ * @library /test/lib
+ * @run main Http10KeepAliveMaxParamTest
+ */
+public class Http10KeepAliveMaxParamTest {
+
+    /**
+     * Sends a HTTP/1.0 request with "Connection: keep-alive" header to the
+     * com.sun.net.httpserver.HttpServer and then verifies that if the server responds back
+     * with a "Keep-Alive" header in the response, then the header value doesn't have the
+     * "max" parameter.
+     */
+    public static void main(final String[] args) throws Exception {
+        final var bindAddr = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+        final int backlog = 0;
+        final HttpServer server = HttpServer.create(bindAddr, backlog);
+        server.createContext("/", (exchange) -> {
+            System.out.println("Sending response for request " + exchange.getRequestURI());
+            exchange.sendResponseHeaders(200, 0);
+            exchange.getResponseBody().close();
+        });
+        server.start();
+        System.out.println("Server started at address " + server.getAddress());
+        try {
+            try (final Socket sock = new Socket(bindAddr.getAddress(), server.getAddress().getPort())) {
+                // send a HTTP/1.0 request
+                final String request = "GET /test/foo HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+                final OutputStream os = sock.getOutputStream();
+                os.write(request.getBytes(StandardCharsets.UTF_8));
+                os.flush();
+                System.out.println("Sent request to server:");
+                System.out.println(request);
+                // read the response headers
+                final HttpHeaderParser headerParser = new HttpHeaderParser(sock.getInputStream());
+                // verify that the response contains 200 status code.
+                // method is oddly named, but it returns status line of response
+                final String statusLine = headerParser.getRequestDetails();
+                System.out.println("Received status line " + statusLine);
+                if (statusLine == null || !statusLine.contains("200")) {
+                    throw new AssertionError("Unexpected response from server," +
+                            " status line = " + statusLine);
+                }
+                System.out.println("Server responded with headers: " + headerParser.getHeaderMap());
+                // spec doesn't mandate the presence of the Keep-Alive header. We skip this test
+                // if the server doesn't send one
+                final List<String> keepAliveHeader = headerParser.getHeaderValue("keep-alive");
+                if (keepAliveHeader == null || keepAliveHeader.isEmpty()) {
+                    // skip the test
+                    System.out.println("Test SKIPPED since the server didn't return a keep-alive" +
+                            " header in response");
+                    return;
+                }
+                // we expect only one keep-alive header and there shouldn't be any "max" parameter
+                // in that value
+                final String val = keepAliveHeader.get(0);
+                if (val.toLowerCase(Locale.ROOT).contains("max")) {
+                    throw new AssertionError("Server wasn't supposed to send " +
+                            "\"max\" parameter in keep-alive response header. " +
+                            "Actual header value = " + val);
+                }
+            }
+        } finally {
+            server.stop(0);
+        }
+    }
+}


### PR DESCRIPTION
Can I please get a review for this change which addresses https://bugs.openjdk.org/browse/JDK-8289291?

As noted in that issue, right now, the Http(s)Server sets an incorrect value for the `max` parameter of the `Keep-Alive` header. The `max` value is supposed to be the number of subsequent requests that the server is willing to serve over that specific connection. The current value it sets is instead the number of idle connections that are configured for the server.

The commit in this PR removes that `max` parameter altogether, since it isn't mandated by the spec, nor does the Http(s)Server have any specific construct to come up with a right value. Furthermore, on the client side the HttpURLConnection based client doesn't mandate the presence of this parameter in the `Keep-Alive` header. So this change won't cause any regressions in that area.

tier1, tier2 and tier3 testing passed without any related issues after this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289291](https://bugs.openjdk.org/browse/JDK-8289291): HttpServer sets incorrect value for "max" parameter in Keep-Alive header value


### Reviewers
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9326/head:pull/9326` \
`$ git checkout pull/9326`

Update a local copy of the PR: \
`$ git checkout pull/9326` \
`$ git pull https://git.openjdk.org/jdk pull/9326/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9326`

View PR using the GUI difftool: \
`$ git pr show -t 9326`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9326.diff">https://git.openjdk.org/jdk/pull/9326.diff</a>

</details>
