### PR TITLE
JDK-8282434: Leading combining diacritic character in string renders incorrectly

### DIFF
--- a/test/langtools/jdk/jshell/SimpleRegressionTest.java
+++ b/test/langtools/jdk/jshell/SimpleRegressionTest.java
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test 8130450 8158906 8154374 8166400 8171892 8173807 8173848
+ * @test 8130450 8158906 8154374 8166400 8171892 8173807 8173848 8282434
  * @summary simple regression test
  * @build KullaTesting TestingInputStream
  * @run testng SimpleRegressionTest
@@ -207,6 +207,10 @@ public class SimpleRegressionTest extends KullaTesting {
                    "\"\"");
         assertEval("(String)null",
                    "null");
+        assertEval("\"\\u032Ea\"",
+                   "\"\\u032Ea\"");
+        assertEval("\"a\\u032Ea\"",
+                   "\"a\u032Ea\"");
     }
 
     public void testCharRepresentation() {
@@ -222,5 +226,7 @@ public class SimpleRegressionTest extends KullaTesting {
                 "'\\035'");
         assertEval("\"a\\bb\\tc\\nd\\fe\\rf\\\"g'\\\\h\".charAt(1)",
                 "'\\b'");
+        assertEval("\"\\u032E\".charAt(0)",
+                "'\\u032E'");
     }
 }


### PR DESCRIPTION
There's a group of characters, that add diacritics to the preceding character. JShell wraps String values into double quotes, and so when such a combining character is the first character of a string, there is a double quote followed by the diacritics. On some terminals, it may print the diacritics merged with the double quote.

Sadly, the behavior seems to differ much between terminals, so the proposal here is to use Unicode escape sequences for these characters when they would immediately follow the opening double quote. Sample output:
$1 ==> "\u032Ea"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282434](https://bugs.openjdk.org/browse/JDK-8282434): Leading combining diacritic character in string renders incorrectly


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9540/head:pull/9540` \
`$ git checkout pull/9540`

Update a local copy of the PR: \
`$ git checkout pull/9540` \
`$ git pull https://git.openjdk.org/jdk pull/9540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9540`

View PR using the GUI difftool: \
`$ git pr show -t 9540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9540.diff">https://git.openjdk.org/jdk/pull/9540.diff</a>

</details>
