### PR TITLE
8290399: [macos] Aqua LAF does not fire an action event if combo box menu is displayed

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaComboBoxUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaComboBoxUI.java
@@ -252,9 +252,8 @@ public class AquaComboBoxUI extends BasicComboBoxUI implements Sizeable {
                         if (editor instanceof AquaCustomComboTextField) {
                             ((AquaCustomComboTextField)editor).selectAll();
                         }
-                    } else {
-                        action.actionPerformed(e);
                     }
+                    action.actionPerformed(e);
                 }
             });
         }

--- a/test/jdk/javax/swing/JComboBox/JComboBoxActionEvent.java
+++ b/test/jdk/javax/swing/JComboBox/JComboBoxActionEvent.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8290399
+ * @requires (os.family == "mac")
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @summary Tests if AquaL&F fire actionevent if combobox menu is displayed.

--- a/test/jdk/javax/swing/JComboBox/JComboBoxActionEvent.java
+++ b/test/jdk/javax/swing/JComboBox/JComboBoxActionEvent.java
@@ -42,8 +42,8 @@ import javax.swing.UIManager;
 
 public class JComboBoxActionEvent {
     private static final String instructionsText = " Click the arrow to display the menu.\n" +
-         "While the menu is displayed, edit the text to create a new value.\n" + 
-         "Type return.\n" + 
+         "While the menu is displayed, edit the text to create a new value.\n" +
+         "Type return.\n" +
          "If a dialog appears with \"ActionCommand received\"\n" +
          "press Pass, else Fail";
 

--- a/test/jdk/javax/swing/JComboBox/JComboBoxActionEvent.java
+++ b/test/jdk/javax/swing/JComboBox/JComboBoxActionEvent.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8290399
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Tests if AquaL&F fire actionevent if combobox menu is displayed.
+ * @run main/manual JComboBoxActionEvent
+ */
+
+import java.awt.FlowLayout;
+
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class JComboBoxActionEvent {
+    private static final String instructionsText = " Click the arrow to display the menu.\n" +
+         "While the menu is displayed, edit the text to create a new value.\n" + 
+         "Type return.\n" + 
+         "If a dialog appears with \"ActionCommand received\"\n" +
+         "press Pass, else Fail";
+
+    private static JFrame frame;
+
+    public static void createAndShowGUI() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+
+            JComboBox<String> comboBox = new JComboBox<>(new String[]
+                    { "Apple", "Orange", "Pear" });
+            comboBox.setEditable(true);
+            comboBox.addActionListener(e -> {
+               System.out.println("Action Listener called: " + e.getActionCommand());
+               if (e.getActionCommand().contains("comboBoxEdited")) {
+                   JOptionPane.showMessageDialog(null, "ActionCommand received");
+               }
+            });
+
+            FlowLayout layout = new FlowLayout();
+            JPanel panel = new JPanel(layout);
+            panel.add(comboBox);
+            frame = new JFrame("Test Editable Combo Box");
+            frame.getContentPane().add(panel);
+            frame.setVisible(true);
+            frame.pack();
+            frame.setLocationRelativeTo(null);
+
+            PassFailJFrame.addTestWindow(frame);
+            PassFailJFrame.positionTestWindow(frame,
+                    PassFailJFrame.Position.HORIZONTAL);
+        });
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        UIManager.setLookAndFeel("com.apple.laf.AquaLookAndFeel");
+
+        PassFailJFrame pfjFrame = new PassFailJFrame("JScrollPane "
+                + "Test Instructions", instructionsText, 5);
+
+        createAndShowGUI();
+
+        pfjFrame.awaitAndCheck();
+    }
+}


### PR DESCRIPTION
When the user types Enter in an editable combo box, Aqua LAF fails to fire an action event if the menu is displayed.
It seems actionEvent is fired when popup menu is not visible. 
Fix is to make sure ActionEvent is fired irrespective of popup visiblity as is done in other L&F 
(for ex, in MetalL&F it calls "ENTER", JTextField.notifyAction, where it calls postActionEvent irrespectively)
https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/javax/swing/JTextField.java#L856

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290399](https://bugs.openjdk.org/browse/JDK-8290399): [macos] Aqua LAF does not fire an action event if combo box menu is displayed


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9551/head:pull/9551` \
`$ git checkout pull/9551`

Update a local copy of the PR: \
`$ git checkout pull/9551` \
`$ git pull https://git.openjdk.org/jdk pull/9551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9551`

View PR using the GUI difftool: \
`$ git pr show -t 9551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9551.diff">https://git.openjdk.org/jdk/pull/9551.diff</a>

</details>
