### PR TITLE
8290062: Remove nmethodLocker for nmethods on-stack

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1072,8 +1072,6 @@ Handle SharedRuntime::find_callee_info(Bytecodes::Code& bc, CallInfo& callinfo, 
 Method* SharedRuntime::extract_attached_method(vframeStream& vfst) {
   CompiledMethod* caller = vfst.nm();
 
-  nmethodLocker caller_lock(caller);
-
   address pc = vfst.frame_pc();
   { // Get call instruction under lock because another thread may be busy patching it.
     CompiledICLocker ic_locker(caller);
@@ -1364,11 +1362,6 @@ methodHandle SharedRuntime::resolve_sub_helper(bool is_virtual, bool is_optimize
   CodeBlob* caller_cb = caller_frame.cb();
   guarantee(caller_cb != NULL && caller_cb->is_compiled(), "must be called from compiled method");
   CompiledMethod* caller_nm = caller_cb->as_compiled_method_or_null();
-
-  // make sure caller is not getting deoptimized
-  // and removed before we are done with it.
-  // CLEANUP - with lazy deopt shouldn't need this lock
-  nmethodLocker caller_lock(caller_nm);
 
   // determine call info & receiver
   // note: a) receiver is NULL for static calls
@@ -1851,10 +1844,6 @@ methodHandle SharedRuntime::reresolve_call_site(TRAPS) {
       // Location of call instruction
       call_addr = caller_nm->call_instruction_address(pc);
     }
-    // Make sure nmethod doesn't get deoptimized and removed until
-    // this is done with it.
-    // CLEANUP - with lazy deopt shouldn't need this lock
-    nmethodLocker nmlock(caller_nm);
 
     // Check relocations for the matching call to 1) avoid false positives,
     // and 2) determine the type.


### PR DESCRIPTION
From JBS:

> The nmethodLocker is pretty nasty as it prevents an nmethod from being freed, but without really keeping it alive. We would like to minimize its use. The most obvious places where it can be removed, is when "protecting" nmethods that are already on-stack. Neither the sweeper nor the GC is interested in making nmethods on-stack not live. These ones simply do not do anything.

Removed the `nmethodLocker` where the nmethod is a caller on the stack.

Testing: tier1-7

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290062](https://bugs.openjdk.org/browse/JDK-8290062): Remove nmethodLocker for nmethods on-stack


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9444/head:pull/9444` \
`$ git checkout pull/9444`

Update a local copy of the PR: \
`$ git checkout pull/9444` \
`$ git pull https://git.openjdk.org/jdk pull/9444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9444`

View PR using the GUI difftool: \
`$ git pr show -t 9444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9444.diff">https://git.openjdk.org/jdk/pull/9444.diff</a>

</details>
