### PR TITLE
8289572: InputStream wrapping with BufferedInputStream is redundant in HttpTimestamper

### DIFF
--- a/src/java.base/share/classes/sun/security/timestamp/HttpTimestamper.java
+++ b/src/java.base/share/classes/sun/security/timestamp/HttpTimestamper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,14 @@
 
 package sun.security.timestamp;
 
-import java.io.BufferedInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.HttpURLConnection;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import sun.security.util.Debug;
 
@@ -123,7 +124,7 @@ public class HttpTimestamper implements Timestamper {
 
         // Receive the reply
         byte[] replyBuffer = null;
-        try (var input = new BufferedInputStream(connection.getInputStream())) {
+        try (var input = connection.getInputStream()) {
             if (debug != null) {
                 String header = connection.getHeaderField(0);
                 debug.println(header);


### PR DESCRIPTION
In case we read all bytes from an `InputStream` we don't need wrapping with `BufferedInputStream` as the bytes are not written into internal buffer. With removal of redundant buffer we save 8 kB of allocated memory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289572](https://bugs.openjdk.org/browse/JDK-8289572): InputStream wrapping with BufferedInputStream is redundant in HttpTimestamper


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9343/head:pull/9343` \
`$ git checkout pull/9343`

Update a local copy of the PR: \
`$ git checkout pull/9343` \
`$ git pull https://git.openjdk.org/jdk pull/9343/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9343`

View PR using the GUI difftool: \
`$ git pr show -t 9343`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9343.diff">https://git.openjdk.org/jdk/pull/9343.diff</a>

</details>
