### PR TITLE
JDK-8290016: IGV: Fix graph panning when mouse dragged outside of window

### DIFF
--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramScene.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramScene.java
@@ -23,7 +23,6 @@
  */
 package com.sun.hotspot.igv.view;
 
-import javax.swing.text.DefaultCaret;
 import com.sun.hotspot.igv.data.ChangedListener;
 import com.sun.hotspot.igv.data.ControllableChangedListener;
 import com.sun.hotspot.igv.data.InputBlock;
@@ -38,7 +37,6 @@ import com.sun.hotspot.igv.hierarchicallayout.LinearLayoutManager;
 import com.sun.hotspot.igv.hierarchicallayout.HierarchicalLayoutManager;
 import com.sun.hotspot.igv.layout.LayoutGraph;
 import com.sun.hotspot.igv.layout.Link;
-import com.sun.hotspot.igv.selectioncoordinator.*;
 import com.sun.hotspot.igv.selectioncoordinator.SelectionCoordinator;
 import com.sun.hotspot.igv.util.ColorIcon;
 import com.sun.hotspot.igv.util.CustomSelectAction;

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramScene.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramScene.java
@@ -23,6 +23,7 @@
  */
 package com.sun.hotspot.igv.view;
 
+import javax.swing.text.DefaultCaret;
 import com.sun.hotspot.igv.data.ChangedListener;
 import com.sun.hotspot.igv.data.ControllableChangedListener;
 import com.sun.hotspot.igv.data.InputBlock;
@@ -38,6 +39,7 @@ import com.sun.hotspot.igv.hierarchicallayout.HierarchicalLayoutManager;
 import com.sun.hotspot.igv.layout.LayoutGraph;
 import com.sun.hotspot.igv.layout.Link;
 import com.sun.hotspot.igv.selectioncoordinator.*;
+import com.sun.hotspot.igv.selectioncoordinator.SelectionCoordinator;
 import com.sun.hotspot.igv.util.ColorIcon;
 import com.sun.hotspot.igv.util.CustomSelectAction;
 import com.sun.hotspot.igv.util.DoubleClickAction;
@@ -91,7 +93,6 @@ public class DiagramScene extends ObjectScene implements DiagramViewer {
     private Widget bottomRight;
     private DiagramViewModel model;
     private DiagramViewModel modelCopy;
-    private WidgetAction zoomAction;
     private boolean rebuilding;
 
     /**
@@ -267,16 +268,6 @@ public class DiagramScene extends ObjectScene implements DiagramViewer {
         }
     };
 
-    private MouseWheelListener mouseWheelListener = new MouseWheelListener() {
-
-        @Override
-        public void mouseWheelMoved(MouseWheelEvent e) {
-            if (e.isControlDown()) {
-                DiagramScene.this.relayoutWithoutLayout(null);
-            }
-        }
-    };
-
     public Point getScrollPosition() {
         return getScrollPane().getViewport().getViewPosition();
     }
@@ -406,7 +397,7 @@ public class DiagramScene extends ObjectScene implements DiagramViewer {
         // This panAction handles the event only when the left mouse button is
         // pressed without any modifier keys, otherwise it will not consume it
         // and the selection action (below) will handle the event
-        panAction = new CustomizablePanAction(~0, MouseEvent.BUTTON1_DOWN_MASK);
+        panAction = new CustomizablePanAction(MouseEvent.BUTTON1_DOWN_MASK);
         this.getActions().addAction(panAction);
 
         selectAction = new CustomSelectAction(new SelectProvider() {
@@ -455,17 +446,10 @@ public class DiagramScene extends ObjectScene implements DiagramViewer {
         bottomRight.setPreferredLocation(new Point(-BORDER_SIZE, -BORDER_SIZE));
         this.addChild(bottomRight);
 
-        LayerWidget selectionLayer = new LayerWidget(this);
-        this.addChild(selectionLayer);
-
         this.setLayout(LayoutFactory.createAbsoluteLayout());
-
         this.getInputBindings().setZoomActionModifiers(Utilities.isMac() ? KeyEvent.META_MASK : KeyEvent.CTRL_MASK);
-        zoomAction = ActionFactory.createMouseCenteredZoomAction(1.2);
-        this.getActions().addAction(zoomAction);
-        this.getView().addMouseWheelListener(mouseWheelListener);
+        this.getActions().addAction(ActionFactory.createMouseCenteredZoomAction(1.1));
         this.getActions().addAction(ActionFactory.createPopupMenuAction(popupMenuProvider));
-
         this.getActions().addAction(ActionFactory.createWheelPanAction());
 
         LayerWidget selectLayer = new LayerWidget(this);


### PR DESCRIPTION
A graph in IGV can be moved by dragging it with the left mouse button (called panning). 
![panning](https://user-images.githubusercontent.com/71546117/178509416-24dd900f-131b-484b-af47-c7a78e791434.png)

If the mouse left the visible window of the graph during dragging, the diagram started to move in the opposite direction. This was annoying. Now panning stops as soon as the mouse leaves the window. 
![stop reverse panning](https://user-images.githubusercontent.com/71546117/178509309-3df03b7a-ada4-45a3-b9a7-d6e10664033d.png)

In selection mode, the graph still moves when the mouse is dragged outside the window, as this is meant to make a larger selection. 
![keep panning for selection](https://user-images.githubusercontent.com/71546117/178509302-74fa41d2-e611-40a3-b6b0-c937ef4b2462.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290016](https://bugs.openjdk.org/browse/JDK-8290016): IGV: Fix graph panning when mouse dragged outside of window


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [942a34d5](https://git.openjdk.org/jdk/pull/9470/files/942a34d5570d9d0598c93ae887c204eebf924d62)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9470/head:pull/9470` \
`$ git checkout pull/9470`

Update a local copy of the PR: \
`$ git checkout pull/9470` \
`$ git pull https://git.openjdk.org/jdk pull/9470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9470`

View PR using the GUI difftool: \
`$ git pr show -t 9470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9470.diff">https://git.openjdk.org/jdk/pull/9470.diff</a>

</details>
