### PR TITLE
8289755: Remove --enable-reproducible-build from jib profile

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -254,12 +254,7 @@ var getJibProfilesCommon = function (input, data) {
             "--disable-jvm-feature-shenandoahgc",
             versionArgs(input, common))
     };
-    // Extra settings for release profiles
-    common.release_profile_base = {
-        configure_args: [
-            "--enable-reproducible-build",
-        ],
-    };
+
     // Extra settings for debug profiles
     common.debug_suffix = "-debug";
     common.debug_profile_base = {
@@ -852,13 +847,6 @@ var getJibProfilesProfiles = function (input, common, data) {
             // Do not inherit artifact definitions from base profile
             delete profiles[cmpBaselineName].artifacts;
         });
-    });
-
-    // After creating all derived profiles, we can add the release profile base
-    // to the main profiles
-    common.main_profile_names.forEach(function (name) {
-        profiles[name] = concatObjects(profiles[name],
-            common.release_profile_base);
     });
 
     // Artifacts of JCov profiles


### PR DESCRIPTION
Since [JDK-8288396](https://bugs.openjdk.org/browse/JDK-8288396), the flag ` --enable-reproducible-build` is deprecated, and does nothing but print a warning. It is still included in the jib profiles, which make they output a warning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289755](https://bugs.openjdk.org/browse/JDK-8289755): Remove --enable-reproducible-build from jib profile


### Reviewers
 * [Bradford Wetmore](https://openjdk.org/census#wetmore) (@bradfordwetmore - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9379/head:pull/9379` \
`$ git checkout pull/9379`

Update a local copy of the PR: \
`$ git checkout pull/9379` \
`$ git pull https://git.openjdk.org/jdk pull/9379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9379`

View PR using the GUI difftool: \
`$ git pr show -t 9379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9379.diff">https://git.openjdk.org/jdk/pull/9379.diff</a>

</details>
