### PR TITLE
8290115: ArrayCopyObject JMH has wrong package

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/ArrayCopyObject.java
+++ b/test/micro/org/openjdk/bench/java/lang/ArrayCopyObject.java
@@ -22,7 +22,7 @@
  * questions.
  */
 
-package org.openjdk.bench.vm.compiler;
+package org.openjdk.bench.java.lang;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;


### PR DESCRIPTION
This JMH was accidentally committed with package vm.compiler but it is in the path bench/java/lang. I renamed the package so as to more easily run it with the other ArrayCopy JMH.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290115](https://bugs.openjdk.org/browse/JDK-8290115): ArrayCopyObject JMH has wrong package


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9472/head:pull/9472` \
`$ git checkout pull/9472`

Update a local copy of the PR: \
`$ git checkout pull/9472` \
`$ git pull https://git.openjdk.org/jdk pull/9472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9472`

View PR using the GUI difftool: \
`$ git pr show -t 9472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9472.diff">https://git.openjdk.org/jdk/pull/9472.diff</a>

</details>
