### PR TITLE
[macosx] In Nimbus LaF, Ctrl+Alt mnemonic doesn't work

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
@@ -721,6 +721,11 @@ public class SynthLookAndFeel extends BasicLookAndFeel {
                 "KP_RIGHT", "selectParent",
                   });
 
+        table.put("Menu.shortcutKeys",
+                  new int[] {
+                          SwingUtilities2.getSystemMnemonicKeyMask(),
+                  });
+
         // enabled antialiasing depending on desktop settings
         flushUnreferenced();
         SwingUtilities2.putAATextInfo(useLAFConditions(), table);


### PR DESCRIPTION
In SwingSet2 application, "File" menu has a visible mnemonic set on F.

![image](https://user-images.githubusercontent.com/43534309/178932400-ab70602a-9c4f-4cab-b3b7-0508b26d2ebe.png)

Now, with Aqua, Java (Metal), and Motif LaF, one can open the menu pressing Ctrl+Alt+F. 
But with Nimbus L&F, to open File menu, you have to press Alt+F even on OS X.

It should work with Ctrl+Alt+F as sun/lwawt/macosx/LWCToolkit.java. getFocusAcceleratorKeyMask() 
has CTRL_MASK | ALT_MASK

Fix is to add Menu.shortcutKeys in SynthLookAndFeel default table so that it can call SwingUtilities2.getSystemMnemonicKeyMask() which will call either LWCToolkit.getFocusAcceleratorKeyMask() or SunToolkit.getFocusAcceleratorKeyMask() depending on platform.

No regression test is added as it can be checked with SwingSet2 app.
