### PR TITLE
8290018: Remove dead declarations in G1BlockOffsetTablePart

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -120,18 +120,6 @@ private:
   // at "end" to point back to the card before "start"; [start, end]
   void set_remainder_to_point_to_start_incl(size_t start, size_t end);
 
-  inline size_t block_size(const HeapWord* p) const;
-
-  // Returns the address of a block whose start is at most "addr".
-  inline HeapWord* block_at_or_preceding(const void* addr) const;
-
-  // Return the address of the beginning of the block that contains "addr".
-  // "q" is a block boundary that is <= "addr"; "n" is the address of the
-  // next block (or the end of the space.)
-  inline HeapWord* forward_to_block_containing_addr(HeapWord* q, HeapWord* n,
-                                                    const void* addr,
-                                                    HeapWord* pb) const;
-
   // Update BOT entries corresponding to the mem range [blk_start, blk_end).
   void update_for_block_work(HeapWord* blk_start, HeapWord* blk_end);
 


### PR DESCRIPTION
Hi all,

  please review this removal of dead code in `G1BlockOffsetTablePart`.

Testing: compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290018](https://bugs.openjdk.org/browse/JDK-8290018): Remove dead declarations in G1BlockOffsetTablePart


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9429/head:pull/9429` \
`$ git checkout pull/9429`

Update a local copy of the PR: \
`$ git checkout pull/9429` \
`$ git pull https://git.openjdk.org/jdk pull/9429/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9429`

View PR using the GUI difftool: \
`$ git pr show -t 9429`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9429.diff">https://git.openjdk.org/jdk/pull/9429.diff</a>

</details>
