### PR TITLE
8289804: Remove redundant stream() call before forEach in jdk.jshell

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/Feedback.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/Feedback.java
@@ -165,7 +165,7 @@ class Feedback {
     }
 
     public void markModesReadOnly() {
-        modeMap.values().stream()
+        modeMap.values()
                 .forEach(m -> m.readOnly = true);
     }
 

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
@@ -341,16 +341,15 @@ public class JShellTool implements MessageHandler {
         // return a new Options, with parameter options overriding receiver options
         Options override(Options newer) {
             Options result = new Options(this);
-            newer.optMap.entrySet().stream()
-                    .forEach(e -> {
-                        if (e.getKey().onlyOne) {
-                            // Only one allowed, override last
-                            result.optMap.put(e.getKey(), e.getValue());
-                        } else {
-                            // Additive
-                            result.addAll(e.getKey(), e.getValue());
-                        }
-                    });
+            newer.optMap.forEach((key, value) -> {
+                if (key.onlyOne) {
+                    // Only one allowed, override last
+                    result.optMap.put(key, value);
+                } else {
+                    // Additive
+                    result.addAll(key, value);
+                }
+            });
             return result;
         }
     }
@@ -3543,8 +3542,7 @@ public class JShellTool implements MessageHandler {
             errormsg(d.isError() ? "jshell.msg.error" : "jshell.msg.warning");
             List<String> disp = new ArrayList<>();
             displayableDiagnostic(source, d, disp);
-            disp.stream()
-                    .forEach(l -> error("%s", l));
+            disp.forEach(l -> error("%s", l));
         }
     }
 

--- a/src/jdk.jshell/share/classes/jdk/jshell/Eval.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/Eval.java
@@ -1008,8 +1008,8 @@ class Eval {
         while (true) {
             state.debug(DBG_GEN, "compileAndLoad  %s\n", ins);
 
-            ins.stream().forEach(Unit::initialize);
-            ins.stream().forEach(u -> u.setWrap(ins, ins));
+            ins.forEach(Unit::initialize);
+            ins.forEach(u -> u.setWrap(ins, ins));
 
             if (ins.stream().anyMatch(u -> u.snippet().kind() == Kind.METHOD)) {
                 //if there is any method declaration, check the body of the method for
@@ -1052,24 +1052,24 @@ class Eval {
                 });
 
                 if (ins.addAll(overloads)) {
-                    ins.stream().forEach(Unit::initialize);
-                    ins.stream().forEach(u -> u.setWrap(ins, ins));
+                    ins.forEach(Unit::initialize);
+                    ins.forEach(u -> u.setWrap(ins, ins));
                 }
             }
 
             state.taskFactory.analyze(outerWrapSet(ins), at -> {
-                ins.stream().forEach(u -> u.setDiagnostics(at));
+                ins.forEach(u -> u.setDiagnostics(at));
 
                 // corral any Snippets that need it
                 if (ins.stream().filter(u -> u.corralIfNeeded(ins)).count() > 0) {
                     // if any were corralled, re-analyze everything
                     state.taskFactory.analyze(outerWrapSet(ins), cat -> {
-                        ins.stream().forEach(u -> u.setCorralledDiagnostics(cat));
-                        ins.stream().forEach(u -> u.setStatus(cat));
+                        ins.forEach(u -> u.setCorralledDiagnostics(cat));
+                        ins.forEach(u -> u.setStatus(cat));
                         return null;
                     });
                 } else {
-                    ins.stream().forEach(u -> u.setStatus(at));
+                    ins.forEach(u -> u.setStatus(at));
                 }
                 return null;
             });
@@ -1086,7 +1086,7 @@ class Eval {
                     success = true;
                 } else {
                     // re-wrap with legit imports
-                    legit.stream().forEach(u -> u.setWrap(ins, legit));
+                    legit.forEach(u -> u.setWrap(ins, legit));
 
                     // generate class files for those capable
                     Result res = state.taskFactory.compile(outerWrapSet(legit), ct -> {
@@ -1116,9 +1116,9 @@ class Eval {
                         // loop by replacing all that have been replaced
                         if (!toReplace.isEmpty()) {
                             replaced.addAll(toReplace);
-                            replaced.stream().forEach(Unit::markForReplacement);
+                            replaced.forEach(Unit::markForReplacement);
                             //ensure correct classnames are set in the snippets:
-                            replaced.stream().forEach(u -> u.setWrap(ins, legit));
+                            replaced.forEach(u -> u.setWrap(ins, legit));
                         }
 
                         return toReplace.isEmpty() ? Result.SUCESS : Result.FAILURE;
@@ -1144,7 +1144,7 @@ class Eval {
                 // all classes that could not be directly loaded (because they
                 // are new) have been redefined, and no new dependnencies were
                 // identified
-                ins.stream().forEach(Unit::finish);
+                ins.forEach(Unit::finish);
                 return ins;
             }
         }


### PR DESCRIPTION
There are several places in the jdk.jshell implementation that use stream().forEach(...), these can be cleaned up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289804](https://bugs.openjdk.org/browse/JDK-8289804): Remove redundant stream() call before forEach in jdk.jshell


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9370/head:pull/9370` \
`$ git checkout pull/9370`

Update a local copy of the PR: \
`$ git checkout pull/9370` \
`$ git pull https://git.openjdk.org/jdk pull/9370/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9370`

View PR using the GUI difftool: \
`$ git pr show -t 9370`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9370.diff">https://git.openjdk.org/jdk/pull/9370.diff</a>

</details>
