### PR TITLE
8288882: JFileChooser - empty (0 bytes) file is displayed as 1 KB

### DIFF
--- a/src/java.desktop/share/classes/sun/swing/FilePane.java
+++ b/src/java.desktop/share/classes/sun/swing/FilePane.java
@@ -1190,18 +1190,24 @@ public class FilePane extends JPanel implements PropertyChangeListener {
                 setIcon(icon);
 
             } else if (value instanceof Long) {
-                long len = ((Long) value) / 1024L;
+                long len = ((Long) value);
                 if (listViewWindowsStyle) {
+                    len /= 1024L;
                     text = MessageFormat.format(kiloByteString, len + 1);
                 } else if (len < 1024L) {
-                    text = MessageFormat.format(kiloByteString, (len == 0L) ? 1L : len);
+                    text = (len == 0L) ? 0 + " bytes" : len + " bytes";
                 } else {
                     len /= 1024L;
                     if (len < 1024L) {
-                        text = MessageFormat.format(megaByteString, len);
+                        text = MessageFormat.format(kiloByteString, len);
                     } else {
                         len /= 1024L;
-                        text = MessageFormat.format(gigaByteString, len);
+                        if (len < 1024L) {
+                            text = MessageFormat.format(megaByteString, len);
+                        } else {
+                            len /= 1024L;
+                            text = MessageFormat.format(gigaByteString, len);
+                        }
                     }
                 }
 

--- a/test/jdk/javax/swing/JFileChooser/ZeroFileSizeCheck.java
+++ b/test/jdk/javax/swing/JFileChooser/ZeroFileSizeCheck.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8288882
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary To test if the TEST-EMPTY-FILE size shows 0 bytes.
+ * @run main/manual ZeroFileSizeCheck
+ */
+
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.Path;
+import javax.swing.JFileChooser;
+
+public class ZeroFileSizeCheck {
+
+    private static JFrame frame;
+    private static final String text =
+            "Click the \"Details\" button in right-top corner.\n\nScroll Down if required. \n\nIf the size of TEST-EMPTY-FILE shows Zero bytes in \nDetails view," +
+                    " press PASS.\n\n";
+
+    public static void createAndShowGUI() throws InterruptedException,
+            InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> {
+            frame = new JFrame("JFileChooser");
+            JFileChooser fc = new JFileChooser();
+            try {
+                Path currentDir = Paths.get(System.getProperty("java.io.tmpdir"));
+                // create empty file
+                Path emptyFile = currentDir.resolve("TEST-EMPTY-FILE.txt");
+                if (!Files.exists(emptyFile)) {
+                    Files.createFile(emptyFile);
+                }
+                fc.setCurrentDirectory(currentDir.toFile());
+            }catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+            frame.getContentPane().add(fc);
+            frame.setSize(400, 400);
+            frame.setLocationRelativeTo(null);
+            frame.setVisible(true);
+
+            PassFailJFrame.addTestFrame(frame);
+            PassFailJFrame.positionTestFrame(frame,
+                    PassFailJFrame.Position.HORIZONTAL);
+        });
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame passFailJFrame = new PassFailJFrame("JFileChooser " +
+                "Test Instructions", text, 5, 19, 35);
+        createAndShowGUI();
+        passFailJFrame.awaitAndCheck();
+    }
+}


### PR DESCRIPTION
JFileChooser - empty file size issue fixed. 
For empty file, now the size 0 bytes.
Manual Test Case "ZeroFileSizeCheck.java" created.