### PR TITLE
8170762: Document that ISO10126Padding pads with random bytes

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/ISO10126Padding.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/ISO10126Padding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,10 +29,11 @@ import javax.crypto.ShortBufferException;
 
 /**
  * This class implements padding as specified in the W3 XML ENC standard.
+ * Though the standard does not specify or require the padding bytes to be
+ * random, this implementation pads with random bytes (until the last byte,
+ * which provides the length of padding, as specified).
  *
  * @author Valerie Peng
- *
- *
  * @see Padding
  */
 final class ISO10126Padding implements Padding {


### PR DESCRIPTION
JDK-8170762 - update Javadoc to indicate ISO10126Padding pads with random bytes, though the spec does not require random bytes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8170762](https://bugs.openjdk.org/browse/JDK-8170762): Document that ISO10126Padding pads with random bytes


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9350/head:pull/9350` \
`$ git checkout pull/9350`

Update a local copy of the PR: \
`$ git checkout pull/9350` \
`$ git pull https://git.openjdk.org/jdk pull/9350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9350`

View PR using the GUI difftool: \
`$ git pr show -t 9350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9350.diff">https://git.openjdk.org/jdk/pull/9350.diff</a>

</details>
