### PR TITLE
8290082: [PPC64] ZGC C2 load barrier stub needs to preserve vector registers

### DIFF
--- a/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.cpp
@@ -400,36 +400,40 @@ OptoReg::Name ZBarrierSetAssembler::refine_register(const Node* node, OptoReg::N
 #define __ _masm->
 
 class ZSaveLiveRegisters {
-
- private:
   MacroAssembler* _masm;
   RegMask _reg_mask;
   Register _result_reg;
+  int _frame_size;
 
  public:
   ZSaveLiveRegisters(MacroAssembler *masm, ZLoadBarrierStubC2 *stub)
       : _masm(masm), _reg_mask(stub->live()), _result_reg(stub->ref()) {
 
-    const int total_regs_amount = iterate_over_register_mask(ACTION_SAVE);
+    const int register_save_size = iterate_over_register_mask(ACTION_COUNT_ONLY) * BytesPerWord;
+    _frame_size = align_up(register_save_size, frame::alignment_in_bytes)
+                  + frame::abi_reg_args_size;
 
     __ save_LR_CR(R0);
-    __ push_frame_reg_args(total_regs_amount * BytesPerWord, R0);
+    __ push_frame(_frame_size, R0);
+
+    iterate_over_register_mask(ACTION_SAVE, _frame_size);
   }
 
   ~ZSaveLiveRegisters() {
-    __ pop_frame();
-    __ restore_LR_CR(R0);
+    iterate_over_register_mask(ACTION_RESTORE, _frame_size);
 
-    iterate_over_register_mask(ACTION_RESTORE);
+    __ addi(R1_SP, R1_SP, _frame_size);
+    __ restore_LR_CR(R0);
   }
 
  private:
   enum IterationAction : int {
-    ACTION_SAVE = 0,
-    ACTION_RESTORE = 1
+    ACTION_SAVE,
+    ACTION_RESTORE,
+    ACTION_COUNT_ONLY
   };
 
-  int iterate_over_register_mask(IterationAction action) {
+  int iterate_over_register_mask(IterationAction action, int offset = 0) {
     int reg_save_index = 0;
     RegMaskIterator live_regs_iterator(_reg_mask);
 
@@ -454,11 +458,11 @@ class ZSaveLiveRegisters {
           reg_save_index++;
 
           if (action == ACTION_SAVE) {
-            _masm->std(std_reg, (intptr_t) -reg_save_index * BytesPerWord, R1_SP);
+            _masm->std(std_reg, offset - reg_save_index * BytesPerWord, R1_SP);
           } else if (action == ACTION_RESTORE) {
-            _masm->ld(std_reg, (intptr_t) -reg_save_index * BytesPerWord, R1_SP);
+            _masm->ld(std_reg, offset - reg_save_index * BytesPerWord, R1_SP);
           } else {
-            fatal("Sanity");
+            assert(action == ACTION_COUNT_ONLY, "Sanity");
           }
         }
       } else if (vm_reg->is_FloatRegister()) {
@@ -467,11 +471,11 @@ class ZSaveLiveRegisters {
           reg_save_index++;
 
           if (action == ACTION_SAVE) {
-            _masm->stfd(fp_reg, (intptr_t) -reg_save_index * BytesPerWord, R1_SP);
+            _masm->stfd(fp_reg, offset - reg_save_index * BytesPerWord, R1_SP);
           } else if (action == ACTION_RESTORE) {
-            _masm->lfd(fp_reg, (intptr_t) -reg_save_index * BytesPerWord, R1_SP);
+            _masm->lfd(fp_reg, offset - reg_save_index * BytesPerWord, R1_SP);
           } else {
-            fatal("Sanity");
+            assert(action == ACTION_COUNT_ONLY, "Sanity");
           }
         }
       } else if (vm_reg->is_ConditionRegister()) {
@@ -483,11 +487,14 @@ class ZSaveLiveRegisters {
           reg_save_index += 2;
 
           Register spill_addr = R0;
-          _masm->addi(spill_addr, R1_SP, -reg_save_index * BytesPerWord);
           if (action == ACTION_SAVE) {
+            _masm->addi(spill_addr, R1_SP, offset - reg_save_index * BytesPerWord);
             _masm->stxvd2x(vs_reg, spill_addr);
           } else if (action == ACTION_RESTORE) {
+            _masm->addi(spill_addr, R1_SP, offset - reg_save_index * BytesPerWord);
             _masm->lxvd2x(vs_reg, spill_addr);
+          } else {
+            assert(action == ACTION_COUNT_ONLY, "Sanity");
           }
         }
       } else {
@@ -507,7 +514,6 @@ class ZSaveLiveRegisters {
 #define __ _masm->
 
 class ZSetupArguments {
- private:
   MacroAssembler* const _masm;
   const Register        _ref;
   const Address         _ref_addr;

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -254,9 +254,10 @@ register %{
   reg_def SR_SPEFSCR(SOC, SOC, Op_RegP, 4, SR_SPEFSCR->as_VMReg()); // v
   reg_def SR_PPR(    SOC, SOC, Op_RegP, 5, SR_PPR->as_VMReg());     // v
 
-// ----------------------------
-// Vector-Scalar Registers
-// ----------------------------
+  // ----------------------------
+  // Vector-Scalar Registers
+  // ----------------------------
+  // 1st 32 VSRs are aliases for the FPRs wich are already defined above.
   reg_def VSR0 ( SOC, SOC, Op_VecX, 0, VMRegImpl::Bad());
   reg_def VSR1 ( SOC, SOC, Op_VecX, 1, VMRegImpl::Bad());
   reg_def VSR2 ( SOC, SOC, Op_VecX, 2, VMRegImpl::Bad());
@@ -289,38 +290,39 @@ register %{
   reg_def VSR29 ( SOC, SOC, Op_VecX, 29, VMRegImpl::Bad());
   reg_def VSR30 ( SOC, SOC, Op_VecX, 30, VMRegImpl::Bad());
   reg_def VSR31 ( SOC, SOC, Op_VecX, 31, VMRegImpl::Bad());
-  reg_def VSR32 ( SOC, SOC, Op_VecX, 32, VMRegImpl::Bad());
-  reg_def VSR33 ( SOC, SOC, Op_VecX, 33, VMRegImpl::Bad());
-  reg_def VSR34 ( SOC, SOC, Op_VecX, 34, VMRegImpl::Bad());
-  reg_def VSR35 ( SOC, SOC, Op_VecX, 35, VMRegImpl::Bad());
-  reg_def VSR36 ( SOC, SOC, Op_VecX, 36, VMRegImpl::Bad());
-  reg_def VSR37 ( SOC, SOC, Op_VecX, 37, VMRegImpl::Bad());
-  reg_def VSR38 ( SOC, SOC, Op_VecX, 38, VMRegImpl::Bad());
-  reg_def VSR39 ( SOC, SOC, Op_VecX, 39, VMRegImpl::Bad());
-  reg_def VSR40 ( SOC, SOC, Op_VecX, 40, VMRegImpl::Bad());
-  reg_def VSR41 ( SOC, SOC, Op_VecX, 41, VMRegImpl::Bad());
-  reg_def VSR42 ( SOC, SOC, Op_VecX, 42, VMRegImpl::Bad());
-  reg_def VSR43 ( SOC, SOC, Op_VecX, 43, VMRegImpl::Bad());
-  reg_def VSR44 ( SOC, SOC, Op_VecX, 44, VMRegImpl::Bad());
-  reg_def VSR45 ( SOC, SOC, Op_VecX, 45, VMRegImpl::Bad());
-  reg_def VSR46 ( SOC, SOC, Op_VecX, 46, VMRegImpl::Bad());
-  reg_def VSR47 ( SOC, SOC, Op_VecX, 47, VMRegImpl::Bad());
-  reg_def VSR48 ( SOC, SOC, Op_VecX, 48, VMRegImpl::Bad());
-  reg_def VSR49 ( SOC, SOC, Op_VecX, 49, VMRegImpl::Bad());
-  reg_def VSR50 ( SOC, SOC, Op_VecX, 50, VMRegImpl::Bad());
-  reg_def VSR51 ( SOC, SOC, Op_VecX, 51, VMRegImpl::Bad());
-  reg_def VSR52 ( SOC, SOC, Op_VecX, 52, VMRegImpl::Bad());
-  reg_def VSR53 ( SOC, SOC, Op_VecX, 53, VMRegImpl::Bad());
-  reg_def VSR54 ( SOC, SOC, Op_VecX, 54, VMRegImpl::Bad());
-  reg_def VSR55 ( SOC, SOC, Op_VecX, 55, VMRegImpl::Bad());
-  reg_def VSR56 ( SOC, SOC, Op_VecX, 56, VMRegImpl::Bad());
-  reg_def VSR57 ( SOC, SOC, Op_VecX, 57, VMRegImpl::Bad());
-  reg_def VSR58 ( SOC, SOC, Op_VecX, 58, VMRegImpl::Bad());
-  reg_def VSR59 ( SOC, SOC, Op_VecX, 59, VMRegImpl::Bad());
-  reg_def VSR60 ( SOC, SOC, Op_VecX, 60, VMRegImpl::Bad());
-  reg_def VSR61 ( SOC, SOC, Op_VecX, 61, VMRegImpl::Bad());
-  reg_def VSR62 ( SOC, SOC, Op_VecX, 62, VMRegImpl::Bad());
-  reg_def VSR63 ( SOC, SOC, Op_VecX, 63, VMRegImpl::Bad());
+  // 2nd 32 VSRs are aliases for the VRs which are only defined here.
+  reg_def VSR32 ( SOC, SOC, Op_VecX, 32, VSR32->as_VMReg());
+  reg_def VSR33 ( SOC, SOC, Op_VecX, 33, VSR33->as_VMReg());
+  reg_def VSR34 ( SOC, SOC, Op_VecX, 34, VSR34->as_VMReg());
+  reg_def VSR35 ( SOC, SOC, Op_VecX, 35, VSR35->as_VMReg());
+  reg_def VSR36 ( SOC, SOC, Op_VecX, 36, VSR36->as_VMReg());
+  reg_def VSR37 ( SOC, SOC, Op_VecX, 37, VSR37->as_VMReg());
+  reg_def VSR38 ( SOC, SOC, Op_VecX, 38, VSR38->as_VMReg());
+  reg_def VSR39 ( SOC, SOC, Op_VecX, 39, VSR39->as_VMReg());
+  reg_def VSR40 ( SOC, SOC, Op_VecX, 40, VSR40->as_VMReg());
+  reg_def VSR41 ( SOC, SOC, Op_VecX, 41, VSR41->as_VMReg());
+  reg_def VSR42 ( SOC, SOC, Op_VecX, 42, VSR42->as_VMReg());
+  reg_def VSR43 ( SOC, SOC, Op_VecX, 43, VSR43->as_VMReg());
+  reg_def VSR44 ( SOC, SOC, Op_VecX, 44, VSR44->as_VMReg());
+  reg_def VSR45 ( SOC, SOC, Op_VecX, 45, VSR45->as_VMReg());
+  reg_def VSR46 ( SOC, SOC, Op_VecX, 46, VSR46->as_VMReg());
+  reg_def VSR47 ( SOC, SOC, Op_VecX, 47, VSR47->as_VMReg());
+  reg_def VSR48 ( SOC, SOC, Op_VecX, 48, VSR48->as_VMReg());
+  reg_def VSR49 ( SOC, SOC, Op_VecX, 49, VSR49->as_VMReg());
+  reg_def VSR50 ( SOC, SOC, Op_VecX, 50, VSR50->as_VMReg());
+  reg_def VSR51 ( SOC, SOC, Op_VecX, 51, VSR51->as_VMReg());
+  reg_def VSR52 ( SOC, SOC, Op_VecX, 52, VSR52->as_VMReg());
+  reg_def VSR53 ( SOC, SOC, Op_VecX, 53, VSR53->as_VMReg());
+  reg_def VSR54 ( SOC, SOC, Op_VecX, 54, VSR54->as_VMReg());
+  reg_def VSR55 ( SOC, SOC, Op_VecX, 55, VSR55->as_VMReg());
+  reg_def VSR56 ( SOC, SOC, Op_VecX, 56, VSR56->as_VMReg());
+  reg_def VSR57 ( SOC, SOC, Op_VecX, 57, VSR57->as_VMReg());
+  reg_def VSR58 ( SOC, SOC, Op_VecX, 58, VSR58->as_VMReg());
+  reg_def VSR59 ( SOC, SOC, Op_VecX, 59, VSR59->as_VMReg());
+  reg_def VSR60 ( SOC, SOC, Op_VecX, 60, VSR60->as_VMReg());
+  reg_def VSR61 ( SOC, SOC, Op_VecX, 61, VSR61->as_VMReg());
+  reg_def VSR62 ( SOC, SOC, Op_VecX, 62, VSR62->as_VMReg());
+  reg_def VSR63 ( SOC, SOC, Op_VecX, 63, VSR63->as_VMReg());
 
 // ----------------------------
 // Specify priority of register selection within phases of register

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -257,7 +257,7 @@ register %{
 // ----------------------------
 // Vector-Scalar Registers
 // ----------------------------
-  // 1st 32 VSRs are aliases for the FPRs wich are already defined above.
+  // 1st 32 VSRs are aliases for the FPRs which are already defined above.
   reg_def VSR0 ( SOC, SOC, Op_VecX, 0, VMRegImpl::Bad());
   reg_def VSR1 ( SOC, SOC, Op_VecX, 1, VMRegImpl::Bad());
   reg_def VSR2 ( SOC, SOC, Op_VecX, 2, VMRegImpl::Bad());

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -254,9 +254,9 @@ register %{
   reg_def SR_SPEFSCR(SOC, SOC, Op_RegP, 4, SR_SPEFSCR->as_VMReg()); // v
   reg_def SR_PPR(    SOC, SOC, Op_RegP, 5, SR_PPR->as_VMReg());     // v
 
-  // ----------------------------
-  // Vector-Scalar Registers
-  // ----------------------------
+// ----------------------------
+// Vector-Scalar Registers
+// ----------------------------
   // 1st 32 VSRs are aliases for the FPRs wich are already defined above.
   reg_def VSR0 ( SOC, SOC, Op_VecX, 0, VMRegImpl::Bad());
   reg_def VSR1 ( SOC, SOC, Op_VecX, 1, VMRegImpl::Bad());
@@ -272,24 +272,24 @@ register %{
   reg_def VSR11 ( SOC, SOC, Op_VecX, 11, VMRegImpl::Bad());
   reg_def VSR12 ( SOC, SOC, Op_VecX, 12, VMRegImpl::Bad());
   reg_def VSR13 ( SOC, SOC, Op_VecX, 13, VMRegImpl::Bad());
-  reg_def VSR14 ( SOC, SOC, Op_VecX, 14, VMRegImpl::Bad());
-  reg_def VSR15 ( SOC, SOC, Op_VecX, 15, VMRegImpl::Bad());
-  reg_def VSR16 ( SOC, SOC, Op_VecX, 16, VMRegImpl::Bad());
-  reg_def VSR17 ( SOC, SOC, Op_VecX, 17, VMRegImpl::Bad());
-  reg_def VSR18 ( SOC, SOC, Op_VecX, 18, VMRegImpl::Bad());
-  reg_def VSR19 ( SOC, SOC, Op_VecX, 19, VMRegImpl::Bad());
-  reg_def VSR20 ( SOC, SOC, Op_VecX, 20, VMRegImpl::Bad());
-  reg_def VSR21 ( SOC, SOC, Op_VecX, 21, VMRegImpl::Bad());
-  reg_def VSR22 ( SOC, SOC, Op_VecX, 22, VMRegImpl::Bad());
-  reg_def VSR23 ( SOC, SOC, Op_VecX, 23, VMRegImpl::Bad());
-  reg_def VSR24 ( SOC, SOC, Op_VecX, 24, VMRegImpl::Bad());
-  reg_def VSR25 ( SOC, SOC, Op_VecX, 25, VMRegImpl::Bad());
-  reg_def VSR26 ( SOC, SOC, Op_VecX, 26, VMRegImpl::Bad());
-  reg_def VSR27 ( SOC, SOC, Op_VecX, 27, VMRegImpl::Bad());
-  reg_def VSR28 ( SOC, SOC, Op_VecX, 28, VMRegImpl::Bad());
-  reg_def VSR29 ( SOC, SOC, Op_VecX, 29, VMRegImpl::Bad());
-  reg_def VSR30 ( SOC, SOC, Op_VecX, 30, VMRegImpl::Bad());
-  reg_def VSR31 ( SOC, SOC, Op_VecX, 31, VMRegImpl::Bad());
+  reg_def VSR14 ( SOC, SOE, Op_VecX, 14, VMRegImpl::Bad());
+  reg_def VSR15 ( SOC, SOE, Op_VecX, 15, VMRegImpl::Bad());
+  reg_def VSR16 ( SOC, SOE, Op_VecX, 16, VMRegImpl::Bad());
+  reg_def VSR17 ( SOC, SOE, Op_VecX, 17, VMRegImpl::Bad());
+  reg_def VSR18 ( SOC, SOE, Op_VecX, 18, VMRegImpl::Bad());
+  reg_def VSR19 ( SOC, SOE, Op_VecX, 19, VMRegImpl::Bad());
+  reg_def VSR20 ( SOC, SOE, Op_VecX, 20, VMRegImpl::Bad());
+  reg_def VSR21 ( SOC, SOE, Op_VecX, 21, VMRegImpl::Bad());
+  reg_def VSR22 ( SOC, SOE, Op_VecX, 22, VMRegImpl::Bad());
+  reg_def VSR23 ( SOC, SOE, Op_VecX, 23, VMRegImpl::Bad());
+  reg_def VSR24 ( SOC, SOE, Op_VecX, 24, VMRegImpl::Bad());
+  reg_def VSR25 ( SOC, SOE, Op_VecX, 25, VMRegImpl::Bad());
+  reg_def VSR26 ( SOC, SOE, Op_VecX, 26, VMRegImpl::Bad());
+  reg_def VSR27 ( SOC, SOE, Op_VecX, 27, VMRegImpl::Bad());
+  reg_def VSR28 ( SOC, SOE, Op_VecX, 28, VMRegImpl::Bad());
+  reg_def VSR29 ( SOC, SOE, Op_VecX, 29, VMRegImpl::Bad());
+  reg_def VSR30 ( SOC, SOE, Op_VecX, 30, VMRegImpl::Bad());
+  reg_def VSR31 ( SOC, SOE, Op_VecX, 31, VMRegImpl::Bad());
   // 2nd 32 VSRs are aliases for the VRs which are only defined here.
   reg_def VSR32 ( SOC, SOC, Op_VecX, 32, VSR32->as_VMReg());
   reg_def VSR33 ( SOC, SOC, Op_VecX, 33, VSR33->as_VMReg());
@@ -311,18 +311,18 @@ register %{
   reg_def VSR49 ( SOC, SOC, Op_VecX, 49, VSR49->as_VMReg());
   reg_def VSR50 ( SOC, SOC, Op_VecX, 50, VSR50->as_VMReg());
   reg_def VSR51 ( SOC, SOC, Op_VecX, 51, VSR51->as_VMReg());
-  reg_def VSR52 ( SOC, SOC, Op_VecX, 52, VSR52->as_VMReg());
-  reg_def VSR53 ( SOC, SOC, Op_VecX, 53, VSR53->as_VMReg());
-  reg_def VSR54 ( SOC, SOC, Op_VecX, 54, VSR54->as_VMReg());
-  reg_def VSR55 ( SOC, SOC, Op_VecX, 55, VSR55->as_VMReg());
-  reg_def VSR56 ( SOC, SOC, Op_VecX, 56, VSR56->as_VMReg());
-  reg_def VSR57 ( SOC, SOC, Op_VecX, 57, VSR57->as_VMReg());
-  reg_def VSR58 ( SOC, SOC, Op_VecX, 58, VSR58->as_VMReg());
-  reg_def VSR59 ( SOC, SOC, Op_VecX, 59, VSR59->as_VMReg());
-  reg_def VSR60 ( SOC, SOC, Op_VecX, 60, VSR60->as_VMReg());
-  reg_def VSR61 ( SOC, SOC, Op_VecX, 61, VSR61->as_VMReg());
-  reg_def VSR62 ( SOC, SOC, Op_VecX, 62, VSR62->as_VMReg());
-  reg_def VSR63 ( SOC, SOC, Op_VecX, 63, VSR63->as_VMReg());
+  reg_def VSR52 ( SOC, SOE, Op_VecX, 52, VSR52->as_VMReg());
+  reg_def VSR53 ( SOC, SOE, Op_VecX, 53, VSR53->as_VMReg());
+  reg_def VSR54 ( SOC, SOE, Op_VecX, 54, VSR54->as_VMReg());
+  reg_def VSR55 ( SOC, SOE, Op_VecX, 55, VSR55->as_VMReg());
+  reg_def VSR56 ( SOC, SOE, Op_VecX, 56, VSR56->as_VMReg());
+  reg_def VSR57 ( SOC, SOE, Op_VecX, 57, VSR57->as_VMReg());
+  reg_def VSR58 ( SOC, SOE, Op_VecX, 58, VSR58->as_VMReg());
+  reg_def VSR59 ( SOC, SOE, Op_VecX, 59, VSR59->as_VMReg());
+  reg_def VSR60 ( SOC, SOE, Op_VecX, 60, VSR60->as_VMReg());
+  reg_def VSR61 ( SOC, SOE, Op_VecX, 61, VSR61->as_VMReg());
+  reg_def VSR62 ( SOC, SOE, Op_VecX, 62, VSR62->as_VMReg());
+  reg_def VSR63 ( SOC, SOE, Op_VecX, 63, VSR63->as_VMReg());
 
 // ----------------------------
 // Specify priority of register selection within phases of register

--- a/src/hotspot/cpu/ppc/register_ppc.hpp
+++ b/src/hotspot/cpu/ppc/register_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2018 SAP SE. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,11 @@ typedef VMRegImpl* VMReg;
 //  v14-v19   Volatile scratch registers
 //  v20-v31   Non-volatile registers
 //  vrsave    Non-volatile 32-bit register
-
+//
+//  ----------------------------------------------
+//  On processors with VSX feature:
+//  vs0-31    Alias for f0-f31 (64 bit, see above)
+//  vs32-63   Alias for v0-31 (128 bit, see above)
 
 // Use Register as shortcut
 class RegisterImpl;

--- a/src/hotspot/cpu/ppc/vmreg_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vmreg_ppc.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,13 @@ void VMRegImpl::set_regName() {
     if (reg->encoding() < FloatRegisterImpl::number_of_registers-1)
       freg = freg->successor();
   }
-  for ( ; i < ConcreteRegisterImpl::number_of_registers; i++) {
-    regName[i] = "NON-GPR-FPR";
+
+  VectorSRegister vsreg = ::as_VectorSRegister(0);
+  for ( ; i < ConcreteRegisterImpl::max_vsr; ) {
+    regName[i++] = vsreg->name();
+  }
+
+  for ( ; i < ConcreteRegisterImpl::number_of_registers; ) {
+    regName[i++] = "NON-GPR-FPR-VSR";
   }
 }

--- a/src/hotspot/cpu/ppc/vmreg_ppc.hpp
+++ b/src/hotspot/cpu/ppc/vmreg_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ inline bool is_FloatRegister() {
          value() < ConcreteRegisterImpl::max_fpr;
 }
 
-inline bool is_VectorRegister() {
+inline bool is_VectorSRegister() {
   return value() >= ConcreteRegisterImpl::max_fpr &&
          value() < ConcreteRegisterImpl::max_vsr;
 }
@@ -58,6 +58,11 @@ inline Register as_Register() {
 inline FloatRegister as_FloatRegister() {
   assert(is_FloatRegister() && is_even(value()), "must be");
   return ::as_FloatRegister((value() - ConcreteRegisterImpl::max_gpr) >> 1);
+}
+
+inline VectorSRegister as_VectorSRegister() {
+  assert(is_VectorSRegister(), "must be");
+  return ::as_VectorSRegister(value() - ConcreteRegisterImpl::max_fpr);
 }
 
 inline bool is_concrete() {


### PR DESCRIPTION
Preserve volatile vector registers in ZGC C2 load barrier stub.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290082](https://bugs.openjdk.org/browse/JDK-8290082): [PPC64] ZGC C2 load barrier stub needs to preserve vector registers


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to [a1ca2ea5](https://git.openjdk.org/jdk/pull/9453/files/a1ca2ea5267ea56b77f4798f43e29e9d92df68b4)
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**) ⚠️ Review applies to [2d8fa980](https://git.openjdk.org/jdk/pull/9453/files/2d8fa9808279d8ec0190c9d1946f4fbbc0a1aa25)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9453/head:pull/9453` \
`$ git checkout pull/9453`

Update a local copy of the PR: \
`$ git checkout pull/9453` \
`$ git pull https://git.openjdk.org/jdk pull/9453/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9453`

View PR using the GUI difftool: \
`$ git pr show -t 9453`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9453.diff">https://git.openjdk.org/jdk/pull/9453.diff</a>

</details>
