### PR TITLE
8289739: Add G1 specific GC breakpoints for testing

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
@@ -234,6 +234,7 @@ bool G1ConcurrentMarkThread::subphase_remark() {
 }
 
 bool G1ConcurrentMarkThread::phase_rebuild_remembered_sets() {
+  ConcurrentGCBreakpoints::at("AFTER REBUILD STARTED");
   G1ConcPhaseTimer p(_cm, "Concurrent Rebuild Remembered Sets");
   _cm->rebuild_rem_set_concurrently();
   return _cm->has_aborted();
@@ -245,12 +246,14 @@ bool G1ConcurrentMarkThread::phase_delay_to_keep_mmu_before_cleanup() {
 }
 
 bool G1ConcurrentMarkThread::phase_cleanup() {
+  ConcurrentGCBreakpoints::at("BEFORE REBUILD COMPLETED");
   VM_G1PauseCleanup op;
   VMThread::execute(&op);
   return _cm->has_aborted();
 }
 
 bool G1ConcurrentMarkThread::phase_clear_bitmap_for_next_mark() {
+  ConcurrentGCBreakpoints::at("AFTER CLEANUP STARTED");
   G1ConcPhaseTimer p(_cm, "Concurrent Cleanup for Next Mark");
   _cm->cleanup_for_next_mark();
   return _cm->has_aborted();
@@ -318,6 +321,7 @@ void G1ConcurrentMarkThread::concurrent_undo_cycle_do() {
 }
 
 void G1ConcurrentMarkThread::concurrent_cycle_end(bool mark_cycle_completed) {
+  ConcurrentGCBreakpoints::at("BEFORE CLEANUP COMPLETED");
   // Update the number of full collections that have been
   // completed. This will also notify the G1OldGCCount_lock in case a
   // Java thread is waiting for a full GC to happen (e.g., it

--- a/test/hotspot/jtreg/gc/TestConcurrentGCBreakpoints.java
+++ b/test/hotspot/jtreg/gc/TestConcurrentGCBreakpoints.java
@@ -42,6 +42,13 @@ public class TestConcurrentGCBreakpoints {
 
     private static final WhiteBox WB = WhiteBox.getWhiteBox();
 
+    private static void testG1SpecificBreakpoints() {
+        WB.concurrentGCRunTo(WB.G1_AFTER_REBUILD_STARTED);
+        WB.concurrentGCRunTo(WB.G1_BEFORE_REBUILD_COMPLETED);
+        WB.concurrentGCRunTo(WB.G1_AFTER_CLEANUP_STARTED);
+        WB.concurrentGCRunTo(WB.G1_BEFORE_CLEANUP_COMPLETED);
+    }
+
     // All testN() assume initial state is idle, and restore that state.
 
     // Step through the common breakpoints.
@@ -51,10 +58,16 @@ public class TestConcurrentGCBreakpoints {
             // Run one cycle.
             WB.concurrentGCRunTo(WB.AFTER_MARKING_STARTED);
             WB.concurrentGCRunTo(WB.BEFORE_MARKING_COMPLETED);
+            if (GC.G1.isSelected()) {
+                testG1SpecificBreakpoints();
+            }
             WB.concurrentGCRunToIdle();
             // Run a second cycle.
             WB.concurrentGCRunTo(WB.AFTER_MARKING_STARTED);
             WB.concurrentGCRunTo(WB.BEFORE_MARKING_COMPLETED);
+            if (GC.G1.isSelected()) {
+                testG1SpecificBreakpoints();
+            }
             WB.concurrentGCRunToIdle();
         } finally {
             WB.concurrentGCRunToIdle();

--- a/test/lib/sun/hotspot/WhiteBox.java
+++ b/test/lib/sun/hotspot/WhiteBox.java
@@ -488,6 +488,12 @@ public class WhiteBox {
   public final String AFTER_CONCURRENT_REFERENCE_PROCESSING_STARTED =
     "AFTER CONCURRENT REFERENCE PROCESSING STARTED";
 
+  // G1 specific GC breakpoints.
+  public final String G1_AFTER_REBUILD_STARTED = "AFTER REBUILD STARTED";
+  public final String G1_BEFORE_REBUILD_COMPLETED = "BEFORE REBUILD COMPLETED";
+  public final String G1_AFTER_CLEANUP_STARTED = "AFTER CLEANUP STARTED";
+  public final String G1_BEFORE_CLEANUP_COMPLETED = "BEFORE CLEANUP COMPLETED";
+
   public void concurrentGCAcquireControl() {
     checkConcurrentGCBreakpointsSupported();
     if (concurrentGCIsControlled) {


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that adds a few G1 specific GC breakpoints for future testing [JDK-8289740](https://bugs.openjdk.org/browse/JDK-8289740).

Testing: gha, local testing

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289739](https://bugs.openjdk.org/browse/JDK-8289739): Add G1 specific GC breakpoints for testing


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9376/head:pull/9376` \
`$ git checkout pull/9376`

Update a local copy of the PR: \
`$ git checkout pull/9376` \
`$ git pull https://git.openjdk.org/jdk pull/9376/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9376`

View PR using the GUI difftool: \
`$ git pr show -t 9376`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9376.diff">https://git.openjdk.org/jdk/pull/9376.diff</a>

</details>
