### PR TITLE
8290291: G1: Merge multiple calls of block_size in HeapRegion::block_start

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -144,6 +144,10 @@ private:
   // This version synchronizes with other calls to par_allocate_impl().
   inline HeapWord* par_allocate_impl(size_t min_word_size, size_t desired_word_size, size_t* actual_word_size);
 
+  inline HeapWord* advance_to_block_containing_addr(const void* addr,
+                                                    HeapWord* const pb,
+                                                    HeapWord* first_block) const;
+
   static bool obj_is_filler(oop obj);
 
 public:

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -144,13 +144,6 @@ private:
   // This version synchronizes with other calls to par_allocate_impl().
   inline HeapWord* par_allocate_impl(size_t min_word_size, size_t desired_word_size, size_t* actual_word_size);
 
-  // Return the address of the beginning of the block that contains "addr".
-  // "q" is a block boundary that is <= "addr"; "n" is the address of the
-  // next block (or the end of the HeapRegion.)
-  inline HeapWord* forward_to_block_containing_addr(HeapWord* q, HeapWord* n,
-                                                    const void* addr,
-                                                    HeapWord* pb) const;
-
   static bool obj_is_filler(oop obj);
 
 public:

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -82,35 +82,26 @@ inline HeapWord* HeapRegion::par_allocate_impl(size_t min_word_size,
   } while (true);
 }
 
-inline HeapWord* HeapRegion::forward_to_block_containing_addr(HeapWord* q, HeapWord* n,
-                                                              const void* addr,
-                                                              HeapWord* pb) const {
-  while (n <= addr) {
-    // When addr is not covered by the block starting at q we need to
-    // step forward until we find the correct block. With the BOT
-    // being precise, we should never have to step through more than
-    // a single card.
-    assert(!G1BlockOffsetTablePart::is_crossing_card_boundary(n, (HeapWord*)addr), "must be");
-    q = n;
-    assert(cast_to_oop(q)->klass_or_null() != nullptr,
-        "start of block must be an initialized object");
-    n += block_size(q, pb);
-  }
-  assert(q <= addr, "wrong order for q and addr");
-  assert(addr < n, "wrong order for addr and n");
-  return q;
-}
-
 inline HeapWord* HeapRegion::block_start(const void* addr) const {
   return block_start(addr, parsable_bottom_acquire());
 }
 
 inline HeapWord* HeapRegion::block_start(const void* addr, HeapWord* const pb) const {
-  HeapWord* q = _bot_part.block_start_reaching_into_card(addr);
-  // The returned address is the block that reaches into the card of addr. Walk
-  // the heap to get to the block reaching into addr.
-  HeapWord* n = q + block_size(q, pb);
-  return forward_to_block_containing_addr(q, n, addr, pb);
+  HeapWord* first_block = _bot_part.block_start_reaching_into_card(addr);
+  // The returned address is the first block that reaches into the card of
+  // addr. Walk the heap to get to the block including addr.
+  HeapWord* cur_block = first_block;
+  while (true) {
+    HeapWord* next_block = cur_block + block_size(cur_block, pb);
+    if (next_block > addr) {
+      assert(cur_block <= addr, "postcondition");
+      return cur_block;
+    }
+    cur_block = next_block;
+    // Because the BOT is precise, we should never step into the next card
+    // (i.e. crossing the card boundary).
+    assert(!G1BlockOffsetTablePart::is_crossing_card_boundary(cur_block, (HeapWord*)addr), "must be");
+  }
 }
 
 inline bool HeapRegion::obj_in_unparsable_area(oop obj, HeapWord* const pb) {

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -86,10 +86,9 @@ inline HeapWord* HeapRegion::block_start(const void* addr) const {
   return block_start(addr, parsable_bottom_acquire());
 }
 
-inline HeapWord* HeapRegion::block_start(const void* addr, HeapWord* const pb) const {
-  HeapWord* first_block = _bot_part.block_start_reaching_into_card(addr);
-  // The returned address is the first block that reaches into the card of
-  // addr. Walk the heap to get to the block including addr.
+inline HeapWord* HeapRegion::advance_to_block_containing_addr(const void* addr,
+                                                              HeapWord* const pb,
+                                                              HeapWord* first_block) const {
   HeapWord* cur_block = first_block;
   while (true) {
     HeapWord* next_block = cur_block + block_size(cur_block, pb);
@@ -102,6 +101,11 @@ inline HeapWord* HeapRegion::block_start(const void* addr, HeapWord* const pb) c
     // (i.e. crossing the card boundary).
     assert(!G1BlockOffsetTablePart::is_crossing_card_boundary(cur_block, (HeapWord*)addr), "must be");
   }
+}
+
+inline HeapWord* HeapRegion::block_start(const void* addr, HeapWord* const pb) const {
+  HeapWord* first_block = _bot_part.block_start_reaching_into_card(addr);
+  return advance_to_block_containing_addr(addr, pb, first_block);
 }
 
 inline bool HeapRegion::obj_in_unparsable_area(oop obj, HeapWord* const pb) {


### PR DESCRIPTION
Simple change of merging duplicate inline calls. It reduces asm footprint, e.g. `G1RemSet::refine_card_concurrently` by ~200 bytes.

(The first commit is what I had originally -- inlining the block-walking logic, because block-walking logic is not used by others and highly specific to its sole caller. Ofc, this is subjective.)

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290291](https://bugs.openjdk.org/browse/JDK-8290291): G1: Merge multiple calls of block_size in HeapRegion::block_start


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9490/head:pull/9490` \
`$ git checkout pull/9490`

Update a local copy of the PR: \
`$ git checkout pull/9490` \
`$ git pull https://git.openjdk.org/jdk pull/9490/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9490`

View PR using the GUI difftool: \
`$ git pr show -t 9490`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9490.diff">https://git.openjdk.org/jdk/pull/9490.diff</a>

</details>
