### PR TITLE
8290000: Bump macOS GitHub actions to macOS 11

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -49,7 +49,7 @@ on:
 jobs:
   build-macos:
     name: build
-    runs-on: macos-10.15
+    runs-on: macos-12
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -49,7 +49,7 @@ on:
 jobs:
   build-macos:
     name: build
-    runs-on: macos-12
+    runs-on: macos-11
 
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -204,7 +204,7 @@ jobs:
     uses: ./.github/workflows/build-macos.yml
     with:
       platform: macos-x64
-      xcode-toolset-version: '13.3.1'
+      xcode-toolset-version: '11.7'
     if: needs.select.outputs.macos-x64 == 'true'
 
   build-macos-aarch64:
@@ -213,7 +213,7 @@ jobs:
     uses: ./.github/workflows/build-macos.yml
     with:
       platform: macos-aarch64
-      xcode-toolset-version: '13.3.1'
+      xcode-toolset-version: '12.4'
       extra-conf-options: '--openjdk-target=aarch64-apple-darwin'
     if: needs.select.outputs.macos-aarch64 == 'true'
 
@@ -271,7 +271,7 @@ jobs:
     with:
       platform: macos-x64
       bootjdk-platform: macos-x64
-      runs-on: macos-12
+      runs-on: macos-11
 
   test-windows-x64:
     name: windows-x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -271,7 +271,7 @@ jobs:
     with:
       platform: macos-x64
       bootjdk-platform: macos-x64
-      runs-on: macos-10.15
+      runs-on: macos-12
 
   test-windows-x64:
     name: windows-x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -204,7 +204,7 @@ jobs:
     uses: ./.github/workflows/build-macos.yml
     with:
       platform: macos-x64
-      xcode-toolset-version: '11.3.1'
+      xcode-toolset-version: '13.3.1'
     if: needs.select.outputs.macos-x64 == 'true'
 
   build-macos-aarch64:
@@ -213,7 +213,7 @@ jobs:
     uses: ./.github/workflows/build-macos.yml
     with:
       platform: macos-aarch64
-      xcode-toolset-version: '12.4'
+      xcode-toolset-version: '13.3.1'
       extra-conf-options: '--openjdk-target=aarch64-apple-darwin'
     if: needs.select.outputs.macos-aarch64 == 'true'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,7 @@ jobs:
         run: |
           # On macOS we need to install some dependencies for testing
           brew install make
-          sudo xcode-select --switch /Applications/Xcode_11.3.1.app/Contents/Developer
+          sudo xcode-select --switch /Applications/Xcode_11.7.app/Contents/Developer
           # This will make GNU make available as 'make' and not only as 'gmake'
           echo '/usr/local/opt/make/libexec/gnubin' >> $GITHUB_PATH
         if: runner.os == 'macOS'


### PR DESCRIPTION
macOS 10.15 has been deprecated for some time and will be removed completely on August 30th. See https://github.com/actions/virtual-environments#available-environments and https://github.com/actions/virtual-environments/issues/5583 for context.

It's also worth pointing out that they are shutting down the agents already which means that we likely see longer wait times for executors so this should speed up the workflow for developers. We'll need to backport this all the way down to JDK8u to avoid breaking the CI system.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290000](https://bugs.openjdk.org/browse/JDK-8290000): Bump macOS GitHub actions to macOS 11


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9426/head:pull/9426` \
`$ git checkout pull/9426`

Update a local copy of the PR: \
`$ git checkout pull/9426` \
`$ git pull https://git.openjdk.org/jdk pull/9426/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9426`

View PR using the GUI difftool: \
`$ git pr show -t 9426`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9426.diff">https://git.openjdk.org/jdk/pull/9426.diff</a>

</details>
