### PR TITLE
8289984: Files:isDirectory and isRegularFile methods not throwing SecurityException

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
@@ -156,6 +156,7 @@ public abstract class UnixFileSystemProvider
     {
         if (type == BasicFileAttributes.class && Util.followLinks(options)) {
             UnixPath file = UnixPath.toUnixPath(path);
+            file.checkRead();
             try {
                 @SuppressWarnings("unchecked")
                 A attrs = (A) UnixFileAttributes.getIfExists(file);

--- a/test/jdk/java/nio/file/Files/CheckPermissions.java
+++ b/test/jdk/java/nio/file/Files/CheckPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -217,6 +217,14 @@ public class CheckPermissions {
 
             prepare();
             exists(file);
+            assertCheckRead(file);
+
+            prepare();
+            isDirectory(file);
+            assertCheckRead(file);
+
+            prepare();
+            isRegularFile(file);
             assertCheckRead(file);
 
             prepare();

--- a/test/jdk/java/nio/file/Files/CheckPermissions.java
+++ b/test/jdk/java/nio/file/Files/CheckPermissions.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 6866804 7006126 8028270 8065109
+ * @bug 6866804 7006126 8028270 8065109 8289984
  * @summary Unit test for java.nio.file.Files
  * @library ..
  * @build CheckPermissions


### PR DESCRIPTION
Hi all,

Please review this change to address the fact that we were missing a permissions check when the SecurityManager is enabled

The failing jck tests are passing locally and just waiting on another platform to complete on Mach5  and will be good to go

Best
Lance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289984](https://bugs.openjdk.org/browse/JDK-8289984): Files:isDirectory and isRegularFile methods not throwing SecurityException


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [b2d2cf75](https://git.openjdk.org/jdk/pull/9433/files/b2d2cf75c9d5d9cfc51ee7d44f7ea08d8734bd63)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [b2d2cf75](https://git.openjdk.org/jdk/pull/9433/files/b2d2cf75c9d5d9cfc51ee7d44f7ea08d8734bd63)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9433/head:pull/9433` \
`$ git checkout pull/9433`

Update a local copy of the PR: \
`$ git checkout pull/9433` \
`$ git pull https://git.openjdk.org/jdk pull/9433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9433`

View PR using the GUI difftool: \
`$ git pr show -t 9433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9433.diff">https://git.openjdk.org/jdk/pull/9433.diff</a>

</details>
