### PR TITLE
8285935: Spurious lint warning for static method accessed through instance qualifier

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4473,7 +4473,11 @@ public class Attr extends JCTree.Visitor {
                    sym.name != names._class) {
             // If the qualified item is not a type and the selected item is static, report
             // a warning. Make allowance for the class of an array type e.g. Object[].class)
-            chk.warnStatic(tree, Warnings.StaticNotQualifiedByType(sym.kind.kindName(), sym.owner));
+            if (!sym.owner.isAnonymous()) {
+                chk.warnStatic(tree, Warnings.StaticNotQualifiedByType(sym.kind.kindName(), sym.owner));
+            } else {
+                chk.warnStatic(tree, Warnings.StaticNotQualifiedByType2(sym.kind.kindName()));
+            }
         }
 
         // If we are selecting an instance member via a `super', ...

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -2012,7 +2012,7 @@ compiler.warn.static.not.qualified.by.type=\
 
 # 0: kind name
 compiler.warn.static.not.qualified.by.type2=\
-    static {0} should not be qualified as a member of an anonymous class
+    static {0} should not be used as a member of an anonymous class
 
 # 0: string
 compiler.warn.source.no.bootclasspath=\

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -2010,6 +2010,10 @@ compiler.warn.big.major.version=\
 compiler.warn.static.not.qualified.by.type=\
     static {0} should be qualified by type name, {1}, instead of by an expression
 
+# 0: kind name
+compiler.warn.static.not.qualified.by.type2=\
+    static {0} should not be qualified as a member of an anonymous class
+
 # 0: string
 compiler.warn.source.no.bootclasspath=\
     bootstrap class path not set in conjunction with -source {0}

--- a/test/langtools/tools/javac/4880220/T4880220.error.out
+++ b/test/langtools/tools/javac/4880220/T4880220.error.out
@@ -4,6 +4,8 @@ T4880220.java:22:27: compiler.warn.static.not.qualified.by.type: kindname.variab
 T4880220.java:24:29: compiler.warn.static.not.qualified.by.type: kindname.method, T4880220.C
 T4880220.java:25:29: compiler.warn.static.not.qualified.by.type: kindname.variable, T4880220.C
 T4880220.java:26:29: compiler.warn.static.not.qualified.by.type: kindname.variable, T4880220.C
+T4880220.java:39:12: compiler.warn.static.not.qualified.by.type2: kindname.method
+T4880220.java:40:20: compiler.warn.static.not.qualified.by.type2: kindname.variable
 - compiler.err.warnings.and.werror
 1 error
-6 warnings
+8 warnings

--- a/test/langtools/tools/javac/4880220/T4880220.java
+++ b/test/langtools/tools/javac/4880220/T4880220.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 4880220
+ * @bug 4880220 8285935
  * @summary Add a warning when accessing a static method via an reference
  *
  * @compile/ref=T4880220.empty.out                                                   T4880220.java
@@ -29,6 +29,15 @@ public class T4880220 {
     void m2() {
         Class<?> good_1 = C.class;
         Class<?> good_2 = C[].class;
+    }
+
+    void m3() {
+        var obj = new Object() {
+            static void foo() {}
+            static int i = 0;
+        };
+        obj.foo();
+        int j = obj.i;
     }
 
     C c() {

--- a/test/langtools/tools/javac/4880220/T4880220.warn.out
+++ b/test/langtools/tools/javac/4880220/T4880220.warn.out
@@ -4,4 +4,6 @@ T4880220.java:22:27: compiler.warn.static.not.qualified.by.type: kindname.variab
 T4880220.java:24:29: compiler.warn.static.not.qualified.by.type: kindname.method, T4880220.C
 T4880220.java:25:29: compiler.warn.static.not.qualified.by.type: kindname.variable, T4880220.C
 T4880220.java:26:29: compiler.warn.static.not.qualified.by.type: kindname.variable, T4880220.C
-6 warnings
+T4880220.java:39:12: compiler.warn.static.not.qualified.by.type2: kindname.method
+T4880220.java:40:20: compiler.warn.static.not.qualified.by.type2: kindname.variable
+8 warnings

--- a/test/langtools/tools/javac/diags/examples/StaticNotQualifiedByType.java
+++ b/test/langtools/tools/javac/diags/examples/StaticNotQualifiedByType.java
@@ -22,11 +22,19 @@
  */
 
 // key: compiler.warn.static.not.qualified.by.type
+// key: compiler.warn.static.not.qualified.by.type2
 // options: -Xlint:static
 
 class StaticNotQualifiedByType {
     int m(Other other) {
         return other.i;
+    }
+
+    void m2() {
+        var obj = new Object() {
+            static void foo() {}
+        };
+        obj.foo();
     }
 }
 


### PR DESCRIPTION
Please review this simple fix which is adding a more precise, I hope, warning for the case when a static method or field is being accessed using an anonymous class instance.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285935](https://bugs.openjdk.org/browse/JDK-8285935): Spurious lint warning for static method accessed through instance qualifier


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9521/head:pull/9521` \
`$ git checkout pull/9521`

Update a local copy of the PR: \
`$ git checkout pull/9521` \
`$ git pull https://git.openjdk.org/jdk pull/9521/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9521`

View PR using the GUI difftool: \
`$ git pr show -t 9521`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9521.diff">https://git.openjdk.org/jdk/pull/9521.diff</a>

</details>
