### PR TITLE
8290269: gc/shenandoah/TestVerifyJCStress.java fails due to invalid tag: required after JDK-8290023

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/TestVerifyJCStress.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestVerifyJCStress.java
@@ -96,7 +96,7 @@
  * @test id=iu
  * @summary Tests that we pass at least one jcstress-like test with all verification turned on
  * @requires vm.gc.Shenandoah
- * @required !vm.debug
+ * @requires !vm.debug
  * @modules java.base/jdk.internal.misc
  *          java.management
  *


### PR DESCRIPTION

Hi all,

Please review the trivial fix which fixes a typo (`required` --> `requires`).

Thanks.
Best regards,
Jie