### PR TITLE
JDK-8273860: Javadoc Deprecated API list should not use italic font for description column

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
@@ -121,7 +121,7 @@ public class DeprecatedListWriter extends SummaryListWriter<DeprecatedAPIListBui
     protected void addComments(Element e, Content desc) {
         List<? extends DeprecatedTree> tags = utils.getDeprecatedTrees(e);
         if (!tags.isEmpty()) {
-            addInlineDeprecatedComment(e, tags.get(0), desc);
+            addInlineComment(e, tags.get(0), desc);
         } else {
             desc.add(Text.EMPTY);
         }

--- a/test/langtools/jdk/javadoc/doclet/testDeprecatedDocs/TestDeprecatedDocs.java
+++ b/test/langtools/jdk/javadoc/doclet/testDeprecatedDocs/TestDeprecatedDocs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug      4927552 8026567 8071982 8162674 8175200 8175218 8183511 8186332
- *           8169819 8074407 8191030 8182765 8184205 8243533 8261976
+ *           8169819 8074407 8191030 8182765 8184205 8243533 8261976 8273860
  * @summary  test generated docs for deprecated items
  * @library  ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -292,7 +292,7 @@ public class TestDeprecatedDocs extends JavadocTester {
                     <div class="table-header col-last">Description</div>
                     <div class="col-summary-item-name even-row-color"><a href="pkg/TestEnum.html" title="enum class in pkg">pkg.TestEnum</a></div>
                     <div class="col-last even-row-color">
-                    <div class="deprecation-comment">enum_test1 passes.</div>
+                    <div class="block">enum_test1 passes.</div>
                     </div>""",
                 """
                     <div id="exception-class">
@@ -302,11 +302,11 @@ public class TestDeprecatedDocs extends JavadocTester {
                     <div class="table-header col-last">Description</div>
                     <div class="col-summary-item-name even-row-color"><a href="pkg/TestError.html" title="class in pkg">pkg.TestError</a></div>
                     <div class="col-last even-row-color">
-                    <div class="deprecation-comment">error_test1 passes.</div>
+                    <div class="block">error_test1 passes.</div>
                     </div>
                     <div class="col-summary-item-name odd-row-color"><a href="pkg/TestException.html" title="class in pkg">pkg.TestException</a></div>
                     <div class="col-last odd-row-color">
-                    <div class="deprecation-comment">exception_test1 passes.</div>
+                    <div class="block">exception_test1 passes.</div>
                     </div>""",
                 """
                     <div id="field">
@@ -318,23 +318,23 @@ public class TestDeprecatedDocs extends JavadocTester {
                     <div class="col-last even-row-color"></div>
                     <div class="col-summary-item-name odd-row-color"><a href="pkg/TestAnnotationType.html#field">pkg.TestAnnotationType.field</a></div>
                     <div class="col-last odd-row-color">
-                    <div class="deprecation-comment">annotation_test4 passes.</div>
+                    <div class="block">annotation_test4 passes.</div>
                     </div>
                     <div class="col-summary-item-name even-row-color"><a href="pkg/TestClass.html#field">pkg.TestClass.field</a></div>
                     <div class="col-last even-row-color">
-                    <div class="deprecation-comment">class_test2 passes. This is the second sentence of deprecated description for a field.</div>
+                    <div class="block">class_test2 passes. This is the second sentence of deprecated description for a field.</div>
                     </div>
                     <div class="col-summary-item-name odd-row-color"><a href="pkg/TestError.html#field">pkg.TestError.field</a></div>
                     <div class="col-last odd-row-color">
-                    <div class="deprecation-comment">error_test2 passes.</div>
+                    <div class="block">error_test2 passes.</div>
                     </div>
                     <div class="col-summary-item-name even-row-color"><a href="pkg/TestException.html#field">pkg.TestException.field</a></div>
                     <div class="col-last even-row-color">
-                    <div class="deprecation-comment">exception_test2 passes.</div>
+                    <div class="block">exception_test2 passes.</div>
                     </div>
                     <div class="col-summary-item-name odd-row-color"><a href="pkg/TestInterface.html#field">pkg.TestInterface.field</a></div>
                     <div class="col-last odd-row-color">
-                    <div class="deprecation-comment">interface_test2 passes.</div>
+                    <div class="block">interface_test2 passes.</div>
                     </div>
                     </div>
                     </div>""",
@@ -348,23 +348,23 @@ public class TestDeprecatedDocs extends JavadocTester {
                     <div class="col-last even-row-color"></div>
                     <div class="col-summary-item-name odd-row-color"><a href="pkg/TestAnnotationType.html#optional()">pkg.TestAnnotationType.optional()</a></div>
                     <div class="col-last odd-row-color">
-                    <div class="deprecation-comment">annotation_test2 passes.</div>
+                    <div class="block">annotation_test2 passes.</div>
                     </div>
                     <div class="col-summary-item-name even-row-color"><a href="pkg/TestAnnotationType.html#required()">pkg.TestAnnotationType.required()</a></div>
                     <div class="col-last even-row-color">
-                    <div class="deprecation-comment">annotation_test3 passes.</div>
+                    <div class="block">annotation_test3 passes.</div>
                     </div>
                     <div class="col-summary-item-name odd-row-color"><a href="pkg/TestClass.html#method()">pkg.TestClass.method()</a></div>
                     <div class="col-last odd-row-color">
-                    <div class="deprecation-comment">class_test5 passes. This is the second sentence of deprecated description for a method.</div>
+                    <div class="block">class_test5 passes. This is the second sentence of deprecated description for a method.</div>
                     </div>
                     <div class="col-summary-item-name even-row-color"><a href="pkg/TestClass.html#overloadedMethod(int)">pkg.TestClass.overloadedMethod<wbr>(int)</a></div>
                     <div class="col-last even-row-color">
-                    <div class="deprecation-comment">class_test7 passes. Overloaded method 2.</div>
+                    <div class="block">class_test7 passes. Overloaded method 2.</div>
                     </div>
                     <div class="col-summary-item-name odd-row-color"><a href="pkg/TestClass.html#overloadedMethod(java.lang.String)">pkg.TestClass.overloadedMethod<wbr>(String)</a></div>
                     <div class="col-last odd-row-color">
-                    <div class="deprecation-comment">class_test6 passes. Overloaded method 1.</div>
+                    <div class="block">class_test6 passes. Overloaded method 1.</div>
                     </div>""",
                 """
                     <div id="constructor">
@@ -376,11 +376,11 @@ public class TestDeprecatedDocs extends JavadocTester {
                     <div class="col-last even-row-color"></div>
                     <div class="col-summary-item-name odd-row-color"><a href="pkg/TestClass.html#%3Cinit%3E()">pkg.TestClass()</a></div>
                     <div class="col-last odd-row-color">
-                    <div class="deprecation-comment">class_test3 passes. This is the second sentence of deprecated description for a constructor.</div>
+                    <div class="block">class_test3 passes. This is the second sentence of deprecated description for a constructor.</div>
                     </div>
                     <div class="col-summary-item-name even-row-color"><a href="pkg/TestClass.html#%3Cinit%3E(java.lang.String)">pkg.TestClass<wbr>(String)</a></div>
                     <div class="col-last even-row-color">
-                    <div class="deprecation-comment">class_test4 passes. Overloaded constructor.</div>
+                    <div class="block">class_test4 passes. Overloaded constructor.</div>
                     </div>""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -704,13 +704,13 @@ public class TestHtmlTableTags extends JavadocTester {
                 """
                     <div class="col-summary-item-name even-row-color"><a href="pkg2/C2.html#dep_field">pkg2.C2.dep_field</a></div>
                     <div class="col-last even-row-color">
-                    <div class="deprecation-comment">don't use this field anymore.</div>
+                    <div class="block">don't use this field anymore.</div>
                     </div>""",
                 """
                     <div class="col-summary-item-name even-row-color"><a href="pkg1/C1.html#deprecat\
                     edMethod()">pkg1.C1.deprecatedMethod()</a></div>
                     <div class="col-last even-row-color">
-                    <div class="deprecation-comment">don't use this anymore.</div>
+                    <div class="block">don't use this anymore.</div>
                     </div>""");
 
         // Constant values

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
@@ -1117,7 +1117,7 @@ public class TestModules extends JavadocTester {
                 """
                     <div class="col-summary-item-name even-row-color"><a href="moduleA/module-summary.html">moduleA</a></div>
                     <div class="col-last even-row-color">
-                    <div class="deprecation-comment">This module is deprecated.</div>""");
+                    <div class="block">This module is deprecated.</div>""");
         checkOutput("moduleB/module-summary.html", !found,
                 """
                     <div class="deprecation-block"><span class="deprecated-label">Deprecated.</span>

--- a/test/langtools/jdk/javadoc/doclet/testRecordTypes/TestRecordTypes.java
+++ b/test/langtools/jdk/javadoc/doclet/testRecordTypes/TestRecordTypes.java
@@ -524,7 +524,7 @@ public class TestRecordTypes extends JavadocTester {
                     <div class="table-header col-last">Description</div>
                     <div class="col-summary-item-name even-row-color"><a href="p/R.html" title="class in p">p.R</a></div>
                     <div class="col-last even-row-color">
-                    <div class="deprecation-comment">Do not use.</div>
+                    <div class="block">Do not use.</div>
                     </div>""");
     }
 


### PR DESCRIPTION
Please review a trivial change to use plain font for deprecation comments in the Deprecated API page. Italic font is used to make deprecation comments stand out against other parts of the documentation, but here the content consists exclusively of deprecation comments so the same so the font style should be the same as in other API summary pages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273860](https://bugs.openjdk.org/browse/JDK-8273860): Javadoc Deprecated API list should not use italic font for description column


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9375/head:pull/9375` \
`$ git checkout pull/9375`

Update a local copy of the PR: \
`$ git checkout pull/9375` \
`$ git pull https://git.openjdk.org/jdk pull/9375/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9375`

View PR using the GUI difftool: \
`$ git pr show -t 9375`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9375.diff">https://git.openjdk.org/jdk/pull/9375.diff</a>

</details>
