### PR TITLE
8290066: Remove KNL specific handling for new CPU target check in IR annotation

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -938,8 +938,6 @@ void VM_Version::get_processor_features() {
     _features &= ~CPU_HT;
   }
 
-  // Note: Any modifications to following suppressed feature list for KNL target
-  // should also be applied to test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
   if (is_intel()) { // Intel cpus specific settings
     if (is_knights_family()) {
       _features &= ~CPU_VZEROUPPER;

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -134,6 +134,8 @@ public class TestFramework {
                     "Xmixed",
                     "server",
                     "Xlog",
+                    "UseAVX",
+                    "UseKNLSetting",
                     "LogCompilation"
             )
     );

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -134,8 +134,6 @@ public class TestFramework {
                     "Xmixed",
                     "server",
                     "Xlog",
-                    "UseAVX",
-                    "UseKNLSetting",
                     "LogCompilation"
             )
     );

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -280,30 +280,7 @@ public class IREncodingPrinter {
             return false;
         }
         String cpuFeatures = WHITE_BOX.getCPUFeatures();
-        // Following feature list is in sync with suppressed feature list for KNL target.
-        // Please refer vm_version_x86.cpp for details.
-        HashSet<String> knlFeatureSet = new HashSet<>();
-        knlFeatureSet.add("AVX512BW");
-        knlFeatureSet.add("AVX512VL");
-        knlFeatureSet.add("AVX512DQ");
-        knlFeatureSet.add("AVX512_VNNI");
-        knlFeatureSet.add("AVX512_VAES");
-        knlFeatureSet.add("AVX512_VPOPCNTDQ");
-        knlFeatureSet.add("AVX512_VPCLMULQDQ");
-        knlFeatureSet.add("AVX512_VBMI");
-        knlFeatureSet.add("AVX512_VBMI2");
-        knlFeatureSet.add("CLWB");
-        knlFeatureSet.add("FLUSHOPT");
-        knlFeatureSet.add("GFNI");
-        knlFeatureSet.add("AVX512_BITALG");
-        Boolean isKNLFlagEnabled = WHITE_BOX.getBooleanVMFlag("UseKNLSetting");
-        // Perform the feature check if UseKNLSetting flag is set to off or if
-        // feature is supported by KNL target.
-        if (isKNLFlagEnabled == null ||
-             (isKNLFlagEnabled && (!knlFeatureSet.contains(feature.toUpperCase()) || falseValue))) {
-            return (trueValue && cpuFeatures.contains(feature)) || (falseValue && !cpuFeatures.contains(feature));
-        }
-        return false;
+        return (trueValue && cpuFeatures.contains(feature)) || (falseValue && !cpuFeatures.contains(feature));
     }
 
     private boolean hasNoRequiredFlags(String[] orRules, String ruleType) {

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestCPUFeatureCheck.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestCPUFeatureCheck.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-package compiler.vectorapi;
+package ir_framework.tests;
 
 import compiler.lib.ir_framework.*;
 import compiler.lib.ir_framework.driver.irmatching.IRViolationException;
@@ -32,16 +32,17 @@ import compiler.lib.ir_framework.driver.irmatching.IRViolationException;
  * @requires vm.cpu.features ~= ".*avx512f.*"
  * @requires os.arch=="amd64" | os.arch=="x86_64"
  * @library /test/lib /
- * @run driver compiler.vectorapi.TestCPUFeatureCheck
+ * @run driver ir_framework.tests.TestCPUFeatureCheck
  */
 
 public class TestCPUFeatureCheck {
-    private static int a[] = new int[1000];
-    private static int b[] = new int[1000];
-    private static int res[] = new int[1000];
+    private static final int SIZE = 1000;
+    private static int a[] = new int[SIZE];
+    private static int b[] = new int[SIZE];
+    private static int res[] = new int[SIZE];
 
     public static void setup() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < SIZE; i++) {
             a[i] = i;
             b[i] = i;
         }
@@ -49,16 +50,13 @@ public class TestCPUFeatureCheck {
 
     public static void main(String args[]) {
         setup();
-        TestFramework.runWithFlags("-XX:-TieredCompilation",
-                                   "-XX:UseAVX=3",
-                                   "-XX:+UseKNLSetting",
-                                   "-XX:CompileThresholdScaling=0.3");
+        TestFramework.runWithFlags("-XX:+UseKNLSetting");
     }
 
     @Test
     @IR(counts = {IRNode.ADD_VI, "> 0"}, applyIfCPUFeature = {"avx512bw", "false"})
     public static void test1() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < SIZE; i++) {
             res[i] = a[i] + b[i];
         }
     }
@@ -67,7 +65,7 @@ public class TestCPUFeatureCheck {
     @Test
     @IR(counts = {IRNode.ADD_VI, "> 0"}, applyIfCPUFeatureAnd = {"avx512bw", "false", "avx512f", "true"})
     public static void test2() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < SIZE; i++) {
             res[i] = a[i] + b[i];
         }
     }
@@ -76,7 +74,7 @@ public class TestCPUFeatureCheck {
     @Test
     @IR(counts = {IRNode.ADD_VI,  "> 0"}, applyIfCPUFeatureOr = {"avx512bw", "true", "avx512f", "true"})
     public static void test3() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < SIZE; i++) {
             res[i] = a[i] + b[i];
         }
     }


### PR DESCRIPTION
- Newly added annotations query the CPU feature using white box API which returns the list of features enabled during VM initialization.
- With JVM flag UseKNLSetting, during VM initialization AVX512 features not supported by KNL target are disabled, thus we do not need any special handling for KNL in newly introduced IR annotations (applyCPUFeature, applyCPUFeatureOr, applyCPUFeatureAnd).

Please review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290066](https://bugs.openjdk.org/browse/JDK-8290066): Remove KNL specific handling for new CPU target check in IR annotation


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9452/head:pull/9452` \
`$ git checkout pull/9452`

Update a local copy of the PR: \
`$ git checkout pull/9452` \
`$ git pull https://git.openjdk.org/jdk pull/9452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9452`

View PR using the GUI difftool: \
`$ git pr show -t 9452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9452.diff">https://git.openjdk.org/jdk/pull/9452.diff</a>

</details>
