### PR TITLE
8289137: Automatically adapt Young/OldPLABSize and when setting only MinTLABSize

### DIFF
--- a/src/hotspot/share/gc/shared/plab.cpp
+++ b/src/hotspot/share/gc/shared/plab.cpp
@@ -31,6 +31,7 @@
 #include "logging/log.hpp"
 #include "memory/universe.hpp"
 #include "oops/oop.inline.hpp"
+#include "runtime/globals_extension.hpp"
 
 size_t PLAB::min_size() {
   // Make sure that we return something that is larger than AlignmentReserve
@@ -39,6 +40,17 @@ size_t PLAB::min_size() {
 
 size_t PLAB::max_size() {
   return ThreadLocalAllocBuffer::max_size();
+}
+
+void PLAB::startup_initialization() {
+  if (!FLAG_IS_DEFAULT(MinTLABSize)) {
+    if (FLAG_IS_DEFAULT(YoungPLABSize)) {
+      FLAG_SET_ERGO(YoungPLABSize, MAX2(ThreadLocalAllocBuffer::min_size(), YoungPLABSize));
+    }
+    if (FLAG_IS_DEFAULT(OldPLABSize)) {
+      FLAG_SET_ERGO(OldPLABSize, MAX2(ThreadLocalAllocBuffer::min_size(), OldPLABSize));
+    }
+  }
 }
 
 PLAB::PLAB(size_t desired_plab_sz_) :

--- a/src/hotspot/share/gc/shared/plab.hpp
+++ b/src/hotspot/share/gc/shared/plab.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/plab.hpp
+++ b/src/hotspot/share/gc/shared/plab.hpp
@@ -69,6 +69,8 @@ protected:
   void undo_last_allocation(HeapWord* obj, size_t word_sz);
 
 public:
+  static void startup_initialization();
+
   // Initializes the buffer to be empty, but with the given "word_sz".
   // Must get initialized with "set_buf" for an allocation to succeed.
   PLAB(size_t word_sz);

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -43,6 +43,7 @@
 #include "gc/shared/gcLogPrecious.hpp"
 #include "gc/shared/gcTraceTime.inline.hpp"
 #include "gc/shared/oopStorageSet.hpp"
+#include "gc/shared/plab.hpp"
 #include "gc/shared/stringdedup/stringDedup.hpp"
 #include "gc/shared/tlab_globals.hpp"
 #include "logging/log.hpp"
@@ -841,7 +842,6 @@ jint Universe::initialize_heap() {
 void Universe::initialize_tlab() {
   ThreadLocalAllocBuffer::set_max_size(Universe::heap()->max_tlab_size());
   PLAB::startup_initialization();
-
   if (UseTLAB) {
     ThreadLocalAllocBuffer::startup_initialization();
   }

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -840,6 +840,8 @@ jint Universe::initialize_heap() {
 
 void Universe::initialize_tlab() {
   ThreadLocalAllocBuffer::set_max_size(Universe::heap()->max_tlab_size());
+  PLAB::startup_initialization();
+
   if (UseTLAB) {
     ThreadLocalAllocBuffer::startup_initialization();
   }

--- a/test/hotspot/jtreg/gc/TestPLABAdaptToMinTLABSize.java
+++ b/test/hotspot/jtreg/gc/TestPLABAdaptToMinTLABSize.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-package gc.g1;
+package gc;
 
 /*
  * @test TestPLABAdaptToMinTLABSize
@@ -30,7 +30,7 @@ package gc.g1;
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver gc.g1.TestPLABAdaptToMinTLABSize
+ * @run driver gc.TestPLABAdaptToMinTLABSize
  */
 
 import java.util.ArrayList;

--- a/test/hotspot/jtreg/gc/TestPLABAdaptToMinTLABSize.java
+++ b/test/hotspot/jtreg/gc/TestPLABAdaptToMinTLABSize.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package gc.g1;
+
+/*
+ * @test TestPLABAdaptToMinTLABSize
+ * @bug 8289137
+ * @summary Make sure that Young/OldPLABSize adapt to MinTLABSize setting.
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver gc.g1.TestPLABAdaptToMinTLABSize
+ */
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestPLABAdaptToMinTLABSize {
+    private static void runTest(boolean shouldSucceed, String... extraArgs) throws Exception {
+        ArrayList<String> testArguments = new ArrayList<String>();
+        testArguments.add("-Xmx12m");
+        testArguments.add("-XX:+PrintFlagsFinal");
+        Collections.addAll(testArguments, extraArgs);
+        testArguments.add("-version");
+
+        ProcessBuilder pb = ProcessTools.createTestJvm(testArguments);
+
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+
+        System.out.println(output.getStderr());
+
+        if (shouldSucceed) {
+            output.shouldHaveExitValue(0);
+
+            long oldPLABSize = Long.parseLong(output.firstMatch("OldPLABSize\\s+=\\s(\\d+)",1));
+            long youngPLABSize = Long.parseLong(output.firstMatch("YoungPLABSize\\s+=\\s(\\d+)",1));
+            long minTLABSize = Long.parseLong(output.firstMatch("MinTLABSize\\s+=\\s(\\d+)",1));
+
+            System.out.println("OldPLABSize=" + oldPLABSize + " YoungPLABSize=" + youngPLABSize +
+                               "MinTLABSize=" + minTLABSize);
+
+        } else {
+            output.shouldNotHaveExitValue(0);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        runTest(true, "-XX:MinTLABSize=100k");
+        // Should not succeed when explicitly specifying invalid combination.
+        runTest(false, "-XX:MinTLABSize=100k", "-XX:OldPLABSize=5k");
+        runTest(false, "-XX:MinTLABSize=100k", "-XX:YoungPLABSize=5k");
+    }
+}


### PR DESCRIPTION
Hi all,

  can I get reviews for this enhancement fixing a sometimes annoying UI issue where setting `-XX:MinTLABSize` does not automatically update `-XX:YoungPLABSize` and `-XX:OldPLABSize` if they are not set?
This avoids some unnecessary retries.

Testing: gha, test case

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289137](https://bugs.openjdk.org/browse/JDK-8289137): Automatically adapt Young/OldPLABSize and when setting only MinTLABSize


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Sangheon Kim](https://openjdk.org/census#sangheki) (@sangheon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9425/head:pull/9425` \
`$ git checkout pull/9425`

Update a local copy of the PR: \
`$ git checkout pull/9425` \
`$ git pull https://git.openjdk.org/jdk pull/9425/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9425`

View PR using the GUI difftool: \
`$ git pr show -t 9425`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9425.diff">https://git.openjdk.org/jdk/pull/9425.diff</a>

</details>
