### PR TITLE
8290280: riscv: Clean up stack and register handling in interpreter

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -141,8 +141,10 @@ REGISTER_DECLARATION(Register, xthread,   x23);
 REGISTER_DECLARATION(Register, xbcp,      x22);
 // Dispatch table base
 REGISTER_DECLARATION(Register, xdispatch, x21);
-// Java stack pointer
+// Java expression stack pointer
 REGISTER_DECLARATION(Register, esp,       x20);
+// Sender's SP while in interpreter
+REGISTER_DECLARATION(Register, x19_sender_sp, x19);
 
 // temporary register(caller-save registers)
 REGISTER_DECLARATION(Register, t0, x5);

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -327,6 +327,10 @@ void frame::interpreter_frame_set_last_sp(intptr_t* last_sp) {
   *((intptr_t**)addr_at(interpreter_frame_last_sp_offset)) = last_sp;
 }
 
+void frame::interpreter_frame_set_extended_sp(intptr_t* sp) {
+  *((intptr_t**)addr_at(interpreter_frame_extended_sp_offset)) = sp;
+}
+
 frame frame::sender_for_entry_frame(RegisterMap* map) const {
   assert(map != NULL, "map must be set");
   // Java frame called from C; skip all C frames and return top C
@@ -544,6 +548,7 @@ void frame::describe_pd(FrameValues& values, int frame_no) {
     DESCRIBE_FP_OFFSET(interpreter_frame_last_sp);
     DESCRIBE_FP_OFFSET(interpreter_frame_method);
     DESCRIBE_FP_OFFSET(interpreter_frame_mdp);
+    DESCRIBE_FP_OFFSET(interpreter_frame_extended_sp);
     DESCRIBE_FP_OFFSET(interpreter_frame_mirror);
     DESCRIBE_FP_OFFSET(interpreter_frame_cache);
     DESCRIBE_FP_OFFSET(interpreter_frame_locals);

--- a/src/hotspot/cpu/riscv/frame_riscv.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.hpp
@@ -47,13 +47,13 @@
 //    [constant pool cache   ]                   = cache()              cache_offset
 
 //    [klass of method       ]                   = mirror()             mirror_offset
-//    [padding               ]
+//    [extended SP           ]                                          extended_sp offset
 
 //    [methodData            ]                   = mdp()                mdx_offset
 //    [Method                ]                   = method()             method_offset
 
 //    [last esp              ]                   = last_sp()            last_sp_offset
-//    [old stack pointer     ]                     (sender_sp)          sender_sp_offset
+//    [sender's SP           ]                     (sender_sp)          sender_sp_offset
 
 //    [old frame pointer     ]
 //    [return pc             ]
@@ -120,8 +120,8 @@
     interpreter_frame_last_sp_offset                 = interpreter_frame_sender_sp_offset - 1,
     interpreter_frame_method_offset                  = interpreter_frame_last_sp_offset - 1,
     interpreter_frame_mdp_offset                     = interpreter_frame_method_offset - 1,
-    interpreter_frame_padding_offset                 = interpreter_frame_mdp_offset - 1,
-    interpreter_frame_mirror_offset                  = interpreter_frame_padding_offset - 1,
+    interpreter_frame_extended_sp_offset             = interpreter_frame_mdp_offset - 1,
+    interpreter_frame_mirror_offset                  = interpreter_frame_extended_sp_offset - 1,
     interpreter_frame_cache_offset                   = interpreter_frame_mirror_offset - 1,
     interpreter_frame_locals_offset                  = interpreter_frame_cache_offset - 1,
     interpreter_frame_bcp_offset                     = interpreter_frame_locals_offset - 1,
@@ -199,6 +199,8 @@
 
   // expression stack tos if we are nested in a java call
   intptr_t* interpreter_frame_last_sp() const;
+
+  void interpreter_frame_set_extended_sp(intptr_t* sp);
 
   template <typename RegisterMapT>
   static void update_map_with_saved_link(RegisterMapT* map, intptr_t** link_addr);

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -466,7 +466,7 @@ void InterpreterMacroAssembler::load_double(Address src) {
 
 void InterpreterMacroAssembler::prepare_to_jump_from_interpreted() {
   // set sender sp
-  mv(x30, sp);
+  mv(x19_sender_sp, sp);
   // record last_sp
   sd(esp, Address(fp, frame::interpreter_frame_last_sp_offset * wordSize));
 }

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.hpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.hpp
@@ -82,6 +82,30 @@ class InterpreterMacroAssembler: public MacroAssembler {
     ld(xcpool, Address(fp, frame::interpreter_frame_cache_offset * wordSize));
   }
 
+  void restore_sp_after_call() {
+    Label L;
+    ld(t0, Address(fp, frame::interpreter_frame_extended_sp_offset * wordSize));
+#ifdef ASSERT
+    bnez(t0, L);
+    stop("SP is null");
+#endif
+    bind(L);
+    mv(sp, t0);
+  }
+
+  void check_extended_sp(const char* msg =  "check extended SP") {
+#ifdef ASSERT
+    Label L;
+    ld(t0, Address(fp, frame::interpreter_frame_extended_sp_offset * wordSize));
+    beq(sp, t0, L);
+    stop(msg);
+    bind(L);
+#endif
+  }
+
+#define check_extended_sp()                                                                    \
+  check_extended_sp("SP does not match extended SP in frame at " __FILE__ ":" XSTR(__LINE__))
+
   void get_dispatch();
 
   // Helpers for runtime call arguments/results

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.hpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.hpp
@@ -93,7 +93,7 @@ class InterpreterMacroAssembler: public MacroAssembler {
     mv(sp, t0);
   }
 
-  void check_extended_sp(const char* msg =  "check extended SP") {
+  void check_extended_sp(const char* msg = "check extended SP") {
 #ifdef ASSERT
     Label L;
     ld(t0, Address(fp, frame::interpreter_frame_extended_sp_offset * wordSize));

--- a/src/hotspot/cpu/riscv/methodHandles_riscv.cpp
+++ b/src/hotspot/cpu/riscv/methodHandles_riscv.cpp
@@ -188,7 +188,7 @@ address MethodHandles::generate_method_handle_interpreter_entry(MacroAssembler* 
     return NULL;
   }
 
-  // x30: sender SP (must preserve; see prepare_to_jump_from_interpreted)
+  // x19_sender_sp: sender SP (must preserve; see prepare_to_jump_from_interpreted)
   // xmethod: Method*
   // x13: argument locator (parameter slot count, added to sp)
   // x11: used as temp to hold mh or receiver
@@ -274,7 +274,7 @@ void MethodHandles::generate_method_handle_dispatch(MacroAssembler* _masm,
   // temps used in this code are not used in *either* compiled or interpreted calling sequences
   Register temp1 = x7;
   Register temp2 = x28;
-  Register temp3 = x29;  // x30 is live by this point: it contains the sender SP
+  Register temp3 = x29;
   if (for_compiler_entry) {
     assert(receiver_reg == (iid == vmIntrinsics::_linkToStatic ? noreg : j_rarg0), "only valid assignment");
     assert_different_registers(temp1, j_rarg0, j_rarg1, j_rarg2, j_rarg3, j_rarg4, j_rarg5, j_rarg6, j_rarg7);
@@ -345,7 +345,7 @@ void MethodHandles::generate_method_handle_dispatch(MacroAssembler* _masm,
     // Live registers at this point:
     //  member_reg - MemberName that was the trailing argument
     //  temp1_recv_klass - klass of stacked receiver, if needed
-    //  x30 - interpreter linkage (if interpreted)
+    //  x19 - interpreter linkage (if interpreted)
     //  x11 ... x10 - compiler arguments (if compiled)
 
     Label L_incompatible_class_change_error;
@@ -430,7 +430,7 @@ void MethodHandles::generate_method_handle_dispatch(MacroAssembler* _masm,
         break;
     }
 
-    // live at this point:  xmethod, x30 (if interpreted)
+    // live at this point:  xmethod, x19_sender_sp (if interpreted)
 
     // After figuring out which concrete method to call, jump into it.
     // Note that this works in the interpreter with no data motion.

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -386,7 +386,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
 
   int extraspace = total_args_passed * Interpreter::stackElementSize;
 
-  __ mv(x30, sp);
+  __ mv(x19_sender_sp, sp);
 
   // stack is aligned, keep it that way
   extraspace = align_up(extraspace, 2 * wordSize);
@@ -498,6 +498,11 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm,
                                     int comp_args_on_stack,
                                     const BasicType *sig_bt,
                                     const VMRegPair *regs) {
+  // Note: x19_sender_sp contains the senderSP on entry. We must
+  // preserve it since we may do a i2c -> c2i transition if we lose a
+  // race where compiled code goes non-entrant while we get args
+  // ready.
+
   // Cut-out for having no stack args.
   int comp_words_on_stack = align_up(comp_args_on_stack * VMRegImpl::stack_slot_size, wordSize) >> LogBytesPerWord;
   if (comp_args_on_stack != 0) {

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -288,9 +288,9 @@ class StubGenerator: public StubCodeGenerator {
 
     // call Java entry -- passing methdoOop, and current sp
     //      xmethod: Method*
-    //      x30: sender sp
+    //      x19_sender_sp: sender sp
     BLOCK_COMMENT("call Java function");
-    __ mv(x30, sp);
+    __ mv(x19_sender_sp, sp);
     __ jalr(c_rarg4);
 
     // save current address for use by exception handling code

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -705,8 +705,7 @@ void TemplateInterpreterGenerator::lock_method() {
   __ check_extended_sp();
   __ add(sp, sp, - entry_size); // add space for a monitor entry
   __ add(esp, esp, - entry_size);
-  __ mv(t0, sp);
-  __ sd(t0, Address(fp, frame::interpreter_frame_extended_sp_offset * wordSize));
+  __ sd(sp, Address(fp, frame::interpreter_frame_extended_sp_offset * wordSize));
   __ sd(esp, monitor_block_top);  // set new monitor block top
   // store object
   __ sd(x10, Address(esp, BasicObjectLock::obj_offset_in_bytes()));
@@ -776,14 +775,13 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call) {
     __ slli(t0, t0, 3);
     __ sub(t0, sp, t0);
     __ andi(t0, t0, -16);
-    // Store extender SP and mirror
+    // Store extended SP and mirror
     __ sd(t0, Address(sp, 5 * wordSize));
     __ sd(t2, Address(sp, 4 * wordSize));
     // Move SP out of the way
     __ mv(sp, t0);
   } else {
-    __ mv(t0, sp);
-    __ sd(t0, Address(sp, 5 * wordSize));
+    __ sd(sp, Address(sp, 5 * wordSize));
     __ sd(zr, Address(sp, 4 * wordSize));
   }
 }

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -139,7 +139,7 @@ address TemplateInterpreterGenerator::generate_slow_signature_handler() {
 // Various method entries
 address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::MethodKind kind) {
   // xmethod: Method*
-  // x30: sender sp
+  // x19_sender_sp: sender sp
   // esp: args
 
   if (!InlineIntrinsics) {
@@ -170,18 +170,18 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       entry_point = __ pc();
       __ fld(f10, Address(esp));
       __ fabs_d(f10, f10);
-      __ mv(sp, x30); // Restore caller's SP
+      __ mv(sp, x19_sender_sp); // Restore caller's SP
       break;
     case Interpreter::java_lang_math_sqrt:
       entry_point = __ pc();
       __ fld(f10, Address(esp));
       __ fsqrt_d(f10, f10);
-      __ mv(sp, x30);
+      __ mv(sp, x19_sender_sp);
       break;
     case Interpreter::java_lang_math_sin :
       entry_point = __ pc();
       __ fld(f10, Address(esp));
-      __ mv(sp, x30);
+      __ mv(sp, x19_sender_sp);
       __ mv(x9, ra);
       continuation = x9;  // The first callee-saved register
       if (StubRoutines::dsin() == NULL) {
@@ -195,7 +195,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
     case Interpreter::java_lang_math_cos :
       entry_point = __ pc();
       __ fld(f10, Address(esp));
-      __ mv(sp, x30);
+      __ mv(sp, x19_sender_sp);
       __ mv(x9, ra);
       continuation = x9;  // The first callee-saved register
       if (StubRoutines::dcos() == NULL) {
@@ -209,7 +209,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
     case Interpreter::java_lang_math_tan :
       entry_point = __ pc();
       __ fld(f10, Address(esp));
-      __ mv(sp, x30);
+      __ mv(sp, x19_sender_sp);
       __ mv(x9, ra);
       continuation = x9;  // The first callee-saved register
       if (StubRoutines::dtan() == NULL) {
@@ -223,7 +223,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
     case Interpreter::java_lang_math_log :
       entry_point = __ pc();
       __ fld(f10, Address(esp));
-      __ mv(sp, x30);
+      __ mv(sp, x19_sender_sp);
       __ mv(x9, ra);
       continuation = x9;  // The first callee-saved register
       if (StubRoutines::dlog() == NULL) {
@@ -237,7 +237,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
     case Interpreter::java_lang_math_log10 :
       entry_point = __ pc();
       __ fld(f10, Address(esp));
-      __ mv(sp, x30);
+      __ mv(sp, x19_sender_sp);
       __ mv(x9, ra);
       continuation = x9;  // The first callee-saved register
       if (StubRoutines::dlog10() == NULL) {
@@ -251,7 +251,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
     case Interpreter::java_lang_math_exp :
       entry_point = __ pc();
       __ fld(f10, Address(esp));
-      __ mv(sp, x30);
+      __ mv(sp, x19_sender_sp);
       __ mv(x9, ra);
       continuation = x9;  // The first callee-saved register
       if (StubRoutines::dexp() == NULL) {
@@ -268,7 +268,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       continuation = x9;
       __ fld(f10, Address(esp, 2 * Interpreter::stackElementSize));
       __ fld(f11, Address(esp));
-      __ mv(sp, x30);
+      __ mv(sp, x19_sender_sp);
       if (StubRoutines::dpow() == NULL) {
         fn = CAST_FROM_FN_PTR(address, SharedRuntime::dpow);
       } else {
@@ -284,7 +284,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
         __ fld(f11, Address(esp, 2 * Interpreter::stackElementSize));
         __ fld(f12, Address(esp));
         __ fmadd_d(f10, f10, f11, f12);
-        __ mv(sp, x30); // Restore caller's SP
+        __ mv(sp, x19_sender_sp); // Restore caller's SP
       }
       break;
     case Interpreter::java_lang_math_fmaF :
@@ -294,7 +294,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
         __ flw(f11, Address(esp, Interpreter::stackElementSize));
         __ flw(f12, Address(esp));
         __ fmadd_s(f10, f10, f11, f12);
-        __ mv(sp, x30); // Restore caller's SP
+        __ mv(sp, x19_sender_sp); // Restore caller's SP
       }
       break;
     default:
@@ -311,7 +311,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
 // Attempt to execute abstract method. Throw exception
 address TemplateInterpreterGenerator::generate_abstract_entry(void) {
   // xmethod: Method*
-  // x30: sender SP
+  // x19_sender_sp: sender SP
 
   address entry_point = __ pc();
 
@@ -459,14 +459,7 @@ address TemplateInterpreterGenerator::generate_return_entry_for(TosState state, 
   __ shadd(esp, x11, esp, t0, 3);
 
   // Restore machine SP
-  __ ld(t0, Address(xmethod, Method::const_offset()));
-  __ lhu(t0, Address(t0, ConstMethod::max_stack_offset()));
-  __ addi(t0, t0, frame::interpreter_frame_monitor_size() + 2);
-  __ ld(t1,
-        Address(fp, frame::interpreter_frame_initial_sp_offset * wordSize));
-  __ slli(t0, t0, 3);
-  __ sub(t0, t1, t0);
-  __ andi(sp, t0, -16);
+  __ restore_sp_after_call();
 
  __ check_and_handle_popframe(xthread);
  __ check_and_handle_earlyret(xthread);
@@ -487,14 +480,7 @@ address TemplateInterpreterGenerator::generate_deopt_entry_for(TosState state,
   __ get_method(xmethod);
   __ get_dispatch();
 
-  // Calculate stack limit
-  __ ld(t0, Address(xmethod, Method::const_offset()));
-  __ lhu(t0, Address(t0, ConstMethod::max_stack_offset()));
-  __ addi(t0, t0, frame::interpreter_frame_monitor_size() + 2);
-  __ ld(t1, Address(fp, frame::interpreter_frame_initial_sp_offset * wordSize));
-  __ slli(t0, t0, 3);
-  __ sub(t0, t1, t0);
-  __ andi(sp, t0, -16);
+  __ restore_sp_after_call();  // Restore SP to extended SP
 
   // Restore expression stack pointer
   __ ld(esp, Address(fp, frame::interpreter_frame_last_sp_offset * wordSize));
@@ -659,9 +645,9 @@ void TemplateInterpreterGenerator::generate_stack_overflow_check(void) {
   // was in the caller.  This is not strictly necessary, but unless we
   // do so the stack frame may have a garbage FP; this ensures a
   // correct call stack that we can always unwind.  The ANDI should be
-  // unnecessary because the sender SP in x30 is always aligned, but
+  // unnecessary because the sender SP in x19 is always aligned, but
   // it doesn't hurt.
-  __ andi(sp, x30, -16);
+  __ andi(sp, x19_sender_sp, -16);
 
   // Note: the restored frame is not necessarily interpreted.
   // Use the shared runtime version of the StackOverflowError.
@@ -716,10 +702,12 @@ void TemplateInterpreterGenerator::lock_method() {
   }
 
   // add space for monitor & lock
+  __ check_extended_sp();
   __ add(sp, sp, - entry_size); // add space for a monitor entry
   __ add(esp, esp, - entry_size);
-  __ mv(t0, esp);
-  __ sd(t0, monitor_block_top);  // set new monitor block top
+  __ mv(t0, sp);
+  __ sd(t0, Address(fp, frame::interpreter_frame_extended_sp_offset * wordSize));
+  __ sd(esp, monitor_block_top);  // set new monitor block top
   // store object
   __ sd(x10, Address(esp, BasicObjectLock::obj_offset_in_bytes()));
   __ mv(c_rarg1, esp); // object address
@@ -764,11 +752,6 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call) {
   __ sd(xmethod, Address(sp, 7 * wordSize));
   __ sd(ProfileInterpreter ? t0 : zr, Address(sp, 6 * wordSize));
 
-  // Get mirror and store it in the frame as GC root for this Method*
-  __ load_mirror(t2, xmethod);
-  __ sd(zr, Address(sp, 5 * wordSize));
-  __ sd(t2, Address(sp, 4 * wordSize));
-
   __ ld(xcpool, Address(xmethod, Method::const_offset()));
   __ ld(xcpool, Address(xcpool, ConstMethod::constants_offset()));
   __ ld(xcpool, Address(xcpool, ConstantPool::cache_offset_in_bytes()));
@@ -781,17 +764,27 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call) {
 
   // set sender sp
   // leave last_sp as null
-  __ sd(x30, Address(sp, 9 * wordSize));
+  __ sd(x19_sender_sp, Address(sp, 9 * wordSize));
   __ sd(zr, Address(sp, 8 * wordSize));
 
-  // Move SP out of the way
+  // Get mirror
+  __ load_mirror(t2, xmethod);
   if (!native_call) {
     __ ld(t0, Address(xmethod, Method::const_offset()));
     __ lhu(t0, Address(t0, ConstMethod::max_stack_offset()));
-    __ add(t0, t0, frame::interpreter_frame_monitor_size() + 2);
+    __ add(t0, t0, MAX2(3, Method::extra_stack_entries()));
     __ slli(t0, t0, 3);
     __ sub(t0, sp, t0);
-    __ andi(sp, t0, -16);
+    __ andi(t0, t0, -16);
+    // Store extender SP and mirror
+    __ sd(t0, Address(sp, 5 * wordSize));
+    __ sd(t2, Address(sp, 4 * wordSize));
+    // Move SP out of the way
+    __ mv(sp, t0);
+  } else {
+    __ mv(t0, sp);
+    __ sd(t0, Address(sp, 5 * wordSize));
+    __ sd(zr, Address(sp, 4 * wordSize));
   }
 }
 
@@ -836,7 +829,7 @@ address TemplateInterpreterGenerator::generate_Reference_get_entry(void) {
   // This code is based on generate_accessor_entry.
   //
   // xmethod: Method*
-  // x30: senderSP must preserve for slow path, set SP to it on fast path
+  // x19_sender_sp: senderSP must preserve for slow path, set SP to it on fast path
 
   // ra is live.  It must be saved around calls.
 
@@ -852,15 +845,13 @@ address TemplateInterpreterGenerator::generate_Reference_get_entry(void) {
   __ ld(local_0, Address(esp, 0));
   __ beqz(local_0, slow_path);
 
-  __ mv(x9, x30);   // Move senderSP to a callee-saved register
-
   // Load the value of the referent field.
   const Address field_address(local_0, referent_offset);
   BarrierSetAssembler *bs = BarrierSet::barrier_set()->barrier_set_assembler();
   bs->load_at(_masm, IN_HEAP | ON_WEAK_OOP_REF, T_OBJECT, local_0, field_address, /*tmp1*/ t1, /*tmp2*/ t0);
 
   // areturn
-  __ andi(sp, x9, -16);  // done with stack
+  __ andi(sp, x19_sender_sp, -16);  // done with stack
   __ ret();
 
   // generate a vanilla interpreter entry as the slow path
@@ -1506,14 +1497,8 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
                           InterpreterRuntime::exception_handler_for_exception),
              c_rarg1);
 
-  // Calculate stack limit
-  __ ld(t0, Address(xmethod, Method::const_offset()));
-  __ lhu(t0, Address(t0, ConstMethod::max_stack_offset()));
-  __ add(t0, t0, frame::interpreter_frame_monitor_size() + 4);
-  __ ld(t1, Address(fp, frame::interpreter_frame_initial_sp_offset * wordSize));
-  __ slli(t0, t0, 3);
-  __ sub(t0, t1, t0);
-  __ andi(sp, t0, -16);
+  // Restore machine SP
+  __ restore_sp_after_call();
 
   // x10: exception handler entry point
   // x13: preserved exception oop
@@ -1639,13 +1624,7 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
 #endif // INCLUDE_JVMTI
 
   // Restore machine SP
-  __ ld(t0, Address(xmethod, Method::const_offset()));
-  __ lhu(t0, Address(t0, ConstMethod::max_stack_offset()));
-  __ add(t0, t0, frame::interpreter_frame_monitor_size() + 4);
-  __ ld(t1, Address(fp, frame::interpreter_frame_initial_sp_offset * wordSize));
-  __ slliw(t0, t0, 3);
-  __ sub(t0, t1, t0);
-  __ andi(sp, t0, -16);
+  __ restore_sp_after_call();
 
   __ dispatch_next(vtos);
   // end of PopFrame support

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -342,7 +342,7 @@ address TemplateInterpreterGenerator::generate_StackOverflowError_handler() {
     __ mv(t1, sp);
     // maximal sp for current fp (stack grows negative)
     // check if frame is complete
-    __ bge(t0, t1, L);
+    __ bge(t0, sp, L);
     __ stop ("interpreter frame not set up");
     __ bind(L);
   }

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -339,7 +339,6 @@ address TemplateInterpreterGenerator::generate_StackOverflowError_handler() {
   {
     Label L;
     __ ld(t0, Address(fp, frame::interpreter_frame_monitor_block_top_offset * wordSize));
-    __ mv(t1, sp);
     // maximal sp for current fp (stack grows negative)
     // check if frame is complete
     __ bge(t0, sp, L);

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -3834,12 +3834,17 @@ void TemplateTable::monitorenter()
    {
      Label entry, loop;
      // 1. compute new pointers            // esp: old expression stack top
+
+     __ check_extended_sp();
+     __ sub(sp, sp, entry_size);           // make room for the monitor
+     __ mv(t0, sp);
+     __ sd(t0, Address(fp, frame::interpreter_frame_extended_sp_offset * wordSize));
+
      __ ld(c_rarg1, monitor_block_bot);    // c_rarg1: old expression stack bottom
      __ sub(esp, esp, entry_size);         // move expression stack top
      __ sub(c_rarg1, c_rarg1, entry_size); // move expression stack bottom
      __ mv(c_rarg3, esp);                  // set start value for copy loop
      __ sd(c_rarg1, monitor_block_bot);    // set new monitor block bottom
-     __ sub(sp, sp, entry_size);           // make room for the monitor
 
      __ j(entry);
      // 2. move expression stack contents

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -3837,8 +3837,7 @@ void TemplateTable::monitorenter()
 
      __ check_extended_sp();
      __ sub(sp, sp, entry_size);           // make room for the monitor
-     __ mv(t0, sp);
-     __ sd(t0, Address(fp, frame::interpreter_frame_extended_sp_offset * wordSize));
+     __ sd(sp, Address(fp, frame::interpreter_frame_extended_sp_offset * wordSize));
 
      __ ld(c_rarg1, monitor_block_bot);    // c_rarg1: old expression stack bottom
      __ sub(esp, esp, entry_size);         // move expression stack top


### PR DESCRIPTION
As [JDK-8288971](https://bugs.openjdk.org/browse/JDK-8288971) described, we have the same issue on riscv backend:

1. We use x30 to pass the caller's SP to a callee through adapters. x30 is not a callee-saved register in native ABI [1], we choose x19 for this patch.
2. We frequently recalculate the location where the native SP needs to go. We have a spare slot in the interpreter frame, so we should calculate it once, when the frame is created, and use it.
3. Relate to 1, we should clearly label all the places where the caller's SP is passed to a callee.

[1]. https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-cc.adoc

Additional tests:
- hotspot/jdk tier1 on  QEMU with Release JDK
- hotspot tier1 on HiFive Unmatched board with Release JDK
- hotspot tier1 on QEMU with Fastdebug JDK
- jtreg full on QEMU with Release JDK

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290280](https://bugs.openjdk.org/browse/JDK-8290280): riscv: Clean up stack and register handling in interpreter


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9487/head:pull/9487` \
`$ git checkout pull/9487`

Update a local copy of the PR: \
`$ git checkout pull/9487` \
`$ git pull https://git.openjdk.org/jdk pull/9487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9487`

View PR using the GUI difftool: \
`$ git pr show -t 9487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9487.diff">https://git.openjdk.org/jdk/pull/9487.diff</a>

</details>
