### PR TITLE
8289184: runtime/ClassUnload/DictionaryDependsTest.java failed with "Test failed: should be unloaded"

### DIFF
--- a/test/hotspot/jtreg/runtime/BadObjectClass/TestUnloadClassError.java
+++ b/test/hotspot/jtreg/runtime/BadObjectClass/TestUnloadClassError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,9 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.compiler
- * @run main TestUnloadClassError
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI TestUnloadClassError
  */
 
 import jdk.test.lib.compiler.InMemoryJavaCompiler;

--- a/test/hotspot/jtreg/runtime/Nestmates/membership/TestNestHostErrorWithClassUnload.java
+++ b/test/hotspot/jtreg/runtime/Nestmates/membership/TestNestHostErrorWithClassUnload.java
@@ -34,8 +34,10 @@
  *          PackagedNestHost.java
  *          PackagedNestHost2.java
  * @compile PackagedNestHost2Member.jcod
- *
- * @run main/othervm -Xlog:class+unload=trace TestNestHostErrorWithClassUnload
+
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:class+unload=trace TestNestHostErrorWithClassUnload
  */
 
 // Test setup:

--- a/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@
  * @library /test/lib
  * @library classes
  * @build test.Empty
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run driver ClassLoadUnloadTest
  */
 
@@ -77,7 +79,9 @@ public class ClassLoadUnloadTest {
         List<String> argsList = new ArrayList<>();
         Collections.addAll(argsList, args);
         Collections.addAll(argsList, "-Xmn8m");
-        Collections.addAll(argsList, "-Dtest.class.path=" + System.getProperty("test.class.path", "."));
+        Collections.addAll(argsList, "-Xbootclasspath/a:.");
+        Collections.addAll(argsList, "-XX:+UnlockDiagnosticVMOptions");
+        Collections.addAll(argsList, "-XX:+WhiteBoxAPI");
         Collections.addAll(argsList, "-XX:+ClassUnloading");
         Collections.addAll(argsList, ClassUnloadTestMain.class.getName());
         return ProcessTools.createJavaProcessBuilder(argsList);

--- a/test/hotspot/jtreg/runtime/logging/LoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/LoaderConstraintsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@
  * @modules java.base/jdk.internal.misc
  * @library /test/lib classes
  * @build test.Empty
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run driver LoaderConstraintsTest
  */
 
@@ -60,7 +62,9 @@ public class LoaderConstraintsTest {
         List<String> argsList = new ArrayList<>();
         Collections.addAll(argsList, args);
         Collections.addAll(argsList, "-Xmn8m");
-        Collections.addAll(argsList, "-Dtest.classes=" + System.getProperty("test.classes","."));
+        Collections.addAll(argsList, "-Xbootclasspath/a:.");
+        Collections.addAll(argsList, "-XX:+UnlockDiagnosticVMOptions");
+        Collections.addAll(argsList, "-XX:+WhiteBoxAPI");
         Collections.addAll(argsList, ClassUnloadTestMain.class.getName());
         return ProcessTools.createJavaProcessBuilder(argsList);
     }

--- a/test/lib/jdk/test/lib/classloader/ClassUnloadCommon.java
+++ b/test/lib/jdk/test/lib/classloader/ClassUnloadCommon.java
@@ -23,12 +23,13 @@
 
 
 /*
- * To use ClassUnloadCommon from a sub-process, see hotspot/test/runtime/logging/ClassLoadUnloadTest.java
+ * To use ClassUnloadCommon from a sub-process, see test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
  * for an example.
  */
 
 
 package jdk.test.lib.classloader;
+import jdk.test.whitebox.WhiteBox;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -62,8 +63,8 @@ public class ClassUnloadCommon {
     }
 
     public static void triggerUnloading() {
-        allocateMemory(16 * 1024); // force young collection
-        System.gc();
+        WhiteBox wb = WhiteBox.getWhiteBox();
+        wb.fullGC();  // will do class unloading
     }
 
     /**


### PR DESCRIPTION
Some allocation and System.gc() isn't sufficient to cause class unloading.  It works almost all the time, but it's better to call WhiteBox.fullGC() from ClassUnloadCommon.triggerUnloading().  This requires building and copying WhiteBox classes to the test.classes directory.
Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289184](https://bugs.openjdk.org/browse/JDK-8289184): runtime/ClassUnload/DictionaryDependsTest.java failed with "Test failed: should be unloaded"


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Harold Seigel](https://openjdk.org/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9435/head:pull/9435` \
`$ git checkout pull/9435`

Update a local copy of the PR: \
`$ git checkout pull/9435` \
`$ git pull https://git.openjdk.org/jdk pull/9435/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9435`

View PR using the GUI difftool: \
`$ git pr show -t 9435`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9435.diff">https://git.openjdk.org/jdk/pull/9435.diff</a>

</details>
