### PR TITLE
8290246: test fails "assert(init != __null) failed: initialization not  found"

### DIFF
--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1622,11 +1622,15 @@ Node *AllocateArrayNode::make_ideal_length(const TypeOopPtr* oop_type, PhaseTran
              "narrow type must be narrower than length type");
 
       // Return NULL if new nodes are not allowed
-      if (!allow_new_nodes) return NULL;
+      if (!allow_new_nodes) {
+        return NULL;
+      }
       // Create a cast which is control dependent on the initialization to
       // propagate the fact that the array length must be positive.
       InitializeNode* init = initialization();
-      assert(init != NULL, "initialization not found");
+      if (init == NULL) {
+        return NULL; // Return NULL if dead path
+      }
       length = new CastIINode(length, narrow_length_type);
       length->set_req(TypeFunc::Control, init->proj_out_or_null(TypeFunc::Control));
     }

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1628,11 +1628,10 @@ Node *AllocateArrayNode::make_ideal_length(const TypeOopPtr* oop_type, PhaseTran
       // Create a cast which is control dependent on the initialization to
       // propagate the fact that the array length must be positive.
       InitializeNode* init = initialization();
-      if (init == NULL) {
-        return NULL; // Return NULL if dead path
+      if (init != NULL) {
+        length = new CastIINode(length, narrow_length_type);
+        length->set_req(TypeFunc::Control, init->proj_out_or_null(TypeFunc::Control));
       }
-      length = new CastIINode(length, narrow_length_type);
-      length->set_req(TypeFunc::Control, init->proj_out_or_null(TypeFunc::Control));
     }
   }
 


### PR DESCRIPTION
CTW test (which compiles methods without running them - no profiling) failed when run with stress flag and particular RNG seed `-XX:+StressIGVN -XX:StressSeed=1743550013`. The failure is intermittent because of RNG.

The compiled method [BasicPopupMenuUI$BasicMenuKeyListener::menuKeyPressed()](https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicPopupMenuUI.java#L331) has allocation in loop at line [L360](https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicPopupMenuUI.java#L360) which is followed by call `item.isArmed()` at line L366. This call is not "linked" and uncommon trap is generated for it. As result the allocation result become un-used.
Due to shuffling done with `StressIGVN` flag LoadRangeNode is processed after InitializeNode is removed from graph but AllocateArrayNode is not. We hit assert because of that.

The fix replaces the assert with check.

Tested with replay file from bug report. I was not able to reproduce failure with standalone test because it is hard to force LoadRangeNode processing at right time. I attached to bug report a test which work on.

Testing tier1-3,xcomp

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290246](https://bugs.openjdk.org/browse/JDK-8290246): test fails "assert(init != __null) failed: initialization not found"


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9497/head:pull/9497` \
`$ git checkout pull/9497`

Update a local copy of the PR: \
`$ git checkout pull/9497` \
`$ git pull https://git.openjdk.org/jdk pull/9497/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9497`

View PR using the GUI difftool: \
`$ git pr show -t 9497`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9497.diff">https://git.openjdk.org/jdk/pull/9497.diff</a>

</details>
