### PR TITLE
8289534: Change 'uncomplicated' hotspot runtime options

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2519,7 +2519,7 @@ int FileMapHeader::compute_crc() {
 bool FileMapHeader::validate() {
   if (_obj_alignment != ObjectAlignmentInBytes) {
     FileMapInfo::fail_continue("The shared archive file's ObjectAlignmentInBytes of %d"
-                  " does not equal the current ObjectAlignmentInBytes of " INTX_FORMAT ".",
+                  " does not equal the current ObjectAlignmentInBytes of %d.",
                   _obj_alignment, ObjectAlignmentInBytes);
     return false;
   }

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -1580,7 +1580,7 @@ void MetaspaceShared::print_on(outputStream* st) {
     address top = (address)MetaspaceObj::shared_metaspace_top();
     st->print("[" PTR_FORMAT "-" PTR_FORMAT "-" PTR_FORMAT "), ", p2i(base), p2i(static_top), p2i(top));
     st->print("size " SIZE_FORMAT ", ", top - base);
-    st->print("SharedBaseAddress: " PTR_FORMAT ", ArchiveRelocationMode: %d.", SharedBaseAddress, (int)ArchiveRelocationMode);
+    st->print("SharedBaseAddress: " PTR_FORMAT ", ArchiveRelocationMode: %d.", SharedBaseAddress, ArchiveRelocationMode);
   } else {
     st->print("CDS archive(s) not mapped");
   }

--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -194,7 +194,7 @@ JVMCIObjectArray CompilerToVM::initialize_intrinsics(JVMCI_TRAPS) {
   return vmIntrinsics;
 }
 
-#define PREDEFINED_CONFIG_FLAGS(do_bool_flag, do_intx_flag, do_uintx_flag) \
+#define PREDEFINED_CONFIG_FLAGS(do_bool_flag, do_int_flag, do_intx_flag, do_uintx_flag) \
   do_intx_flag(AllocateInstancePrefetchLines)                              \
   do_intx_flag(AllocatePrefetchDistance)                                   \
   do_intx_flag(AllocatePrefetchInstr)                                      \
@@ -218,7 +218,7 @@ JVMCIObjectArray CompilerToVM::initialize_intrinsics(JVMCI_TRAPS) {
   do_intx_flag(JVMCICounterSize)                                           \
   do_bool_flag(JVMCIPrintProperties)                                       \
   do_bool_flag(JVMCIUseFastLocking)                                        \
-  do_intx_flag(ObjectAlignmentInBytes)                                     \
+  do_int_flag(ObjectAlignmentInBytes)                                      \
   do_bool_flag(PrintInlining)                                              \
   do_bool_flag(ReduceInitialCardMarks)                                     \
   do_bool_flag(RestrictContended)                                          \
@@ -393,14 +393,15 @@ jobjectArray readConfiguration0(JNIEnv *env, JVMCI_TRAPS) {
   JVMCIENV->put_object_at(vmFlags, i++, vmFlagObj);                                    \
 }
 #define ADD_BOOL_FLAG(name)  ADD_FLAG(bool, name, BOXED_BOOLEAN)
+#define ADD_INT_FLAG(name)   ADD_FLAG(int, name, BOXED_LONG)
 #define ADD_INTX_FLAG(name)  ADD_FLAG(intx, name, BOXED_LONG)
 #define ADD_UINTX_FLAG(name) ADD_FLAG(uintx, name, BOXED_LONG)
 
-  len = 0 + PREDEFINED_CONFIG_FLAGS(COUNT_FLAG, COUNT_FLAG, COUNT_FLAG);
+  len = 0 + PREDEFINED_CONFIG_FLAGS(COUNT_FLAG, COUNT_FLAG, COUNT_FLAG, COUNT_FLAG);
   JVMCIObjectArray vmFlags = JVMCIENV->new_VMFlag_array(len, JVMCI_CHECK_NULL);
   int i = 0;
   JVMCIObject value;
-  PREDEFINED_CONFIG_FLAGS(ADD_BOOL_FLAG, ADD_INTX_FLAG, ADD_UINTX_FLAG)
+  PREDEFINED_CONFIG_FLAGS(ADD_BOOL_FLAG, ADD_INT_FLAG, ADD_INTX_FLAG, ADD_UINTX_FLAG)
 
   JVMCIObjectArray vmIntrinsics = CompilerToVM::initialize_intrinsics(JVMCI_CHECK_NULL);
 

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
@@ -32,10 +32,10 @@
 #include "runtime/task.hpp"
 #include "utilities/powerOfTwo.hpp"
 
-JVMFlag::Error ObjectAlignmentInBytesConstraintFunc(intx value, bool verbose) {
+JVMFlag::Error ObjectAlignmentInBytesConstraintFunc(int value, bool verbose) {
   if (!is_power_of_2(value)) {
     JVMFlag::printError(verbose,
-                        "ObjectAlignmentInBytes (" INTX_FORMAT ") must be "
+                        "ObjectAlignmentInBytes (%d) must be "
                         "power of 2\n",
                         value);
     return JVMFlag::VIOLATES_CONSTRAINT;
@@ -43,7 +43,7 @@ JVMFlag::Error ObjectAlignmentInBytesConstraintFunc(intx value, bool verbose) {
   // In case page size is very small.
   if (value >= (intx)os::vm_page_size()) {
     JVMFlag::printError(verbose,
-                        "ObjectAlignmentInBytes (" INTX_FORMAT ") must be "
+                        "ObjectAlignmentInBytes (%d) must be "
                         "less than page size (%d)\n",
                         value, os::vm_page_size());
     return JVMFlag::VIOLATES_CONSTRAINT;

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.hpp
@@ -34,7 +34,7 @@
  */
 
 #define RUNTIME_CONSTRAINTS(f)                        \
-  f(intx,   ObjectAlignmentInBytesConstraintFunc)     \
+  f(int,    ObjectAlignmentInBytesConstraintFunc)     \
   f(intx,   ContendedPaddingWidthConstraintFunc)      \
   f(intx,   PerfDataSamplingIntervalFunc)             \
   f(intx,   ExtentLocalCacheSizeConstraintFunc)        \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -129,7 +129,7 @@ const size_t minimumSymbolTableSize = 1024;
           "Use 32-bit class pointers in 64-bit VM. "                        \
           "lp64_product means flag is always constant in 32 bit VM")        \
                                                                             \
-  product(intx, ObjectAlignmentInBytes, 8,                                  \
+  product(int, ObjectAlignmentInBytes, 8,                                   \
           "Default object alignment in bytes, 8 is minimum")                \
           range(8, 256)                                                     \
           constraint(ObjectAlignmentInBytesConstraintFunc, AtParse)
@@ -146,7 +146,7 @@ const size_t minimumSymbolTableSize = 1024;
                            constraint)
 const bool UseCompressedOops = false;
 const bool UseCompressedClassPointers = false;
-const intx ObjectAlignmentInBytes = 8;
+const int ObjectAlignmentInBytes = 8;
 
 #endif // _LP64
 
@@ -474,13 +474,13 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, ExecutingUnitTests, false,                                  \
           "Whether the JVM is running unit tests or not")                   \
                                                                             \
-  develop(uintx, ErrorHandlerTest, 0,                                       \
+  develop(uint, ErrorHandlerTest, 0,                                        \
           "If > 0, provokes an error after VM initialization; the value "   \
           "determines which error to provoke. See controlled_crash() "      \
           "in vmError.cpp.")                                                \
           range(0, 17)                                                      \
                                                                             \
-  develop(uintx, TestCrashInErrorHandler, 0,                                \
+  develop(uint, TestCrashInErrorHandler, 0,                                 \
           "If > 0, provokes an error inside VM error handler (a secondary " \
           "crash). see controlled_crash() in vmError.cpp")                  \
           range(0, 17)                                                      \
@@ -796,7 +796,7 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, RestrictContended, true,                                    \
           "Restrict @Contended to trusted classes")                         \
                                                                             \
-  product(intx, DiagnoseSyncOnValueBasedClasses, 0, DIAGNOSTIC,             \
+  product(int, DiagnoseSyncOnValueBasedClasses, 0, DIAGNOSTIC,              \
              "Detect and take action upon identifying synchronization on "  \
              "value based classes. Modes: "                                 \
              "0: off; "                                                     \
@@ -1609,7 +1609,7 @@ const intx ObjectAlignmentInBytes = 8;
   /* Priorities */                                                          \
   product_pd(bool, UseThreadPriorities,  "Use native thread priorities")    \
                                                                             \
-  product(intx, ThreadPriorityPolicy, 0,                                    \
+  product(int, ThreadPriorityPolicy, 0,                                     \
           "0 : Normal.                                                     "\
           "    VM chooses priorities that are appropriate for normal       "\
           "    applications.                                               "\
@@ -1634,53 +1634,53 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, ThreadPriorityVerbose, false,                               \
           "Print priority changes")                                         \
                                                                             \
-  product(intx, CompilerThreadPriority, -1,                                 \
+  product(int, CompilerThreadPriority, -1,                                  \
           "The native priority at which compiler threads should run "       \
           "(-1 means no change)")                                           \
           range(min_jint, max_jint)                                         \
                                                                             \
-  product(intx, VMThreadPriority, -1,                                       \
+  product(int, VMThreadPriority, -1,                                        \
           "The native priority at which the VM thread should run "          \
           "(-1 means no change)")                                           \
           range(-1, 127)                                                    \
                                                                             \
-  product(intx, JavaPriority1_To_OSPriority, -1,                            \
+  product(int, JavaPriority1_To_OSPriority, -1,                             \
           "Map Java priorities to OS priorities")                           \
           range(-1, 127)                                                    \
                                                                             \
-  product(intx, JavaPriority2_To_OSPriority, -1,                            \
+  product(int, JavaPriority2_To_OSPriority, -1,                             \
           "Map Java priorities to OS priorities")                           \
           range(-1, 127)                                                    \
                                                                             \
-  product(intx, JavaPriority3_To_OSPriority, -1,                            \
+  product(int, JavaPriority3_To_OSPriority, -1,                             \
           "Map Java priorities to OS priorities")                           \
           range(-1, 127)                                                    \
                                                                             \
-  product(intx, JavaPriority4_To_OSPriority, -1,                            \
+  product(int, JavaPriority4_To_OSPriority, -1,                             \
           "Map Java priorities to OS priorities")                           \
           range(-1, 127)                                                    \
                                                                             \
-  product(intx, JavaPriority5_To_OSPriority, -1,                            \
+  product(int, JavaPriority5_To_OSPriority, -1,                             \
           "Map Java priorities to OS priorities")                           \
           range(-1, 127)                                                    \
                                                                             \
-  product(intx, JavaPriority6_To_OSPriority, -1,                            \
+  product(int, JavaPriority6_To_OSPriority, -1,                             \
           "Map Java priorities to OS priorities")                           \
           range(-1, 127)                                                    \
                                                                             \
-  product(intx, JavaPriority7_To_OSPriority, -1,                            \
+  product(int, JavaPriority7_To_OSPriority, -1,                             \
           "Map Java priorities to OS priorities")                           \
           range(-1, 127)                                                    \
                                                                             \
-  product(intx, JavaPriority8_To_OSPriority, -1,                            \
+  product(int, JavaPriority8_To_OSPriority, -1,                             \
           "Map Java priorities to OS priorities")                           \
           range(-1, 127)                                                    \
                                                                             \
-  product(intx, JavaPriority9_To_OSPriority, -1,                            \
+  product(int, JavaPriority9_To_OSPriority, -1,                             \
           "Map Java priorities to OS priorities")                           \
           range(-1, 127)                                                    \
                                                                             \
-  product(intx, JavaPriority10_To_OSPriority,-1,                            \
+  product(int, JavaPriority10_To_OSPriority,-1,                             \
           "Map Java priorities to OS priorities")                           \
           range(-1, 127)                                                    \
                                                                             \
@@ -1760,12 +1760,12 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, PerfDisableSharedMem, false,                                \
           "Store performance data in standard memory")                      \
                                                                             \
-  product(intx, PerfDataMemorySize, 32*K,                                   \
+  product(int, PerfDataMemorySize, 32*K,                                    \
           "Size of performance data memory region. Will be rounded "        \
           "up to a multiple of the native os page size.")                   \
           range(128, 32*64*K)                                               \
                                                                             \
-  product(intx, PerfMaxStringConstLength, 1024,                             \
+  product(int, PerfMaxStringConstLength, 1024,                              \
           "Maximum PerfStringConstant string length before truncation")     \
           range(32, 32*K)                                                   \
                                                                             \
@@ -1775,7 +1775,7 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, PerfBypassFileSystemCheck, false,                           \
           "Bypass Win32 file system criteria checks (Windows Only)")        \
                                                                             \
-  product(intx, UnguardOnExecutionViolation, 0,                             \
+  product(int, UnguardOnExecutionViolation, 0,                              \
           "Unguard page and retry on no-execute fault (Win32 only) "        \
           "0=off, 1=conservative, 2=aggressive")                            \
           range(0, 2)                                                       \
@@ -1823,7 +1823,7 @@ const intx ObjectAlignmentInBytes = 8;
   product(ccstr, SharedArchiveConfigFile, NULL,                             \
           "Data to add to the CDS archive file")                            \
                                                                             \
-  product(uintx, SharedSymbolTableBucketSize, 4,                            \
+  product(uint, SharedSymbolTableBucketSize, 4,                             \
           "Average number of symbols per bucket in shared table")           \
           range(2, 246)                                                     \
                                                                             \
@@ -1949,7 +1949,7 @@ const intx ObjectAlignmentInBytes = 8;
   product(ccstr, ExtraSharedClassListFile, NULL,                            \
           "Extra classlist for building the CDS archive file")              \
                                                                             \
-  product(intx, ArchiveRelocationMode, 0, DIAGNOSTIC,                       \
+  product(int, ArchiveRelocationMode, 0, DIAGNOSTIC,                        \
            "(0) first map at preferred address, and if "                    \
            "unsuccessful, map at alternative address (default); "           \
            "(1) always map at alternative address; "                        \

--- a/src/hotspot/share/runtime/perfMemory.cpp
+++ b/src/hotspot/share/runtime/perfMemory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/perfMemory.cpp
+++ b/src/hotspot/share/runtime/perfMemory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,7 +96,7 @@ void PerfMemory::initialize() {
   size_t capacity = align_up(PerfDataMemorySize,
                              os::vm_allocation_granularity());
 
-  log_debug(perf, memops)("PerfDataMemorySize = " SIZE_FORMAT ","
+  log_debug(perf, memops)("PerfDataMemorySize = %d,"
                           " os::vm_allocation_granularity = %d,"
                           " adjusted size = " SIZE_FORMAT,
                           PerfDataMemorySize,

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -553,14 +553,14 @@ void VMError::report(outputStream* st, bool _verbose) {
   // error handler after a secondary crash works.
   STEP("test secondary crash 1")
     if (_verbose && TestCrashInErrorHandler == TEST_SECONDARY_CRASH) {
-      st->print_cr("Will crash now (TestCrashInErrorHandler=" UINTX_FORMAT ")...",
+      st->print_cr("Will crash now (TestCrashInErrorHandler=%u)...",
         TestCrashInErrorHandler);
       controlled_crash(TestCrashInErrorHandler);
     }
 
   STEP("test secondary crash 2")
     if (_verbose && TestCrashInErrorHandler == TEST_SECONDARY_CRASH) {
-      st->print_cr("Will crash now (TestCrashInErrorHandler=" UINTX_FORMAT ")...",
+      st->print_cr("Will crash now (TestCrashInErrorHandler=%u)...",
         TestCrashInErrorHandler);
       controlled_crash(TestCrashInErrorHandler);
     }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -975,7 +975,7 @@ public class VM {
   public int getObjectAlignmentInBytes() {
     if (objectAlignmentInBytes == 0) {
         Flag flag = getCommandLineFlag("ObjectAlignmentInBytes");
-        objectAlignmentInBytes = (flag == null) ? 8 : (int)flag.getIntx();
+        objectAlignmentInBytes = (flag == null) ? 8 : (int)flag.getInt();
     }
     return objectAlignmentInBytes;
   }

--- a/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
+++ b/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
@@ -304,7 +304,7 @@ public class GetObjectSizeIntrinsicsTest extends ASimpleInstrumentationTestCase 
     static final Boolean COMPRESSED_OOPS = WhiteBox.getWhiteBox().getBooleanVMFlag("UseCompressedOops");
     static final long REF_SIZE = (COMPRESSED_OOPS == null || COMPRESSED_OOPS == true) ? 4 : 8;
 
-    static final Long align = WhiteBox.getWhiteBox().getIntxVMFlag("ObjectAlignmentInBytes");
+    static final Long align = WhiteBox.getWhiteBox().getIntVMFlag("ObjectAlignmentInBytes");
     static final int OBJ_ALIGN = (align == null ? 8 : align.intValue());
 
     static final int SMALL_ARRAY_SIZE = 1024;


### PR DESCRIPTION
Please review this small fix to change range constrained JVM runtime options from 64 bits to 32 bits.  This fix was tested with Mach5 tiers 1-2 on Linux, Mac OS, and Windows, and Mach5 tiers 3-5 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289534](https://bugs.openjdk.org/browse/JDK-8289534): Change 'uncomplicated' hotspot runtime options


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [b71c60d8](https://git.openjdk.org/jdk/pull/9338/files/b71c60d8fb38a7c0c286064ca39cab7305c58327)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [b71c60d8](https://git.openjdk.org/jdk/pull/9338/files/b71c60d8fb38a7c0c286064ca39cab7305c58327)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9338/head:pull/9338` \
`$ git checkout pull/9338`

Update a local copy of the PR: \
`$ git checkout pull/9338` \
`$ git pull https://git.openjdk.org/jdk pull/9338/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9338`

View PR using the GUI difftool: \
`$ git pr show -t 9338`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9338.diff">https://git.openjdk.org/jdk/pull/9338.diff</a>

</details>
