### PR TITLE
8290253: gc/g1/TestVerificationInConcurrentCycle.java#id1 fails with "Error. can't find sun.hotspot.WhiteBox in test directory or libraries"

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestVerificationInConcurrentCycle.java
+++ b/test/hotspot/jtreg/gc/g1/TestVerificationInConcurrentCycle.java
@@ -48,8 +48,8 @@ package gc.g1;
  * @summary Basic testing of various GC pause verification during the G1 concurrent cycle. It leaves
  *          out G1VerifyBitmaps as this is a debug-only option.
  * @library /test/lib
- * @build sun.hotspot.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm
  *   -Xbootclasspath/a:.
  *   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI


### PR DESCRIPTION
Hi,

  can I have reviews for this fix to the `TestVerificationInConcurrentCycle.java` test that due to a merge issue referenced the old WhiteBox library which fails during testing because it had been deleted in the meantime.

Testing: gha, test passes in release and debug locally

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290253](https://bugs.openjdk.org/browse/JDK-8290253): gc/g1/TestVerificationInConcurrentCycle.java#id1 fails with "Error. can't find sun.hotspot.WhiteBox in test directory or libraries"


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9483/head:pull/9483` \
`$ git checkout pull/9483`

Update a local copy of the PR: \
`$ git checkout pull/9483` \
`$ git pull https://git.openjdk.org/jdk pull/9483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9483`

View PR using the GUI difftool: \
`$ git pr show -t 9483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9483.diff">https://git.openjdk.org/jdk/pull/9483.diff</a>

</details>
