### PR TITLE
8290344: Start/stop displaysync affects performance in metal rendering pipeline

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.h
@@ -55,6 +55,7 @@
 @property (readwrite, assign) int topInset;
 @property (readwrite, assign) int leftInset;
 @property (readwrite, assign) CVDisplayLinkRef displayLink;
+@property (readwrite, atomic) int displayLinkCount;
 
 - (id) initWithJavaLayer:(jobject)layer;
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.m
@@ -29,6 +29,7 @@
 #import "LWCToolkit.h"
 #import "MTLSurfaceData.h"
 #import "JNIUtilities.h"
+#define KEEP_ALIVE_INC 4
 
 @implementation MTLLayer
 
@@ -42,6 +43,7 @@
 @synthesize leftInset;
 @synthesize nextDrawableCount;
 @synthesize displayLink;
+@synthesize displayLinkCount;
 
 - (id) initWithJavaLayer:(jobject)layer
 {
@@ -74,12 +76,15 @@
     self.opaque = YES;
     CVDisplayLinkCreateWithActiveCGDisplays(&displayLink);
     CVDisplayLinkSetOutputCallback(displayLink, &displayLinkCallback, (__bridge void*)self);
+    self.displayLinkCount = 0;
     return self;
 }
 
 - (void) blitTexture {
     if (self.ctx == NULL || self.javaLayer == NULL || self.buffer == nil || self.ctx.device == nil) {
-        J2dTraceLn4(J2D_TRACE_VERBOSE, "MTLLayer.blitTexture: uninitialized (mtlc=%p, javaLayer=%p, buffer=%p, devide=%p)", self.ctx, self.javaLayer, self.buffer, ctx.device);
+        J2dTraceLn4(J2D_TRACE_VERBOSE,
+                    "MTLLayer.blitTexture: uninitialized (mtlc=%p, javaLayer=%p, buffer=%p, devide=%p)", self.ctx,
+                    self.javaLayer, self.buffer, ctx.device);
         [self stopDisplayLink];
         return;
     }
@@ -100,9 +105,9 @@
         NSUInteger src_h = self.buffer.height - src_y;
 
         if (src_h <= 0 || src_w <= 0) {
-           J2dTraceLn(J2D_TRACE_VERBOSE, "MTLLayer.blitTexture: Invalid src width or height.");
-           [self stopDisplayLink];
-           return;
+            J2dTraceLn(J2D_TRACE_VERBOSE, "MTLLayer.blitTexture: Invalid src width or height.");
+            [self stopDisplayLink];
+            return;
         }
 
         id<MTLCommandBuffer> commandBuf = [self.ctx createBlitCommandBuffer];
@@ -134,7 +139,11 @@
         }];
 
         [commandBuf commit];
-        [self stopDisplayLink];
+
+        if (--self.displayLinkCount <= 0) {
+            self.displayLinkCount = 0;
+            [self stopDisplayLink];
+        }
     }
 }
 
@@ -177,13 +186,18 @@
 }
 
 - (void) startDisplayLink {
-    if (!CVDisplayLinkIsRunning(self.displayLink))
+    if (!CVDisplayLinkIsRunning(self.displayLink)) {
         CVDisplayLinkStart(self.displayLink);
+        J2dTraceLn(J2D_TRACE_VERBOSE, "MTLLayer_startDisplayLink");
+    }
+    displayLinkCount += KEEP_ALIVE_INC; // Keep alive displaylink counter
 }
 
 - (void) stopDisplayLink {
-    if (CVDisplayLinkIsRunning(self.displayLink))
+    if (CVDisplayLinkIsRunning(self.displayLink)) {
         CVDisplayLinkStop(self.displayLink);
+        J2dTraceLn(J2D_TRACE_VERBOSE, "MTLLayer_stopDisplayLink");
+    }
 }
 
 CVReturn displayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeStamp* now, const CVTimeStamp* outputTime, CVOptionFlags flagsIn, CVOptionFlags* flagsOut, void* displayLinkContext)


### PR DESCRIPTION
Reuse displaysync thread for subsequent updates

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290344](https://bugs.openjdk.org/browse/JDK-8290344): Start/stop displaysync affects performance in metal rendering pipeline


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - Committer)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9512/head:pull/9512` \
`$ git checkout pull/9512`

Update a local copy of the PR: \
`$ git checkout pull/9512` \
`$ git pull https://git.openjdk.org/jdk pull/9512/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9512`

View PR using the GUI difftool: \
`$ git pr show -t 9512`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9512.diff">https://git.openjdk.org/jdk/pull/9512.diff</a>

</details>
