### PR TITLE
8289484: Cleanup unnecessary null comparison before instanceof check in java.rmi

### DIFF
--- a/src/java.rmi/share/classes/java/rmi/MarshalledObject.java
+++ b/src/java.rmi/share/classes/java/rmi/MarshalledObject.java
@@ -213,8 +213,7 @@ public final class MarshalledObject<T> implements Serializable {
         if (obj == this)
             return true;
 
-        if (obj != null && obj instanceof MarshalledObject) {
-            MarshalledObject<?> other = (MarshalledObject<?>) obj;
+        if (obj instanceof MarshalledObject<?> other) {
 
             // if either is a ref to null, both must be
             if (objBytes == null || other.objBytes == null)

--- a/src/java.rmi/share/classes/sun/rmi/transport/LiveRef.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/LiveRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -178,8 +178,7 @@ public class LiveRef implements Cloneable {
     }
 
     public boolean equals(Object obj) {
-        if (obj != null && obj instanceof LiveRef) {
-            LiveRef ref = (LiveRef) obj;
+        if (obj instanceof LiveRef ref) {
 
             return (ep.equals(ref.ep) && id.equals(ref.id) &&
                     isLocal == ref.isLocal);
@@ -189,8 +188,7 @@ public class LiveRef implements Cloneable {
     }
 
     public boolean remoteEquals(Object obj) {
-        if (obj != null && obj instanceof LiveRef) {
-            LiveRef ref = (LiveRef) obj;
+        if (obj instanceof LiveRef ref) {
 
             TCPEndpoint thisEp = ((TCPEndpoint) ep);
             TCPEndpoint refEp = ((TCPEndpoint) ref.ep);

--- a/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPEndpoint.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPEndpoint.java
@@ -489,8 +489,7 @@ public class TCPEndpoint implements Endpoint {
     }
 
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof TCPEndpoint)) {
-            TCPEndpoint ep = (TCPEndpoint) obj;
+        if (obj instanceof TCPEndpoint ep) {
             if (port != ep.port || !host.equals(ep.host))
                 return false;
             if (((csf == null) ^ (ep.csf == null)) ||


### PR DESCRIPTION
Update code checks both non-null and instance of a class in jdk.hotspot.agent module classes.
The checks and explicit casts could also be replaced with pattern matching for the instanceof operator.

For example, the following code:

        if ((obj != null) && (obj instanceof TCPEndpoint)) {
            TCPEndpoint ep = (TCPEndpoint) obj;
            if (port != ep.port || !host.equals(ep.host))

Can be simplified to:

        if (obj instanceof TCPEndpoint ep) {
            if (port != ep.port || !host.equals(ep.host))


See similar cleanup in java.base - [JDK-8258422](https://bugs.openjdk.java.net/browse/JDK-8258422)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289484](https://bugs.openjdk.org/browse/JDK-8289484): Cleanup unnecessary null comparison before instanceof check in java.rmi


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Attila Szegedi](https://openjdk.org/census#attila) (@szegedi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9332/head:pull/9332` \
`$ git checkout pull/9332`

Update a local copy of the PR: \
`$ git checkout pull/9332` \
`$ git pull https://git.openjdk.org/jdk pull/9332/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9332`

View PR using the GUI difftool: \
`$ git pr show -t 9332`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9332.diff">https://git.openjdk.org/jdk/pull/9332.diff</a>

</details>
