### PR TITLE
8289695: [TESTBUG] TestMemoryAwareness.java fails on cgroups v2 and crun

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -114,9 +114,8 @@ public class TestMemoryAwareness {
     private static void testOOM(String dockerMemLimit, int sizeToAllocInMb) throws Exception {
         Common.logNewTestCase("OOM");
 
-        // add "--memory-swappiness 0" so as to disable anonymous page swapping.
         DockerRunOptions opts = Common.newOpts(imageName, "AttemptOOM")
-            .addDockerOpts("--memory", dockerMemLimit, "--memory-swappiness", "0", "--memory-swap", dockerMemLimit);
+            .addDockerOpts("--memory", dockerMemLimit, "--memory-swap", dockerMemLimit);
         opts.classParams.add("" + sizeToAllocInMb);
 
         // make sure we avoid inherited Xmx settings from the jtreg vmoptions


### PR DESCRIPTION
Please review this test change to also support `crun` on cgroups v2 systems. `crun` aborts any invocation that includes `--memory-swappiness` CLI option. I don't think it's needed for the purpose of the test. `--memory X` and `--memory-swap X` where `X` is the same value already tells the system to not use swap.

Tested on Linux x86_64, cgroups v1 and cgroups v2 systems (including an affected one).