### PR TITLE
8288107: Auto-vectorization for integer min/max

### DIFF
--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -1082,6 +1082,85 @@ static bool can_overflow(const TypeInt* t, jint c) {
           (c > 0 && (java_add(t_hi, c) < t_hi)));
 }
 
+// Ideal transformations for MaxINode
+Node* MaxINode::Ideal(PhaseGVN* phase, bool can_reshape) {
+  // Force a right-spline graph
+  Node* l = in(1);
+  Node* r = in(2);
+  // Transform  MaxI1(MaxI2(a,b), c)  into  MaxI1(a, MaxI2(b,c))
+  // to force a right-spline graph for the rest of MaxINode::Ideal().
+  if(l->Opcode() == Op_MaxI) {
+    assert(l != l->in(1), "dead loop in MaxINode::Ideal");
+    r = phase->transform(new MaxINode(l->in(2), r));
+    l = l->in(1);
+    set_req_X(1, l, phase);
+    set_req_X(2, r, phase);
+    return this;
+  }
+
+  // Get left input & constant
+  Node* x = l;
+  jint x_off = 0;
+  if(x->Opcode() == Op_AddI && // Check for "x+c0" and collect constant
+      x->in(2)->is_Con()) {
+    const Type* t = x->in(2)->bottom_type();
+    if(t == Type::TOP) return NULL;  // No progress
+    x_off = t->is_int()->get_con();
+    x = x->in(1);
+  }
+
+  // Scan a right-spline-tree for MAXs
+  Node* y = r;
+  jint y_off = 0;
+  // Check final part of MAX tree
+  if(y->Opcode() == Op_AddI && // Check for "y+c1" and collect constant
+      y->in(2)->is_Con()) {
+    const Type* t = y->in(2)->bottom_type();
+    if(t == Type::TOP) return NULL;  // No progress
+    y_off = t->is_int()->get_con();
+    y = y->in(1);
+  }
+  if(x->_idx > y->_idx && r->Opcode() != Op_MaxI) {
+    swap_edges(1, 2);
+    return this;
+  }
+
+  const TypeInt* tx = phase->type(x)->isa_int();
+
+  if(r->Opcode() == Op_MaxI) {
+    assert(r != r->in(2), "dead loop in MaxINode::Ideal");
+    y = r->in(1);
+    // Check final part of MAX tree
+    if(y->Opcode() == Op_AddI &&// Check for "y+c1" and collect constant
+        y->in(2)->is_Con()) {
+      const Type* t = y->in(2)->bottom_type();
+      if(t == Type::TOP) return NULL;  // No progress
+      y_off = t->is_int()->get_con();
+      y = y->in(1);
+    }
+
+    if(x->_idx > y->_idx)
+      return new MaxINode(r->in(1), phase->transform(new MaxINode(l, r->in(2))));
+
+    // Transform MAX2(x + c0, MAX2(x + c1, z)) into MAX2(x + MAX2(c0, c1), z)
+    // if x == y and the additions can't overflow.
+    if (x == y && tx != NULL &&
+        !can_overflow(tx, x_off) &&
+        !can_overflow(tx, y_off)) {
+      return new MaxINode(phase->transform(new AddINode(x, phase->intcon(MAX2(x_off, y_off)))), r->in(2));
+    }
+  } else {
+    // Transform MAX2(x + c0, y + c1) into x + MAX2(c0, c1)
+    // if x == y and the additions can't overflow.
+    if (x == y && tx != NULL &&
+        !can_overflow(tx, x_off) &&
+        !can_overflow(tx, y_off)) {
+      return new AddINode(x, phase->intcon(MAX2(x_off, y_off)));
+    }
+  }
+ return NULL;
+}
+
 //=============================================================================
 //------------------------------Idealize---------------------------------------
 // MINs show up in range-check loop limit calculations.  Look for

--- a/src/hotspot/share/opto/addnode.hpp
+++ b/src/hotspot/share/opto/addnode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -299,6 +299,7 @@ public:
   virtual uint ideal_reg() const { return Op_RegI; }
   int max_opcode() const { return Op_MaxI; }
   int min_opcode() const { return Op_MinI; }
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
 };
 
 //------------------------------MinINode---------------------------------------

