### PR TITLE
8289644: Add a throwIf method to RuntimeException

### DIFF
--- a/src/java.base/share/classes/java/lang/RuntimeException.java
+++ b/src/java.base/share/classes/java/lang/RuntimeException.java
@@ -117,4 +117,27 @@ public class RuntimeException extends Exception {
                                boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
     }
+
+    /**
+     * Throws a new RuntimeException if the given parameter
+     * evaluates to true. Otherwise, the method exits with no action.
+     *
+     * This allows for concise checking of preconditions at the start
+     * of a method. Also, if a child class of RuntimeException calls
+     * this method, then that child class will be the exception that
+     * is thrown rather than RuntimeException itself. For example,
+     * IllegalArgumentException.throwIf(3 > 2) will throw an
+     * IllegalArgumentException instead of a RuntimeException. This
+     * change is inspired by and in the same family of
+     * Objects.requireNonNull().
+     *
+     * @param  throwGuard the boolean expression which will trigger
+     *             an exception if it evaluates to true.
+     *
+     */
+    public void throwIf (boolean throwGuard) {
+        if (throwGuard) {
+            throw this;
+        }
+    }
 }

--- a/src/java.base/share/classes/java/lang/RuntimeException.java
+++ b/src/java.base/share/classes/java/lang/RuntimeException.java
@@ -117,4 +117,28 @@ public class RuntimeException extends Exception {
                                boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
     }
+    
+    /**
+     * Throws a new RuntimeException if the given parameter
+     * evaluates to true. Otherwise, the method exits with no action.
+     * 
+     * This allows for concise checking of preconditions at the start 
+     * of a method. Also, if a child class of RuntimeException calls
+     * this method, then that child class will be the exception that
+     * is thrown rather than RuntimeException itself. For example,
+     * IllegalArgumentException.throwIf(i <= 0) will throw an
+     * IllegalArgumentException instead of a RuntimeException. This
+     * change is inspired by and in the same family of
+     * Objects.requireNonNull().
+     * 
+     * @param  throwGuard the boolean expression which will trigger
+     *             an exception if it evaluates to true.
+     *
+     */
+    public void throwIf (boolean throwGuard) {
+        if (throwGuard) {
+            throw this;
+        }
+    }
+    
 }

--- a/src/java.base/share/classes/java/lang/RuntimeException.java
+++ b/src/java.base/share/classes/java/lang/RuntimeException.java
@@ -123,21 +123,16 @@ public class RuntimeException extends Exception {
      * evaluates to true. Otherwise, the method exits with no action.
      *
      * This allows for concise checking of preconditions at the start
-     * of a method. Also, if a child class of RuntimeException calls
-     * this method, then that child class will be the exception that
-     * is thrown rather than RuntimeException itself. For example,
-     * IllegalArgumentException.throwIf(3 > 2) will throw an
-     * IllegalArgumentException instead of a RuntimeException. This
-     * change is inspired by and in the same family of
+     * of a method. This change is inspired by and in the same family of
      * Objects.requireNonNull().
      *
      * @param  throwGuard the boolean expression which will trigger
      *             an exception if it evaluates to true.
      *
      */
-    public void throwIf (boolean throwGuard) {
+    public static void throwIf (String message, boolean throwGuard) {
         if (throwGuard) {
-            throw this;
+            throw new RuntimeException(message);
         }
     }
 }

--- a/src/java.base/share/classes/java/lang/RuntimeException.java
+++ b/src/java.base/share/classes/java/lang/RuntimeException.java
@@ -117,27 +117,4 @@ public class RuntimeException extends Exception {
                                boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
     }
-
-    /**
-     * Throws a new RuntimeException if the given parameter
-     * evaluates to true. Otherwise, the method exits with no action.
-     *
-     * This allows for concise checking of preconditions at the start
-     * of a method. Also, if a child class of RuntimeException calls
-     * this method, then that child class will be the exception that
-     * is thrown rather than RuntimeException itself. For example,
-     * IllegalArgumentException.throwIf(i <= 0) will throw an
-     * IllegalArgumentException instead of a RuntimeException. This
-     * change is inspired by and in the same family of
-     * Objects.requireNonNull().
-     *
-     * @param  throwGuard the boolean expression which will trigger
-     *             an exception if it evaluates to true.
-     *
-     */
-    public void throwIf (boolean throwGuard) {
-        if (throwGuard) {
-            throw this;
-        }
-    }
 }

