### PR TITLE
8137280: Remove eager reclaim of humongous controls

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2685,9 +2685,7 @@ bool G1CollectedHeap::is_potential_eager_reclaim_candidate(HeapRegion* r) const 
   // the assumption that such objects are likely still live.
   HeapRegionRemSet* rem_set = r->rem_set();
 
-  return G1EagerReclaimHumongousObjectsWithStaleRefs ?
-         rem_set->occupancy_less_or_equal_than(G1EagerReclaimRemSetThreshold) :
-         G1EagerReclaimHumongousObjects && rem_set->is_empty();
+  return rem_set->occupancy_less_or_equal_than(G1EagerReclaimRemSetThreshold);
 }
 
 #ifndef PRODUCT
@@ -2921,18 +2919,6 @@ void G1CollectedHeap::make_pending_list_reachable() {
       _cm->mark_in_next_bitmap(0 /* worker_id */, pll_head);
     }
   }
-}
-
-static bool do_humongous_object_logging() {
-  return log_is_enabled(Debug, gc, humongous);
-}
-
-bool G1CollectedHeap::should_do_eager_reclaim() const {
-  // As eager reclaim logging also gives information about humongous objects in
-  // the heap in general, always do the eager reclaim pass even without known
-  // candidates.
-  return (G1EagerReclaimHumongousObjects &&
-          (has_humongous_reclaim_candidates() || do_humongous_object_logging()));
 }
 
 void G1CollectedHeap::set_humongous_stats(uint num_humongous_total, uint num_humongous_candidates) {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -236,8 +236,6 @@ public:
   uint num_humongous_reclaim_candidates() const { return _num_humongous_reclaim_candidates; }
   bool has_humongous_reclaim_candidates() const { return _num_humongous_reclaim_candidates > 0; }
 
-  bool should_do_eager_reclaim() const;
-
   void set_humongous_stats(uint num_humongous_total, uint num_humongous_candidates);
 
   bool should_sample_collection_set_candidates() const;

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
@@ -496,9 +496,8 @@ double G1GCPhaseTimes::print_post_evacuate_collection_set(bool evacuation_failed
 #if COMPILER2_OR_JVMCI
   debug_phase(_gc_par_phases[UpdateDerivedPointers], 1);
 #endif
-  if (G1CollectedHeap::heap()->should_do_eager_reclaim()) {
-    debug_phase(_gc_par_phases[EagerlyReclaimHumongousObjects], 1);
-  }
+  debug_phase(_gc_par_phases[EagerlyReclaimHumongousObjects], 1);
+
   if (G1CollectedHeap::heap()->should_sample_collection_set_candidates()) {
     debug_phase(_gc_par_phases[SampleCollectionSetCandidates], 1);
   }

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -280,8 +280,6 @@ public:
     g1h->decrement_summary_bytes(_bytes_freed);
   }
 
-  static bool should_execute() {   return G1CollectedHeap::heap()->should_do_eager_reclaim(); }
-
   double worker_cost() const override { return 1.0; }
   void do_work(uint worker_id) override {
     G1CollectedHeap* g1h = G1CollectedHeap::heap();
@@ -673,9 +671,7 @@ G1PostEvacuateCollectionSetCleanupTask2::G1PostEvacuateCollectionSetCleanupTask2
 #if COMPILER2_OR_JVMCI
   add_serial_task(new UpdateDerivedPointersTask());
 #endif
-  if (EagerlyReclaimHumongousObjectsTask::should_execute()) {
-    add_serial_task(new EagerlyReclaimHumongousObjectsTask());
-  }
+  add_serial_task(new EagerlyReclaimHumongousObjectsTask());
 
   if (evac_failure_regions->evacuation_failed()) {
     add_parallel_task(new RestorePreservedMarksTask(per_thread_states->preserved_marks_set()));

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -310,13 +310,6 @@
           "The target number of mixed GCs after a marking cycle.")          \
           range(0, max_uintx)                                               \
                                                                             \
-  product(bool, G1EagerReclaimHumongousObjects, true, EXPERIMENTAL,         \
-          "Try to reclaim dead large objects at every young GC.")           \
-                                                                            \
-  product(bool, G1EagerReclaimHumongousObjectsWithStaleRefs, true, EXPERIMENTAL, \
-          "Try to reclaim dead large objects that have a few stale "        \
-          "references at every young GC.")                                  \
-                                                                            \
   product(uint, G1EagerReclaimRemSetThreshold, 0, EXPERIMENTAL,             \
           "Maximum number of remembered set entries a humongous region "    \
           "otherwise eligible for eager reclaim may have to be a candidate "\

--- a/test/hotspot/jtreg/gc/g1/TestGreyReclaimedHumongousObjects.java
+++ b/test/hotspot/jtreg/gc/g1/TestGreyReclaimedHumongousObjects.java
@@ -30,9 +30,6 @@ package gc.g1;
  * @summary Test handling of marked but unscanned reclaimed humongous objects.
  * @modules jdk.management
  * @run main/othervm -XX:+UseG1GC -Xss32m -Xmx128m -XX:G1HeapRegionSize=1m
- *      -XX:+UnlockExperimentalVMOptions
- *          -XX:+G1EagerReclaimHumongousObjects
- *          -XX:+G1EagerReclaimHumongousObjectsWithStaleRefs
  *      gc.g1.TestGreyReclaimedHumongousObjects 1048576 90
  */
 


### PR DESCRIPTION
Simple change of removing two experiment flags whose default value is `true`.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8137280](https://bugs.openjdk.org/browse/JDK-8137280): Remove eager reclaim of humongous controls


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9392/head:pull/9392` \
`$ git checkout pull/9392`

Update a local copy of the PR: \
`$ git checkout pull/9392` \
`$ git pull https://git.openjdk.org/jdk pull/9392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9392`

View PR using the GUI difftool: \
`$ git pr show -t 9392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9392.diff">https://git.openjdk.org/jdk/pull/9392.diff</a>

</details>