--- a/test/hotspot/jtreg/compiler/c2/irTests/MaxINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/MaxINodeIdealizationTests.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.c2.irTests;
+
+import jdk.test.lib.Asserts;
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8288107
+ * @summary Test that Ideal transformations of MaxINode* are being performed as expected.
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.MaxINodeIdealizationTests
+ */
+
+public class MaxINodeIdealizationTests {
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @Run(test = {"test1", "test2", "test3"})
+    public void runMethod() {
+        int a = RunInfo.getRandom().nextInt();
+        int min = Integer.MIN_VALUE;
+        int max = Integer.MAX_VALUE;
+
+        assertResult(a);
+        assertResult(0);
+        assertResult(min);
+        assertResult(max);
+    }
+
+    @DontCompile
+    public void assertResult(int a) {
+        Asserts.assertEQ(Math.max(((a >> 1) + 100), Math.max(((a >> 1) + 150), 200)), test1(a));
+        Asserts.assertEQ(Math.max(((a >> 1) + 10), ((a >> 1) + 11))                 , test2(a));
+        Asserts.assertEQ(Math.max(a, a)                                             , test3(a));
+    }
+
+    // The transformations in test1 and test2 can happen only if the compiler has enough information
+    // to determine that the two addition operations can not overflow.
+
+    // Transform max(x + c0, max(y + c1, z)) to max(add(x, c2), z) if x == y, where c2 = MAX2(c0, c1).
+    // c0,c1 and c2 are constants. x,y,z can be any valid c2 nodes. In this example, x and y are
+    // RShiftI nodes and z is a ConI.
+    @Test
+    @IR(counts = {IRNode.Max_I, "1",
+                  IRNode.ADD, "1",
+                 })
+    public int test1(int i) {
+        return Math.max(((i >> 1) + 100), Math.max(((i >> 1) + 150), 200));
+    }
+
+    // Transform max(x + c0, y + c1) to add(x, c2) if x == y, where c2 = MAX2(c0, c1).
+    // c0,c1,c2 are constants. x and y can be any valid c2 nodes. If they are equal, this
+    // transformation would take place. In this example, x and y are same RShiftI nodes.
+    @Test
+    @IR(failOn = {IRNode.Max_I})
+    @IR(counts = {IRNode.ADD, "1"})
+    public int test2(int i) {
+        return Math.max((i >> 1) + 10, (i >> 1) + 11);
+    }
+
+    // Do not perform a max operation when comparing the same node. As long as the same node is being
+    // compared, a max operation will not be performed and instead the same node is returned. In this
+    // test, an integer is being compared with itself but it can be any valid c2 node.
+    @Test
+    @IR(failOn = {IRNode.Max_I})
+    public int test3(int i) {
+        return Math.max(i, i);
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -209,6 +209,10 @@ public class IRNode {
     public static final String VECTOR_UCAST_I2X = START + "VectorUCastI2X" + MID + END;
     public static final String VECTOR_REINTERPRET = START + "VectorReinterpret" + MID + END;
 
+    public static final String Max_I = START + "MaxI" + MID + END;
+    public static final String Min_V = START + "MinV" + MID + END;
+    public static final String Max_V = START + "MaxV" + MID + END;
+
     public static final String FAST_LOCK   = START + "FastLock" + MID + END;
     public static final String FAST_UNLOCK = START + "FastUnlock" + MID + END;
 

--- a/test/hotspot/jtreg/compiler/vectorization/TestAutoVecIntMinMax.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestAutoVecIntMinMax.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+/*
+ * @test
+ * @bug 8288107
+ * @summary Auto-vectorization enhancement for integer Math.max/Math.min operations
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @requires (os.simpleArch == "x64" & ((vm.cpu.features ~= ".*avx.*")
+ *           | (vm.cpu.features ~= ".*sse4.*"))) | os.arch == "aarch64" | os.arch == "riscv64"
+ * @run driver compiler.c2.irTests.TestAutoVecIntMinMax
+ */
+
+public class TestAutoVecIntMinMax {
+    private final static int LENGTH = 2000;
+    private final static Random RANDOM = Utils.getRandomInstance();
+
+    private static int[] a;
+    private static int[] b;
+    private static int[] c;
+
+    static {
+        a = new int[LENGTH];
+        b = new int[LENGTH];
+        c = new int[LENGTH];
+        for(int i = 0; i < LENGTH; i++) {
+            a[i] = RANDOM.nextInt();
+            b[i] = RANDOM.nextInt();
+        }
+    }
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    // Test for auto-vectorization of Math.min operation on an array of integers
+    @Test
+    @IR(counts = {IRNode.LOAD_VECTOR,  " >0 "})
+    @IR(counts = {IRNode.Min_V,        " >0 "})
+    @IR(counts = {IRNode.STORE_VECTOR, " >0 "})
+    private static void testIntMin(int[] a, int[] b) {
+        for(int i = 0; i < LENGTH; i++) {
+            c[i] = Math.min(a[i], b[i]);
+        }
+    }
+
+    // Test for auto-vectorization of StrictMath.min operation on an array of integers
+    @Test
+    @IR(counts = {IRNode.LOAD_VECTOR,  " >0 "})
+    @IR(counts = {IRNode.Min_V,        " >0 "})
+    @IR(counts = {IRNode.STORE_VECTOR, " >0 "})
+    private static void testIntStrictMin(int[] a, int[] b) {
+        for(int i = 0; i < LENGTH; i++) {
+            c[i] = StrictMath.min(a[i], b[i]);
+        }
+    }
+
+    // Test for auto-vectorization of Math.max operation on an array of integers
+    @Test
+    @IR(counts = {IRNode.LOAD_VECTOR,  " >0 "})
+    @IR(counts = {IRNode.Max_V,        " >0 "})
+    @IR(counts = {IRNode.STORE_VECTOR, " >0 "})
+    private static void testIntMax(int[] a, int[] b) {
+        for(int i = 0; i < LENGTH; i++) {
+            c[i] = Math.max(a[i], b[i]);
+        }
+    }
+
+    // Test for auto-vectorization of StrictMath.max operation on an array of integers
+    @Test
+    @IR(counts = {IRNode.LOAD_VECTOR,  " >0 "})
+    @IR(counts = {IRNode.Max_V,        " >0 "})
+    @IR(counts = {IRNode.STORE_VECTOR, " >0 "})
+    private static void testIntStrictMax(int[] a, int[] b) {
+        for(int i = 0; i < LENGTH; i++) {
+            c[i] = StrictMath.max(a[i], b[i]);
+        }
+    }
+
+    @Run(test = {"testIntMin", "testIntStrictMin", "testIntMax", "testIntStrictMax"})
+    private void testIntMinMax_runner() {
+        testIntMin(a, b);
+        testIntStrictMin(a, b);
+        testIntMax(a, b);
+        testIntStrictMax(a, b);
+    }
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/VectorIntMinMax.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/VectorIntMinMax.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.*;
+
+import java.util.concurrent.TimeUnit;
+import java.util.Random;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+public class VectorIntMinMax {
+    @Param({"2048"})
+    private int LENGTH;
+
+    private int[] ia;
+    private int[] ib;
+    private int[] ic;
+
+    @Param("0")
+    private int seed;
+    private Random random = new Random(seed);
+
+    @Setup
+    public void init() {
+        ia = new int[LENGTH];
+        ib = new int[LENGTH];
+        ic = new int[LENGTH];
+
+        for (int i = 0; i < LENGTH; i++) {
+            ia[i] = random.nextInt();
+            ib[i] = random.nextInt();
+        }
+    }
+
+    // Test Math.max for int arrays
+    @Benchmark
+    public void testMaxInt() {
+        for (int i = 0; i < LENGTH; i++) {
+            ic[i] = Math.max(ia[i], ib[i]);
+        }
+    }
+
+    // Test Math.min for int arrays
+    @Benchmark
+    public void testMinInt() {
+        for (int i = 0; i < LENGTH; i++) {
+            ic[i] = Math.min(ia[i], ib[i]);
+        }
+    }
+
+    // Test StrictMath.min for int arrays
+    @Benchmark
+    public void testStrictMinInt() {
+        for (int i = 0; i < LENGTH; i++) {
+            ic[i] = StrictMath.min(ia[i], ib[i]);
+        }
+    }
+
+    // Test StrictMath.max for int arrays
+    @Benchmark
+    public void testStrictMaxInt() {
+        for (int i = 0; i < LENGTH; i++) {
+            ic[i] = StrictMath.max(ia[i], ib[i]);
+        }
+    }
+}


### PR DESCRIPTION
When Math.min/max is invoked on integer arrays, it generates the CMP-CMOVE instructions instead of vectorizing the loop(if vectorizable and relevant ISA is available) using vector equivalent of min/max instructions. Emitting MaxI/MinI nodes instead of Cmp/CmoveI nodes results in the loop getting vectorized eventually and the architecture specific min/max vector instructions are generated.
A test for the same to test the performance of Math.max/min and StrictMath.max/min is added. On aarch64, the smin/smax instructions are generated when the loop is vectorized. On x86-64, vectorization support for min/max is available only in SSE4 (pmaxsd/pminsd are generated) and AVX version >= 1 (vpmaxsd/vpminsd are generated). This patch generates these instructions only when the loop is vectorized and generates the usual cmp-cmove instructions when the loop is not vectorizable or when the max/min operations are called outside of the loop. Performance comparisons for the VectorIntMinMax.java test with and without the patch are given below :

Before this patch:
aarch64:
  Benchmark                         (length)  (seed)  Mode  Cnt     Score   Error  Units
  VectorIntMinMax.testMaxInt            2048       0  avgt   25  1593.510 ± 1.488  ns/op
  VectorIntMinMax.testMinInt            2048       0  avgt   25  1593.123 ± 1.365  ns/op
  VectorIntMinMax.testStrictMaxInt      2048       0  avgt   25  1593.112 ± 0.985  ns/op
  VectorIntMinMax.testStrictMinInt      2048       0  avgt   25  1593.290 ± 1.219  ns/op

x86-64:
  Benchmark                         (length)  (seed)  Mode  Cnt     Score   Error  Units
  VectorIntMinMax.testMaxInt            2048       0  avgt   25  2084.717 ± 4.780  ns/op
  VectorIntMinMax.testMinInt            2048       0  avgt   25  2087.322 ± 4.158  ns/op
  VectorIntMinMax.testStrictMaxInt      2048       0  avgt   25  2084.568 ± 4.838  ns/op
  VectorIntMinMax.testStrictMinInt      2048       0  avgt   25  2086.595 ± 4.025  ns/op

After this patch:
aarch64:
Benchmark                         (length)  (seed)  Mode  Cnt    Score   Error  Units
  VectorIntMinMax.testMaxInt            2048       0  avgt   25  323.911 ± 0.206  ns/op
  VectorIntMinMax.testMinInt            2048       0  avgt   25  324.084 ± 0.231  ns/op
  VectorIntMinMax.testStrictMaxInt      2048       0  avgt   25  323.892 ± 0.234  ns/op
  VectorIntMinMax.testStrictMinInt      2048       0  avgt   25  323.990 ± 0.295  ns/op

x86-64:
Benchmark                         (length)  (seed)  Mode  Cnt    Score   Error  Units
  VectorIntMinMax.testMaxInt            2048       0  avgt   25  387.639 ± 0.512  ns/op
  VectorIntMinMax.testMinInt            2048       0  avgt   25  387.999 ± 0.740  ns/op
  VectorIntMinMax.testStrictMaxInt      2048       0  avgt   25  387.605 ± 0.376  ns/op
  VectorIntMinMax.testStrictMinInt      2048       0  avgt   25  387.765 ± 0.498  ns/op

With autovectorization, both the machines exhibit a significant performance gain. On both the machines the runtime is ~80% better than the case without the patch. Also ran the patch with -XX:-UseSuperWord to make sure the performance does not degrade in cases where vectorization does not happen. The performance numbers are shown below :
aarch64:
Benchmark                         (length)  (seed)  Mode  Cnt     Score   Error  Units
  VectorIntMinMax.testMaxInt            2048       0  avgt   25  1449.792 ± 1.072  ns/op
  VectorIntMinMax.testMinInt            2048       0  avgt   25  1450.636 ± 1.057  ns/op
  VectorIntMinMax.testStrictMaxInt      2048       0  avgt   25  1450.214 ± 1.093  ns/op
  VectorIntMinMax.testStrictMinInt      2048       0  avgt   25  1450.615 ± 1.098  ns/op

x86-64:
Benchmark                         (length)  (seed)  Mode  Cnt     Score   Error  Units
  VectorIntMinMax.testMaxInt            2048       0  avgt   25  2059.673 ± 4.726  ns/op
  VectorIntMinMax.testMinInt            2048       0  avgt   25  2059.853 ± 4.754  ns/op
  VectorIntMinMax.testStrictMaxInt      2048       0  avgt   25  2059.920 ± 4.658  ns/op
  VectorIntMinMax.testStrictMinInt      2048       0  avgt   25  2059.622 ± 4.768  ns/op
There is no degradation when vectorization is disabled.

This patch also implements Ideal transformations for the MaxINode which are similar to the ones defined for the MinINode to transform/optimize a couple of commonly occurring patterns such as -
MaxI(x + c0, MaxI(y + c1, z))  ==> MaxI(AddI(x, MAX2(c0, c1)), z) when x == y
MaxI(x + c0, y + c1) ==> AddI(x, MAX2(c0,c1)) when x == y