### PR TITLE
JDK-8289799: Build warning in methodData.cpp memset zero-length parameter

### DIFF
--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1245,7 +1245,9 @@ void MethodData::initialize() {
   int extra_size = extra_data_count * DataLayout::compute_size_in_bytes(0);
 
   // Let's zero the space for the extra data
-  Copy::zero_to_bytes(((address)_data) + data_size, extra_size);
+  if (extra_size > 0) {
+    Copy::zero_to_bytes(((address)_data) + data_size, extra_size);
+  }
 
   // Add a cell to record information about modified arguments.
   // Set up _args_modified array after traps cells so that


### PR DESCRIPTION
Trivial fix for a compiler warning we see in our CI on Fedora 12 with GCC 8.3:

```
void Copy::pd_zero_to_bytes(void*, size_t)' at /home/ubuntu/client_home/workspace/build-user-branch-linux_x86_64/SapMachine/src/hotspot/cpu/x86/copy_x86.hpp:59:15,
    inlined from 'static void Copy::zero_to_bytes(void*, size_t)' at /home/ubuntu/client_home/workspace/build-user-branch-linux_x86_64/SapMachine/src/hotspot/share/utilities/copy.hpp:298:21,
    inlined from 'void MethodData::initialize()' at 

/home/ubuntu/client_home/workspace/build-user-branch-linux_x86_64/SapMachine/src/hotspot/share/oops/methodData.cpp:1248:22:
/opt/devkits/devkit-fedora-gcc-12-8.3.0/x86_64-linux-gnu/sysroot/usr/include/bits/string3.h:82:30: error: call to '__warn_memset_zero_len' declared with attribute warning: memset used with constant zero length parameter; this could be due to transposed parameters [-Werror]
       __warn_memset_zero_len ();
       ~~~~~~~~~~~~~~~~~~~~~~~^~
```

The "size" argument for memset (which Copy::zero_to_bytes() ultimately expands on x64) is compile-time evaluated here to be 0 and GCC does not like this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289799](https://bugs.openjdk.org/browse/JDK-8289799): Build warning in methodData.cpp memset zero-length parameter


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9390/head:pull/9390` \
`$ git checkout pull/9390`

Update a local copy of the PR: \
`$ git checkout pull/9390` \
`$ git pull https://git.openjdk.org/jdk pull/9390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9390`

View PR using the GUI difftool: \
`$ git pr show -t 9390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9390.diff">https://git.openjdk.org/jdk/pull/9390.diff</a>

</details>
