### PR TITLE
6463708: DefaultButtonModel.setMnemonic generates ChangeEvent for no change

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/DefaultButtonModel.java
+++ b/src/java.desktop/share/classes/javax/swing/DefaultButtonModel.java
@@ -290,8 +290,10 @@ public class DefaultButtonModel implements ButtonModel, Serializable {
      * {@inheritDoc}
      */
     public void setMnemonic(int key) {
-        mnemonic = key;
-        fireStateChanged();
+        if (this.mnemonic != key) {
+            this.mnemonic = key;
+            fireStateChanged();
+        }
     }
 
     /**

--- a/test/jdk/javax/swing/DefaultButtonModel/TestMnemonicEvent.java
+++ b/test/jdk/javax/swing/DefaultButtonModel/TestMnemonicEvent.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* 
+ * @test
+ * @bug 6463708
+ * @summary Verifies if DefaultButtonModel.setMnemonic
+ *          generates ChangeEvent for no change
+ * @run main TestMnemonicEvent
+ */
+
+import javax.swing.DefaultButtonModel;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
+public class TestMnemonicEvent implements ChangeListener {
+
+    private static ChangeEvent lastEvent;
+  
+    public void stateChanged(ChangeEvent e) {
+        lastEvent = e;
+    }
+  
+    public static void main(String[] args) {
+        TestMnemonicEvent test = new TestMnemonicEvent();	    
+        DefaultButtonModel m = new DefaultButtonModel();
+        m.addChangeListener(test);
+        m.setMnemonic(70);
+        System.out.println("Event triggered: " + (lastEvent != null));
+    
+        // clear the recorded event, set the same mnemonic then check if another
+        // event is triggered...
+        lastEvent = null;
+        m.setMnemonic(70);
+        System.out.println("Event triggered: " + (lastEvent != null));
+        if (lastEvent != null) {
+            throw new RuntimeException("ChangeEvent triggered for same mnemonic");
+        }
+    }
+}

--- a/test/jdk/javax/swing/DefaultButtonModel/TestMnemonicEvent.java
+++ b/test/jdk/javax/swing/DefaultButtonModel/TestMnemonicEvent.java
@@ -36,11 +36,11 @@ import javax.swing.event.ChangeListener;
 public class TestMnemonicEvent implements ChangeListener {
 
     private static ChangeEvent lastEvent;
- 
+
     public void stateChanged(ChangeEvent e) {
         lastEvent = e;
     }
- 
+
     public static void main(String[] args) {
         TestMnemonicEvent test = new TestMnemonicEvent();
         DefaultButtonModel m = new DefaultButtonModel();

--- a/test/jdk/javax/swing/DefaultButtonModel/TestMnemonicEvent.java
+++ b/test/jdk/javax/swing/DefaultButtonModel/TestMnemonicEvent.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/* 
+/*
  * @test
  * @bug 6463708
  * @summary Verifies if DefaultButtonModel.setMnemonic
@@ -36,18 +36,18 @@ import javax.swing.event.ChangeListener;
 public class TestMnemonicEvent implements ChangeListener {
 
     private static ChangeEvent lastEvent;
-  
+ 
     public void stateChanged(ChangeEvent e) {
         lastEvent = e;
     }
-  
+ 
     public static void main(String[] args) {
-        TestMnemonicEvent test = new TestMnemonicEvent();	    
+        TestMnemonicEvent test = new TestMnemonicEvent();
         DefaultButtonModel m = new DefaultButtonModel();
         m.addChangeListener(test);
         m.setMnemonic(70);
         System.out.println("Event triggered: " + (lastEvent != null));
-    
+
         // clear the recorded event, set the same mnemonic then check if another
         // event is triggered...
         lastEvent = null;


### PR DESCRIPTION
For a DefaultButtonModel, setMnemonic() generates a ChangeEvent even if the new value is the same as the old value (that is, even if nothing has changed). 
Fix is to fire StateChange event only if the value has changed. 

This is consistent with other places like 
https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/javax/swing/colorchooser/DefaultColorSelectionModel.java#L103
https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/javax/swing/DefaultSingleSelectionModel.java#L79
https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/javax/swing/DefaultBoundedRangeModel.java#L309

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6463708](https://bugs.openjdk.org/browse/JDK-6463708): DefaultButtonModel.setMnemonic generates ChangeEvent for no change


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9536/head:pull/9536` \
`$ git checkout pull/9536`

Update a local copy of the PR: \
`$ git checkout pull/9536` \
`$ git pull https://git.openjdk.org/jdk pull/9536/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9536`

View PR using the GUI difftool: \
`$ git pr show -t 9536`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9536.diff">https://git.openjdk.org/jdk/pull/9536.diff</a>

</details>
