### PR TITLE
8290402: jpackage exe uninstallers don't return correct exit code in case of failure

### DIFF
--- a/src/jdk.jpackage/windows/native/msiwrapper/MsiWrapper.cpp
+++ b/src/jdk.jpackage/windows/native/msiwrapper/MsiWrapper.cpp
@@ -50,8 +50,9 @@ void launchApp() {
                 (const char*)productCodeUtf8.data(), productCodeUtf8.size()));
 
         // Uninstall product.
-        msi::uninstall().setProductCode(productCode)();
-        exitCode = 0;
+        msi::SuppressUI suppressUI;
+        exitCode = (int)msi::uninstall().setProductCode(productCode)(
+                                                    std::nothrow).getValue();
         return;
     }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290402](https://bugs.openjdk.org/browse/JDK-8290402): jpackage exe uninstallers don't return correct exit code in case of failure


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9532/head:pull/9532` \
`$ git checkout pull/9532`

Update a local copy of the PR: \
`$ git checkout pull/9532` \
`$ git pull https://git.openjdk.org/jdk pull/9532/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9532`

View PR using the GUI difftool: \
`$ git pr show -t 9532`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9532.diff">https://git.openjdk.org/jdk/pull/9532.diff</a>

</details>
