### PR TITLE
8290223: Initialize G1CardClosure in card scanning once

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -768,6 +768,8 @@ class G1ScanHRForRegionClosure : public HeapRegionClosure {
 
   G1RemSetScanState* _scan_state;
 
+  G1ScanCardClosure _scan_closure;
+
   G1GCPhaseTimes::GCParPhases _phase;
 
   uint   _worker_id;
@@ -787,9 +789,8 @@ class G1ScanHRForRegionClosure : public HeapRegionClosure {
 
   HeapWord* scan_memregion(uint region_idx_for_card, MemRegion mr) {
     HeapRegion* const card_region = _g1h->region_at(region_idx_for_card);
-    G1ScanCardClosure card_cl(_g1h, _pss, _heap_roots_found);
 
-    HeapWord* const scanned_to = card_region->oops_on_memregion_seq_iterate_careful<true>(mr, &card_cl);
+    HeapWord* const scanned_to = card_region->oops_on_memregion_seq_iterate_careful<true>(mr, &_scan_closure);
     assert(scanned_to != NULL, "Should be able to scan range");
     assert(scanned_to >= mr.end(), "Scanned to " PTR_FORMAT " less than range " PTR_FORMAT, p2i(scanned_to), p2i(mr.end()));
 
@@ -877,6 +878,7 @@ public:
     _bot(_g1h->bot()),
     _pss(pss),
     _scan_state(scan_state),
+    _scan_closure(_g1h, _pss, _heap_roots_found),
     _phase(phase),
     _worker_id(worker_id),
     _cards_scanned(0),


### PR DESCRIPTION
Hi all,

  please review this minor change to avoid repeatedly initializing `G1CardClosure` in card scanning.

Testing: gha, local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290223](https://bugs.openjdk.org/browse/JDK-8290223): Initialize G1CardClosure in card scanning once


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9478/head:pull/9478` \
`$ git checkout pull/9478`

Update a local copy of the PR: \
`$ git checkout pull/9478` \
`$ git pull https://git.openjdk.org/jdk pull/9478/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9478`

View PR using the GUI difftool: \
`$ git pr show -t 9478`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9478.diff">https://git.openjdk.org/jdk/pull/9478.diff</a>

</details>
