### PR TITLE
8289003: JavaThread::check_is_terminated() implementation should rely on Thread-SMR

### DIFF
--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -564,9 +564,10 @@ bool JavaThread::is_interrupted(bool clear_interrupted) {
 void JavaThread::block_if_vm_exited() {
   if (_terminated == _vm_exited) {
     // _vm_exited is set at safepoint, and Threads_lock is never released
-    // we will block here forever.
+    // so we will block here forever.
     // Here we can be doing a jump from a safe state to an unsafe state without
-    // proper transition, but it happens after the final safepoint has begun.
+    // proper transition, but it happens after the final safepoint has begun so
+    // this jump won't cause any safepoint problems.
     set_thread_state(_thread_in_vm);
     Threads_lock->lock();
     ShouldNotReachHere();

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -568,7 +568,7 @@ private:
   // thread's GC barrier is NOT detached and thread is NOT terminated
   bool is_oop_safe() const;
   // thread is terminated (no longer on the threads list); the thread must
-  // protected by a ThreadsListHandle to avoid potential crashes.
+  // be protected by a ThreadsListHandle to avoid potential crashes.
   bool check_is_terminated(TerminatedTypes l_terminated) const {
     return l_terminated == _thread_terminated || l_terminated == _vm_exited;
   }

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -567,12 +567,10 @@ private:
   bool is_exiting() const;
   // thread's GC barrier is NOT detached and thread is NOT terminated
   bool is_oop_safe() const;
-  // thread is terminated (no longer on the threads list); we compare
-  // against the three non-terminated values so that a freed JavaThread
-  // will also be considered terminated.
+  // thread is terminated (no longer on the threads list); the thread must
+  // protected by a ThreadsListHandle to avoid potential crashes.
   bool check_is_terminated(TerminatedTypes l_terminated) const {
-    return l_terminated != _not_terminated && l_terminated != _thread_exiting &&
-           l_terminated != _thread_gc_barrier_detached;
+    return l_terminated == _thread_terminated || l_terminated == _vm_exited;
   }
   bool is_terminated() const;
   void set_terminated(TerminatedTypes t);

--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -367,7 +367,7 @@ int VM_Exit::set_vm_exited() {
   _shutdown_thread = thr_cur;
   _vm_exited = true;                                // global flag
   for (JavaThreadIteratorWithHandle jtiwh; JavaThread *thr = jtiwh.next(); ) {
-    if (thr!=thr_cur && thr->thread_state() == _thread_in_native) {
+    if (thr != thr_cur && thr->thread_state() == _thread_in_native) {
       ++num_active;
       thr->set_terminated(JavaThread::_vm_exited);  // per-thread flag
     }
@@ -495,7 +495,7 @@ void VM_Exit::wait_if_vm_exited() {
   if (_vm_exited &&
       Thread::current_or_null() != _shutdown_thread) {
     // _vm_exited is set at safepoint, and the Threads_lock is never released
-    // we will block here until the process dies
+    // so we will block here until the process dies.
     Threads_lock->lock();
     ShouldNotReachHere();
   }


### PR DESCRIPTION
A small fix to change `JavaThread::check_is_terminated()` to rely on Thread-SMR.
The change is textually trivial, but requires a bit of thinking about the JavaThread
lifecycle. Since this is a cleanup of some old Thread-SMR related changes, I also
took the time to cleanup some comments and white space while I was visiting the
uses of `_vm_exited`.

Mach5 Tier1 has no related failures. Mach5 Tier[23] testing has just started.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289003](https://bugs.openjdk.org/browse/JDK-8289003): JavaThread::check_is_terminated() implementation should rely on Thread-SMR


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [baf43a88](https://git.openjdk.org/jdk/pull/9502/files/baf43a887bdf5cca961ce7c570159c52d3e0e6f1)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**) ⚠️ Review applies to [baf43a88](https://git.openjdk.org/jdk/pull/9502/files/baf43a887bdf5cca961ce7c570159c52d3e0e6f1)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9502/head:pull/9502` \
`$ git checkout pull/9502`

Update a local copy of the PR: \
`$ git checkout pull/9502` \
`$ git pull https://git.openjdk.org/jdk pull/9502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9502`

View PR using the GUI difftool: \
`$ git pr show -t 9502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9502.diff">https://git.openjdk.org/jdk/pull/9502.diff</a>

</details>
