### PR TITLE
8290149: java/nio/file/Files/probeContentType/Basic.java fails on Windows Server 2019/2022

### DIFF
--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -165,7 +165,7 @@ public class Basic {
                 new ExType("gz", List.of("application/gzip", "application/x-gzip")),
                 new ExType("jar", List.of("application/java-archive", "application/x-java-archive", "application/jar")),
                 new ExType("jpg", List.of("image/jpeg")),
-                new ExType("js", List.of("text/javascript", "application/javascript")),
+                new ExType("js", List.of("text/plain", "text/javascript", "application/javascript")),
                 new ExType("json", List.of("application/json")),
                 new ExType("markdown", List.of("text/markdown")),
                 new ExType("md", List.of("text/markdown", "application/x-genesis-rom")),


### PR DESCRIPTION
On Windows Server 2019/2022, default content type of ".js" is set to "text/plain" in registry.

```
C:\>reg query HKEY_CLASSES_ROOT\.js /v "Content Type"

HKEY_CLASSES_ROOT\.js
    Content Type    REG_SZ    text/plain
```

So, "text/plain" should be added for content type of ".js".

I propose to add default registry value to expected list. After fix, test passes on Windows Server 2022.

Could you review this fix, please?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290149](https://bugs.openjdk.org/browse/JDK-8290149): java/nio/file/Files/probeContentType/Basic.java fails on Windows Server 2019/2022


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9459/head:pull/9459` \
`$ git checkout pull/9459`

Update a local copy of the PR: \
`$ git checkout pull/9459` \
`$ git pull https://git.openjdk.org/jdk pull/9459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9459`

View PR using the GUI difftool: \
`$ git pr show -t 9459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9459.diff">https://git.openjdk.org/jdk/pull/9459.diff</a>

</details>
