### PR TITLE
8290327: Remove java/lang/reflect/callerCache/ReflectionCallerCacheTest.java from ProblemList-Xcomp.txt

### DIFF
--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -29,4 +29,3 @@
 
 java/lang/invoke/MethodHandles/CatchExceptionTest.java 8146623 generic-all
 java/lang/ref/ReferenceEnqueue.java 8284236 generic-all
-java/lang/reflect/callerCache/ReflectionCallerCacheTest.java 8288286 generic-all


### PR DESCRIPTION
It's expected that [JDK-8287596](https://bugs.openjdk.org/browse/JDK-8287596) has resolved [JDK-8288286](https://bugs.openjdk.org/browse/JDK-8288286). Remove ReflectionCallerCacheTest.java from the problem list for test execution.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290327](https://bugs.openjdk.org/browse/JDK-8290327): Remove java/lang/reflect/callerCache/ReflectionCallerCacheTest.java from ProblemList-Xcomp.txt


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9500/head:pull/9500` \
`$ git checkout pull/9500`

Update a local copy of the PR: \
`$ git checkout pull/9500` \
`$ git pull https://git.openjdk.org/jdk pull/9500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9500`

View PR using the GUI difftool: \
`$ git pr show -t 9500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9500.diff">https://git.openjdk.org/jdk/pull/9500.diff</a>

</details>