--- a/src/java.base/share/classes/java/lang/RuntimeException.java
+++ b/src/java.base/share/classes/java/lang/RuntimeException.java
@@ -117,12 +117,12 @@ public class RuntimeException extends Exception {
                                boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
     }
-    
+
     /**
      * Throws a new RuntimeException if the given parameter
      * evaluates to true. Otherwise, the method exits with no action.
-     * 
-     * This allows for concise checking of preconditions at the start 
+     *
+     * This allows for concise checking of preconditions at the start
      * of a method. Also, if a child class of RuntimeException calls
      * this method, then that child class will be the exception that
      * is thrown rather than RuntimeException itself. For example,
@@ -130,7 +130,7 @@ public class RuntimeException extends Exception {
      * IllegalArgumentException instead of a RuntimeException. This
      * change is inspired by and in the same family of
      * Objects.requireNonNull().
-     * 
+     *
      * @param  throwGuard the boolean expression which will trigger
      *             an exception if it evaluates to true.
      *
@@ -140,5 +140,4 @@ public class RuntimeException extends Exception {
             throw this;
         }
     }
-    
 }

--- a/src/java.base/share/classes/java/lang/Throwable.java
+++ b/src/java.base/share/classes/java/lang/Throwable.java
@@ -1130,4 +1130,27 @@ public class Throwable implements Serializable {
         else
             return suppressedExceptions.toArray(EMPTY_THROWABLE_ARRAY);
     }
+
+    /**
+     * Throws a new Throwable if the given parameter
+     * evaluates to true. Otherwise, the method exits with no action.
+     *
+     * This allows for concise checking of preconditions at the start
+     * of a method. Also, if a child class of Throwable calls
+     * this method, then that child class will be the exception that
+     * is thrown rather than Throwable itself. For example,
+     * IllegalArgumentException.throwIf(3 > 2) will throw an
+     * IllegalArgumentException instead of a Throwable. This
+     * change is inspired by and in the same family of
+     * Objects.requireNonNull().
+     *
+     * @param  throwGuard the boolean expression which will trigger
+     *             an exception if it evaluates to true.
+     *
+     */
+    public void throwIf (boolean throwGuard) {
+        if (throwGuard) {
+            throw this;
+        }
+    }
 }

--- a/src/java.base/share/classes/java/lang/Throwable.java
+++ b/src/java.base/share/classes/java/lang/Throwable.java
@@ -1130,27 +1130,4 @@ public class Throwable implements Serializable {
         else
             return suppressedExceptions.toArray(EMPTY_THROWABLE_ARRAY);
     }
-
-    /**
-     * Throws a new Throwable if the given parameter
-     * evaluates to true. Otherwise, the method exits with no action.
-     *
-     * This allows for concise checking of preconditions at the start
-     * of a method. Also, if a child class of Throwable calls
-     * this method, then that child class will be the exception that
-     * is thrown rather than Throwable itself. For example,
-     * IllegalArgumentException.throwIf(3 > 2) will throw an
-     * IllegalArgumentException instead of a Throwable. This
-     * change is inspired by and in the same family of
-     * Objects.requireNonNull().
-     *
-     * @param  throwGuard the boolean expression which will trigger
-     *             an exception if it evaluates to true.
-     *
-     */
-    public void throwIf (boolean throwGuard) {
-        if (throwGuard) {
-            throw this;
-        }
-    }
 }


### PR DESCRIPTION
Adding a new method to RuntimeException that will allow it to concisely validate preconditions. This is meant to be similar functionality to Objects.requireNonNull().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8289644](https://bugs.openjdk.org/browse/JDK-8289644): Add a throwIf method to RuntimeException


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9355/head:pull/9355` \
`$ git checkout pull/9355`

Update a local copy of the PR: \
`$ git checkout pull/9355` \
`$ git pull https://git.openjdk.org/jdk pull/9355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9355`

View PR using the GUI difftool: \
`$ git pr show -t 9355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9355.diff">https://git.openjdk.org/jdk/pull/9355.diff</a>

</details>
