### PR TITLE
8290463: Fix several comment typos in sun.security.ec

### DIFF
--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
@@ -176,7 +176,7 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
         // (point of infinity).  However, the point of infinity has no
         // affine coordinates, although the point of infinity could
         // be encoded.  Per IEEE 1363.3-2013 (see section A.6.4.1),
-        // the point of inifinity is represented by a pair of
+        // the point of infinity is represented by a pair of
         // coordinates (x, y) not on the curve.  For EC prime finite
         // field (q = p^m), the point of infinity is (0, 0) unless
         // b = 0; in which case it is (0, 1).

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDSAOperations.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDSAOperations.java
@@ -114,7 +114,7 @@ public class ECDSAOperations {
      * @return the ECDSA signature value
      * @throws IntermediateValueException if the signature cannot be produced
      *      due to an unacceptable intermediate or final value. If this
-     *      exception is thrown, then the caller should discard the nonnce and
+     *      exception is thrown, then the caller should discard the nonce and
      *      try again with an entirely new nonce value.
      */
     public byte[] signDigest(byte[] privateKey, byte[] digest, Seed seed)
@@ -142,7 +142,7 @@ public class ECDSAOperations {
      * @return the ECDSA signature value
      * @throws IntermediateValueException if the signature cannot be produced
      *      due to an unacceptable intermediate or final value. If this
-     *      exception is thrown, then the caller should discard the nonnce and
+     *      exception is thrown, then the caller should discard the nonce and
      *      try again with an entirely new nonce value.
      */
     public byte[] signDigest(byte[] privateKey, byte[] digest, Nonce nonce)

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAParameters.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAParameters.java
@@ -85,7 +85,7 @@ public class EdDSAParameters {
             return new SHAKE256Digester(114);
         }
 
-        // Ed448 uses 64bytes long hasg for the signature message
+        // Ed448 uses 64bytes long hash for the signature message
         @Override
         public Digester createDigester(int len) {
             return new SHAKE256Digester(len);


### PR DESCRIPTION
inifinity -> infinity
nonnce -> nonce
hasg -> hash

Signed-off-by: Hollow Man <hollowman@opensuse.org>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290463](https://bugs.openjdk.org/browse/JDK-8290463): Fix several comment typos in sun.security.ec


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9541/head:pull/9541` \
`$ git checkout pull/9541`

Update a local copy of the PR: \
`$ git checkout pull/9541` \
`$ git pull https://git.openjdk.org/jdk pull/9541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9541`

View PR using the GUI difftool: \
`$ git pr show -t 9541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9541.diff">https://git.openjdk.org/jdk/pull/9541.diff</a>

</details>
