### PR TITLE
JDK-8290460: Alpine: disable some panama tests that rely on std::thread

### DIFF
--- a/test/jdk/java/foreign/TestUpcallAsync.java
+++ b/test/jdk/java/foreign/TestUpcallAsync.java
@@ -25,6 +25,7 @@
  * @test
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @requires !vm.musl
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
  * @run testng/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies

--- a/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccess.java
+++ b/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccess.java
@@ -25,6 +25,8 @@
  * @test
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @requires !vm.musl
+ *
  * @library /test/lib
  * @build TestEnableNativeAccess
  *        panama_module/*


### PR DESCRIPTION
Until [JDK-8290059](https://bugs.openjdk.org/browse/JDK-8290059) is solved, I'd like to disable

- java/foreign/TestUpcallAsync.java
- java/foreign/enablenativeaccess/TestEnableNativeAccess.java

on muslc to take load from our CIs.

Tests: tested locally that the tests are excluded on Alpine, and remain active on other platforms.