### PR TITLE
8290133: JFR: Remove unused methods in Bits.java

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Bits.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Bits.java
@@ -37,14 +37,6 @@ public final class Bits {
 
     // -- Swapping --
 
-    private static short swap(short x) {
-        return Short.reverseBytes(x);
-    }
-
-    private static char swap(char x) {
-        return Character.reverseBytes(x);
-    }
-
     private static int swap(int x) {
         return Integer.reverseBytes(x);
     }
@@ -69,12 +61,6 @@ public final class Bits {
 
     // -- Primitives stored per byte
 
-    private static byte char1(char x) { return (byte)(x >> 8); }
-    private static byte char0(char x) { return (byte)(x     ); }
-
-    private static byte short1(short x) { return (byte)(x >> 8); }
-    private static byte short0(short x) { return (byte)(x     ); }
-
     private static byte int3(int x) { return (byte)(x >> 24); }
     private static byte int2(int x) { return (byte)(x >> 16); }
     private static byte int1(int x) { return (byte)(x >>  8); }
@@ -88,16 +74,6 @@ public final class Bits {
     private static byte long2(long x) { return (byte)(x >> 16); }
     private static byte long1(long x) { return (byte)(x >>  8); }
     private static byte long0(long x) { return (byte)(x      ); }
-
-    private static void putCharBigEndianUnaligned(long a, char x) {
-        putByte_(a    , char1(x));
-        putByte_(a + 1, char0(x));
-    }
-
-    private static void putShortBigEndianUnaligned(long a, short x) {
-        putByte_(a    , short1(x));
-        putByte_(a + 1, short0(x));
-    }
 
     private static void putIntBigEndianUnaligned(long a, int x) {
         putByte_(a    , int3(x));
@@ -129,24 +105,8 @@ public final class Bits {
         unsafe.putByte(a, b);
     }
 
-    private static void putBoolean_(long a, boolean x) {
-        unsafe.putBoolean(null, a, x);
-    }
-
-    private static void putChar_(long a, char x) {
-        unsafe.putChar(a, bigEndian ? x : swap(x));
-    }
-
-    private static void putShort_(long a, short x) {
-        unsafe.putShort(a, bigEndian ? x : swap(x));
-    }
-
     private static void putInt_(long a, int x) {
         unsafe.putInt(a, bigEndian ? x : swap(x));
-    }
-
-    private static void putLong_(long a, long x) {
-        unsafe.putLong(a, bigEndian ? x : swap(x));
     }
 
     private static void putFloat_(long a, float x) {
@@ -158,34 +118,6 @@ public final class Bits {
     }
 
     // external api
-    public static int putByte(long a, byte x) {
-        putByte_(a, x);
-        return Byte.BYTES;
-    }
-
-    public static int putBoolean(long a, boolean x) {
-        putBoolean_(a, x);
-        return Byte.BYTES;
-    }
-
-    static int putChar(long a, char x) {
-        if (unalignedAccess || isAddressAligned(a, Character.BYTES)) {
-            putChar_(a, x);
-            return Character.BYTES;
-        }
-        putCharBigEndianUnaligned(a, x);
-        return Character.BYTES;
-    }
-
-    static int putShort(long a, short x) {
-        if (unalignedAccess || isAddressAligned(a, Short.BYTES)) {
-            putShort_(a, x);
-            return Short.BYTES;
-        }
-        putShortBigEndianUnaligned(a, x);
-        return Short.BYTES;
-    }
-
     public static int putInt(long a, int x) {
         if (unalignedAccess || isAddressAligned(a, Integer.BYTES)) {
             putInt_(a, x);
@@ -193,15 +125,6 @@ public final class Bits {
         }
         putIntBigEndianUnaligned(a, x);
         return Integer.BYTES;
-    }
-
-    static int putLong(long a, long x) {
-         if (unalignedAccess || isAddressAligned(a, Long.BYTES)) {
-            putLong_(a, x);
-            return Long.BYTES;
-        }
-        putLongBigEndianUnaligned(a, x);
-        return Long.BYTES;
     }
 
     public static int putFloat(long a, float x) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/event/EventWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/event/EventWriter.java
@@ -81,7 +81,8 @@ public final class EventWriter {
 
     public void putBoolean(boolean i) {
         if (isValidForSize(Byte.BYTES)) {
-            currentPosition += Bits.putBoolean(currentPosition, i);
+            unsafe.putBoolean(null, currentPosition, i);
+            ++currentPosition;
         }
     }
 
@@ -289,7 +290,7 @@ public final class EventWriter {
             Bits.putInt(startPosition, makePaddedInt(eventSize));
         } else {
             if (eventSize < 128) {
-                Bits.putByte(startPosition, (byte) eventSize);
+                unsafe.putByte(startPosition, (byte) eventSize);
             } else {
                 eventType.setLargeSize();
                 reset();


### PR DESCRIPTION
Could I have a review of PR that removes some unused methods. 

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290133](https://bugs.openjdk.org/browse/JDK-8290133): JFR: Remove unused methods in Bits.java


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9457/head:pull/9457` \
`$ git checkout pull/9457`

Update a local copy of the PR: \
`$ git checkout pull/9457` \
`$ git pull https://git.openjdk.org/jdk pull/9457/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9457`

View PR using the GUI difftool: \
`$ git pr show -t 9457`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9457.diff">https://git.openjdk.org/jdk/pull/9457.diff</a>

</details>
