### PR TITLE
8290197: test/jdk/java/nio/file/Files/probeContentType/Basic.java fails on some systems for the ".rar" extension

### DIFF
--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -180,7 +180,7 @@ public class Basic {
                 new ExType("ppt", List.of("application/vnd.ms-powerpoint")),
                 new ExType("pptx",List.of("application/vnd.openxmlformats-officedocument.presentationml.presentation")),
                 new ExType("py", List.of("text/plain", "text/x-python", "text/x-python-script")),
-                new ExType("rar", List.of("application/rar", "application/vnd.rar", "application/x-rar")),
+                new ExType("rar", List.of("application/rar", "application/vnd.rar", "application/x-rar", "application/x-rar-compressed")),
                 new ExType("rtf", List.of("application/rtf", "text/rtf")),
                 new ExType("webm", List.of("video/webm")),
                 new ExType("webp", List.of("image/webp")),


### PR DESCRIPTION
Add `application/x-rar-compressed` to the list of MIME types expected for the `rar` file extension.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290197](https://bugs.openjdk.org/browse/JDK-8290197): test/jdk/java/nio/file/Files/probeContentType/Basic.java fails on some systems for the ".rar" extension


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9475/head:pull/9475` \
`$ git checkout pull/9475`

Update a local copy of the PR: \
`$ git checkout pull/9475` \
`$ git pull https://git.openjdk.org/jdk pull/9475/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9475`

View PR using the GUI difftool: \
`$ git pr show -t 9475`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9475.diff">https://git.openjdk.org/jdk/pull/9475.diff</a>

</details>
