### PR TITLE
8289729: G1: Incorrect verification logic in G1ConcurrentMark::clear_next_bitmap

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -704,7 +704,7 @@ void G1ConcurrentMark::clear_next_bitmap(WorkerThreads* workers, bool may_yield)
 
   log_debug(gc, ergo)("Running %s with %u workers for " SIZE_FORMAT " work units.", cl.name(), num_workers, num_chunks);
   workers->run_task(&cl, num_workers);
-  guarantee(!may_yield || cl.is_complete(), "Must have completed iteration when not yielding.");
+  guarantee(may_yield || cl.is_complete(), "Must have completed iteration when not yielding.");
 }
 
 void G1ConcurrentMark::cleanup_for_next_mark() {


### PR DESCRIPTION
One line change of negating a condition.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289729](https://bugs.openjdk.org/browse/JDK-8289729): G1: Incorrect verification logic in G1ConcurrentMark::clear_next_bitmap


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9374/head:pull/9374` \
`$ git checkout pull/9374`

Update a local copy of the PR: \
`$ git checkout pull/9374` \
`$ git pull https://git.openjdk.org/jdk pull/9374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9374`

View PR using the GUI difftool: \
`$ git pr show -t 9374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9374.diff">https://git.openjdk.org/jdk/pull/9374.diff</a>

</details>
