### PR TITLE
8289604: compiler/vectorapi/VectorLogicalOpIdentityTest.java failed on x86 AVX1 system

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/VectorLogicalOpIdentityTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorLogicalOpIdentityTest.java
@@ -429,12 +429,12 @@ public class VectorLogicalOpIdentityTest {
     @Warmup(10000)
     @IR(failOn = {IRNode.AND_V, IRNode.AND_V_MASK}, counts = {IRNode.STORE_VECTOR, ">=1"})
     public static void testMaskAndZero() {
-        VectorMask<Long> ma = VectorMask.fromArray(L_SPECIES, m, 0);
-        VectorMask<Long> mb = L_SPECIES.maskAll(false);
+        VectorMask<Short> ma = VectorMask.fromArray(S_SPECIES, m, 0);
+        VectorMask<Short> mb = S_SPECIES.maskAll(false);
         ma.and(mb).intoArray(mr, 0);
 
         // Verify results
-        for (int i = 0; i < L_SPECIES.length(); i++) {
+        for (int i = 0; i < S_SPECIES.length(); i++) {
             Asserts.assertEquals(false, mr[i]);
         }
     }


### PR DESCRIPTION
The sub-test "`testMaskAndZero()`" failed on x86 systems when
`UseAVX=1` with the IR check failure:
```
  - counts: Graph contains wrong number of nodes:
     * Regex 1: (\\d+(\\s){2}(StoreVector.*)+(\\s){2}===.*)
        - Failed comparison: [found] 0 >= 1 [given]
        - No nodes matched!
```
The root cause is the `VectorMask.fromArray/intoArray` APIs
are not intrinsified when "`UseAVX=1`" for long type vectors
with following reasons:
 1) The system supported max vector size is 128 bits for
integral vector operations when "`UseAVX=1`".
 2) The match rule of `VectorLoadMaskNode/VectorStoreMaskNode`
are not supported for vectors with 2 elements (see [1]).

Note that `VectorMask.fromArray()` needs to be intrinsified
with "`LoadVector+VectorLoadMask`". And `VectorMask.intoArray()`
needs to be intrinsified with "`VectorStoreMask+StoreVector`".
Either "`VectorStoreMask`" or "`StoreVector`" not supported by the
compiler backend will forbit the relative API intrinsification.

Replacing the vector type from Long to other integral types
in the test case can fix the issue.

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/x86/x86.ad#L1861

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289604](https://bugs.openjdk.org/browse/JDK-8289604): compiler/vectorapi/VectorLogicalOpIdentityTest.java failed on x86 AVX1 system


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)
 * @kristylee88 (no known github.com user name / role)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9373/head:pull/9373` \
`$ git checkout pull/9373`

Update a local copy of the PR: \
`$ git checkout pull/9373` \
`$ git pull https://git.openjdk.org/jdk pull/9373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9373`

View PR using the GUI difftool: \
`$ git pr show -t 9373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9373.diff">https://git.openjdk.org/jdk/pull/9373.diff</a>

</details>
