### PR TITLE
8289697: buffer overflow in MTLVertexCache.m: MTLVertexCache_AddGlyphQuad

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.m
@@ -65,7 +65,8 @@ static id<MTLRenderCommandEncoder> encoder = NULL;
         MTLVC_ADD_VERTEX(TX1, TY1, DX1, DY1, 0); \
     } while (0)
 
-//Next define should exactly match to the amount of MTLVC_ADD_VERTEX in MTLVC_ADD_TRIANGLES
+// Next define should exactly match to the amount
+// of MTLVC_ADD_VERTEX in MTLVC_ADD_TRIANGLES
 #define VERTS_FOR_A_QUAD 6
 
 jboolean
@@ -222,7 +223,8 @@ MTLVertexCache_AddMaskQuad(MTLContext *mtlc,
     J2dTraceLn1(J2D_TRACE_INFO, "MTLVertexCache_AddMaskQuad: %d",
                 maskCacheIndex);
 
-    // MTLVC_ADD_TRIANGLES at the end of this function will place VERTS_FOR_A_QUAD vertexes to the vertex cache
+    // MTLVC_ADD_TRIANGLES at the end of this function
+    // will place VERTS_FOR_A_QUAD vertexes to the vertex cache
     // check free space and flush if needed.
     if ((maskCacheIndex >= MTLVC_MASK_CACHE_MAX_INDEX) || ((vertexCacheIndex + VERTS_FOR_A_QUAD) >= MTLVC_MAX_INDEX))
     {
@@ -310,7 +312,8 @@ MTLVertexCache_AddGlyphQuad(MTLContext *mtlc,
 {
     J2dTraceLn(J2D_TRACE_INFO, "MTLVertexCache_AddGlyphQuad");
 
-    // MTLVC_ADD_TRIANGLES adds VERTS_FOR_A_QUAD vertexes into Cache, so need to check space for VERTS_FOR_A_QUAD elements
+    // MTLVC_ADD_TRIANGLES adds VERTS_FOR_A_QUAD vertexes into Cache
+    // so need to check space for VERTS_FOR_A_QUAD elements
     if ((vertexCacheIndex + VERTS_FOR_A_QUAD) >= MTLVC_MAX_INDEX)
     {
         J2dTraceLn2(J2D_TRACE_INFO, "maskCacheIndex = %d, vertexCacheIndex = %d", maskCacheIndex, vertexCacheIndex);

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.m
@@ -219,7 +219,9 @@ MTLVertexCache_AddMaskQuad(MTLContext *mtlc,
     J2dTraceLn1(J2D_TRACE_INFO, "MTLVertexCache_AddMaskQuad: %d",
                 maskCacheIndex);
 
-    if (maskCacheIndex >= MTLVC_MASK_CACHE_MAX_INDEX)
+    // MTLVC_ADD_TRIANGLES at the end of this function will place 6 vertexes to the vertex cache
+    // check free space and flush if needed.
+    if ((maskCacheIndex >= MTLVC_MASK_CACHE_MAX_INDEX) || ((vertexCacheIndex + 6) >= MTLVC_MAX_INDEX))
     {
         J2dTraceLn2(J2D_TRACE_INFO, "maskCacheIndex = %d, vertexCacheIndex = %d", maskCacheIndex, vertexCacheIndex);
         MTLVertexCache_FlushVertexCache(mtlc);

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.m
@@ -65,6 +65,9 @@ static id<MTLRenderCommandEncoder> encoder = NULL;
         MTLVC_ADD_VERTEX(TX1, TY1, DX1, DY1, 0); \
     } while (0)
 
+//Next define should exactly match to the amount of MTLVC_ADD_VERTEX in MTLVC_ADD_TRIANGLES
+#define MTL_TRIS_IN_VERTEX 6
+
 jboolean
 MTLVertexCache_InitVertexCache()
 {
@@ -219,9 +222,9 @@ MTLVertexCache_AddMaskQuad(MTLContext *mtlc,
     J2dTraceLn1(J2D_TRACE_INFO, "MTLVertexCache_AddMaskQuad: %d",
                 maskCacheIndex);
 
-    // MTLVC_ADD_TRIANGLES at the end of this function will place 6 vertexes to the vertex cache
+    // MTLVC_ADD_TRIANGLES at the end of this function will place MTL_TRIS_IN_VERTEX vertexes to the vertex cache
     // check free space and flush if needed.
-    if ((maskCacheIndex >= MTLVC_MASK_CACHE_MAX_INDEX) || ((vertexCacheIndex + 6) >= MTLVC_MAX_INDEX))
+    if ((maskCacheIndex >= MTLVC_MASK_CACHE_MAX_INDEX) || ((vertexCacheIndex + MTL_TRIS_IN_VERTEX) >= MTLVC_MAX_INDEX))
     {
         J2dTraceLn2(J2D_TRACE_INFO, "maskCacheIndex = %d, vertexCacheIndex = %d", maskCacheIndex, vertexCacheIndex);
         MTLVertexCache_FlushVertexCache(mtlc);
@@ -307,8 +310,8 @@ MTLVertexCache_AddGlyphQuad(MTLContext *mtlc,
 {
     J2dTraceLn(J2D_TRACE_INFO, "MTLVertexCache_AddGlyphQuad");
 
-    // MTLVC_ADD_TRIANGLES adds 6 vertexes into Cache, so need to check space for 6 elements
-    if ((vertexCacheIndex + 6) >= MTLVC_MAX_INDEX)
+    // MTLVC_ADD_TRIANGLES adds MTL_TRIS_IN_VERTEX vertexes into Cache, so need to check space for MTL_TRIS_IN_VERTEX elements
+    if ((vertexCacheIndex + MTL_TRIS_IN_VERTEX) >= MTLVC_MAX_INDEX)
     {
         J2dTraceLn2(J2D_TRACE_INFO, "maskCacheIndex = %d, vertexCacheIndex = %d", maskCacheIndex, vertexCacheIndex);
         MTLVertexCache_FlushGlyphVertexCache();

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.m
@@ -310,7 +310,7 @@ MTLVertexCache_AddGlyphQuad(MTLContext *mtlc,
 {
     J2dTraceLn(J2D_TRACE_INFO, "MTLVertexCache_AddGlyphQuad");
 
-    // MTLVC_ADD_TRIANGLES adds VERTS_FOR_A_QUAD vertexes into Cache, so need to check space for MTL_TRIS_IN_VERTEX elements
+    // MTLVC_ADD_TRIANGLES adds VERTS_FOR_A_QUAD vertexes into Cache, so need to check space for VERTS_FOR_A_QUAD elements
     if ((vertexCacheIndex + VERTS_FOR_A_QUAD) >= MTLVC_MAX_INDEX)
     {
         J2dTraceLn2(J2D_TRACE_INFO, "maskCacheIndex = %d, vertexCacheIndex = %d", maskCacheIndex, vertexCacheIndex);

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.m
@@ -305,7 +305,8 @@ MTLVertexCache_AddGlyphQuad(MTLContext *mtlc,
 {
     J2dTraceLn(J2D_TRACE_INFO, "MTLVertexCache_AddGlyphQuad");
 
-    if (vertexCacheIndex >= MTLVC_MAX_INDEX)
+    // MTLVC_ADD_TRIANGLES adds 6 vertexes into Cache, so need to check space for 6 elements
+    if ((vertexCacheIndex + 6) >= MTLVC_MAX_INDEX)
     {
         J2dTraceLn2(J2D_TRACE_INFO, "maskCacheIndex = %d, vertexCacheIndex = %d", maskCacheIndex, vertexCacheIndex);
         MTLVertexCache_FlushGlyphVertexCache();

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.m
@@ -226,7 +226,8 @@ MTLVertexCache_AddMaskQuad(MTLContext *mtlc,
     // MTLVC_ADD_TRIANGLES at the end of this function
     // will place VERTS_FOR_A_QUAD vertexes to the vertex cache
     // check free space and flush if needed.
-    if ((maskCacheIndex >= MTLVC_MASK_CACHE_MAX_INDEX) || ((vertexCacheIndex + VERTS_FOR_A_QUAD) >= MTLVC_MAX_INDEX))
+    if ((maskCacheIndex >= MTLVC_MASK_CACHE_MAX_INDEX) ||
+         ((vertexCacheIndex + VERTS_FOR_A_QUAD) >= MTLVC_MAX_INDEX))
     {
         J2dTraceLn2(J2D_TRACE_INFO, "maskCacheIndex = %d, vertexCacheIndex = %d", maskCacheIndex, vertexCacheIndex);
         MTLVertexCache_FlushVertexCache(mtlc);

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.m
@@ -66,7 +66,7 @@ static id<MTLRenderCommandEncoder> encoder = NULL;
     } while (0)
 
 //Next define should exactly match to the amount of MTLVC_ADD_VERTEX in MTLVC_ADD_TRIANGLES
-#define MTL_TRIS_IN_VERTEX 6
+#define VERTS_FOR_A_QUAD 6
 
 jboolean
 MTLVertexCache_InitVertexCache()
@@ -224,7 +224,7 @@ MTLVertexCache_AddMaskQuad(MTLContext *mtlc,
 
     // MTLVC_ADD_TRIANGLES at the end of this function will place MTL_TRIS_IN_VERTEX vertexes to the vertex cache
     // check free space and flush if needed.
-    if ((maskCacheIndex >= MTLVC_MASK_CACHE_MAX_INDEX) || ((vertexCacheIndex + MTL_TRIS_IN_VERTEX) >= MTLVC_MAX_INDEX))
+    if ((maskCacheIndex >= MTLVC_MASK_CACHE_MAX_INDEX) || ((vertexCacheIndex + VERTS_FOR_A_QUAD) >= MTLVC_MAX_INDEX))
     {
         J2dTraceLn2(J2D_TRACE_INFO, "maskCacheIndex = %d, vertexCacheIndex = %d", maskCacheIndex, vertexCacheIndex);
         MTLVertexCache_FlushVertexCache(mtlc);
@@ -311,7 +311,7 @@ MTLVertexCache_AddGlyphQuad(MTLContext *mtlc,
     J2dTraceLn(J2D_TRACE_INFO, "MTLVertexCache_AddGlyphQuad");
 
     // MTLVC_ADD_TRIANGLES adds MTL_TRIS_IN_VERTEX vertexes into Cache, so need to check space for MTL_TRIS_IN_VERTEX elements
-    if ((vertexCacheIndex + MTL_TRIS_IN_VERTEX) >= MTLVC_MAX_INDEX)
+    if ((vertexCacheIndex + VERTS_FOR_A_QUAD) >= MTLVC_MAX_INDEX)
     {
         J2dTraceLn2(J2D_TRACE_INFO, "maskCacheIndex = %d, vertexCacheIndex = %d", maskCacheIndex, vertexCacheIndex);
         MTLVertexCache_FlushGlyphVertexCache();

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.m
@@ -222,7 +222,7 @@ MTLVertexCache_AddMaskQuad(MTLContext *mtlc,
     J2dTraceLn1(J2D_TRACE_INFO, "MTLVertexCache_AddMaskQuad: %d",
                 maskCacheIndex);
 
-    // MTLVC_ADD_TRIANGLES at the end of this function will place MTL_TRIS_IN_VERTEX vertexes to the vertex cache
+    // MTLVC_ADD_TRIANGLES at the end of this function will place VERTS_FOR_A_QUAD vertexes to the vertex cache
     // check free space and flush if needed.
     if ((maskCacheIndex >= MTLVC_MASK_CACHE_MAX_INDEX) || ((vertexCacheIndex + VERTS_FOR_A_QUAD) >= MTLVC_MAX_INDEX))
     {
@@ -310,7 +310,7 @@ MTLVertexCache_AddGlyphQuad(MTLContext *mtlc,
 {
     J2dTraceLn(J2D_TRACE_INFO, "MTLVertexCache_AddGlyphQuad");
 
-    // MTLVC_ADD_TRIANGLES adds MTL_TRIS_IN_VERTEX vertexes into Cache, so need to check space for MTL_TRIS_IN_VERTEX elements
+    // MTLVC_ADD_TRIANGLES adds VERTS_FOR_A_QUAD vertexes into Cache, so need to check space for MTL_TRIS_IN_VERTEX elements
     if ((vertexCacheIndex + VERTS_FOR_A_QUAD) >= MTLVC_MAX_INDEX)
     {
         J2dTraceLn2(J2D_TRACE_INFO, "maskCacheIndex = %d, vertexCacheIndex = %d", maskCacheIndex, vertexCacheIndex);


### PR DESCRIPTION
Please review this simple patch. When running idea on jdk17 with asan I have found this buffer overflow.
The code checks the cache for at least one free element, while placing 6 elements to the cache.
The fix checks the presence of 6 free elements.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289697](https://bugs.openjdk.org/browse/JDK-8289697): buffer overflow in MTLVertexCache.m: MTLVertexCache_AddGlyphQuad


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [2676028f](https://git.openjdk.org/jdk/pull/9368/files/2676028f80505e53a5a4463c388b2465a4a5eeee)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9368/head:pull/9368` \
`$ git checkout pull/9368`

Update a local copy of the PR: \
`$ git checkout pull/9368` \
`$ git pull https://git.openjdk.org/jdk pull/9368/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9368`

View PR using the GUI difftool: \
`$ git pr show -t 9368`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9368.diff">https://git.openjdk.org/jdk/pull/9368.diff</a>

</details>
