### PR TITLE
8290398: jpackage exe installers are not installed in jtreg tests

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
@@ -414,7 +414,26 @@ public final class PackageTest extends RunnablePackageTest {
                     terminated = true;
                 }
 
-                if (aborted) {
+                boolean skip = false;
+
+                if (unhandledAction != null) {
+                    switch (unhandledAction) {
+                        case CREATE:
+                            skip = true;
+                            break;
+                        case UNPACK:
+                        case INSTALL:
+                            skip = (action == Action.VERIFY_INSTALL);
+                            break;
+                        case UNINSTALL:
+                            skip = (action == Action.VERIFY_UNINSTALL);
+                            break;
+                    }
+                }
+
+                if (skip) {
+                    TKit.trace(String.format("Skip [%s] action of %s command",
+                            action, cmd.getPrintableCommandLine()));
                     return;
                 }
 
@@ -429,38 +448,44 @@ public final class PackageTest extends RunnablePackageTest {
                 switch (action) {
                     case UNPACK: {
                         cmd.setUnpackedPackageLocation(null);
-                        var handler = packageHandlers.get(type).unpackHandler;
-                        if (!(aborted = (handler == null))) {
-                            unpackDir = TKit.createTempDirectory(
+                        handleAction(action,
+                                packageHandlers.get(type).unpackHandler,
+                                handler -> {
+                                    unpackDir = TKit.createTempDirectory(
                                             String.format("unpacked-%s",
                                                     type.getName()));
-                            unpackDir = handler.apply(cmd, unpackDir);
-                            cmd.setUnpackedPackageLocation(unpackDir);
-                        }
+                                    unpackDir = handler.apply(cmd, unpackDir);
+                                    cmd.setUnpackedPackageLocation(unpackDir);
+                                });
                         break;
                     }
 
                     case INSTALL: {
                         cmd.setUnpackedPackageLocation(null);
-                        var handler = packageHandlers.get(type).installHandler;
-                        if (!(aborted = (handler == null))) {
-                            handler.accept(curCmd.get());
-                        }
+                        handleAction(action,
+                                packageHandlers.get(type).installHandler,
+                                handler -> {
+                                    handler.accept(curCmd.get());
+                                });
                         break;
                     }
 
                     case UNINSTALL: {
-                        var handler = packageHandlers.get(type).uninstallHandler;
-                        if (!(aborted = (handler == null))) {
-                            handler.accept(curCmd.get());
-                        }
+                        handleAction(action,
+                                packageHandlers.get(type).uninstallHandler,
+                                handler -> {
+                                    handler.accept(curCmd.get());
+                                });
                         break;
                     }
 
                     case CREATE:
                         cmd.setUnpackedPackageLocation(null);
                         handler.accept(action, curCmd.get());
-                        aborted = (expectedJPackageExitCode != 0);
+                        handleAction(action,
+                                (expectedJPackageExitCode == 0) ? Boolean.TRUE : null,
+                                handler -> {
+                                });
                         return;
 
                     default:
@@ -468,15 +493,25 @@ public final class PackageTest extends RunnablePackageTest {
                         break;
                 }
 
-                if (aborted) {
-                    TKit.trace(
-                            String.format("Aborted [%s] action of %s command",
-                                    action, cmd.getPrintableCommandLine()));
+                Optional.ofNullable(unhandledAction).ifPresent(v -> {
+                    TKit.trace(String.format(
+                            "No handler of [%s] action for %s command", v,
+                            cmd.getPrintableCommandLine()));
+                });
+            }
+
+            private <T> void handleAction(Action action, T handler,
+                    ThrowingConsumer<T> consumer) throws Throwable {
+                if (handler == null) {
+                    unhandledAction = action;
+                } else {
+                    unhandledAction = null;
+                    consumer.accept(handler);
                 }
             }
 
             private Path unpackDir;
-            private boolean aborted;
+            private Action unhandledAction;
             private boolean terminated;
             private final JPackageCommand cmd = Functional.identity(() -> {
                 JPackageCommand result = new JPackageCommand();


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290398](https://bugs.openjdk.org/browse/JDK-8290398): jpackage exe installers are not installed in jtreg tests


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9530/head:pull/9530` \
`$ git checkout pull/9530`

Update a local copy of the PR: \
`$ git checkout pull/9530` \
`$ git pull https://git.openjdk.org/jdk pull/9530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9530`

View PR using the GUI difftool: \
`$ git pr show -t 9530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9530.diff">https://git.openjdk.org/jdk/pull/9530.diff</a>

</details>
