### PR TITLE
8224267: JOptionPane message string with 5000+ newlines produces StackOverflowError

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
@@ -459,7 +459,7 @@ public class BasicOptionPaneUI extends OptionPaneUI {
                 // break up newlines
                 if (nl == 0) {
                     @SuppressWarnings("serial") // anonymous class
-                            JPanel breakPanel = new JPanel() {
+                    JPanel breakPanel = new JPanel() {
                         public Dimension getPreferredSize() {
                             Font f = getFont();
 
@@ -471,10 +471,10 @@ public class BasicOptionPaneUI extends OptionPaneUI {
                     };
                     breakPanel.setName("OptionPane.break");
                     addMessageComponents(container, cons, breakPanel, maxll,
-                            true);
+                                         true);
                 } else {
                     addMessageComponents(container, cons, s.substring(0, nl),
-                            maxll, false);
+                                      maxll, false);
                 }
                 // Prevent recursion of more than
                 // 200 successive newlines in a message
@@ -483,7 +483,7 @@ public class BasicOptionPaneUI extends OptionPaneUI {
                     return;
                 }
                 addMessageComponents(container, cons, s.substring(nl + nll), maxll,
-                        false);
+                                     false);
 
             } else if (len > maxll) {
                 Container c = Box.createVerticalBox();

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
@@ -455,29 +455,32 @@ public class BasicOptionPaneUI extends OptionPaneUI {
                 nll = 1;
             }
             if (nl >= 0) {
-                // break up newlines
-                if (nl == 0) {
-                    @SuppressWarnings("serial") // anonymous class
-                    JPanel breakPanel = new JPanel() {
-                        public Dimension getPreferredSize() {
-                            Font       f = getFont();
+                try {
+                    // break up newlines
+                    if (nl == 0) {
+                        @SuppressWarnings("serial") // anonymous class
+                                JPanel breakPanel = new JPanel() {
+                            public Dimension getPreferredSize() {
+                                Font f = getFont();
 
-                            if (f != null) {
-                                return new Dimension(1, f.getSize() + 2);
+                                if (f != null) {
+                                    return new Dimension(1, f.getSize() + 2);
+                                }
+                                return new Dimension(0, 0);
                             }
-                            return new Dimension(0, 0);
-                        }
-                    };
-                    breakPanel.setName("OptionPane.break");
-                    addMessageComponents(container, cons, breakPanel, maxll,
-                                         true);
-                } else {
-                    addMessageComponents(container, cons, s.substring(0, nl),
-                                      maxll, false);
+                        };
+                        breakPanel.setName("OptionPane.break");
+                        addMessageComponents(container, cons, breakPanel, maxll,
+                                true);
+                    } else {
+                        addMessageComponents(container, cons, s.substring(0, nl),
+                                maxll, false);
+                    }
+                    addMessageComponents(container, cons, s.substring(nl + nll), maxll,
+                            false);
+                } catch (StackOverflowError e) {
+                    return;
                 }
-                addMessageComponents(container, cons, s.substring(nl + nll), maxll,
-                                  false);
-
             } else if (len > maxll) {
                 Container c = Box.createVerticalBox();
                 c.setName("OptionPane.verticalBox");

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
@@ -89,6 +89,7 @@ public class BasicOptionPaneUI extends OptionPaneUI {
     public static final int MinimumHeight = 90;
 
     private static String newline;
+    private static int recursionCount;
 
     /**
      * {@code JOptionPane} that the receiver is providing the
@@ -455,32 +456,35 @@ public class BasicOptionPaneUI extends OptionPaneUI {
                 nll = 1;
             }
             if (nl >= 0) {
-                try {
-                    // break up newlines
-                    if (nl == 0) {
-                        @SuppressWarnings("serial") // anonymous class
-                                JPanel breakPanel = new JPanel() {
-                            public Dimension getPreferredSize() {
-                                Font f = getFont();
+                // break up newlines
+                if (nl == 0) {
+                    @SuppressWarnings("serial") // anonymous class
+                            JPanel breakPanel = new JPanel() {
+                        public Dimension getPreferredSize() {
+                            Font f = getFont();
 
-                                if (f != null) {
-                                    return new Dimension(1, f.getSize() + 2);
-                                }
-                                return new Dimension(0, 0);
+                            if (f != null) {
+                                return new Dimension(1, f.getSize() + 2);
                             }
-                        };
-                        breakPanel.setName("OptionPane.break");
-                        addMessageComponents(container, cons, breakPanel, maxll,
-                                true);
-                    } else {
-                        addMessageComponents(container, cons, s.substring(0, nl),
-                                maxll, false);
-                    }
-                    addMessageComponents(container, cons, s.substring(nl + nll), maxll,
-                            false);
-                } catch (StackOverflowError e) {
+                            return new Dimension(0, 0);
+                        }
+                    };
+                    breakPanel.setName("OptionPane.break");
+                    addMessageComponents(container, cons, breakPanel, maxll,
+                            true);
+                } else {
+                    addMessageComponents(container, cons, s.substring(0, nl),
+                            maxll, false);
+                }
+                // Prevent recursion of more than
+                // 200 successive newlines in a message
+                if (recursionCount++ > 200) {
+                    recursionCount = 0;
                     return;
                 }
+                addMessageComponents(container, cons, s.substring(nl + nll), maxll,
+                        false);
+
             } else if (len > maxll) {
                 Container c = Box.createVerticalBox();
                 c.setName("OptionPane.verticalBox");

--- a/test/jdk/javax/swing/JOptionPane/TestOptionPaneStackOverflow.java
+++ b/test/jdk/javax/swing/JOptionPane/TestOptionPaneStackOverflow.java
@@ -35,7 +35,6 @@ import javax.swing.SwingUtilities;
 
 public class TestOptionPaneStackOverflow
 {
-    static JDialog dialog;
     static JFrame frame;
 
     public static void main(String[] argv) throws Exception
@@ -46,7 +45,7 @@ public class TestOptionPaneStackOverflow
             SwingUtilities.invokeAndWait(() -> {
                 frame = new JFrame();
                 JOptionPane optionPane = new JOptionPane();
-                dialog = optionPane.createDialog(frame, null);
+                optionPane.createDialog(frame, null);
                 optionPane.setMessage(message);
             });
         } finally {
@@ -55,6 +54,6 @@ public class TestOptionPaneStackOverflow
                     frame.dispose();
                 }
             });
-        }	    
+        }
     }
-} 
+}

--- a/test/jdk/javax/swing/JOptionPane/TestOptionPaneStackOverflow.java
+++ b/test/jdk/javax/swing/JOptionPane/TestOptionPaneStackOverflow.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 8224267
+   @key headful
+   @summary Verifies if StackOverflowError is not thrown for multiple newlines
+   @run main TestOptionPaneStackOverflow
+ */
+
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
+
+public class TestOptionPaneStackOverflow
+{
+    static JDialog dialog;
+    static JFrame frame;
+
+    public static void main(String[] argv) throws Exception
+    {
+        try {
+            String message = java.nio.CharBuffer.allocate(5000).toString().
+                                  replace('\0','\n');
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame();
+	        JOptionPane optionPane = new JOptionPane();
+                dialog = optionPane.createDialog(frame, null);
+		optionPane.setMessage(message);
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }	    
+    }
+} 

--- a/test/jdk/javax/swing/JOptionPane/TestOptionPaneStackOverflow.java
+++ b/test/jdk/javax/swing/JOptionPane/TestOptionPaneStackOverflow.java
@@ -45,7 +45,7 @@ public class TestOptionPaneStackOverflow
                                   replace('\0','\n');
             SwingUtilities.invokeAndWait(() -> {
                 frame = new JFrame();
-	        JOptionPane optionPane = new JOptionPane();
+                JOptionPane optionPane = new JOptionPane();
                 dialog = optionPane.createDialog(frame, null);
                 optionPane.setMessage(message);
             });

--- a/test/jdk/javax/swing/JOptionPane/TestOptionPaneStackOverflow.java
+++ b/test/jdk/javax/swing/JOptionPane/TestOptionPaneStackOverflow.java
@@ -47,7 +47,7 @@ public class TestOptionPaneStackOverflow
                 frame = new JFrame();
 	        JOptionPane optionPane = new JOptionPane();
                 dialog = optionPane.createDialog(frame, null);
-		optionPane.setMessage(message);
+                optionPane.setMessage(message);
             });
         } finally {
             SwingUtilities.invokeAndWait(() -> {


### PR DESCRIPTION
BasicOptionPaneUI.addMessageComponents() uses recursion to split message strings at newlines, generating a StackOverflowError when the message string contains an unusually large number of newlines.
Fixed by catching StackOverflow and ignoring so that application is not stuck.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8224267](https://bugs.openjdk.org/browse/JDK-8224267): JOptionPane message string with 5000+ newlines produces StackOverflowError


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Author) ⚠️ Review applies to [9376b0ff](https://git.openjdk.org/jdk/pull/9388/files/9376b0ff26216c36cf9464725e5e139403cdd93e)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9388/head:pull/9388` \
`$ git checkout pull/9388`

Update a local copy of the PR: \
`$ git checkout pull/9388` \
`$ git pull https://git.openjdk.org/jdk pull/9388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9388`

View PR using the GUI difftool: \
`$ git pr show -t 9388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9388.diff">https://git.openjdk.org/jdk/pull/9388.diff</a>

</details>
