### PR TITLE
8278479: RunThese test failure with +UseHeavyMonitors and +VerifyHeavyMonitors

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -2558,6 +2558,11 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
   Register hdr = op->hdr_opr()->as_register();
   Register lock = op->lock_opr()->as_register();
   if (UseHeavyMonitors) {
+    if (op->info() != NULL) {
+      int null_check_offset = __ offset();
+      __ null_check(obj);
+      add_debug_info_for_null_check(null_check_offset, op->info());
+    }
     __ b(*op->stub()->entry());
   } else if (op->code() == lir_lock) {
     assert(BasicLock::displaced_header_offset_in_bytes() == 0, "lock_reg must point to the displaced header");

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -2559,9 +2559,8 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
   Register lock = op->lock_opr()->as_register();
   if (UseHeavyMonitors) {
     if (op->info() != NULL) {
-      int null_check_offset = __ offset();
+      add_debug_info_for_null_check_here(op->info());
       __ null_check(obj, -1);
-      add_debug_info_for_null_check(null_check_offset, op->info());
     }
     __ b(*op->stub()->entry());
   } else if (op->code() == lir_lock) {

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -2560,7 +2560,7 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
   if (UseHeavyMonitors) {
     if (op->info() != NULL) {
       int null_check_offset = __ offset();
-      __ null_check(obj);
+      __ null_check(obj, -1);
       add_debug_info_for_null_check(null_check_offset, op->info());
     }
     __ b(*op->stub()->entry());

--- a/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
@@ -2432,6 +2432,11 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
   Register lock = op->lock_opr()->as_pointer_register();
 
   if (UseHeavyMonitors) {
+    if (op->info() != NULL) {
+      int null_check_offset = __ offset();
+      __ null_check(obj);
+      add_debug_info_for_null_check(null_check_offset, op->info());
+    }
     __ b(*op->stub()->entry());
   } else if (op->code() == lir_lock) {
     assert(BasicLock::displaced_header_offset_in_bytes() == 0, "lock_reg must point to the displaced header");

--- a/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
@@ -2433,9 +2433,8 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
 
   if (UseHeavyMonitors) {
     if (op->info() != NULL) {
-      int null_check_offset = __ offset();
+      add_debug_info_for_null_check_here(op->info());
       __ null_check(obj);
-      add_debug_info_for_null_check(null_check_offset, op->info());
     }
     __ b(*op->stub()->entry());
   } else if (op->code() == lir_lock) {

--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -2697,6 +2697,11 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
       //       simpler and requires less duplicated code - additionally, the
       //       slow locking code is the same in either case which simplifies
       //       debugging.
+      if (op->info() != NULL) {
+        int null_check_offset = __ offset();
+        __ null_check(obj);
+        add_debug_info_for_null_check(null_check_offset, op->info());
+      }
       __ b(*op->stub()->entry());
     }
   } else {

--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -2698,9 +2698,8 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
       //       slow locking code is the same in either case which simplifies
       //       debugging.
       if (op->info() != NULL) {
-        int null_check_offset = __ offset();
+        add_debug_info_for_null_check_here(op->info());
         __ null_check(obj);
-        add_debug_info_for_null_check(null_check_offset, op->info());
       }
       __ b(*op->stub()->entry());
     }

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -1496,6 +1496,11 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
   Register hdr = op->hdr_opr()->as_register();
   Register lock = op->lock_opr()->as_register();
   if (UseHeavyMonitors) {
+    if (op->info() != NULL) {
+      int null_check_offset = __ offset();
+      __ null_check(obj);
+      add_debug_info_for_null_check(null_check_offset, op->info());
+    }
     __ j(*op->stub()->entry());
   } else if (op->code() == lir_lock) {
     assert(BasicLock::displaced_header_offset_in_bytes() == 0, "lock_reg must point to the displaced header");

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -1497,9 +1497,8 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
   Register lock = op->lock_opr()->as_register();
   if (UseHeavyMonitors) {
     if (op->info() != NULL) {
-      int null_check_offset = __ offset();
+      add_debug_info_for_null_check_here(op->info());
       __ null_check(obj);
-      add_debug_info_for_null_check(null_check_offset, op->info());
     }
     __ j(*op->stub()->entry());
   } else if (op->code() == lir_lock) {

--- a/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
@@ -2722,9 +2722,8 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
   Register lock = op->lock_opr()->as_register();
   if (UseHeavyMonitors) {
     if (op->info() != NULL) {
-      int null_check_offset = __ offset();
+      add_debug_info_for_null_check_here(op->info());
       __ null_check(obj);
-      add_debug_info_for_null_check(null_check_offset, op->info());
     }
     __ branch_optimized(Assembler::bcondAlways, *op->stub()->entry());
   } else if (op->code() == lir_lock) {

--- a/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
@@ -2721,6 +2721,11 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
   Register hdr = op->hdr_opr()->as_register();
   Register lock = op->lock_opr()->as_register();
   if (UseHeavyMonitors) {
+    if (op->info() != NULL) {
+      int null_check_offset = __ offset();
+      __ null_check(obj);
+      add_debug_info_for_null_check(null_check_offset, op->info());
+    }
     __ branch_optimized(Assembler::bcondAlways, *op->stub()->entry());
   } else if (op->code() == lir_lock) {
     assert(BasicLock::displaced_header_offset_in_bytes() == 0, "lock_reg must point to the displaced header");

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -3495,6 +3495,11 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
   Register hdr = op->hdr_opr()->as_register();
   Register lock = op->lock_opr()->as_register();
   if (UseHeavyMonitors) {
+    if (op->info() != NULL) {
+      int null_check_offset = __ offset();
+      __ null_check(obj);
+      add_debug_info_for_null_check(null_check_offset, op->info());
+    }
     __ jmp(*op->stub()->entry());
   } else if (op->code() == lir_lock) {
     assert(BasicLock::displaced_header_offset_in_bytes() == 0, "lock_reg must point to the displaced header");

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -3496,9 +3496,8 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
   Register lock = op->lock_opr()->as_register();
   if (UseHeavyMonitors) {
     if (op->info() != NULL) {
-      int null_check_offset = __ offset();
+      add_debug_info_for_null_check_here(op->info());
       __ null_check(obj);
-      add_debug_info_for_null_check(null_check_offset, op->info());
     }
     __ jmp(*op->stub()->entry());
   } else if (op->code() == lir_lock) {

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1066,11 +1066,11 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, ErrorFileToStdout, false,                                   \
           "If true, error data is printed to stdout instead of a file")     \
                                                                             \
-  develop(bool, UseHeavyMonitors, false,                                    \
+  develop(bool, UseHeavyMonitors, true,                                     \
           "(Deprecated) Use heavyweight instead of lightweight Java "       \
           "monitors")                                                       \
                                                                             \
-  develop(bool, VerifyHeavyMonitors, false,                                 \
+  develop(bool, VerifyHeavyMonitors, true,                                  \
           "Checks that no stack locking happens when using "                \
           "+UseHeavyMonitors")                                              \
                                                                             \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1066,11 +1066,11 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, ErrorFileToStdout, false,                                   \
           "If true, error data is printed to stdout instead of a file")     \
                                                                             \
-  develop(bool, UseHeavyMonitors, true,                                     \
+  develop(bool, UseHeavyMonitors, false,                                    \
           "(Deprecated) Use heavyweight instead of lightweight Java "       \
           "monitors")                                                       \
                                                                             \
-  develop(bool, VerifyHeavyMonitors, true,                                  \
+  develop(bool, VerifyHeavyMonitors, false,                                 \
           "Checks that no stack locking happens when using "                \
           "+UseHeavyMonitors")                                              \
                                                                             \


### PR DESCRIPTION
This change adds a null check before calling into Runtime1::monitorenter when -XX:+UseHeavyMonitors is set. There's a null check in the C2 and interpreter code before calling the runtime function but not C1.

Tested with tier1-7 (a little of 8) and built on most non-oracle platforms as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278479](https://bugs.openjdk.org/browse/JDK-8278479): RunThese test failure with +UseHeavyMonitors and +VerifyHeavyMonitors


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [912dc5cd](https://git.openjdk.org/jdk/pull/9339/files/912dc5cdfc7ae9678b9bc7dc86043699f3d335f3)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to [912dc5cd](https://git.openjdk.org/jdk/pull/9339/files/912dc5cdfc7ae9678b9bc7dc86043699f3d335f3)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [912dc5cd](https://git.openjdk.org/jdk/pull/9339/files/912dc5cdfc7ae9678b9bc7dc86043699f3d335f3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9339/head:pull/9339` \
`$ git checkout pull/9339`

Update a local copy of the PR: \
`$ git checkout pull/9339` \
`$ git pull https://git.openjdk.org/jdk pull/9339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9339`

View PR using the GUI difftool: \
`$ git pr show -t 9339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9339.diff">https://git.openjdk.org/jdk/pull/9339.diff</a>

</details>
