### PR TITLE
8289698: AArch64: Need to relativize extended_sp in frame

### DIFF
--- a/src/hotspot/cpu/aarch64/continuationFreezeThaw_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/continuationFreezeThaw_aarch64.inline.hpp
@@ -153,6 +153,7 @@ inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, co
   *hf.addr_at(frame::interpreter_frame_locals_offset) = frame::sender_sp_offset + f.interpreter_frame_method()->max_locals() - 1;
 
   relativize_one(vfp, hfp, frame::interpreter_frame_initial_sp_offset); // == block_top == block_bottom
+  relativize_one(vfp, hfp, frame::interpreter_frame_extended_sp_offset);
 
   assert((hf.fp() - hf.unextended_sp()) == (f.fp() - f.unextended_sp()), "");
   assert(hf.unextended_sp() == (intptr_t*)hf.at(frame::interpreter_frame_last_sp_offset), "");
@@ -292,6 +293,7 @@ inline void ThawBase::derelativize_interpreted_frame_metadata(const frame& hf, c
 
   derelativize_one(vfp, frame::interpreter_frame_last_sp_offset);
   derelativize_one(vfp, frame::interpreter_frame_initial_sp_offset);
+  derelativize_one(vfp, frame::interpreter_frame_extended_sp_offset);
 }
 
 inline void ThawBase::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {


### PR DESCRIPTION
With the addition of the extended_sp field in interpreter frames, we need to make sure it is de-relativized and re-relativized when freezing and thawing a vthread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289698](https://bugs.openjdk.org/browse/JDK-8289698): AArch64: Need to relativize extended_sp in frame


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9367/head:pull/9367` \
`$ git checkout pull/9367`

Update a local copy of the PR: \
`$ git checkout pull/9367` \
`$ git pull https://git.openjdk.org/jdk pull/9367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9367`

View PR using the GUI difftool: \
`$ git pr show -t 9367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9367.diff">https://git.openjdk.org/jdk/pull/9367.diff</a>

</details>
