### PR TITLE
8289164: Convert ResolutionErrorTable to use ResourceHashtable

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -87,7 +87,6 @@
 #include "jfr/jfr.hpp"
 #endif
 
-ResolutionErrorTable*  SystemDictionary::_resolution_errors   = NULL;
 SymbolPropertyTable*   SystemDictionary::_invoke_method_table = NULL;
 ProtectionDomainCacheTable*   SystemDictionary::_pd_cache_table = NULL;
 
@@ -1605,7 +1604,7 @@ bool SystemDictionary::do_unloading(GCTimer* gc_timer) {
       MutexLocker ml1(is_concurrent ? SystemDictionary_lock : NULL);
       ClassLoaderDataGraph::clean_module_and_package_info();
       constraints()->purge_loader_constraints();
-      resolution_errors()->purge_resolution_errors();
+      ResolutionErrorTable::purge_resolution_errors();
     }
   }
 
@@ -1647,7 +1646,6 @@ void SystemDictionary::initialize(TRAPS) {
   // Allocate arrays
   _placeholders        = new PlaceholderTable(_placeholder_table_size);
   _loader_constraints  = new LoaderConstraintTable(_loader_constraint_size);
-  _resolution_errors   = new ResolutionErrorTable(_resolution_error_size);
   _invoke_method_table = new SymbolPropertyTable(_invoke_method_size);
   _pd_cache_table = new ProtectionDomainCacheTable(defaultProtectionDomainCacheSize);
 
@@ -1848,30 +1846,27 @@ bool SystemDictionary::add_loader_constraint(Symbol* class_name,
 void SystemDictionary::add_resolution_error(const constantPoolHandle& pool, int which,
                                             Symbol* error, Symbol* message,
                                             Symbol* cause, Symbol* cause_msg) {
-  unsigned int hash = resolution_errors()->compute_hash(pool, which);
-  int index = resolution_errors()->hash_to_index(hash);
   {
     MutexLocker ml(Thread::current(), SystemDictionary_lock);
-    ResolutionErrorEntry* entry = resolution_errors()->find_entry(index, hash, pool, which);
+    ResolutionErrorEntry* entry = ResolutionErrorTable::find_entry(pool, which);
     if (entry == NULL) {
-      resolution_errors()->add_entry(index, hash, pool, which, error, message, cause, cause_msg);
+      ResolutionErrorTable::add_entry(pool, which, error, message, cause, cause_msg);
     }
   }
 }
 
 // Delete a resolution error for RedefineClasses for a constant pool is going away
 void SystemDictionary::delete_resolution_error(ConstantPool* pool) {
-  resolution_errors()->delete_entry(pool);
+  ResolutionErrorTable::delete_entry(pool);
 }
 
 // Lookup resolution error table. Returns error if found, otherwise NULL.
 Symbol* SystemDictionary::find_resolution_error(const constantPoolHandle& pool, int which,
                                                 Symbol** message, Symbol** cause, Symbol** cause_msg) {
-  unsigned int hash = resolution_errors()->compute_hash(pool, which);
-  int index = resolution_errors()->hash_to_index(hash);
+
   {
     MutexLocker ml(Thread::current(), SystemDictionary_lock);
-    ResolutionErrorEntry* entry = resolution_errors()->find_entry(index, hash, pool, which);
+    ResolutionErrorEntry* entry = ResolutionErrorTable::find_entry(pool, which);
     if (entry != NULL) {
       *message = entry->message();
       *cause = entry->cause();
@@ -1887,14 +1882,13 @@ Symbol* SystemDictionary::find_resolution_error(const constantPoolHandle& pool, 
 // validating a nest host. This is used to construct informative error
 // messages when IllegalAccessError's occur. If an entry already exists it will
 // be updated with the nest host error message.
+
 void SystemDictionary::add_nest_host_error(const constantPoolHandle& pool,
                                            int which,
                                            const char* message) {
-  unsigned int hash = resolution_errors()->compute_hash(pool, which);
-  int index = resolution_errors()->hash_to_index(hash);
   {
     MutexLocker ml(Thread::current(), SystemDictionary_lock);
-    ResolutionErrorEntry* entry = resolution_errors()->find_entry(index, hash, pool, which);
+    ResolutionErrorEntry* entry = ResolutionErrorTable::find_entry(pool, which);
     if (entry != NULL && entry->nest_host_error() == NULL) {
       // An existing entry means we had a true resolution failure (LinkageError) with our nest host, but we
       // still want to add the error message for the higher-level access checks to report. We should
@@ -1902,18 +1896,16 @@ void SystemDictionary::add_nest_host_error(const constantPoolHandle& pool,
       // the message. If we see it is already set then we can ignore it.
       entry->set_nest_host_error(message);
     } else {
-      resolution_errors()->add_entry(index, hash, pool, which, message);
+      ResolutionErrorTable::add_entry(pool, which, message);
     }
   }
 }
 
 // Lookup any nest host error
 const char* SystemDictionary::find_nest_host_error(const constantPoolHandle& pool, int which) {
-  unsigned int hash = resolution_errors()->compute_hash(pool, which);
-  int index = resolution_errors()->hash_to_index(hash);
   {
     MutexLocker ml(Thread::current(), SystemDictionary_lock);
-    ResolutionErrorEntry* entry = resolution_errors()->find_entry(index, hash, pool, which);
+    ResolutionErrorEntry* entry = ResolutionErrorTable::find_entry(pool, which);
     if (entry != NULL) {
       return entry->nest_host_error();
     } else {
@@ -1921,7 +1913,6 @@ const char* SystemDictionary::find_nest_host_error(const constantPoolHandle& poo
     }
   }
 }
-
 
 // Signature constraints ensure that callers and callees agree about
 // the meaning of type names in their signatures.  This routine is the

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -71,7 +71,6 @@ class ClassFileStream;
 class ClassLoadInfo;
 class Dictionary;
 template <MEMFLAGS F> class HashtableBucket;
-class ResolutionErrorTable;
 class SymbolPropertyTable;
 class PackageEntry;
 class ProtectionDomainCacheTable;
@@ -293,9 +292,6 @@ public:
  private:
   // Static tables owned by the SystemDictionary
 
-  // Resolution errors
-  static ResolutionErrorTable*   _resolution_errors;
-
   // Invoke methods (JSR 292)
   static SymbolPropertyTable*    _invoke_method_table;
 
@@ -312,7 +308,6 @@ private:
   static OopHandle  _java_system_loader;
   static OopHandle  _java_platform_loader;
 
-  static ResolutionErrorTable* resolution_errors() { return _resolution_errors; }
   static SymbolPropertyTable* invoke_method_table() { return _invoke_method_table; }
 
 private:

--- a/src/hotspot/share/interpreter/linkResolver.cpp
+++ b/src/hotspot/share/interpreter/linkResolver.cpp
@@ -27,7 +27,6 @@
 #include "cds/archiveUtils.hpp"
 #include "classfile/defaultMethods.hpp"
 #include "classfile/javaClasses.hpp"
-#include "classfile/resolutionErrors.hpp"
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "classfile/vmClasses.hpp"

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -34,7 +34,6 @@
 #include "classfile/classLoaderData.inline.hpp"
 #include "classfile/javaClasses.hpp"
 #include "classfile/moduleEntry.hpp"
-#include "classfile/resolutionErrors.hpp"
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "classfile/systemDictionaryShared.hpp"

--- a/test/hotspot/jtreg/runtime/ClassResolutionFail/ErrorsDemoTest.java
+++ b/test/hotspot/jtreg/runtime/ClassResolutionFail/ErrorsDemoTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+* @test 8289164
+* @summary Test that tests the ResolutionErrorTable
+*/
+
+import java.io.File;
+import java.io.*;
+
+
+public class ErrorsDemoTest {
+    static int x = 0;
+
+    public static void main(String args[]) {
+        String classDirectory = System.getProperty("test.classes");
+        String filename = classDirectory + File.separator + "DeleteMe.class";
+        File file = new File(filename);
+        boolean success = file.delete();
+        String oldMessage = null;
+
+        for (int i = 0; i < 2; i++) {
+            try {
+                ErrorInResolution.doit();
+            }
+            catch (Throwable t) {
+                String s = t.getMessage();
+                if (oldMessage == null){
+                oldMessage = s;
+                }
+                else {
+                    if(!s.equals(oldMessage)){
+                        RuntimeException e = new RuntimeException();
+                        throw e;
+                    }
+                }
+            }
+        }
+    }
+}
+
+class DeleteMe {
+    static int x;
+}
+
+class ErrorInResolution {
+    static int doit() {
+        return DeleteMe.x;
+    }
+}


### PR DESCRIPTION
Please review my change of converting the resolutionErrorTable from hashtable to resource hashtable. I tested my changes with a mach5 tier1-4 test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289164](https://bugs.openjdk.org/browse/JDK-8289164): Convert ResolutionErrorTable to use ResourceHashtable


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9337/head:pull/9337` \
`$ git checkout pull/9337`

Update a local copy of the PR: \
`$ git checkout pull/9337` \
`$ git pull https://git.openjdk.org/jdk pull/9337/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9337`

View PR using the GUI difftool: \
`$ git pr show -t 9337`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9337.diff">https://git.openjdk.org/jdk/pull/9337.diff</a>

</details>
