### PR TITLE
JDK-8289633: Forbid raw C-heap allocation functions in hotspot and fix findings

### DIFF
--- a/src/hotspot/cpu/ppc/macroAssembler_ppc_sha.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc_sha.cpp
@@ -23,6 +23,9 @@
 // (http://www.iwar.org.uk/comsec/resources/cipher/sha256-384-512.pdf).
 
 #include "asm/macroAssembler.inline.hpp"
+#ifdef AIX
+#include "runtime/os.hpp" // malloc
+#endif
 #include "runtime/stubRoutines.hpp"
 
 /**********************************************************************
@@ -402,7 +405,7 @@ void MacroAssembler::sha256(bool multi_block) {
 #ifdef AIX
   // malloc provides 16 byte alignment
   if (((uintptr_t)sha256_round_consts & 0xF) != 0) {
-    uint32_t *new_round_consts = (uint32_t*)malloc(sizeof(sha256_round_table));
+    uint32_t *new_round_consts = (uint32_t*)os::malloc(sizeof(sha256_round_table));
     guarantee(new_round_consts, "oom");
     memcpy(new_round_consts, sha256_round_consts, sizeof(sha256_round_table));
     sha256_round_consts = (const uint32_t*)new_round_consts;
@@ -957,7 +960,7 @@ void MacroAssembler::sha512(bool multi_block) {
 #ifdef AIX
   // malloc provides 16 byte alignment
   if (((uintptr_t)sha512_round_consts & 0xF) != 0) {
-    uint64_t *new_round_consts = (uint64_t*)malloc(sizeof(sha512_round_table));
+    uint64_t *new_round_consts = (uint64_t*)os::malloc(sizeof(sha512_round_table));
     guarantee(new_round_consts, "oom");
     memcpy(new_round_consts, sha512_round_consts, sizeof(sha512_round_table));
     sha512_round_consts = (const uint64_t*)new_round_consts;

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc_sha.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc_sha.cpp
@@ -23,9 +23,7 @@
 // (http://www.iwar.org.uk/comsec/resources/cipher/sha256-384-512.pdf).
 
 #include "asm/macroAssembler.inline.hpp"
-#ifdef AIX
 #include "runtime/os.hpp" // malloc
-#endif
 #include "runtime/stubRoutines.hpp"
 
 /**********************************************************************
@@ -405,7 +403,7 @@ void MacroAssembler::sha256(bool multi_block) {
 #ifdef AIX
   // malloc provides 16 byte alignment
   if (((uintptr_t)sha256_round_consts & 0xF) != 0) {
-    uint32_t *new_round_consts = (uint32_t*)os::malloc(sizeof(sha256_round_table));
+    uint32_t *new_round_consts = (uint32_t*)os::malloc(sizeof(sha256_round_table), mtCompiler);
     guarantee(new_round_consts, "oom");
     memcpy(new_round_consts, sha256_round_consts, sizeof(sha256_round_table));
     sha256_round_consts = (const uint32_t*)new_round_consts;
@@ -960,7 +958,7 @@ void MacroAssembler::sha512(bool multi_block) {
 #ifdef AIX
   // malloc provides 16 byte alignment
   if (((uintptr_t)sha512_round_consts & 0xF) != 0) {
-    uint64_t *new_round_consts = (uint64_t*)os::malloc(sizeof(sha512_round_table));
+    uint64_t *new_round_consts = (uint64_t*)os::malloc(sizeof(sha512_round_table), mtCompiler);
     guarantee(new_round_consts, "oom");
     memcpy(new_round_consts, sha512_round_consts, sizeof(sha512_round_table));
     sha512_round_consts = (const uint64_t*)new_round_consts;

--- a/src/hotspot/cpu/ppc/stubRoutines_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/stubRoutines_ppc_64.cpp
@@ -25,6 +25,7 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.inline.hpp"
+#include "runtime/os.hpp" // malloc
 #include "runtime/stubRoutines.hpp"
 #include "runtime/vm_version.hpp"
 
@@ -89,7 +90,7 @@ address StubRoutines::ppc::generate_crc_constants(juint reverse_poly) {
   const int vector_size = 16 * (CRC32_UNROLL_FACTOR2 + CRC32_UNROLL_FACTOR / CRC32_UNROLL_FACTOR2);
 
   const int size = use_vector ? CRC32_TABLE_SIZE + vector_size : (4 BIG_ENDIAN_ONLY(+1)) * CRC32_TABLE_SIZE;
-  const address consts = (address)malloc(size);
+  const address consts = (address)os::malloc(size, mtInternal);
   if (consts == NULL) {
     vm_exit_out_of_memory(size, OOM_MALLOC_ERROR, "CRC constants: no enough space");
   }

--- a/src/hotspot/os/linux/decoder_linux.cpp
+++ b/src/hotspot/os/linux/decoder_linux.cpp
@@ -47,7 +47,7 @@ bool ElfDecoder::demangle(const char* symbol, char *buf, int buflen) {
   if ((result = abi::__cxa_demangle(symbol, NULL, NULL, &status)) != NULL) {
     jio_snprintf(buf, buflen, "%s", result);
       // call c library's free
-      ALLOW_C_FUNCTION(free, ::free(result);)
+      ALLOW_C_FUNCTION(::free, ::free(result);)
       return true;
   }
   return false;

--- a/src/hotspot/os/linux/decoder_linux.cpp
+++ b/src/hotspot/os/linux/decoder_linux.cpp
@@ -26,6 +26,7 @@
 #include "runtime/os.hpp"
 #include "utilities/decoder_elf.hpp"
 #include "utilities/elfFile.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 #include <cxxabi.h>
 
@@ -46,7 +47,7 @@ bool ElfDecoder::demangle(const char* symbol, char *buf, int buflen) {
   if ((result = abi::__cxa_demangle(symbol, NULL, NULL, &status)) != NULL) {
     jio_snprintf(buf, buflen, "%s", result);
       // call c library's free
-      ::free(result);
+      ALLOW_C_FUNCTION(free, ::free(result);)
       return true;
   }
   return false;

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -73,6 +73,7 @@
 #include "utilities/events.hpp"
 #include "utilities/elfFile.hpp"
 #include "utilities/growableArray.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/powerOfTwo.hpp"
 #include "utilities/vmError.hpp"

--- a/src/hotspot/os/linux/os_perf_linux.cpp
+++ b/src/hotspot/os/linux/os_perf_linux.cpp
@@ -785,7 +785,7 @@ char* SystemProcessInterface::SystemProcesses::ProcessIterator::get_exe_path() {
 
   jio_snprintf(buffer, PATH_MAX, "/proc/%s/exe", _entry->d_name);
   buffer[PATH_MAX - 1] = '\0';
-  return realpath(buffer, _exePath);
+  ALLOW_C_FUNCTION(::realpath, return realpath(buffer, _exePath);)
 }
 
 char* SystemProcessInterface::SystemProcesses::ProcessIterator::allocate_string(const char* str) const {

--- a/src/hotspot/os/linux/os_perf_linux.cpp
+++ b/src/hotspot/os/linux/os_perf_linux.cpp
@@ -785,7 +785,7 @@ char* SystemProcessInterface::SystemProcesses::ProcessIterator::get_exe_path() {
 
   jio_snprintf(buffer, PATH_MAX, "/proc/%s/exe", _entry->d_name);
   buffer[PATH_MAX - 1] = '\0';
-  ALLOW_C_FUNCTION(::realpath, return realpath(buffer, _exePath);)
+  return os::Posix::realpath(buffer, _exePath, PATH_MAX);
 }
 
 char* SystemProcessInterface::SystemProcesses::ProcessIterator::allocate_string(const char* str) const {

--- a/src/hotspot/os/posix/gc/z/zUtils_posix.cpp
+++ b/src/hotspot/os/posix/gc/z/zUtils_posix.cpp
@@ -24,13 +24,16 @@
 #include "precompiled.hpp"
 #include "gc/z/zUtils.hpp"
 #include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 #include <stdlib.h>
 
 uintptr_t ZUtils::alloc_aligned(size_t alignment, size_t size) {
   void* res = NULL;
 
-  if (posix_memalign(&res, alignment, size) != 0) {
+  // Use raw posix_memalign as long as we have no wrapper for it
+  ALLOW_C_FUNCTION(::posix_memalign, int rc = posix_memalign(&res, alignment, size);)
+  if (rc != 0) {
     fatal("posix_memalign() failed");
   }
 

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -33,7 +33,6 @@
 #include "os_posix.inline.hpp"
 #include "runtime/globals_extension.hpp"
 #include "runtime/osThread.hpp"
-#include "utilities/globalDefinitions.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/sharedRuntime.hpp"
@@ -48,6 +47,7 @@
 #include "utilities/align.hpp"
 #include "utilities/events.hpp"
 #include "utilities/formatBuffer.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/vmError.hpp"
 
@@ -905,7 +905,7 @@ char* os::Posix::realpath(const char* filename, char* outbuf, size_t outbuflen) 
   // This assumes platform realpath() is implemented according to POSIX.1-2008.
   // POSIX.1-2008 allows to specify NULL for the output buffer, in which case
   // output buffer is dynamically allocated and must be ::free()'d by the caller.
-  char* p = ::realpath(filename, NULL);
+  ALLOW_C_FUNCTION(::realpath, char* p = ::realpath(filename, NULL);)
   if (p != NULL) {
     if (strlen(p) < outbuflen) {
       strcpy(outbuf, p);
@@ -913,7 +913,7 @@ char* os::Posix::realpath(const char* filename, char* outbuf, size_t outbuflen) 
     } else {
       errno = ENAMETOOLONG;
     }
-    ::free(p); // *not* os::free
+    ALLOW_C_FUNCTION(::free, ::free(p);) // *not* os::free
   } else {
     // Fallback for platforms struggling with modern Posix standards (AIX 5.3, 6.1). If realpath
     // returns EINVAL, this may indicate that realpath is not POSIX.1-2008 compatible and
@@ -922,7 +922,7 @@ char* os::Posix::realpath(const char* filename, char* outbuf, size_t outbuflen) 
     // a memory overwrite.
     if (errno == EINVAL) {
       outbuf[outbuflen - 1] = '\0';
-      p = ::realpath(filename, outbuf);
+      ALLOW_C_FUNCTION(::realpath, p = ::realpath(filename, outbuf);)
       if (p != NULL) {
         guarantee(outbuf[outbuflen - 1] == '\0', "realpath buffer overwrite detected.");
         result = p;

--- a/src/hotspot/share/compiler/compilerEvent.cpp
+++ b/src/hotspot/share/compiler/compilerEvent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@
 #include "jfr/metadata/jfrSerializer.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/javaThread.hpp"
+#include "runtime/os.hpp" // malloc
 #include "runtime/semaphore.inline.hpp"
 #include "utilities/growableArray.hpp"
 
@@ -101,7 +102,7 @@ int CompilerEvent::PhaseEvent::get_phase_id(const char* phase_name, bool may_exi
     }
 
     index = phase_names->length();
-    phase_names->append(use_strdup ? strdup(phase_name) : phase_name);
+    phase_names->append(use_strdup ? os::strdup(phase_name) : phase_name);
   }
   if (register_jfr_serializer) {
     JfrSerializer::register_serializer(TYPE_COMPILERPHASETYPE, false, new CompilerPhaseTypeConstant());

--- a/src/hotspot/share/gc/shared/gcLogPrecious.cpp
+++ b/src/hotspot/share/gc/shared/gcLogPrecious.cpp
@@ -25,6 +25,7 @@
 #include "gc/shared/gcLogPrecious.hpp"
 #include "runtime/mutex.hpp"
 #include "runtime/mutexLocker.hpp"
+#include "runtime/os.hpp" // malloc
 #include "utilities/ostream.hpp"
 
 stringStream* GCLogPrecious::_lines = NULL;
@@ -67,7 +68,7 @@ void GCLogPrecious::vwrite_and_debug(LogTargetHandle log,
   {
     MutexLocker locker(_lock, Mutex::_no_safepoint_check_flag);
     vwrite_inner(log, format, args);
-    DEBUG_ONLY(debug_message = strdup(_temp->base()));
+    DEBUG_ONLY(debug_message = os::strdup(_temp->base()));
   }
 
   // report error outside lock scope, since report_vm_error will call print_on_error

--- a/src/hotspot/share/jvmci/jvmci.cpp
+++ b/src/hotspot/share/jvmci/jvmci.cpp
@@ -35,6 +35,7 @@
 #include "memory/universe.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/atomic.hpp"
+#include "runtime/os.hpp" // malloc
 #include "utilities/events.hpp"
 
 JVMCIRuntime* JVMCI::_compiler_runtimes = nullptr;
@@ -91,7 +92,7 @@ void* JVMCI::get_shared_library(char*& path, bool load) {
       fatal("Unable to load JVMCI shared library from %s: %s", path, ebuf);
     }
     _shared_library_handle = handle;
-    _shared_library_path = strdup(path);
+    _shared_library_path = os::strdup(path);
 
     JVMCI_event_1("loaded JVMCI shared library from %s", path);
   }

--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
@@ -37,6 +37,7 @@
 #include "prims/methodHandles.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/jniHandles.inline.hpp"
+#include "runtime/os.hpp" // malloc
 #include "runtime/sharedRuntime.hpp"
 #include "utilities/align.hpp"
 
@@ -705,7 +706,7 @@ JVMCI::CodeInstallResult CodeInstaller::install(JVMCICompiler* compiler,
     if (name == nullptr) {
       JVMCI_ERROR_OK("stub should have a name");
     }
-    name = strdup(name);
+    name = os::strdup(name); // Note: this leaks. See JDK-8289632
     cb = RuntimeStub::new_runtime_stub(name,
                                        &buffer,
                                        _offsets.value(CodeOffsets::Frame_Complete),

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -658,7 +658,7 @@ void* os::malloc(size_t size, MEMFLAGS memflags, const NativeCallStack& stack) {
 
   const size_t outer_size = size + MemTracker::overhead_per_malloc();
 
-  void* const outer_ptr = ::malloc(outer_size);
+  ALLOW_C_FUNCTION(::malloc, void* const outer_ptr = ::malloc(outer_size);)
   if (outer_ptr == NULL) {
     return NULL;
   }
@@ -708,7 +708,7 @@ void* os::realloc(void *memblock, size_t size, MEMFLAGS memflags, const NativeCa
   // If NMT is enabled, this checks for heap overwrites, then de-accounts the old block.
   void* const old_outer_ptr = MemTracker::record_free(memblock);
 
-  void* const new_outer_ptr = ::realloc(old_outer_ptr, new_outer_size);
+  ALLOW_C_FUNCTION(::realloc, void* const new_outer_ptr = ::realloc(old_outer_ptr, new_outer_size);)
   if (new_outer_ptr == NULL) {
     return NULL;
   }
@@ -736,7 +736,7 @@ void  os::free(void *memblock) {
   // If NMT is enabled, this checks for heap overwrites, then de-accounts the old block.
   void* const old_outer_ptr = MemTracker::record_free(memblock);
 
-  ::free(old_outer_ptr);
+  ALLOW_C_FUNCTION(::realloc, ::free(old_outer_ptr);)
 }
 
 void os::init_random(unsigned int initval) {

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -736,7 +736,7 @@ void  os::free(void *memblock) {
   // If NMT is enabled, this checks for heap overwrites, then de-accounts the old block.
   void* const old_outer_ptr = MemTracker::record_free(memblock);
 
-  ALLOW_C_FUNCTION(::realloc, ::free(old_outer_ptr);)
+  ALLOW_C_FUNCTION(::free, ::free(old_outer_ptr);)
 }
 
 void os::init_random(unsigned int initval) {

--- a/src/hotspot/share/services/nmtPreInit.cpp
+++ b/src/hotspot/share/services/nmtPreInit.cpp
@@ -33,9 +33,9 @@
 
 // Obviously we cannot use os::malloc for any dynamic allocation during pre-NMT-init, so we must use
 // raw malloc; to make this very clear, wrap them.
-static void* raw_malloc(size_t s)               { return ::malloc(s); }
-static void* raw_realloc(void* old, size_t s)   { return ::realloc(old, s); }
-static void  raw_free(void* p)                  { ::free(p); }
+static void* raw_malloc(size_t s)               { ALLOW_C_FUNCTION(::malloc, return ::malloc(s);) }
+static void* raw_realloc(void* old, size_t s)   { ALLOW_C_FUNCTION(::realloc, return ::realloc(old, s);) }
+static void  raw_free(void* p)                  { ALLOW_C_FUNCTION(::free, ::free(p);) }
 
 // We must ensure that the start of the payload area of the nmt lookup table nodes is malloc-aligned
 static const size_t malloc_alignment = 2 * sizeof(void*); // could we use max_align_t?

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -169,6 +169,22 @@ FORBID_C_FUNCTION(char* strtok(char*, const char*), "use strtok_r");
 FORBID_C_FUNCTION(int vsprintf(char*, const char*, va_list), "use os::vsnprintf");
 FORBID_C_FUNCTION(int vsnprintf(char*, size_t, const char*, va_list), "use os::vsnprintf");
 
+// All of the following functions return raw C-heap pointers (sometimes as an option, e.g. realpath or getwd)
+// or, in case of free(), take raw C-heap pointers. Don't use them unless you are really sure you must.
+FORBID_C_FUNCTION(void* malloc(size_t size), "use os::malloc");
+FORBID_C_FUNCTION(void* calloc(size_t nmemb, size_t size), "use os::malloc and zero out manually");
+FORBID_C_FUNCTION(void free(void *ptr), "use os::free");
+FORBID_C_FUNCTION(void* realloc(void *ptr, size_t size), "use os::realloc");
+FORBID_C_FUNCTION(char* strdup(const char *s), "use os::realloc");
+FORBID_C_FUNCTION(char* strndup(const char *s, size_t n), "use os::strdup");
+FORBID_C_FUNCTION(int posix_memalign(void **memptr, size_t alignment, size_t size), "don't use");
+FORBID_C_FUNCTION(void* aligned_alloc(size_t alignment, size_t size), "don't use");
+FORBID_C_FUNCTION(char* realpath(const char* path, char* resolved_path), "don't use");
+FORBID_C_FUNCTION(char* get_current_dir_name(void), "don't use");
+FORBID_C_FUNCTION(char* getwd(char *buf), "don't use");
+FORBID_C_FUNCTION(wchar_t* wcsdup(const wchar_t *s), "don't use");
+FORBID_C_FUNCTION(void* reallocf(void *ptr, size_t size), "don't use");
+
 //----------------------------------------------------------------------------------------------------
 // Constants
 

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -175,13 +175,13 @@ FORBID_C_FUNCTION(void* malloc(size_t size), "use os::malloc");
 FORBID_C_FUNCTION(void* calloc(size_t nmemb, size_t size), "use os::malloc and zero out manually");
 FORBID_C_FUNCTION(void free(void *ptr), "use os::free");
 FORBID_C_FUNCTION(void* realloc(void *ptr, size_t size), "use os::realloc");
-FORBID_C_FUNCTION(char* strdup(const char *s), "use os::realloc");
-FORBID_C_FUNCTION(char* strndup(const char *s, size_t n), "use os::strdup");
+FORBID_C_FUNCTION(char* strdup(const char *s), "use os::strdup");
+FORBID_C_FUNCTION(char* strndup(const char *s, size_t n), "don't use");
 FORBID_C_FUNCTION(int posix_memalign(void **memptr, size_t alignment, size_t size), "don't use");
 FORBID_C_FUNCTION(void* aligned_alloc(size_t alignment, size_t size), "don't use");
-FORBID_C_FUNCTION(char* realpath(const char* path, char* resolved_path), "don't use");
-FORBID_C_FUNCTION(char* get_current_dir_name(void), "don't use");
-FORBID_C_FUNCTION(char* getwd(char *buf), "don't use");
+FORBID_C_FUNCTION(char* realpath(const char* path, char* resolved_path), "use os::Posix::realpath");
+FORBID_C_FUNCTION(char* get_current_dir_name(void), "use os::get_current_directory()");
+FORBID_C_FUNCTION(char* getwd(char *buf), "use os::get_current_directory()");
 FORBID_C_FUNCTION(wchar_t* wcsdup(const wchar_t *s), "don't use");
 FORBID_C_FUNCTION(void* reallocf(void *ptr, size_t size), "don't use");
 

--- a/test/hotspot/gtest/gtestMain.cpp
+++ b/test/hotspot/gtest/gtestMain.cpp
@@ -40,6 +40,7 @@
 
 #include "runtime/os.hpp"
 #include "runtime/thread.inline.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 // Default value for -new-thread option: true on AIX because we run into
 // problems when attempting to initialize the JVM on the primordial thread.
@@ -193,7 +194,7 @@ static int num_args_to_skip(char* arg) {
 
 static char** remove_test_runner_arguments(int* argcp, char **argv) {
   int argc = *argcp;
-  char** new_argv = (char**) malloc(sizeof(char*) * argc);
+  ALLOW_C_FUNCTION(::malloc, char** new_argv = (char**) malloc(sizeof(char*) * argc);)
   int new_argc = 0;
 
   int i = 0;
@@ -288,6 +289,8 @@ static void runUnitTestsInner(int argc, char** argv) {
   }
 
   int result = RUN_ALL_TESTS();
+
+  ALLOW_C_FUNCTION(::free, ::free(argv);)
 
   // vm_assert and other_vm tests never reach this point as they either abort, or call
   // exit() - see TEST_OTHER_VM macro. We will reach here when all same_vm tests have

--- a/test/hotspot/gtest/logging/test_logDecorators.cpp
+++ b/test/hotspot/gtest/logging/test_logDecorators.cpp
@@ -25,6 +25,7 @@
 #include "jvm.h"
 #include "logging/logDecorators.hpp"
 #include "unittest.hpp"
+#include "runtime/os.hpp" // malloc
 
 static LogDecorators::Decorator decorator_array[] = {
 #define DECORATOR(name, abbr) LogDecorators::name##_decorator,
@@ -79,10 +80,10 @@ TEST(LogDecorators, from_and_to_name) {
     EXPECT_EQ(decorator, decorator2);
 
     // Test case insensitivity
-    char* name_cpy = strdup(name);
+    char* name_cpy = os::strdup(name, mtTest);
     name_cpy[0] = toupper(name_cpy[0]);
     decorator2 = LogDecorators::from_string(name_cpy);
-    free(name_cpy);
+    os::free(name_cpy);
     EXPECT_EQ(decorator, decorator2);
   }
 }
@@ -99,10 +100,10 @@ TEST(LogDecorators, from_and_to_abbr) {
     ASSERT_EQ(decorator, decorator2);
 
     // Test case insensitivity
-    char* abbr_cpy = strdup(abbr);
+    char* abbr_cpy = os::strdup(abbr);
     abbr_cpy[0] = toupper(abbr_cpy[0]);
     decorator2 = LogDecorators::from_string(abbr_cpy);
-    free(abbr_cpy);
+    os::free(abbr_cpy);
     EXPECT_EQ(decorator, decorator2);
   }
 }

--- a/test/hotspot/gtest/utilities/test_bitMap_setops.cpp
+++ b/test/hotspot/gtest/utilities/test_bitMap_setops.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "precompiled.hpp"
+#include "runtime/os.hpp" // malloc
 #include "utilities/align.hpp"
 #include "utilities/bitMap.inline.hpp"
 #include "utilities/copy.hpp"
@@ -45,11 +46,11 @@ private:
 public:
   BitMapMemory(idx_t bits) :
     _words(BitMap::calc_size_in_words(bits)),
-    _memory(static_cast<bm_word_t*>(malloc(_words * sizeof(bm_word_t))))
+    _memory(static_cast<bm_word_t*>(os::malloc(_words * sizeof(bm_word_t), mtTest)))
   { }
 
   ~BitMapMemory() {
-    free(_memory);
+    os::free(_memory);
   }
 
   BitMapView make_view(idx_t bits, bm_word_t value) {

--- a/test/hotspot/gtest/utilities/test_concurrentHashtable.cpp
+++ b/test/hotspot/gtest/utilities/test_concurrentHashtable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 #include "precompiled.hpp"
 #include "runtime/mutex.hpp"
+#include "runtime/os.hpp" // malloc
 #include "runtime/semaphore.hpp"
 #include "runtime/thread.hpp"
 #include "runtime/vmThread.hpp"
@@ -42,10 +43,10 @@ struct Pointer : public AllStatic {
     return (uintx)value;
   }
   static void* allocate_node(void* context, size_t size, const Value& value) {
-    return ::malloc(size);
+    return os::malloc(size, mtTest);
   }
   static void free_node(void* context, void* memory, const Value& value) {
-    ::free(memory);
+    os::free(memory);
   }
 };
 
@@ -60,7 +61,7 @@ struct Allocator {
   uint cur_index;
 
   Allocator() : cur_index(0) {
-    elements = (TableElement*)::malloc(nelements * sizeof(TableElement));
+    elements = (TableElement*)os::malloc(nelements * sizeof(TableElement), mtTest);
   }
 
   void* allocate_node() {
@@ -74,7 +75,7 @@ struct Allocator {
   }
 
   ~Allocator() {
-    ::free(elements);
+    os::free(elements);
   }
 };
 


### PR DESCRIPTION
[JDK-8214976](https://bugs.openjdk.org/browse/JDK-8214976) introduced a way to forbid functions from being called outside of explicitly allowed contexts. Kim [1] proposed to use that functionality to forbid raw malloc and friends. That would have prevented [JDK-8289477](https://bugs.openjdk.org/browse/JDK-8289477), which sneaked in raw malloc and free via C-runtime defined macros.

We forbid now all functions that return C-heap, even if that is only optional, like with `realpath`. Note that there may be more functions, but these are all I know from the top of my head. We forbid them even if they are exotic to prevent devs from using them in the future and also from creep-in via system macros.

I found a number of places where raw allocation functions were used, mostly strdup. I either changes those places to use os::xxx where I was confident that works, or where I saw we really must use the raw functions I marked them with ALLOW_C_FUNCTION.

Places that allow raw C functions:
- decoder on Linux, since the C++ demangler returns raw C heap
- realpath, in conjunction with allowing real free for the returned buffer
- ZGC uses posix_memalign for a static global buffer that never is deleted. Keeping to use posix_memalign is probably ok, but we should add an os::posix_memalign at some point
- UL, LogTagSet, since UL may also be used for logging inside NMT and we don't want circularities
- obviously os::malloc and friends
- NMT pre-initialization code because circularities
- In gtest main function - I think gtest should work always, even if os::malloc is broken.

Places I fixed:
- ZGC, mountpoint string handling
- In CompilerEvent we hold a global lookup table with phase names. The names in there leak, but this table never gets cleared, so I think that's okay
- gcLogPrecious, string is fed to VMError::report_and_die, so it probably does not matter
- there were several places in JVMCI, one where we ::strdup a string which we give to a new code blob as blob name. These strings actually leak. I opened https://bugs.openjdk.org/browse/JDK-8289632 to track this
- A couple of places in gtests.

Note, wherever I introduced os::xxx and had to add os.hpp, I commented the include with "//malloc" to earmark those in case we ever want to move os::malloc and friends into its own header.

----

Tests: I build and ran gtests manually on x64 fastdebug, release, arm fastdebug, aarch64 fastdebug, x86 fastdebug (all Linux). I also tested build on Alpine x64.

GHAs are in work.


[1] https://mail.openjdk.org/pipermail/hotspot-dev/2022-July/061602.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289633](https://bugs.openjdk.org/browse/JDK-8289633): Forbid raw C-heap allocation functions in hotspot and fix findings


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9356/head:pull/9356` \
`$ git checkout pull/9356`

Update a local copy of the PR: \
`$ git checkout pull/9356` \
`$ git pull https://git.openjdk.org/jdk pull/9356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9356`

View PR using the GUI difftool: \
`$ git pr show -t 9356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9356.diff">https://git.openjdk.org/jdk/pull/9356.diff</a>

</details>
