### PR TITLE
8289996: Fix array range check hoisting for some scaled loop iv

### DIFF
--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -270,11 +270,20 @@ Node *MulINode::Ideal(PhaseGVN *phase, bool can_reshape) {
     unsigned int bit2 = abs_con - bit1;
     bit2 = bit2 & (0 - bit2);          // Extract 2nd bit
     if (bit2 + bit1 == abs_con) {    // Found all bits in con?
+      if (!phase->C->post_loop_opts_phase()) {
+        // Defer this because it breaks loop range check hoisting
+        phase->C->record_for_post_loop_opts_igvn(this);
+        return NULL;
+      }
       Node *n1 = phase->transform(new LShiftINode(in(1), phase->intcon(log2i_exact(bit1))));
       Node *n2 = phase->transform(new LShiftINode(in(1), phase->intcon(log2i_exact(bit2))));
       res = new AddINode(n2, n1);
     } else if (is_power_of_2(abs_con + 1)) {
-      // Sleezy: power-of-2 - 1.  Next time be generic.
+      if (!phase->C->post_loop_opts_phase()) {
+        // Defer this because it breaks loop range check hoisting
+        phase->C->record_for_post_loop_opts_igvn(this);
+        return NULL;
+      }
       unsigned int temp = abs_con + 1;
       Node *n1 = phase->transform(new LShiftINode(in(1), phase->intcon(log2i_exact(temp))));
       res = new SubINode(n1, in(1));

--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8289996
+ * @summary Test range check hoisting for some scaled iv at array index
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @run driver compiler.rangechecks.TestRangeCheckHoistingScaledIV
+ */
+
+package compiler.rangechecks;
+
+import compiler.lib.ir_framework.*;
+
+public class TestRangeCheckHoistingScaledIV {
+
+    private static final int SIZE = 16000;
+
+    private static int[] a = new int[SIZE];
+    private static int[] b = new int[SIZE];
+    private static int count = 567;
+
+    // If the loop predication successfully hoists range checks in below
+    // loops, there is only uncommon trap with reason='predicate' and no
+    // uncommon trap with reason='range_check'.
+
+    @Test
+    @IR(failOn = {IRNode.RANGE_CHECK_TRAP})
+    public static void ivMul3() {
+        for (int i = 0; i < count; i++) {
+            b[3 * i] = a[3 * i];
+        }
+    }
+
+    @Test
+    @IR(failOn = {IRNode.RANGE_CHECK_TRAP})
+    public static void ivMul6() {
+        for (int i = 0; i < count; i++) {
+            b[6 * i] = a[6 * i];
+        }
+    }
+
+    @Test
+    @IR(failOn = {IRNode.RANGE_CHECK_TRAP})
+    public static void ivMul7() {
+        for (int i = 0; i < count; i++) {
+            b[7 * i] = a[7 * i];
+        }
+    }
+
+    @Test
+    @IR(failOn = {IRNode.RANGE_CHECK_TRAP})
+    public static void ivMulMinus3() {
+        for (int i = 0; i > -count; i--) {
+            b[-3 * i] = a[-3 * i];
+        }
+    }
+
+    @Test
+    @IR(failOn = {IRNode.RANGE_CHECK_TRAP})
+    public static void ivMulMinus6() {
+        for (int i = 0; i > -count; i--) {
+            b[-6 * i] = a[-6 * i];
+        }
+    }
+
+    @Test
+    @IR(failOn = {IRNode.RANGE_CHECK_TRAP})
+    public static void ivMulMinus9() {
+        for (int i = 0; i > -count; i--) {
+            b[-9 * i] = a[-9 * i];
+        }
+    }
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/RangeCheckHoisting.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/RangeCheckHoisting.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class RangeCheckHoisting {
+
+    private static final int SIZE = 65536;
+
+    @Param("6789") private int count;
+
+    private static int[] a = new int[SIZE];
+    private static int[] b = new int[SIZE];
+
+    @Benchmark
+    public void ivScaled3() {
+        for (int i = 0; i < count; i++) {
+            b[3 * i] = a[3 * i];
+        }
+    }
+
+    @Benchmark
+    public void ivScaled7() {
+        for (int i = 0; i < count; i++) {
+            b[7 * i] = a[7 * i];
+        }
+    }
+}


### PR DESCRIPTION
Recently we found some array range checks in loops are not hoisted by
C2's loop predication phase as expected. Below is a typical case.
```
  for (int i = 0; i < size; i++) {
    b[3 * i] = a[3 * i];
  }
```
Ideally, C2 can hoist the range check of an array access in loop if the
array index is a linear function of the loop's induction variable (iv).
Say, range check in `arr[exp]` can be hoisted if
```
  exp = k1 * iv + k2 + inv
```
where `k1` and `k2` are compile-time constants, and `inv` is an optional
loop invariant. But in above case, C2 igvn does some strength reduction
on the `MulINode` used to compute `3 * i`. It results in the linear index
expression not being recognized. So far we found 2 ideal transformations
that may affect linear expression recognition. They are

- `k * iv` --> `iv << m + iv << n` if k is the sum of 2 pow-of-2 values
- `k * iv` --> `iv << m - iv` if k+1 is a pow-of-2 value

To avoid range check hoisting and further optimizations being broken, we
have tried improving the linear recognition. But after some experiments,
we found complex and recursive pattern match does not always work well.
In this patch we propose to defer these 2 ideal transformations to the
phase of post loop igvn. In other words, these 2 strength reductions can
only be done after all loop optimizations are over.

Tested hotspot::hotspot_all_no_apps, jdk::tier1~3 and langtools::tier1.
We also tested the performance via JMH and see obvious improvement.
```
Benchmark                        Improvement
RangeCheckHoisting.ivScaled3          +21.2%
RangeCheckHoisting.ivScaled7           +6.6%
```
