### PR TITLE
8252329: runtime/LoadClass/TestResize.java timed out

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -992,18 +992,22 @@ void ClassLoaderData::print_on(outputStream* out) const {
   }
   out->print_cr(" - handles             %d", _handles.count());
   out->print_cr(" - dependency count    %d", _dependency_count);
+  out->print   (" - klasses             { ");
   if (Verbose) {
-    out->print   (" - klasses             {");
     PrintKlassClosure closure(out);
     ((ClassLoaderData*)this)->classes_do(&closure);
+  } else {
+     out->print("...");
   }
   out->print_cr(" }");
   out->print_cr(" - packages            " INTPTR_FORMAT, p2i(_packages));
   out->print_cr(" - module              " INTPTR_FORMAT, p2i(_modules));
   out->print_cr(" - unnamed module      " INTPTR_FORMAT, p2i(_unnamed_module));
-  out->print_cr(" - dictionary          " INTPTR_FORMAT, p2i(_dictionary));
   if (_dictionary != nullptr) {
+    out->print   (" - dictionary          " INTPTR_FORMAT " ", p2i(_dictionary));
     _dictionary->print_size(out);
+  } else {
+    out->print_cr(" - dictionary          " INTPTR_FORMAT, p2i(_dictionary));
   }
   if (_jmethod_ids != NULL) {
     out->print   (" - jmethod count       ");

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -992,14 +992,19 @@ void ClassLoaderData::print_on(outputStream* out) const {
   }
   out->print_cr(" - handles             %d", _handles.count());
   out->print_cr(" - dependency count    %d", _dependency_count);
-  out->print   (" - klasses             {");
-  PrintKlassClosure closure(out);
-  ((ClassLoaderData*)this)->classes_do(&closure);
+  if (Verbose) {
+    out->print   (" - klasses             {");
+    PrintKlassClosure closure(out);
+    ((ClassLoaderData*)this)->classes_do(&closure);
+  }
   out->print_cr(" }");
   out->print_cr(" - packages            " INTPTR_FORMAT, p2i(_packages));
   out->print_cr(" - module              " INTPTR_FORMAT, p2i(_modules));
   out->print_cr(" - unnamed module      " INTPTR_FORMAT, p2i(_unnamed_module));
   out->print_cr(" - dictionary          " INTPTR_FORMAT, p2i(_dictionary));
+  if (_dictionary != nullptr) {
+    _dictionary->print_size(out);
+  }
   if (_jmethod_ids != NULL) {
     out->print   (" - jmethod count       ");
     Method::print_jmethod_ids_count(this, out);

--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -586,13 +586,17 @@ void DictionaryEntry::print_count(outputStream *st) {
 
 // ----------------------------------------------------------------------------
 
+void Dictionary::print_size(outputStream* st) const {
+  st->print_cr("Java dictionary (table_size=%d, classes=%d, resizable=%s)",
+               table_size(), number_of_entries(), BOOL_TO_STR(_resizable));
+}
+
 void Dictionary::print_on(outputStream* st) const {
   ResourceMark rm;
 
   assert(loader_data() != NULL, "loader data should not be null");
   assert(!loader_data()->has_class_mirror_holder(), "cld should have a ClassLoader holder not a Class holder");
-  st->print_cr("Java dictionary (table_size=%d, classes=%d, resizable=%s)",
-               table_size(), number_of_entries(), BOOL_TO_STR(_resizable));
+  print_size(st);
   st->print_cr("^ indicates that initiating loader is different from defining loader");
 
   for (int index = 0; index < table_size(); index++) {

--- a/src/hotspot/share/classfile/dictionary.hpp
+++ b/src/hotspot/share/classfile/dictionary.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,6 +79,7 @@ public:
                                   TRAPS);
 
   void print_on(outputStream* st) const;
+  void print_size(outputStream* st) const;
   void verify();
 
  private:

--- a/test/hotspot/jtreg/runtime/LoadClass/TestResize.java
+++ b/test/hotspot/jtreg/runtime/LoadClass/TestResize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,14 +113,14 @@ public class TestResize {
   }
 
   public static void main(String[] args) throws Exception {
-    // -XX:+PrintSystemDictionaryAtExit will print the details of system dictionary,
+    // -XX:+PrintClassLoaderDataGraphAtExit will print the summary of the dictionaries,
     // that will allow us to calculate the table's load factor.
     // -Xlog:safepoint+cleanup will print out cleanup details at safepoint
     // that will allow us to detect if the system dictionary resized.
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+PrintSystemDictionaryAtExit",
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+PrintClassLoaderDataGraphAtExit",
                                                               "-Xlog:safepoint+cleanup",
                                                               "TriggerResize",
-                                                              "50000");
+                                                              "30000");
     analyzeOutputOn(pb);
   }
 }


### PR DESCRIPTION
This test loads 50k classes and then does PrintSystemDictionaryAtExit.  The timeout seems to be during processing the output to find the load factor of the dictionary.  I reduced the number of classes to 30K, which causes the one resize, and added the output to PrintClassLoaderDataAtExit, which is only 100 lines of output vs. 51000 lines of output.
I also added Verbose to PrintClassLoaderDataAtExit to print all the classes, since if you really want all the classes, you should use PrintSystemDictionaryAtExit.
Tested with tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8252329](https://bugs.openjdk.org/browse/JDK-8252329): runtime/LoadClass/TestResize.java timed out


### Reviewers
 * [Harold Seigel](https://openjdk.org/census#hseigel) (@hseigel - **Reviewer**) ⚠️ Review applies to [1181c82f](https://git.openjdk.org/jdk/pull/9394/files/1181c82ff2c52989318cb6688f9744c764eb4065)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9394/head:pull/9394` \
`$ git checkout pull/9394`

Update a local copy of the PR: \
`$ git checkout pull/9394` \
`$ git pull https://git.openjdk.org/jdk pull/9394/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9394`

View PR using the GUI difftool: \
`$ git pr show -t 9394`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9394.diff">https://git.openjdk.org/jdk/pull/9394.diff</a>

</details>
