### PR TITLE
8290178: failure_handler: run netstat without name lookups

### DIFF
--- a/test/failure_handler/src/share/conf/mac.properties
+++ b/test/failure_handler/src/share/conf/mac.properties
@@ -83,7 +83,8 @@ environment=\
   process.ps process.top \
   memory.vmstat \
   files \
-  net.netstat.av net.netstat.aL net.netstat.m net.netstat.s net.ifconfig net.hostsfile \
+  net.netstat.anv net.netstat.av net.netstat.aL net.netstat.m net.netstat.s \
+  net.ifconfig net.hostsfile \
   scutil.nwi scutil.proxy \
   screenshot
 ################################################################################
@@ -121,6 +122,7 @@ files.app=lsof
 
 net.netstat.app=netstat
 net.netstat.av.args=-av
+net.netstat.anv.args=-anv
 net.netstat.aL.args=-aL
 net.netstat.m.args=-mm
 net.netstat.s.args=-s


### PR DESCRIPTION
`netstat -av` in Mac OS X failure handler is frequently running into the 20 second timeout, leaving us with no socket information. This PR proposes running `netstat -anv` along with the existing `netstat -av`, so that we have at least some socket information if the original command times out.

`netstat -anv` does not perform reverse DNS lookups on the socket IP addresses. The output contains IP addresses instead of DNS names. The command usually finishes in a few milliseconds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290178](https://bugs.openjdk.org/browse/JDK-8290178): failure_handler: run netstat without name lookups


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Mark Sheppard](https://openjdk.org/census#msheppar) (@msheppar - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9469/head:pull/9469` \
`$ git checkout pull/9469`

Update a local copy of the PR: \
`$ git checkout pull/9469` \
`$ git pull https://git.openjdk.org/jdk pull/9469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9469`

View PR using the GUI difftool: \
`$ git pr show -t 9469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9469.diff">https://git.openjdk.org/jdk/pull/9469.diff</a>

</details>
