### PR TITLE
8290511: compiler/vectorapi/TestMaskedMacroLogicVector.java fails IR verification

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/TestMaskedMacroLogicVector.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestMaskedMacroLogicVector.java
@@ -280,17 +280,17 @@ public class TestMaskedMacroLogicVector {
     }
 
     @Test
-    @IR(applyIf = {"UseAVX", "3"}, counts = {"AndV", " > 0 ", "XorV", " > 0 "})
+    @IR(applyIfAnd = {"UseAVX", "3", "UseSSE", " > 3 "}, counts = {"AndV", " > 0 ", "XorV", " > 0 "})
     public void testInt4_Int128(int[] r, int[] a, int[] b, int[] c, boolean [] mask) {
         testInt4Kernel(IntVector.SPECIES_128, r, a, b, c, mask);
     }
     @Test
-    @IR(applyIf = {"UseAVX", "3"}, counts = {"AndV", " > 0 ", "XorV", " > 0 "})
+    @IR(applyIfAnd = {"UseAVX", "3", "UseSSE", " > 3 "}, counts = {"AndV", " > 0 ", "XorV", " > 0 "})
     public void testInt4_Int256(int[] r, int[] a, int[] b, int[] c, boolean [] mask) {
         testInt4Kernel(IntVector.SPECIES_256, r, a, b, c, mask);
     }
     @Test
-    @IR(applyIf = {"UseAVX", "3"}, counts = {"AndV", " > 0 ", "XorV", " > 0 "})
+    @IR(applyIfAnd = {"UseAVX", "3", "UseSSE", " > 3 "}, counts = {"AndV", " > 0 ", "XorV", " > 0 "})
     public void testInt4_Int512(int[] r, int[] a, int[] b, int[] c, boolean [] mask) {
         testInt4Kernel(IntVector.SPECIES_512, r, a, b, c, mask);
     }


### PR DESCRIPTION
Hi all,

Please review this trivial patch which fixes the TestMaskedMacroLogicVector.java failure when `-XX:UseSSE < 4` on AVX512 machines.

The reason is that masked `AndV` requires `Op_VectorBlend`.
However, `Op_VectorBlend` is not supported when `UseSSE < 4`.

So part of the sub-tests (which check the masked `AndV > 0`) should be skipped when `UseSSE < 4`

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290511](https://bugs.openjdk.org/browse/JDK-8290511): compiler/vectorapi/TestMaskedMacroLogicVector.java fails IR verification


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9559/head:pull/9559` \
`$ git checkout pull/9559`

Update a local copy of the PR: \
`$ git checkout pull/9559` \
`$ git pull https://git.openjdk.org/jdk pull/9559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9559`

View PR using the GUI difftool: \
`$ git pr show -t 9559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9559.diff">https://git.openjdk.org/jdk/pull/9559.diff</a>

</details>
