### PR TITLE
8289778: ZGC: incorrect use of os::free() for mountpoint string handling after JDK-8289633

### DIFF
--- a/src/hotspot/os/linux/gc/z/zMountPoint_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zMountPoint_linux.cpp
@@ -61,11 +61,11 @@ char* ZMountPoint::get_mountpoint(const char* line, const char* filesystem) cons
       strcmp(line_filesystem, filesystem) != 0 ||
       access(line_mountpoint, R_OK|W_OK|X_OK) != 0) {
     // Not a matching or accessible filesystem
-    os::free(line_mountpoint);
+    ALLOW_C_FUNCTION(::free, ::free(line_mountpoint);) // *not* os::free
     line_mountpoint = NULL;
   }
 
-  os::free(line_filesystem);
+  ALLOW_C_FUNCTION(::free, ::free(line_filesystem);) // *not* os::free
 
   return line_mountpoint;
 }
@@ -88,14 +88,14 @@ void ZMountPoint::get_mountpoints(const char* filesystem, ZArray<char*>* mountpo
     }
   }
 
-  os::free(line);
+  ALLOW_C_FUNCTION(::free, ::free(line);) // *not* os::free
   fclose(fd);
 }
 
 void ZMountPoint::free_mountpoints(ZArray<char*>* mountpoints) const {
   ZArrayIterator<char*> iter(mountpoints);
   for (char* mountpoint; iter.next(&mountpoint);) {
-    os::free(mountpoint);
+    ALLOW_C_FUNCTION(::free, ::free(mountpoint);) // *not* os::free
   }
   mountpoints->clear();
 }

--- a/src/hotspot/os/linux/gc/z/zMountPoint_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zMountPoint_linux.cpp
@@ -28,6 +28,7 @@
 #include "gc/z/zMountPoint_linux.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/os.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 #include <stdio.h>
 #include <unistd.h>
@@ -61,7 +62,8 @@ char* ZMountPoint::get_mountpoint(const char* line, const char* filesystem) cons
       strcmp(line_filesystem, filesystem) != 0 ||
       access(line_mountpoint, R_OK|W_OK|X_OK) != 0) {
     // Not a matching or accessible filesystem
-    ALLOW_C_FUNCTION(::free, ::free(line_mountpoint);) // *not* os::free
+    // sscanf, using %m, will return malloced memory. Need raw ::free, not os::free.
+    ALLOW_C_FUNCTION(::free, ::free(line_mountpoint);)
     line_mountpoint = NULL;
   }
 
@@ -88,7 +90,8 @@ void ZMountPoint::get_mountpoints(const char* filesystem, ZArray<char*>* mountpo
     }
   }
 
-  ALLOW_C_FUNCTION(::free, ::free(line);) // *not* os::free
+  // readline will return malloced memory. Need raw ::free, not os::free.
+  ALLOW_C_FUNCTION(::free, ::free(line);)
   fclose(fd);
 }
 

--- a/src/hotspot/os/linux/gc/z/zMountPoint_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zMountPoint_linux.cpp
@@ -58,16 +58,16 @@ char* ZMountPoint::get_mountpoint(const char* line, const char* filesystem) cons
   // Parse line and return a newly allocated string containing the mount point if
   // the line contains a matching filesystem and the mount point is accessible by
   // the current user.
+  // sscanf, using %m, will return malloced memory. Need raw ::free, not os::free.
   if (sscanf(line, "%*u %*u %*u:%*u %*s %ms %*[^-]- %ms", &line_mountpoint, &line_filesystem) != 2 ||
       strcmp(line_filesystem, filesystem) != 0 ||
       access(line_mountpoint, R_OK|W_OK|X_OK) != 0) {
     // Not a matching or accessible filesystem
-    // sscanf, using %m, will return malloced memory. Need raw ::free, not os::free.
     ALLOW_C_FUNCTION(::free, ::free(line_mountpoint);)
     line_mountpoint = NULL;
   }
 
-  ALLOW_C_FUNCTION(::free, ::free(line_filesystem);) // *not* os::free
+  ALLOW_C_FUNCTION(::free, ::free(line_filesystem);)
 
   return line_mountpoint;
 }


### PR DESCRIPTION
Hi all,

ZGC crashes were observed by us after JDK-8289633 due to incorrect use of `os::free()` for mountpoint string handling.

For example, `line_mountpoint` and `line_filesystem` will be allocated by `sscanf` @line60. 
And `line` will be allocated by `getline` @line84.

```
 53 char* ZMountPoint::get_mountpoint(const char* line, const char* filesystem) const {
 54   char* line_mountpoint = NULL;
 55   char* line_filesystem = NULL;
 56 
 57   // Parse line and return a newly allocated string containing the mount point if
 58   // the line contains a matching filesystem and the mount point is accessible by
 59   // the current user.
 60   if (sscanf(line, "%*u %*u %*u:%*u %*s %ms %*[^-]- %ms", &line_mountpoint, &line_filesystem) != 2 ||
 61       strcmp(line_filesystem, filesystem) != 0 ||
 62       access(line_mountpoint, R_OK|W_OK|X_OK) != 0) {
 63     // Not a matching or accessible filesystem
 64     os::free(line_mountpoint);
 65     line_mountpoint = NULL;
 66   }
 67 
 68   os::free(line_filesystem);
 69 
 70   return line_mountpoint;
 71 }
 72 
 73 void ZMountPoint::get_mountpoints(const char* filesystem, ZArray<char*>* mountpoints) const {
 74   FILE* fd = os::fopen(PROC_SELF_MOUNTINFO, "r");
 75   if (fd == NULL) {
 76     ZErrno err;
 77     log_error_p(gc)("Failed to open %s: %s", PROC_SELF_MOUNTINFO, err.to_string());
 78     return;
 79   }
 80 
 81   char* line = NULL;
 82   size_t length = 0;
 83 
 84   while (getline(&line, &length, fd) != -1) {
 85     char* const mountpoint = get_mountpoint(line, filesystem);
 86     if (mountpoint != NULL) {
 87       mountpoints->append(mountpoint);
 88     }
 89   }
 90 
 91   os::free(line);
 92   fclose(fd);
 93 }
```

See the anaylis of the crash reason in https://bugs.openjdk.org/browse/JDK-8289477
```
That means we have raw `::malloc() -> os::free()`, which is unbalanced.
Raw `::malloc()` does not write the header `os::free()` expects.
If NMT is on, we assert now, because NMT does not find its header in os::free().
```

The fix just reverts `os::free()` to `::free()`.

Testing:
  - hotspot/jtreg/gc/z on Linux/x64, all passed

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289778](https://bugs.openjdk.org/browse/JDK-8289778): ZGC: incorrect use of os::free() for mountpoint string handling after JDK-8289633


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [8ae3bfcf](https://git.openjdk.org/jdk/pull/9387/files/8ae3bfcf6aebd2d648c6c33932ab9d3c6735802c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9387/head:pull/9387` \
`$ git checkout pull/9387`

Update a local copy of the PR: \
`$ git checkout pull/9387` \
`$ git pull https://git.openjdk.org/jdk pull/9387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9387`

View PR using the GUI difftool: \
`$ git pr show -t 9387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9387.diff">https://git.openjdk.org/jdk/pull/9387.diff</a>

</details>
