### PR TITLE
8290090: Change CodeBlobType from unscoped enum to enum class

### DIFF
--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -41,14 +41,12 @@ class OopMapSet;
 
 // CodeBlob Types
 // Used in the CodeCache to assign CodeBlobs to different CodeHeaps
-struct CodeBlobType {
-  enum {
-    MethodNonProfiled   = 0,    // Execution level 1 and 4 (non-profiled) nmethods (including native nmethods)
-    MethodProfiled      = 1,    // Execution level 2 and 3 (profiled) nmethods
-    NonNMethod          = 2,    // Non-nmethods like Buffers, Adapters and Runtime Stubs
-    All                 = 3,    // All types (No code cache segmentation)
-    NumTypes            = 4     // Number of CodeBlobTypes
-  };
+enum class CodeBlobType {
+  MethodNonProfiled   = 0,    // Execution level 1 and 4 (non-profiled) nmethods (including native nmethods)
+  MethodProfiled      = 1,    // Execution level 2 and 3 (profiled) nmethods
+  NonNMethod          = 2,    // Non-nmethods like Buffers, Adapters and Runtime Stubs
+  All                 = 3,    // All types (No code cache segmentation)
+  NumTypes            = 4     // Number of CodeBlobTypes
 };
 
 // CodeBlob - superclass for all entries in the CodeCache.

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -172,10 +172,10 @@ int CodeCache::Sweep::_compiled_method_iterators = 0;
 bool CodeCache::Sweep::_pending_sweep = false;
 
 // Initialize arrays of CodeHeap subsets
-GrowableArray<CodeHeap*>* CodeCache::_heaps = new(ResourceObj::C_HEAP, mtCode) GrowableArray<CodeHeap*> (CodeBlobType::All, mtCode);
-GrowableArray<CodeHeap*>* CodeCache::_compiled_heaps = new(ResourceObj::C_HEAP, mtCode) GrowableArray<CodeHeap*> (CodeBlobType::All, mtCode);
-GrowableArray<CodeHeap*>* CodeCache::_nmethod_heaps = new(ResourceObj::C_HEAP, mtCode) GrowableArray<CodeHeap*> (CodeBlobType::All, mtCode);
-GrowableArray<CodeHeap*>* CodeCache::_allocable_heaps = new(ResourceObj::C_HEAP, mtCode) GrowableArray<CodeHeap*> (CodeBlobType::All, mtCode);
+GrowableArray<CodeHeap*>* CodeCache::_heaps = new(ResourceObj::C_HEAP, mtCode) GrowableArray<CodeHeap*> (static_cast<int>(CodeBlobType::All), mtCode);
+GrowableArray<CodeHeap*>* CodeCache::_compiled_heaps = new(ResourceObj::C_HEAP, mtCode) GrowableArray<CodeHeap*> (static_cast<int>(CodeBlobType::All), mtCode);
+GrowableArray<CodeHeap*>* CodeCache::_nmethod_heaps = new(ResourceObj::C_HEAP, mtCode) GrowableArray<CodeHeap*> (static_cast<int>(CodeBlobType::All), mtCode);
+GrowableArray<CodeHeap*>* CodeCache::_allocable_heaps = new(ResourceObj::C_HEAP, mtCode) GrowableArray<CodeHeap*> (static_cast<int>(CodeBlobType::All), mtCode);
 
 void CodeCache::check_heap_sizes(size_t non_nmethod_size, size_t profiled_size, size_t non_profiled_size, size_t cache_size, bool all_set) {
   size_t total_size = non_nmethod_size + profiled_size + non_profiled_size;
@@ -369,7 +369,7 @@ ReservedCodeSpace CodeCache::reserve_heap_memory(size_t size) {
 }
 
 // Heaps available for allocation
-bool CodeCache::heap_available(int code_blob_type) {
+bool CodeCache::heap_available(CodeBlobType code_blob_type) {
   if (!SegmentedCodeCache) {
     // No segmentation: use a single code heap
     return (code_blob_type == CodeBlobType::All);
@@ -386,7 +386,7 @@ bool CodeCache::heap_available(int code_blob_type) {
   }
 }
 
-const char* CodeCache::get_code_heap_flag_name(int code_blob_type) {
+const char* CodeCache::get_code_heap_flag_name(CodeBlobType code_blob_type) {
   switch(code_blob_type) {
   case CodeBlobType::NonNMethod:
     return "NonNMethodCodeHeapSize";
@@ -397,16 +397,17 @@ const char* CodeCache::get_code_heap_flag_name(int code_blob_type) {
   case CodeBlobType::MethodProfiled:
     return "ProfiledCodeHeapSize";
     break;
+  default:
+    ShouldNotReachHere();
+    return NULL;
   }
-  ShouldNotReachHere();
-  return NULL;
 }
 
 int CodeCache::code_heap_compare(CodeHeap* const &lhs, CodeHeap* const &rhs) {
   if (lhs->code_blob_type() == rhs->code_blob_type()) {
     return (lhs > rhs) ? 1 : ((lhs < rhs) ? -1 : 0);
   } else {
-    return lhs->code_blob_type() - rhs->code_blob_type();
+    return static_cast<int>(lhs->code_blob_type()) - static_cast<int>(rhs->code_blob_type());
   }
 }
 
@@ -415,7 +416,7 @@ void CodeCache::add_heap(CodeHeap* heap) {
 
   _heaps->insert_sorted<code_heap_compare>(heap);
 
-  int type = heap->code_blob_type();
+  CodeBlobType type = heap->code_blob_type();
   if (code_blob_type_accepts_compiled(type)) {
     _compiled_heaps->insert_sorted<code_heap_compare>(heap);
   }
@@ -427,7 +428,7 @@ void CodeCache::add_heap(CodeHeap* heap) {
   }
 }
 
-void CodeCache::add_heap(ReservedSpace rs, const char* name, int code_blob_type) {
+void CodeCache::add_heap(ReservedSpace rs, const char* name, CodeBlobType code_blob_type) {
   // Check if heap is needed
   if (!heap_available(code_blob_type)) {
     return;
@@ -469,7 +470,7 @@ CodeHeap* CodeCache::get_code_heap(const CodeBlob* cb) {
   return NULL;
 }
 
-CodeHeap* CodeCache::get_code_heap(int code_blob_type) {
+CodeHeap* CodeCache::get_code_heap(CodeBlobType code_blob_type) {
   FOR_ALL_HEAPS(heap) {
     if ((*heap)->accepts(code_blob_type)) {
       return *heap;
@@ -518,7 +519,7 @@ CodeBlob* CodeCache::first_blob(CodeHeap* heap) {
   return (CodeBlob*)heap->first();
 }
 
-CodeBlob* CodeCache::first_blob(int code_blob_type) {
+CodeBlob* CodeCache::first_blob(CodeBlobType code_blob_type) {
   if (heap_available(code_blob_type)) {
     return first_blob(get_code_heap(code_blob_type));
   } else {
@@ -539,7 +540,7 @@ CodeBlob* CodeCache::next_blob(CodeHeap* heap, CodeBlob* cb) {
  * run the constructor for the CodeBlob subclass he is busy
  * instantiating.
  */
-CodeBlob* CodeCache::allocate(int size, int code_blob_type, bool handle_alloc_failure, int orig_code_blob_type) {
+CodeBlob* CodeCache::allocate(int size, CodeBlobType code_blob_type, bool handle_alloc_failure, CodeBlobType orig_code_blob_type) {
   // Possibly wakes up the sweeper thread.
   NMethodSweeper::report_allocation();
   assert_locked_or_safepoint(CodeCache_lock);
@@ -567,7 +568,7 @@ CodeBlob* CodeCache::allocate(int size, int code_blob_type, bool handle_alloc_fa
         // NonNMethod -> MethodNonProfiled -> MethodProfiled (-> MethodNonProfiled)
         // Note that in the sweeper, we check the reverse_free_ratio of the code heap
         // and force stack scanning if less than 10% of the entire code cache are free.
-        int type = code_blob_type;
+        CodeBlobType type = code_blob_type;
         switch (type) {
         case CodeBlobType::NonNMethod:
           type = CodeBlobType::MethodNonProfiled;
@@ -580,6 +581,8 @@ CodeBlob* CodeCache::allocate(int size, int code_blob_type, bool handle_alloc_fa
           if (type == orig_code_blob_type) {
             type = CodeBlobType::MethodNonProfiled;
           }
+          break;
+        default:
           break;
         }
         if (type != code_blob_type && type != orig_code_blob_type && heap_available(type)) {
@@ -872,7 +875,7 @@ void CodeCache::verify_oops() {
   }
 }
 
-int CodeCache::blob_count(int code_blob_type) {
+int CodeCache::blob_count(CodeBlobType code_blob_type) {
   CodeHeap* heap = get_code_heap(code_blob_type);
   return (heap != NULL) ? heap->blob_count() : 0;
 }
@@ -885,7 +888,7 @@ int CodeCache::blob_count() {
   return count;
 }
 
-int CodeCache::nmethod_count(int code_blob_type) {
+int CodeCache::nmethod_count(CodeBlobType code_blob_type) {
   CodeHeap* heap = get_code_heap(code_blob_type);
   return (heap != NULL) ? heap->nmethod_count() : 0;
 }
@@ -898,7 +901,7 @@ int CodeCache::nmethod_count() {
   return count;
 }
 
-int CodeCache::adapter_count(int code_blob_type) {
+int CodeCache::adapter_count(CodeBlobType code_blob_type) {
   CodeHeap* heap = get_code_heap(code_blob_type);
   return (heap != NULL) ? heap->adapter_count() : 0;
 }
@@ -911,12 +914,12 @@ int CodeCache::adapter_count() {
   return count;
 }
 
-address CodeCache::low_bound(int code_blob_type) {
+address CodeCache::low_bound(CodeBlobType code_blob_type) {
   CodeHeap* heap = get_code_heap(code_blob_type);
   return (heap != NULL) ? (address)heap->low_boundary() : NULL;
 }
 
-address CodeCache::high_bound(int code_blob_type) {
+address CodeCache::high_bound(CodeBlobType code_blob_type) {
   CodeHeap* heap = get_code_heap(code_blob_type);
   return (heap != NULL) ? (address)heap->high_boundary() : NULL;
 }
@@ -929,7 +932,7 @@ size_t CodeCache::capacity() {
   return cap;
 }
 
-size_t CodeCache::unallocated_capacity(int code_blob_type) {
+size_t CodeCache::unallocated_capacity(CodeBlobType code_blob_type) {
   CodeHeap* heap = get_code_heap(code_blob_type);
   return (heap != NULL) ? heap->unallocated_capacity() : 0;
 }
@@ -1304,7 +1307,7 @@ void CodeCache::verify() {
 // A CodeHeap is full. Print out warning and report event.
 PRAGMA_DIAG_PUSH
 PRAGMA_FORMAT_NONLITERAL_IGNORED
-void CodeCache::report_codemem_full(int code_blob_type, bool print) {
+void CodeCache::report_codemem_full(CodeBlobType code_blob_type, bool print) {
   // Get nmethod heap for the given CodeBlobType and build CodeCacheFull event
   CodeHeap* heap = get_code_heap(code_blob_type);
   assert(heap != NULL, "heap is null");

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -104,17 +104,17 @@ class CodeCache : AllStatic {
   // Check the code heap sizes set by the user via command line
   static void check_heap_sizes(size_t non_nmethod_size, size_t profiled_size, size_t non_profiled_size, size_t cache_size, bool all_set);
   // Creates a new heap with the given name and size, containing CodeBlobs of the given type
-  static void add_heap(ReservedSpace rs, const char* name, int code_blob_type);
+  static void add_heap(ReservedSpace rs, const char* name, CodeBlobType code_blob_type);
   static CodeHeap* get_code_heap_containing(void* p);         // Returns the CodeHeap containing the given pointer, or NULL
   static CodeHeap* get_code_heap(const CodeBlob* cb);         // Returns the CodeHeap for the given CodeBlob
-  static CodeHeap* get_code_heap(int code_blob_type);         // Returns the CodeHeap for the given CodeBlobType
+  static CodeHeap* get_code_heap(CodeBlobType code_blob_type);         // Returns the CodeHeap for the given CodeBlobType
   // Returns the name of the VM option to set the size of the corresponding CodeHeap
-  static const char* get_code_heap_flag_name(int code_blob_type);
+  static const char* get_code_heap_flag_name(CodeBlobType code_blob_type);
   static ReservedCodeSpace reserve_heap_memory(size_t size);  // Reserves one continuous chunk of memory for the CodeHeaps
 
   // Iteration
   static CodeBlob* first_blob(CodeHeap* heap);                // Returns the first CodeBlob on the given CodeHeap
-  static CodeBlob* first_blob(int code_blob_type);            // Returns the first CodeBlob of the given type
+  static CodeBlob* first_blob(CodeBlobType code_blob_type);            // Returns the first CodeBlob of the given type
   static CodeBlob* next_blob(CodeHeap* heap, CodeBlob* cb);   // Returns the next CodeBlob on the given CodeHeap
  public:
 
@@ -153,7 +153,7 @@ class CodeCache : AllStatic {
   static const GrowableArray<CodeHeap*>* nmethod_heaps() { return _nmethod_heaps; }
 
   // Allocation/administration
-  static CodeBlob* allocate(int size, int code_blob_type, bool handle_alloc_failure = true, int orig_code_blob_type = CodeBlobType::All); // allocates a new CodeBlob
+  static CodeBlob* allocate(int size, CodeBlobType code_blob_type, bool handle_alloc_failure = true, CodeBlobType orig_code_blob_type = CodeBlobType::All); // allocates a new CodeBlob
   static void commit(CodeBlob* cb);                        // called when the allocated CodeBlob has been filled
   static int  alignment_unit();                            // guaranteed alignment of all CodeBlobs
   static int  alignment_offset();                          // guaranteed offset of first CodeBlob byte within alignment unit (i.e., allocation header)
@@ -176,11 +176,11 @@ class CodeCache : AllStatic {
   static CompiledMethod* find_compiled(void* start);
 
   static int       blob_count();                        // Returns the total number of CodeBlobs in the cache
-  static int       blob_count(int code_blob_type);
+  static int       blob_count(CodeBlobType code_blob_type);
   static int       adapter_count();                     // Returns the total number of Adapters in the cache
-  static int       adapter_count(int code_blob_type);
+  static int       adapter_count(CodeBlobType code_blob_type);
   static int       nmethod_count();                     // Returns the total number of nmethods in the cache
-  static int       nmethod_count(int code_blob_type);
+  static int       nmethod_count(CodeBlobType code_blob_type);
 
   // GC support
   static void verify_oops();
@@ -214,8 +214,8 @@ class CodeCache : AllStatic {
   static void print_summary(outputStream* st, bool detailed = true); // Prints a summary of the code cache usage
   static void log_state(outputStream* st);
   LINUX_ONLY(static void write_perf_map();)
-  static const char* get_code_heap_name(int code_blob_type)  { return (heap_available(code_blob_type) ? get_code_heap(code_blob_type)->name() : "Unused"); }
-  static void report_codemem_full(int code_blob_type, bool print);
+  static const char* get_code_heap_name(CodeBlobType code_blob_type)  { return (heap_available(code_blob_type) ? get_code_heap(code_blob_type)->name() : "Unused"); }
+  static void report_codemem_full(CodeBlobType code_blob_type, bool print);
 
   // Dcmd (Diagnostic commands)
   static void print_codelist(outputStream* st);
@@ -223,13 +223,13 @@ class CodeCache : AllStatic {
 
   // The full limits of the codeCache
   static address low_bound()                          { return _low_bound; }
-  static address low_bound(int code_blob_type);
+  static address low_bound(CodeBlobType code_blob_type);
   static address high_bound()                         { return _high_bound; }
-  static address high_bound(int code_blob_type);
+  static address high_bound(CodeBlobType code_blob_type);
 
   // Profiling
   static size_t capacity();
-  static size_t unallocated_capacity(int code_blob_type);
+  static size_t unallocated_capacity(CodeBlobType code_blob_type);
   static size_t unallocated_capacity();
   static size_t max_capacity();
 
@@ -242,29 +242,29 @@ class CodeCache : AllStatic {
   static void cleanup_inline_caches();                // clean unloaded/zombie nmethods from inline caches
 
   // Returns true if an own CodeHeap for the given CodeBlobType is available
-  static bool heap_available(int code_blob_type);
+  static bool heap_available(CodeBlobType code_blob_type);
 
   // Returns the CodeBlobType for the given CompiledMethod
-  static int get_code_blob_type(CompiledMethod* cm) {
+  static CodeBlobType get_code_blob_type(CompiledMethod* cm) {
     return get_code_heap(cm)->code_blob_type();
   }
 
-  static bool code_blob_type_accepts_compiled(int type) {
-    bool result = type == CodeBlobType::All || type <= CodeBlobType::MethodProfiled;
+  static bool code_blob_type_accepts_compiled(CodeBlobType code_blob_type) {
+    bool result = code_blob_type == CodeBlobType::All || code_blob_type <= CodeBlobType::MethodProfiled;
     return result;
   }
 
-  static bool code_blob_type_accepts_nmethod(int type) {
+  static bool code_blob_type_accepts_nmethod(CodeBlobType type) {
     return type == CodeBlobType::All || type <= CodeBlobType::MethodProfiled;
   }
 
-  static bool code_blob_type_accepts_allocable(int type) {
+  static bool code_blob_type_accepts_allocable(CodeBlobType type) {
     return type <= CodeBlobType::All;
   }
 
 
   // Returns the CodeBlobType for the given compilation level
-  static int get_code_blob_type(int comp_level) {
+  static CodeBlobType get_code_blob_type(int comp_level) {
     if (comp_level == CompLevel_none ||
         comp_level == CompLevel_simple ||
         comp_level == CompLevel_full_optimization) {
@@ -276,7 +276,7 @@ class CodeCache : AllStatic {
       return CodeBlobType::MethodProfiled;
     }
     ShouldNotReachHere();
-    return 0;
+    return static_cast<CodeBlobType>(0);
   }
 
   static void verify_clean_inline_caches();
@@ -309,7 +309,7 @@ class CodeCache : AllStatic {
   // tells how many nmethods have dependencies
   static int number_of_nmethods_with_dependencies();
 
-  static int get_codemem_full_count(int code_blob_type) {
+  static int get_codemem_full_count(CodeBlobType code_blob_type) {
     CodeHeap* heap = get_code_heap(code_blob_type);
     return (heap != NULL) ? heap->full_count() : 0;
   }

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2417,7 +2417,7 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
  * This function needs to be called only from CodeCache::allocate(),
  * since we currently handle a full code cache uniformly.
  */
-void CompileBroker::handle_full_code_cache(int code_blob_type) {
+void CompileBroker::handle_full_code_cache(CodeBlobType code_blob_type) {
   UseInterpreter = true;
   if (UseCompiler || AlwaysCompileLoopMethods ) {
     if (xtty != NULL) {

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -358,7 +358,7 @@ public:
   static bool is_compilation_disabled_forever() {
     return _should_compile_new_jobs == shutdown_compilation;
   }
-  static void handle_full_code_cache(int code_blob_type);
+  static void handle_full_code_cache(CodeBlobType code_blob_type);
   // Ensures that warning is only printed once.
   static bool should_print_compiler_warning() {
     jint old = Atomic::cmpxchg(&_print_compilation_warning, 0, 1);

--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -592,7 +592,8 @@ TRACE_REQUEST_FUNC(CompilerConfiguration) {
 
 TRACE_REQUEST_FUNC(CodeCacheStatistics) {
   // Emit stats for all available code heaps
-  for (int bt = 0; bt < CodeBlobType::NumTypes; ++bt) {
+  for (int bt_index = 0; bt_index < static_cast<int>(CodeBlobType::NumTypes); ++bt_index) {
+    const CodeBlobType bt = static_cast<CodeBlobType>(bt_index);
     if (CodeCache::heap_available(bt)) {
       EventCodeCacheStatistics event;
       event.set_codeBlobType((u1)bt);

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrType.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrType.cpp
@@ -248,11 +248,11 @@ void NarrowOopModeConstant::serialize(JfrCheckpointWriter& writer) {
 }
 
 void CodeBlobTypeConstant::serialize(JfrCheckpointWriter& writer) {
-  static const u4 nof_entries = CodeBlobType::NumTypes;
+  static const u4 nof_entries = static_cast<u4>(CodeBlobType::NumTypes);
   writer.write_count(nof_entries);
   for (u4 i = 0; i < nof_entries; ++i) {
     writer.write_key(i);
-    writer.write(CodeCache::get_code_heap_name(i));
+    writer.write(CodeCache::get_code_heap_name(static_cast<CodeBlobType>(i)));
   }
 };
 

--- a/src/hotspot/share/memory/heap.cpp
+++ b/src/hotspot/share/memory/heap.cpp
@@ -33,7 +33,7 @@
 
 // Implementation of Heap
 
-CodeHeap::CodeHeap(const char* name, const int code_blob_type)
+CodeHeap::CodeHeap(const char* name, const CodeBlobType code_blob_type)
   : _code_blob_type(code_blob_type) {
   _name                         = name;
   _number_of_committed_segments = 0;

--- a/src/hotspot/share/memory/heap.hpp
+++ b/src/hotspot/share/memory/heap.hpp
@@ -99,7 +99,7 @@ class CodeHeap : public CHeapObj<mtCode> {
   size_t       _max_allocated_capacity;          // Peak capacity that was allocated during lifetime of the heap
 
   const char*  _name;                            // Name of the CodeHeap
-  const int    _code_blob_type;                  // CodeBlobType it contains
+  const CodeBlobType _code_blob_type;            // CodeBlobType it contains
   int          _blob_count;                      // Number of CodeBlobs
   int          _nmethod_count;                   // Number of nmethods
   int          _adapter_count;                   // Number of adapters
@@ -146,7 +146,7 @@ class CodeHeap : public CHeapObj<mtCode> {
   void on_code_mapping(char* base, size_t size);
 
  public:
-  CodeHeap(const char* name, const int code_blob_type);
+  CodeHeap(const char* name, const CodeBlobType code_blob_type);
 
   // Heap extents
   bool  reserve(ReservedSpace rs, size_t committed_size, size_t segment_size);
@@ -205,9 +205,9 @@ class CodeHeap : public CHeapObj<mtCode> {
   size_t unallocated_capacity() const            { return max_capacity() - allocated_capacity(); }
 
   // Returns true if the CodeHeap contains CodeBlobs of the given type
-  bool accepts(int code_blob_type) const         { return (_code_blob_type == CodeBlobType::All) ||
+  bool accepts(CodeBlobType code_blob_type) const{ return (_code_blob_type == CodeBlobType::All) ||
                                                           (_code_blob_type == code_blob_type); }
-  int code_blob_type() const                     { return _code_blob_type; }
+  CodeBlobType code_blob_type() const            { return _code_blob_type; }
 
   // Debugging / Profiling
   const char* name() const                       { return _name; }

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1472,12 +1472,12 @@ WB_ENTRY(jstring, WB_GetCPUFeatures(JNIEnv* env, jobject o))
   return features_string;
 WB_END
 
-int WhiteBox::get_blob_type(const CodeBlob* code) {
+CodeBlobType WhiteBox::get_blob_type(const CodeBlob* code) {
   guarantee(WhiteBoxAPI, "internal testing API :: WhiteBox has to be enabled");
   return CodeCache::get_code_heap(code)->code_blob_type();
 }
 
-CodeHeap* WhiteBox::get_code_heap(int blob_type) {
+CodeHeap* WhiteBox::get_code_heap(CodeBlobType blob_type) {
   guarantee(WhiteBoxAPI, "internal testing API :: WhiteBox has to be enabled");
   return CodeCache::get_code_heap(blob_type);
 }
@@ -1486,7 +1486,7 @@ struct CodeBlobStub {
   CodeBlobStub(const CodeBlob* blob) :
       name(os::strdup(blob->name())),
       size(blob->size()),
-      blob_type(WhiteBox::get_blob_type(blob)),
+      blob_type(static_cast<jint>(WhiteBox::get_blob_type(blob))),
       address((jlong) blob) { }
   ~CodeBlobStub() { os::free((void*) name); }
   const char* const name;
@@ -1566,7 +1566,7 @@ WB_ENTRY(jobjectArray, WB_GetNMethod(JNIEnv* env, jobject o, jobject method, jbo
   return result;
 WB_END
 
-CodeBlob* WhiteBox::allocate_code_blob(int size, int blob_type) {
+CodeBlob* WhiteBox::allocate_code_blob(int size, CodeBlobType blob_type) {
   guarantee(WhiteBoxAPI, "internal testing API :: WhiteBox has to be enabled");
   BufferBlob* blob;
   int full_size = CodeBlob::align_code_offset(sizeof(BufferBlob));
@@ -1590,7 +1590,7 @@ WB_ENTRY(jlong, WB_AllocateCodeBlob(JNIEnv* env, jobject o, jint size, jint blob
     THROW_MSG_0(vmSymbols::java_lang_IllegalArgumentException(),
       err_msg("WB_AllocateCodeBlob: size is negative: " INT32_FORMAT, size));
   }
-  return (jlong) WhiteBox::allocate_code_blob(size, blob_type);
+  return (jlong) WhiteBox::allocate_code_blob(size, static_cast<CodeBlobType>(blob_type));
 WB_END
 
 WB_ENTRY(void, WB_FreeCodeBlob(JNIEnv* env, jobject o, jlong addr))
@@ -1605,7 +1605,7 @@ WB_ENTRY(jobjectArray, WB_GetCodeHeapEntries(JNIEnv* env, jobject o, jint blob_t
   GrowableArray<CodeBlobStub*> blobs;
   {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-    CodeHeap* heap = WhiteBox::get_code_heap(blob_type);
+    CodeHeap* heap = WhiteBox::get_code_heap(static_cast<CodeBlobType>(blob_type));
     if (heap == NULL) {
       return NULL;
     }

--- a/src/hotspot/share/prims/whitebox.hpp
+++ b/src/hotspot/share/prims/whitebox.hpp
@@ -46,6 +46,7 @@ public:
 };
 
 class CodeBlob;
+enum class CodeBlobType;
 class CodeHeap;
 class JavaThread;
 
@@ -60,9 +61,9 @@ class WhiteBox : public AllStatic {
     Symbol* signature_symbol);
   static const char* lookup_jstring(const char* field_name, oop object);
   static bool lookup_bool(const char* field_name, oop object);
-  static int get_blob_type(const CodeBlob* code);
-  static CodeHeap* get_code_heap(int blob_type);
-  static CodeBlob* allocate_code_blob(int size, int blob_type);
+  static CodeBlobType get_blob_type(const CodeBlob* code);
+  static CodeHeap* get_code_heap(CodeBlobType blob_type);
+  static CodeBlob* allocate_code_blob(int size, CodeBlobType blob_type);
   static int array_bytes_to_length(size_t bytes);
   static void register_methods(JNIEnv* env, jclass wbclass, JavaThread* thread,
     JNINativeMethod* method_array, int method_count);


### PR DESCRIPTION
Change: 
```C++
struct CodeBlobType { 
  enum { [...] } 
}
```
To: 
```C++
enum class CodeBlobType { 
  [...] 
}; 
```
Using C++11 scoped enums provides a more clear view of intent, as enums can be enforced by the type system instead of being passed around as ints.

Testing: Tier 1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290090](https://bugs.openjdk.org/browse/JDK-8290090): Change CodeBlobType from unscoped enum to enum class


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9460/head:pull/9460` \
`$ git checkout pull/9460`

Update a local copy of the PR: \
`$ git checkout pull/9460` \
`$ git pull https://git.openjdk.org/jdk pull/9460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9460`

View PR using the GUI difftool: \
`$ git pr show -t 9460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9460.diff">https://git.openjdk.org/jdk/pull/9460.diff</a>

</details>
