### PR TITLE
8283276: java/io/ObjectStreamClass/ObjectStreamClassCaching.java fails with various GCs

### DIFF
--- a/test/jdk/java/io/ObjectStreamClass/ObjectStreamClassCaching.java
+++ b/test/jdk/java/io/ObjectStreamClass/ObjectStreamClassCaching.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,6 @@ public class ObjectStreamClassCaching {
     @Test
     public void testCachingEffectiveness() throws Exception {
         var ref = lookupObjectStreamClass(TestClass.class);
-        System.gc();
         Thread.sleep(100L);
         // to trigger any ReferenceQueue processing...
         lookupObjectStreamClass(AnotherTestClass.class);


### PR DESCRIPTION
Test appears to pass fine with G1. But it fails with other GCs, for example Parallel, Shenandoah, etc, it fails:

```
$ CONF=linux-x86_64-server-fastdebug make test TEST=java/io/ObjectStreamClass/ObjectStreamClassCaching.java TEST_VM_OPTS="-XX:+UseParallelGC"

test ObjectStreamClassCaching.testCacheReleaseUnderMemoryPressure(): success
test ObjectStreamClassCaching.testCachingEffectiveness(): failure
java.lang.AssertionError: Cache lost entry although memory was not under pressure expected [false] but found [true]
	at org.testng.Assert.fail(Assert.java:99)
	at org.testng.Assert.failNotEquals(Assert.java:1037)
	at org.testng.Assert.assertFalse(Assert.java:67)
```

I believe this is because `System.gc()` is not that reliable about what happens with weak references. As seen with other GCs, they can clear the weakrefs on Full GC. In fact, the test fails with G1 if we do a second System.gc() in this test. So the test itself is flaky. The fix is to avoid doing `System.gc()` altogether in that subtest. The test is still retained to see that reference is not cleared for a while.

Additional testing:
 - [x] Linux x86_64 fastdebug, affected test with `-XX:+UseSerialGC`, 100 repetitions
 - [x] Linux x86_64 fastdebug, affected test with `-XX:+UseParallelGC`, 100 repetitions
 - [x] Linux x86_64 fastdebug, affected test with `-XX:+UseG1GC`, 100 repetitions
 - [x] Linux x86_64 fastdebug, affected test with `-XX:+UseShenandoahGC`, 100 repetitions
 - [x] Linux x86_64 fastdebug, affected test with `-XX:+UseZGC`, 100 repetitions

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283276](https://bugs.openjdk.org/browse/JDK-8283276): java/io/ObjectStreamClass/ObjectStreamClassCaching.java fails with various GCs


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9533/head:pull/9533` \
`$ git checkout pull/9533`

Update a local copy of the PR: \
`$ git checkout pull/9533` \
`$ git pull https://git.openjdk.org/jdk pull/9533/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9533`

View PR using the GUI difftool: \
`$ git pr show -t 9533`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9533.diff">https://git.openjdk.org/jdk/pull/9533.diff</a>

</details>
