### PR TITLE
8290218: AIX build failure by JDK-8289780

### DIFF
--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -667,12 +667,9 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
 // Method to let libcollector know about a dynamically loaded function.
 // Because it is weakly bound, the calls become NOP's when the library
 // isn't present.
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(_AIX)
 // XXXDARWIN: Link errors occur even when __attribute__((weak_import))
 // is added
-#define collector_func_load(x0,x1,x2,x3,x4,x5,x6) ((void) 0)
-#define collector_func_load_enabled() false
-#elif defined(_AIX)
 #define collector_func_load(x0,x1,x2,x3,x4,x5,x6) ((void) 0)
 #define collector_func_load_enabled() false
 #else
@@ -687,7 +684,7 @@ void    collector_func_load(char* name,
 #define collector_func_load(x0,x1,x2,x3,x4,x5,x6) \
         ( collector_func_load ? collector_func_load(x0,x1,x2,x3,x4,x5,x6),(void)0 : (void)0 )
 #define collector_func_load_enabled() (collector_func_load ? true : false)
-#endif // __APPLE__
+#endif // __APPLE__ || _AIX
 #endif // !_WINDOWS
 
 } // end extern "C"

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -667,9 +667,12 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
 // Method to let libcollector know about a dynamically loaded function.
 // Because it is weakly bound, the calls become NOP's when the library
 // isn't present.
-#ifdef __APPLE__
+#if defined(__APPLE__)
 // XXXDARWIN: Link errors occur even when __attribute__((weak_import))
 // is added
+#define collector_func_load(x0,x1,x2,x3,x4,x5,x6) ((void) 0)
+#define collector_func_load_enabled() false
+#elif defined(_AIX)
 #define collector_func_load(x0,x1,x2,x3,x4,x5,x6) ((void) 0)
 #define collector_func_load_enabled() false
 #else


### PR DESCRIPTION
AIX build was failed by following messages:
```
* For target hotspot_variant-server_libjvm_objs_BUILD_LIBJVM_link:
ld: 0711-317 ERROR: Undefined symbol: collector_func_load
ld: 0711-317 ERROR: Undefined symbol: .collector_func_load
ld: 0711-344 See the loadmap file /home/jdkbld/git/jdk/build/aix-ppc64-server-release/hotspot/variant-server/libjvm/objs/libjvm.loadmap for more information.
```
In my investigation, [JDK-8289780](https://bugs.openjdk.org/browse/JDK-8289780) affects this issue on src/hotspot/share/prims/forte.cpp.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290218](https://bugs.openjdk.org/browse/JDK-8290218): AIX build failure by JDK-8289780


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9482/head:pull/9482` \
`$ git checkout pull/9482`

Update a local copy of the PR: \
`$ git checkout pull/9482` \
`$ git pull https://git.openjdk.org/jdk pull/9482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9482`

View PR using the GUI difftool: \
`$ git pr show -t 9482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9482.diff">https://git.openjdk.org/jdk/pull/9482.diff</a>

</details>
