### PR TITLE
8290290: Remove addition of TimeInstants

### DIFF
--- a/src/hotspot/share/utilities/ticks.hpp
+++ b/src/hotspot/share/utilities/ticks.hpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -214,9 +214,6 @@ class TimeInstant : public Rep<TimeSource> {
   TimeInstant<Rep, TimeSource>& operator-=(const TimeInterval<Rep, TimeSource>& rhs) {
     Rep<TimeSource>::operator-=(rhs);
     return *this;
-  }
-  TimeInterval<Rep, TimeSource> operator+(const TimeInstant<Rep, TimeSource>& end) const {
-    return TimeInterval<Rep, TimeSource>(end, *this);
   }
   TimeInterval<Rep, TimeSource> operator-(const TimeInstant<Rep, TimeSource>& start) const {
     return TimeInterval<Rep, TimeSource>(*this, start);


### PR DESCRIPTION
Please review this trivial change to remove the unused and semantically suspect
function TimeInstant::operator+(TimeInstant).
