### PR TITLE
8290316: Ensure that all directory streams are closed in java.base

### DIFF
--- a/src/java.base/share/classes/java/time/chrono/HijrahChronology.java
+++ b/src/java.base/share/classes/java/time/chrono/HijrahChronology.java
@@ -1037,7 +1037,7 @@ public final class HijrahChronology extends AbstractChronology implements Serial
             (PrivilegedAction<Void>)() -> {
                 if (Files.isDirectory(CONF_PATH)) {
                     try (Stream<Path> stream = Files.list(CONF_PATH)) {
-                            stream.map(p -> p.getFileName().toString())
+                        stream.map(p -> p.getFileName().toString())
                             .filter(fn -> fn.matches("hijrah-config-[^\\.]+\\.properties"))
                             .map(fn -> fn.replaceAll("(hijrah-config-|\\.properties)", ""))
                             .forEach(idtype -> {

--- a/src/java.base/share/classes/java/time/chrono/HijrahChronology.java
+++ b/src/java.base/share/classes/java/time/chrono/HijrahChronology.java
@@ -86,6 +86,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Stream;
 
 import sun.util.logging.PlatformLogger;
 
@@ -1035,9 +1036,8 @@ public final class HijrahChronology extends AbstractChronology implements Serial
         AccessController.doPrivileged(
             (PrivilegedAction<Void>)() -> {
                 if (Files.isDirectory(CONF_PATH)) {
-                    try {
-                        Files.list(CONF_PATH)
-                            .map(p -> p.getFileName().toString())
+                    try (Stream<Path> stream = Files.list(CONF_PATH)) {
+                            stream.map(p -> p.getFileName().toString())
                             .filter(fn -> fn.matches("hijrah-config-[^\\.]+\\.properties"))
                             .map(fn -> fn.replaceAll("(hijrah-config-|\\.properties)", ""))
                             .forEach(idtype -> {

--- a/src/java.base/share/classes/jdk/internal/jrtfs/ExplodedImage.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/ExplodedImage.java
@@ -259,7 +259,7 @@ class ExplodedImage extends SystemImage {
                         contentsStream.filter(Files::isDirectory).forEach((p) -> {
                             p = module.relativize(p);
                             String pkgName = slashesToDots(p.toString());
-                            // skip META-INFO and empty strings
+                            // skip META-INF and empty strings
                             if (!pkgName.isEmpty() && !pkgName.startsWith("META-INF")) {
                                 List<String> moduleNames = packageToModules.get(pkgName);
                                 if (moduleNames == null) {
@@ -269,6 +269,7 @@ class ExplodedImage extends SystemImage {
                                 moduleNames.add(moduleName);
                             }
                         });
+                    }
                 }
             }
         }

--- a/src/java.base/share/classes/jdk/internal/jrtfs/ExplodedImage.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/ExplodedImage.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import jdk.internal.jimage.ImageReader.Node;
 
@@ -254,19 +255,20 @@ class ExplodedImage extends SystemImage {
                     String moduleName = module.getFileName().toString();
                     // make sure "/modules/<moduleName>" is created
                     findModulesNode(MODULES + moduleName);
-                    Files.walk(module).filter(Files::isDirectory).forEach((p) -> {
-                        p = module.relativize(p);
-                        String pkgName = slashesToDots(p.toString());
-                        // skip META-INFO and empty strings
-                        if (!pkgName.isEmpty() && !pkgName.startsWith("META-INF")) {
-                            List<String> moduleNames = packageToModules.get(pkgName);
-                            if (moduleNames == null) {
-                                moduleNames = new ArrayList<>();
-                                packageToModules.put(pkgName, moduleNames);
+                    try (Stream<Path> contentsStream = Files.walk(module)) {
+                        contentsStream.filter(Files::isDirectory).forEach((p) -> {
+                            p = module.relativize(p);
+                            String pkgName = slashesToDots(p.toString());
+                            // skip META-INFO and empty strings
+                            if (!pkgName.isEmpty() && !pkgName.startsWith("META-INF")) {
+                                List<String> moduleNames = packageToModules.get(pkgName);
+                                if (moduleNames == null) {
+                                    moduleNames = new ArrayList<>();
+                                    packageToModules.put(pkgName, moduleNames);
+                                }
+                                moduleNames.add(moduleName);
                             }
-                            moduleNames.add(moduleName);
-                        }
-                    });
+                        });
                 }
             }
         }

--- a/src/java.base/share/classes/jdk/internal/module/ModuleHashes.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleHashes.java
@@ -115,20 +115,19 @@ public final class ModuleHashes {
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalArgumentException(e);
         }
-        try {
-            byte[] buf = new byte[32*1024];
-            try (Stream<String> stream = reader.list()) {
-                stream.sorted().forEach(rn -> {
-                    md.update(rn.getBytes(StandardCharsets.UTF_8));
-                    try (InputStream in = reader.open(rn).orElseThrow()) {
-                        int n;
-                        while ((n = in.read(buf)) > 0) {
-                            md.update(buf, 0, n);
-                        }
-                    } catch (IOException ioe) {
-                        throw new UncheckedIOException(ioe);
+        byte[] buf = new byte[32*1024];
+        try (Stream<String> stream = reader.list()) {
+            stream.sorted().forEach(rn -> {
+                md.update(rn.getBytes(StandardCharsets.UTF_8));
+                try (InputStream in = reader.open(rn).orElseThrow()) {
+                    int n;
+                    while ((n = in.read(buf)) > 0) {
+                        md.update(buf, 0, n);
                     }
-                });
+                } catch (IOException ioe) {
+                    throw new UncheckedIOException(ioe);
+                }
+            });
         } catch (IOException ioe) {
             throw new UncheckedIOException(ioe);
         }

--- a/src/java.base/share/classes/jdk/internal/module/ModuleHashes.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleHashes.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 /**
  * The result of hashing the contents of a number of module artifacts.
@@ -116,17 +117,18 @@ public final class ModuleHashes {
         }
         try {
             byte[] buf = new byte[32*1024];
-            reader.list().sorted().forEach(rn -> {
-                md.update(rn.getBytes(StandardCharsets.UTF_8));
-                try (InputStream in = reader.open(rn).orElseThrow()) {
-                    int n;
-                    while ((n = in.read(buf)) > 0) {
-                        md.update(buf, 0, n);
+            try (Stream<String> stream = reader.list()) {
+                stream.sorted().forEach(rn -> {
+                    md.update(rn.getBytes(StandardCharsets.UTF_8));
+                    try (InputStream in = reader.open(rn).orElseThrow()) {
+                        int n;
+                        while ((n = in.read(buf)) > 0) {
+                            md.update(buf, 0, n);
+                        }
+                    } catch (IOException ioe) {
+                        throw new UncheckedIOException(ioe);
                     }
-                } catch (IOException ioe) {
-                    throw new UncheckedIOException(ioe);
-                }
-            });
+                });
         } catch (IOException ioe) {
             throw new UncheckedIOException(ioe);
         }

--- a/src/java.base/share/classes/jdk/internal/module/ModulePatcher.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModulePatcher.java
@@ -131,14 +131,15 @@ public final class ModulePatcher {
 
                     // exploded directory without following sym links
                     Path top = file;
-                    Files.find(top, Integer.MAX_VALUE,
-                               ((path, attrs) -> attrs.isRegularFile()))
-                            .filter(path -> (!isAutomatic
-                                    || path.toString().endsWith(".class"))
-                                    && !isHidden(path))
-                            .map(path -> toPackageName(top, path))
-                            .filter(Checks::isPackageName)
-                            .forEach(packages::add);
+                    try (Stream<Path> stream = Files.find(top, Integer.MAX_VALUE,
+                            ((path, attrs) -> attrs.isRegularFile()))) {
+                            stream.filter(path -> (!isAutomatic
+                                || path.toString().endsWith(".class"))
+                                && !isHidden(path))
+                                .map(path -> toPackageName(top, path))
+                                .filter(Checks::isPackageName)
+                                .forEach(packages::add);
+                    }
 
                 }
             }

--- a/src/java.base/share/classes/jdk/internal/module/ModulePatcher.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModulePatcher.java
@@ -133,12 +133,12 @@ public final class ModulePatcher {
                     Path top = file;
                     try (Stream<Path> stream = Files.find(top, Integer.MAX_VALUE,
                             ((path, attrs) -> attrs.isRegularFile()))) {
-                            stream.filter(path -> (!isAutomatic
-                                || path.toString().endsWith(".class"))
-                                && !isHidden(path))
-                                .map(path -> toPackageName(top, path))
-                                .filter(Checks::isPackageName)
-                                .forEach(packages::add);
+                        stream.filter(path -> (!isAutomatic
+                            || path.toString().endsWith(".class"))
+                            && !isHidden(path))
+                            .map(path -> toPackageName(top, path))
+                            .filter(Checks::isPackageName)
+                            .forEach(packages::add);
                     }
 
                 }

--- a/src/java.base/share/classes/jdk/internal/module/ModulePatcher.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModulePatcher.java
@@ -134,8 +134,8 @@ public final class ModulePatcher {
                     try (Stream<Path> stream = Files.find(top, Integer.MAX_VALUE,
                             ((path, attrs) -> attrs.isRegularFile()))) {
                         stream.filter(path -> (!isAutomatic
-                            || path.toString().endsWith(".class"))
-                            && !isHidden(path))
+                                      || path.toString().endsWith(".class"))
+                                      && !isHidden(path))
                             .map(path -> toPackageName(top, path))
                             .filter(Checks::isPackageName)
                             .forEach(packages::add);

--- a/src/java.base/share/classes/jdk/internal/module/ModulePath.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModulePath.java
@@ -664,8 +664,8 @@ public class ModulePath implements ModuleFinder {
 
     private Set<String> explodedPackages(Path dir) {
         String separator = dir.getFileSystem().getSeparator();
-        try (Stream<Path> stream =
-                Files.find(dir, Integer.MAX_VALUE, (path, attrs) -> attrs.isRegularFile() && !isHidden(path))) {
+        try (Stream<Path> stream = Files.find(dir, Integer.MAX_VALUE,
+                (path, attrs) -> attrs.isRegularFile() && !isHidden(path))) {
             return stream.map(dir::relativize)
                 .map(path -> toPackageName(path, separator))
                 .flatMap(Optional::stream)

--- a/src/java.base/share/classes/jdk/internal/module/ModulePath.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModulePath.java
@@ -58,6 +58,7 @@ import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
@@ -663,13 +664,12 @@ public class ModulePath implements ModuleFinder {
 
     private Set<String> explodedPackages(Path dir) {
         String separator = dir.getFileSystem().getSeparator();
-        try {
-            return Files.find(dir, Integer.MAX_VALUE,
-                    ((path, attrs) -> attrs.isRegularFile() && !isHidden(path)))
-                    .map(path -> dir.relativize(path))
-                    .map(path -> toPackageName(path, separator))
-                    .flatMap(Optional::stream)
-                    .collect(Collectors.toSet());
+        try (Stream<Path> stream =
+                Files.find(dir, Integer.MAX_VALUE, (path, attrs) -> attrs.isRegularFile() && !isHidden(path))) {
+            return stream.map(dir::relativize)
+                .map(path -> toPackageName(path, separator))
+                .flatMap(Optional::stream)
+                .collect(Collectors.toSet());
         } catch (IOException x) {
             throw new UncheckedIOException(x);
         }


### PR DESCRIPTION
This commit guards uses of Files methods returning path streams in
java.base to use try-with-resources.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290316](https://bugs.openjdk.org/browse/JDK-8290316): Ensure that all directory streams are closed in java.base


### Reviewers
 * [Chris Hegarty](https://openjdk.org/census#chegar) (@ChrisHegarty - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9518/head:pull/9518` \
`$ git checkout pull/9518`

Update a local copy of the PR: \
`$ git checkout pull/9518` \
`$ git pull https://git.openjdk.org/jdk pull/9518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9518`

View PR using the GUI difftool: \
`$ git pr show -t 9518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9518.diff">https://git.openjdk.org/jdk/pull/9518.diff</a>

</details>
