### PR TITLE
JDK-8290532: Adjust PKCS11Exception and handle more PKCS11 error codes

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
@@ -88,7 +88,6 @@ public class PKCS11Exception extends Exception {
         CKR_ATTRIBUTE_SENSITIVE(0x00000011L),
         CKR_ATTRIBUTE_TYPE_INVALID(0x00000012L),
         CKR_ATTRIBUTE_VALUE_INVALID(0x00000013L),
-        CKR_COPY_PROHIBITED(0x0000001AL),
         CKR_ACTION_PROHIBITED(0x0000001BL),
         CKR_DATA_INVALID(0x00000020L),
         CKR_DATA_LEN_RANGE(0x00000021L),
@@ -172,13 +171,23 @@ public class PKCS11Exception extends Exception {
         CKR_FUNCTION_REJECTED(0x00000200L),
         CKR_TOKEN_RESOURCE_EXCEEDED(0x00000201L),
         CKR_OPERATION_CANCEL_FAILED(0x00000202L),
-        CKR_VENDOR_DEFINED(0x80000000L),
-        CKR_NETSCAPE_CERTDB_FAILED(0xCE534351L),
-        CKR_NETSCAPE_KEYDB_FAILED(0xCE534352L);
+        CKR_VENDOR_DEFINED(0x80000000L);
 
         private final long value;
 
         RV(long value) {
+            this.value = value;
+        }
+    };
+
+    public static enum RV_VENDOR {
+        // NSS
+        CKR_NSS_CERTDB_FAILED(0xCE534351L),
+        CKR_NSS_KEYDB_FAILED(0xCE534352L);
+
+        private final long value;
+
+        RV_VENDOR(long value) {
             this.value = value;
         }
     };
@@ -189,8 +198,20 @@ public class PKCS11Exception extends Exception {
                 return r.name();
             }
         }
-        // for unknown PKCS11 return values, just use hex as its string
-        return "unknown PKCS11 error code 0x" + Functions.toFullHexString((int)errorCode);
+        // for unknown PKCS11 return values, use hex as its string
+        String res = "0x" + Functions.toFullHexString((int)errorCode);
+        // for vendor-defined values, check the enum for vendors and include
+        // potential matches
+        if ((errorCode & 0x80000000L) != 0) {
+            // for unknown PKCS11 return values, just use hex as its string
+            for (RV_VENDOR r : RV_VENDOR.values()) {
+                if (r.value == errorCode) {
+                    res += ("(" + r.name() + ")");
+                    break;
+                }
+            }
+        }
+        return res;
     }
 
     /**

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
@@ -203,10 +203,9 @@ public class PKCS11Exception extends Exception {
         // for vendor-defined values, check the enum for vendors and include
         // potential matches
         if ((errorCode & 0x80000000L) != 0) {
-            // for unknown PKCS11 return values, just use hex as its string
             for (RV_VENDOR r : RV_VENDOR.values()) {
                 if (r.value == errorCode) {
-                    res += ("(" + r.name() + ")");
+                    res += "(" + r.name() + ")";
                     break;
                 }
             }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
@@ -88,6 +88,7 @@ public class PKCS11Exception extends Exception {
         CKR_ATTRIBUTE_SENSITIVE(0x00000011L),
         CKR_ATTRIBUTE_TYPE_INVALID(0x00000012L),
         CKR_ATTRIBUTE_VALUE_INVALID(0x00000013L),
+        CKR_COPY_PROHIBITED(0x0000001AL),
         CKR_ACTION_PROHIBITED(0x0000001BL),
         CKR_DATA_INVALID(0x00000020L),
         CKR_DATA_LEN_RANGE(0x00000021L),
@@ -171,7 +172,9 @@ public class PKCS11Exception extends Exception {
         CKR_FUNCTION_REJECTED(0x00000200L),
         CKR_TOKEN_RESOURCE_EXCEEDED(0x00000201L),
         CKR_OPERATION_CANCEL_FAILED(0x00000202L),
-        CKR_VENDOR_DEFINED(0x80000000L);
+        CKR_VENDOR_DEFINED(0x80000000L),
+        CKR_NETSCAPE_CERTDB_FAILED(0xCE534351L),
+        CKR_NETSCAPE_KEYDB_FAILED(0xCE534352L);
 
         private final long value;
 
@@ -187,7 +190,7 @@ public class PKCS11Exception extends Exception {
             }
         }
         // for unknown PKCS11 return values, just use hex as its string
-        return "0x" + Functions.toFullHexString((int)errorCode);
+        return "unknown PKCS11 error code 0x" + Functions.toFullHexString((int)errorCode);
     }
 
     /**


### PR DESCRIPTION
The issue https://bugs.openjdk.org/browse/JDK-8282538 gave an example of the following PKCS11 exception (see attached jtr files of that bug) :

.... Caused by: sun.security.pkcs11.wrapper.PKCS11Exception: 0xCE534351

Unfortunately the error code 0xCE534351 is currently not in the RV/errorMap table of PKCS11Exception, That's why we get this
hex code and no more descriptive output, this could be improved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290532](https://bugs.openjdk.org/browse/JDK-8290532): Adjust PKCS11Exception and handle more PKCS11 error codes


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9555/head:pull/9555` \
`$ git checkout pull/9555`

Update a local copy of the PR: \
`$ git checkout pull/9555` \
`$ git pull https://git.openjdk.org/jdk pull/9555/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9555`

View PR using the GUI difftool: \
`$ git pr show -t 9555`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9555.diff">https://git.openjdk.org/jdk/pull/9555.diff</a>

</details>
