### PR TITLE
8289768

### DIFF
--- a/src/java.base/macosx/native/libjava/ProcessHandleImpl_macosx.c
+++ b/src/java.base/macosx/native/libjava/ProcessHandleImpl_macosx.c
@@ -237,9 +237,9 @@ static uid_t getUID(pid_t pid) {
  * into the Info object.
  */
 void os_getCmdlineAndUserInfo(JNIEnv *env, jobject jinfo, pid_t pid) {
-    int mib[3], maxargs, nargs, i;
+    int mib[3], maxargs, nargs;
     size_t size;
-    char *args, *cp, *sp, *np;
+    char *args, *cp;
 
     // Get the UID first. This is done here because it is cheap to do it here
     // on other platforms like Linux/Solaris/AIX where the uid comes from the

--- a/src/java.base/macosx/native/libjli/java_md_macosx.m
+++ b/src/java.base/macosx/native/libjli/java_md_macosx.m
@@ -362,8 +362,6 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
                            char jrepath[], jint so_jrepath,
                            char jvmpath[], jint so_jvmpath,
                            char jvmcfg[],  jint so_jvmcfg) {
-    jboolean jvmpathExists;
-
     /* Compute/set the name of the executable */
     SetExecname(*pargv);
 
@@ -547,7 +545,6 @@ GetJREPath(char *path, jint pathsize, jboolean speculative)
 jboolean
 LoadJavaVM(const char *jvmpath, InvocationFunctions *ifn)
 {
-    Dl_info dlinfo;
     void *libjvm;
 
     JLI_TraceLauncher("JVM path is %s\n", jvmpath);

--- a/src/java.base/macosx/native/libnet/DefaultProxySelector.c
+++ b/src/java.base/macosx/native/libnet/DefaultProxySelector.c
@@ -168,7 +168,6 @@ Java_sun_net_spi_DefaultProxySelector_getSystemProxies(JNIEnv *env,
 {
     CFDictionaryRef proxyDicRef = NULL;
     CFURLRef        urlRef = NULL;
-    bool proxyFound = false;
     jobjectArray proxyArray = NULL;
     const char *cproto;
     const char *chost;

--- a/src/java.base/macosx/native/libnio/fs/BsdNativeDispatcher.c
+++ b/src/java.base/macosx/native/libnio/fs/BsdNativeDispatcher.c
@@ -147,7 +147,6 @@ Java_sun_nio_fs_BsdNativeDispatcher_fsstatEntry(JNIEnv* env, jclass this,
     char* dir;
     char* fstype;
     char* options;
-    dev_t dev;
 
     if (iter == NULL || iter->pos >= iter->nentries)
        return -1;

--- a/src/java.base/share/native/launcher/defines.h
+++ b/src/java.base/share/native/launcher/defines.h
@@ -62,7 +62,6 @@ static const char** const_extra_jargs = NULL;
 static const char* const_progname = "java";
 static const char** const_jargs = NULL;
 static const char** const_extra_jargs = NULL;
-static const char* const_appclasspath[] = { NULL };
 #endif /* JAVA_ARGS */
 
 #ifdef LAUNCHER_NAME

--- a/src/java.base/share/native/libjava/NativeLibraries.c
+++ b/src/java.base/share/native/libjava/NativeLibraries.c
@@ -191,7 +191,6 @@ JNIEXPORT void JNICALL
 Java_jdk_internal_loader_NativeLibraries_unload
 (JNIEnv *env, jclass cls, jstring name, jboolean isBuiltin, jlong address)
 {
-    const char *onUnloadSymbols[] = JNI_ONUNLOAD_SYMBOLS;
     void *handle;
     JNI_OnUnload_t JNI_OnUnload;
     const char *cname;
@@ -254,7 +253,6 @@ Java_jdk_internal_loader_NativeLibraries_findBuiltinLib
     size_t len;
     jstring lib;
     void *ret;
-    const char *onLoadSymbols[] = JNI_ONLOAD_SYMBOLS;
 
     if (name == NULL) {
         JNU_ThrowInternalError(env, "NULL filename for native library");

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -966,13 +966,9 @@ SelectVersion(int argc, char **argv, char **main_class)
 {
     char    *arg;
     char    *operand;
-    char    *version = NULL;
-    char    *jre = NULL;
     int     jarflag = 0;
     int     headlessflag = 0;
-    int     restrict_search = -1;               /* -1 implies not known */
     manifest_info info;
-    char    env_entry[MAXNAMELEN + 24] = ENV_ENTRY "=";
     char    *splash_file_name = NULL;
     char    *splash_jar_name = NULL;
     char    *env_in;
@@ -2007,7 +2003,6 @@ ReadKnownVMs(const char *jvmCfgName, jboolean speculative)
     int vmType;
     char *tmpPtr;
     char *altVMName = NULL;
-    char *serverClassVMName = NULL;
     static char *whiteSpace = " \t";
     if (JLI_IsTraceLauncher()) {
         start = CurrentTimeMicros();

--- a/src/java.base/share/native/libjli/parse_manifest.c
+++ b/src/java.base/share/native/libjli/parse_manifest.c
@@ -583,7 +583,6 @@ JLI_ParseManifest(char *jarfile, manifest_info *info)
     char    *name;
     char    *value;
     int     rc;
-    char    *splashscreen_name = NULL;
 
     if ((fd = JLI_Open(jarfile, O_RDONLY
 #ifdef O_LARGEFILE

--- a/src/java.base/share/native/libverify/check_code.c
+++ b/src/java.base/share/native/libverify/check_code.c
@@ -1861,7 +1861,6 @@ run_dataflow(context_type *context) {
                 work_to_do = JNI_TRUE;
 #ifdef DEBUG
                 if (verify_verbose) {
-                    int opcode = this_idata->opcode;
                     jio_fprintf(stdout, "Instruction %d: ", inumber);
                     print_stack(context, &this_idata->stack_info);
                     print_registers(context, &this_idata->register_info);

--- a/src/java.base/share/native/libzip/zip_util.c
+++ b/src/java.base/share/native/libzip/zip_util.c
@@ -1552,7 +1552,6 @@ JNIEXPORT jboolean
 ZIP_InflateFully(void *inBuf, jlong inLen, void *outBuf, jlong outLen, char **pmsg)
 {
     z_stream strm;
-    int i = 0;
     memset(&strm, 0, sizeof(z_stream));
 
     *pmsg = 0; /* Reset error message */

--- a/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
+++ b/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
@@ -71,9 +71,6 @@ void shutItDown() {
  * - the data strings for fields in ChildStuff
  */
 void initChildStuff (int fdin, int fdout, ChildStuff *c) {
-    int n;
-    int argvBytes, nargv, envvBytes, nenvv;
-    int dirlen;
     char *buf;
     SpawnInfo sp;
     int bufsize, offset=0;
@@ -132,7 +129,6 @@ void initChildStuff (int fdin, int fdout, ChildStuff *c) {
 
 int main(int argc, char *argv[]) {
     ChildStuff c;
-    int t;
     struct stat buf;
     /* argv[0] contains the fd number to read all the child info */
     int r, fdin, fdout;

--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -399,10 +399,8 @@ copyPipe(int from[2], int to[2])
  */
 static void arraysize(const char * const *arg, int *nelems, int *nbytes)
 {
-    int i, bytes, count;
+    int bytes, count;
     const char * const *a = arg;
-    char *p;
-    int *q;
     if (arg == 0) {
         *nelems = 0;
         *nbytes = 0;
@@ -488,7 +486,6 @@ forkChild(ChildStuff *c) {
 static pid_t
 spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) {
     pid_t resultPid;
-    jboolean isCopy;
     int i, offset, rval, bufsize, magic;
     char *buf, buf1[16];
     char *hlpargs[2];

--- a/src/java.base/unix/native/libjava/TimeZone_md.c
+++ b/src/java.base/unix/native/libjava/TimeZone_md.c
@@ -151,7 +151,6 @@ findZoneinfoFile(char *buf, size_t size, const char *dir)
     struct dirent *dp = NULL;
     char *pathname = NULL;
     char *tz = NULL;
-    int res;
 
     if (strcmp(dir, ZONEINFO_DIR) == 0) {
         /* fast path for 1st iteration */

--- a/src/java.base/unix/native/libjava/java_props_md.c
+++ b/src/java.base/unix/native/libjava/java_props_md.c
@@ -353,7 +353,6 @@ java_props_t *
 GetJavaProperties(JNIEnv *env)
 {
     static java_props_t sprops;
-    char *v; /* tmp var */
 
     if (sprops.user_dir) {
         return &sprops;

--- a/src/java.base/unix/native/libjava/path_util.c
+++ b/src/java.base/unix/native/libjava/path_util.c
@@ -119,7 +119,6 @@ collapse(char *path)
     int nc;
     char **ix;
     int i, j;
-    char *p, *q;
 
     nc = collapsible(names);
     if (nc < 2) return;         /* Nothing to do */

--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -298,7 +298,6 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
                            char jvmcfg[],  jint so_jvmcfg) {
 
     char * jvmtype = NULL;
-    int argc = *pargc;
     char **argv = *pargv;
 
 #ifdef SETENV_REQUIRED

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -159,7 +159,6 @@ FindExecName(char *program)
 
     /* relative path? */
     if (JLI_StrRChr(program, FILE_SEPARATOR) != NULL) {
-        char buf[PATH_MAX+2];
         return Resolve(getcwd(cwdbuf, sizeof(cwdbuf)), program);
     }
 

--- a/src/java.base/unix/native/libnet/DefaultProxySelector.c
+++ b/src/java.base/unix/native/libnet/DefaultProxySelector.c
@@ -237,7 +237,6 @@ static jobjectArray getProxyByGConf(JNIEnv *env, const char* cproto,
     }
 
     if (use_proxy) {
-        jstring jhost;
         char *noproxyfor;
         char *s;
 

--- a/src/java.base/unix/native/libnet/Inet6AddressImpl.c
+++ b/src/java.base/unix/native/libnet/Inet6AddressImpl.c
@@ -81,8 +81,7 @@ lookupIfLocalhost(JNIEnv *env, const char *hostname, jboolean includeV6, int cha
     jobjectArray result = NULL;
     char myhostname[NI_MAXHOST + 1];
     struct ifaddrs *ifa = NULL;
-    int familyOrder = 0;
-    int count = 0, i, j;
+    int i, j;
     int addrs4 = 0, addrs6 = 0, numV4Loopbacks = 0, numV6Loopbacks = 0;
     jboolean includeLoopback = JNI_FALSE;
     jobject name;

--- a/src/java.base/unix/native/libnet/NetworkInterface.c
+++ b/src/java.base/unix/native/libnet/NetworkInterface.c
@@ -704,7 +704,6 @@ static jobject createNetworkInterface(JNIEnv *env, netif *ifs) {
     jobjectArray addrArr;
     jobjectArray bindArr;
     jobjectArray childArr;
-    netaddr *addrs;
     jint addr_index, addr_count, bind_index;
     jint child_count, child_index;
     netaddr *addrP;
@@ -902,7 +901,6 @@ static netif *enumInterfaces(JNIEnv *env) {
  */
 static void freeif(netif *ifs) {
     netif *currif = ifs;
-    netif *child = NULL;
 
     while (currif != NULL) {
         netaddr *addrP = currif->addr;

--- a/src/java.base/unix/native/libnet/net_util_md.c
+++ b/src/java.base/unix/native/libnet/net_util_md.c
@@ -680,7 +680,6 @@ int
 NET_Bind(int fd, SOCKETADDRESS *sa, int len)
 {
     int rv;
-    int arg, alen;
 
 #ifdef __linux__
     /*

--- a/src/java.base/unix/native/libnio/ch/NativeThread.c
+++ b/src/java.base/unix/native/libnio/ch/NativeThread.c
@@ -62,7 +62,6 @@ Java_sun_nio_ch_NativeThread_init(JNIEnv *env, jclass cl)
      * should somehow be unified, perhaps within the VM.
      */
 
-    sigset_t ss;
     struct sigaction sa, osa;
     sa.sa_handler = nullHandler;
     sa.sa_flags = 0;

--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -529,7 +529,6 @@ Java_sun_nio_ch_Net_setIntOption0(JNIEnv *env, jclass clazz, jobject fdo,
                                   jboolean mayNeedConversion, jint level,
                                   jint opt, jint arg, jboolean isIPv6)
 {
-    int result;
     struct linger linger;
     u_char carg;
     void *parg;

--- a/src/java.base/unix/native/libnio/ch/UnixDomainSockets.c
+++ b/src/java.base/unix/native/libnio/ch/UnixDomainSockets.c
@@ -184,7 +184,6 @@ Java_sun_nio_ch_UnixDomainSockets_localAddress0(JNIEnv *env, jclass clazz, jobje
 {
     struct sockaddr_un sa;
     socklen_t sa_len = sizeof(struct sockaddr_un);
-    int port;
     if (getsockname(fdval(env, fdo), (struct sockaddr *)&sa, &sa_len) < 0) {
         handleSocketError(env, errno);
         return NULL;

--- a/src/java.base/windows/native/libjava/ProcessHandleImpl_win.c
+++ b/src/java.base/windows/native/libjava/ProcessHandleImpl_win.c
@@ -417,7 +417,6 @@ Java_java_lang_ProcessHandleImpl_00024Info_info0(JNIEnv *env,
                                                  jobject jinfo,
                                                  jlong jpid) {
     DWORD pid = (DWORD)jpid;
-    int ret = 0;
     HANDLE handle =
         OpenProcess(THREAD_QUERY_INFORMATION | PROCESS_QUERY_LIMITED_INFORMATION,
                     FALSE, pid);

--- a/src/java.base/windows/native/libjava/TimeZone_md.c
+++ b/src/java.base/windows/native/libjava/TimeZone_md.c
@@ -406,7 +406,6 @@ static int getWinTimeZone(char *winZoneName)
 static char *matchJavaTZ(const char *java_home_dir, char *tzName)
 {
     int line;
-    int IDmatched = 0;
     FILE *fp;
     char *javaTZName = NULL;
     char *items[TZ_NITEMS];

--- a/src/java.base/windows/native/libjava/io_util_md.c
+++ b/src/java.base/windows/native/libjava/io_util_md.c
@@ -100,7 +100,6 @@ currentDirLength(const WCHAR* ps, int pathlen) {
         static int curDirLenCached = -1;
         //relative to both drive and directory
         if (curDirLenCached == -1) {
-            int dirlen = -1;
             dir = _wgetcwd(NULL, MAX_PATH);
             if (dir != NULL) {
                 curDirLenCached = (int)wcslen(dir);
@@ -180,7 +179,6 @@ pathToNTPath(JNIEnv *env, jstring path, jboolean throwFNFE) {
                    (therefore allocate the sufficient memory block) before calling
                    _wfullpath(), we have to get the length of "current" dir first.
                 */
-                WCHAR *abpath = NULL;
                 int dirlen = currentDirLength(ps, pathlen);
                 if (dirlen + pathlen + 1 > max_path - 1) {
                     pathbuf = prefixAbpath(ps, pathlen, dirlen + pathlen);

--- a/src/java.base/windows/native/libjli/java_md.c
+++ b/src/java.base/windows/native/libjli/java_md.c
@@ -546,8 +546,6 @@ static errno_t convert_to_unicode(const char* path, const wchar_t* prefix, wchar
  */
 static wchar_t* create_unc_path(const char* path, errno_t* err) {
     wchar_t* wpath = NULL;
-    size_t converted_chars = 0;
-    size_t path_len = strlen(path) + 1; /* includes the terminating NULL */
     if (path[0] == '\\' && path[1] == '\\') {
         if (path[2] == '?' && path[3] == '\\') {
             /* if it already has a \\?\ don't do the prefix */

--- a/src/java.base/windows/native/libnet/NetworkInterface.c
+++ b/src/java.base/windows/native/libnet/NetworkInterface.c
@@ -834,7 +834,6 @@ JNIEXPORT jobject JNICALL Java_java_net_NetworkInterface_getByIndex0
 JNIEXPORT jboolean JNICALL Java_java_net_NetworkInterface_boundInetAddress0
     (JNIEnv *env, jclass cls, jobject iaObj)
 {
-    jobject netifObj = NULL;
     DWORD i;
 
     int family = getInetAddress_family(env, iaObj);

--- a/src/java.base/windows/native/libnio/ch/Net.c
+++ b/src/java.base/windows/native/libnio/ch/Net.c
@@ -643,7 +643,6 @@ JNIEXPORT jint JNICALL
 Java_sun_nio_ch_Net_poll(JNIEnv* env, jclass this, jobject fdo, jint events, jlong timeout)
 {
     int rv;
-    int revents = 0;
     struct timeval t;
     fd_set rd, wr, ex;
     jint fd = fdval(env, fdo);

--- a/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
+++ b/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
@@ -683,7 +683,6 @@ Java_sun_nio_fs_WindowsNativeDispatcher_SetFileSecurity0(JNIEnv* env, jclass thi
 {
     LPCWSTR lpFileName = jlong_to_ptr(pathAddress);
     PSECURITY_DESCRIPTOR pSecurityDescriptor = jlong_to_ptr(descAddress);
-    DWORD lengthNeeded = 0;
 
     BOOL res = SetFileSecurityW(lpFileName,
                                 (SECURITY_INFORMATION)requestedInformation,
@@ -1256,7 +1255,6 @@ Java_sun_nio_fs_WindowsNativeDispatcher_ReadDirectoryChangesW(JNIEnv* env, jclas
 {
     BOOL res;
     BOOL subtree = (watchSubTree == JNI_TRUE) ? TRUE : FALSE;
-    LPOVERLAPPED ov = (LPOVERLAPPED)jlong_to_ptr(pOverlapped);
 
     res = ReadDirectoryChangesW((HANDLE)jlong_to_ptr(hDirectory),
                                 (LPVOID)jlong_to_ptr(bufferAddress),

--- a/src/java.instrument/windows/native/libinstrument/FileSystemSupport_md.c
+++ b/src/java.instrument/windows/native/libinstrument/FileSystemSupport_md.c
@@ -199,7 +199,6 @@ static char* normalizePath(const char* path, int len, int off) {
 char* normalize(char* path) {
     int n = (int)strlen(path);
     int i;
-    char c = 0;
     int prev = 0;
     for (i = 0; i < n; i++) {
         char c = path[i];

--- a/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c
+++ b/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c
@@ -48,7 +48,6 @@ Java_sun_security_jgss_wrapper_GSSLibStub_init(JNIEnv *env,
                                                jboolean jDebug) {
     const char *libName;
     int failed;
-    char *error = NULL;
 
     if (!jDebug) {
       JGSS_DEBUG = 0;

--- a/src/java.security.jgss/windows/native/libsspi_bridge/sspi.cpp
+++ b/src/java.security.jgss/windows/native/libsspi_bridge/sspi.cpp
@@ -736,8 +736,6 @@ gss_acquire_cred(OM_uint32 *minor_status,
             PP("Cannot get owner name of default creds");
             goto err;
         }
-        SEC_WCHAR* rnames = realname->name;
-        SEC_WCHAR* dnames = desired_name->name;
         int equals = 0;
         gss_compare_name(minor_status, realname, desired_name, &equals);
         gss_release_name(minor_status, &realname);

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_keymgmt.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_keymgmt.c
@@ -156,7 +156,6 @@ Java_sun_security_pkcs11_wrapper_PKCS11_getNativeKeyInfo
     jbyte* nativeKeyInfoArrayRawCkAttributesPtr = NULL;
     jbyte* nativeKeyInfoArrayRawDataPtr = NULL;
     CK_MECHANISM_PTR ckpMechanism = NULL;
-    char iv[16] = {0x0};
     CK_ULONG ckWrappedKeyLength = 0U;
     jbyte* wrappedKeySizeWrappedKeyArrayPtr = NULL;
     CK_BYTE_PTR wrappedKeyBufferPtr = NULL;
@@ -419,7 +418,6 @@ Java_sun_security_pkcs11_wrapper_PKCS11_createNativeKey
     jbyte* wrappedKeySizePtr = NULL;
     unsigned int i = 0U;
     CK_MECHANISM_PTR ckpMechanism = NULL;
-    char iv[16] = {0x0};
     CK_ULONG ckWrappedKeyLength = 0UL;
     CK_FUNCTION_LIST_PTR ckpFunctions = getFunctionList(env, obj);
 

--- a/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/p11_md.c
+++ b/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/p11_md.c
@@ -79,7 +79,6 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
     jstring jGetFunctionList) {
 
     void *hModule;
-    char *error;
     int i;
     CK_ULONG ulCount = 0;
     CK_C_GetInterfaceList C_GetInterfaceList = NULL;

--- a/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
+++ b/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
@@ -2561,7 +2561,6 @@ JNIEXPORT jobject JNICALL Java_sun_security_mscapi_CKeyStore_storePrivateKey
 JNIEXPORT jobject JNICALL Java_sun_security_mscapi_CSignature_importECPublicKey
     (JNIEnv *env, jclass clazz, jstring alg, jbyteArray keyBlob, jint keySize)
 {
-    BCRYPT_ALG_HANDLE hSignAlg = NULL;
     NCRYPT_KEY_HANDLE       hTmpKey         = NULL;
     DWORD dwBlobLen;
     BYTE * pbKeyBlob = NULL;

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.cpp
@@ -352,7 +352,6 @@ extern "C"
 JNIEXPORT jlong JNICALL Java_sun_jvm_hotspot_debugger_linux_LinuxDebuggerLocal_lookupByName0
   (JNIEnv *env, jobject this_obj, jstring objectName, jstring symbolName) {
   jlong addr;
-  jboolean isCopy;
   struct ps_prochandle* ph = get_proc_handle(env, this_obj);
   // Note, objectName is ignored, and may in fact be NULL.
   // lookup_symbol will always search all objects/libs

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.c
@@ -220,7 +220,6 @@ bool read_eh_frame(struct ps_prochandle* ph, lib_info* lib) {
   ELF_SHDR* shbuf = NULL;
   ELF_SHDR* sh = NULL;
   char* strtab = NULL;
-  void* result = NULL;
   int cnt;
 
   current_pos = lseek(lib->fd, (off_t)0L, SEEK_CUR);

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
@@ -729,7 +729,6 @@ JNIEXPORT struct ps_prochandle* JNICALL
 Pgrab_core(const char* exec_file, const char* core_file) {
   ELF_EHDR core_ehdr;
   ELF_EHDR exec_ehdr;
-  ELF_EHDR lib_ehdr;
 
   struct ps_prochandle* ph = (struct ps_prochandle*) calloc(1, sizeof(struct ps_prochandle));
   if (ph == NULL) {

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/symtab.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/symtab.c
@@ -292,7 +292,6 @@ static struct symtab* build_symtab_from_build_id(Elf64_Nhdr *note)
 // try to open an associated debuginfo file
 static struct symtab* build_symtab_internal(int fd, const char *filename, bool try_debuginfo) {
   ELF_EHDR ehdr;
-  char *names = NULL;
   struct symtab* symtab = NULL;
 
   // Reading of elf header
@@ -307,7 +306,6 @@ static struct symtab* build_symtab_internal(int fd, const char *filename, bool t
   ELF_SHDR* shbuf = NULL;
   ELF_SHDR* cursct = NULL;
   ELF_PHDR* phbuf = NULL;
-  ELF_PHDR* phdr = NULL;
   int sym_section = SHT_DYNSYM;
 
   uintptr_t baseaddr = (uintptr_t)-1;
@@ -550,7 +548,6 @@ uintptr_t search_symbol(struct symtab* symtab, uintptr_t base,
     return rslt;
   }
 
-quit:
   free(item.key);
   return (uintptr_t) NULL;
 }

--- a/src/jdk.jdi/share/native/libdt_shmem/SharedMemoryTransport.c
+++ b/src/jdk.jdi/share/native/libdt_shmem/SharedMemoryTransport.c
@@ -185,7 +185,6 @@ JNIEXPORT jlong JNICALL Java_com_sun_tools_jdi_SharedMemoryTransportService_star
 {
     const char *addrChars = NULL;
     jint rc;
-    jstring retAddress = NULL;
     SharedMemoryTransport *transport = NULL;
 
 

--- a/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
@@ -224,8 +224,6 @@ void
 setup_logging(const char *filename, unsigned flags)
 {
 #ifdef JDWP_LOGGING
-    FILE *fp = NULL;
-
     /* Turn off logging */
     logging = 0;
     gdata->log_flags = 0;

--- a/src/jdk.management/unix/native/libmanagement_ext/OperatingSystemImpl.c
+++ b/src/jdk.management/unix/native/libmanagement_ext/OperatingSystemImpl.c
@@ -87,7 +87,6 @@ static jlong page_size = 0;
 static jlong get_total_or_available_swap_space_size(JNIEnv* env, jboolean available) {
 #if defined(__linux__)
     int ret;
-    FILE *fp;
     jlong total = 0, avail = 0;
 
     struct sysinfo si;

--- a/src/jdk.sctp/unix/native/libsctp/SctpNet.c
+++ b/src/jdk.sctp/unix/native/libsctp/SctpNet.c
@@ -496,7 +496,6 @@ int mapSocketOption
 JNIEXPORT void JNICALL Java_sun_nio_ch_sctp_SctpNet_setIntOption0
   (JNIEnv *env, jclass klass, jint fd, jint opt, int arg) {
     int klevel, kopt;
-    int result;
     struct linger linger;
     void *parg;
     int arglen;


### PR DESCRIPTION
This patch removes many unused variables and one unused label reported by the compilers when relevant warnings are enabled. 

The unused code was found by compiling after removing `unused` from the list of disabled warnings for [gcc](https://github.com/openjdk/jdk/blob/master/make/autoconf/flags-cflags.m4#L190) and [clang](https://github.com/openjdk/jdk/blob/master/make/autoconf/flags-cflags.m4#L203), and enabling [C4189](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4189?view=msvc-170) MSVC warning.

I only removed variables that were uninitialized or initialized without side effects. I verified that the removed variables were not used in any `#ifdef`'d code. I checked that the changed code still compiles on Windows, Linux and Mac, both in release and debug versions.
