### PR TITLE
8286844: com/sun/jdi/RedefineCrossEvent.java failed with 1 threads completed while VM suspended

### DIFF
--- a/test/jdk/com/sun/jdi/DebuggerThreadTest.java
+++ b/test/jdk/com/sun/jdi/DebuggerThreadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,6 @@ public class DebuggerThreadTest extends TestScaffold {
      * Move to top ThreadGroup and dump all threads.
      */
     public void dumpThreads() {
-        int finishedThreads = 0;
         ThreadGroup tg = Thread.currentThread().getThreadGroup();
         ThreadGroup parent = tg.getParent();
         while (parent != null) {
@@ -82,7 +81,6 @@ public class DebuggerThreadTest extends TestScaffold {
             String groupName;
             if (tga == null) {
                 groupName = "<completed>";
-                finishedThreads++ ;
             } else {
                 groupName = tga.getName();
             }
@@ -97,10 +95,6 @@ public class DebuggerThreadTest extends TestScaffold {
                 failure("FAIL: non-daemon thread '" + t.getName() +
                         "' found in ThreadGroup '" + groupName + "'");
             }
-        }
-        if (finishedThreads > 0 ) {
-            failure("FAIL: " + finishedThreads +
-                    " threads completed while VM suspended.");
         }
     }
 


### PR DESCRIPTION
The test verifies that JDI threads are daemon threads.
But enumerating threads at breakpoint it performs sanity check that all threads returned by ThreadGroup.enumerate hasn't terminated.
But this is wrong assumption,  as the test enumerates _debugger_ threads and not _debuggee_ threads.

The fix drops this sanity check.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286844](https://bugs.openjdk.org/browse/JDK-8286844): com/sun/jdi/RedefineCrossEvent.java failed with 1 threads completed while VM suspended


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9547/head:pull/9547` \
`$ git checkout pull/9547`

Update a local copy of the PR: \
`$ git checkout pull/9547` \
`$ git pull https://git.openjdk.org/jdk pull/9547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9547`

View PR using the GUI difftool: \
`$ git pr show -t 9547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9547.diff">https://git.openjdk.org/jdk/pull/9547.diff</a>

</details>
