### PR TITLE
8278923: Document Klass::is_loader_alive

### DIFF
--- a/src/hotspot/share/oops/klass.inline.hpp
+++ b/src/hotspot/share/oops/klass.inline.hpp
@@ -45,7 +45,7 @@ inline bool Klass::is_non_strong_hidden() const {
 // Klass is considered alive. This is safe to call before the CLD is marked as
 // unloading, and hence during concurrent class unloading.
 // This returns false if the Klass is unloaded, or about to be unloaded because the holder of
-// the CLD is strongly reachable.
+// the CLD is no longer strongly reachable.
 // The return value of this function may change from true to false after a safepoint. So the caller
 // of this function must ensure that a safepoint doesn't happen while interpreting the return value.
 inline bool Klass::is_loader_alive() const {

--- a/src/hotspot/share/oops/klass.inline.hpp
+++ b/src/hotspot/share/oops/klass.inline.hpp
@@ -47,7 +47,7 @@ inline bool Klass::is_non_strong_hidden() const {
 // This returns false if the Klass is unloaded, or about to be unloaded because the holder of
 // the CLD is strongly reachable.
 // The return value of this function may change from true to false after a safepoint. So the caller
-// of this function must ensure that a safepoint doesn't happen when interpreting the return value.
+// of this function must ensure that a safepoint doesn't happen while interpreting the return value.
 inline bool Klass::is_loader_alive() const {
   return class_loader_data()->is_alive();
 }

--- a/src/hotspot/share/oops/klass.inline.hpp
+++ b/src/hotspot/share/oops/klass.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,10 @@ inline bool Klass::is_non_strong_hidden() const {
 // Iff the class loader (or mirror for non-strong hidden classes) is alive the
 // Klass is considered alive. This is safe to call before the CLD is marked as
 // unloading, and hence during concurrent class unloading.
+// This returns false if the Klass is unloaded, or about to be unloaded because the holder of
+// the CLD is strongly reachable.
+// The return value of this function may change from true to false after a safepoint. So the caller
+// of this function must ensure that a safepoint doesn't happen when interpreting the return value.
 inline bool Klass::is_loader_alive() const {
   return class_loader_data()->is_alive();
 }


### PR DESCRIPTION
This trivial change just adds a comment to Klass::is_loader_alive.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278923](https://bugs.openjdk.org/browse/JDK-8278923): Document Klass::is_loader_alive


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9400/head:pull/9400` \
`$ git checkout pull/9400`

Update a local copy of the PR: \
`$ git checkout pull/9400` \
`$ git pull https://git.openjdk.org/jdk pull/9400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9400`

View PR using the GUI difftool: \
`$ git pr show -t 9400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9400.diff">https://git.openjdk.org/jdk/pull/9400.diff</a>

</details>
