### PR TITLE
8290080: G1: Remove unnecessary is-obj-dead check in HeapRegion::do_oops_on_memregion_in_humongous

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -374,12 +374,6 @@ HeapWord* HeapRegion::do_oops_on_memregion_in_humongous(MemRegion mr,
   // Only filler objects follow a humongous object in the containing
   // regions, and we can ignore those.  So only process the one
   // humongous object.
-  HeapWord* const pb = in_gc_pause ? sr->parsable_bottom() : sr->parsable_bottom_acquire();
-  if (sr->is_obj_dead(obj, pb)) {
-    // The object is dead. There can be no other object in this region, so return
-    // the end of that region.
-    return end();
-  }
   if (obj->is_objArray() || (sr->bottom() < mr.start())) {
     // objArrays are always marked precisely, so limit processing
     // with mr.  Non-objArrays might be precisely marked, and since


### PR DESCRIPTION
Simple change of removing an `if` check.

Test: tier1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290080](https://bugs.openjdk.org/browse/JDK-8290080): G1: Remove unnecessary is-obj-dead check in HeapRegion::do_oops_on_memregion_in_humongous


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9462/head:pull/9462` \
`$ git checkout pull/9462`

Update a local copy of the PR: \
`$ git checkout pull/9462` \
`$ git pull https://git.openjdk.org/jdk pull/9462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9462`

View PR using the GUI difftool: \
`$ git pr show -t 9462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9462.diff">https://git.openjdk.org/jdk/pull/9462.diff</a>

</details>
