### PR TITLE
8290162: Reset recursion counter missed in fix of JDK-8224267

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
@@ -374,6 +374,7 @@ public class BasicOptionPaneUI extends OptionPaneUI {
                       "OptionPane.messageAnchor", GridBagConstraints.CENTER);
         cons.insets = new Insets(0,0,3,0);
 
+        recursionCount = 0;
         addMessageComponents(body, cons, getMessage(),
                           getMaxCharactersPerLineCount(), false);
         top.add(realBody, BorderLayout.CENTER);
@@ -478,8 +479,11 @@ public class BasicOptionPaneUI extends OptionPaneUI {
                 }
                 // Prevent recursion of more than
                 // 200 successive newlines in a message
+                // and indicate message is truncated via ellipsis
                 if (recursionCount++ > 200) {
                     recursionCount = 0;
+                    addMessageComponents(container, cons, new String("..."),
+                                         maxll,false);
                     return;
                 }
                 addMessageComponents(container, cons, s.substring(nl + nll), maxll,

--- a/test/jdk/javax/swing/JOptionPane/TestOptionPaneStackOverflow.java
+++ b/test/jdk/javax/swing/JOptionPane/TestOptionPaneStackOverflow.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
-   @bug 8224267
+   @bug 8224267 8290162
    @key headful
    @summary Verifies if StackOverflowError is not thrown for multiple newlines
    @run main TestOptionPaneStackOverflow


### PR DESCRIPTION
`recursionCount` counter added in fix of JDK-8224267 is only reset when limit is reached,  so it will behave incorrectly if JOptionPane.showMessageDialog continuously with the same message having newlines, so it needs to be reset also at appropriate location. 
Fix to reset the counter before the recursive method is called.

Also, fix added to indicate the original message is truncated by adding ... (ellipsis) to the previous line of text if it recurses more than limit set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290162](https://bugs.openjdk.org/browse/JDK-8290162): Reset recursion counter missed in fix of JDK-8224267


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9464/head:pull/9464` \
`$ git checkout pull/9464`

Update a local copy of the PR: \
`$ git checkout pull/9464` \
`$ git pull https://git.openjdk.org/jdk pull/9464/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9464`

View PR using the GUI difftool: \
`$ git pr show -t 9464`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9464.diff">https://git.openjdk.org/jdk/pull/9464.diff</a>

</details>
