### PR TITLE
improve scanning process of the parser

### DIFF
--- a/src/java.xml/share/classes/com/sun/java_cup/internal/runtime/lr_parser.java
+++ b/src/java.xml/share/classes/com/sun/java_cup/internal/runtime/lr_parser.java
@@ -404,9 +404,18 @@ public abstract class lr_parser {
               || opLimit > 0 && opCount > opLimit
               || totalOpLimit > 0 && totalOpCount > totalOpLimit) {
           overLimit = true;
+          //throw exception to break scanning procss in the middle when limit is over
+          throw new XPathOverLimitException();
       }
 
     return s;
+  }
+
+  protected class XPathOverLimitException extends Exception{
+    private static final long serialVersionUID = 8620931730244388104L;
+
+    public XPathOverLimitException() {
+    }
   }
 
   private boolean contains(final int[] arr, final int key) {

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/XPathParser.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/XPathParser.java
@@ -1114,7 +1114,13 @@ public class XPathParser extends lr_parser {
         try {
             _expression = expression;
             _lineNumber = lineNumber;
-            Symbol s = super.parse();
+
+            Symbol s = null;
+            try {
+                super.parse();
+            }catch(XPathOverLimitException ex){
+                //only catch this exception;ignore all of other exceptions
+            }
             /*
              * While the Java CUP parser is used for parsing symbols, the error
              * report mechanism has so far been kept within the Xalan implementation.


### PR DESCRIPTION
While scanning, if any limit is over, the process will be stopped and XPathOverLimitException is raised to allow XPathParser to return an error message to the client.