### PR TITLE
8289257: Some custom loader tests failed due to symbol refcount not decremented

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -27,9 +27,6 @@
 #
 #############################################################################
 
-runtime/cds/appcds/customLoader/HelloCustom.java              8289257   generic-all
-runtime/cds/appcds/customLoader/HelloCustom_JFR.java          8289257   generic-all
-runtime/cds/appcds/dynamicArchive/HelloDynamicCustomUnload.java 8289257   generic-all
 resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java 8276539   generic-all
 serviceability/sa/CDSJMapClstats.java                         8276539   generic-all
 serviceability/sa/ClhsdbJhisto.java                           8276539   generic-all

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
@@ -99,22 +99,11 @@ public class HelloUnload {
         ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should be live here");
 
         if (doUnload) {
-            String loaderName = urlClassLoader.getName();
-            int loadedRefcount = wb.getSymbolRefcount(loaderName);
-            System.out.println("Refcount of symbol " + loaderName + " is " + loadedRefcount);
-
             urlClassLoader = null; c = null; o = null;
             ClassUnloadCommon.triggerUnloading();
             System.out.println("Is CustomLoadee alive? " + wb.isClassAlive(className));
             ClassUnloadCommon.failIf(wb.isClassAlive(className), "should have been unloaded");
 
-            int unloadedRefcount = wb.getSymbolRefcount(loaderName);
-            System.out.println("Refcount of symbol " + loaderName + " is " + unloadedRefcount);
-
-            // refcount of a permanent symbol will not be decremented
-            if (loadedRefcount != 65535) {
-                ClassUnloadCommon.failIf(unloadedRefcount != (loadedRefcount - 1), "Refcount must be decremented");
-            }
         }
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
@@ -73,7 +73,7 @@ public class HelloUnload {
         }
 
         URLClassLoader urlClassLoader =
-            new URLClassLoader("HelloClassLoader" + System.currentTimeMillis(), urls, null);
+            new URLClassLoader("HelloClassLoader", urls, null);
         Class c = Class.forName(className, true, urlClassLoader);
         if (keepAlive) {
             keptC = c;


### PR DESCRIPTION
Removing the test for class loader name symbol refcount since similar test exists in runtime/ClassUnload/UnloadTest.java.

Tested locally on linux-x64 with ZGC. Running more tests via mach5.

An alternative approach would be adding a `WB.fullGC()` call after `ClassUnloadCommon.triggerUnloading()` as follows:

```
--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
@@ -105,6 +105,7 @@ public class HelloUnload {
 
             urlClassLoader = null; c = null; o = null;
             ClassUnloadCommon.triggerUnloading();
+            wb.fullGC();
             System.out.println("Is CustomLoadee alive? " + wb.isClassAlive(className));
             ClassUnloadCommon.failIf(wb.isClassAlive(className), "should have been unloaded");
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289257](https://bugs.openjdk.org/browse/JDK-8289257): Some custom loader tests failed due to symbol refcount not decremented


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to [a963936c](https://git.openjdk.org/jdk/pull/9340/files/a963936c99988ff1777cfb4a26cc02daae14e97f)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9340/head:pull/9340` \
`$ git checkout pull/9340`

Update a local copy of the PR: \
`$ git checkout pull/9340` \
`$ git pull https://git.openjdk.org/jdk pull/9340/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9340`

View PR using the GUI difftool: \
`$ git pr show -t 9340`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9340.diff">https://git.openjdk.org/jdk/pull/9340.diff</a>

</details>
