### PR TITLE
8289919: [test] LoadLibraryUnloadTest.java failed with "Failed to unload native library"

### DIFF
--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
@@ -165,10 +165,10 @@ public class LoadLibraryUnload {
         // before exiting the test.
         for (int i = 0; i < LOADER_COUNT; i++) {
             System.gc();
-            var res = refQueue.remove();
+            var res = refQueue.remove(5 * 1000L);
             System.out.println(i + " dequeued: " + res);
             if (res == null) {
-                Asserts.fail("Too few cleared Weak references");
+                Asserts.fail("Too few cleared WeakReferences");
             }
         }
     }

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
@@ -40,7 +40,8 @@
  * @run main/othervm/native -Xcheck:jni LoadLibraryUnload
  */
 import jdk.test.lib.Asserts;
-import jdk.test.lib.util.ForceGC;
+import jdk.test.lib.Utils;
+
 import java.lang.*;
 import java.lang.ref.ReferenceQueue;
 import java.lang.reflect.*;
@@ -165,7 +166,7 @@ public class LoadLibraryUnload {
         // before exiting the test.
         for (int i = 0; i < LOADER_COUNT; i++) {
             System.gc();
-            var res = refQueue.remove(5 * 1000L);
+            var res = refQueue.remove(Utils.adjustTimeout(5 * 1000L));
             System.out.println(i + " dequeued: " + res);
             if (res == null) {
                 Asserts.fail("Too few cleared WeakReferences");

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
@@ -28,7 +28,7 @@
  */
 /*
  * @test
- * @bug 8266310
+ * @bug 8266310 8289919
  * @summary Checks that JNI_OnLoad is invoked only once when multiple threads
  *          call System.loadLibrary concurrently, and JNI_OnUnload is invoked
  *          when the native library is loaded from a custom class loader.

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, BELLSOFT. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -102,5 +102,8 @@ public class LoadLibraryUnloadTest {
         Asserts.assertTrue(
                 countLines(outputAnalyzer, "Native library unloaded.") == refCount,
                 "Failed to unload native library");
+
+        Asserts.assertEquals(0, outputAnalyzer.getExitValue(),
+                "LoadLibraryUnload exit value not zero");
     }
 }

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/p/Class1.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/p/Class1.java
@@ -36,7 +36,9 @@ public class Class1 {
     public void loadLibrary(Object obj) throws Exception {
         System.loadLibrary("loadLibraryUnload");
         System.out.println("Native library loaded from Class1.");
-        setRef(obj);
+        synchronized (Class1.class) {
+            setRef(obj);
+        }
     }
 
     /**

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/p/Class1.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/p/Class1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, BELLSOFT. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -33,8 +33,16 @@ public class Class1 {
     }
 
     // method called from java threads
-    public void loadLibrary() throws Exception {
+    public void loadLibrary(Object obj) throws Exception {
         System.loadLibrary("loadLibraryUnload");
         System.out.println("Native library loaded from Class1.");
+        setRef(obj);
     }
+
+    /**
+     * Native method to store an object ref in a native Global reference
+     * to be cleared when the library is unloaded.
+     * @param obj an object
+     */
+    private static native void setRef(Object obj);
 }


### PR DESCRIPTION
The test `java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java`
Fails intermittently when expected output from a subprocess is not found.

I suspect a race between the Cleaner that is going to call JNI_OnUnload (in NativeLibraries.java:377) when the ClassLoader is no longer referenced and the test code that exits as soon as it detects that the p.Class1 is no longer referenced.

The proposed fix is to create a canary object referenced by the native library and released when the library is unloaded.
The Java side of the test provides the canary object and uses a WeakReference to wait for it to be released.
When released the child process exits and the driver test will find all of the output it expects.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289919](https://bugs.openjdk.org/browse/JDK-8289919): [test] LoadLibraryUnloadTest.java failed with "Failed to unload native library"


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9474/head:pull/9474` \
`$ git checkout pull/9474`

Update a local copy of the PR: \
`$ git checkout pull/9474` \
`$ git pull https://git.openjdk.org/jdk pull/9474/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9474`

View PR using the GUI difftool: \
`$ git pr show -t 9474`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9474.diff">https://git.openjdk.org/jdk/pull/9474.diff</a>

</details>
