### PR TITLE
8289646: configure script failed on WSL

### DIFF
--- a/make/scripts/fixpath.sh
+++ b/make/scripts/fixpath.sh
@@ -146,15 +146,11 @@ function import_path() {
   fi
 
   if [[ "$path" != "" ]]; then
-    # Store current unix path
-    unixpath="$path"
+    if [[ ! -e "$path" && -e "$path.exe" ]]; then
+      path="$path.exe"
+    fi
     # Now turn it into a windows path
     winpath="$($PATHTOOL -w "$path" 2>/dev/null)"
-    # If it fails, try again with an added .exe (needed on WSL)
-    if [[ $? -ne 0 ]]; then
-      unixpath="$unixpath.exe"
-      winpath="$($PATHTOOL -w "$unixpath" 2>/dev/null)"
-    fi
     if [[ $? -eq 0 ]]; then
       if [[ ! "$winpath" =~ ^"$ENVROOT"\\.*$ ]] ; then
         # If it is not in envroot, it's a generic windows path
@@ -163,25 +159,21 @@ function import_path() {
           # This monster of a command uses the %~s support from cmd.exe to
           # reliably convert to short paths on all winenvs.
           shortpath="$($CMD /q /c for %I in \( "$winpath" \) do echo %~sI 2>/dev/null | tr -d \\n\\r)"
-          unixpath="$($PATHTOOL -u "$shortpath")"
-          # unixpath is based on short name
+          path="$($PATHTOOL -u "$shortpath")"
+          # path is based on short name
         fi
         # Make it lower case
-        path="$(echo "$unixpath" | tr '[:upper:]' '[:lower:]')"
+        path="$(echo "$path" | tr '[:upper:]' '[:lower:]')"
       fi
     else
       # On WSL1, PATHTOOL will fail for files in envroot. If the unix path
       # exists, we assume that $path is a valid unix path.
 
       if [[ ! -e $path ]]; then
-        if [[ -e $path.exe ]]; then
-          path="$path.exe"
-        else
-          if [[ $QUIET != true ]]; then
-            echo fixpath: warning: Path "'"$path"'" does not exist >&2
-          fi
-          # This is not a fatal error, maybe the path will be created later on
+        if [[ $QUIET != true ]]; then
+          echo fixpath: warning: Path "'"$path"'" does not exist >&2
         fi
+        # This is not a fatal error, maybe the path will be created later on
       fi
     fi
   fi

--- a/make/scripts/fixpath.sh
+++ b/make/scripts/fixpath.sh
@@ -154,7 +154,7 @@ function import_path() {
     fi
     # Now turn it into a windows path
     winpath="$($PATHTOOL -w "$unixpath" 2>/dev/null)"
-    if [[ $? -eq 0 ]]; then
+    if [[ $? -eq 0 && -e "$unixpath" ]]; then
       if [[ ! "$winpath" =~ ^"$ENVROOT"\\.*$ ]] ; then
         # If it is not in envroot, it's a generic windows path
         if [[ ! $winpath =~ ^[-_.:\\a-zA-Z0-9]*$ ]] ; then

--- a/make/scripts/fixpath.sh
+++ b/make/scripts/fixpath.sh
@@ -146,11 +146,14 @@ function import_path() {
   fi
 
   if [[ "$path" != "" ]]; then
-    if [[ ! -e "$path" && -e "$path.exe" ]]; then
-      path="$path.exe"
+    # Store current unix path
+    unixpath="$path"
+    # If $unixpath does not exist, add .exe (needed on WSL)
+    if [[ ! -e "$unixpath" ]]; then
+      unixpath="$unixpath.exe"
     fi
     # Now turn it into a windows path
-    winpath="$($PATHTOOL -w "$path" 2>/dev/null)"
+    winpath="$($PATHTOOL -w "$unixpath" 2>/dev/null)"
     if [[ $? -eq 0 ]]; then
       if [[ ! "$winpath" =~ ^"$ENVROOT"\\.*$ ]] ; then
         # If it is not in envroot, it's a generic windows path
@@ -159,21 +162,25 @@ function import_path() {
           # This monster of a command uses the %~s support from cmd.exe to
           # reliably convert to short paths on all winenvs.
           shortpath="$($CMD /q /c for %I in \( "$winpath" \) do echo %~sI 2>/dev/null | tr -d \\n\\r)"
-          path="$($PATHTOOL -u "$shortpath")"
-          # path is based on short name
+          unixpath="$($PATHTOOL -u "$shortpath")"
+          # unixpath is based on short name
         fi
         # Make it lower case
-        path="$(echo "$path" | tr '[:upper:]' '[:lower:]')"
+        path="$(echo "$unixpath" | tr '[:upper:]' '[:lower:]')"
       fi
     else
       # On WSL1, PATHTOOL will fail for files in envroot. If the unix path
       # exists, we assume that $path is a valid unix path.
 
       if [[ ! -e $path ]]; then
-        if [[ $QUIET != true ]]; then
-          echo fixpath: warning: Path "'"$path"'" does not exist >&2
+        if [[ -e $path.exe ]]; then
+          path="$path.exe"
+        else
+          if [[ $QUIET != true ]]; then
+            echo fixpath: warning: Path "'"$path"'" does not exist >&2
+          fi
+          # This is not a fatal error, maybe the path will be created later on
         fi
-        # This is not a fatal error, maybe the path will be created later on
       fi
     fi
   fi


### PR DESCRIPTION
configure failed as following when I run it on WSL 1.

```
checking for version string... 20-internal-adhoc.yasuenag.jdk
configure: Found potential Boot JDK using configure arguments
configure: The command for java_to_test, which resolves as "/mnt/d/java/jdk-18/bin/java", can not be found.
configure: error: Cannot locate /mnt/d/java/jdk-18/bin/java
configure exiting with result code 1
```

fixpath.sh would attempt to add ".exe" (e.g. "java" -> "java.exe") if `wslpath -w" failed (returns non-zero value). However it returns zero even if the path does not exist in recent WSL (v0.61.4 at least).

WSL v0.60.0.0
```
$ wslpath -w silver-bullet
wslpath: silver-bullet: No such file or directory
$ echo $?
1
```

WSL v0.61.4.0
```
$ wslpath -w silver-bullet
silver-bullet
$ echo $?
0
```

We should add ".exe" at the tail of path regardless of return value from wslpath.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289646](https://bugs.openjdk.org/browse/JDK-8289646): configure script failed on WSL


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9357/head:pull/9357` \
`$ git checkout pull/9357`

Update a local copy of the PR: \
`$ git checkout pull/9357` \
`$ git pull https://git.openjdk.org/jdk pull/9357/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9357`

View PR using the GUI difftool: \
`$ git pr show -t 9357`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9357.diff">https://git.openjdk.org/jdk/pull/9357.diff</a>

</details>
