### PR TITLE
8290400: Must run exe installers in jpackage jtreg tests without UI

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
@@ -132,7 +132,9 @@ public class WindowsHelper {
         BiConsumer<JPackageCommand, Boolean> installExe = (cmd, install) -> {
             cmd.verifyIsOfType(PackageType.WIN_EXE);
             Executor exec = new Executor().setExecutable(cmd.outputBundle());
-            if (!install) {
+            if (install) {
+                exec.addArgument("/qn").addArgument("/norestart");
+            } else {
                 exec.addArgument("uninstall");
             }
             runMsiexecWithRetries(exec);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290400](https://bugs.openjdk.org/browse/JDK-8290400): Must run exe installers in jpackage jtreg tests without UI


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9531/head:pull/9531` \
`$ git checkout pull/9531`

Update a local copy of the PR: \
`$ git checkout pull/9531` \
`$ git pull https://git.openjdk.org/jdk pull/9531/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9531`

View PR using the GUI difftool: \
`$ git pr show -t 9531`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9531.diff">https://git.openjdk.org/jdk/pull/9531.diff</a>

</details>
