### PR TITLE
8289997: gc/g1/TestVerificationInConcurrentCycle.java fails due to use of debug-only option

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestVerificationInConcurrentCycle.java
+++ b/test/hotspot/jtreg/gc/g1/TestVerificationInConcurrentCycle.java
@@ -34,8 +34,9 @@ package gc.g1;
  *   -Xbootclasspath/a:.
  *   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *   -XX:+VerifyBeforeGC -XX:+VerifyDuringGC -XX:+VerifyAfterGC
- *   -XX:+G1VerifyBitmaps -XX:+G1VerifyRSetsDuringFullGC -XX:+G1VerifyHeapRegionCodeRoots
+ *   -XX:+G1VerifyRSetsDuringFullGC -XX:+G1VerifyHeapRegionCodeRoots
  *   -XX:+VerifyRememberedSets -XX:+VerifyObjectStartArray
+ *   -XX:+IgnoreUnrecognizedVMOptions -XX:+G1VerifyBitmaps
  *   gc.g1.TestVerificationInConcurrentCycle
  */
 


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that fixes failures in product VMs due to use of a debug-only verification option?

The change has the VM ignore that option as needed.

Thanks,
  Thomas

Testing: local testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289997](https://bugs.openjdk.org/browse/JDK-8289997): gc/g1/TestVerificationInConcurrentCycle.java fails due to use of debug-only option


### Reviewers
 * [Leo Korinth](https://openjdk.org/census#lkorinth) (@lkorinth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9424/head:pull/9424` \
`$ git checkout pull/9424`

Update a local copy of the PR: \
`$ git checkout pull/9424` \
`$ git pull https://git.openjdk.org/jdk pull/9424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9424`

View PR using the GUI difftool: \
`$ git pr show -t 9424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9424.diff">https://git.openjdk.org/jdk/pull/9424.diff</a>

</details>
