### PR TITLE
8289745: JfrStructCopyFailed uses heap words instead of bytes for object sizes

### DIFF
--- a/src/hotspot/share/gc/g1/g1Trace.cpp
+++ b/src/hotspot/share/gc/g1/g1Trace.cpp
@@ -163,9 +163,9 @@ void G1NewTracer::send_evacuation_failed_event(const EvacuationFailedInfo& ef_in
     // Create JFR structured failure data
     JfrStructCopyFailed evac_failed;
     evac_failed.set_objectCount(ef_info.failed_count());
-    evac_failed.set_firstSize(ef_info.first_size());
-    evac_failed.set_smallestSize(ef_info.smallest_size());
-    evac_failed.set_totalSize(ef_info.total_size());
+    evac_failed.set_firstSize(ef_info.first_size() * HeapWordSize);
+    evac_failed.set_smallestSize(ef_info.smallest_size() * HeapWordSize);
+    evac_failed.set_totalSize(ef_info.total_size() * HeapWordSize);
     // Add to the event
     e.set_gcId(GCId::current());
     e.set_evacuationFailed(evac_failed);

--- a/src/hotspot/share/gc/shared/gcTraceSend.cpp
+++ b/src/hotspot/share/gc/shared/gcTraceSend.cpp
@@ -157,9 +157,9 @@ void OldGCTracer::send_old_gc_event() const {
 static JfrStructCopyFailed to_struct(const CopyFailedInfo& cf_info) {
   JfrStructCopyFailed failed_info;
   failed_info.set_objectCount(cf_info.failed_count());
-  failed_info.set_firstSize(cf_info.first_size());
-  failed_info.set_smallestSize(cf_info.smallest_size());
-  failed_info.set_totalSize(cf_info.total_size());
+  failed_info.set_firstSize(cf_info.first_size() * HeapWordSize);
+  failed_info.set_smallestSize(cf_info.smallest_size() * HeapWordSize);
+  failed_info.set_totalSize(cf_info.total_size() * HeapWordSize);
   return failed_info;
 }
 

--- a/test/jdk/jdk/jfr/event/gc/detailed/PromotionFailedEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/PromotionFailedEvent.java
@@ -49,12 +49,16 @@ public class PromotionFailedEvent {
         // This test can not always trigger the expected event.
         // Test is ok even if no events found.
         List<RecordedEvent> events = RecordingFile.readAllEvents(Paths.get(jfr_file));
+        int minObjectAlignment = 8;
         for (RecordedEvent event : events) {
             System.out.println("Event: " + event);
             long smallestSize = Events.assertField(event, "promotionFailed.smallestSize").atLeast(1L).getValue();
+            Asserts.assertTrue((smallestSize % minObjectAlignment) == 0, "smallestSize " + smallestSize + " is not a valid size.");
             long firstSize = Events.assertField(event, "promotionFailed.firstSize").atLeast(smallestSize).getValue();
+            Asserts.assertTrue((firstSize % minObjectAlignment) == 0, "firstSize " + firstSize + " is not a valid size.");
             long totalSize = Events.assertField(event, "promotionFailed.totalSize").atLeast(firstSize).getValue();
             long objectCount = Events.assertField(event, "promotionFailed.objectCount").atLeast(1L).getValue();
+            Asserts.assertTrue((totalSize % minObjectAlignment) == 0, "totalSize " + totalSize + " is not a valid size.");
             Asserts.assertLessThanOrEqual(smallestSize * objectCount, totalSize, "smallestSize * objectCount <= totalSize");
         }
     }

--- a/test/jdk/jdk/jfr/event/gc/detailed/TestEvacuationFailedEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestEvacuationFailedEvent.java
@@ -76,13 +76,17 @@ public class TestEvacuationFailedEvent {
 
         // Verify recording
         List<RecordedEvent> events = Events.fromRecording(recording);
+        int minObjectAlignment = 8;
 
         Events.hasEvents(events);
         for (RecordedEvent event : events) {
             long objectCount = Events.assertField(event, "evacuationFailed.objectCount").atLeast(1L).getValue();
             long smallestSize = Events.assertField(event, "evacuationFailed.smallestSize").atLeast(1L).getValue();
+            Asserts.assertTrue((smallestSize % minObjectAlignment) == 0, "smallestSize " + smallestSize + " is not a valid size.");
             long firstSize = Events.assertField(event, "evacuationFailed.firstSize").atLeast(smallestSize).getValue();
+            Asserts.assertTrue((firstSize % minObjectAlignment) == 0, "firstSize " + firstSize + " is not a valid size.");
             long totalSize = Events.assertField(event, "evacuationFailed.totalSize").atLeast(firstSize).getValue();
+            Asserts.assertTrue((totalSize % minObjectAlignment) == 0, "totalSize " + totalSize + " is not a valid size.");
             Asserts.assertLessThanOrEqual(smallestSize * objectCount, totalSize, "smallestSize * objectCount <= totalSize");
         }
         recording.close();


### PR DESCRIPTION
The values for smallestSize, firstSize and totalSize in the CopyFailed type are set as the number of heap words, but should be number of bytes. This leads to wrong values in the PromotionFailed and EvacuationFailed JFR events containing this type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289745](https://bugs.openjdk.org/browse/JDK-8289745): JfrStructCopyFailed uses heap words instead of bytes for object sizes


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9378/head:pull/9378` \
`$ git checkout pull/9378`

Update a local copy of the PR: \
`$ git checkout pull/9378` \
`$ git pull https://git.openjdk.org/jdk pull/9378/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9378`

View PR using the GUI difftool: \
`$ git pr show -t 9378`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9378.diff">https://git.openjdk.org/jdk/pull/9378.diff</a>

</details>
