### PR TITLE
8290164: compiler/runtime/TestConstantsInError.java fails on riscv

### DIFF
--- a/test/hotspot/jtreg/compiler/runtime/TestConstantsInError.java
+++ b/test/hotspot/jtreg/compiler/runtime/TestConstantsInError.java
@@ -130,7 +130,7 @@ public abstract class TestConstantsInError implements OutputProcessor {
             results.shouldMatch("Test_C1/.*::test \\(3 bytes\\)$")
                    .shouldMatch("Test_C2/.*::test \\(3 bytes\\)$");
 
-            if (isC1 && Platform.isAArch64()) { // no code patching
+            if (isC1 && (Platform.isAArch64() || Platform.isRISCV64())) { // no code patching
                 results.shouldMatch("Test_C1/.*::test \\(3 bytes\\)   made not entrant")
                        .shouldMatch("Test_C2/.*::test \\(3 bytes\\)   made not entrant");
             } else {
@@ -168,7 +168,7 @@ public abstract class TestConstantsInError implements OutputProcessor {
                    .shouldMatch("Test_MH3/.*::test \\(3 bytes\\)$")
                    .shouldMatch("Test_MH4/.*::test \\(3 bytes\\)$");
 
-            if (isC1 && Platform.isAArch64()) { // no code patching
+            if (isC1 && (Platform.isAArch64() || Platform.isRISCV64())) { // no code patching
                 results.shouldMatch("Test_MH1/.*::test \\(3 bytes\\)   made not entrant")
                        .shouldMatch("Test_MH2/.*::test \\(3 bytes\\)   made not entrant")
                        .shouldMatch("Test_MH3/.*::test \\(3 bytes\\)   made not entrant")
@@ -191,7 +191,7 @@ public abstract class TestConstantsInError implements OutputProcessor {
             results.shouldMatch("Test_MT1/.*::test \\(3 bytes\\)$")
                    .shouldMatch("Test_MT2/.*::test \\(3 bytes\\)$");
 
-            if (isC1 && Platform.isAArch64()) { // no code patching
+            if (isC1 && (Platform.isAArch64() || Platform.isRISCV64())) { // no code patching
                 results.shouldMatch("Test_MT1/.*::test \\(3 bytes\\)   made not entrant")
                        .shouldMatch("Test_MT2/.*::test \\(3 bytes\\)   made not entrant");
             } else {
@@ -235,7 +235,7 @@ public abstract class TestConstantsInError implements OutputProcessor {
                    .shouldMatch("Test_CD3.*::test \\(3 bytes\\)$")
                    .shouldMatch("Test_CD4.*::test \\(3 bytes\\)$");
 
-            if (isC1 && Platform.isAArch64()) { // no code patching
+            if (isC1 && (Platform.isAArch64() || Platform.isRISCV64())) { // no code patching
                 results.shouldMatch("Test_CD1.*::test \\(3 bytes\\)   made not entrant")
                        .shouldMatch("Test_CD2.*::test \\(3 bytes\\)   made not entrant")
                        .shouldMatch("Test_CD3.*::test \\(3 bytes\\)   made not entrant")


### PR DESCRIPTION
compiler/runtime/TestConstantsInError.java fails on riscv with the following error:

```
Execution failed: `main' threw exception: java.lang.RuntimeException: 'made not entrant' found in stdout
```

Similar to AArch64, RISCV64 does not patch C1 compiled code (see [JDK-8223613](https://bugs.openjdk.org/browse/JDK-8223613)). So we should add `Platform.isRISCV64` too for the test.

This test requires vm.flagless. According to [JDK-8246494](https://bugs.openjdk.org/browse/JDK-8246494), tests with `vm.flagless` will be excluded from runs w/ any other X / XX flags passed via -vmoption / -javaoption. 
Since we added `-Xmx` option for all jtreg tests, so this failure does not menifest before. 

After this fixing, compiler/runtime/TestConstantsInError.java passed without failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290164](https://bugs.openjdk.org/browse/JDK-8290164): compiler/runtime/TestConstantsInError.java fails on riscv


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Yadong Wang](https://openjdk.org/census#yadongwang) (@yadongw - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9463/head:pull/9463` \
`$ git checkout pull/9463`

Update a local copy of the PR: \
`$ git checkout pull/9463` \
`$ git pull https://git.openjdk.org/jdk pull/9463/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9463`

View PR using the GUI difftool: \
`$ git pr show -t 9463`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9463.diff">https://git.openjdk.org/jdk/pull/9463.diff</a>

</details>
