### PR TITLE
8290017: Directly call HeapRegion::block_start in G1CMObjArrayProcessor::process_slice

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkObjArrayProcessor.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkObjArrayProcessor.cpp
@@ -59,7 +59,7 @@ size_t G1CMObjArrayProcessor::process_slice(HeapWord* slice) {
 
   HeapWord* const start_address = r->is_humongous() ?
                                   r->humongous_start_region()->bottom() :
-                                  g1h->block_start(slice);
+                                  r->block_start(slice);
 
   assert(cast_to_oop(start_address)->is_objArray(), "Address " PTR_FORMAT " does not refer to an object array ", p2i(start_address));
   assert(start_address < slice,


### PR DESCRIPTION
Hi all,

  please review this small change to have `G1CMObjArrayProcessor::process_slice` call `HeapRegion::block` directly instead of indirectly via `G1CollectedHeap`. This saves a check and an indirection (but generally isn't perf sensitive anyway, but still).

Testing: tier1-3

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290017](https://bugs.openjdk.org/browse/JDK-8290017): Directly call HeapRegion::block_start in G1CMObjArrayProcessor::process_slice


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9428/head:pull/9428` \
`$ git checkout pull/9428`

Update a local copy of the PR: \
`$ git checkout pull/9428` \
`$ git pull https://git.openjdk.org/jdk pull/9428/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9428`

View PR using the GUI difftool: \
`$ git pr show -t 9428`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9428.diff">https://git.openjdk.org/jdk/pull/9428.diff</a>

</details>
