### PR TITLE
8290376: G1: Refactor G1MMUTracker::when_sec

### DIFF
--- a/src/hotspot/share/gc/g1/g1MMUTracker.cpp
+++ b/src/hotspot/share/gc/g1/g1MMUTracker.cpp
@@ -112,8 +112,8 @@ void G1MMUTracker::add_pause(double start, double end) {
 }
 
 //                                                current_timestamp
-//                   GC events                   /  pause_time
-//                 /     |     \                | /  /
+//                       GC events               /  pause_time
+//                 /     |     \     \          | /  /
 // -------------[----]-[---]--[--]---[---]------|[--]-----> Time
 //              |         |                     |
 //              |         |                     |
@@ -158,9 +158,9 @@ double G1MMUTracker::when_sec(double current_timestamp, double pause_time) {
     // This duration would exceed (strictly greater than) the budget.
     if (duration > gc_budget) {
       // This timestamp captures the instant the budget is balanced (or used up).
-      double balance_timesstamp = elem->end_time() - gc_budget;
-      assert(balance_timesstamp >= limit, "inv");
-      return balance_timesstamp - limit;
+      double balance_timestamp = elem->end_time() - gc_budget;
+      assert(balance_timestamp >= limit, "inv");
+      return balance_timestamp - limit;
     }
 
     gc_budget -= duration;

--- a/src/hotspot/share/gc/g1/g1MMUTracker.hpp
+++ b/src/hotspot/share/gc/g1/g1MMUTracker.hpp
@@ -104,6 +104,7 @@ private:
   // given timestamp.
   double calculate_gc_time(double current_timestamp);
 
+  double old_when_sec(double current_timestamp, double pause_time);
 public:
   G1MMUTracker(double time_slice, double max_gc_time);
 
@@ -112,6 +113,8 @@ public:
   // Minimum delay required from current_timestamp until a GC pause of duration
   // pause_time may be scheduled without violating the MMU constraint.
   double when_sec(double current_timestamp, double pause_time);
+
+  double time_till_next_gc_sec(double current_timestamp, double pause_time);
 
   double max_gc_time() const {
     return _max_gc_time;

--- a/src/hotspot/share/gc/g1/g1MMUTracker.hpp
+++ b/src/hotspot/share/gc/g1/g1MMUTracker.hpp
@@ -103,8 +103,6 @@ private:
   // Returns the amount of time spent in gc pauses in the time slice before the
   // given timestamp.
   double calculate_gc_time(double current_timestamp);
-
-  double old_when_sec(double current_timestamp, double pause_time);
 public:
   G1MMUTracker(double time_slice, double max_gc_time);
 
@@ -113,8 +111,6 @@ public:
   // Minimum delay required from current_timestamp until a GC pause of duration
   // pause_time may be scheduled without violating the MMU constraint.
   double when_sec(double current_timestamp, double pause_time);
-
-  double time_till_next_gc_sec(double current_timestamp, double pause_time);
 
   double max_gc_time() const {
     return _max_gc_time;


### PR DESCRIPTION
Introducing a more intuitive implementation.

This PR consists of two commits: the first adds the new algorithm and verifies the result is same as before. The second commit removes the old implementation.

Test: tier1-6 for the first commit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290376](https://bugs.openjdk.org/browse/JDK-8290376): G1: Refactor G1MMUTracker::when_sec


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [a52a6f54](https://git.openjdk.org/jdk/pull/9517/files/a52a6f548f51e1c73a6bb507f537082f17cd9402)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**) ⚠️ Review applies to [a52a6f54](https://git.openjdk.org/jdk/pull/9517/files/a52a6f548f51e1c73a6bb507f537082f17cd9402)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9517/head:pull/9517` \
`$ git checkout pull/9517`

Update a local copy of the PR: \
`$ git checkout pull/9517` \
`$ git pull https://git.openjdk.org/jdk pull/9517/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9517`

View PR using the GUI difftool: \
`$ git pr show -t 9517`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9517.diff">https://git.openjdk.org/jdk/pull/9517.diff</a>

</details>
