### PR TITLE
8289687: [JVMCI] bug in HotSpotResolvedJavaMethodImpl.equals

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -500,29 +500,29 @@ final class CompilerToVM {
      * @throws JVMCIError if there is something wrong with the compiled code or the associated
      *             metadata.
      */
-     int installCode(HotSpotCompiledCode compiledCode, InstalledCode code, long failedSpeculationsAddress, byte[] speculations) {
-         int codeInstallFlags = getInstallCodeFlags();
-         boolean withComments = (codeInstallFlags & 0x0001) != 0;
-         boolean withMethods = (codeInstallFlags & 0x0002) != 0;
-         boolean withTypeInfo;
-         if ((codeInstallFlags & 0x0004) != 0 && HotSpotJVMCIRuntime.Option.CodeSerializationTypeInfo.isDefault) {
-             withTypeInfo = true;
-         } else {
-             withTypeInfo = HotSpotJVMCIRuntime.Option.CodeSerializationTypeInfo.getBoolean();
-         }
-         try (HotSpotCompiledCodeStream stream = new HotSpotCompiledCodeStream(compiledCode, withTypeInfo, withComments, withMethods)) {
-             return installCode0(stream.headChunk, stream.timeNS, withTypeInfo, compiledCode, stream.objectPool, code, failedSpeculationsAddress, speculations);
-         }
+    int installCode(HotSpotCompiledCode compiledCode, InstalledCode code, long failedSpeculationsAddress, byte[] speculations) {
+        int codeInstallFlags = getInstallCodeFlags();
+        boolean withComments = (codeInstallFlags & 0x0001) != 0;
+        boolean withMethods = (codeInstallFlags & 0x0002) != 0;
+        boolean withTypeInfo;
+        if ((codeInstallFlags & 0x0004) != 0 && HotSpotJVMCIRuntime.Option.CodeSerializationTypeInfo.isDefault) {
+            withTypeInfo = true;
+        } else {
+            withTypeInfo = HotSpotJVMCIRuntime.Option.CodeSerializationTypeInfo.getBoolean();
+        }
+        try (HotSpotCompiledCodeStream stream = new HotSpotCompiledCodeStream(compiledCode, withTypeInfo, withComments, withMethods)) {
+            return installCode0(stream.headChunk, stream.timeNS, withTypeInfo, compiledCode, stream.objectPool, code, failedSpeculationsAddress, speculations);
+        }
      }
 
-     native int installCode0(long compiledCodeBuffer,
-                     long serializationNS,
-                     boolean withTypeInfo,
-                     HotSpotCompiledCode compiledCode,
-                     Object[] objectPool,
-                     InstalledCode code,
-                     long failedSpeculationsAddress,
-                     byte[] speculations);
+    native int installCode0(long compiledCodeBuffer,
+                    long serializationNS,
+                    boolean withTypeInfo,
+                    HotSpotCompiledCode compiledCode,
+                    Object[] objectPool,
+                    InstalledCode code,
+                    long failedSpeculationsAddress,
+                    byte[] speculations);
 
     /**
      * Gets flags specifying optional parts of code info. Only if a flag is set, will the

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
@@ -166,7 +166,7 @@ final class HotSpotResolvedJavaMethodImpl extends HotSpotMethod implements HotSp
         }
         if (obj instanceof HotSpotResolvedJavaMethodImpl) {
             HotSpotResolvedJavaMethodImpl that = (HotSpotResolvedJavaMethodImpl) obj;
-            return getMethodPointer() == getMethodPointer();
+            return that.getMethodPointer() == getMethodPointer();
         }
         return false;
     }

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaField.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaField.java
@@ -68,6 +68,17 @@ public class TestResolvedJavaField extends FieldUniverse {
     }
 
     @Test
+    public void equalsTest() {
+        for (ResolvedJavaField f : fields.values()) {
+            for (ResolvedJavaField that : fields.values()) {
+                boolean expect = f == that;
+                boolean actual = f.equals(that);
+                assertEquals(expect, actual);
+            }
+        }
+    }
+
+    @Test
     public void getModifiersTest() {
         for (Map.Entry<Field, ResolvedJavaField> e : fields.entrySet()) {
             int expected = e.getKey().getModifiers();

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java
@@ -91,6 +91,17 @@ public class TestResolvedJavaType extends TypeUniverse {
     public TestResolvedJavaType() {
     }
 
+    @Test
+    public void equalsTest() {
+        for (ResolvedJavaType t : javaTypes) {
+            for (ResolvedJavaType that : javaTypes) {
+                boolean expect = t == that;
+                boolean actual = t.equals(that);
+                assertEquals(expect, actual);
+            }
+        }
+    }
+
     @SuppressWarnings("unchecked")
     private static Class<? extends Annotation> findPolymorphicSignatureClass() {
         Class<? extends Annotation> signaturePolyAnnotation = null;


### PR DESCRIPTION
A bug[1] slipped in with [JDK-8289094](https://bugs.openjdk.org/browse/JDK-8289094) that broke `HotSpotResolvedJavaMethodImpl.equals`.This PR fixes and adds a test for it. The test was added to `TestResolvedJavaMethod` which was disabled (see [JDK-8249621](https://bugs.openjdk.org/browse/JDK-8249621)). This test class has been re-enabled and the 2 other failing tests in it (`canBeStaticallyBoundTest` and `asStackTraceElementTest`) have been fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289687](https://bugs.openjdk.org/browse/JDK-8289687): [JVMCI] bug in HotSpotResolvedJavaMethodImpl.equals


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9364/head:pull/9364` \
`$ git checkout pull/9364`

Update a local copy of the PR: \
`$ git checkout pull/9364` \
`$ git pull https://git.openjdk.org/jdk pull/9364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9364`

View PR using the GUI difftool: \
`$ git pr show -t 9364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9364.diff">https://git.openjdk.org/jdk/pull/9364.diff</a>

</details>
