### PR TITLE
8290177: Improve documentation in G1MMUTracker

### DIFF
--- a/src/hotspot/share/gc/g1/g1MMUTracker.cpp
+++ b/src/hotspot/share/gc/g1/g1MMUTracker.cpp
@@ -56,9 +56,9 @@ void G1MMUTracker::remove_expired_entries(double current_time) {
   guarantee(_no_entries == 0, "should have no entries in the array");
 }
 
-double G1MMUTracker::calculate_gc_time(double time_stamp) {
+double G1MMUTracker::calculate_gc_time(double timestamp) {
   double gc_time = 0.0;
-  double limit = time_stamp - _time_slice;
+  double limit = timestamp - _time_slice;
   for (int i = 0; i < _no_entries; ++i) {
     int index = trim_index(_tail_index + i);
     G1MMUTrackerElem *elem = &_array[index];
@@ -111,13 +111,13 @@ void G1MMUTracker::add_pause(double start, double end) {
   }
 }
 
-double G1MMUTracker::when_sec(double current_time, double pause_time) {
+double G1MMUTracker::when_sec(double current_timestamp, double pause_time) {
   // If the pause is over the maximum, just assume that it's the maximum.
   double adjusted_pause_time =
     (pause_time > max_gc_time()) ? max_gc_time() : pause_time;
 
   // Earliest end time of a hypothetical pause starting now, taking pause_time.
-  double earliest_end_time = current_time + adjusted_pause_time;
+  double earliest_end_time = current_timestamp + adjusted_pause_time;
   double gc_time_in_recent_time_slice = calculate_gc_time(earliest_end_time) + adjusted_pause_time;
 
   // How much gc time is needed to pass within the MMU window to fit the given pause into the MMU.
@@ -132,7 +132,7 @@ double G1MMUTracker::when_sec(double current_time, double pause_time) {
   // the time slice and maximum gc pause, counted from the end of the last pause.
   if (adjusted_pause_time == max_gc_time()) {
     G1MMUTrackerElem *elem = &_array[_head_index];
-    return (elem->end_time() + (_time_slice - max_gc_time())) - current_time;
+    return (elem->end_time() + (_time_slice - max_gc_time())) - current_timestamp;
   }
 
   // Now go through the recent pause time events,

--- a/src/hotspot/share/gc/g1/g1MMUTracker.cpp
+++ b/src/hotspot/share/gc/g1/g1MMUTracker.cpp
@@ -56,7 +56,7 @@ void G1MMUTracker::remove_expired_entries(double current_time) {
   guarantee(_no_entries == 0, "should have no entries in the array");
 }
 
-double G1MMUTracker::calculate_gc_time(double timestamp) {
+double G1MMUTracker::calculate_gc_time(double current_timestamp) {
   double gc_time = 0.0;
   double limit = timestamp - _time_slice;
   for (int i = 0; i < _no_entries; ++i) {

--- a/src/hotspot/share/gc/g1/g1MMUTracker.cpp
+++ b/src/hotspot/share/gc/g1/g1MMUTracker.cpp
@@ -58,7 +58,7 @@ void G1MMUTracker::remove_expired_entries(double current_time) {
 
 double G1MMUTracker::calculate_gc_time(double current_timestamp) {
   double gc_time = 0.0;
-  double limit = timestamp - _time_slice;
+  double limit = current_timestamp - _time_slice;
   for (int i = 0; i < _no_entries; ++i) {
     int index = trim_index(_tail_index + i);
     G1MMUTrackerElem *elem = &_array[index];

--- a/src/hotspot/share/gc/g1/g1MMUTracker.cpp
+++ b/src/hotspot/share/gc/g1/g1MMUTracker.cpp
@@ -56,9 +56,9 @@ void G1MMUTracker::remove_expired_entries(double current_time) {
   guarantee(_no_entries == 0, "should have no entries in the array");
 }
 
-double G1MMUTracker::calculate_gc_time(double current_time) {
+double G1MMUTracker::calculate_gc_time(double time_stamp) {
   double gc_time = 0.0;
-  double limit = current_time - _time_slice;
+  double limit = time_stamp - _time_slice;
   for (int i = 0; i < _no_entries; ++i) {
     int index = trim_index(_tail_index + i);
     G1MMUTrackerElem *elem = &_array[index];
@@ -112,31 +112,43 @@ void G1MMUTracker::add_pause(double start, double end) {
 }
 
 double G1MMUTracker::when_sec(double current_time, double pause_time) {
-  // if the pause is over the maximum, just assume that it's the maximum
+  // If the pause is over the maximum, just assume that it's the maximum.
   double adjusted_pause_time =
     (pause_time > max_gc_time()) ? max_gc_time() : pause_time;
-  double earliest_end = current_time + adjusted_pause_time;
-  double limit = earliest_end - _time_slice;
-  double gc_time = calculate_gc_time(earliest_end);
-  double diff = gc_time + adjusted_pause_time - max_gc_time();
-  if (is_double_leq_0(diff))
-    return 0.0;
 
-  if (adjusted_pause_time == max_gc_time()) {
-    G1MMUTrackerElem *elem = &_array[_head_index];
-    return elem->end_time() - limit;
+  // Earliest end time of a hypothetical pause starting now, taking pause_time.
+  double earliest_end_time = current_time + adjusted_pause_time;
+  double gc_time_in_recent_time_slice = calculate_gc_time(earliest_end_time) + adjusted_pause_time;
+
+  // How much gc time is needed to pass within the MMU window to fit the given pause into the MMU.
+  double gc_time_to_pass = gc_time_in_recent_time_slice - max_gc_time();
+
+  // If that time to pass is zero or negative we could start the pause immediately.
+  if (is_double_leq_0(gc_time_to_pass)) {
+    return 0.0;
   }
 
+  // Trivially, if the pause is of maximum pause time, the required delay is what the MMU dictates by
+  // the time slice and maximum gc pause, counted from the end of the last pause.
+  if (adjusted_pause_time == max_gc_time()) {
+    G1MMUTrackerElem *elem = &_array[_head_index];
+    return (elem->end_time() + (_time_slice - max_gc_time())) - current_time;
+  }
+
+  // Now go through the recent pause time events,
+  double limit = earliest_end_time - _time_slice;
   int index = _tail_index;
   while ( 1 ) {
     G1MMUTrackerElem *elem = &_array[index];
     if (elem->end_time() > limit) {
-      if (elem->start_time() > limit)
-        diff -= elem->duration();
-      else
-        diff -= elem->end_time() - limit;
-      if (is_double_leq_0(diff))
-        return elem->end_time() + diff - limit;
+      if (elem->start_time() > limit) {
+        gc_time_to_pass -= elem->duration();
+      } else {
+        gc_time_to_pass -= elem->end_time() - limit;
+      }
+      if (is_double_leq_0(gc_time_to_pass)) {
+        return elem->end_time() + (_time_slice + gc_time_to_pass) - earliest_end_time;
+      }
     }
     index = trim_index(index+1);
     guarantee(index != trim_index(_head_index + 1), "should not go past head");

--- a/src/hotspot/share/gc/g1/g1MMUTracker.hpp
+++ b/src/hotspot/share/gc/g1/g1MMUTracker.hpp
@@ -109,8 +109,8 @@ public:
 
   void add_pause(double start, double end);
 
-  // Distance to the earliest possible GC pause of length pause_time from
-  // current_timestamp without violating the MMU constraint.
+  // Minimum delay required from current_timestamp until a GC pause of duration
+  // pause_time may be scheduled without violating the MMU constraint.
   double when_sec(double current_timestamp, double pause_time);
 
   double max_gc_time() const {

--- a/src/hotspot/share/gc/g1/g1MMUTracker.hpp
+++ b/src/hotspot/share/gc/g1/g1MMUTracker.hpp
@@ -102,7 +102,7 @@ private:
   void remove_expired_entries(double current_time);
   // Returns the amount of time spent in gc pauses in the time slice before the
   // given timestamp.
-  double calculate_gc_time(double timestamp);
+  double calculate_gc_time(double current_timestamp);
 
 public:
   G1MMUTracker(double time_slice, double max_gc_time);

--- a/src/hotspot/share/gc/g1/g1MMUTracker.hpp
+++ b/src/hotspot/share/gc/g1/g1MMUTracker.hpp
@@ -100,13 +100,17 @@ private:
   }
 
   void remove_expired_entries(double current_time);
-  double calculate_gc_time(double current_time);
+  // Returns the amount of time spent in gc pauses in the time slice before the
+  // given time stamp.
+  double calculate_gc_time(double time_stamp);
 
 public:
   G1MMUTracker(double time_slice, double max_gc_time);
 
   void add_pause(double start, double end);
 
+  // Determines how many seconds relative to current_time a pause of pause_time length
+  // would fit the MMU.
   double when_sec(double current_time, double pause_time);
 
   double max_gc_time() const {

--- a/src/hotspot/share/gc/g1/g1MMUTracker.hpp
+++ b/src/hotspot/share/gc/g1/g1MMUTracker.hpp
@@ -101,17 +101,17 @@ private:
 
   void remove_expired_entries(double current_time);
   // Returns the amount of time spent in gc pauses in the time slice before the
-  // given time stamp.
-  double calculate_gc_time(double time_stamp);
+  // given timestamp.
+  double calculate_gc_time(double timestamp);
 
 public:
   G1MMUTracker(double time_slice, double max_gc_time);
 
   void add_pause(double start, double end);
 
-  // Determines how many seconds relative to current_time a pause of pause_time length
-  // would fit the MMU.
-  double when_sec(double current_time, double pause_time);
+  // Distance to the earliest possible GC pause of length pause_time from
+  // current_timestamp without violating the MMU constraint.
+  double when_sec(double current_timestamp, double pause_time);
 
   double max_gc_time() const {
     return _max_gc_time;


### PR DESCRIPTION
Hi all,

  please review this change to improve the naming and documentation in `G1MMUTracker::when_sec`. Recently we have been looking at some young gen sizing issues (for another time), and it took some time to understand what the code does and how it works. This is kind of the result of this internal discussion, but I'm open to improve this further.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290177](https://bugs.openjdk.org/browse/JDK-8290177): Improve documentation in G1MMUTracker


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**) ⚠️ Review applies to [f336a8c0](https://git.openjdk.org/jdk/pull/9471/files/f336a8c06a960fcf47968578f66a51613f153de2)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [f336a8c0](https://git.openjdk.org/jdk/pull/9471/files/f336a8c06a960fcf47968578f66a51613f153de2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9471/head:pull/9471` \
`$ git checkout pull/9471`

Update a local copy of the PR: \
`$ git checkout pull/9471` \
`$ git pull https://git.openjdk.org/jdk pull/9471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9471`

View PR using the GUI difftool: \
`$ git pr show -t 9471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9471.diff">https://git.openjdk.org/jdk/pull/9471.diff</a>

</details>
