### PR TITLE
8290065: [JVMCI] only check HotSpotCompiledCode stream is empty if installation succeeds

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
@@ -692,7 +692,7 @@ JVMCI::CodeInstallResult CodeInstaller::install(JVMCICompiler* compiler,
   JVMCI::CodeInstallResult result = initialize_buffer(compiled_code, buffer, stream, code_flags, JVMCI_CHECK_OK);
 
   u4 available = stream->available();
-  if (available != 0) {
+  if (result == JVMCI::ok && available != 0) {
     JVMCI_ERROR_OK("%d bytes remaining in stream%s", available, stream->context());
   }
 


### PR DESCRIPTION
Decoding the HotSpotCompiledCode stream (see [JDK-8289094](https://bugs.openjdk.org/browse/JDK-8289094)) can be short circuited if certain limits are encountered such as the code cache being full or `JVMCINMethodSizeLimit` being exceeded.
This PR omits the check that the complete stream has been read should be emitted if such a limit is hit.