### PR TITLE
8288706: Unused parameter 'boolean newln' in method java.lang.VersionProps#print(boolean, boolean)

### DIFF
--- a/src/java.base/share/classes/java/lang/VersionProps.java.template
+++ b/src/java.base/share/classes/java/lang/VersionProps.java.template
@@ -186,25 +186,13 @@ class VersionProps {
         }
     }
 
-    /**
-     * In case you were wondering this method is called by java -version.
-     */
-    public static void print(boolean err) {
-        print(err, false);
-    }
 
-    /**
-     * This is the same as print except that it adds an extra line-feed
-     * at the end, typically used by the -showversion in the launcher
-     */
-    public static void println(boolean err) {
-        print(err, true);
-    }
 
     /**
      * Print version info.
+     * In case you were wondering this method is called by java -version.
      */
-    private static void print(boolean err, boolean newln) {
+    private static void print(boolean err) {
         PrintStream ps = err ? System.err : System.out;
 
         /* First line: platform version. */

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -123,7 +123,7 @@ static void TranslateApplicationArgs(int jargc, const char **jargv, int *pargc, 
 static jboolean AddApplicationOptions(int cpathc, const char **cpathv);
 static void SetApplicationClassPath(const char**);
 
-static void PrintJavaVersion(JNIEnv *env, jboolean extraLF);
+static void PrintJavaVersion(JNIEnv *env);
 static void PrintUsage(JNIEnv* env, jboolean doXUsage);
 static void ShowSettings(JNIEnv* env, char *optString);
 static void ShowResolvedModules(JNIEnv* env);
@@ -441,7 +441,7 @@ JavaMain(void* _args)
     }
 
     if (printVersion || showVersion) {
-        PrintJavaVersion(env, showVersion);
+        PrintJavaVersion(env);
         CHECK_EXCEPTION_LEAVE(0);
         if (printVersion) {
             LEAVE();
@@ -1804,7 +1804,7 @@ static void SetJavaLauncherProp() {
  * Prints the version information from the java.version and other properties.
  */
 static void
-PrintJavaVersion(JNIEnv *env, jboolean extraLF)
+PrintJavaVersion(JNIEnv *env)
 {
     jclass ver;
     jmethodID print;
@@ -1812,7 +1812,7 @@ PrintJavaVersion(JNIEnv *env, jboolean extraLF)
     NULL_CHECK(ver = FindBootStrapClass(env, "java/lang/VersionProps"));
     NULL_CHECK(print = (*env)->GetStaticMethodID(env,
                                                  ver,
-                                                 (extraLF == JNI_TRUE) ? "println" : "print",
+                                                 "print",
                                                  "(Z)V"
                                                  )
               );


### PR DESCRIPTION
Hi all,

This PR cleans up `VersionProps::print` removing the unused parameter `newln`.

Mach5 tiers1-3 are currently running.

Best,
Lance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288706](https://bugs.openjdk.org/browse/JDK-8288706): Unused parameter 'boolean newln' in method java.lang.VersionProps#print(boolean, boolean)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9382/head:pull/9382` \
`$ git checkout pull/9382`

Update a local copy of the PR: \
`$ git checkout pull/9382` \
`$ git pull https://git.openjdk.org/jdk pull/9382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9382`

View PR using the GUI difftool: \
`$ git pr show -t 9382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9382.diff">https://git.openjdk.org/jdk/pull/9382.diff</a>

</details>
