### PR TITLE
8290074: Remove implicit arguments for RegisterMap constructor

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -741,12 +741,12 @@ extern "C" void pf(uintptr_t sp, uintptr_t fp, uintptr_t pc,
     reg_map = NEW_C_HEAP_OBJ(RegisterMap, mtInternal);
     ::new (reg_map) RegisterMap((JavaThread*)thread,
                                 RegisterMap::UpdateMap::skip,
-                                RegisterMap::ProcessFrames::yes,
+                                RegisterMap::ProcessFrames::include,
                                 RegisterMap::WalkContinuation::skip);
   } else {
     *reg_map = RegisterMap((JavaThread*)thread,
                            RegisterMap::UpdateMap::skip,
-                           RegisterMap::ProcessFrames::yes,
+                           RegisterMap::ProcessFrames::include,
                            RegisterMap::WalkContinuation::skip);
   }
 

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -739,9 +739,15 @@ extern "C" void pf(uintptr_t sp, uintptr_t fp, uintptr_t pc,
                    uintptr_t bcx, uintptr_t thread) {
   if (!reg_map) {
     reg_map = NEW_C_HEAP_OBJ(RegisterMap, mtInternal);
-    ::new (reg_map) RegisterMap((JavaThread*)thread, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+    ::new (reg_map) RegisterMap((JavaThread*)thread,
+                                RegisterMap::UpdateMap::skip,
+                                RegisterMap::ProcessFrames::yes,
+                                RegisterMap::WalkContinuation::skip);
   } else {
-    *reg_map = RegisterMap((JavaThread*)thread, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+    *reg_map = RegisterMap((JavaThread*)thread,
+                           RegisterMap::UpdateMap::skip,
+                           RegisterMap::ProcessFrames::yes,
+                           RegisterMap::WalkContinuation::skip);
   }
 
   {

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -739,9 +739,9 @@ extern "C" void pf(uintptr_t sp, uintptr_t fp, uintptr_t pc,
                    uintptr_t bcx, uintptr_t thread) {
   if (!reg_map) {
     reg_map = NEW_C_HEAP_OBJ(RegisterMap, mtInternal);
-    ::new (reg_map) RegisterMap((JavaThread*)thread, false);
+    ::new (reg_map) RegisterMap((JavaThread*)thread, false /* update_map */, true /* process_frames */, false /* walk_cont */);
   } else {
-    *reg_map = RegisterMap((JavaThread*)thread, false);
+    *reg_map = RegisterMap((JavaThread*)thread, false /* update_map */, true /* process_frames */, false /* walk_cont */);
   }
 
   {

--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetNMethod_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetNMethod_aarch64.cpp
@@ -100,7 +100,7 @@ void BarrierSetNMethod::deoptimize(nmethod* nm, address* return_address_ptr) {
   JavaThread *thread = JavaThread::current();
   RegisterMap reg_map(thread,
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   frame frame = thread->last_frame();
 

--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetNMethod_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetNMethod_aarch64.cpp
@@ -98,7 +98,7 @@ void BarrierSetNMethod::deoptimize(nmethod* nm, address* return_address_ptr) {
   frame_pointers_t *new_frame = (frame_pointers_t *)(return_address_ptr - 5);
 
   JavaThread *thread = JavaThread::current();
-  RegisterMap reg_map(thread, false);
+  RegisterMap reg_map(thread, false /* update_map */, true /* process_frames */, false /* walk_cont */);
   frame frame = thread->last_frame();
 
   assert(frame.is_compiled_frame() || frame.is_native_frame(), "must be");

--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetNMethod_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetNMethod_aarch64.cpp
@@ -98,7 +98,10 @@ void BarrierSetNMethod::deoptimize(nmethod* nm, address* return_address_ptr) {
   frame_pointers_t *new_frame = (frame_pointers_t *)(return_address_ptr - 5);
 
   JavaThread *thread = JavaThread::current();
-  RegisterMap reg_map(thread, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(thread,
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   frame frame = thread->last_frame();
 
   assert(frame.is_compiled_frame() || frame.is_native_frame(), "must be");

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetNMethod_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetNMethod_riscv.cpp
@@ -113,7 +113,7 @@ void BarrierSetNMethod::deoptimize(nmethod* nm, address* return_address_ptr) {
   JavaThread *thread = JavaThread::current();
   RegisterMap reg_map(thread,
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   frame frame = thread->last_frame();
 

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetNMethod_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetNMethod_riscv.cpp
@@ -111,7 +111,10 @@ void BarrierSetNMethod::deoptimize(nmethod* nm, address* return_address_ptr) {
   frame_pointers_t *new_frame = (frame_pointers_t *)(return_address_ptr - 5);
 
   JavaThread *thread = JavaThread::current();
-  RegisterMap reg_map(thread, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(thread,
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   frame frame = thread->last_frame();
 
   assert(frame.is_compiled_frame() || frame.is_native_frame(), "must be");

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetNMethod_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetNMethod_riscv.cpp
@@ -111,7 +111,7 @@ void BarrierSetNMethod::deoptimize(nmethod* nm, address* return_address_ptr) {
   frame_pointers_t *new_frame = (frame_pointers_t *)(return_address_ptr - 5);
 
   JavaThread *thread = JavaThread::current();
-  RegisterMap reg_map(thread, false);
+  RegisterMap reg_map(thread, false /* update_map */, true /* process_frames */, false /* walk_cont */);
   frame frame = thread->last_frame();
 
   assert(frame.is_compiled_frame() || frame.is_native_frame(), "must be");

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -168,7 +168,7 @@ address Runtime1::arraycopy_count_address(BasicType type) {
 static bool caller_is_deopted(JavaThread* current) {
   RegisterMap reg_map(current,
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   frame runtime_frame = current->last_frame();
   frame caller_frame = runtime_frame.sender(&reg_map);
@@ -181,7 +181,7 @@ static void deopt_caller(JavaThread* current) {
   if (!caller_is_deopted(current)) {
     RegisterMap reg_map(current,
                         RegisterMap::UpdateMap::skip,
-                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::ProcessFrames::include,
                         RegisterMap::WalkContinuation::skip);
     frame runtime_frame = current->last_frame();
     frame caller_frame = runtime_frame.sender(&reg_map);
@@ -448,7 +448,7 @@ static nmethod* counter_overflow_helper(JavaThread* current, int branch_bci, Met
 
   RegisterMap map(current,
                   RegisterMap::UpdateMap::skip,
-                  RegisterMap::ProcessFrames::yes,
+                  RegisterMap::ProcessFrames::include,
                   RegisterMap::WalkContinuation::skip);
   frame fr =  current->last_frame().sender(&map);
   nmethod* nm = (nmethod*) fr.cb();
@@ -490,7 +490,7 @@ JRT_BLOCK_ENTRY(address, Runtime1::counter_overflow(JavaThread* current, int bci
     if (osr_nm != NULL) {
       RegisterMap map(current,
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
       frame fr =  current->last_frame().sender(&map);
       Deoptimization::deoptimize_frame(current, fr.id());
@@ -539,7 +539,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
   if (nm->is_deopt_pc(pc)) {
     RegisterMap map(current,
                     RegisterMap::UpdateMap::skip,
-                    RegisterMap::ProcessFrames::yes,
+                    RegisterMap::ProcessFrames::include,
                     RegisterMap::WalkContinuation::skip);
     frame exception_frame = current->last_frame().sender(&map);
     // if the frame isn't deopted then pc must not correspond to the caller of last_frame
@@ -580,8 +580,8 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
     // these same catches and throws as it unwound the frame.
 
     RegisterMap reg_map(current,
-                        RegisterMap::UpdateMap::yes,
-                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::UpdateMap::include,
+                        RegisterMap::ProcessFrames::include,
                         RegisterMap::WalkContinuation::skip);
     frame stub_frame = current->last_frame();
     frame caller_frame = stub_frame.sender(&reg_map);
@@ -780,7 +780,7 @@ JRT_ENTRY(void, Runtime1::deoptimize(JavaThread* current, jint trap_request))
   // Called from within the owner thread, so no need for safepoint
   RegisterMap reg_map(current,
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   frame stub_frame = current->last_frame();
   assert(stub_frame.is_runtime_frame(), "Sanity check");
@@ -932,7 +932,7 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
   ResourceMark rm(current);
   RegisterMap reg_map(current,
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   frame runtime_frame = current->last_frame();
   frame caller_frame = runtime_frame.sender(&reg_map);
@@ -1300,7 +1300,7 @@ void Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_id) {
 
   RegisterMap reg_map(current,
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
 
   frame runtime_frame = current->last_frame();
@@ -1430,7 +1430,7 @@ JRT_ENTRY(void, Runtime1::predicate_failed_trap(JavaThread* current))
 
   RegisterMap reg_map(current,
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   frame runtime_frame = current->last_frame();
   frame caller_frame = runtime_frame.sender(&reg_map);

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -166,7 +166,7 @@ address Runtime1::arraycopy_count_address(BasicType type) {
 // entered the VM has been deoptimized
 
 static bool caller_is_deopted(JavaThread* current) {
-  RegisterMap reg_map(current, false);
+  RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
   frame runtime_frame = current->last_frame();
   frame caller_frame = runtime_frame.sender(&reg_map);
   assert(caller_frame.is_compiled_frame(), "must be compiled");
@@ -176,7 +176,7 @@ static bool caller_is_deopted(JavaThread* current) {
 // Stress deoptimization
 static void deopt_caller(JavaThread* current) {
   if (!caller_is_deopted(current)) {
-    RegisterMap reg_map(current, false);
+    RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
     frame runtime_frame = current->last_frame();
     frame caller_frame = runtime_frame.sender(&reg_map);
     Deoptimization::deoptimize_frame(current, caller_frame.id());
@@ -440,7 +440,7 @@ static nmethod* counter_overflow_helper(JavaThread* current, int branch_bci, Met
   nmethod* osr_nm = NULL;
   methodHandle method(current, m);
 
-  RegisterMap map(current, false);
+  RegisterMap map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
   frame fr =  current->last_frame().sender(&map);
   nmethod* nm = (nmethod*) fr.cb();
   assert(nm!= NULL && nm->is_nmethod(), "Sanity check");
@@ -479,7 +479,7 @@ JRT_BLOCK_ENTRY(address, Runtime1::counter_overflow(JavaThread* current, int bci
   JRT_BLOCK
     osr_nm = counter_overflow_helper(current, bci, method);
     if (osr_nm != NULL) {
-      RegisterMap map(current, false);
+      RegisterMap map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
       frame fr =  current->last_frame().sender(&map);
       Deoptimization::deoptimize_frame(current, fr.id());
     }
@@ -525,7 +525,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
   assert(nm != NULL, "this is not an nmethod");
   // Adjust the pc as needed/
   if (nm->is_deopt_pc(pc)) {
-    RegisterMap map(current, false);
+    RegisterMap map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
     frame exception_frame = current->last_frame().sender(&map);
     // if the frame isn't deopted then pc must not correspond to the caller of last_frame
     assert(exception_frame.is_deoptimized_frame(), "must be deopted");
@@ -564,7 +564,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
     // notifications since the interpreter would also notify about
     // these same catches and throws as it unwound the frame.
 
-    RegisterMap reg_map(current);
+    RegisterMap reg_map(current, true /* update_map */, true /* process_frames */, false /* walk_cont */);
     frame stub_frame = current->last_frame();
     frame caller_frame = stub_frame.sender(&reg_map);
 
@@ -760,7 +760,7 @@ JRT_END
 // Cf. OptoRuntime::deoptimize_caller_frame
 JRT_ENTRY(void, Runtime1::deoptimize(JavaThread* current, jint trap_request))
   // Called from within the owner thread, so no need for safepoint
-  RegisterMap reg_map(current, false);
+  RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
   frame stub_frame = current->last_frame();
   assert(stub_frame.is_runtime_frame(), "Sanity check");
   frame caller_frame = stub_frame.sender(&reg_map);
@@ -1274,7 +1274,7 @@ void Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_id) {
     tty->print_cr("Deoptimizing because patch is needed");
   }
 
-  RegisterMap reg_map(current, false);
+  RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
 
   frame runtime_frame = current->last_frame();
   frame caller_frame = runtime_frame.sender(&reg_map);
@@ -1401,7 +1401,7 @@ JRT_END
 JRT_ENTRY(void, Runtime1::predicate_failed_trap(JavaThread* current))
   ResourceMark rm;
 
-  RegisterMap reg_map(current, false);
+  RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
   frame runtime_frame = current->last_frame();
   frame caller_frame = runtime_frame.sender(&reg_map);
 

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -166,7 +166,10 @@ address Runtime1::arraycopy_count_address(BasicType type) {
 // entered the VM has been deoptimized
 
 static bool caller_is_deopted(JavaThread* current) {
-  RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(current,
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   frame runtime_frame = current->last_frame();
   frame caller_frame = runtime_frame.sender(&reg_map);
   assert(caller_frame.is_compiled_frame(), "must be compiled");
@@ -176,7 +179,10 @@ static bool caller_is_deopted(JavaThread* current) {
 // Stress deoptimization
 static void deopt_caller(JavaThread* current) {
   if (!caller_is_deopted(current)) {
-    RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+    RegisterMap reg_map(current,
+                        RegisterMap::UpdateMap::skip,
+                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::WalkContinuation::skip);
     frame runtime_frame = current->last_frame();
     frame caller_frame = runtime_frame.sender(&reg_map);
     Deoptimization::deoptimize_frame(current, caller_frame.id());
@@ -440,7 +446,10 @@ static nmethod* counter_overflow_helper(JavaThread* current, int branch_bci, Met
   nmethod* osr_nm = NULL;
   methodHandle method(current, m);
 
-  RegisterMap map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap map(current,
+                  RegisterMap::UpdateMap::skip,
+                  RegisterMap::ProcessFrames::yes,
+                  RegisterMap::WalkContinuation::skip);
   frame fr =  current->last_frame().sender(&map);
   nmethod* nm = (nmethod*) fr.cb();
   assert(nm!= NULL && nm->is_nmethod(), "Sanity check");
@@ -479,7 +488,10 @@ JRT_BLOCK_ENTRY(address, Runtime1::counter_overflow(JavaThread* current, int bci
   JRT_BLOCK
     osr_nm = counter_overflow_helper(current, bci, method);
     if (osr_nm != NULL) {
-      RegisterMap map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+      RegisterMap map(current,
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
       frame fr =  current->last_frame().sender(&map);
       Deoptimization::deoptimize_frame(current, fr.id());
     }
@@ -525,7 +537,10 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
   assert(nm != NULL, "this is not an nmethod");
   // Adjust the pc as needed/
   if (nm->is_deopt_pc(pc)) {
-    RegisterMap map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+    RegisterMap map(current,
+                    RegisterMap::UpdateMap::skip,
+                    RegisterMap::ProcessFrames::yes,
+                    RegisterMap::WalkContinuation::skip);
     frame exception_frame = current->last_frame().sender(&map);
     // if the frame isn't deopted then pc must not correspond to the caller of last_frame
     assert(exception_frame.is_deoptimized_frame(), "must be deopted");
@@ -564,7 +579,10 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
     // notifications since the interpreter would also notify about
     // these same catches and throws as it unwound the frame.
 
-    RegisterMap reg_map(current, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+    RegisterMap reg_map(current,
+                        RegisterMap::UpdateMap::yes,
+                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::WalkContinuation::skip);
     frame stub_frame = current->last_frame();
     frame caller_frame = stub_frame.sender(&reg_map);
 
@@ -760,7 +778,10 @@ JRT_END
 // Cf. OptoRuntime::deoptimize_caller_frame
 JRT_ENTRY(void, Runtime1::deoptimize(JavaThread* current, jint trap_request))
   // Called from within the owner thread, so no need for safepoint
-  RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(current,
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   frame stub_frame = current->last_frame();
   assert(stub_frame.is_runtime_frame(), "Sanity check");
   frame caller_frame = stub_frame.sender(&reg_map);
@@ -909,7 +930,10 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
 #endif
 
   ResourceMark rm(current);
-  RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(current,
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   frame runtime_frame = current->last_frame();
   frame caller_frame = runtime_frame.sender(&reg_map);
 
@@ -1274,7 +1298,10 @@ void Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_id) {
     tty->print_cr("Deoptimizing because patch is needed");
   }
 
-  RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(current,
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
 
   frame runtime_frame = current->last_frame();
   frame caller_frame = runtime_frame.sender(&reg_map);
@@ -1401,7 +1428,10 @@ JRT_END
 JRT_ENTRY(void, Runtime1::predicate_failed_trap(JavaThread* current))
   ResourceMark rm;
 
-  RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(current,
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   frame runtime_frame = current->last_frame();
   frame caller_frame = runtime_frame.sender(&reg_map);
 

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -909,7 +909,7 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
 #endif
 
   ResourceMark rm(current);
-  RegisterMap reg_map(current, false);
+  RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
   frame runtime_frame = current->last_frame();
   frame caller_frame = runtime_frame.sender(&reg_map);
 

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2749,7 +2749,7 @@ void java_lang_Throwable::fill_in_stack_trace(Handle throwable, const methodHand
   RegisterMap map(thread,
                   RegisterMap::UpdateMap::skip,
                   RegisterMap::ProcessFrames::skip,
-                  RegisterMap::WalkContinuation::yes);
+                  RegisterMap::WalkContinuation::include);
   int decode_offset = 0;
   CompiledMethod* nm = NULL;
   bool skip_fillInStackTrace_check = false;

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2746,7 +2746,10 @@ void java_lang_Throwable::fill_in_stack_trace(Handle throwable, const methodHand
   vframeStream st(thread, false /* stop_at_java_call_stub */, false /* process_frames */);
 #endif
   int total_count = 0;
-  RegisterMap map(thread, false /* update_map */, false /* process_frames */, true /* walk_cont */);
+  RegisterMap map(thread,
+                  RegisterMap::UpdateMap::skip,
+                  RegisterMap::ProcessFrames::skip,
+                  RegisterMap::WalkContinuation::yes);
   int decode_offset = 0;
   CompiledMethod* nm = NULL;
   bool skip_fillInStackTrace_check = false;

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2746,7 +2746,7 @@ void java_lang_Throwable::fill_in_stack_trace(Handle throwable, const methodHand
   vframeStream st(thread, false /* stop_at_java_call_stub */, false /* process_frames */);
 #endif
   int total_count = 0;
-  RegisterMap map(thread, false /* update */, false /* process_frames */, true /* walk_cont */);
+  RegisterMap map(thread, false /* update_map */, false /* process_frames */, true /* walk_cont */);
   int decode_offset = 0;
   CompiledMethod* nm = NULL;
   bool skip_fillInStackTrace_check = false;

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -760,7 +760,7 @@ void CompilationPolicy::compile(const methodHandle& mh, int bci, CompLevel level
       JavaThread* jt = THREAD;
       RegisterMap map(jt,
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
       frame fr = jt->last_frame().sender(&map);
       Deoptimization::deoptimize_frame(jt, fr.id());

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -758,7 +758,10 @@ void CompilationPolicy::compile(const methodHandle& mh, int bci, CompLevel level
       }
       // Deoptimize immediately (we don't have to wait for a compile).
       JavaThread* jt = THREAD;
-      RegisterMap map(jt, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+      RegisterMap map(jt,
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
       frame fr = jt->last_frame().sender(&map);
       Deoptimization::deoptimize_frame(jt, fr.id());
     }

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -758,7 +758,7 @@ void CompilationPolicy::compile(const methodHandle& mh, int bci, CompLevel level
       }
       // Deoptimize immediately (we don't have to wait for a compile).
       JavaThread* jt = THREAD;
-      RegisterMap map(jt, false);
+      RegisterMap map(jt, false /* update_map */, true /* process_frames */, false /* walk_cont */);
       frame fr = jt->last_frame().sender(&map);
       Deoptimization::deoptimize_frame(jt, fr.id());
     }

--- a/src/hotspot/share/jfr/periodic/sampling/jfrCallTrace.cpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrCallTrace.cpp
@@ -36,7 +36,7 @@
 
 bool JfrGetCallTrace::find_top_frame(frame& top_frame, Method** method, frame& first_frame) {
   assert(top_frame.cb() != NULL, "invariant");
-  RegisterMap map(_thread, false, false);
+  RegisterMap map(_thread, false /* update_map */,  false /* process_frames */, false /* walk_cont */);
   frame candidate = top_frame;
   for (u4 i = 0; i < MAX_STACK_DEPTH * 2; ++i) {
     if (candidate.is_entry_frame()) {

--- a/src/hotspot/share/jfr/periodic/sampling/jfrCallTrace.cpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrCallTrace.cpp
@@ -36,7 +36,10 @@
 
 bool JfrGetCallTrace::find_top_frame(frame& top_frame, Method** method, frame& first_frame) {
   assert(top_frame.cb() != NULL, "invariant");
-  RegisterMap map(_thread, false /* update_map */,  false /* process_frames */, false /* walk_cont */);
+  RegisterMap map(_thread,
+                  RegisterMap::UpdateMap::skip,
+                  RegisterMap::ProcessFrames::skip,
+                  RegisterMap::WalkContinuation::skip);
   frame candidate = top_frame;
   for (u4 i = 0; i < MAX_STACK_DEPTH * 2; ++i) {
     if (candidate.is_entry_frame()) {

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.cpp
@@ -152,7 +152,7 @@ JfrVframeStream::JfrVframeStream(JavaThread* jt, const frame& fr, bool stop_at_j
   vframeStreamCommon(RegisterMap(jt,
                                  RegisterMap::UpdateMap::skip,
                                  RegisterMap::ProcessFrames::skip,
-                                 RegisterMap::WalkContinuation::yes)),
+                                 RegisterMap::WalkContinuation::include)),
     _cont_entry(JfrThreadLocal::is_vthread(jt) ? jt->last_continuation() : nullptr),
     _async_mode(async_mode), _vthread(JfrThreadLocal::is_vthread(jt)) {
   assert(!_vthread || _cont_entry != nullptr, "invariant");

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.cpp
@@ -149,7 +149,10 @@ class JfrVframeStream : public vframeStreamCommon {
 };
 
 JfrVframeStream::JfrVframeStream(JavaThread* jt, const frame& fr, bool stop_at_java_call_stub, bool async_mode) :
-  vframeStreamCommon(RegisterMap(jt, false /* update_map */, false /* process_frames */, true /* walk_cont */)),
+  vframeStreamCommon(RegisterMap(jt,
+                                 RegisterMap::UpdateMap::skip,
+                                 RegisterMap::ProcessFrames::skip,
+                                 RegisterMap::WalkContinuation::yes)),
     _cont_entry(JfrThreadLocal::is_vthread(jt) ? jt->last_continuation() : nullptr),
     _async_mode(async_mode), _vthread(JfrThreadLocal::is_vthread(jt)) {
   assert(!_vthread || _cont_entry != nullptr, "invariant");

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.cpp
@@ -149,7 +149,8 @@ class JfrVframeStream : public vframeStreamCommon {
 };
 
 JfrVframeStream::JfrVframeStream(JavaThread* jt, const frame& fr, bool stop_at_java_call_stub, bool async_mode) :
-  vframeStreamCommon(RegisterMap(jt, false, false, true)), _cont_entry(JfrThreadLocal::is_vthread(jt) ? jt->last_continuation() : nullptr),
+  vframeStreamCommon(RegisterMap(jt, false /* update_map */, false /* process_frames */, true /* walk_cont */)),
+    _cont_entry(JfrThreadLocal::is_vthread(jt) ? jt->last_continuation() : nullptr),
     _async_mode(async_mode), _vthread(JfrThreadLocal::is_vthread(jt)) {
   assert(!_vthread || _cont_entry != nullptr, "invariant");
   _reg_map.set_async(async_mode);

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -65,7 +65,7 @@ static bool caller_is_deopted() {
   JavaThread* thread = JavaThread::current();
   RegisterMap reg_map(thread,
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   frame runtime_frame = thread->last_frame();
   frame caller_frame = runtime_frame.sender(&reg_map);
@@ -79,7 +79,7 @@ static void deopt_caller() {
     JavaThread* thread = JavaThread::current();
     RegisterMap reg_map(thread,
                         RegisterMap::UpdateMap::skip,
-                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::ProcessFrames::include,
                         RegisterMap::WalkContinuation::skip);
     frame runtime_frame = thread->last_frame();
     frame caller_frame = runtime_frame.sender(&reg_map);
@@ -263,7 +263,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
   if (cm->is_deopt_pc(pc)) {
     RegisterMap map(current,
                     RegisterMap::UpdateMap::skip,
-                    RegisterMap::ProcessFrames::yes,
+                    RegisterMap::ProcessFrames::include,
                     RegisterMap::WalkContinuation::skip);
     frame exception_frame = current->last_frame().sender(&map);
     // if the frame isn't deopted then pc must not correspond to the caller of last_frame
@@ -305,8 +305,8 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
     // these same catches and throws as it unwound the frame.
 
     RegisterMap reg_map(current,
-                        RegisterMap::UpdateMap::yes,
-                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::UpdateMap::include,
+                        RegisterMap::ProcessFrames::include,
                         RegisterMap::WalkContinuation::skip);
     frame stub_frame = current->last_frame();
     frame caller_frame = stub_frame.sender(&reg_map);

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -63,7 +63,7 @@
 
 static bool caller_is_deopted() {
   JavaThread* thread = JavaThread::current();
-  RegisterMap reg_map(thread, false);
+  RegisterMap reg_map(thread, false /* update_map */,  true /* process_frames */, false /* walk_cont */);
   frame runtime_frame = thread->last_frame();
   frame caller_frame = runtime_frame.sender(&reg_map);
   assert(caller_frame.is_compiled_frame(), "must be compiled");
@@ -74,7 +74,7 @@ static bool caller_is_deopted() {
 static void deopt_caller() {
   if ( !caller_is_deopted()) {
     JavaThread* thread = JavaThread::current();
-    RegisterMap reg_map(thread, false);
+    RegisterMap reg_map(thread, false /* update_map */,  true /* process_frames */, false /* walk_cont */);
     frame runtime_frame = thread->last_frame();
     frame caller_frame = runtime_frame.sender(&reg_map);
     Deoptimization::deoptimize_frame(thread, caller_frame.id(), Deoptimization::Reason_constraint);
@@ -255,7 +255,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
   assert(cm != NULL, "this is not a compiled method");
   // Adjust the pc as needed/
   if (cm->is_deopt_pc(pc)) {
-    RegisterMap map(current, false);
+    RegisterMap map(current, false /* update_map */,  true /* process_frames */, false /* walk_cont */);
     frame exception_frame = current->last_frame().sender(&map);
     // if the frame isn't deopted then pc must not correspond to the caller of last_frame
     assert(exception_frame.is_deoptimized_frame(), "must be deopted");
@@ -295,7 +295,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
     // notifications since the interpreter would also notify about
     // these same catches and throws as it unwound the frame.
 
-    RegisterMap reg_map(current);
+    RegisterMap reg_map(current, true /* update_map */,  true /* process_frames */, false /* walk_cont */);
     frame stub_frame = current->last_frame();
     frame caller_frame = stub_frame.sender(&reg_map);
 

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -63,7 +63,10 @@
 
 static bool caller_is_deopted() {
   JavaThread* thread = JavaThread::current();
-  RegisterMap reg_map(thread, false /* update_map */,  true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(thread,
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   frame runtime_frame = thread->last_frame();
   frame caller_frame = runtime_frame.sender(&reg_map);
   assert(caller_frame.is_compiled_frame(), "must be compiled");
@@ -74,7 +77,10 @@ static bool caller_is_deopted() {
 static void deopt_caller() {
   if ( !caller_is_deopted()) {
     JavaThread* thread = JavaThread::current();
-    RegisterMap reg_map(thread, false /* update_map */,  true /* process_frames */, false /* walk_cont */);
+    RegisterMap reg_map(thread,
+                        RegisterMap::UpdateMap::skip,
+                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::WalkContinuation::skip);
     frame runtime_frame = thread->last_frame();
     frame caller_frame = runtime_frame.sender(&reg_map);
     Deoptimization::deoptimize_frame(thread, caller_frame.id(), Deoptimization::Reason_constraint);
@@ -255,7 +261,10 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
   assert(cm != NULL, "this is not a compiled method");
   // Adjust the pc as needed/
   if (cm->is_deopt_pc(pc)) {
-    RegisterMap map(current, false /* update_map */,  true /* process_frames */, false /* walk_cont */);
+    RegisterMap map(current,
+                    RegisterMap::UpdateMap::skip,
+                    RegisterMap::ProcessFrames::yes,
+                    RegisterMap::WalkContinuation::skip);
     frame exception_frame = current->last_frame().sender(&map);
     // if the frame isn't deopted then pc must not correspond to the caller of last_frame
     assert(exception_frame.is_deoptimized_frame(), "must be deopted");
@@ -295,7 +304,10 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
     // notifications since the interpreter would also notify about
     // these same catches and throws as it unwound the frame.
 
-    RegisterMap reg_map(current, true /* update_map */,  true /* process_frames */, false /* walk_cont */);
+    RegisterMap reg_map(current,
+                        RegisterMap::UpdateMap::yes,
+                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::WalkContinuation::skip);
     frame stub_frame = current->last_frame();
     frame caller_frame = stub_frame.sender(&reg_map);
 

--- a/src/hotspot/share/oops/instanceStackChunkKlass.cpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.cpp
@@ -169,9 +169,9 @@ public:
   DescribeStackChunkClosure(stackChunkOop chunk)
     : _chunk(chunk),
       _map((JavaThread*)nullptr,
-           RegisterMap::UpdateMap::yes,
+           RegisterMap::UpdateMap::include,
            RegisterMap::ProcessFrames::skip,
-           RegisterMap::WalkContinuation::yes),
+           RegisterMap::WalkContinuation::include),
       _frame_no(0) {
     _map.set_include_argument_oops(false);
   }

--- a/src/hotspot/share/oops/instanceStackChunkKlass.cpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.cpp
@@ -167,7 +167,12 @@ class DescribeStackChunkClosure {
 
 public:
   DescribeStackChunkClosure(stackChunkOop chunk)
-    : _chunk(chunk), _map((JavaThread*)nullptr, true, false, true), _frame_no(0) {
+    : _chunk(chunk),
+      _map((JavaThread*)nullptr,
+           RegisterMap::UpdateMap::yes,
+           RegisterMap::ProcessFrames::skip,
+           RegisterMap::WalkContinuation::yes),
+      _frame_no(0) {
     _map.set_include_argument_oops(false);
   }
 

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -199,9 +199,9 @@ inline void stackChunkOopDesc::iterate_stack(StackChunkFrameClosureType* closure
 
   if (f.is_stub()) {
     RegisterMap full_map((JavaThread*)nullptr,
-                         RegisterMap::UpdateMap::yes,
+                         RegisterMap::UpdateMap::include,
                          RegisterMap::ProcessFrames::skip,
-                         RegisterMap::WalkContinuation::yes);
+                         RegisterMap::WalkContinuation::include);
     full_map.set_include_argument_oops(false);
 
     f.next(&full_map);

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -198,7 +198,7 @@ inline void stackChunkOopDesc::iterate_stack(StackChunkFrameClosureType* closure
   bool should_continue = true;
 
   if (f.is_stub()) {
-    RegisterMap full_map((JavaThread*)nullptr, true, false, true);
+    RegisterMap full_map((JavaThread*)nullptr, true /* update_map */, false /* process_frames */, true /* walk_cont */);
     full_map.set_include_argument_oops(false);
 
     f.next(&full_map);

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -198,7 +198,10 @@ inline void stackChunkOopDesc::iterate_stack(StackChunkFrameClosureType* closure
   bool should_continue = true;
 
   if (f.is_stub()) {
-    RegisterMap full_map((JavaThread*)nullptr, true /* update_map */, false /* process_frames */, true /* walk_cont */);
+    RegisterMap full_map((JavaThread*)nullptr,
+                         RegisterMap::UpdateMap::yes,
+                         RegisterMap::ProcessFrames::skip,
+                         RegisterMap::WalkContinuation::yes);
     full_map.set_include_argument_oops(false);
 
     f.next(&full_map);

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -118,7 +118,7 @@ static bool check_compiled_frame(JavaThread* thread) {
   assert(thread->last_frame().is_runtime_frame(), "cannot call runtime directly from compiled code");
   RegisterMap map(thread,
                   RegisterMap::UpdateMap::skip,
-                  RegisterMap::ProcessFrames::yes,
+                  RegisterMap::ProcessFrames::include,
                   RegisterMap::WalkContinuation::skip);
   frame caller = thread->last_frame().sender(&map);
   assert(caller.is_compiled_frame(), "not being called from compiled like code");
@@ -1404,7 +1404,7 @@ JRT_ENTRY_NO_ASYNC(address, OptoRuntime::handle_exception_C_helper(JavaThread* c
       deopting = true;
       RegisterMap map(current,
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
       frame deoptee = current->last_frame().sender(&map);
       assert(deoptee.is_deoptimized_frame(), "must be deopted");
@@ -1577,8 +1577,8 @@ void OptoRuntime::deoptimize_caller_frame(JavaThread *thread, bool doit) {
 void OptoRuntime::deoptimize_caller_frame(JavaThread *thread) {
   // Called from within the owner thread, so no need for safepoint
   RegisterMap reg_map(thread,
-                      RegisterMap::UpdateMap::yes,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::UpdateMap::include,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   frame stub_frame = thread->last_frame();
   assert(stub_frame.is_runtime_frame() || exception_blob()->contains(stub_frame.pc()), "sanity check");
@@ -1592,8 +1592,8 @@ void OptoRuntime::deoptimize_caller_frame(JavaThread *thread) {
 bool OptoRuntime::is_deoptimized_caller_frame(JavaThread *thread) {
   // Called from within the owner thread, so no need for safepoint
   RegisterMap reg_map(thread,
-                      RegisterMap::UpdateMap::yes,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::UpdateMap::include,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   frame stub_frame = thread->last_frame();
   assert(stub_frame.is_runtime_frame() || exception_blob()->contains(stub_frame.pc()), "sanity check");

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -116,7 +116,7 @@ ExceptionBlob* OptoRuntime::_exception_blob;
 #ifdef ASSERT
 static bool check_compiled_frame(JavaThread* thread) {
   assert(thread->last_frame().is_runtime_frame(), "cannot call runtime directly from compiled code");
-  RegisterMap map(thread, false);
+  RegisterMap map(thread, false /* update_map */,  true /* process_frames */, false /* walk_cont */);
   frame caller = thread->last_frame().sender(&map);
   assert(caller.is_compiled_frame(), "not being called from compiled like code");
   return true;
@@ -1399,7 +1399,7 @@ JRT_ENTRY_NO_ASYNC(address, OptoRuntime::handle_exception_C_helper(JavaThread* c
     bool deopting = false;
     if (nm->is_deopt_pc(pc)) {
       deopting = true;
-      RegisterMap map(current, false);
+      RegisterMap map(current, false /* update_map */,  true /* process_frames */, false /* walk_cont */);
       frame deoptee = current->last_frame().sender(&map);
       assert(deoptee.is_deoptimized_frame(), "must be deopted");
       // Adjust the pc back to the original throwing pc
@@ -1480,7 +1480,7 @@ address OptoRuntime::handle_exception_C(JavaThread* current) {
   // deoptimized frame
 
   if (nm != NULL) {
-    RegisterMap map(current, false /* update_map */, false /* process_frames */);
+    RegisterMap map(current, false /* update_map */, false /* process_frames */, false /* walk_cont */);
     frame caller = current->last_frame().sender(&map);
 #ifdef ASSERT
     assert(caller.is_compiled_frame(), "must be");
@@ -1567,7 +1567,7 @@ void OptoRuntime::deoptimize_caller_frame(JavaThread *thread, bool doit) {
 
 void OptoRuntime::deoptimize_caller_frame(JavaThread *thread) {
   // Called from within the owner thread, so no need for safepoint
-  RegisterMap reg_map(thread);
+  RegisterMap reg_map(thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
   frame stub_frame = thread->last_frame();
   assert(stub_frame.is_runtime_frame() || exception_blob()->contains(stub_frame.pc()), "sanity check");
   frame caller_frame = stub_frame.sender(&reg_map);
@@ -1579,7 +1579,7 @@ void OptoRuntime::deoptimize_caller_frame(JavaThread *thread) {
 
 bool OptoRuntime::is_deoptimized_caller_frame(JavaThread *thread) {
   // Called from within the owner thread, so no need for safepoint
-  RegisterMap reg_map(thread);
+  RegisterMap reg_map(thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
   frame stub_frame = thread->last_frame();
   assert(stub_frame.is_runtime_frame() || exception_blob()->contains(stub_frame.pc()), "sanity check");
   frame caller_frame = stub_frame.sender(&reg_map);

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -116,7 +116,10 @@ ExceptionBlob* OptoRuntime::_exception_blob;
 #ifdef ASSERT
 static bool check_compiled_frame(JavaThread* thread) {
   assert(thread->last_frame().is_runtime_frame(), "cannot call runtime directly from compiled code");
-  RegisterMap map(thread, false /* update_map */,  true /* process_frames */, false /* walk_cont */);
+  RegisterMap map(thread,
+                  RegisterMap::UpdateMap::skip,
+                  RegisterMap::ProcessFrames::yes,
+                  RegisterMap::WalkContinuation::skip);
   frame caller = thread->last_frame().sender(&map);
   assert(caller.is_compiled_frame(), "not being called from compiled like code");
   return true;
@@ -1399,7 +1402,10 @@ JRT_ENTRY_NO_ASYNC(address, OptoRuntime::handle_exception_C_helper(JavaThread* c
     bool deopting = false;
     if (nm->is_deopt_pc(pc)) {
       deopting = true;
-      RegisterMap map(current, false /* update_map */,  true /* process_frames */, false /* walk_cont */);
+      RegisterMap map(current,
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
       frame deoptee = current->last_frame().sender(&map);
       assert(deoptee.is_deoptimized_frame(), "must be deopted");
       // Adjust the pc back to the original throwing pc
@@ -1480,7 +1486,10 @@ address OptoRuntime::handle_exception_C(JavaThread* current) {
   // deoptimized frame
 
   if (nm != NULL) {
-    RegisterMap map(current, false /* update_map */, false /* process_frames */, false /* walk_cont */);
+    RegisterMap map(current,
+                    RegisterMap::UpdateMap::skip,
+                    RegisterMap::ProcessFrames::skip,
+                    RegisterMap::WalkContinuation::skip);
     frame caller = current->last_frame().sender(&map);
 #ifdef ASSERT
     assert(caller.is_compiled_frame(), "must be");
@@ -1567,7 +1576,10 @@ void OptoRuntime::deoptimize_caller_frame(JavaThread *thread, bool doit) {
 
 void OptoRuntime::deoptimize_caller_frame(JavaThread *thread) {
   // Called from within the owner thread, so no need for safepoint
-  RegisterMap reg_map(thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(thread,
+                      RegisterMap::UpdateMap::yes,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   frame stub_frame = thread->last_frame();
   assert(stub_frame.is_runtime_frame() || exception_blob()->contains(stub_frame.pc()), "sanity check");
   frame caller_frame = stub_frame.sender(&reg_map);
@@ -1579,7 +1591,10 @@ void OptoRuntime::deoptimize_caller_frame(JavaThread *thread) {
 
 bool OptoRuntime::is_deoptimized_caller_frame(JavaThread *thread) {
   // Called from within the owner thread, so no need for safepoint
-  RegisterMap reg_map(thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(thread,
+                      RegisterMap::UpdateMap::yes,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   frame stub_frame = thread->last_frame();
   assert(stub_frame.is_runtime_frame() || exception_blob()->contains(stub_frame.pc()), "sanity check");
   frame caller_frame = stub_frame.sender(&reg_map);

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -91,7 +91,10 @@ static bool is_decipherable_interpreted_frame(JavaThread* thread,
 vframeStreamForte::vframeStreamForte(JavaThread *jt,
                                      frame fr,
                                      bool stop_at_java_call_stub)
-    : vframeStreamCommon(RegisterMap(jt, false /* update_map */, false /* process_frames */, false /* walk_cont */)) {
+    : vframeStreamCommon(RegisterMap(jt,
+                                     RegisterMap::UpdateMap::skip,
+                                     RegisterMap::ProcessFrames::skip,
+                                     RegisterMap::WalkContinuation::skip)) {
   _reg_map.set_async(true);
   _stop_at_java_call_stub = stop_at_java_call_stub;
   _frame = fr;
@@ -318,7 +321,10 @@ static bool find_initial_Java_frame(JavaThread* thread,
   // Instead, try to do Zero-specific search for Java frame.
 
   {
-    RegisterMap map(thread, false /* update_map */, false /* process_frames */, false /* walk_cont */);
+    RegisterMap map(thread,
+                    RegisterMap::UpdateMap::skip,
+                    RegisterMap::ProcessFrames::skip,
+                    RegisterMap::WalkContinuation::skip);
 
     while (true) {
       // Cannot walk this frame? Cannot do anything anymore.
@@ -362,7 +368,10 @@ static bool find_initial_Java_frame(JavaThread* thread,
     // See if we can find a useful frame
     int loop_count;
     int loop_max = MaxJavaStackTraceDepth * 2;
-    RegisterMap map(thread, false /* update_map */, false /* process_frames */, false /* walk_cont */);
+    RegisterMap map(thread,
+                    RegisterMap::UpdateMap::skip,
+                    RegisterMap::ProcessFrames::skip,
+                    RegisterMap::WalkContinuation::skip);
 
     for (loop_count = 0; loop_max == 0 || loop_count < loop_max; loop_count++) {
       if (!candidate.safe_for_sender(thread)) return false;
@@ -376,7 +385,10 @@ static bool find_initial_Java_frame(JavaThread* thread,
   // We will hopefully be able to figure out something to do with it.
   int loop_count;
   int loop_max = MaxJavaStackTraceDepth * 2;
-  RegisterMap map(thread, false /* update_map */, false /* process_frames */, false /* walk_cont */);
+  RegisterMap map(thread,
+                  RegisterMap::UpdateMap::skip,
+                  RegisterMap::ProcessFrames::skip,
+                  RegisterMap::WalkContinuation::skip);
 
   for (loop_count = 0; loop_max == 0 || loop_count < loop_max; loop_count++) {
 

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -91,7 +91,7 @@ static bool is_decipherable_interpreted_frame(JavaThread* thread,
 vframeStreamForte::vframeStreamForte(JavaThread *jt,
                                      frame fr,
                                      bool stop_at_java_call_stub)
-    : vframeStreamCommon(RegisterMap(jt, false, false, false)) {
+    : vframeStreamCommon(RegisterMap(jt, false /* update_map */, false /* process_frames */, false /* walk_cont */)) {
   _reg_map.set_async(true);
   _stop_at_java_call_stub = stop_at_java_call_stub;
   _frame = fr;
@@ -362,7 +362,7 @@ static bool find_initial_Java_frame(JavaThread* thread,
     // See if we can find a useful frame
     int loop_count;
     int loop_max = MaxJavaStackTraceDepth * 2;
-    RegisterMap map(thread, false, false);
+    RegisterMap map(thread, false /* update_map */, false /* process_frames */, false /* walk_cont */);
 
     for (loop_count = 0; loop_max == 0 || loop_count < loop_max; loop_count++) {
       if (!candidate.safe_for_sender(thread)) return false;
@@ -376,7 +376,7 @@ static bool find_initial_Java_frame(JavaThread* thread,
   // We will hopefully be able to figure out something to do with it.
   int loop_count;
   int loop_max = MaxJavaStackTraceDepth * 2;
-  RegisterMap map(thread, false, false);
+  RegisterMap map(thread, false /* update_map */, false /* process_frames */, false /* walk_cont */);
 
   for (loop_count = 0; loop_max == 0 || loop_count < loop_max; loop_count++) {
 

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -318,7 +318,7 @@ static bool find_initial_Java_frame(JavaThread* thread,
   // Instead, try to do Zero-specific search for Java frame.
 
   {
-    RegisterMap map(thread, false, false);
+    RegisterMap map(thread, false /* update_map */, false /* process_frames */, false /* walk_cont */);
 
     while (true) {
       // Cannot walk this frame? Cannot do anything anymore.

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -567,9 +567,9 @@ JvmtiEnvBase::jvf_for_thread_and_depth(JavaThread* java_thread, jint depth) {
     return NULL;
   }
   RegisterMap reg_map(java_thread,
-                      RegisterMap::UpdateMap::yes,
+                      RegisterMap::UpdateMap::include,
                       RegisterMap::ProcessFrames::skip,
-                      RegisterMap::WalkContinuation::yes);
+                      RegisterMap::WalkContinuation::include);
   javaVFrame *jvf = java_thread->last_java_vframe(&reg_map);
 
   jvf = JvmtiEnvBase::check_and_skip_hidden_frames(java_thread, jvf);
@@ -849,8 +849,8 @@ JvmtiEnvBase::count_locked_objects(JavaThread *java_thread, Handle hobj) {
   ResourceMark rm(current_thread);
   HandleMark   hm(current_thread);
   RegisterMap  reg_map(java_thread,
-                       RegisterMap::UpdateMap::yes,
-                       RegisterMap::ProcessFrames::yes,
+                       RegisterMap::UpdateMap::include,
+                       RegisterMap::ProcessFrames::include,
                        RegisterMap::WalkContinuation::skip);
 
   for (javaVFrame *jvf = java_thread->last_java_vframe(&reg_map); jvf != NULL;
@@ -935,8 +935,8 @@ JvmtiEnvBase::get_owned_monitors(JavaThread *calling_thread, JavaThread* java_th
     ResourceMark rm(current_thread);
     HandleMark   hm(current_thread);
     RegisterMap  reg_map(java_thread,
-                         RegisterMap::UpdateMap::yes,
-                         RegisterMap::ProcessFrames::yes,
+                         RegisterMap::UpdateMap::include,
+                         RegisterMap::ProcessFrames::include,
                          RegisterMap::WalkContinuation::skip);
 
     int depth = 0;
@@ -1154,7 +1154,7 @@ JvmtiEnvBase::get_stack_trace(JavaThread *java_thread,
 
   if (java_thread->has_last_Java_frame()) {
     RegisterMap reg_map(java_thread,
-                        RegisterMap::UpdateMap::yes,
+                        RegisterMap::UpdateMap::include,
                         RegisterMap::ProcessFrames::skip,
                         RegisterMap::WalkContinuation::skip);
     ResourceMark rm(current_thread);
@@ -1195,8 +1195,8 @@ JvmtiEnvBase::get_frame_count(JavaThread* jt, jint *count_ptr) {
   } else {
     ResourceMark rm(current_thread);
     RegisterMap reg_map(jt,
-                        RegisterMap::UpdateMap::yes,
-                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::UpdateMap::include,
+                        RegisterMap::ProcessFrames::include,
                         RegisterMap::WalkContinuation::skip);
     javaVFrame *jvf = get_cthread_last_java_vframe(jt, &reg_map);
 
@@ -1253,9 +1253,9 @@ JvmtiEnvBase::get_frame_location(JavaThread *java_thread, jint depth,
   ResourceMark rm(current);
   HandleMark hm(current);
   RegisterMap reg_map(java_thread,
-                      RegisterMap::UpdateMap::yes,
+                      RegisterMap::UpdateMap::include,
                       RegisterMap::ProcessFrames::skip,
-                      RegisterMap::WalkContinuation::yes);
+                      RegisterMap::WalkContinuation::include);
   javaVFrame* jvf = JvmtiEnvBase::get_cthread_last_java_vframe(java_thread, &reg_map);
 
   return get_frame_location(jvf, depth, method_ptr, location_ptr);
@@ -2204,9 +2204,9 @@ SetFramePopClosure::doit(Thread *target, bool self) {
     return;
   }
   RegisterMap reg_map(java_thread,
-                      RegisterMap::UpdateMap::yes,
+                      RegisterMap::UpdateMap::include,
                       RegisterMap::ProcessFrames::skip,
-                      RegisterMap::WalkContinuation::yes);
+                      RegisterMap::WalkContinuation::include);
   javaVFrame* jvf = JvmtiEnvBase::get_cthread_last_java_vframe(java_thread, &reg_map);
   _result = ((JvmtiEnvBase*)_env)->set_frame_pop(_state, jvf, _depth);
 }
@@ -2276,8 +2276,8 @@ PrintStackTraceClosure::do_thread_impl(Thread *target) {
 
   if (java_thread->has_last_Java_frame()) {
     RegisterMap reg_map(java_thread,
-                        RegisterMap::UpdateMap::yes,
-                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::UpdateMap::include,
+                        RegisterMap::ProcessFrames::include,
                         RegisterMap::WalkContinuation::skip);
     ResourceMark rm(current_thread);
     HandleMark hm(current_thread);

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -566,7 +566,10 @@ JvmtiEnvBase::jvf_for_thread_and_depth(JavaThread* java_thread, jint depth) {
   if (!java_thread->has_last_Java_frame()) {
     return NULL;
   }
-  RegisterMap reg_map(java_thread, true /* update_map */, false /* process_frames */, true /* walk_cont */);
+  RegisterMap reg_map(java_thread,
+                      RegisterMap::UpdateMap::yes,
+                      RegisterMap::ProcessFrames::skip,
+                      RegisterMap::WalkContinuation::yes);
   javaVFrame *jvf = java_thread->last_java_vframe(&reg_map);
 
   jvf = JvmtiEnvBase::check_and_skip_hidden_frames(java_thread, jvf);
@@ -845,7 +848,10 @@ JvmtiEnvBase::count_locked_objects(JavaThread *java_thread, Handle hobj) {
   Thread* current_thread = Thread::current();
   ResourceMark rm(current_thread);
   HandleMark   hm(current_thread);
-  RegisterMap  reg_map(java_thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap  reg_map(java_thread,
+                       RegisterMap::UpdateMap::yes,
+                       RegisterMap::ProcessFrames::yes,
+                       RegisterMap::WalkContinuation::skip);
 
   for (javaVFrame *jvf = java_thread->last_java_vframe(&reg_map); jvf != NULL;
        jvf = jvf->java_sender()) {
@@ -928,7 +934,10 @@ JvmtiEnvBase::get_owned_monitors(JavaThread *calling_thread, JavaThread* java_th
   if (java_thread->has_last_Java_frame()) {
     ResourceMark rm(current_thread);
     HandleMark   hm(current_thread);
-    RegisterMap  reg_map(java_thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+    RegisterMap  reg_map(java_thread,
+                         RegisterMap::UpdateMap::yes,
+                         RegisterMap::ProcessFrames::yes,
+                         RegisterMap::WalkContinuation::skip);
 
     int depth = 0;
     for (javaVFrame *jvf = get_cthread_last_java_vframe(java_thread, &reg_map);
@@ -1144,7 +1153,10 @@ JvmtiEnvBase::get_stack_trace(JavaThread *java_thread,
   jvmtiError err = JVMTI_ERROR_NONE;
 
   if (java_thread->has_last_Java_frame()) {
-    RegisterMap reg_map(java_thread, true /* update_map */, false /* process_frames */, false /* walk_cont */);
+    RegisterMap reg_map(java_thread,
+                        RegisterMap::UpdateMap::yes,
+                        RegisterMap::ProcessFrames::skip,
+                        RegisterMap::WalkContinuation::skip);
     ResourceMark rm(current_thread);
     javaVFrame *jvf = get_cthread_last_java_vframe(java_thread, &reg_map);
 
@@ -1182,7 +1194,10 @@ JvmtiEnvBase::get_frame_count(JavaThread* jt, jint *count_ptr) {
     *count_ptr = 0;
   } else {
     ResourceMark rm(current_thread);
-    RegisterMap reg_map(jt, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+    RegisterMap reg_map(jt,
+                        RegisterMap::UpdateMap::yes,
+                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::WalkContinuation::skip);
     javaVFrame *jvf = get_cthread_last_java_vframe(jt, &reg_map);
 
     *count_ptr = get_frame_count(jvf);
@@ -1237,7 +1252,10 @@ JvmtiEnvBase::get_frame_location(JavaThread *java_thread, jint depth,
   }
   ResourceMark rm(current);
   HandleMark hm(current);
-  RegisterMap reg_map(java_thread, true /* update_map */, false /* process_frames */, true /* walk_cont */);
+  RegisterMap reg_map(java_thread,
+                      RegisterMap::UpdateMap::yes,
+                      RegisterMap::ProcessFrames::skip,
+                      RegisterMap::WalkContinuation::yes);
   javaVFrame* jvf = JvmtiEnvBase::get_cthread_last_java_vframe(java_thread, &reg_map);
 
   return get_frame_location(jvf, depth, method_ptr, location_ptr);
@@ -2185,7 +2203,10 @@ SetFramePopClosure::doit(Thread *target, bool self) {
     _result = JVMTI_ERROR_NO_MORE_FRAMES;
     return;
   }
-  RegisterMap reg_map(java_thread, true /* update_map */, false /* process_frames */, true /* walk_cont */);
+  RegisterMap reg_map(java_thread,
+                      RegisterMap::UpdateMap::yes,
+                      RegisterMap::ProcessFrames::skip,
+                      RegisterMap::WalkContinuation::yes);
   javaVFrame* jvf = JvmtiEnvBase::get_cthread_last_java_vframe(java_thread, &reg_map);
   _result = ((JvmtiEnvBase*)_env)->set_frame_pop(_state, jvf, _depth);
 }
@@ -2254,7 +2275,10 @@ PrintStackTraceClosure::do_thread_impl(Thread *target) {
                    java_thread->is_VTMS_transition_disabler(), java_thread->is_in_VTMS_transition());
 
   if (java_thread->has_last_Java_frame()) {
-    RegisterMap reg_map(java_thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+    RegisterMap reg_map(java_thread,
+                        RegisterMap::UpdateMap::yes,
+                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::WalkContinuation::skip);
     ResourceMark rm(current_thread);
     HandleMark hm(current_thread);
     javaVFrame *jvf = java_thread->last_java_vframe(&reg_map);

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -845,7 +845,7 @@ JvmtiEnvBase::count_locked_objects(JavaThread *java_thread, Handle hobj) {
   Thread* current_thread = Thread::current();
   ResourceMark rm(current_thread);
   HandleMark   hm(current_thread);
-  RegisterMap  reg_map(java_thread, /* update_map */ true, /* process_frames */ true);
+  RegisterMap  reg_map(java_thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
 
   for (javaVFrame *jvf = java_thread->last_java_vframe(&reg_map); jvf != NULL;
        jvf = jvf->java_sender()) {
@@ -928,7 +928,7 @@ JvmtiEnvBase::get_owned_monitors(JavaThread *calling_thread, JavaThread* java_th
   if (java_thread->has_last_Java_frame()) {
     ResourceMark rm(current_thread);
     HandleMark   hm(current_thread);
-    RegisterMap  reg_map(java_thread);
+    RegisterMap  reg_map(java_thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
 
     int depth = 0;
     for (javaVFrame *jvf = get_cthread_last_java_vframe(java_thread, &reg_map);
@@ -1144,7 +1144,7 @@ JvmtiEnvBase::get_stack_trace(JavaThread *java_thread,
   jvmtiError err = JVMTI_ERROR_NONE;
 
   if (java_thread->has_last_Java_frame()) {
-    RegisterMap reg_map(java_thread, /* update_map */ true, /* process_frames */ false);
+    RegisterMap reg_map(java_thread, true /* update_map */, false /* process_frames */, false /* walk_cont */);
     ResourceMark rm(current_thread);
     javaVFrame *jvf = get_cthread_last_java_vframe(java_thread, &reg_map);
 
@@ -1182,7 +1182,7 @@ JvmtiEnvBase::get_frame_count(JavaThread* jt, jint *count_ptr) {
     *count_ptr = 0;
   } else {
     ResourceMark rm(current_thread);
-    RegisterMap reg_map(jt, true, true);
+    RegisterMap reg_map(jt, true /* update_map */, true /* process_frames */, false /* walk_cont */);
     javaVFrame *jvf = get_cthread_last_java_vframe(jt, &reg_map);
 
     *count_ptr = get_frame_count(jvf);
@@ -2254,7 +2254,7 @@ PrintStackTraceClosure::do_thread_impl(Thread *target) {
                    java_thread->is_VTMS_transition_disabler(), java_thread->is_in_VTMS_transition());
 
   if (java_thread->has_last_Java_frame()) {
-    RegisterMap reg_map(java_thread, /* update_map */ true, /* process_frames */ true);
+    RegisterMap reg_map(java_thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
     ResourceMark rm(current_thread);
     HandleMark hm(current_thread);
     javaVFrame *jvf = java_thread->last_java_vframe(&reg_map);

--- a/src/hotspot/share/prims/jvmtiEnvThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvThreadState.cpp
@@ -320,7 +320,7 @@ class GetCurrentLocationClosure : public HandshakeClosure {
     ResourceMark rmark; // jt != Thread::current()
     RegisterMap rm(jt,
                    RegisterMap::UpdateMap::skip,
-                   RegisterMap::ProcessFrames::yes,
+                   RegisterMap::ProcessFrames::include,
                    RegisterMap::WalkContinuation::skip);
     // There can be a race condition between a handshake
     // and the target thread exiting from Java execution.

--- a/src/hotspot/share/prims/jvmtiEnvThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvThreadState.cpp
@@ -318,7 +318,7 @@ class GetCurrentLocationClosure : public HandshakeClosure {
   void do_thread(Thread *target) {
     JavaThread *jt = JavaThread::cast(target);
     ResourceMark rmark; // jt != Thread::current()
-    RegisterMap rm(jt, false);
+    RegisterMap rm(jt, false /* update_map */, true /* process_frames */, false /* walk_cont */);
     // There can be a race condition between a handshake
     // and the target thread exiting from Java execution.
     // We must recheck that the last Java frame still exists.

--- a/src/hotspot/share/prims/jvmtiEnvThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvThreadState.cpp
@@ -318,7 +318,10 @@ class GetCurrentLocationClosure : public HandshakeClosure {
   void do_thread(Thread *target) {
     JavaThread *jt = JavaThread::cast(target);
     ResourceMark rmark; // jt != Thread::current()
-    RegisterMap rm(jt, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+    RegisterMap rm(jt,
+                   RegisterMap::UpdateMap::skip,
+                   RegisterMap::ProcessFrames::yes,
+                   RegisterMap::WalkContinuation::skip);
     // There can be a race condition between a handshake
     // and the target thread exiting from Java execution.
     // We must recheck that the last Java frame still exists.

--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -771,9 +771,9 @@ vframe *VM_GetOrSetLocal::get_vframe() {
     return NULL;
   }
   RegisterMap reg_map(_thread,
-                      RegisterMap::UpdateMap::yes,
-                      RegisterMap::ProcessFrames::yes,
-                      RegisterMap::WalkContinuation::yes);
+                      RegisterMap::UpdateMap::include,
+                      RegisterMap::ProcessFrames::include,
+                      RegisterMap::WalkContinuation::include);
   vframe *vf = JvmtiEnvBase::get_cthread_last_java_vframe(_thread, &reg_map);
   int d = 0;
   while ((vf != NULL) && (d < _depth)) {

--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -770,7 +770,10 @@ vframe *VM_GetOrSetLocal::get_vframe() {
   if (!_thread->has_last_Java_frame()) {
     return NULL;
   }
-  RegisterMap reg_map(_thread, true /* update_map */, true /* process_frames */, true /* walk_cont */);
+  RegisterMap reg_map(_thread,
+                      RegisterMap::UpdateMap::yes,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::yes);
   vframe *vf = JvmtiEnvBase::get_cthread_last_java_vframe(_thread, &reg_map);
   int d = 0;
   while ((vf != NULL) && (d < _depth)) {

--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -770,7 +770,7 @@ vframe *VM_GetOrSetLocal::get_vframe() {
   if (!_thread->has_last_Java_frame()) {
     return NULL;
   }
-  RegisterMap reg_map(_thread, true, true, true);
+  RegisterMap reg_map(_thread, true /* update_map */, true /* process_frames */, true /* walk_cont */);
   vframe *vf = JvmtiEnvBase::get_cthread_last_java_vframe(_thread, &reg_map);
   int d = 0;
   while ((vf != NULL) && (d < _depth)) {

--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -2650,8 +2650,8 @@ inline bool VM_HeapWalkOperation::collect_stack_roots(JavaThread* java_thread,
     HandleMark hm(current_thread);
 
     RegisterMap reg_map(java_thread,
-                        RegisterMap::UpdateMap::yes,
-                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::UpdateMap::include,
+                        RegisterMap::ProcessFrames::include,
                         RegisterMap::WalkContinuation::skip);
     frame f = java_thread->last_frame();
     vframe* vf = vframe::new_vframe(&f, &reg_map, java_thread);

--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -2649,7 +2649,7 @@ inline bool VM_HeapWalkOperation::collect_stack_roots(JavaThread* java_thread,
     ResourceMark rm(current_thread);
     HandleMark hm(current_thread);
 
-    RegisterMap reg_map(java_thread);
+    RegisterMap reg_map(java_thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
     frame f = java_thread->last_frame();
     vframe* vf = vframe::new_vframe(&f, &reg_map, java_thread);
 

--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -2649,7 +2649,10 @@ inline bool VM_HeapWalkOperation::collect_stack_roots(JavaThread* java_thread,
     ResourceMark rm(current_thread);
     HandleMark hm(current_thread);
 
-    RegisterMap reg_map(java_thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+    RegisterMap reg_map(java_thread,
+                        RegisterMap::UpdateMap::yes,
+                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::WalkContinuation::skip);
     frame f = java_thread->last_frame();
     vframe* vf = vframe::new_vframe(&f, &reg_map, java_thread);
 

--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -578,7 +578,7 @@ int JvmtiThreadState::count_frames() {
     RegisterMap reg_map(thread,
                         RegisterMap::UpdateMap::skip,
                         RegisterMap::ProcessFrames::skip,
-                        RegisterMap::WalkContinuation::yes);
+                        RegisterMap::WalkContinuation::include);
     jvf = thread->last_java_vframe(&reg_map);
     jvf = JvmtiEnvBase::check_and_skip_hidden_frames(thread, jvf);
   }

--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -575,7 +575,10 @@ int JvmtiThreadState::count_frames() {
            "call by myself / at safepoint / at handshake");
     if (!thread->has_last_Java_frame()) return 0;  // No Java frames.
     // TBD: This might need to be corrected for detached carrier threads.
-    RegisterMap reg_map(thread, false /* update_map */, false /* process_frames */, true /* walk_cont */);
+    RegisterMap reg_map(thread,
+                        RegisterMap::UpdateMap::skip,
+                        RegisterMap::ProcessFrames::skip,
+                        RegisterMap::WalkContinuation::yes);
     jvf = thread->last_java_vframe(&reg_map);
     jvf = JvmtiEnvBase::check_and_skip_hidden_frames(thread, jvf);
   }

--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -575,7 +575,7 @@ int JvmtiThreadState::count_frames() {
            "call by myself / at safepoint / at handshake");
     if (!thread->has_last_Java_frame()) return 0;  // No Java frames.
     // TBD: This might need to be corrected for detached carrier threads.
-    RegisterMap reg_map(thread, /* update_map */ false, /* process_frames */ false, /* walk_cont */ true);
+    RegisterMap reg_map(thread, false /* update_map */, false /* process_frames */, true /* walk_cont */);
     jvf = thread->last_java_vframe(&reg_map);
     jvf = JvmtiEnvBase::check_and_skip_hidden_frames(thread, jvf);
   }

--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -89,8 +89,8 @@ public:
 
     frame last_frame = jt->last_frame();
     RegisterMap register_map(jt,
-                             RegisterMap::UpdateMap::yes,
-                             RegisterMap::ProcessFrames::yes,
+                             RegisterMap::UpdateMap::include,
+                             RegisterMap::ProcessFrames::include,
                              RegisterMap::WalkContinuation::skip);
 
     if (last_frame.is_safepoint_blob_frame()) {

--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -88,7 +88,10 @@ public:
     }
 
     frame last_frame = jt->last_frame();
-    RegisterMap register_map(jt, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+    RegisterMap register_map(jt,
+                             RegisterMap::UpdateMap::yes,
+                             RegisterMap::ProcessFrames::yes,
+                             RegisterMap::WalkContinuation::skip);
 
     if (last_frame.is_safepoint_blob_frame()) {
       last_frame = last_frame.sender(&register_map);

--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -88,7 +88,7 @@ public:
     }
 
     frame last_frame = jt->last_frame();
-    RegisterMap register_map(jt, true);
+    RegisterMap register_map(jt, true /* update_map */, true /* process_frames */, false /* walk_cont */);
 
     if (last_frame.is_safepoint_blob_frame()) {
       last_frame = last_frame.sender(&register_map);

--- a/src/hotspot/share/prims/stackwalk.cpp
+++ b/src/hotspot/share/prims/stackwalk.cpp
@@ -430,10 +430,10 @@ oop StackWalk::walk(Handle stackStream, jlong mode, int skip_frames, Handle cont
   if (live_frame_info(mode)) {
     assert(use_frames_array(mode), "Bad mode for get live frame");
     RegisterMap regMap = cont.is_null() ? RegisterMap(jt,
-                                                      RegisterMap::UpdateMap::yes,
-                                                      RegisterMap::ProcessFrames::yes,
-                                                      RegisterMap::WalkContinuation::yes)
-                                        : RegisterMap(cont(), RegisterMap::UpdateMap::yes);
+                                                      RegisterMap::UpdateMap::include,
+                                                      RegisterMap::ProcessFrames::include,
+                                                      RegisterMap::WalkContinuation::include)
+                                        : RegisterMap(cont(), RegisterMap::UpdateMap::include);
     LiveFrameStream stream(jt, &regMap, cont_scope, cont);
     return fetchFirstBatch(stream, stackStream, mode, skip_frames, frame_count,
                            start_index, frames_array, THREAD);

--- a/src/hotspot/share/prims/stackwalk.cpp
+++ b/src/hotspot/share/prims/stackwalk.cpp
@@ -429,8 +429,8 @@ oop StackWalk::walk(Handle stackStream, jlong mode, int skip_frames, Handle cont
   // Setup traversal onto my stack.
   if (live_frame_info(mode)) {
     assert(use_frames_array(mode), "Bad mode for get live frame");
-    RegisterMap regMap = cont.is_null() ? RegisterMap(jt, true, true, true)
-                                        : RegisterMap(cont(), true);
+    RegisterMap regMap = cont.is_null() ? RegisterMap(jt, true /* update_map */, true /* process_frames */, true /* walk_cont */)
+                                        : RegisterMap(cont(), true /* update_map */);
     LiveFrameStream stream(jt, &regMap, cont_scope, cont);
     return fetchFirstBatch(stream, stackStream, mode, skip_frames, frame_count,
                            start_index, frames_array, THREAD);

--- a/src/hotspot/share/prims/stackwalk.cpp
+++ b/src/hotspot/share/prims/stackwalk.cpp
@@ -429,8 +429,11 @@ oop StackWalk::walk(Handle stackStream, jlong mode, int skip_frames, Handle cont
   // Setup traversal onto my stack.
   if (live_frame_info(mode)) {
     assert(use_frames_array(mode), "Bad mode for get live frame");
-    RegisterMap regMap = cont.is_null() ? RegisterMap(jt, true /* update_map */, true /* process_frames */, true /* walk_cont */)
-                                        : RegisterMap(cont(), true /* update_map */);
+    RegisterMap regMap = cont.is_null() ? RegisterMap(jt,
+                                                      RegisterMap::UpdateMap::yes,
+                                                      RegisterMap::ProcessFrames::yes,
+                                                      RegisterMap::WalkContinuation::yes)
+                                        : RegisterMap(cont(), RegisterMap::UpdateMap::yes);
     LiveFrameStream stream(jt, &regMap, cont_scope, cont);
     return fetchFirstBatch(stream, stackStream, mode, skip_frames, frame_count,
                            start_index, frames_array, THREAD);

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -768,8 +768,8 @@ WB_ENTRY(jboolean, WB_IsFrameDeoptimized(JNIEnv* env, jobject o, jint depth))
   bool result = false;
   if (thread->has_last_Java_frame()) {
     RegisterMap reg_map(thread,
-                        RegisterMap::UpdateMap::yes,
-                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::UpdateMap::include,
+                        RegisterMap::ProcessFrames::include,
                         RegisterMap::WalkContinuation::skip);
     javaVFrame *jvf = thread->last_java_vframe(&reg_map);
     for (jint d = 0; d < depth && jvf != NULL; d++) {
@@ -2107,8 +2107,8 @@ WB_ENTRY(jboolean, WB_HandshakeReadMonitors(JNIEnv* env, jobject wb, jobject thr
         return;
       }
       RegisterMap rmap(jt,
-                       RegisterMap::UpdateMap::yes,
-                       RegisterMap::ProcessFrames::yes,
+                       RegisterMap::UpdateMap::include,
+                       RegisterMap::ProcessFrames::include,
                        RegisterMap::WalkContinuation::skip);
       for (javaVFrame* vf = jt->last_java_vframe(&rmap); vf != NULL; vf = vf->java_sender()) {
         GrowableArray<MonitorInfo*> *monitors = vf->monitors();

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -767,7 +767,7 @@ WB_END
 WB_ENTRY(jboolean, WB_IsFrameDeoptimized(JNIEnv* env, jobject o, jint depth))
   bool result = false;
   if (thread->has_last_Java_frame()) {
-    RegisterMap reg_map(thread);
+    RegisterMap reg_map(thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
     javaVFrame *jvf = thread->last_java_vframe(&reg_map);
     for (jint d = 0; d < depth && jvf != NULL; d++) {
       jvf = jvf->java_sender();
@@ -2103,7 +2103,7 @@ WB_ENTRY(jboolean, WB_HandshakeReadMonitors(JNIEnv* env, jobject wb, jobject thr
       if (!jt->has_last_Java_frame()) {
         return;
       }
-      RegisterMap rmap(jt);
+      RegisterMap rmap(jt, true /* update_map */, true /* process_frames */, false /* walk_cont */);
       for (javaVFrame* vf = jt->last_java_vframe(&rmap); vf != NULL; vf = vf->java_sender()) {
         GrowableArray<MonitorInfo*> *monitors = vf->monitors();
         if (monitors != NULL) {

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -767,7 +767,10 @@ WB_END
 WB_ENTRY(jboolean, WB_IsFrameDeoptimized(JNIEnv* env, jobject o, jint depth))
   bool result = false;
   if (thread->has_last_Java_frame()) {
-    RegisterMap reg_map(thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+    RegisterMap reg_map(thread,
+                        RegisterMap::UpdateMap::yes,
+                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::WalkContinuation::skip);
     javaVFrame *jvf = thread->last_java_vframe(&reg_map);
     for (jint d = 0; d < depth && jvf != NULL; d++) {
       jvf = jvf->java_sender();
@@ -2103,7 +2106,10 @@ WB_ENTRY(jboolean, WB_HandshakeReadMonitors(JNIEnv* env, jobject wb, jobject thr
       if (!jt->has_last_Java_frame()) {
         return;
       }
-      RegisterMap rmap(jt, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+      RegisterMap rmap(jt,
+                       RegisterMap::UpdateMap::yes,
+                       RegisterMap::ProcessFrames::yes,
+                       RegisterMap::WalkContinuation::skip);
       for (javaVFrame* vf = jt->last_java_vframe(&rmap); vf != NULL; vf = vf->java_sender()) {
         GrowableArray<MonitorInfo*> *monitors = vf->monitors();
         if (monitors != NULL) {

--- a/src/hotspot/share/runtime/continuationEntry.cpp
+++ b/src/hotspot/share/runtime/continuationEntry.cpp
@@ -122,7 +122,10 @@ bool ContinuationEntry::assert_entry_frame_laid_out(JavaThread* thread) {
   } else {
     sp = unextended_sp;
     bool interpreted_bottom = false;
-    RegisterMap map(thread, false /* update_map */, false /* process_frames */, false /* walk_cont */);
+    RegisterMap map(thread,
+                    RegisterMap::UpdateMap::skip,
+                    RegisterMap::ProcessFrames::skip,
+                    RegisterMap::WalkContinuation::skip);
     frame f;
     for (f = thread->last_frame();
          !f.is_first_frame() && f.sp() <= unextended_sp && !Continuation::is_continuation_enterSpecial(f);

--- a/src/hotspot/share/runtime/continuationEntry.cpp
+++ b/src/hotspot/share/runtime/continuationEntry.cpp
@@ -122,7 +122,7 @@ bool ContinuationEntry::assert_entry_frame_laid_out(JavaThread* thread) {
   } else {
     sp = unextended_sp;
     bool interpreted_bottom = false;
-    RegisterMap map(thread, false, false, false);
+    RegisterMap map(thread, false /* update_map */, false /* process_frames */, false /* walk_cont */);
     frame f;
     for (f = thread->last_frame();
          !f.is_first_frame() && f.sp() <= unextended_sp && !Continuation::is_continuation_enterSpecial(f);

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -1145,7 +1145,7 @@ NOINLINE freeze_result FreezeBase::recurse_freeze_stub_frame(frame& f, frame& ca
   _freeze_size += fsize;
 
   RegisterMap map(_cont.thread(),
-                  RegisterMap::UpdateMap::yes,
+                  RegisterMap::UpdateMap::include,
                   RegisterMap::ProcessFrames::skip,
                   RegisterMap::WalkContinuation::skip);
   map.set_include_argument_oops(false);
@@ -1342,7 +1342,7 @@ static void jvmti_yield_cleanup(JavaThread* thread, ContinuationWrapper& cont) {
 static bool monitors_on_stack(JavaThread* thread) {
   ContinuationEntry* ce = thread->last_continuation();
   RegisterMap map(thread,
-                  RegisterMap::UpdateMap::yes,
+                  RegisterMap::UpdateMap::include,
                   RegisterMap::ProcessFrames::skip,
                   RegisterMap::WalkContinuation::skip);
   map.set_include_argument_oops(false);
@@ -1470,7 +1470,7 @@ static freeze_result is_pinned0(JavaThread* thread, oop cont_scope, bool safepoi
   }
 
   RegisterMap map(thread,
-                  RegisterMap::UpdateMap::yes,
+                  RegisterMap::UpdateMap::include,
                   RegisterMap::ProcessFrames::skip,
                   RegisterMap::WalkContinuation::skip);
   map.set_include_argument_oops(false);
@@ -2139,7 +2139,7 @@ void ThawBase::recurse_thaw_stub_frame(const frame& hf, frame& caller, int num_f
 
   {
     RegisterMap map(nullptr,
-                    RegisterMap::UpdateMap::yes,
+                    RegisterMap::UpdateMap::include,
                     RegisterMap::ProcessFrames::skip,
                     RegisterMap::WalkContinuation::skip);
     map.set_include_argument_oops(false);
@@ -2170,7 +2170,7 @@ void ThawBase::recurse_thaw_stub_frame(const frame& hf, frame& caller, int num_f
 
   { // can only fix caller once this frame is thawed (due to callee saved regs)
     RegisterMap map(nullptr,
-                    RegisterMap::UpdateMap::yes,
+                    RegisterMap::UpdateMap::include,
                     RegisterMap::ProcessFrames::skip,
                     RegisterMap::WalkContinuation::skip); // map.clear();
     map.set_include_argument_oops(false);
@@ -2402,8 +2402,8 @@ static void log_frames(JavaThread* thread) {
   }
 
   RegisterMap map(thread,
-                  RegisterMap::UpdateMap::yes,
-                  RegisterMap::ProcessFrames::yes,
+                  RegisterMap::UpdateMap::include,
+                  RegisterMap::ProcessFrames::include,
                   RegisterMap::WalkContinuation::skip);
   map.set_include_argument_oops(false);
 
@@ -2444,7 +2444,7 @@ static void print_frame_layout(const frame& f, bool callee_complete, outputStrea
   RegisterMap map(f.is_heap_frame() ?
                     (JavaThread*)nullptr :
                     JavaThread::current(),
-                  RegisterMap::UpdateMap::yes,
+                  RegisterMap::UpdateMap::include,
                   RegisterMap::ProcessFrames::skip,
                   RegisterMap::WalkContinuation::skip);
   map.set_include_argument_oops(false);

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -1144,7 +1144,10 @@ NOINLINE freeze_result FreezeBase::recurse_freeze_stub_frame(frame& f, frame& ca
   NOT_PRODUCT(_frames++;)
   _freeze_size += fsize;
 
-  RegisterMap map(_cont.thread(), true /* update_map */, false /* process_frames */, false /* walk_cont */);
+  RegisterMap map(_cont.thread(),
+                  RegisterMap::UpdateMap::yes,
+                  RegisterMap::ProcessFrames::skip,
+                  RegisterMap::WalkContinuation::skip);
   map.set_include_argument_oops(false);
   ContinuationHelper::update_register_map<ContinuationHelper::StubFrame>(f, &map);
   f.oop_map()->update_register_map(&f, &map); // we have callee-save registers in this case
@@ -1338,7 +1341,10 @@ static void jvmti_yield_cleanup(JavaThread* thread, ContinuationWrapper& cont) {
 #ifdef ASSERT
 static bool monitors_on_stack(JavaThread* thread) {
   ContinuationEntry* ce = thread->last_continuation();
-  RegisterMap map(thread, true /* update_map */, false /* process_frames */, false /* walk_cont */);
+  RegisterMap map(thread,
+                  RegisterMap::UpdateMap::yes,
+                  RegisterMap::ProcessFrames::skip,
+                  RegisterMap::WalkContinuation::skip);
   map.set_include_argument_oops(false);
   for (frame f = thread->last_frame(); Continuation::is_frame_in_continuation(ce, f); f = f.sender(&map)) {
     if ((f.is_interpreted_frame() && ContinuationHelper::InterpretedFrame::is_owning_locks(f)) ||
@@ -1351,7 +1357,10 @@ static bool monitors_on_stack(JavaThread* thread) {
 
 static bool interpreted_native_or_deoptimized_on_stack(JavaThread* thread) {
   ContinuationEntry* ce = thread->last_continuation();
-  RegisterMap map(thread, false /* update_map */, false /* process_frames */, false /* walk_cont */);
+  RegisterMap map(thread,
+                  RegisterMap::UpdateMap::skip,
+                  RegisterMap::ProcessFrames::skip,
+                  RegisterMap::WalkContinuation::skip);
   map.set_include_argument_oops(false);
   for (frame f = thread->last_frame(); Continuation::is_frame_in_continuation(ce, f); f = f.sender(&map)) {
     if (f.is_interpreted_frame() || f.is_native_frame() || f.is_deoptimized_frame()) {
@@ -1460,7 +1469,10 @@ static freeze_result is_pinned0(JavaThread* thread, oop cont_scope, bool safepoi
     return freeze_pinned_monitor;
   }
 
-  RegisterMap map(thread, true /* update_map */, false /* process_frames */, false /* walk_cont */);
+  RegisterMap map(thread,
+                  RegisterMap::UpdateMap::yes,
+                  RegisterMap::ProcessFrames::skip,
+                  RegisterMap::WalkContinuation::skip);
   map.set_include_argument_oops(false);
   frame f = thread->last_frame();
 
@@ -2126,7 +2138,10 @@ void ThawBase::recurse_thaw_stub_frame(const frame& hf, frame& caller, int num_f
   DEBUG_ONLY(_frames++;)
 
   {
-    RegisterMap map(nullptr, true /* update_map */, false /* process_frames */, false /* walk_cont */);
+    RegisterMap map(nullptr,
+                    RegisterMap::UpdateMap::yes,
+                    RegisterMap::ProcessFrames::skip,
+                    RegisterMap::WalkContinuation::skip);
     map.set_include_argument_oops(false);
     _stream.next(&map);
     assert(!_stream.is_done(), "");
@@ -2154,7 +2169,10 @@ void ThawBase::recurse_thaw_stub_frame(const frame& hf, frame& caller, int num_f
                   fsize + frame::metadata_words);
 
   { // can only fix caller once this frame is thawed (due to callee saved regs)
-    RegisterMap map(nullptr, true /* update_map */, false /* process_frames */, false /* walk_cont */); // map.clear();
+    RegisterMap map(nullptr,
+                    RegisterMap::UpdateMap::yes,
+                    RegisterMap::ProcessFrames::skip,
+                    RegisterMap::WalkContinuation::skip); // map.clear();
     map.set_include_argument_oops(false);
     f.oop_map()->update_register_map(&f, &map);
     ContinuationHelper::update_register_map_with_callee(caller, &map);
@@ -2383,7 +2401,10 @@ static void log_frames(JavaThread* thread) {
     ls.print_cr("NO ANCHOR!");
   }
 
-  RegisterMap map(thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap map(thread,
+                  RegisterMap::UpdateMap::yes,
+                  RegisterMap::ProcessFrames::yes,
+                  RegisterMap::WalkContinuation::skip);
   map.set_include_argument_oops(false);
 
   if (false) {
@@ -2421,8 +2442,11 @@ static void print_frame_layout(const frame& f, bool callee_complete, outputStrea
   FrameValues values;
   assert(f.get_cb() != nullptr, "");
   RegisterMap map(f.is_heap_frame() ?
-                  (JavaThread*)nullptr :
-                  JavaThread::current(), true /* update_map */, false /* process_frames */, false /* walk_cont */);
+                    (JavaThread*)nullptr :
+                    JavaThread::current(),
+                  RegisterMap::UpdateMap::yes,
+                  RegisterMap::ProcessFrames::skip,
+                  RegisterMap::WalkContinuation::skip);
   map.set_include_argument_oops(false);
   map.set_skip_missing(true);
   if (callee_complete) {

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -1144,7 +1144,7 @@ NOINLINE freeze_result FreezeBase::recurse_freeze_stub_frame(frame& f, frame& ca
   NOT_PRODUCT(_frames++;)
   _freeze_size += fsize;
 
-  RegisterMap map(_cont.thread(), true, false, false);
+  RegisterMap map(_cont.thread(), true /* update_map */, false /* process_frames */, false /* walk_cont */);
   map.set_include_argument_oops(false);
   ContinuationHelper::update_register_map<ContinuationHelper::StubFrame>(f, &map);
   f.oop_map()->update_register_map(&f, &map); // we have callee-save registers in this case
@@ -1338,7 +1338,7 @@ static void jvmti_yield_cleanup(JavaThread* thread, ContinuationWrapper& cont) {
 #ifdef ASSERT
 static bool monitors_on_stack(JavaThread* thread) {
   ContinuationEntry* ce = thread->last_continuation();
-  RegisterMap map(thread, true, false, false);
+  RegisterMap map(thread, true /* update_map */, false /* process_frames */, false /* walk_cont */);
   map.set_include_argument_oops(false);
   for (frame f = thread->last_frame(); Continuation::is_frame_in_continuation(ce, f); f = f.sender(&map)) {
     if ((f.is_interpreted_frame() && ContinuationHelper::InterpretedFrame::is_owning_locks(f)) ||
@@ -1351,7 +1351,7 @@ static bool monitors_on_stack(JavaThread* thread) {
 
 static bool interpreted_native_or_deoptimized_on_stack(JavaThread* thread) {
   ContinuationEntry* ce = thread->last_continuation();
-  RegisterMap map(thread, false, false, false);
+  RegisterMap map(thread, false /* update_map */, false /* process_frames */, false /* walk_cont */);
   map.set_include_argument_oops(false);
   for (frame f = thread->last_frame(); Continuation::is_frame_in_continuation(ce, f); f = f.sender(&map)) {
     if (f.is_interpreted_frame() || f.is_native_frame() || f.is_deoptimized_frame()) {
@@ -1460,7 +1460,7 @@ static freeze_result is_pinned0(JavaThread* thread, oop cont_scope, bool safepoi
     return freeze_pinned_monitor;
   }
 
-  RegisterMap map(thread, true, false, false);
+  RegisterMap map(thread, true /* update_map */, false /* process_frames */, false /* walk_cont */);
   map.set_include_argument_oops(false);
   frame f = thread->last_frame();
 
@@ -2154,7 +2154,7 @@ void ThawBase::recurse_thaw_stub_frame(const frame& hf, frame& caller, int num_f
                   fsize + frame::metadata_words);
 
   { // can only fix caller once this frame is thawed (due to callee saved regs)
-    RegisterMap map(nullptr, true, false, false); // map.clear();
+    RegisterMap map(nullptr, true /* update_map */, false /* process_frames */, false /* walk_cont */); // map.clear();
     map.set_include_argument_oops(false);
     f.oop_map()->update_register_map(&f, &map);
     ContinuationHelper::update_register_map_with_callee(caller, &map);
@@ -2383,7 +2383,7 @@ static void log_frames(JavaThread* thread) {
     ls.print_cr("NO ANCHOR!");
   }
 
-  RegisterMap map(thread, true, true, false);
+  RegisterMap map(thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
   map.set_include_argument_oops(false);
 
   if (false) {
@@ -2422,7 +2422,7 @@ static void print_frame_layout(const frame& f, bool callee_complete, outputStrea
   assert(f.get_cb() != nullptr, "");
   RegisterMap map(f.is_heap_frame() ?
                   (JavaThread*)nullptr :
-                  JavaThread::current(), true, false, false);
+                  JavaThread::current(), true /* update_map */, false /* process_frames */, false /* walk_cont */);
   map.set_include_argument_oops(false);
   map.set_skip_missing(true);
   if (callee_complete) {

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -2126,7 +2126,7 @@ void ThawBase::recurse_thaw_stub_frame(const frame& hf, frame& caller, int num_f
   DEBUG_ONLY(_frames++;)
 
   {
-    RegisterMap map(nullptr, true, false, false);
+    RegisterMap map(nullptr, true /* update_map */, false /* process_frames */, false /* walk_cont */);
     map.set_include_argument_oops(false);
     _stream.next(&map);
     assert(!_stream.is_done(), "");

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -375,12 +375,12 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
 
   frame stub_frame = current->last_frame(); // Makes stack walkable as side effect
   RegisterMap map(current,
-                  RegisterMap::UpdateMap::yes,
-                  RegisterMap::ProcessFrames::yes,
+                  RegisterMap::UpdateMap::include,
+                  RegisterMap::ProcessFrames::include,
                   RegisterMap::WalkContinuation::skip);
   RegisterMap dummy_map(current,
                         RegisterMap::UpdateMap::skip,
-                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::ProcessFrames::include,
                         RegisterMap::WalkContinuation::skip);
   // Now get the deoptee with a valid map
   frame deoptee = stub_frame.sender(&map);
@@ -800,7 +800,7 @@ JRT_LEAF(BasicType, Deoptimization::unpack_frames(JavaThread* thread, int exec_m
     vframeArray* cur_array = thread->vframe_array_last();
     RegisterMap rm(thread,
                    RegisterMap::UpdateMap::skip,
-                   RegisterMap::ProcessFrames::yes,
+                   RegisterMap::ProcessFrames::include,
                    RegisterMap::WalkContinuation::skip);
     rm.set_include_argument_oops(false);
     bool is_top_frame = true;
@@ -1669,7 +1669,7 @@ address Deoptimization::deoptimize_for_missing_exception_handler(CompiledMethod*
   JavaThread* thread = JavaThread::current();
   RegisterMap reg_map(thread,
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   frame runtime_frame = thread->last_frame();
   frame caller_frame = runtime_frame.sender(&reg_map);
@@ -1705,7 +1705,7 @@ void Deoptimization::deoptimize_frame_internal(JavaThread* thread, intptr_t* id,
   // Compute frame and register map based on thread and sp.
   RegisterMap reg_map(thread,
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   frame fr = thread->last_frame();
   while (fr.id() != id) {
@@ -1884,13 +1884,13 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
 #if INCLUDE_JVMCI
   // JVMCI might need to get an exception from the stack, which in turn requires the register map to be valid
   RegisterMap reg_map(current,
-                      RegisterMap::UpdateMap::yes,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::UpdateMap::include,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
 #else
   RegisterMap reg_map(current,
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
 #endif
   frame stub_frame = current->last_frame();

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -374,8 +374,8 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
   current->set_deopt_mark(dmark);
 
   frame stub_frame = current->last_frame(); // Makes stack walkable as side effect
-  RegisterMap map(current, true);
-  RegisterMap dummy_map(current, false);
+  RegisterMap map(current, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap dummy_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
   // Now get the deoptee with a valid map
   frame deoptee = stub_frame.sender(&map);
   // Set the deoptee nmethod
@@ -792,7 +792,7 @@ JRT_LEAF(BasicType, Deoptimization::unpack_frames(JavaThread* thread, int exec_m
     // Verify that the just-unpacked frames match the interpreter's
     // notions of expression stack and locals
     vframeArray* cur_array = thread->vframe_array_last();
-    RegisterMap rm(thread, false);
+    RegisterMap rm(thread, false /* update_map */, true /* process_frames */, false /* walk_cont */);
     rm.set_include_argument_oops(false);
     bool is_top_frame = true;
     int callee_size_of_parameters = 0;
@@ -1658,7 +1658,7 @@ address Deoptimization::deoptimize_for_missing_exception_handler(CompiledMethod*
   // it also patches the return pc but we do not care about that
   // since we return a continuation to the deopt_blob below.
   JavaThread* thread = JavaThread::current();
-  RegisterMap reg_map(thread, false);
+  RegisterMap reg_map(thread, false /* update_map */, true /* process_frames */, false /* walk_cont */);
   frame runtime_frame = thread->last_frame();
   frame caller_frame = runtime_frame.sender(&reg_map);
   assert(caller_frame.cb()->as_compiled_method_or_null() == cm, "expect top frame compiled method");
@@ -1691,7 +1691,7 @@ void Deoptimization::deoptimize_frame_internal(JavaThread* thread, intptr_t* id,
          SafepointSynchronize::is_at_safepoint(),
          "can only deoptimize other thread at a safepoint/handshake");
   // Compute frame and register map based on thread and sp.
-  RegisterMap reg_map(thread, false);
+  RegisterMap reg_map(thread, false /* update_map */, true /* process_frames */, false /* walk_cont */);
   frame fr = thread->last_frame();
   while (fr.id() != id) {
     fr = fr.sender(&reg_map);
@@ -1868,7 +1868,7 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
 
 #if INCLUDE_JVMCI
   // JVMCI might need to get an exception from the stack, which in turn requires the register map to be valid
-  RegisterMap reg_map(current, true);
+  RegisterMap reg_map(current, true /* update_map */, true /* process_frames */, false /* walk_cont */);
 #else
   RegisterMap reg_map(current, false);
 #endif

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -374,8 +374,14 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
   current->set_deopt_mark(dmark);
 
   frame stub_frame = current->last_frame(); // Makes stack walkable as side effect
-  RegisterMap map(current, true /* update_map */, true /* process_frames */, false /* walk_cont */);
-  RegisterMap dummy_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap map(current,
+                  RegisterMap::UpdateMap::yes,
+                  RegisterMap::ProcessFrames::yes,
+                  RegisterMap::WalkContinuation::skip);
+  RegisterMap dummy_map(current,
+                        RegisterMap::UpdateMap::skip,
+                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::WalkContinuation::skip);
   // Now get the deoptee with a valid map
   frame deoptee = stub_frame.sender(&map);
   // Set the deoptee nmethod
@@ -792,7 +798,10 @@ JRT_LEAF(BasicType, Deoptimization::unpack_frames(JavaThread* thread, int exec_m
     // Verify that the just-unpacked frames match the interpreter's
     // notions of expression stack and locals
     vframeArray* cur_array = thread->vframe_array_last();
-    RegisterMap rm(thread, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+    RegisterMap rm(thread,
+                   RegisterMap::UpdateMap::skip,
+                   RegisterMap::ProcessFrames::yes,
+                   RegisterMap::WalkContinuation::skip);
     rm.set_include_argument_oops(false);
     bool is_top_frame = true;
     int callee_size_of_parameters = 0;
@@ -1658,7 +1667,10 @@ address Deoptimization::deoptimize_for_missing_exception_handler(CompiledMethod*
   // it also patches the return pc but we do not care about that
   // since we return a continuation to the deopt_blob below.
   JavaThread* thread = JavaThread::current();
-  RegisterMap reg_map(thread, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(thread,
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   frame runtime_frame = thread->last_frame();
   frame caller_frame = runtime_frame.sender(&reg_map);
   assert(caller_frame.cb()->as_compiled_method_or_null() == cm, "expect top frame compiled method");
@@ -1691,7 +1703,10 @@ void Deoptimization::deoptimize_frame_internal(JavaThread* thread, intptr_t* id,
          SafepointSynchronize::is_at_safepoint(),
          "can only deoptimize other thread at a safepoint/handshake");
   // Compute frame and register map based on thread and sp.
-  RegisterMap reg_map(thread, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(thread,
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   frame fr = thread->last_frame();
   while (fr.id() != id) {
     fr = fr.sender(&reg_map);
@@ -1868,9 +1883,15 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
 
 #if INCLUDE_JVMCI
   // JVMCI might need to get an exception from the stack, which in turn requires the register map to be valid
-  RegisterMap reg_map(current, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(current,
+                      RegisterMap::UpdateMap::yes,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
 #else
-  RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(current,
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
 #endif
   frame stub_frame = current->last_frame();
   frame fr = stub_frame.sender(&reg_map);

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1870,7 +1870,7 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
   // JVMCI might need to get an exception from the stack, which in turn requires the register map to be valid
   RegisterMap reg_map(current, true /* update_map */, true /* process_frames */, false /* walk_cont */);
 #else
-  RegisterMap reg_map(current, false);
+  RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
 #endif
   frame stub_frame = current->last_frame();
   frame fr = stub_frame.sender(&reg_map);

--- a/src/hotspot/share/runtime/escapeBarrier.cpp
+++ b/src/hotspot/share/runtime/escapeBarrier.cpp
@@ -80,7 +80,10 @@ bool EscapeBarrier::deoptimize_objects(int d1, int d2) {
     KeepStackGCProcessedMark ksgcpm(deoptee_thread());
     ResourceMark rm(calling_thread());
     HandleMark   hm(calling_thread());
-    RegisterMap  reg_map(deoptee_thread(), false /* update_map */, false /* process_frames */, false /* walk_cont */);
+    RegisterMap  reg_map(deoptee_thread(),
+                         RegisterMap::UpdateMap::skip,
+                         RegisterMap::ProcessFrames::skip,
+                         RegisterMap::WalkContinuation::skip);
     vframe* vf = deoptee_thread()->last_java_vframe(&reg_map);
     int cur_depth = 0;
 
@@ -132,7 +135,10 @@ bool EscapeBarrier::deoptimize_objects_all_threads() {
     }
     if (jt->has_last_Java_frame()) {
       KeepStackGCProcessedMark ksgcpm(jt);
-      RegisterMap reg_map(jt, false /* update_map */, false /* process_frames */, false /* walk_cont */);
+      RegisterMap reg_map(jt,
+                          RegisterMap::UpdateMap::skip,
+                          RegisterMap::ProcessFrames::skip,
+                          RegisterMap::WalkContinuation::skip);
       vframe* vf = jt->last_java_vframe(&reg_map);
       assert(jt->frame_anchor()->walkable(),
              "The stack of JavaThread " PTR_FORMAT " is not walkable. Thread state is %d",

--- a/src/hotspot/share/runtime/escapeBarrier.cpp
+++ b/src/hotspot/share/runtime/escapeBarrier.cpp
@@ -80,7 +80,7 @@ bool EscapeBarrier::deoptimize_objects(int d1, int d2) {
     KeepStackGCProcessedMark ksgcpm(deoptee_thread());
     ResourceMark rm(calling_thread());
     HandleMark   hm(calling_thread());
-    RegisterMap  reg_map(deoptee_thread(), false /* update_map */, false /* process_frames */);
+    RegisterMap  reg_map(deoptee_thread(), false /* update_map */, false /* process_frames */, false /* walk_cont */);
     vframe* vf = deoptee_thread()->last_java_vframe(&reg_map);
     int cur_depth = 0;
 
@@ -132,7 +132,7 @@ bool EscapeBarrier::deoptimize_objects_all_threads() {
     }
     if (jt->has_last_Java_frame()) {
       KeepStackGCProcessedMark ksgcpm(jt);
-      RegisterMap reg_map(jt, false /* update_map */, false /* process_frames */);
+      RegisterMap reg_map(jt, false /* update_map */, false /* process_frames */, false /* walk_cont */);
       vframe* vf = jt->last_java_vframe(&reg_map);
       assert(jt->frame_anchor()->walkable(),
              "The stack of JavaThread " PTR_FORMAT " is not walkable. Thread state is %d",

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -62,15 +62,15 @@
 
 RegisterMap::RegisterMap(JavaThread *thread, UpdateMap update_map, ProcessFrames process_frames, WalkContinuation walk_cont) {
   _thread         = thread;
-  _update_map     = update_map == UpdateMap::yes;
-  _process_frames = process_frames == ProcessFrames::yes;
-  _walk_cont      = walk_cont == WalkContinuation::yes;
+  _update_map     = update_map == UpdateMap::include;
+  _process_frames = process_frames == ProcessFrames::include;
+  _walk_cont      = walk_cont == WalkContinuation::include;
   clear();
   DEBUG_ONLY (_update_for_id = NULL;)
   NOT_PRODUCT(_skip_missing = false;)
   NOT_PRODUCT(_async = false;)
 
-  if (walk_cont == WalkContinuation::yes && thread != NULL && thread->last_continuation() != NULL) {
+  if (walk_cont == WalkContinuation::include && thread != NULL && thread->last_continuation() != NULL) {
     _chunk = stackChunkHandle(Thread::current()->handle_area()->allocate_null_handle(), true /* dummy */);
   }
   _chunk_index = -1;
@@ -82,7 +82,7 @@ RegisterMap::RegisterMap(JavaThread *thread, UpdateMap update_map, ProcessFrames
 
 RegisterMap::RegisterMap(oop continuation, UpdateMap update_map) {
   _thread         = NULL;
-  _update_map     = update_map == UpdateMap::yes;
+  _update_map     = update_map == UpdateMap::include;
   _process_frames = false;
   _walk_cont      = true;
   clear();
@@ -276,7 +276,7 @@ bool frame::is_safepoint_blob_frame() const {
 bool frame::is_first_java_frame() const {
   RegisterMap map(JavaThread::current(),
                   RegisterMap::UpdateMap::skip,
-                  RegisterMap::ProcessFrames::yes,
+                  RegisterMap::ProcessFrames::include,
                   RegisterMap::WalkContinuation::skip); // No update
   frame s;
   for (s = sender(&map); !(s.is_java_frame() || s.is_first_frame()); s = s.sender(&map));
@@ -371,7 +371,7 @@ void frame::deoptimize(JavaThread* thread) {
     if (is_older(check.id())) {
       RegisterMap map(thread,
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
       while (id() != check.id()) {
         check = check.sender(&map);
@@ -385,7 +385,7 @@ void frame::deoptimize(JavaThread* thread) {
 frame frame::java_sender() const {
   RegisterMap map(JavaThread::current(),
                   RegisterMap::UpdateMap::skip,
-                  RegisterMap::ProcessFrames::yes,
+                  RegisterMap::ProcessFrames::include,
                   RegisterMap::WalkContinuation::skip);
   frame s;
   for (s = sender(&map); !(s.is_java_frame() || s.is_first_frame()); s = s.sender(&map)) ;

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -60,17 +60,17 @@
 #include "utilities/decoder.hpp"
 #include "utilities/formatBuffer.hpp"
 
-RegisterMap::RegisterMap(JavaThread *thread, bool update_map, bool process_frames, bool walk_cont) {
+RegisterMap::RegisterMap(JavaThread *thread, UpdateMap update_map, ProcessFrames process_frames, WalkContinuation walk_cont) {
   _thread         = thread;
-  _update_map     = update_map;
-  _process_frames = process_frames;
-  _walk_cont      = walk_cont;
+  _update_map     = update_map == UpdateMap::yes;
+  _process_frames = process_frames == ProcessFrames::yes;
+  _walk_cont      = walk_cont == WalkContinuation::yes;
   clear();
   DEBUG_ONLY (_update_for_id = NULL;)
   NOT_PRODUCT(_skip_missing = false;)
   NOT_PRODUCT(_async = false;)
 
-  if (walk_cont && thread != NULL && thread->last_continuation() != NULL) {
+  if (walk_cont == WalkContinuation::yes && thread != NULL && thread->last_continuation() != NULL) {
     _chunk = stackChunkHandle(Thread::current()->handle_area()->allocate_null_handle(), true /* dummy */);
   }
   _chunk_index = -1;
@@ -80,9 +80,9 @@ RegisterMap::RegisterMap(JavaThread *thread, bool update_map, bool process_frame
 #endif /* PRODUCT */
 }
 
-RegisterMap::RegisterMap(oop continuation, bool update_map) {
+RegisterMap::RegisterMap(oop continuation, UpdateMap update_map) {
   _thread         = NULL;
-  _update_map     = update_map;
+  _update_map     = update_map == UpdateMap::yes;;
   _process_frames = false;
   _walk_cont      = true;
   clear();
@@ -274,7 +274,10 @@ bool frame::is_safepoint_blob_frame() const {
 // testers
 
 bool frame::is_first_java_frame() const {
-  RegisterMap map(JavaThread::current(), false /* update_map */, true /* process_frames */, false /* walk_cont */); // No update
+  RegisterMap map(JavaThread::current(),
+                  RegisterMap::UpdateMap::skip,
+                  RegisterMap::ProcessFrames::yes,
+                  RegisterMap::WalkContinuation::skip); // No update
   frame s;
   for (s = sender(&map); !(s.is_java_frame() || s.is_first_frame()); s = s.sender(&map));
   return s.is_first_frame();
@@ -366,7 +369,10 @@ void frame::deoptimize(JavaThread* thread) {
   if (thread != NULL) {
     frame check = thread->last_frame();
     if (is_older(check.id())) {
-      RegisterMap map(thread, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+      RegisterMap map(thread,
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
       while (id() != check.id()) {
         check = check.sender(&map);
       }
@@ -377,7 +383,10 @@ void frame::deoptimize(JavaThread* thread) {
 }
 
 frame frame::java_sender() const {
-  RegisterMap map(JavaThread::current(), false /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap map(JavaThread::current(),
+                  RegisterMap::UpdateMap::skip,
+                  RegisterMap::ProcessFrames::yes,
+                  RegisterMap::WalkContinuation::skip);
   frame s;
   for (s = sender(&map); !(s.is_java_frame() || s.is_first_frame()); s = s.sender(&map)) ;
   guarantee(s.is_java_frame(), "tried to get caller of first java frame");

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -82,7 +82,7 @@ RegisterMap::RegisterMap(JavaThread *thread, UpdateMap update_map, ProcessFrames
 
 RegisterMap::RegisterMap(oop continuation, UpdateMap update_map) {
   _thread         = NULL;
-  _update_map     = update_map == UpdateMap::yes;;
+  _update_map     = update_map == UpdateMap::yes;
   _process_frames = false;
   _walk_cont      = true;
   clear();

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -274,7 +274,7 @@ bool frame::is_safepoint_blob_frame() const {
 // testers
 
 bool frame::is_first_java_frame() const {
-  RegisterMap map(JavaThread::current(), false); // No update
+  RegisterMap map(JavaThread::current(), false /* update_map */, true /* process_frames */, false /* walk_cont */); // No update
   frame s;
   for (s = sender(&map); !(s.is_java_frame() || s.is_first_frame()); s = s.sender(&map));
   return s.is_first_frame();
@@ -366,7 +366,7 @@ void frame::deoptimize(JavaThread* thread) {
   if (thread != NULL) {
     frame check = thread->last_frame();
     if (is_older(check.id())) {
-      RegisterMap map(thread, false);
+      RegisterMap map(thread, false /* update_map */, true /* process_frames */, false /* walk_cont */);
       while (id() != check.id()) {
         check = check.sender(&map);
       }
@@ -377,7 +377,7 @@ void frame::deoptimize(JavaThread* thread) {
 }
 
 frame frame::java_sender() const {
-  RegisterMap map(JavaThread::current(), false);
+  RegisterMap map(JavaThread::current(), false /* update_map */, true /* process_frames */, false /* walk_cont */);
   frame s;
   for (s = sender(&map); !(s.is_java_frame() || s.is_first_frame()); s = s.sender(&map)) ;
   guarantee(s.is_java_frame(), "tried to get caller of first java frame");

--- a/src/hotspot/share/runtime/interfaceSupport.cpp
+++ b/src/hotspot/share/runtime/interfaceSupport.cpp
@@ -163,8 +163,8 @@ void InterfaceSupport::walk_stack() {
   if (!thread->has_last_Java_frame()) return;
   ResourceMark rm(thread);
   RegisterMap reg_map(thread,
-                      RegisterMap::UpdateMap::yes,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::UpdateMap::include,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   walk_stack_from(thread->last_java_vframe(&reg_map));
 }
@@ -233,8 +233,8 @@ void InterfaceSupport::verify_last_frame() {
   JavaThread* thread = JavaThread::current();
   ResourceMark rm(thread);
   RegisterMap reg_map(thread,
-                      RegisterMap::UpdateMap::yes,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::UpdateMap::include,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   frame fr = thread->last_frame();
   fr.verify(&reg_map);

--- a/src/hotspot/share/runtime/interfaceSupport.cpp
+++ b/src/hotspot/share/runtime/interfaceSupport.cpp
@@ -162,7 +162,7 @@ void InterfaceSupport::walk_stack() {
   walk_stack_counter++;
   if (!thread->has_last_Java_frame()) return;
   ResourceMark rm(thread);
-  RegisterMap reg_map(thread);
+  RegisterMap reg_map(thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
   walk_stack_from(thread->last_java_vframe(&reg_map));
 }
 
@@ -229,7 +229,7 @@ void InterfaceSupport::verify_stack() {
 void InterfaceSupport::verify_last_frame() {
   JavaThread* thread = JavaThread::current();
   ResourceMark rm(thread);
-  RegisterMap reg_map(thread);
+  RegisterMap reg_map(thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
   frame fr = thread->last_frame();
   fr.verify(&reg_map);
 }

--- a/src/hotspot/share/runtime/interfaceSupport.cpp
+++ b/src/hotspot/share/runtime/interfaceSupport.cpp
@@ -162,7 +162,10 @@ void InterfaceSupport::walk_stack() {
   walk_stack_counter++;
   if (!thread->has_last_Java_frame()) return;
   ResourceMark rm(thread);
-  RegisterMap reg_map(thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(thread,
+                      RegisterMap::UpdateMap::yes,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   walk_stack_from(thread->last_java_vframe(&reg_map));
 }
 
@@ -229,7 +232,10 @@ void InterfaceSupport::verify_stack() {
 void InterfaceSupport::verify_last_frame() {
   JavaThread* thread = JavaThread::current();
   ResourceMark rm(thread);
-  RegisterMap reg_map(thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(thread,
+                      RegisterMap::UpdateMap::yes,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   frame fr = thread->last_frame();
   fr.verify(&reg_map);
 }

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1056,7 +1056,7 @@ void JavaThread::handle_async_exception(oop java_throwable) {
       // handler table may not be valid.
       RegisterMap reg_map(this,
                           RegisterMap::UpdateMap::skip,
-                          RegisterMap::ProcessFrames::yes,
+                          RegisterMap::ProcessFrames::include,
                           RegisterMap::WalkContinuation::skip);
       frame compiled_frame = f.sender(&reg_map);
       if (!StressCompiledExceptionHandlers && compiled_frame.can_be_deoptimized()) {
@@ -1708,8 +1708,8 @@ void JavaThread::print_stack_on(outputStream* st) {
   HandleMark hm(current_thread);
 
   RegisterMap reg_map(this,
-                      RegisterMap::UpdateMap::yes,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::UpdateMap::include,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   vframe* start_vf = platform_thread_last_java_vframe(&reg_map);
   int count = 0;
@@ -1856,8 +1856,8 @@ void JavaThread::trace_stack() {
   ResourceMark rm(current_thread);
   HandleMark hm(current_thread);
   RegisterMap reg_map(this,
-                      RegisterMap::UpdateMap::yes,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::UpdateMap::include,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   trace_stack_from(last_java_vframe(&reg_map));
 }

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1054,7 +1054,7 @@ void JavaThread::handle_async_exception(oop java_throwable) {
       // OptoRuntime from compiled code. Some runtime stubs (new, monitor_exit..)
       // must deoptimize the caller before continuing, as the compiled exception
       // handler table may not be valid.
-      RegisterMap reg_map(this, false);
+      RegisterMap reg_map(this, false /* update_map */, true /* process_frames */, false /* walk_cont */);
       frame compiled_frame = f.sender(&reg_map);
       if (!StressCompiledExceptionHandlers && compiled_frame.can_be_deoptimized()) {
         Deoptimization::deoptimize(this, compiled_frame);
@@ -1556,7 +1556,7 @@ void JavaThread::frames_do(void f(frame*, const RegisterMap* map)) {
   // ignore if there is no stack
   if (!has_last_Java_frame()) return;
   // traverse the stack frames. Starts from top frame.
-  for (StackFrameStream fst(this, true /* update */, true /* process_frames */); !fst.is_done(); fst.next()) {
+  for (StackFrameStream fst(this, true /* update_map */, true /* process_frames */, false /* walk_cont */); !fst.is_done(); fst.next()) {
     frame* fr = fst.current();
     f(fr, fst.register_map());
   }
@@ -1704,7 +1704,7 @@ void JavaThread::print_stack_on(outputStream* st) {
   ResourceMark rm(current_thread);
   HandleMark hm(current_thread);
 
-  RegisterMap reg_map(this, true, true);
+  RegisterMap reg_map(this, true /* update_map */, true /* process_frames */, false /* walk_cont */);
   vframe* start_vf = platform_thread_last_java_vframe(&reg_map);
   int count = 0;
   for (vframe* f = start_vf; f != NULL; f = f->sender()) {
@@ -1849,7 +1849,7 @@ void JavaThread::trace_stack() {
   Thread* current_thread = Thread::current();
   ResourceMark rm(current_thread);
   HandleMark hm(current_thread);
-  RegisterMap reg_map(this, true, true);
+  RegisterMap reg_map(this, true /* update_map */, true /* process_frames */, false /* walk_cont */);
   trace_stack_from(last_java_vframe(&reg_map));
 }
 

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1054,7 +1054,10 @@ void JavaThread::handle_async_exception(oop java_throwable) {
       // OptoRuntime from compiled code. Some runtime stubs (new, monitor_exit..)
       // must deoptimize the caller before continuing, as the compiled exception
       // handler table may not be valid.
-      RegisterMap reg_map(this, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+      RegisterMap reg_map(this,
+                          RegisterMap::UpdateMap::skip,
+                          RegisterMap::ProcessFrames::yes,
+                          RegisterMap::WalkContinuation::skip);
       frame compiled_frame = f.sender(&reg_map);
       if (!StressCompiledExceptionHandlers && compiled_frame.can_be_deoptimized()) {
         Deoptimization::deoptimize(this, compiled_frame);
@@ -1704,7 +1707,10 @@ void JavaThread::print_stack_on(outputStream* st) {
   ResourceMark rm(current_thread);
   HandleMark hm(current_thread);
 
-  RegisterMap reg_map(this, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(this,
+                      RegisterMap::UpdateMap::yes,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   vframe* start_vf = platform_thread_last_java_vframe(&reg_map);
   int count = 0;
   for (vframe* f = start_vf; f != NULL; f = f->sender()) {
@@ -1849,7 +1855,10 @@ void JavaThread::trace_stack() {
   Thread* current_thread = Thread::current();
   ResourceMark rm(current_thread);
   HandleMark hm(current_thread);
-  RegisterMap reg_map(this, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(this,
+                      RegisterMap::UpdateMap::yes,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   trace_stack_from(last_java_vframe(&reg_map));
 }
 

--- a/src/hotspot/share/runtime/registerMap.hpp
+++ b/src/hotspot/share/runtime/registerMap.hpp
@@ -70,9 +70,9 @@ class RegisterMap : public StackObj {
     location_valid_type_size = sizeof(LocationValidType)*8,
     location_valid_size = (reg_count+location_valid_type_size-1)/location_valid_type_size
   };
-  enum class UpdateMap { skip, yes };
-  enum class ProcessFrames { skip, yes };
-  enum class WalkContinuation   { skip, yes };
+  enum class UpdateMap { skip, include };
+  enum class ProcessFrames { skip, include };
+  enum class WalkContinuation { skip, include };
  private:
   intptr_t*         _location[reg_count];     // Location of registers (intptr_t* looks better than address in the debugger)
   LocationValidType _location_valid[location_valid_size];

--- a/src/hotspot/share/runtime/registerMap.hpp
+++ b/src/hotspot/share/runtime/registerMap.hpp
@@ -94,8 +94,8 @@ class RegisterMap : public StackObj {
 
  public:
   DEBUG_ONLY(intptr_t* _update_for_id;) // Assert that RegisterMap is not updated twice for same frame
-  RegisterMap(JavaThread *thread, bool update_map = true, bool process_frames = true, bool walk_cont = false);
-  RegisterMap(oop continuation, bool update_map = true);
+  RegisterMap(JavaThread *thread, bool update_map, bool process_frames, bool walk_cont);
+  RegisterMap(oop continuation, bool update_map);
   RegisterMap(const RegisterMap* map);
 
   address location(VMReg reg, intptr_t* sp) const {

--- a/src/hotspot/share/runtime/registerMap.hpp
+++ b/src/hotspot/share/runtime/registerMap.hpp
@@ -60,7 +60,8 @@ class JavaThread;
 //      values of the callee-saved registers does not matter, e.g., if you
 //      only need the static properties such as frame type, pc, and such.
 //      Updating of the RegisterMap can be turned off by instantiating the
-//      register map as: RegisterMap map(thread, false);
+//      register map as: RegisterMap map(thread, false /* update_map */,
+//      true /* process_frames */, false /* walk_cont */);
 
 class RegisterMap : public StackObj {
  public:

--- a/src/hotspot/share/runtime/registerMap.hpp
+++ b/src/hotspot/share/runtime/registerMap.hpp
@@ -60,8 +60,7 @@ class JavaThread;
 //      values of the callee-saved registers does not matter, e.g., if you
 //      only need the static properties such as frame type, pc, and such.
 //      Updating of the RegisterMap can be turned off by instantiating the
-//      register map as: RegisterMap map(thread, false /* update_map */,
-//      true /* process_frames */, false /* walk_cont */);
+//      register map with RegisterMap::UpdateMap::skip
 
 class RegisterMap : public StackObj {
  public:
@@ -71,6 +70,9 @@ class RegisterMap : public StackObj {
     location_valid_type_size = sizeof(LocationValidType)*8,
     location_valid_size = (reg_count+location_valid_type_size-1)/location_valid_type_size
   };
+  enum class UpdateMap { skip, yes };
+  enum class ProcessFrames { skip, yes };
+  enum class WalkContinuation   { skip, yes };
  private:
   intptr_t*         _location[reg_count];     // Location of registers (intptr_t* looks better than address in the debugger)
   LocationValidType _location_valid[location_valid_size];
@@ -95,8 +97,8 @@ class RegisterMap : public StackObj {
 
  public:
   DEBUG_ONLY(intptr_t* _update_for_id;) // Assert that RegisterMap is not updated twice for same frame
-  RegisterMap(JavaThread *thread, bool update_map, bool process_frames, bool walk_cont);
-  RegisterMap(oop continuation, bool update_map);
+  RegisterMap(JavaThread *thread, UpdateMap update_map, ProcessFrames process_frames, WalkContinuation walk_cont);
+  RegisterMap(oop continuation, UpdateMap update_map);
   RegisterMap(const RegisterMap* map);
 
   address location(VMReg reg, intptr_t* sp) const {

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -916,7 +916,7 @@ void ThreadSafepointState::handle_polling_page_exception() {
   CodeBlob* stub_cb = stub_fr.cb();
   assert(stub_cb->is_safepoint_stub(), "must be a safepoint stub");
   RegisterMap map(self,
-                  RegisterMap::UpdateMap::yes,
+                  RegisterMap::UpdateMap::include,
                   RegisterMap::ProcessFrames::skip,
                   RegisterMap::WalkContinuation::skip);
   frame caller_fr = stub_fr.sender(&map);
@@ -984,7 +984,7 @@ void ThreadSafepointState::handle_polling_page_exception() {
     // If an exception has been installed we must verify that the top frame wasn't deoptimized.
     if (self->has_pending_exception() ) {
       RegisterMap map(self,
-                      RegisterMap::UpdateMap::yes,
+                      RegisterMap::UpdateMap::include,
                       RegisterMap::ProcessFrames::skip,
                       RegisterMap::WalkContinuation::skip);
       frame caller_fr = stub_fr.sender(&map);

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -915,7 +915,7 @@ void ThreadSafepointState::handle_polling_page_exception() {
   frame stub_fr = self->last_frame();
   CodeBlob* stub_cb = stub_fr.cb();
   assert(stub_cb->is_safepoint_stub(), "must be a safepoint stub");
-  RegisterMap map(self, true, false);
+  RegisterMap map(self, true /* update_map */, false /* process_frames */, false /* walk_cont */);
   frame caller_fr = stub_fr.sender(&map);
 
   // Should only be poll_return or poll
@@ -980,7 +980,7 @@ void ThreadSafepointState::handle_polling_page_exception() {
 
     // If an exception has been installed we must verify that the top frame wasn't deoptimized.
     if (self->has_pending_exception() ) {
-      RegisterMap map(self, true, false);
+      RegisterMap map(self, true /* update_map */, false /* process_frames */, false /* walk_cont */);
       frame caller_fr = stub_fr.sender(&map);
       if (caller_fr.is_deoptimized_frame()) {
         // The exception path will destroy registers that are still

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -915,7 +915,10 @@ void ThreadSafepointState::handle_polling_page_exception() {
   frame stub_fr = self->last_frame();
   CodeBlob* stub_cb = stub_fr.cb();
   assert(stub_cb->is_safepoint_stub(), "must be a safepoint stub");
-  RegisterMap map(self, true /* update_map */, false /* process_frames */, false /* walk_cont */);
+  RegisterMap map(self,
+                  RegisterMap::UpdateMap::yes,
+                  RegisterMap::ProcessFrames::skip,
+                  RegisterMap::WalkContinuation::skip);
   frame caller_fr = stub_fr.sender(&map);
 
   // Should only be poll_return or poll
@@ -980,7 +983,10 @@ void ThreadSafepointState::handle_polling_page_exception() {
 
     // If an exception has been installed we must verify that the top frame wasn't deoptimized.
     if (self->has_pending_exception() ) {
-      RegisterMap map(self, true /* update_map */, false /* process_frames */, false /* walk_cont */);
+      RegisterMap map(self,
+                      RegisterMap::UpdateMap::yes,
+                      RegisterMap::ProcessFrames::skip,
+                      RegisterMap::WalkContinuation::skip);
       frame caller_fr = stub_fr.sender(&map);
       if (caller_fr.is_deoptimized_frame()) {
         // The exception path will destroy registers that are still

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1152,8 +1152,8 @@ Handle SharedRuntime::find_callee_info_helper(vframeStream& vfst, Bytecodes::Cod
     // This register map must be update since we need to find the receiver for
     // compiled frames. The receiver might be in a register.
     RegisterMap reg_map2(current,
-                         RegisterMap::UpdateMap::yes,
-                         RegisterMap::ProcessFrames::yes,
+                         RegisterMap::UpdateMap::include,
+                         RegisterMap::ProcessFrames::include,
                          RegisterMap::WalkContinuation::skip);
     frame stubFrame   = current->last_frame();
     // Caller-frame is a compiled frame
@@ -1229,7 +1229,7 @@ methodHandle SharedRuntime::find_callee_method(TRAPS) {
     // find the target method from the stub frame.
     RegisterMap reg_map(current,
                         RegisterMap::UpdateMap::skip,
-                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::ProcessFrames::include,
                         RegisterMap::WalkContinuation::skip);
     frame fr = current->last_frame();
     assert(fr.is_runtime_frame(), "must be a runtimeStub");
@@ -1366,7 +1366,7 @@ methodHandle SharedRuntime::resolve_sub_helper(bool is_virtual, bool is_optimize
   ResourceMark rm(current);
   RegisterMap cbl_map(current,
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   frame caller_frame = current->last_frame().sender(&cbl_map);
 
@@ -1467,7 +1467,7 @@ JRT_BLOCK_ENTRY(address, SharedRuntime::handle_wrong_method_ic_miss(JavaThread* 
 #ifdef ASSERT
   RegisterMap reg_map(current,
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   frame stub_frame = current->last_frame();
   assert(stub_frame.is_runtime_frame(), "sanity check");
@@ -1500,7 +1500,7 @@ JRT_BLOCK_ENTRY(address, SharedRuntime::handle_wrong_method(JavaThread* current)
   // safepoint is possible and have trouble gc'ing the compiled args.
   RegisterMap reg_map(current,
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   frame stub_frame = current->last_frame();
   assert(stub_frame.is_runtime_frame(), "sanity check");
@@ -1552,8 +1552,8 @@ JRT_BLOCK_ENTRY(address, SharedRuntime::handle_wrong_method_abstract(JavaThread*
 
   // Find the compiled caller frame.
   RegisterMap reg_map(current,
-                      RegisterMap::UpdateMap::yes,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::UpdateMap::include,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   frame stubFrame = current->last_frame();
   assert(stubFrame.is_runtime_frame(), "must be");
@@ -1586,7 +1586,7 @@ JRT_BLOCK_ENTRY(address, SharedRuntime::resolve_static_call_C(JavaThread* curren
     if (current->is_interp_only_mode()) {
       RegisterMap reg_map(current,
                           RegisterMap::UpdateMap::skip,
-                          RegisterMap::ProcessFrames::yes,
+                          RegisterMap::ProcessFrames::include,
                           RegisterMap::WalkContinuation::skip);
       frame stub_frame = current->last_frame();
       assert(stub_frame.is_runtime_frame(), "must be a runtimeStub");
@@ -1743,7 +1743,7 @@ methodHandle SharedRuntime::handle_ic_miss_helper(TRAPS) {
     if (TraceCallFixup) {
       RegisterMap reg_map(current,
                           RegisterMap::UpdateMap::skip,
-                          RegisterMap::ProcessFrames::yes,
+                          RegisterMap::ProcessFrames::include,
                           RegisterMap::WalkContinuation::skip);
       frame caller_frame = current->last_frame().sender(&reg_map);
       ResourceMark rm(current);
@@ -1772,7 +1772,7 @@ methodHandle SharedRuntime::handle_ic_miss_helper(TRAPS) {
     MutexLocker m(VMStatistic_lock);
     RegisterMap reg_map(current,
                         RegisterMap::UpdateMap::skip,
-                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::ProcessFrames::include,
                         RegisterMap::WalkContinuation::skip);
     frame f = current->last_frame().real_sender(&reg_map);// skip runtime stub
     // produce statistics under the lock
@@ -1793,7 +1793,7 @@ methodHandle SharedRuntime::handle_ic_miss_helper(TRAPS) {
   // that refills them.
   RegisterMap reg_map(current,
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   frame caller_frame = current->last_frame().sender(&reg_map);
   CodeBlob* cb = caller_frame.cb();
@@ -1840,7 +1840,7 @@ methodHandle SharedRuntime::reresolve_call_site(TRAPS) {
   ResourceMark rm(current);
   RegisterMap reg_map(current,
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip);
   frame stub_frame = current->last_frame();
   assert(stub_frame.is_runtime_frame(), "must be a runtimeStub");
@@ -3336,7 +3336,7 @@ JRT_LEAF(intptr_t*, SharedRuntime::OSR_migration_begin( JavaThread *current) )
 
   RegisterMap map(current,
                   RegisterMap::UpdateMap::skip,
-                  RegisterMap::ProcessFrames::yes,
+                  RegisterMap::ProcessFrames::include,
                   RegisterMap::WalkContinuation::skip);
   frame sender = fr.sender(&map);
   if (sender.is_interpreted_frame()) {

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1151,7 +1151,7 @@ Handle SharedRuntime::find_callee_info_helper(vframeStream& vfst, Bytecodes::Cod
   if (has_receiver) {
     // This register map must be update since we need to find the receiver for
     // compiled frames. The receiver might be in a register.
-    RegisterMap reg_map2(current);
+    RegisterMap reg_map2(current, true /* update_map */, true /* process_frames */, false /* walk_cont */);
     frame stubFrame   = current->last_frame();
     // Caller-frame is a compiled frame
     frame callerFrame = stubFrame.sender(&reg_map2);
@@ -1224,7 +1224,7 @@ methodHandle SharedRuntime::find_callee_method(TRAPS) {
     // No Java frames were found on stack since we did the JavaCall.
     // Hence the stack can only contain an entry_frame.  We need to
     // find the target method from the stub frame.
-    RegisterMap reg_map(current, false);
+    RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
     frame fr = current->last_frame();
     assert(fr.is_runtime_frame(), "must be a runtimeStub");
     fr = fr.sender(&reg_map);
@@ -1358,7 +1358,7 @@ bool SharedRuntime::resolve_sub_helper_internal(methodHandle callee_method, cons
 methodHandle SharedRuntime::resolve_sub_helper(bool is_virtual, bool is_optimized, TRAPS) {
   JavaThread* current = THREAD;
   ResourceMark rm(current);
-  RegisterMap cbl_map(current, false);
+  RegisterMap cbl_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
   frame caller_frame = current->last_frame().sender(&cbl_map);
 
   CodeBlob* caller_cb = caller_frame.cb();
@@ -1456,7 +1456,7 @@ methodHandle SharedRuntime::resolve_sub_helper(bool is_virtual, bool is_optimize
 // Inline caches exist only in compiled code
 JRT_BLOCK_ENTRY(address, SharedRuntime::handle_wrong_method_ic_miss(JavaThread* current))
 #ifdef ASSERT
-  RegisterMap reg_map(current, false);
+  RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
   frame stub_frame = current->last_frame();
   assert(stub_frame.is_runtime_frame(), "sanity check");
   frame caller_frame = stub_frame.sender(&reg_map);
@@ -1486,7 +1486,7 @@ JRT_BLOCK_ENTRY(address, SharedRuntime::handle_wrong_method(JavaThread* current)
   // place the callee method in the callee_target. It is stashed
   // there because if we try and find the callee by normal means a
   // safepoint is possible and have trouble gc'ing the compiled args.
-  RegisterMap reg_map(current, false);
+  RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
   frame stub_frame = current->last_frame();
   assert(stub_frame.is_runtime_frame(), "sanity check");
   frame caller_frame = stub_frame.sender(&reg_map);
@@ -1536,7 +1536,7 @@ JRT_BLOCK_ENTRY(address, SharedRuntime::handle_wrong_method_abstract(JavaThread*
   DEBUG_ONLY( invoke.verify(); )
 
   // Find the compiled caller frame.
-  RegisterMap reg_map(current);
+  RegisterMap reg_map(current, true /* update_map */, true /* process_frames */, false /* walk_cont */);
   frame stubFrame = current->last_frame();
   assert(stubFrame.is_runtime_frame(), "must be");
   frame callerFrame = stubFrame.sender(&reg_map);
@@ -1566,7 +1566,7 @@ JRT_BLOCK_ENTRY(address, SharedRuntime::resolve_static_call_C(JavaThread* curren
     current->set_vm_result_2(callee_method());
 
     if (current->is_interp_only_mode()) {
-      RegisterMap reg_map(current, false);
+      RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
       frame stub_frame = current->last_frame();
       assert(stub_frame.is_runtime_frame(), "must be a runtimeStub");
       frame caller = stub_frame.sender(&reg_map);
@@ -1720,7 +1720,7 @@ methodHandle SharedRuntime::handle_ic_miss_helper(TRAPS) {
   if (call_info.resolved_method()->can_be_statically_bound()) {
     methodHandle callee_method = SharedRuntime::reresolve_call_site(CHECK_(methodHandle()));
     if (TraceCallFixup) {
-      RegisterMap reg_map(current, false);
+      RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
       frame caller_frame = current->last_frame().sender(&reg_map);
       ResourceMark rm(current);
       tty->print("converting IC miss to reresolve (%s) call to", Bytecodes::name(bc));
@@ -1746,7 +1746,7 @@ methodHandle SharedRuntime::handle_ic_miss_helper(TRAPS) {
 
   if (ICMissHistogram) {
     MutexLocker m(VMStatistic_lock);
-    RegisterMap reg_map(current, false);
+    RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
     frame f = current->last_frame().real_sender(&reg_map);// skip runtime stub
     // produce statistics under the lock
     trace_ic_miss(f.pc());
@@ -1764,7 +1764,7 @@ methodHandle SharedRuntime::handle_ic_miss_helper(TRAPS) {
   // Transitioning IC caches may require transition stubs. If we run out
   // of transition stubs, we have to drop locks and perform a safepoint
   // that refills them.
-  RegisterMap reg_map(current, false);
+  RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
   frame caller_frame = current->last_frame().sender(&reg_map);
   CodeBlob* cb = caller_frame.cb();
   CompiledMethod* caller_nm = cb->as_compiled_method();
@@ -1808,7 +1808,7 @@ static bool clear_ic_at_addr(CompiledMethod* caller_nm, address call_addr, bool 
 methodHandle SharedRuntime::reresolve_call_site(TRAPS) {
   JavaThread* current = THREAD;
   ResourceMark rm(current);
-  RegisterMap reg_map(current, false);
+  RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
   frame stub_frame = current->last_frame();
   assert(stub_frame.is_runtime_frame(), "must be a runtimeStub");
   frame caller = stub_frame.sender(&reg_map);
@@ -3301,7 +3301,7 @@ JRT_LEAF(intptr_t*, SharedRuntime::OSR_migration_begin( JavaThread *current) )
   }
   assert(i - max_locals == active_monitor_count*2, "found the expected number of monitors");
 
-  RegisterMap map(current, false);
+  RegisterMap map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
   frame sender = fr.sender(&map);
   if (sender.is_interpreted_frame()) {
     current->push_cont_fastpath(sender.sp());
@@ -3375,7 +3375,7 @@ frame SharedRuntime::look_for_reserved_stack_annotated_method(JavaThread* curren
 
   assert(fr.is_java_frame(), "Must start on Java frame");
 
-  RegisterMap map(JavaThread::current(), false, false); // don't walk continuations
+  RegisterMap map(JavaThread::current(), false /* update_map */, false /* process_frames */, false /* walk_cont */); // don't walk continuations
   for (; !fr.is_first_frame(); fr = fr.sender(&map)) {
     if (!fr.is_java_frame()) {
       continue;

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1151,7 +1151,10 @@ Handle SharedRuntime::find_callee_info_helper(vframeStream& vfst, Bytecodes::Cod
   if (has_receiver) {
     // This register map must be update since we need to find the receiver for
     // compiled frames. The receiver might be in a register.
-    RegisterMap reg_map2(current, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+    RegisterMap reg_map2(current,
+                         RegisterMap::UpdateMap::yes,
+                         RegisterMap::ProcessFrames::yes,
+                         RegisterMap::WalkContinuation::skip);
     frame stubFrame   = current->last_frame();
     // Caller-frame is a compiled frame
     frame callerFrame = stubFrame.sender(&reg_map2);
@@ -1224,7 +1227,10 @@ methodHandle SharedRuntime::find_callee_method(TRAPS) {
     // No Java frames were found on stack since we did the JavaCall.
     // Hence the stack can only contain an entry_frame.  We need to
     // find the target method from the stub frame.
-    RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+    RegisterMap reg_map(current,
+                        RegisterMap::UpdateMap::skip,
+                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::WalkContinuation::skip);
     frame fr = current->last_frame();
     assert(fr.is_runtime_frame(), "must be a runtimeStub");
     fr = fr.sender(&reg_map);
@@ -1358,7 +1364,10 @@ bool SharedRuntime::resolve_sub_helper_internal(methodHandle callee_method, cons
 methodHandle SharedRuntime::resolve_sub_helper(bool is_virtual, bool is_optimized, TRAPS) {
   JavaThread* current = THREAD;
   ResourceMark rm(current);
-  RegisterMap cbl_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap cbl_map(current,
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   frame caller_frame = current->last_frame().sender(&cbl_map);
 
   CodeBlob* caller_cb = caller_frame.cb();
@@ -1456,7 +1465,10 @@ methodHandle SharedRuntime::resolve_sub_helper(bool is_virtual, bool is_optimize
 // Inline caches exist only in compiled code
 JRT_BLOCK_ENTRY(address, SharedRuntime::handle_wrong_method_ic_miss(JavaThread* current))
 #ifdef ASSERT
-  RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(current,
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   frame stub_frame = current->last_frame();
   assert(stub_frame.is_runtime_frame(), "sanity check");
   frame caller_frame = stub_frame.sender(&reg_map);
@@ -1486,7 +1498,10 @@ JRT_BLOCK_ENTRY(address, SharedRuntime::handle_wrong_method(JavaThread* current)
   // place the callee method in the callee_target. It is stashed
   // there because if we try and find the callee by normal means a
   // safepoint is possible and have trouble gc'ing the compiled args.
-  RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(current,
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   frame stub_frame = current->last_frame();
   assert(stub_frame.is_runtime_frame(), "sanity check");
   frame caller_frame = stub_frame.sender(&reg_map);
@@ -1536,7 +1551,10 @@ JRT_BLOCK_ENTRY(address, SharedRuntime::handle_wrong_method_abstract(JavaThread*
   DEBUG_ONLY( invoke.verify(); )
 
   // Find the compiled caller frame.
-  RegisterMap reg_map(current, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(current,
+                      RegisterMap::UpdateMap::yes,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   frame stubFrame = current->last_frame();
   assert(stubFrame.is_runtime_frame(), "must be");
   frame callerFrame = stubFrame.sender(&reg_map);
@@ -1566,7 +1584,10 @@ JRT_BLOCK_ENTRY(address, SharedRuntime::resolve_static_call_C(JavaThread* curren
     current->set_vm_result_2(callee_method());
 
     if (current->is_interp_only_mode()) {
-      RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+      RegisterMap reg_map(current,
+                          RegisterMap::UpdateMap::skip,
+                          RegisterMap::ProcessFrames::yes,
+                          RegisterMap::WalkContinuation::skip);
       frame stub_frame = current->last_frame();
       assert(stub_frame.is_runtime_frame(), "must be a runtimeStub");
       frame caller = stub_frame.sender(&reg_map);
@@ -1720,7 +1741,10 @@ methodHandle SharedRuntime::handle_ic_miss_helper(TRAPS) {
   if (call_info.resolved_method()->can_be_statically_bound()) {
     methodHandle callee_method = SharedRuntime::reresolve_call_site(CHECK_(methodHandle()));
     if (TraceCallFixup) {
-      RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+      RegisterMap reg_map(current,
+                          RegisterMap::UpdateMap::skip,
+                          RegisterMap::ProcessFrames::yes,
+                          RegisterMap::WalkContinuation::skip);
       frame caller_frame = current->last_frame().sender(&reg_map);
       ResourceMark rm(current);
       tty->print("converting IC miss to reresolve (%s) call to", Bytecodes::name(bc));
@@ -1746,7 +1770,10 @@ methodHandle SharedRuntime::handle_ic_miss_helper(TRAPS) {
 
   if (ICMissHistogram) {
     MutexLocker m(VMStatistic_lock);
-    RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+    RegisterMap reg_map(current,
+                        RegisterMap::UpdateMap::skip,
+                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::WalkContinuation::skip);
     frame f = current->last_frame().real_sender(&reg_map);// skip runtime stub
     // produce statistics under the lock
     trace_ic_miss(f.pc());
@@ -1764,7 +1791,10 @@ methodHandle SharedRuntime::handle_ic_miss_helper(TRAPS) {
   // Transitioning IC caches may require transition stubs. If we run out
   // of transition stubs, we have to drop locks and perform a safepoint
   // that refills them.
-  RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(current,
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   frame caller_frame = current->last_frame().sender(&reg_map);
   CodeBlob* cb = caller_frame.cb();
   CompiledMethod* caller_nm = cb->as_compiled_method();
@@ -1808,7 +1838,10 @@ static bool clear_ic_at_addr(CompiledMethod* caller_nm, address call_addr, bool 
 methodHandle SharedRuntime::reresolve_call_site(TRAPS) {
   JavaThread* current = THREAD;
   ResourceMark rm(current);
-  RegisterMap reg_map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap reg_map(current,
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip);
   frame stub_frame = current->last_frame();
   assert(stub_frame.is_runtime_frame(), "must be a runtimeStub");
   frame caller = stub_frame.sender(&reg_map);
@@ -3301,7 +3334,10 @@ JRT_LEAF(intptr_t*, SharedRuntime::OSR_migration_begin( JavaThread *current) )
   }
   assert(i - max_locals == active_monitor_count*2, "found the expected number of monitors");
 
-  RegisterMap map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap map(current,
+                  RegisterMap::UpdateMap::skip,
+                  RegisterMap::ProcessFrames::yes,
+                  RegisterMap::WalkContinuation::skip);
   frame sender = fr.sender(&map);
   if (sender.is_interpreted_frame()) {
     current->push_cont_fastpath(sender.sp());
@@ -3375,7 +3411,10 @@ frame SharedRuntime::look_for_reserved_stack_annotated_method(JavaThread* curren
 
   assert(fr.is_java_frame(), "Must start on Java frame");
 
-  RegisterMap map(JavaThread::current(), false /* update_map */, false /* process_frames */, false /* walk_cont */); // don't walk continuations
+  RegisterMap map(JavaThread::current(),
+                  RegisterMap::UpdateMap::skip,
+                  RegisterMap::ProcessFrames::skip,
+                  RegisterMap::WalkContinuation::skip); // don't walk continuations
   for (; !fr.is_first_frame(); fr = fr.sender(&map)) {
     if (!fr.is_java_frame()) {
       continue;

--- a/src/hotspot/share/runtime/stackFrameStream.cpp
+++ b/src/hotspot/share/runtime/stackFrameStream.cpp
@@ -28,8 +28,8 @@
 
 StackFrameStream::StackFrameStream(JavaThread *thread, bool update, bool process_frames, bool allow_missing_reg)
   : _reg_map(thread,
-             update ? RegisterMap::UpdateMap::yes : RegisterMap::UpdateMap::skip,
-             process_frames ? RegisterMap::ProcessFrames::yes : RegisterMap::ProcessFrames::skip,
+             update ? RegisterMap::UpdateMap::include : RegisterMap::UpdateMap::skip,
+             process_frames ? RegisterMap::ProcessFrames::include : RegisterMap::ProcessFrames::skip,
              RegisterMap::WalkContinuation::skip) {
   assert(thread->has_last_Java_frame(), "sanity check");
   _fr = thread->last_frame();

--- a/src/hotspot/share/runtime/stackFrameStream.cpp
+++ b/src/hotspot/share/runtime/stackFrameStream.cpp
@@ -26,7 +26,11 @@
 #include "runtime/stackFrameStream.inline.hpp"
 #include "utilities/debug.hpp"
 
-StackFrameStream::StackFrameStream(JavaThread *thread, bool update, bool process_frames, bool allow_missing_reg) : _reg_map(thread, update, process_frames, false /* walk_cont */) {
+StackFrameStream::StackFrameStream(JavaThread *thread, bool update, bool process_frames, bool allow_missing_reg)
+  : _reg_map(thread,
+             update ? RegisterMap::UpdateMap::yes : RegisterMap::UpdateMap::skip,
+             process_frames ? RegisterMap::ProcessFrames::yes : RegisterMap::ProcessFrames::skip,
+             RegisterMap::WalkContinuation::skip) {
   assert(thread->has_last_Java_frame(), "sanity check");
   _fr = thread->last_frame();
   _is_done = false;

--- a/src/hotspot/share/runtime/stackFrameStream.cpp
+++ b/src/hotspot/share/runtime/stackFrameStream.cpp
@@ -26,7 +26,7 @@
 #include "runtime/stackFrameStream.inline.hpp"
 #include "utilities/debug.hpp"
 
-StackFrameStream::StackFrameStream(JavaThread *thread, bool update, bool process_frames, bool allow_missing_reg) : _reg_map(thread, update, process_frames) {
+StackFrameStream::StackFrameStream(JavaThread *thread, bool update, bool process_frames, bool allow_missing_reg) : _reg_map(thread, update, process_frames, false /* walk_cont */) {
   assert(thread->has_last_Java_frame(), "sanity check");
   _fr = thread->last_frame();
   _is_done = false;

--- a/src/hotspot/share/runtime/stackWatermark.inline.hpp
+++ b/src/hotspot/share/runtime/stackWatermark.inline.hpp
@@ -87,7 +87,10 @@ inline void StackWatermark::before_unwind() {
   frame f = _jt->last_frame();
 
   // Skip any stub frames etc up until the frame that triggered before_unwind().
-  RegisterMap map(_jt, false /* update_map */, false /* process_frames */, false /* walk_cont */);
+  RegisterMap map(_jt,
+                  RegisterMap::UpdateMap::skip,
+                  RegisterMap::ProcessFrames::skip,
+                  RegisterMap::WalkContinuation::skip);
   if (f.is_safepoint_blob_frame() || f.is_runtime_frame()) {
     f = f.sender(&map);
   }
@@ -108,7 +111,10 @@ inline void StackWatermark::after_unwind() {
 
   if (f.is_safepoint_blob_frame() || f.is_runtime_frame()) {
     // Skip safepoint blob.
-    RegisterMap map(_jt, false /* update_map */, false /* process_frames */, false /* walk_cont */);
+    RegisterMap map(_jt,
+                    RegisterMap::UpdateMap::skip,
+                    RegisterMap::ProcessFrames::skip,
+                    RegisterMap::WalkContinuation::skip);
     f = f.sender(&map);
   }
 

--- a/src/hotspot/share/runtime/stackWatermark.inline.hpp
+++ b/src/hotspot/share/runtime/stackWatermark.inline.hpp
@@ -87,7 +87,7 @@ inline void StackWatermark::before_unwind() {
   frame f = _jt->last_frame();
 
   // Skip any stub frames etc up until the frame that triggered before_unwind().
-  RegisterMap map(_jt, false /* update_map */, false /* process_frames */);
+  RegisterMap map(_jt, false /* update_map */, false /* process_frames */, false /* walk_cont */);
   if (f.is_safepoint_blob_frame() || f.is_runtime_frame()) {
     f = f.sender(&map);
   }
@@ -108,7 +108,7 @@ inline void StackWatermark::after_unwind() {
 
   if (f.is_safepoint_blob_frame() || f.is_runtime_frame()) {
     // Skip safepoint blob.
-    RegisterMap map(_jt, false /* update_map */, false /* process_frames */);
+    RegisterMap map(_jt, false /* update_map */, false /* process_frames */, false /* walk_cont */);
     f = f.sender(&map);
   }
 

--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -63,8 +63,8 @@ vframe::vframe(const frame* fr, const RegisterMap* reg_map, JavaThread* thread)
 
 vframe::vframe(const frame* fr, JavaThread* thread)
 : _reg_map(thread,
-           RegisterMap::UpdateMap::yes,
-           RegisterMap::ProcessFrames::yes,
+           RegisterMap::UpdateMap::include,
+           RegisterMap::ProcessFrames::include,
            RegisterMap::WalkContinuation::skip),
   _thread(thread), _chunk() {
   assert(fr != NULL, "must have frame");
@@ -534,9 +534,9 @@ void vframeStreamCommon::found_bad_method_frame() const {
 vframeStream::vframeStream(JavaThread* thread, frame top_frame,
                           bool stop_at_java_call_stub) :
     vframeStreamCommon(RegisterMap(thread,
-                                   RegisterMap::UpdateMap::yes,
-                                   RegisterMap::ProcessFrames::yes,
-                                   RegisterMap::WalkContinuation::yes)) {
+                                   RegisterMap::UpdateMap::include,
+                                   RegisterMap::ProcessFrames::include,
+                                   RegisterMap::WalkContinuation::include)) {
   _stop_at_java_call_stub = stop_at_java_call_stub;
 
   // skip top frame, as it may not be at safepoint
@@ -548,9 +548,9 @@ vframeStream::vframeStream(JavaThread* thread, frame top_frame,
 
 vframeStream::vframeStream(JavaThread* thread, Handle continuation_scope, bool stop_at_java_call_stub)
  : vframeStreamCommon(RegisterMap(thread,
-                                  RegisterMap::UpdateMap::yes,
-                                  RegisterMap::ProcessFrames::yes,
-                                  RegisterMap::WalkContinuation::yes)) {
+                                  RegisterMap::UpdateMap::include,
+                                  RegisterMap::ProcessFrames::include,
+                                  RegisterMap::WalkContinuation::include)) {
 
   _stop_at_java_call_stub = stop_at_java_call_stub;
   _continuation_scope = continuation_scope;
@@ -568,7 +568,7 @@ vframeStream::vframeStream(JavaThread* thread, Handle continuation_scope, bool s
 }
 
 vframeStream::vframeStream(oop continuation, Handle continuation_scope)
- : vframeStreamCommon(RegisterMap(continuation, RegisterMap::UpdateMap::yes)) {
+ : vframeStreamCommon(RegisterMap(continuation, RegisterMap::UpdateMap::include)) {
 
   _stop_at_java_call_stub = false;
   _continuation_scope = continuation_scope;

--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -62,7 +62,7 @@ vframe::vframe(const frame* fr, const RegisterMap* reg_map, JavaThread* thread)
 }
 
 vframe::vframe(const frame* fr, JavaThread* thread)
-: _reg_map(thread), _thread(thread), _chunk() {
+: _reg_map(thread, true /* update_map */, true /* process_frames */, false /* walk_cont */), _thread(thread), _chunk() {
   assert(fr != NULL, "must have frame");
   _fr = *fr;
   assert(!_reg_map.in_cont(), "");
@@ -529,7 +529,7 @@ void vframeStreamCommon::found_bad_method_frame() const {
 // top-frame will be skipped
 vframeStream::vframeStream(JavaThread* thread, frame top_frame,
                           bool stop_at_java_call_stub) :
-    vframeStreamCommon(RegisterMap(thread, true, true, true)) {
+    vframeStreamCommon(RegisterMap(thread, true /* update_map */, true /* process_frames */, true /* walk_cont */)) {
   _stop_at_java_call_stub = stop_at_java_call_stub;
 
   // skip top frame, as it may not be at safepoint
@@ -540,7 +540,7 @@ vframeStream::vframeStream(JavaThread* thread, frame top_frame,
 }
 
 vframeStream::vframeStream(JavaThread* thread, Handle continuation_scope, bool stop_at_java_call_stub)
- : vframeStreamCommon(RegisterMap(thread, true, true, true)) {
+ : vframeStreamCommon(RegisterMap(thread, true /* update_map */, true /* process_frames */, true /* walk_cont */)) {
 
   _stop_at_java_call_stub = stop_at_java_call_stub;
   _continuation_scope = continuation_scope;
@@ -558,7 +558,7 @@ vframeStream::vframeStream(JavaThread* thread, Handle continuation_scope, bool s
 }
 
 vframeStream::vframeStream(oop continuation, Handle continuation_scope)
- : vframeStreamCommon(RegisterMap(continuation, true)) {
+ : vframeStreamCommon(RegisterMap(continuation, true /* update_map */)) {
 
   _stop_at_java_call_stub = false;
   _continuation_scope = continuation_scope;

--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -62,7 +62,11 @@ vframe::vframe(const frame* fr, const RegisterMap* reg_map, JavaThread* thread)
 }
 
 vframe::vframe(const frame* fr, JavaThread* thread)
-: _reg_map(thread, true /* update_map */, true /* process_frames */, false /* walk_cont */), _thread(thread), _chunk() {
+: _reg_map(thread,
+           RegisterMap::UpdateMap::yes,
+           RegisterMap::ProcessFrames::yes,
+           RegisterMap::WalkContinuation::skip),
+  _thread(thread), _chunk() {
   assert(fr != NULL, "must have frame");
   _fr = *fr;
   assert(!_reg_map.in_cont(), "");
@@ -529,7 +533,10 @@ void vframeStreamCommon::found_bad_method_frame() const {
 // top-frame will be skipped
 vframeStream::vframeStream(JavaThread* thread, frame top_frame,
                           bool stop_at_java_call_stub) :
-    vframeStreamCommon(RegisterMap(thread, true /* update_map */, true /* process_frames */, true /* walk_cont */)) {
+    vframeStreamCommon(RegisterMap(thread,
+                                   RegisterMap::UpdateMap::yes,
+                                   RegisterMap::ProcessFrames::yes,
+                                   RegisterMap::WalkContinuation::yes)) {
   _stop_at_java_call_stub = stop_at_java_call_stub;
 
   // skip top frame, as it may not be at safepoint
@@ -540,7 +547,10 @@ vframeStream::vframeStream(JavaThread* thread, frame top_frame,
 }
 
 vframeStream::vframeStream(JavaThread* thread, Handle continuation_scope, bool stop_at_java_call_stub)
- : vframeStreamCommon(RegisterMap(thread, true /* update_map */, true /* process_frames */, true /* walk_cont */)) {
+ : vframeStreamCommon(RegisterMap(thread,
+                                  RegisterMap::UpdateMap::yes,
+                                  RegisterMap::ProcessFrames::yes,
+                                  RegisterMap::WalkContinuation::yes)) {
 
   _stop_at_java_call_stub = stop_at_java_call_stub;
   _continuation_scope = continuation_scope;
@@ -558,7 +568,7 @@ vframeStream::vframeStream(JavaThread* thread, Handle continuation_scope, bool s
 }
 
 vframeStream::vframeStream(oop continuation, Handle continuation_scope)
- : vframeStreamCommon(RegisterMap(continuation, true /* update_map */)) {
+ : vframeStreamCommon(RegisterMap(continuation, RegisterMap::UpdateMap::yes)) {
 
   _stop_at_java_call_stub = false;
   _continuation_scope = continuation_scope;

--- a/src/hotspot/share/runtime/vframe.inline.hpp
+++ b/src/hotspot/share/runtime/vframe.inline.hpp
@@ -111,9 +111,9 @@ inline void vframeStreamCommon::next() {
 
 inline vframeStream::vframeStream(JavaThread* thread, bool stop_at_java_call_stub, bool process_frame, bool vthread_carrier)
   : vframeStreamCommon(RegisterMap(thread,
-                                   RegisterMap::UpdateMap::yes,
-                                   process_frame ? RegisterMap::ProcessFrames::yes : RegisterMap::ProcessFrames::skip ,
-                                   RegisterMap::WalkContinuation::yes)) {
+                                   RegisterMap::UpdateMap::include,
+                                   process_frame ? RegisterMap::ProcessFrames::include : RegisterMap::ProcessFrames::skip ,
+                                   RegisterMap::WalkContinuation::include)) {
   _stop_at_java_call_stub = stop_at_java_call_stub;
 
   if (!thread->has_last_Java_frame()) {

--- a/src/hotspot/share/runtime/vframe.inline.hpp
+++ b/src/hotspot/share/runtime/vframe.inline.hpp
@@ -110,7 +110,7 @@ inline void vframeStreamCommon::next() {
 }
 
 inline vframeStream::vframeStream(JavaThread* thread, bool stop_at_java_call_stub, bool process_frame, bool vthread_carrier)
-  : vframeStreamCommon(RegisterMap(thread, true, process_frame, true)) {
+  : vframeStreamCommon(RegisterMap(thread, true /* update_map */, process_frame, true /* walk_cont */)) {
   _stop_at_java_call_stub = stop_at_java_call_stub;
 
   if (!thread->has_last_Java_frame()) {

--- a/src/hotspot/share/runtime/vframe.inline.hpp
+++ b/src/hotspot/share/runtime/vframe.inline.hpp
@@ -110,7 +110,10 @@ inline void vframeStreamCommon::next() {
 }
 
 inline vframeStream::vframeStream(JavaThread* thread, bool stop_at_java_call_stub, bool process_frame, bool vthread_carrier)
-  : vframeStreamCommon(RegisterMap(thread, true /* update_map */, process_frame, true /* walk_cont */)) {
+  : vframeStreamCommon(RegisterMap(thread,
+                                   RegisterMap::UpdateMap::yes,
+                                   process_frame ? RegisterMap::ProcessFrames::yes : RegisterMap::ProcessFrames::skip ,
+                                   RegisterMap::WalkContinuation::yes)) {
   _stop_at_java_call_stub = stop_at_java_call_stub;
 
   if (!thread->has_last_Java_frame()) {

--- a/src/hotspot/share/runtime/vframeArray.cpp
+++ b/src/hotspot/share/runtime/vframeArray.cpp
@@ -453,8 +453,8 @@ void vframeArrayElement::unpack_on_stack(int caller_actual_parameters,
     tty->print_cr("[%d. Interpreted Frame]", ++unpack_counter);
     iframe()->print_on(tty);
     RegisterMap map(thread,
-                    RegisterMap::UpdateMap::yes,
-                    RegisterMap::ProcessFrames::yes,
+                    RegisterMap::UpdateMap::include,
+                    RegisterMap::ProcessFrames::include,
                     RegisterMap::WalkContinuation::skip);
     vframe* f = vframe::new_vframe(iframe(), &map, thread);
     f->print();
@@ -572,7 +572,7 @@ void vframeArray::unpack_to_stack(frame &unpack_frame, int exec_mode, int caller
 
   RegisterMap map(current,
                   RegisterMap::UpdateMap::skip,
-                  RegisterMap::ProcessFrames::yes,
+                  RegisterMap::ProcessFrames::include,
                   RegisterMap::WalkContinuation::skip);
   // Get the youngest frame we will unpack (last to be unpacked)
   frame me = unpack_frame.sender(&map);

--- a/src/hotspot/share/runtime/vframeArray.cpp
+++ b/src/hotspot/share/runtime/vframeArray.cpp
@@ -452,7 +452,10 @@ void vframeArrayElement::unpack_on_stack(int caller_actual_parameters,
     ttyLocker ttyl;
     tty->print_cr("[%d. Interpreted Frame]", ++unpack_counter);
     iframe()->print_on(tty);
-    RegisterMap map(thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+    RegisterMap map(thread,
+                    RegisterMap::UpdateMap::yes,
+                    RegisterMap::ProcessFrames::yes,
+                    RegisterMap::WalkContinuation::skip);
     vframe* f = vframe::new_vframe(iframe(), &map, thread);
     f->print();
     if (WizardMode && Verbose) method()->print_codes();
@@ -567,7 +570,10 @@ void vframeArray::unpack_to_stack(frame &unpack_frame, int exec_mode, int caller
   // Find the skeletal interpreter frames to unpack into
   JavaThread* current = JavaThread::current();
 
-  RegisterMap map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
+  RegisterMap map(current,
+                  RegisterMap::UpdateMap::skip,
+                  RegisterMap::ProcessFrames::yes,
+                  RegisterMap::WalkContinuation::skip);
   // Get the youngest frame we will unpack (last to be unpacked)
   frame me = unpack_frame.sender(&map);
   int index;

--- a/src/hotspot/share/runtime/vframeArray.cpp
+++ b/src/hotspot/share/runtime/vframeArray.cpp
@@ -452,7 +452,7 @@ void vframeArrayElement::unpack_on_stack(int caller_actual_parameters,
     ttyLocker ttyl;
     tty->print_cr("[%d. Interpreted Frame]", ++unpack_counter);
     iframe()->print_on(tty);
-    RegisterMap map(thread);
+    RegisterMap map(thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
     vframe* f = vframe::new_vframe(iframe(), &map, thread);
     f->print();
     if (WizardMode && Verbose) method()->print_codes();
@@ -567,7 +567,7 @@ void vframeArray::unpack_to_stack(frame &unpack_frame, int exec_mode, int caller
   // Find the skeletal interpreter frames to unpack into
   JavaThread* current = JavaThread::current();
 
-  RegisterMap map(current, false);
+  RegisterMap map(current, false /* update_map */, true /* process_frames */, false /* walk_cont */);
   // Get the youngest frame we will unpack (last to be unpacked)
   frame me = unpack_frame.sender(&map);
   int index;

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -2026,8 +2026,8 @@ int VM_HeapDumper::do_thread(JavaThread* java_thread, u4 thread_serial_num) {
     HandleMark hm(current_thread);
 
     RegisterMap reg_map(java_thread,
-                        RegisterMap::UpdateMap::yes,
-                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::UpdateMap::include,
+                        RegisterMap::ProcessFrames::include,
                         RegisterMap::WalkContinuation::skip);
     frame f = java_thread->last_frame();
     vframe* vf = vframe::new_vframe(&f, &reg_map, java_thread);

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -2025,7 +2025,7 @@ int VM_HeapDumper::do_thread(JavaThread* java_thread, u4 thread_serial_num) {
     ResourceMark rm(current_thread);
     HandleMark hm(current_thread);
 
-    RegisterMap reg_map(java_thread);
+    RegisterMap reg_map(java_thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
     frame f = java_thread->last_frame();
     vframe* vf = vframe::new_vframe(&f, &reg_map, java_thread);
     frame* last_entry_frame = NULL;

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -2025,7 +2025,10 @@ int VM_HeapDumper::do_thread(JavaThread* java_thread, u4 thread_serial_num) {
     ResourceMark rm(current_thread);
     HandleMark hm(current_thread);
 
-    RegisterMap reg_map(java_thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+    RegisterMap reg_map(java_thread,
+                        RegisterMap::UpdateMap::yes,
+                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::WalkContinuation::skip);
     frame f = java_thread->last_frame();
     vframe* vf = vframe::new_vframe(&f, &reg_map, java_thread);
     frame* last_entry_frame = NULL;

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -688,8 +688,8 @@ void ThreadStackTrace::dump_stack_at_safepoint(int maxDepth, ObjectMonitorsHasht
 
   if (_thread->has_last_Java_frame()) {
     RegisterMap reg_map(_thread,
-                        RegisterMap::UpdateMap::yes,
-                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::UpdateMap::include,
+                        RegisterMap::ProcessFrames::include,
                         RegisterMap::WalkContinuation::skip);
 
     // If full, we want to print both vthread and carrier frames

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -687,7 +687,10 @@ void ThreadStackTrace::dump_stack_at_safepoint(int maxDepth, ObjectMonitorsHasht
   assert(SafepointSynchronize::is_at_safepoint(), "all threads are stopped");
 
   if (_thread->has_last_Java_frame()) {
-    RegisterMap reg_map(_thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+    RegisterMap reg_map(_thread,
+                        RegisterMap::UpdateMap::yes,
+                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::WalkContinuation::skip);
 
     // If full, we want to print both vthread and carrier frames
     vframe* start_vf = !full && _thread->is_vthread_mounted()

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -687,7 +687,7 @@ void ThreadStackTrace::dump_stack_at_safepoint(int maxDepth, ObjectMonitorsHasht
   assert(SafepointSynchronize::is_at_safepoint(), "all threads are stopped");
 
   if (_thread->has_last_Java_frame()) {
-    RegisterMap reg_map(_thread);
+    RegisterMap reg_map(_thread, true /* update_map */, true /* process_frames */, false /* walk_cont */);
 
     // If full, we want to print both vthread and carrier frames
     vframe* start_vf = !full && _thread->is_vthread_mounted()

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -530,8 +530,8 @@ extern "C" JNIEXPORT void ps() { // print stack
   } else {
     frame f = os::current_frame();
     RegisterMap reg_map(p,
-                        RegisterMap::UpdateMap::yes,
-                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::UpdateMap::include,
+                        RegisterMap::ProcessFrames::include,
                         RegisterMap::WalkContinuation::skip);
     f = f.sender(&reg_map);
     tty->print("(guessing starting frame id=" PTR_FORMAT " based on current fp)\n", p2i(f.id()));

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -529,7 +529,7 @@ extern "C" JNIEXPORT void ps() { // print stack
     if (Verbose) p->trace_stack();
   } else {
     frame f = os::current_frame();
-    RegisterMap reg_map(p);
+    RegisterMap reg_map(p, true /* update_map */, true /* process_frames */, false /* walk_cont */);
     f = f.sender(&reg_map);
     tty->print("(guessing starting frame id=" PTR_FORMAT " based on current fp)\n", p2i(f.id()));
     p->trace_stack_from(vframe::new_vframe(&f, &reg_map, p));

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -529,7 +529,10 @@ extern "C" JNIEXPORT void ps() { // print stack
     if (Verbose) p->trace_stack();
   } else {
     frame f = os::current_frame();
-    RegisterMap reg_map(p, true /* update_map */, true /* process_frames */, false /* walk_cont */);
+    RegisterMap reg_map(p,
+                        RegisterMap::UpdateMap::yes,
+                        RegisterMap::ProcessFrames::yes,
+                        RegisterMap::WalkContinuation::skip);
     f = f.sender(&reg_map);
     tty->print("(guessing starting frame id=" PTR_FORMAT " based on current fp)\n", p2i(f.id()));
     p->trace_stack_from(vframe::new_vframe(&f, &reg_map, p));

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -334,7 +334,7 @@ static frame next_frame(frame fr, Thread* t) {
     if (fr.is_java_frame() || fr.is_native_frame() || fr.is_runtime_frame()) {
       RegisterMap map(JavaThread::cast(t),
                       RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::ProcessFrames::include,
                       RegisterMap::WalkContinuation::skip); // No update
       return fr.sender(&map);
     } else {

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -332,7 +332,10 @@ static frame next_frame(frame fr, Thread* t) {
       return invalid;
     }
     if (fr.is_java_frame() || fr.is_native_frame() || fr.is_runtime_frame()) {
-      RegisterMap map(JavaThread::cast(t), false /* update_map */, true /* process_frames */, false /* walk_cont */); // No update
+      RegisterMap map(JavaThread::cast(t),
+                      RegisterMap::UpdateMap::skip,
+                      RegisterMap::ProcessFrames::yes,
+                      RegisterMap::WalkContinuation::skip); // No update
       return fr.sender(&map);
     } else {
       // is_first_C_frame() does only simple checks for frame pointer,

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -332,7 +332,7 @@ static frame next_frame(frame fr, Thread* t) {
       return invalid;
     }
     if (fr.is_java_frame() || fr.is_native_frame() || fr.is_runtime_frame()) {
-      RegisterMap map(JavaThread::cast(t), false); // No update
+      RegisterMap map(JavaThread::cast(t), false /* update_map */, true /* process_frames */, false /* walk_cont */); // No update
       return fr.sender(&map);
     } else {
       // is_first_C_frame() does only simple checks for frame pointer,


### PR DESCRIPTION
Currently the `RegisterMap` constructor uses implicit boolean arguments to configure its function. Implicit boolean arguments makes code harder to understand and reason about at the call site. Using explicit scoped enums instead makes it both clear what is being configured and the type safety makes mistakes less likely. 

Update `RegisterMap` constructors to use these scoped enum types instead of booleans.
```C++
enum class UpdateMap { skip, yes };
enum class ProcessFrames { skip, yes };
enum class WalkContinuation { skip, yes };
```

Testing: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290074](https://bugs.openjdk.org/browse/JDK-8290074): Remove implicit arguments for RegisterMap constructor


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to [06820e01](https://git.openjdk.org/jdk/pull/9455/files/06820e018dbac020b9278549a911c2172b512552)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9455/head:pull/9455` \
`$ git checkout pull/9455`

Update a local copy of the PR: \
`$ git checkout pull/9455` \
`$ git pull https://git.openjdk.org/jdk pull/9455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9455`

View PR using the GUI difftool: \
`$ git pr show -t 9455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9455.diff">https://git.openjdk.org/jdk/pull/9455.diff</a>

</details>
