### PR TITLE
8290234: [JVMCI] use JVMCIKlassHandle to protect raw Klass* values from concurrent G1 scanning

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -880,8 +880,15 @@ final class CompilerToVM {
         return getResolvedJavaType0(base, displacement, compressed);
     }
 
-    HotSpotResolvedObjectTypeImpl getResolvedJavaType(long displacement, boolean compressed) {
-        return getResolvedJavaType0(null, displacement, compressed);
+    /**
+     * Reads a {@code Klass*} from {@code address} (i.e., {@code address} is a {@code Klass**}
+     * value) and wraps it in a {@link HotSpotResolvedObjectTypeImpl}. This VM call must be used for
+     * any {@code Klass*} value not known to be already wrapped in a
+     * {@link HotSpotResolvedObjectTypeImpl}. The VM call is necessary so that the {@code Klass*} is
+     * wrapped in a {@code JVMCIKlassHandle} to protect it from the concurrent scanning done by G1.
+     */
+    HotSpotResolvedObjectTypeImpl getResolvedJavaType(long address) {
+        return getResolvedJavaType0(null, address, false);
     }
 
     /**

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotMethodData.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotMethodData.java
@@ -308,11 +308,7 @@ final class HotSpotMethodData {
 
     private HotSpotResolvedObjectTypeImpl readKlass(int position, int offsetInBytes) {
         long fullOffsetInBytes = state.computeFullOffset(position, offsetInBytes);
-        long klassPointer = UNSAFE.getAddress(methodDataPointer + fullOffsetInBytes);
-        if (klassPointer == 0) {
-            return null;
-        }
-        return runtime().fromMetaspace(klassPointer);
+        return compilerToVM().getResolvedJavaType(methodDataPointer + fullOffsetInBytes);
     }
 
     /**

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
@@ -35,6 +35,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
+import java.util.Objects;
 
 import jdk.vm.ci.common.JVMCIError;
 import jdk.vm.ci.hotspot.HotSpotJVMCIRuntime.Option;
@@ -89,12 +90,11 @@ final class HotSpotResolvedJavaMethodImpl extends HotSpotMethod implements HotSp
      */
     private static HotSpotResolvedObjectTypeImpl getHolder(long metaspaceHandle) {
         HotSpotVMConfig config = config();
-        long metaspaceMethod = UNSAFE.getLong(metaspaceHandle);
-        assert metaspaceMethod != 0 : metaspaceHandle;
-        final long metaspaceConstMethod = UNSAFE.getAddress(metaspaceMethod + config.methodConstMethodOffset);
-        final long metaspaceConstantPool = UNSAFE.getAddress(metaspaceConstMethod + config.constMethodConstantsOffset);
-        long klassPointer = UNSAFE.getAddress(metaspaceConstantPool + config.constantPoolHolderOffset);
-        return runtime().fromMetaspace(klassPointer);
+        long methodPointer = UNSAFE.getLong(metaspaceHandle);
+        assert methodPointer != 0 : metaspaceHandle;
+        final long constMethodPointer = UNSAFE.getAddress(methodPointer + config.methodConstMethodOffset);
+        final long constantPoolPointer = UNSAFE.getAddress(constMethodPointer + config.constMethodConstantsOffset);
+        return Objects.requireNonNull(compilerToVM().getResolvedJavaType(constantPoolPointer + config.constantPoolHolderOffset));
     }
 
     /**


### PR DESCRIPTION
JVMCI Java code must never read a raw `Klass*` value from memory (using `Unsafe`) that is not already known to be wrapped in a `HotSpotResolvedObjectTypeImpl` without going through a VM call. The VM call is necessary so that the `Klass*` is handlized in a `JVMCIKlassHandle` to protect it from the concurrent scanning done by G1. This PR re-introduces the VM calls that were mistakenly optimized away in [JDK-8289094](https://bugs.openjdk.org/browse/JDK-8289094).