### PR TITLE
8249834: java/util/ArrayList/Bug8146568.java and j/u/Vector/Bug8148174.java use @ignore w/o bug-id

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -584,7 +584,7 @@ jdk_core_manual_no_input = \
     javax/net/ssl/compatibility/BasicConnectTest.java \
     javax/net/ssl/compatibility/HrrTest.java \
     javax/net/ssl/compatibility/SniTest.java \
-    jdk/nio/zipfs/TestLocOffsetFromZip64EF.java
+    jdk/nio/zipfs/TestLocOffsetFromZip64EF.java \
     java/util/ArrayList/Bug8146568.java \
     java/util/Vector/Bug8148174.java
 

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -585,6 +585,8 @@ jdk_core_manual_no_input = \
     javax/net/ssl/compatibility/HrrTest.java \
     javax/net/ssl/compatibility/SniTest.java \
     jdk/nio/zipfs/TestLocOffsetFromZip64EF.java
+    java/util/ArrayList/Bug8146568.java \
+    java/util/Vector/Bug8148174.java
 
 jdk_core_manual_no_input_security = \
     com/sun/crypto/provider/Cipher/DES/PerformanceTest.java \

--- a/test/jdk/java/util/ArrayList/Bug8146568.java
+++ b/test/jdk/java/util/ArrayList/Bug8146568.java
@@ -25,8 +25,8 @@
  * @test
  * @bug 8146568
  * @summary repro for: NegativeArraySizeException in ArrayList.grow(int)
- * @run main/othervm -Xmx17g Bug8146568
- * @ignore This test has huge memory requirements
+ * @run main/manual/othervm -Xmx17g Bug8146568
+ * @requires os.maxMemory>17G
  */
 
 public class Bug8146568 {

--- a/test/jdk/java/util/Vector/Bug8148174.java
+++ b/test/jdk/java/util/Vector/Bug8148174.java
@@ -25,8 +25,8 @@
  * @test
  * @bug 8148174
  * @summary repro for: NegativeArraySizeException in Vector.grow(int)
- * @run main/othervm -Xmx17g Bug8148174
- * @ignore This test has huge memory requirements
+ * @run main/manual/othervm -Xmx17g Bug8148174
+ * @requires os.maxMemory>17G
  */
 
 public class Bug8148174 {


### PR DESCRIPTION
Tests Bug8146568 and Bug8148174 were disabled for high memory consumption, over 17G. This is a task to re-enable these two tests by marking them as manual tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8249834](https://bugs.openjdk.org/browse/JDK-8249834): java/util/ArrayList/Bug8146568.java and j/u/Vector/Bug8148174.java use @ignore w/o bug-id


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9404/head:pull/9404` \
`$ git checkout pull/9404`

Update a local copy of the PR: \
`$ git checkout pull/9404` \
`$ git pull https://git.openjdk.org/jdk pull/9404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9404`

View PR using the GUI difftool: \
`$ git pr show -t 9404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9404.diff">https://git.openjdk.org/jdk/pull/9404.diff</a>

</details>
