### PR TITLE
8290019: Refactor HeapRegion::oops_on_memregion_iterate()

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -280,7 +280,7 @@ private:
   inline HeapWord* oops_on_memregion_iterate(MemRegion mr, Closure* cl);
 
   template <class Closure>
-  inline HeapWord* oops_on_memregion_iterate_in_unparsable(MemRegion mr, HeapWord* pb, Closure* cl);
+  inline HeapWord* oops_on_memregion_iterate_in_unparsable(MemRegion mr, HeapWord* block_start, Closure* cl);
 
   // Iterate over the references covered by the given MemRegion in a humongous
   // object and apply the given closure to them.


### PR DESCRIPTION
Hi all,

  please review this potential refactoring for `HeapRegion::oops_on_memregion_iterate()`; it's a bit subjective imo if the code is better now, so please feel free to say so and I'll retract.

Testing: tier1-3

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290019](https://bugs.openjdk.org/browse/JDK-8290019): Refactor HeapRegion::oops_on_memregion_iterate()


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9430/head:pull/9430` \
`$ git checkout pull/9430`

Update a local copy of the PR: \
`$ git checkout pull/9430` \
`$ git pull https://git.openjdk.org/jdk pull/9430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9430`

View PR using the GUI difftool: \
`$ git pr show -t 9430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9430.diff">https://git.openjdk.org/jdk/pull/9430.diff</a>

</details>
