### PR TITLE
8289939: Add flag to restrict public exponent as described in SP 800-56B

### DIFF
--- a/src/java.base/share/classes/sun/security/rsa/RSAKeyFactory.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/rsa/RSAKeyFactory.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAKeyFactory.java
@@ -94,6 +94,14 @@ public class RSAKeyFactory extends KeyFactorySpi {
         "true".equalsIgnoreCase(GetPropertyAction.privilegedGetProperty(
                 "sun.security.rsa.restrictRSAExponent", "true"));
 
+    public static final BigInteger MIN_EXPONENT_RANGE_VAL = new BigInteger("65537");
+    public static final BigInteger MAX_EXPONENT_RANGE_VAL = new BigInteger("2").pow(256);
+
+    // see NIST SP 800-56B section 6.2.1
+    private static final boolean requireExpRangeCheck =
+        "true".equalsIgnoreCase(GetPropertyAction.privilegedGetProperty(
+                "sun.security.rsa.requireRSAExponentRangeCheck", "false"));
+
     static RSAKeyFactory getInstance(KeyType type) {
         return new RSAKeyFactory(type);
     }
@@ -191,6 +199,16 @@ public class RSAKeyFactory extends KeyFactorySpi {
                 MAX_RESTRICTED_EXPLEN + " bits " +
                 " if modulus is greater than " +
                 MAX_MODLEN_RESTRICT_EXP + " bits");
+        }
+
+         // If a RSAPublicKey and proper flag is set, require a valid range of values for the public exponent, per NIST 800-56B
+        if (requireExpRangeCheck && (exponent != null) &&
+                 (exponent.compareTo(MIN_EXPONENT_RANGE_VAL) == -1 ||
+                         exponent.compareTo(MAX_EXPONENT_RANGE_VAL) != -1)) {
+            throw new InvalidKeyException("RSA exponents must be between " +
+                MIN_EXPONENT_RANGE_VAL + " and " + MAX_EXPONENT_RANGE_VAL +
+                " when the corresponding property is set");
+
         }
     }
 


### PR DESCRIPTION
[SP 800-56B](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Br2.pdf) stipulates that the publicExponent e "shall" be 65,537 ≤ e < 2^256

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Failed to retrieve information on issue `8289939`. Please make sure it exists and is accessible.

### Issue
 * ⚠️ Failed to retrieve information on issue `8289939`.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9413/head:pull/9413` \
`$ git checkout pull/9413`

Update a local copy of the PR: \
`$ git checkout pull/9413` \
`$ git pull https://git.openjdk.org/jdk pull/9413/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9413`

View PR using the GUI difftool: \
`$ git pr show -t 9413`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9413.diff">https://git.openjdk.org/jdk/pull/9413.diff</a>

</details>
