### PR TITLE
8290366: Remove unused during_conc_mark parameter in HeapRegion::note_self_forwarding_removal_start

### DIFF
--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -162,10 +162,8 @@ public:
     hr->clear_index_in_opt_cset();
 
     bool during_concurrent_start = _g1h->collector_state()->in_concurrent_start_gc();
-    bool during_concurrent_mark = _g1h->collector_state()->mark_or_rebuild_in_progress();
 
-    hr->note_self_forwarding_removal_start(during_concurrent_start,
-                                           during_concurrent_mark);
+    hr->note_self_forwarding_removal_start(during_concurrent_start);
 
     _phase_times->record_or_add_thread_work_item(G1GCPhaseTimes::RestoreRetainedRegions,
                                                    _worker_id,

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -271,8 +271,7 @@ void HeapRegion::report_region_type_change(G1HeapRegionTraceType::Type to) {
                                             used());
 }
 
-void HeapRegion::note_self_forwarding_removal_start(bool during_concurrent_start,
-                                                    bool during_conc_mark) {
+void HeapRegion::note_self_forwarding_removal_start(bool during_concurrent_start) {
   // We always scrub the region to make sure the entire region is
   // parsable after the self-forwarding point removal, and update _marked_bytes
   // at the end.

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -521,8 +521,7 @@ public:
 
   // Notify the region that we are about to start processing
   // self-forwarded objects during evac failure handling.
-  void note_self_forwarding_removal_start(bool during_concurrent_start,
-                                          bool during_conc_mark);
+  void note_self_forwarding_removal_start(bool during_concurrent_start);
 
   // Notify the region that we have finished processing self-forwarded
   // objects during evac failure handling.


### PR DESCRIPTION
Hi all,

  can I have reviews for this trivial removal of an unused parameter?

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290366](https://bugs.openjdk.org/browse/JDK-8290366): Remove unused during_conc_mark parameter in HeapRegion::note_self_forwarding_removal_start


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9510/head:pull/9510` \
`$ git checkout pull/9510`

Update a local copy of the PR: \
`$ git checkout pull/9510` \
`$ git pull https://git.openjdk.org/jdk pull/9510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9510`

View PR using the GUI difftool: \
`$ git pr show -t 9510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9510.diff">https://git.openjdk.org/jdk/pull/9510.diff</a>

</details>
