### PR TITLE
8290379: Parse error with parenthesized pattern and guard using an array

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3169,7 +3169,8 @@ public class JavacParser implements Parser {
                         lookahead++;
                         break;
                     } else {
-                        return PatternResult.EXPRESSION;
+                        // This is a potential guard, if we are already in a pattern
+                        return pendingResult;
                     }
                 case LPAREN:
                     if (S.token(lookahead + 1).kind == RPAREN) {

--- a/test/langtools/tools/javac/T8290379.java
+++ b/test/langtools/tools/javac/T8290379.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8290379
+ * @summary Parse error with parenthesized pattern and guard using an array
+ * @compile --enable-preview -source ${jdk.version} T8290379.java
+ * @run main/othervm --enable-preview T8290379
+ */
+public class T8290379 {
+    public static void main(String... args) {
+        assertEquals(0, test("test"));
+        assertEquals(1, test(Integer.valueOf(42)));
+    }
+
+    public static int test(Object o)
+    {
+        int[] arr = {0, 1};
+
+        return switch (o) {
+            case (String s) when (arr[0] == 0) -> 0;
+            case (Integer i) when arr[1] == 1 -> 1;
+            default -> 2;
+        };
+    }
+
+    static void assertEquals(int expected, int actual) {
+        if (expected != actual) {
+            throw new AssertionError("Expected: " + expected + ", actual: " + actual);
+        }
+    }
+}


### PR DESCRIPTION
Addresses the parsing error for the following case:

case (String s) when (arr[0] == 1) -> 0;

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290379](https://bugs.openjdk.org/browse/JDK-8290379): Parse error with parenthesized pattern and guard using an array


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**) ⚠️ Review applies to [32cd4677](https://git.openjdk.org/jdk/pull/9519/files/32cd4677253b3339c275279b2d3349eb1e6c7cad)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9519/head:pull/9519` \
`$ git checkout pull/9519`

Update a local copy of the PR: \
`$ git checkout pull/9519` \
`$ git pull https://git.openjdk.org/jdk pull/9519/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9519`

View PR using the GUI difftool: \
`$ git pr show -t 9519`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9519.diff">https://git.openjdk.org/jdk/pull/9519.diff</a>

</details>
