### PR TITLE
fix issue that Wrong order problem with Set returned by Subject.getXXXCredentials(Class)

### DIFF
--- a/src/java.base/share/classes/javax/security/auth/Subject.java
+++ b/src/java.base/share/classes/javax/security/auth/Subject.java
@@ -963,7 +963,7 @@ public final class Subject implements java.io.Serializable {
             Set<Principal> thatPrincipals;
             synchronized(that.principals) {
                 // avoid deadlock from dual locks
-                thatPrincipals = new HashSet<>(that.principals);
+                thatPrincipals = new LinkedHashSet<>(that.principals);
             }
             if (!principals.equals(thatPrincipals)) {
                 return false;
@@ -972,7 +972,7 @@ public final class Subject implements java.io.Serializable {
             Set<Object> thatPubCredentials;
             synchronized(that.pubCredentials) {
                 // avoid deadlock from dual locks
-                thatPubCredentials = new HashSet<>(that.pubCredentials);
+                thatPubCredentials = new LinkedHashSet<>(that.pubCredentials);
             }
             if (!pubCredentials.equals(thatPubCredentials)) {
                 return false;
@@ -981,7 +981,7 @@ public final class Subject implements java.io.Serializable {
             Set<Object> thatPrivCredentials;
             synchronized(that.privCredentials) {
                 // avoid deadlock from dual locks
-                thatPrivCredentials = new HashSet<>(that.privCredentials);
+                thatPrivCredentials = new LinkedHashSet<>(that.privCredentials);
             }
             return privCredentials.equals(thatPrivCredentials);
         }
@@ -1625,7 +1625,7 @@ public final class Subject implements java.io.Serializable {
         ClassSet(int which, Class<T> c) {
             this.which = which;
             this.c = c;
-            set = new HashSet<T>();
+            set = new LinkedHashSet<T>();
 
             switch (which) {
             case Subject.PRINCIPAL_SET:


### PR DESCRIPTION
The order in which the elements of the Set returned by `Subject.getXXXCredentials(Class)` should be the same as the order in which they were added.
When adding elements, the Set type is `Collections.synchronizedSet` with `SecureSet` embedded, and the bottom layer is `LinkedList` to store elements.
The Set returned by `Subject.getXXXCredentials(Class)` is `ClassSet`, and the bottom layer is `HashSet` to store elements, and the order depends on the `hash` value of the elements.
But the Set returned by `Subject.getXXXCredentials()` is still `Collections.synchronizedSet` with `SecureSet` embedded.
So the order of elements in the Set returned by `Subject.getXXXCredentials(Class)` and `Subject.getXXXCredentials()` may be inconsistent.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9396/head:pull/9396` \
`$ git checkout pull/9396`

Update a local copy of the PR: \
`$ git checkout pull/9396` \
`$ git pull https://git.openjdk.org/jdk pull/9396/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9396`

View PR using the GUI difftool: \
`$ git pr show -t 9396`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9396.diff">https://git.openjdk.org/jdk/pull/9396.diff</a>

</details>
