### PR TITLE
8290495: Micro-optimize Method::can_be_statically_bound assertions

### DIFF
--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -805,12 +805,11 @@ bool Method::is_default_method() const {
 bool Method::can_be_statically_bound(AccessFlags class_access_flags) const {
   if (is_final_method(class_access_flags))  return true;
 #ifdef ASSERT
-  ResourceMark rm;
   bool is_nonv = (vtable_index() == nonvirtual_vtable_index);
-  if (class_access_flags.is_interface()) {
-      assert(is_nonv == is_static() || is_nonv == is_private(),
-             "nonvirtual unexpected for non-static, non-private: %s",
-             name_and_sig_as_C_string());
+  if (class_access_flags.is_interface() && (is_nonv != is_static()) && (is_nonv != is_private())) {
+    ResourceMark rm;
+    fatal("nonvirtual unexpected for non-static, non-private: %s",
+          name_and_sig_as_C_string());
   }
 #endif
   assert(valid_vtable_index() || valid_itable_index(), "method must be linked before we ask this question");

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -806,10 +806,11 @@ bool Method::can_be_statically_bound(AccessFlags class_access_flags) const {
   if (is_final_method(class_access_flags))  return true;
 #ifdef ASSERT
   bool is_nonv = (vtable_index() == nonvirtual_vtable_index);
-  if (class_access_flags.is_interface() && (is_nonv != is_static()) && (is_nonv != is_private())) {
-    ResourceMark rm;
-    fatal("nonvirtual unexpected for non-static, non-private: %s",
-          name_and_sig_as_C_string());
+  if (class_access_flags.is_interface()) {
+      ResourceMark rm;
+      assert(is_nonv == is_static() || is_nonv == is_private(),
+             "nonvirtual unexpected for non-static, non-private: %s",
+             name_and_sig_as_C_string());
   }
 #endif
   assert(valid_vtable_index() || valid_itable_index(), "method must be linked before we ask this question");


### PR DESCRIPTION
See the rationale in the bug.

The test time improves:

```
# Before
real 1m27.397s
user 2m39.937s
sys 0m5.966s

# After
real 1m13.443s ; -16%
user 2m24.238s ; -10%
sys 0m5.885s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290495](https://bugs.openjdk.org/browse/JDK-8290495): Micro-optimize Method::can_be_statically_bound assertions


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9548/head:pull/9548` \
`$ git checkout pull/9548`

Update a local copy of the PR: \
`$ git checkout pull/9548` \
`$ git pull https://git.openjdk.org/jdk pull/9548/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9548`

View PR using the GUI difftool: \
`$ git pr show -t 9548`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9548.diff">https://git.openjdk.org/jdk/pull/9548.diff</a>

</details>
