### PR TITLE
8034864: increase value max event list size before overflow

### DIFF
--- a/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java
+++ b/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java
@@ -37,7 +37,7 @@ abstract class AbstractWatchKey implements WatchKey {
     /**
      * Maximum size of event list (in the future this may be tunable)
      */
-    static final int MAX_EVENT_LIST_SIZE    = 512;
+    static final int MAX_EVENT_LIST_SIZE    = 8192;
 
     /**
      * Special event to signal overflow


### PR DESCRIPTION
# Review number of events in event list before overflow is trigged.

The number of event in event list is to low. The the class has not been reviewed since 2011. 

The number of events, which is 8192, is again very low but the value should also be tunable by user.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8034864](https://bugs.openjdk.org/browse/JDK-8034864)

### Issue
 * [JDK-8034864](https://bugs.openjdk.org/browse/JDK-8034864): AbstractWatchKey limit of 512 events before OVERFLOW is too low ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9358/head:pull/9358` \
`$ git checkout pull/9358`

Update a local copy of the PR: \
`$ git checkout pull/9358` \
`$ git pull https://git.openjdk.org/jdk pull/9358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9358`

View PR using the GUI difftool: \
`$ git pr show -t 9358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9358.diff">https://git.openjdk.org/jdk/pull/9358.diff</a>

</details>
