### PR TITLE
8290512: G1: Fix typo in allocation statistics log message

### DIFF
--- a/src/hotspot/share/gc/g1/g1OldGenAllocationTracker.cpp
+++ b/src/hotspot/share/gc/g1/g1OldGenAllocationTracker.cpp
@@ -50,7 +50,7 @@ void G1OldGenAllocationTracker::reset_after_gc(size_t humongous_bytes_after_gc) 
   _humongous_bytes_after_last_gc = humongous_bytes_after_gc;
 
   log_debug(gc, alloc, stats)("Old generation allocation in the last mutator period, "
-                              "old gen allocated: " SIZE_FORMAT "B, humongous allocated: " SIZE_FORMAT "B,"
+                              "old gen allocated: " SIZE_FORMAT "B, humongous allocated: " SIZE_FORMAT "B, "
                               "old gen growth: " SIZE_FORMAT "B.",
                               _allocated_bytes_since_last_gc,
                               _allocated_humongous_bytes_since_last_gc,

--- a/src/hotspot/share/gc/g1/g1OldGenAllocationTracker.cpp
+++ b/src/hotspot/share/gc/g1/g1OldGenAllocationTracker.cpp
@@ -40,7 +40,7 @@ void G1OldGenAllocationTracker::reset_after_gc(size_t humongous_bytes_after_gc) 
   if (humongous_bytes_after_gc > _humongous_bytes_after_last_gc) {
     last_period_humongous_increase = humongous_bytes_after_gc - _humongous_bytes_after_last_gc;
     assert(last_period_humongous_increase <= _allocated_humongous_bytes_since_last_gc,
-           "Increase larger than allocated " SIZE_FORMAT " <= " SIZE_FORMAT,
+           "Increase larger than allocated %zu <= %zu",
            last_period_humongous_increase, _allocated_humongous_bytes_since_last_gc);
   }
   _last_period_old_gen_growth = _allocated_bytes_since_last_gc + last_period_humongous_increase;
@@ -50,8 +50,8 @@ void G1OldGenAllocationTracker::reset_after_gc(size_t humongous_bytes_after_gc) 
   _humongous_bytes_after_last_gc = humongous_bytes_after_gc;
 
   log_debug(gc, alloc, stats)("Old generation allocation in the last mutator period, "
-                              "old gen allocated: " SIZE_FORMAT "B, humongous allocated: " SIZE_FORMAT "B, "
-                              "old gen growth: " SIZE_FORMAT "B.",
+                              "old gen allocated: %zuB, humongous allocated: %zuB, "
+                              "old gen growth: %zuB.",
                               _allocated_bytes_since_last_gc,
                               _allocated_humongous_bytes_since_last_gc,
                               _last_period_old_gen_growth);


### PR DESCRIPTION
Hi all,

  please review this trivial change to add a whitespace to a log message.

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290512](https://bugs.openjdk.org/browse/JDK-8290512): G1: Fix typo in allocation statistics log message


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to [95baf3a2](https://git.openjdk.org/jdk/pull/9552/files/95baf3a2aa9c0b0822030b5b8f6d06b11b6ac3cf)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9552/head:pull/9552` \
`$ git checkout pull/9552`

Update a local copy of the PR: \
`$ git checkout pull/9552` \
`$ git pull https://git.openjdk.org/jdk pull/9552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9552`

View PR using the GUI difftool: \
`$ git pr show -t 9552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9552.diff">https://git.openjdk.org/jdk/pull/9552.diff</a>

</details>
