### PR TITLE
8290533: Remove G1ConcurrentMark::mark_in_bitmap(uint, HeapRegion*,oop)

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -596,7 +596,6 @@ public:
   void print_on_error(outputStream* st) const;
 
   // Mark the given object on the marking bitmap if it is below TAMS.
-  inline bool mark_in_bitmap(uint worker_id, HeapRegion* const hr, oop const obj);
   inline bool mark_in_bitmap(uint worker_id, oop const obj);
 
   inline bool is_marked_in_bitmap(oop p) const;

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
@@ -77,12 +77,6 @@ inline bool G1CMSubjectToDiscoveryClosure::do_object_b(oop obj) {
 
 inline bool G1ConcurrentMark::mark_in_bitmap(uint const worker_id, oop const obj) {
   HeapRegion* const hr = _g1h->heap_region_containing(obj);
-  return mark_in_bitmap(worker_id, hr, obj);
-}
-
-inline bool G1ConcurrentMark::mark_in_bitmap(uint const worker_id, HeapRegion* const hr, oop const obj) {
-  assert(hr != NULL, "just checking");
-  assert(hr->is_in_reserved(obj), "Attempting to mark object at " PTR_FORMAT " that is not contained in the given region %u", p2i(obj), hr->hrm_index());
 
   if (hr->obj_allocated_since_marking_start(obj)) {
     return false;


### PR DESCRIPTION
Hi all,

  please review this simple change to merge the `G1ConcurrentMark::mark_in_bitmap(uint, HeapRegion*, oop)` method with the other overload as this is its only use.

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290533](https://bugs.openjdk.org/browse/JDK-8290533): Remove G1ConcurrentMark::mark_in_bitmap(uint, HeapRegion*,oop)


### Reviewers
 * [Sangheon Kim](https://openjdk.org/census#sangheki) (@sangheon - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9556/head:pull/9556` \
`$ git checkout pull/9556`

Update a local copy of the PR: \
`$ git checkout pull/9556` \
`$ git pull https://git.openjdk.org/jdk pull/9556/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9556`

View PR using the GUI difftool: \
`$ git pr show -t 9556`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9556.diff">https://git.openjdk.org/jdk/pull/9556.diff</a>

</details>
