### PR TITLE
8290391: Reduce runtime of java.util package microbenchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/java/util/ArraysEquals.java
+++ b/test/micro/org/openjdk/bench/java/util/ArraysEquals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,10 +24,13 @@ package org.openjdk.bench.java.util;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -38,6 +41,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2)
+@Measurement(iterations = 4, time = 2)
+@Fork(value = 3)
 public class ArraysEquals {
 
     public char[] testCharArray1 = "1234567890123456789012345678901234567890123456789012345678901234567890123456789a".toCharArray();

--- a/test/micro/org/openjdk/bench/java/util/ArraysFill.java
+++ b/test/micro/org/openjdk/bench/java/util/ArraysFill.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@ package org.openjdk.bench.java.util;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -39,6 +40,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2)
+@Measurement(iterations = 4, time = 2)
+@Fork(value = 3)
 public class ArraysFill {
 
     @Param({"10", "16", "31", "59", "89", "126", "250", "266", "511", "1021", "2047", "2048", "4095", "8195"})
@@ -65,50 +69,36 @@ public class ArraysFill {
     }
 
     @Benchmark
-    @Warmup(iterations = 3)
-    @Measurement(iterations = 3)
     public void testCharFill() {
         Arrays.fill(testCharArray, (char) -1);
     }
 
     @Benchmark
-    @Warmup(iterations = 3)
-    @Measurement(iterations = 3)
     public void testByteFill() {
         Arrays.fill(testByteArray, (byte) -1);
     }
 
     @Benchmark
-    @Warmup(iterations = 3)
-    @Measurement(iterations = 3)
     public void testShortFill() {
         Arrays.fill(testShortArray, (short) -1);
     }
 
     @Benchmark
-    @Warmup(iterations = 3)
-    @Measurement(iterations = 3)
     public void testIntFill() {
         Arrays.fill(testIntArray, -1);
     }
 
     @Benchmark
-    @Warmup(iterations = 3)
-    @Measurement(iterations = 3)
     public void testLongFill() {
         Arrays.fill(testLongArray, -1);
     }
 
     @Benchmark
-    @Warmup(iterations = 3)
-    @Measurement(iterations = 3)
     public void testFloatFill() {
         Arrays.fill(testFloatArray, (float) -1.0);
     }
 
     @Benchmark
-    @Warmup(iterations = 3)
-    @Measurement(iterations = 3)
     public void testDoubleFill() {
         Arrays.fill(testDoubleArray, -1.0);
     }

--- a/test/micro/org/openjdk/bench/java/util/ArraysFill.java
+++ b/test/micro/org/openjdk/bench/java/util/ArraysFill.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 @Fork(value = 3)
 public class ArraysFill {
 
-    @Param({"10", "16", "31", "59", "89", "126", "250", "266", "511", "1021", "2047", "2048", "4095", "8195"})
+    @Param({"16", "31", "250", "266", "511", "2047", "2048", "8195"})
     public int size;
 
     public byte[] testByteArray;

--- a/test/micro/org/openjdk/bench/java/util/ArraysMismatch.java
+++ b/test/micro/org/openjdk/bench/java/util/ArraysMismatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -45,6 +46,9 @@ import org.openjdk.jmh.annotations.Warmup;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2)
+@Measurement(iterations = 4, time = 2)
+@Fork(value = 3)
 public abstract class ArraysMismatch {
 
     @Param({"90", "800"})
@@ -90,36 +94,26 @@ public abstract class ArraysMismatch {
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int matches() {
             return Arrays.mismatch(left, right_matches);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int differentSubrangeMatches() {
             return Arrays.mismatch(left, leftStartRange, leftEndRange, right_matches, rightStartRange, rightEndRange);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchEnd() {
             return Arrays.mismatch(left, right_endMismatch);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchMid() {
             return Arrays.mismatch(left, right_midMismatch);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchStart() {
             return Arrays.mismatch(left, right_startMismatch);
         }
@@ -146,36 +140,26 @@ public abstract class ArraysMismatch {
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int matches() {
             return Arrays.mismatch(left, right_matches);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int differentSubrangeMatches() {
             return Arrays.mismatch(left, leftStartRange, leftEndRange, right_matches, rightStartRange, rightEndRange);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchEnd() {
             return Arrays.mismatch(left, right_endMismatch);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchMid() {
             return Arrays.mismatch(left, right_midMismatch);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchStart() {
             return Arrays.mismatch(left, right_startMismatch);
         }
@@ -202,36 +186,26 @@ public abstract class ArraysMismatch {
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int matches() {
             return Arrays.mismatch(left, right_matches);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int differentSubrangeMatches() {
             return Arrays.mismatch(left, leftStartRange, leftEndRange, right_matches, rightStartRange, rightEndRange);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchEnd() {
             return Arrays.mismatch(left, right_endMismatch);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchMid() {
             return Arrays.mismatch(left, right_midMismatch);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchStart() {
             return Arrays.mismatch(left, right_startMismatch);
         }
@@ -258,36 +232,26 @@ public abstract class ArraysMismatch {
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int matches() {
             return Arrays.mismatch(left, right_matches);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int differentSubrangeMatches() {
             return Arrays.mismatch(left, leftStartRange, leftEndRange, right_matches, rightStartRange, rightEndRange);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchEnd() {
             return Arrays.mismatch(left, right_endMismatch);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchMid() {
             return Arrays.mismatch(left, right_midMismatch);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchStart() {
             return Arrays.mismatch(left, right_startMismatch);
         }
@@ -314,36 +278,26 @@ public abstract class ArraysMismatch {
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int matches() {
             return Arrays.mismatch(left, right_matches);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int differentSubrangeMatches() {
             return Arrays.mismatch(left, leftStartRange, leftEndRange, right_matches, rightStartRange, rightEndRange);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchEnd() {
             return Arrays.mismatch(left, right_endMismatch);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchMid() {
             return Arrays.mismatch(left, right_midMismatch);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchStart() {
             return Arrays.mismatch(left, right_startMismatch);
         }
@@ -370,36 +324,26 @@ public abstract class ArraysMismatch {
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int matches() {
             return Arrays.mismatch(left, right_matches);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int differentSubrangeMatches() {
             return Arrays.mismatch(left, leftStartRange, leftEndRange, right_matches, rightStartRange, rightEndRange);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchEnd() {
             return Arrays.mismatch(left, right_endMismatch);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchMid() {
             return Arrays.mismatch(left, right_midMismatch);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchStart() {
             return Arrays.mismatch(left, right_startMismatch);
         }
@@ -426,36 +370,26 @@ public abstract class ArraysMismatch {
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int matches() {
             return Arrays.mismatch(left, right_matches);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int differentSubrangeMatches() {
             return Arrays.mismatch(left, leftStartRange, leftEndRange, right_matches, rightStartRange, rightEndRange);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchEnd() {
             return Arrays.mismatch(left, right_endMismatch);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchMid() {
             return Arrays.mismatch(left, right_midMismatch);
         }
 
         @Benchmark
-        @Warmup(iterations = 3)
-        @Measurement(iterations = 3)
         public int mismatchStart() {
             return Arrays.mismatch(left, right_startMismatch);
         }

--- a/test/micro/org/openjdk/bench/java/util/ArraysMismatchPartialInlining.java
+++ b/test/micro/org/openjdk/bench/java/util/ArraysMismatchPartialInlining.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -38,6 +39,9 @@ import org.openjdk.jmh.annotations.Warmup;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2)
+@Measurement(iterations = 4, time = 2)
+@Fork(value = 3)
 public class ArraysMismatchPartialInlining {
 
     @Param({"3", "4", "5", "6", "7", "15", "31", "63", "95", "800"})

--- a/test/micro/org/openjdk/bench/java/util/ArraysMismatchPartialInlining.java
+++ b/test/micro/org/openjdk/bench/java/util/ArraysMismatchPartialInlining.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, cle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Fork(value = 3)
 public class ArraysMismatchPartialInlining {
 
-    @Param({"3", "4", "5", "6", "7", "15", "31", "63", "95", "800"})
+    @Param({"3", "7", "15", "31", "63", "95", "800"})
     private static int size;
 
     byte [] barray1;

--- a/test/micro/org/openjdk/bench/java/util/Base64Decode.java
+++ b/test/micro/org/openjdk/bench/java/util/Base64Decode.java
@@ -34,6 +34,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2)
+@Measurement(iterations = 4, time = 2)
+@Fork(value = 3)
 public class Base64Decode {
 
     private Base64.Encoder encoder, mimeEncoder;

--- a/test/micro/org/openjdk/bench/java/util/Base64Encode.java
+++ b/test/micro/org/openjdk/bench/java/util/Base64Encode.java
@@ -34,6 +34,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2)
+@Measurement(iterations = 4, time = 2)
+@Fork(value = 3)
 public class Base64Encode {
 
     private Base64.Encoder encoder;

--- a/test/micro/org/openjdk/bench/java/util/Base64VarLenDecode.java
+++ b/test/micro/org/openjdk/bench/java/util/Base64VarLenDecode.java
@@ -34,6 +34,9 @@ package org.openjdk.micro.bench.java.util;
 import org.openjdk.jmh.annotations.*;
 import java.util.*;
 
+@Warmup(iterations = 4, time = 2)
+@Measurement(iterations = 4, time = 2)
+@Fork(value = 3)
 public class Base64VarLenDecode {
 
     @State(Scope.Thread)
@@ -84,9 +87,6 @@ public class Base64VarLenDecode {
     }
 
     @Benchmark
-    @Warmup(iterations = 4, time = 2)
-    @Measurement(iterations = 4, time = 2)
-    @Fork(value = 3)
     public void decodeMethod(MyState state) {
        state.decoder.decode(state.encoded, state.decoded);
     }

--- a/test/micro/org/openjdk/bench/java/util/Base64VarLenDecode.java
+++ b/test/micro/org/openjdk/bench/java/util/Base64VarLenDecode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle America, Inc.
+ * Copyright (c) 2020, 2022, Oracle America, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,7 +44,6 @@ public class Base64VarLenDecode {
             ran = new Random(10101); // fixed seed for repeatability
             encoder = Base64.getEncoder();
             decoder = Base64.getDecoder();
-            System.out.println("Do Trial Setup");
         }
 
         @Setup(Level.Invocation)
@@ -85,6 +84,9 @@ public class Base64VarLenDecode {
     }
 
     @Benchmark
+    @Warmup(iterations = 4, time = 2)
+    @Measurement(iterations = 4, time = 2)
+    @Fork(value = 3)
     public void decodeMethod(MyState state) {
        state.decoder.decode(state.encoded, state.decoded);
     }

--- a/test/micro/org/openjdk/bench/java/util/Dates.java
+++ b/test/micro/org/openjdk/bench/java/util/Dates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,10 +24,13 @@ package org.openjdk.bench.java.util;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
@@ -35,6 +38,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2)
+@Measurement(iterations = 4, time = 2)
+@Fork(value = 3)
 public class Dates {
 
     int year = 75;

--- a/test/micro/org/openjdk/bench/java/util/GregorianCalendars.java
+++ b/test/micro/org/openjdk/bench/java/util/GregorianCalendars.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.util;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.Calendar;
 import java.util.GregorianCalendar;
@@ -37,6 +40,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2)
+@Measurement(iterations = 4, time = 2)
+@Fork(value = 3)
 public class GregorianCalendars {
 
     private Calendar calendar;

--- a/test/micro/org/openjdk/bench/java/util/HashMapBench.java
+++ b/test/micro/org/openjdk/bench/java/util/HashMapBench.java
@@ -25,12 +25,15 @@ package org.openjdk.bench.java.util;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -45,6 +48,9 @@ import static java.util.stream.Collectors.toMap;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2)
+@Measurement(iterations = 4, time = 2)
+@Fork(value = 3)
 public class HashMapBench {
     private Supplier<Map<Integer, Integer>> mapSupplier;
     private Map<Integer, Integer> bigMapToAdd;

--- a/test/micro/org/openjdk/bench/java/util/LocaleDefaults.java
+++ b/test/micro/org/openjdk/bench/java/util/LocaleDefaults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,10 +24,13 @@ package org.openjdk.bench.java.util;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -38,6 +41,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 4, time = 2)
+@Measurement(iterations = 4, time = 2)
+@Fork(value = 3)
 public class LocaleDefaults {
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/util/RandomGeneratorNext.java
+++ b/test/micro/org/openjdk/bench/java/util/RandomGeneratorNext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,12 +24,16 @@ package org.openjdk.bench.java.util;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Warmup;
+
 import java.util.random.RandomGenerator;
 import java.util.random.RandomGeneratorFactory;
 import java.util.concurrent.TimeUnit;
@@ -40,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2)
+@Measurement(iterations = 4, time = 2)
+@Fork(value = 3)
 public class RandomGeneratorNext {
 
     RandomGenerator randomGenerator;

--- a/test/micro/org/openjdk/bench/java/util/RandomNext.java
+++ b/test/micro/org/openjdk/bench/java/util/RandomNext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.util;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +42,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2)
+@Measurement(iterations = 4, time = 2)
+@Fork(value = 3)
 public class RandomNext {
 
     public Random rnd;

--- a/test/micro/org/openjdk/bench/java/util/TestAdler32.java
+++ b/test/micro/org/openjdk/bench/java/util/TestAdler32.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ public class TestAdler32 {
     private Random random;
     private byte[] bytes;
 
-    @Param({"64", "128", "256", "512", "1024", "2048", "4096", "8192", "16384", "32768", "65536"})
+    @Param({"64", "128", "256", "512", /* "1024", */ "2048", /* "4096", "8192", */ "16384", /* "32768", */ "65536"})
     private int count;
 
     public TestAdler32() {

--- a/test/micro/org/openjdk/bench/java/util/TestCRC32C.java
+++ b/test/micro/org/openjdk/bench/java/util/TestCRC32C.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,15 +30,16 @@ import org.openjdk.jmh.annotations.*;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
-@Fork(value = 2)
-
+@Warmup(iterations = 4, time = 2)
+@Measurement(iterations = 4, time = 2)
+@Fork(value = 3)
 public class TestCRC32C {
 
     private CRC32C crc32c;
     private Random random;
     private byte[] bytes;
 
-    @Param({"64", "128", "256", "512", "1024", "2048", "4096", "8192", "16384", "32768", "65536"})
+    @Param({"64", "128", "256", "512", /* "1024", */ "2048", /* "4096", "8192", */ "16384", /* "32768", */ "65536"})
     private int count;
 
     public TestCRC32C() {

--- a/test/micro/org/openjdk/bench/java/util/ZipFind.java
+++ b/test/micro/org/openjdk/bench/java/util/ZipFind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.io.IOException;
@@ -44,6 +47,9 @@ import java.util.zip.ZipFile;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2)
+@Measurement(iterations = 4, time = 2)
+@Fork(value = 3)
 public class ZipFind {
 
     // Files that exist in the microbenchmarks.jar zip file


### PR DESCRIPTION
Adds Warmup, Measurement and Fork annotations to reduce the run time from 1 day 16 hours to 8 hours for this set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290391](https://bugs.openjdk.org/browse/JDK-8290391): Reduce runtime of java.util package microbenchmarks


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to [8d71eb4e](https://git.openjdk.org/jdk/pull/9523/files/8d71eb4eef0324592aa6a89bf45858e0906750da)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to [8d71eb4e](https://git.openjdk.org/jdk/pull/9523/files/8d71eb4eef0324592aa6a89bf45858e0906750da)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9523/head:pull/9523` \
`$ git checkout pull/9523`

Update a local copy of the PR: \
`$ git checkout pull/9523` \
`$ git pull https://git.openjdk.org/jdk pull/9523/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9523`

View PR using the GUI difftool: \
`$ git pr show -t 9523`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9523.diff">https://git.openjdk.org/jdk/pull/9523.diff</a>

</details>
