### PR TITLE
8290497: some tests in com/sun/jdi fail on localized Windows platform

### DIFF
--- a/test/jdk/com/sun/jdi/JdbReadTwiceTest.sh
+++ b/test/jdk/com/sun/jdi/JdbReadTwiceTest.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 # 
 # This code is free software; you can redistribute it and/or modify it
@@ -76,7 +76,7 @@ mkFiles()
 
 doit()
 {
-    echo quit | $TESTJAVA/bin/jdb -J-Duser.home=$HOME > $tmpResult 2>&1
+    echo quit | $TESTJAVA/bin/jdb -J-Duser.language=en -J-Duser.country=US -J-Duser.home=$HOME > $tmpResult 2>&1
 }
 
 failIfNot()

--- a/test/jdk/com/sun/jdi/lib/jdb/Jdb.java
+++ b/test/jdk/com/sun/jdi/lib/jdb/Jdb.java
@@ -42,6 +42,8 @@ import jdk.test.lib.process.StreamPumper;
 public class Jdb implements AutoCloseable {
     public Jdb(String... args) {
         ProcessBuilder pb = new ProcessBuilder(JDKToolFinder.getTestJDKTool("jdb"));
+        pb.command().add("-J-Duser.language=en");
+        pb.command().add("-J-Duser.country=US");
         pb.command().addAll(Arrays.asList(args));
         try {
             jdb = pb.start();

--- a/test/jdk/com/sun/jdi/lib/jdb/JdbTest.java
+++ b/test/jdk/com/sun/jdi/lib/jdb/JdbTest.java
@@ -119,7 +119,7 @@ public abstract class JdbTest {
 
         // launch jdb
         try {
-            jdb = new Jdb("-J-Duser.language=en", "-J-Duser.country=US", "-connect", "com.sun.jdi.SocketAttach:port=" + debuggee.getAddress());
+            jdb = new Jdb("-connect", "com.sun.jdi.SocketAttach:port=" + debuggee.getAddress());
         } catch (Throwable ex) {
             // terminate debuggee if something went wrong
             debuggee.shutdown();

--- a/test/jdk/com/sun/jdi/lib/jdb/JdbTest.java
+++ b/test/jdk/com/sun/jdi/lib/jdb/JdbTest.java
@@ -119,7 +119,7 @@ public abstract class JdbTest {
 
         // launch jdb
         try {
-            jdb = new Jdb("-connect", "com.sun.jdi.SocketAttach:port=" + debuggee.getAddress());
+            jdb = new Jdb("-J-Duser.language=en", "-J-Duser.country=US", "-connect", "com.sun.jdi.SocketAttach:port=" + debuggee.getAddress());
         } catch (Throwable ex) {
             // terminate debuggee if something went wrong
             debuggee.shutdown();


### PR DESCRIPTION
Failed tests call java.lang.ProcessBuilder in direct, so not used command options specified when jtreg command run. 
To run non-localized tests, the locale options should be added in ProcessBuilder.

Could you review this fix, please?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290497](https://bugs.openjdk.org/browse/JDK-8290497): some tests in com/sun/jdi fail on localized Windows platform


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [b539d15a](https://git.openjdk.org/jdk/pull/9549/files/b539d15a2a6c7b4786b15e0bb732fbe60520f9e9)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9549/head:pull/9549` \
`$ git checkout pull/9549`

Update a local copy of the PR: \
`$ git checkout pull/9549` \
`$ git pull https://git.openjdk.org/jdk pull/9549/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9549`

View PR using the GUI difftool: \
`$ git pr show -t 9549`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9549.diff">https://git.openjdk.org/jdk/pull/9549.diff</a>

</details>
