### PR TITLE
8289801: [IR Framework] Add flags to whitelist which can be used to simulate a specific machine setup like UseAVX

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -84,6 +84,7 @@ hotspot_containers_extended = \
 
 hotspot_vector_1 = \
   compiler/c2/cr6340864 \
+  compiler/c2/irTests \
   compiler/codegen \
   compiler/loopopts/superword \
   compiler/vectorapi \

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeURShiftSubword.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeURShiftSubword.java
@@ -33,7 +33,7 @@ import jdk.test.lib.Utils;
  * @bug 8283307
  * @key randomness
  * @summary Auto-vectorization enhancement for unsigned shift right on signed subword types
- * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @requires ((os.arch=="amd64" | os.arch=="x86_64") & (vm.opt.UseSSE == "null" | vm.opt.UseSSE > 3)) | os.arch=="aarch64"
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestVectorizeURShiftSubword
  */

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -133,6 +133,9 @@ public class TestFramework {
                     "CompileThreshold",
                     "Xmixed",
                     "server",
+                    "UseAVX",
+                    "UseSSE",
+                    "UseSVE",
                     "Xlog",
                     "LogCompilation"
             )


### PR DESCRIPTION
Hi all,

Please review this trivial change which adds `UseAVX, UseSSE and UseSVE` to the whitelist of IR test framework.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289801](https://bugs.openjdk.org/browse/JDK-8289801): [IR Framework] Add flags to whitelist which can be used to simulate a specific machine setup like UseAVX


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Xiaohong Gong](https://openjdk.org/census#xgong) (@XiaohongGong - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9509/head:pull/9509` \
`$ git checkout pull/9509`

Update a local copy of the PR: \
`$ git checkout pull/9509` \
`$ git pull https://git.openjdk.org/jdk pull/9509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9509`

View PR using the GUI difftool: \
`$ git pr show -t 9509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9509.diff">https://git.openjdk.org/jdk/pull/9509.diff</a>

</details>
