### PR TITLE
8169187: [macosx] Aqua: java/awt/image/multiresolution/MultiresolutionIconTest.java

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaButtonUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaButtonUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaButtonUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaButtonUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -410,7 +410,7 @@ public class AquaButtonUI extends BasicButtonUI implements Sizeable {
             tmpIcon = b.getPressedIcon();
             if (tmpIcon == null) {
                 if (icon instanceof ImageIcon) {
-                    tmpIcon = new ImageIcon(AquaUtils.generateSelectedDarkImage(((ImageIcon) icon).getImage()));
+                    tmpIcon = new ImageIcon(AquaUtils.generateSelectedDarkImage(((ImageIcon)icon).getImage()));
                 }
             }
         } else if (b.isRolloverEnabled() && model.isRollover()) {

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaButtonUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaButtonUI.java
@@ -408,6 +408,11 @@ public class AquaButtonUI extends BasicButtonUI implements Sizeable {
             }
         } else if (model.isPressed() && model.isArmed()) {
             tmpIcon = b.getPressedIcon();
+            if (tmpIcon == null) {
+                if (icon instanceof ImageIcon) {
+                    tmpIcon = new ImageIcon(AquaUtils.generateSelectedDarkImage(((ImageIcon) icon).getImage()));
+                }
+            }
         } else if (b.isRolloverEnabled() && model.isRollover()) {
             if (model.isSelected()) {
                 tmpIcon = b.getRolloverSelectedIcon();

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaButtonUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaButtonUI.java
@@ -408,11 +408,6 @@ public class AquaButtonUI extends BasicButtonUI implements Sizeable {
             }
         } else if (model.isPressed() && model.isArmed()) {
             tmpIcon = b.getPressedIcon();
-            if (tmpIcon == null) {
-                if (icon instanceof ImageIcon) {
-                    tmpIcon = new ImageIcon(AquaUtils.generateSelectedDarkImage(((ImageIcon)icon).getImage()));
-                }
-            }
         } else if (b.isRolloverEnabled() && model.isRollover()) {
             if (model.isSelected()) {
                 tmpIcon = b.getRolloverSelectedIcon();

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -222,7 +222,6 @@ java/awt/Window/LocationAtScreenCorner/LocationAtScreenCorner.java 8203371 linux
 java/awt/font/TextLayout/TextLayoutBounds.java 8169188 generic-all
 java/awt/image/BufferedImage/ICMColorDataTest/ICMColorDataTest.java 8233028 generic-all
 java/awt/image/DrawImage/IncorrectAlphaSurface2SW.java 8056077 linux-all
-java/awt/image/multiresolution/MultiresolutionIconTest.java 8169187,8252812 macosx-all,windows-all,linux-x64
 java/awt/print/Headless/HeadlessPrinterJob.java 8196088 windows-all
 sun/awt/datatransfer/SuplementaryCharactersTransferTest.java 8011371 generic-all
 sun/awt/shell/ShellFolderMemoryLeak.java 8197794 windows-all

--- a/test/jdk/java/awt/image/multiresolution/MultiresolutionIconTest.java
+++ b/test/jdk/java/awt/image/multiresolution/MultiresolutionIconTest.java
@@ -217,6 +217,10 @@ public class MultiresolutionIconTest extends JFrame {
     public static void main(String[] args) throws Exception {
 
         for (UIManager.LookAndFeelInfo LF: UIManager.getInstalledLookAndFeels()) {
+            // skip AquaL&F because Aqua icon darkening fails the test
+            if (LF.getName().equalsIgnoreCase("Mac OS X")) {
+                continue;
+            }
             System.out.println("\nL&F: " + LF.getName());
             (new MultiresolutionIconTest(LF)).doTest();
         }

--- a/test/jdk/java/awt/image/multiresolution/MultiresolutionIconTest.java
+++ b/test/jdk/java/awt/image/multiresolution/MultiresolutionIconTest.java
@@ -128,7 +128,7 @@ public class MultiresolutionIconTest extends JFrame {
 
     private boolean checkPressedColor(int x, int y, Color ok) {
 
-        r.mouseMove(x, y);
+        r.mouseMove(x+5, y+5);
         r.waitForIdle();
         r.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         r.waitForIdle(100);
@@ -136,10 +136,14 @@ public class MultiresolutionIconTest extends JFrame {
         r.waitForIdle(100);
         r.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         r.waitForIdle(100);
-        if (!c.equals(ok)) { return false; }
+        System.out.println("checkPressedColor color: " + c + " expected: " + ok);
+        if (!c.equals(ok)) {
+            return false;
+        }
         // check the icon's color hasn't changed
         // after the mouse was released
         c = r.getPixelColor(x, y);
+        System.out.println("checkPressedColor2 color: " + c + " expected: " + ok);
         return c.equals(ok);
     }
 
@@ -186,9 +190,13 @@ public class MultiresolutionIconTest extends JFrame {
             // check icon color
             c = r.getPixelColor(t, y);
             System.out.print(components[i] + " icon: ");
+            System.out.println("getPixelColor color: " + c + " expected: " + expected);
             if (!c.equals(expected)) {
+//                c.equals(expected);
+                System.out.println("c.equals(expected) color: " + c + " expected: " + expected);
                 curr = false;
             } else {
+                System.out.println("else color: " + c + " expected: " + expected);
                 // check icon color when mouse button pressed - see JDK-8151303
                 curr = checkPressedColor(t, y, expected);
             }

--- a/test/jdk/java/awt/image/multiresolution/MultiresolutionIconTest.java
+++ b/test/jdk/java/awt/image/multiresolution/MultiresolutionIconTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -136,14 +136,10 @@ public class MultiresolutionIconTest extends JFrame {
         r.waitForIdle(100);
         r.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         r.waitForIdle(100);
-        System.out.println("checkPressedColor color: " + c + " expected: " + ok);
-        if (!c.equals(ok)) {
-            return false;
-        }
+        if (!c.equals(ok)) { return false; }
         // check the icon's color hasn't changed
         // after the mouse was released
         c = r.getPixelColor(x, y);
-        System.out.println("checkPressedColor2 color: " + c + " expected: " + ok);
         return c.equals(ok);
     }
 
@@ -190,13 +186,9 @@ public class MultiresolutionIconTest extends JFrame {
             // check icon color
             c = r.getPixelColor(t, y);
             System.out.print(components[i] + " icon: ");
-            System.out.println("getPixelColor color: " + c + " expected: " + expected);
             if (!c.equals(expected)) {
-//                c.equals(expected);
-                System.out.println("c.equals(expected) color: " + c + " expected: " + expected);
                 curr = false;
             } else {
-                System.out.println("else color: " + c + " expected: " + expected);
                 // check icon color when mouse button pressed - see JDK-8151303
                 curr = checkPressedColor(t, y, expected);
             }


### PR DESCRIPTION
Removed darkening of icons on button press in Aqua to match other L&Fs. The icon darkening was causing this test to fail on MacOS.

The test is passing on all platforms after this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8169187](https://bugs.openjdk.org/browse/JDK-8169187): [macosx] Aqua: java/awt/image/multiresolution/MultiresolutionIconTest.java


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9436/head:pull/9436` \
`$ git checkout pull/9436`

Update a local copy of the PR: \
`$ git checkout pull/9436` \
`$ git pull https://git.openjdk.org/jdk pull/9436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9436`

View PR using the GUI difftool: \
`$ git pr show -t 9436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9436.diff">https://git.openjdk.org/jdk/pull/9436.diff</a>

</details>
