### PR TITLE
JDK-8289512: Fix GCC 12 warnings for adlc output_c.cpp

### DIFF
--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -397,7 +397,7 @@ static int pipeline_res_mask_initializer(
   const uint cyclemasksize = (maxcycleused + 31) >> 5;
 
   int i, j;
-  int element_count = 0;
+  uint element_count = 0;
   uint *res_mask = new uint [cyclemasksize];
   uint resources_used             = 0;
   uint resources_used_exclusively = 0;
@@ -524,12 +524,11 @@ static int pipeline_res_mask_initializer(
       fprintf(fp_cpp, "static const Pipeline_Use_Element pipeline_res_mask_%03d[%d] = {\n%s};\n\n",
         ndx+1, element_count, resource_mask);
 
-    char* args = new char [9 + 2*masklen + maskdigit];
+    // "0x012345678, 0x012345678, 4294967295"
+    char* args = new char [37];
 
-    sprintf(args, "0x%0*x, 0x%0*x, %*d",
-      masklen, resources_used,
-      masklen, resources_used_exclusively,
-      maskdigit, element_count);
+    sprintf(args, "0x%x, 0x%x, %u",
+      resources_used, resources_used_exclusively, element_count);
 
     pipeline_res_args.addName(args);
   }
@@ -1159,11 +1158,10 @@ static void check_peepconstraints(FILE *fp, FormDict &globals, PeepMatch *pmatch
       case Form::register_interface: {
         // Check that they are allocated to the same register
         // Need parameter for index position if not result operand
-        char left_reg_index[] = ",instXXXX_idxXXXX";
+        char left_reg_index[] = ",inst4294967295_idx4294967295";
         if( left_op_index != 0 ) {
-          assert( (left_index <= 9999) && (left_op_index <= 9999), "exceed string size");
           // Must have index into operands
-          sprintf(left_reg_index,",inst%d_idx%d", (int)left_index, left_op_index);
+          sprintf(left_reg_index,",inst%u_idx%u", (unsigned)left_index, (unsigned)left_op_index);
         } else {
           strcpy(left_reg_index, "");
         }
@@ -1172,11 +1170,10 @@ static void check_peepconstraints(FILE *fp, FormDict &globals, PeepMatch *pmatch
         fprintf(fp, " == ");
 
         if( right_index != -1 ) {
-          char right_reg_index[18] = ",instXXXX_idxXXXX";
+          char right_reg_index[] = ",inst4294967295_idx4294967295";
           if( right_op_index != 0 ) {
-            assert( (right_index <= 9999) && (right_op_index <= 9999), "exceed string size");
             // Must have index into operands
-            sprintf(right_reg_index,",inst%d_idx%d", (int)right_index, right_op_index);
+            sprintf(right_reg_index,",inst%u_idx%u", (unsigned)right_index, (unsigned)right_op_index);
           } else {
             strcpy(right_reg_index, "");
           }

--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -525,10 +525,11 @@ static int pipeline_res_mask_initializer(
         ndx+1, element_count, resource_mask);
 
     // "0x012345678, 0x012345678, 4294967295"
-    char* args = new char [37];
+    char* args = new char [36 + 1];
 
-    sprintf(args, "0x%x, 0x%x, %u",
+    int printed = sprintf(args, "0x%x, 0x%x, %u",
       resources_used, resources_used_exclusively, element_count);
+    assert(printed <= 36, "overflow");
 
     pipeline_res_args.addName(args);
   }


### PR DESCRIPTION
This fixes three warnings in my gcc 12 build on Ubuntu 22.04.

```
/shared/projects/openjdk/jdk-jdk/source/src/hotspot/share/adlc/output_c.cpp:529:36: error: '%*d' directive writing between 1 and 2147483647 bytes into a region of size between 0 and 2147483637 [-Werror=format-overflow=]
  529 | sprintf(args, "0x%0*x, 0x%0*x, %*d",
      | ^~~
```

Associated code:

```
    char* args = new char [9 + 2*masklen + maskdigit];

    sprintf(args, "0x%0*x, 0x%0*x, %*d",
      masklen, resources_used,
      masklen, resources_used_exclusively,
      maskdigit, element_count);
```

Since the variable-sized width could be smaller than the actual print width of the arguments, we could theoretically print more than what the width arguments specify. This is true for `maskdigit`. For `masklen`, compiler knows its value, since it is a constant. But compiler cannot know that `maskdigit` will always be large enough to print `element_count`.

Unfortunately, fixing this was not easy at all. The most obvious way would be to increase the buffer size. But GCC 12 does not grok the buffer size correctly. See comments in JBS.

In the end, I gave up. Since all this code does is to pretty-print-pad the variables, but the resulting code will be read by the C++ compiler, I removed the padding and the variable width parameters. I made the output character a simple character array holding the maximum width for unsigned int (what the parameters are) and, since I was here, also made the last parameter unsigned to not have to deal with negative sign. 

There were more, but simpler warnings:

```
/shared/projects/openjdk/jdk-jdk/source/src/hotspot/share/adlc/output_c.cpp: In function 'void check_peepconstraints(FILE*, FormDict&, PeepMatch*, PeepConstraint*)':
/shared/projects/openjdk/jdk-jdk/source/src/hotspot/share/adlc/output_c.cpp:1171:42: error: '_idx' directive writing 4 bytes into a region of size between 2 and 12 [-Werror=format-overflow=]
 1171 | sprintf(left_reg_index,",inst%d_idx%d", (int)left_index, left_op_index);
/shared/projects/openjdk/jdk-jdk/source/src/hotspot/share/adlc/output_c.cpp:1184:45: error: '_idx' directive writing 4 bytes into a region of size between 2 and 12 [-Werror=format-overflow=]
 1184 | sprintf(right_reg_index,",inst%d_idx%d", (int)right_index, right_op_index);
```

Here, I just increased the buffer size to hold the max width of the output strings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289512](https://bugs.openjdk.org/browse/JDK-8289512): Fix GCC 12 warnings for adlc output_c.cpp


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9335/head:pull/9335` \
`$ git checkout pull/9335`

Update a local copy of the PR: \
`$ git checkout pull/9335` \
`$ git pull https://git.openjdk.org/jdk pull/9335/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9335`

View PR using the GUI difftool: \
`$ git pr show -t 9335`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9335.diff">https://git.openjdk.org/jdk/pull/9335.diff</a>

</details>
