### PR TITLE
8289559 : java/awt/a11y/AccessibleJPopupMenuTest.java test fails with java.lang.NullPointerException

### DIFF
--- a/test/jdk/java/awt/a11y/AccessibleJPopupMenuTest.java
+++ b/test/jdk/java/awt/a11y/AccessibleJPopupMenuTest.java
@@ -93,7 +93,7 @@ public class AccessibleJPopupMenuTest extends AccessibleComponentTest {
     public static void main(String[] args) throws Exception {
         AccessibleJPopupMenuTest a11yTest = new AccessibleJPopupMenuTest();
 
-        CountDownLatch countDownLatch = a11yTest.createCountDownLatch();
+        countDownLatch = a11yTest.createCountDownLatch();
         SwingUtilities.invokeLater(a11yTest::createTest);
         countDownLatch.await();
 


### PR DESCRIPTION
Fixed the java.lang.NullPointerException & tested .

@shurymury

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289559](https://bugs.openjdk.org/browse/JDK-8289559): java/awt/a11y/AccessibleJPopupMenuTest.java test fails with java.lang.NullPointerException


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9342/head:pull/9342` \
`$ git checkout pull/9342`

Update a local copy of the PR: \
`$ git checkout pull/9342` \
`$ git pull https://git.openjdk.org/jdk pull/9342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9342`

View PR using the GUI difftool: \
`$ git pr show -t 9342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9342.diff">https://git.openjdk.org/jdk/pull/9342.diff</a>

</details>
