### PR TITLE
JDK-8290046: NMT: Remove unused MallocSiteTable::reset()

### DIFF
--- a/src/hotspot/share/services/mallocSiteTable.cpp
+++ b/src/hotspot/share/services/mallocSiteTable.cpp
@@ -178,28 +178,6 @@ MallocSiteHashtableEntry* MallocSiteTable::new_entry(const NativeCallStack& key,
   return ::new (p) MallocSiteHashtableEntry(key, flags);
 }
 
-void MallocSiteTable::reset() {
-  for (int index = 0; index < table_size; index ++) {
-    MallocSiteHashtableEntry* head = _table[index];
-    _table[index] = NULL;
-    delete_linked_list(head);
-  }
-
-  _hash_entry_allocation_stack = NULL;
-  _hash_entry_allocation_site = NULL;
-}
-
-void MallocSiteTable::delete_linked_list(MallocSiteHashtableEntry* head) {
-  MallocSiteHashtableEntry* p;
-  while (head != NULL) {
-    p = head;
-    head = (MallocSiteHashtableEntry*)head->next();
-    if (p != hash_entry_allocation_site()) {
-      delete p;
-    }
-  }
-}
-
 bool MallocSiteTable::walk_malloc_site(MallocSiteWalker* walker) {
   assert(walker != NULL, "NuLL walker");
   return walk(walker);

--- a/src/hotspot/share/services/mallocSiteTable.hpp
+++ b/src/hotspot/share/services/mallocSiteTable.hpp
@@ -174,10 +174,6 @@ class MallocSiteTable : AllStatic {
 
  private:
   static MallocSiteHashtableEntry* new_entry(const NativeCallStack& key, MEMFLAGS flags);
-  static void reset();
-
-  // Delete a bucket linked list
-  static void delete_linked_list(MallocSiteHashtableEntry* head);
 
   static MallocSite* lookup_or_add(const NativeCallStack& key, uint32_t* marker, MEMFLAGS flags);
   static MallocSite* malloc_site(uint32_t marker);


### PR DESCRIPTION
Trivial cleanup. `MallocSiteTable::reset()` and `MallocSiteTable::delete_linked_list()` are not used anymore since [JDK-8256844](https://bugs.openjdk.org/browse/JDK-8256844). They can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290046](https://bugs.openjdk.org/browse/JDK-8290046): NMT: Remove unused MallocSiteTable::reset()


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9441/head:pull/9441` \
`$ git checkout pull/9441`

Update a local copy of the PR: \
`$ git checkout pull/9441` \
`$ git pull https://git.openjdk.org/jdk pull/9441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9441`

View PR using the GUI difftool: \
`$ git pr show -t 9441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9441.diff">https://git.openjdk.org/jdk/pull/9441.diff</a>

</details>
