### PR TITLE
JDK-8288624: Cleanup CommentHelper.getText0

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
@@ -1260,7 +1260,7 @@ public class DocCommentParser {
                     if (ch == '}') {
                         throw new ParseException("dc.no.content");
                     }
-                    DCTree term = ch == '"' ? quotedString() : inlineWord();
+                    DCText term = ch == '"' ? quotedString() : inlineWord();
                     if (term == null) {
                         throw new ParseException("dc.no.content");
                     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -118,7 +118,6 @@ import static com.sun.source.doctree.DocTree.Kind.LINK;
 import static com.sun.source.doctree.DocTree.Kind.LINK_PLAIN;
 import static com.sun.source.doctree.DocTree.Kind.SEE;
 import static com.sun.source.doctree.DocTree.Kind.TEXT;
-import static jdk.javadoc.internal.doclets.toolkit.util.CommentHelper.SPACER;
 
 
 /**
@@ -977,7 +976,6 @@ public class HtmlDocletWriter {
         CommentHelper ch = utils.getCommentHelper(element);
         String tagName = ch.getTagName(see);
 
-        String seeText = utils.normalizeNewlines(ch.getText(see)).toString();
         String refText;
         List<? extends DocTree> label;
         switch (kind) {
@@ -997,26 +995,25 @@ public class HtmlDocletWriter {
             case SEE -> {
                 List<? extends DocTree> ref = ((SeeTree) see).getReference();
                 assert !ref.isEmpty();
-                switch (ref.get(0).getKind()) {
-                    case TEXT -> {
+                DocTree ref0 = ref.get(0);
+                switch (ref0.getKind()) {
+                    case TEXT, START_ELEMENT -> {
                         // @see "Reference"
-                        return Text.of(seeText);
-                    }
-                    case START_ELEMENT -> {
                         // @see <a href="...">...</a>
-                        return RawHtml.of(replaceDocRootDir(removeTrailingSlash(seeText)));
+                        return commentTagsToContent(element, ref, false, false);
                     }
                     case REFERENCE -> {
                         // @see reference label...
-                        refText = ref.get(0).toString();
+                        refText = ref0.toString();
                         label = ref.subList(1, ref.size());
                     }
                     case ERRONEOUS -> {
-                        return invalidTagOutput(resources.getText("doclet.tag.invalid_input", seeText),
+                        return invalidTagOutput(resources.getText("doclet.tag.invalid_input",
+                                        ref0.toString()),
                                 Optional.empty());
                     }
                     default ->
-                        throw new IllegalStateException(ref.get(0).getKind().toString());
+                        throw new IllegalStateException(ref0.getKind().toString());
                 }
             }
 
@@ -1107,7 +1104,7 @@ public class HtmlDocletWriter {
                 if (overriddenMethod != null)
                     containing = utils.getEnclosingTypeElement(overriddenMethod);
             }
-            if (ch.getText(see).trim().startsWith("#") &&
+            if (refText.trim().startsWith("#") &&
                 ! (utils.isPublic(containing) || utils.isLinkable(containing))) {
                 // Since the link is relative and the holder is not even being
                 // documented, this must be an inherited link.  Redirect it.
@@ -1477,6 +1474,26 @@ public class HtmlDocletWriter {
                                         List<? extends DocTree> trees,
                                         TagletWriterImpl.Context context)
     {
+        return commentTagsToContent(element, trees, context, true);
+    }
+
+    /**
+     * Converts inline tags and text to content, expanding the
+     * inline tags along the way.  Called wherever text can contain
+     * an inline tag, such as in comments or in free-form text arguments
+     * to block tags.
+     *
+     * @param element   specific element where comment resides
+     * @param trees     list of text trees and inline tag trees (often alternating)
+     * @param context   the enclosing context for the trees
+     *
+     * @return a Content object
+     */
+    public Content commentTagsToContent(Element element,
+                                        List<? extends DocTree> trees,
+                                        TagletWriterImpl.Context context,
+                                        boolean redirectRelativeLinks)
+    {
         final Content result = new ContentBuilder() {
             @Override
             public ContentBuilder add(CharSequence text) {
@@ -1500,7 +1517,7 @@ public class HtmlDocletWriter {
                 // Ignore any trailing whitespace OR whitespace after removed html comment
                 if ((isLastNode || commentRemoved)
                         && tag.getKind() == TEXT
-                        && ch.getText(tag).isBlank())
+                        && ((tag instanceof TextTree tt) && tt.getBody().isBlank()))
                     continue;
 
                 // Ignore any leading html comments
@@ -1566,7 +1583,7 @@ public class HtmlDocletWriter {
 
                         if (dt instanceof TextTree tt) {
                             String text = tt.getBody();
-                            if (first && isHRef) {
+                            if (first && isHRef && redirectRelativeLinks) {
                                 text = redirectRelativeLinks(element, tt);
                             }
                             content.add(textCleanup(text, isLastNode));
@@ -2462,5 +2479,4 @@ public class HtmlDocletWriter {
                                    HtmlTree.CODE(Text.of(className)),
                                    links);
     }
-
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialFieldWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialFieldWriter.java
@@ -33,11 +33,11 @@ import javax.lang.model.type.TypeMirror;
 
 import com.sun.source.doctree.DocTree;
 
+import com.sun.source.doctree.SerialFieldTree;
 import com.sun.source.doctree.SerialTree;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle;
 import jdk.javadoc.internal.doclets.formats.html.markup.TagName;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlTree;
-import jdk.javadoc.internal.doclets.formats.html.markup.RawHtml;
 import jdk.javadoc.internal.doclets.formats.html.markup.Text;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.SerializedFormWriter;
@@ -130,11 +130,13 @@ public class HtmlSerialFieldWriter extends FieldWriterImpl
      * @param content the content to which the deprecated info will be added
      */
     @Override
-    public void addMemberDescription(VariableElement field, DocTree serialFieldTag, Content content) {
-        CommentHelper ch = utils.getCommentHelper(field);
-        List<? extends DocTree> description = ch.getDescription(serialFieldTag);
+    public void addMemberDescription(VariableElement field, SerialFieldTree serialFieldTag, Content content) {
+        List<? extends DocTree> description = serialFieldTag.getDescription();
         if (!description.isEmpty()) {
-            Content serialFieldContent = RawHtml.of(ch.getText(description)); // should interpret tags
+            Content serialFieldContent = writer.commentTagsToContent(field,
+                    description,
+                    new TagletWriterImpl.Context(false, false),
+                    false);
             var div = HtmlTree.DIV(HtmlStyle.block, serialFieldContent);
             content.add(div);
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
@@ -196,16 +196,16 @@ public class TagletWriterImpl extends TagletWriter {
     }
 
     @Override
-    protected Content codeTagOutput(Element element, DocTree tag) {
-        CommentHelper ch = utils.getCommentHelper(element);
-        return HtmlTree.CODE(Text.of(utils.normalizeNewlines(ch.getText(tag))));
+    protected Content codeTagOutput(Element element, LiteralTree tag) {
+        return HtmlTree.CODE(Text.of(utils.normalizeNewlines(tag.getBody().getBody())));
     }
 
     @Override
     protected Content indexTagOutput(Element element, IndexTree tag) {
         CommentHelper ch = utils.getCommentHelper(element);
 
-        String tagText = ch.getText(tag.getSearchTerm());
+        DocTree searchTerm = tag.getSearchTerm();
+        String tagText = (searchTerm instanceof TextTree tt) ? tt.getBody() : "";
         if (tagText.charAt(0) == '"' && tagText.charAt(tagText.length() - 1) == '"') {
             tagText = tagText.substring(1, tagText.length() - 1)
                              .replaceAll("\\s+", " ");
@@ -272,9 +272,7 @@ public class TagletWriterImpl extends TagletWriter {
 
     @Override
     protected Content literalTagOutput(Element element, LiteralTree tag) {
-        CommentHelper ch = utils.getCommentHelper(element);
-        Content result = Text.of(utils.normalizeNewlines(ch.getText(tag)));
-        return result;
+        return Text.of(utils.normalizeNewlines(tag.getBody().getBody()));
     }
 
     @Override
@@ -346,8 +344,7 @@ public class TagletWriterImpl extends TagletWriter {
             return Text.EMPTY;
         }
         // Use a different style if any link label is longer than 30 chars or contains commas.
-        boolean hasLongLabels = links.stream()
-                .anyMatch(c -> c.charCount() > SEE_TAG_MAX_INLINE_LENGTH || c.toString().contains(","));
+        boolean hasLongLabels = links.stream().anyMatch(this::isLongOrHasComma);
         var seeList = HtmlTree.UL(hasLongLabels ? HtmlStyle.seeListLong : HtmlStyle.seeList);
         links.stream().filter(Predicate.not(Content::isEmpty)).forEach(item -> {
             seeList.add(HtmlTree.LI(item));
@@ -356,6 +353,11 @@ public class TagletWriterImpl extends TagletWriter {
         return new ContentBuilder(
                 HtmlTree.DT(contents.seeAlso),
                 HtmlTree.DD(seeList));
+    }
+
+    private boolean isLongOrHasComma(Content c) {
+        String s = c.toString().replaceAll("<.*?>", "").replaceAll("\\&[a-z0-9]+;?", " ");
+        return s.length() > SEE_TAG_MAX_INLINE_LENGTH || s.contains(",");
     }
 
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/SerializedFormWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/SerializedFormWriter.java
@@ -31,7 +31,7 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 
-import com.sun.source.doctree.DocTree;
+import com.sun.source.doctree.SerialFieldTree;
 import jdk.javadoc.internal.doclets.toolkit.util.DocFileIOException;
 
 /**
@@ -200,7 +200,7 @@ public interface SerializedFormWriter {
          * @param serialFieldTag the field to document (represented by tag)
          * @param content the content to which the member description will be added
          */
-        void addMemberDescription(VariableElement field, DocTree serialFieldTag, Content content);
+        void addMemberDescription(VariableElement field, SerialFieldTree serialFieldTag, Content content);
 
         /**
          * Adds the tag information for this member.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/SerializedFormBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/SerializedFormBuilder.java
@@ -552,7 +552,8 @@ public class SerializedFormBuilder extends AbstractBuilder {
         List<? extends SerialTree> serial = utils.getSerialTrees(element);
         if (!serial.isEmpty()) {
             CommentHelper ch = utils.getCommentHelper(element);
-            String serialtext = Utils.toLowerCase(ch.getText(serial.get(0)));
+            // look for `@serial include|exclude`
+            String serialtext = Utils.toLowerCase(serial.get(0).toString());
             if (serialtext.contains("exclude")) {
                 return false;
             } else if (serialtext.contains("include")) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/CodeTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/CodeTaglet.java
@@ -30,6 +30,7 @@ import java.util.EnumSet;
 import javax.lang.model.element.Element;
 
 import com.sun.source.doctree.DocTree;
+import com.sun.source.doctree.LiteralTree;
 import jdk.javadoc.doclet.Taglet.Location;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 
@@ -53,6 +54,6 @@ public class CodeTaglet extends BaseTaglet {
 
     @Override
     public Content getInlineTagOutput(Element element, DocTree tag, TagletWriter writer) {
-        return writer.codeTagOutput(element, tag);
+        return writer.codeTagOutput(element, (LiteralTree) tag);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletWriter.java
@@ -79,7 +79,7 @@ public abstract class TagletWriter {
      *
      * @return the output
      */
-    protected abstract Content codeTagOutput(Element element, DocTree tag);
+    protected abstract Content codeTagOutput(Element element, LiteralTree tag);
 
     /**
      * Returns the output for a {@code {@index...}} tag.

--- a/test/langtools/jdk/javadoc/doclet/testSeeTag/TestSeeTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSeeTag/TestSeeTag.java
@@ -143,11 +143,95 @@ public class TestSeeTag extends JavadocTester {
                     <dt>See Also:</dt>
                     <dd>
                     <ul class="see-list">
-                    <li><span class="invalid-tag">invalid input: '&lt;a href="'</span></li>
+                    <li><span class="invalid-tag">invalid input: '&lt;'</span></li>
                     </ul>
                     </dd>
                     </dl>
                     """);
+    }
 
+    @Test
+    public void testSeeLongCommas(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                package p;
+                /** Comment. */
+                public class C {
+                    private C() { }
+                    
+                    /**
+                     * Comment.
+                     * @see #noArgs() no args
+                     * @see #oneArg(int) one arg
+                     * @see #twoArgs(int, int) two args
+                     */
+                    public void noComma() { }
+                    
+                    /**
+                     * Comment.
+                     * @see #noArgs() no args
+                     * @see #oneArg(int) one arg
+                     * @see #twoArgs(int, int) two args with a comma , in the description
+                     */
+                    public void commaInDescription() { }
+                    
+                    /**
+                     * Comment.
+                     * @see #noArgs()
+                     * @see #oneArg(int)
+                     * @see #twoArgs(int, int)
+                     */
+                    public void commaInDefaultDescription() { }
+                    
+                    /**
+                     * No arg method.
+                     */
+                    public void noArgs() { }
+                    
+                    /**
+                     * One arg method.
+                     * @param a1 an arg
+                     */
+                    public void oneArg(int a1) { }
+                    
+                    /**
+                     * Two arg method.
+                     * @param a1 an arg
+                     * @param a2 an arg
+                     */
+                    public void twoArgs(int a1, int a2) { }
+                }
+                """);
+
+        javadoc("-d", base.resolve("api").toString(),
+                "-sourcepath", src.toString(),
+                "--no-platform-links",
+                "p");
+        checkExit(Exit.OK);
+
+        checkOrder("p/C.html",
+                "<section class=\"detail\" id=\"noComma()\">",
+                """
+                    <ul class="see-list">
+                    <li><a href="#noArgs()"><code>no args</code></a></li>
+                    <li><a href="#oneArg(int)"><code>one arg</code></a></li>
+                    <li><a href="#twoArgs(int,int)"><code>two args</code></a></li>
+                    </ul>""",
+
+                "<section class=\"detail\" id=\"commaInDescription()\">",
+                """
+                    <ul class="see-list-long">
+                    <li><a href="#noArgs()"><code>no args</code></a></li>
+                    <li><a href="#oneArg(int)"><code>one arg</code></a></li>
+                    <li><a href="#twoArgs(int,int)"><code>two args with a comma , in the description</code></a></li>
+                    </ul>""",
+
+                "<section class=\"detail\" id=\"commaInDefaultDescription()\">",
+                """
+                    <ul class="see-list-long">
+                    <li><a href="#noArgs()"><code>noArgs()</code></a></li>
+                    <li><a href="#oneArg(int)"><code>oneArg(int)</code></a></li>
+                    <li><a href="#twoArgs(int,int)"><code>twoArgs(int, int)</code></a></li>
+                    </ul>""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testSerialWithLink/TestSerialWithLink.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerialWithLink/TestSerialWithLink.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8288624
+ * @summary Test at-serial with {at-link}
+ * @library /tools/lib ../../lib
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build javadoc.tester.* toolbox.ToolBox
+ * @run main TestSerialWithLink
+ */
+
+import java.nio.file.Path;
+
+import toolbox.ToolBox;
+
+import javadoc.tester.JavadocTester;
+
+public class TestSerialWithLink extends JavadocTester {
+    public static void main(String... args) throws Exception {
+        TestSerialWithLink tester = new TestSerialWithLink();
+        tester.runTests();
+    }
+
+    private final ToolBox tb;
+
+    TestSerialWithLink() {
+        tb = new ToolBox();
+    }
+
+    @Test
+    public void testSerialWithLink(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                        package p;
+                        import java.io.Serializable;
+                        import java.io.ObjectStreamField;
+                        /** Comment, */
+                        public class C implements Serializable {
+                            /** Comment. */
+                            C() { }
+                            /**
+                             * The serial persistent fields for this class.
+                             * @serialField item Item An {@link Item} to be serialized.
+                             */
+                            private static final ObjectStreamField[] serialPersistentFields =
+                                { new ObjectStreamField("item", Item.class) };
+                            /**
+                             * An item that is described in serialPersistentFields.
+                             */
+                            private Item item;
+                            
+                            /** A dummy item, not described in serialPersistentFields. */
+                            private int dummy;
+                        }
+                        """, """
+                        package p;
+                        import java.io.Serializable;
+                        /** Comment. */
+                        public class Item implements Serializable {
+                            /**
+                             * Comment.
+                             */
+                            Item() { }
+                        }
+                        """);
+
+        javadoc("-d", base.resolve("api").toString(),
+                "-sourcepath", src.toString(),
+                "--no-platform-links",
+                "p");
+
+        checkOutput("serialized-form.html", true,
+                """
+                    <section class="detail">
+                    <h4>Serialized Fields</h4>
+                    <ul class="block-list">
+                    <li class="block-list">
+                    <h5>item</h5>
+                    <pre><a href="p/Item.html" title="class in p">Item</a> item</pre>
+                    <div class="block">An <a href="p/Item.html" title="class in p"><code>Item</code></a> to be serialized.</div>
+                    </li>
+                    </ul>
+                    </section>""");
+
+    }
+}


### PR DESCRIPTION
Please review a moderately simple fix to clean up (as in _remove_!) `CommentHelper.getText` and friends/overloads.

This is moderately simple, because most of the heavy lifting was done in 
[JDK-8288699](https://bugs.openjdk.org/browse/JDK-8288624), to clean up `commentTagsToContent`.

The uses of `CommentHelper.getText` can generally be replaced by either `commentTagsToContent` or just `DocTree.toString()`.

Two bugs were uncovered as a result of the cleanup.  These are described in detail in a comment with screenshots in the [bug report](https://bugs.openjdk.org/browse/JDK-8288624?focusedCommentId=14508488&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14508488)  

Fixing the `see-list-long` bug was a direct reason to cleanup `commentTagsToContent`. The fix here could maybe be further improved by writing a simple visitor or (preferably) a pattern-switch when that is a standard feature of the language.

Fixing the other bug was mostly an accidental side-effect of just using `commentTagsToContent` instead of `CommentHelper.getText`, since the tags now get interpreted instead of ignored.  However, one tweak was necessary.
The doc comments for serialization info end up in `serialized-form.html` and not in the primary file for the enclosing type.
This means they should not undergo the standard `redirectRelativeLinks` treatment. Links using `{@link...}` are not affected, but links using explicit `<a href="relative-link">...</a>` are affected. Ideally, we should not be using such relative links in the JDK API documentation, but there are too many to change/fix as part of this work. The fix, for now, is to add a new overload to `commentTagsToContent` that provides the ability to disable the call to `redirectRelativeLinks` when needed ... that is, when generating `serialized-form.html`.

Initially, the goal was just a cleanup fix with no change to tests. The work has been tested by comparing generated docs before and after this work. There are a number of instances of differences in the generated docs, but all are instances of the bugs described above ... either the `see-list-long` bug, or the change that inline doc comment tags are now interpretedin places where they were previously ignored.  All existing tests continue to work without modification; new tests have been added for the fixes for the bugs that were discovered in the course of this work.
