### PR TITLE
8289800: G1: G1CollectionSet::finalize_young_part clears survivor list too early

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -415,9 +415,6 @@ double G1CollectionSet::finalize_young_part(double target_pause_time_ms, G1Survi
 
   verify_young_cset_indices();
 
-  // Clear the fields that point to the survivor list - they are all young now.
-  survivors->convert_to_eden();
-
   _bytes_used_before = _inc_bytes_used_before;
 
   // The number of recorded young regions is the incremental
@@ -432,6 +429,9 @@ double G1CollectionSet::finalize_young_part(double target_pause_time_ms, G1Survi
                             "predicted eden time: %1.2fms, predicted base time: %1.2fms, target pause time: %1.2fms, remaining time: %1.2fms",
                             eden_region_length, survivor_region_length,
                             predicted_eden_time, predicted_base_time_ms, target_pause_time_ms, remaining_time_ms);
+
+  // Clear the fields that point to the survivor list - they are all young now.
+  survivors->convert_to_eden();
 
   phase_times()->record_young_cset_choice_time_ms((Ticks::now() - start_time).seconds() * 1000.0);
 


### PR DESCRIPTION
Hi all,

Please review this small change to clear survivor regions list only after predictions for survivor_regions_evac_time are done.

Test: tier1

//Ivan

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289800](https://bugs.openjdk.org/browse/JDK-8289800): G1: G1CollectionSet::finalize_young_part clears survivor list too early


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9401/head:pull/9401` \
`$ git checkout pull/9401`

Update a local copy of the PR: \
`$ git checkout pull/9401` \
`$ git pull https://git.openjdk.org/jdk pull/9401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9401`

View PR using the GUI difftool: \
`$ git pr show -t 9401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9401.diff">https://git.openjdk.org/jdk/pull/9401.diff</a>

</details>
