### PR TITLE
8289575: G1: Remove unnecessary is-marking-active check in G1BarrierSetRuntime::write_ref_field_pre_entry

### DIFF
--- a/src/hotspot/share/gc/g1/g1BarrierSetRuntime.cpp
+++ b/src/hotspot/share/gc/g1/g1BarrierSetRuntime.cpp
@@ -50,7 +50,7 @@ JRT_LEAF(void, G1BarrierSetRuntime::write_ref_field_pre_entry(oopDesc* orig, Jav
   assert(oopDesc::is_oop(orig, true /* ignore mark word */), "Error");
   // store the original value that was in the field reference
   SATBMarkQueue& queue = G1ThreadLocalData::satb_mark_queue(thread);
-  G1BarrierSet::satb_mark_queue_set().enqueue(queue, orig);
+  G1BarrierSet::satb_mark_queue_set().enqueue_known_active(queue, orig);
 JRT_END
 
 // G1 post write barrier slowpath

--- a/src/hotspot/share/gc/shared/satbMarkQueue.hpp
+++ b/src/hotspot/share/gc/shared/satbMarkQueue.hpp
@@ -140,10 +140,6 @@ public:
 
   void flush_queue(SATBMarkQueue& queue);
 
-  // When active, add obj to queue by calling enqueue_known_active.
-  void enqueue(SATBMarkQueue& queue, oop obj) {
-    if (queue.is_active()) enqueue_known_active(queue, obj);
-  }
   // Add obj to queue.  This qset and the queue must be active.
   void enqueue_known_active(SATBMarkQueue& queue, oop obj);
   virtual void filter(SATBMarkQueue& queue) = 0;


### PR DESCRIPTION
Simple change of removing an unnecessary check. After that, the `enqueue` method becomes unused so removed as well.

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289575](https://bugs.openjdk.org/browse/JDK-8289575): G1: Remove unnecessary is-marking-active check in G1BarrierSetRuntime::write_ref_field_pre_entry


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9345/head:pull/9345` \
`$ git checkout pull/9345`

Update a local copy of the PR: \
`$ git checkout pull/9345` \
`$ git pull https://git.openjdk.org/jdk pull/9345/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9345`

View PR using the GUI difftool: \
`$ git pr show -t 9345`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9345.diff">https://git.openjdk.org/jdk/pull/9345.diff</a>

</details>
