### PR TITLE
8290264 :  java/util/concurrent/locks/Lock/OOMEInAQS.java fails with "exit code: 0"

### DIFF
--- a/test/jdk/java/util/concurrent/locks/Lock/OOMEInAQS.java
+++ b/test/jdk/java/util/concurrent/locks/Lock/OOMEInAQS.java
@@ -98,8 +98,8 @@ public class OOMEInAQS extends Thread {
         try {
             started.await();
             for (int i = 0; i < NREPS; i++) {
+                lock.lock();
                 try {
-                    lock.lock();
                     while (turn != id)
                         cond.await();
                     turn = nextId;

--- a/test/jdk/java/util/concurrent/locks/Lock/OOMEInAQS.java
+++ b/test/jdk/java/util/concurrent/locks/Lock/OOMEInAQS.java
@@ -49,18 +49,24 @@ public class OOMEInAQS extends Thread {
     static final Condition condition = mainLock.newCondition();
     static final CountDownLatch started = new CountDownLatch(1);
     static final CountDownLatch filled = new CountDownLatch(1);
+    static final CountDownLatch canFill = new CountDownLatch(NTHREADS);
     static volatile Object data;
+    static volatile Throwable exception;
     static int turn;
 
     /**
      * For each of NTHREADS threads, REPS times: Take turns
-     * executing. Introduce OOM using fillHeap during runs.
+     * executing. Introduce OOM using fillHeap during runs. In
+     * addition to testing AQS, the CountDownLatches ensure that
+     * methods execute at least once before OutOfMemory occurs, to
+     * avoid uncontrollable impact of OOME during class-loading.
      */
     public static void main(String[] args) throws Throwable {
         OOMEInAQS[] threads = new OOMEInAQS[NTHREADS];
         for (int i = 0; i < NTHREADS; ++i)
             (threads[i] = new OOMEInAQS(i)).start();
         started.countDown();
+        canFill.await();
         long t0 = System.nanoTime();
         data = fillHeap();
         filled.countDown();
@@ -69,6 +75,9 @@ public class OOMEInAQS extends Thread {
             threads[i].join();
         data = null;  // free heap before reporting and terminating
         System.gc();
+        Throwable ex = exception;
+        if (ex != null)
+            throw ex;
         System.out.println(
             "fillHeap time: " + (t1 - t0) / 1000_000 +
             " millis, whole test time: " + (System.nanoTime() - t0) / 1000_000 +
@@ -98,12 +107,17 @@ public class OOMEInAQS extends Thread {
                 } finally {
                     lock.unlock();
                 }
-                if (i == 2) // Subsequent AQS methods encounter OOME
+                if (i == 2) {  // Subsequent AQS methods encounter OOME
+                    canFill.countDown();
                     filled.await();
+                }
             }
-        } catch (Throwable ex) { // Could be InterruptedExeption or OOME
             data = null;
-            System.exit(0); // avoid getting stuck trying to recover
+            System.gc(); // avoid getting stuck while exiting
+        } catch (Throwable ex) {
+            data = null;
+            System.gc(); // avoid nested OOME
+            exception = ex;
         }
     }
 


### PR DESCRIPTION
This test now conforms to jtreg rules about not using System.exit to cover untested OutOfMemoryErrors

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290264](https://bugs.openjdk.org/browse/JDK-8290264): java/util/concurrent/locks/Lock/OOMEInAQS.java fails with "exit code: 0"


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [971f3343](https://git.openjdk.org/jdk/pull/9491/files/971f3343224f4c6608d129e2255b3c1262ab70b6)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9491/head:pull/9491` \
`$ git checkout pull/9491`

Update a local copy of the PR: \
`$ git checkout pull/9491` \
`$ git pull https://git.openjdk.org/jdk pull/9491/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9491`

View PR using the GUI difftool: \
`$ git pr show -t 9491`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9491.diff">https://git.openjdk.org/jdk/pull/9491.diff</a>

</details>
