### PR TITLE
JDK-8289620: gtest/MetaspaceUtilsGtests.java failed with unexpected stats values

### DIFF
--- a/test/hotspot/gtest/metaspace/test_metaspaceUtils.cpp
+++ b/test/hotspot/gtest/metaspace/test_metaspaceUtils.cpp
@@ -89,8 +89,8 @@ TEST_VM(MetaspaceUtils, non_compressed_class_pointers) {
 }
 
 static void check_metaspace_stats_are_consistent(const MetaspaceStats& stats) {
-  EXPECT_LT(stats.committed(), stats.reserved());
-  EXPECT_LT(stats.used(), stats.committed());
+  EXPECT_LE(stats.committed(), stats.reserved());
+  EXPECT_LE(stats.used(), stats.committed());
 }
 
 static void check_metaspace_stats_are_not_null(const MetaspaceStats& stats) {


### PR DESCRIPTION
I cannot reproduce this on my machine, but the comparison is obviously wrong in the gtest. The statistics API returns used/committed/reserved metaspace, and used can be equal to committed, committed equal to reserved, albeit rarely.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289620](https://bugs.openjdk.org/browse/JDK-8289620): gtest/MetaspaceUtilsGtests.java failed with unexpected stats values


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9381/head:pull/9381` \
`$ git checkout pull/9381`

Update a local copy of the PR: \
`$ git checkout pull/9381` \
`$ git pull https://git.openjdk.org/jdk pull/9381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9381`

View PR using the GUI difftool: \
`$ git pr show -t 9381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9381.diff">https://git.openjdk.org/jdk/pull/9381.diff</a>

</details>
