### PR TITLE
8290397: LoadLibraryUnload.java failed with "Too few cleared WeakReferences"

### DIFF
--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
@@ -166,7 +166,7 @@ public class LoadLibraryUnload {
         // before exiting the test.
         for (int i = 0; i < LOADER_COUNT; i++) {
             System.gc();
-            var res = refQueue.remove(Utils.adjustTimeout(5 * 1000L));
+            var res = refQueue.remove(Utils.adjustTimeout(30 * 1000L));
             System.out.println(i + " dequeued: " + res);
             if (res == null) {
                 Asserts.fail("Too few cleared WeakReferences");


### PR DESCRIPTION
When running with -Xcomp it seems the wait time for GC to  clear references is insufficient.
Extend timeout waiting for GC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290397](https://bugs.openjdk.org/browse/JDK-8290397): LoadLibraryUnload.java failed with "Too few cleared WeakReferences"


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9545/head:pull/9545` \
`$ git checkout pull/9545`

Update a local copy of the PR: \
`$ git checkout pull/9545` \
`$ git pull https://git.openjdk.org/jdk pull/9545/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9545`

View PR using the GUI difftool: \
`$ git pr show -t 9545`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9545.diff">https://git.openjdk.org/jdk/pull/9545.diff</a>

</details>
