### PR TITLE
remove redundant if-condition after readLine()

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/Request.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/Request.java
@@ -50,9 +50,6 @@ class Request {
         os = rawout;
         do {
             startLine = readLine();
-            if (startLine == null) {
-                return;
-            }
             /* skip blank lines */
         } while (startLine == null ? false : startLine.equals (""));
     }


### PR DESCRIPTION
The condition at line 57 (after `while`) will evaluate to `false` if `startLine == null`, so the previous if-condition is covered.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9528/head:pull/9528` \
`$ git checkout pull/9528`

Update a local copy of the PR: \
`$ git checkout pull/9528` \
`$ git pull https://git.openjdk.org/jdk pull/9528/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9528`

View PR using the GUI difftool: \
`$ git pr show -t 9528`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9528.diff">https://git.openjdk.org/jdk/pull/9528.diff</a>

</details>
