### PR TITLE
8290485: [vector] REVERSE_BYTES for byte type should not emit any instructions

### DIFF
--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1851,15 +1851,20 @@ Node* NegVNode::Ideal(PhaseGVN* phase, bool can_reshape) {
 }
 
 Node* ReverseBytesVNode::Identity(PhaseGVN* phase) {
+  // "(ReverseBytesV X) => X" if the element type is T_BYTE.
+  if (vect_type()->element_basic_type() == T_BYTE) {
+    return in(1);
+  }
+
   if (is_predicated_using_blend()) {
     return this;
   }
-  // ReverseBytesV (ReverseBytesV X , MASK) , MASK =>  X
+  // (ReverseBytesV (ReverseBytesV X MASK) MASK) => X
   if (in(1)->Opcode() == Op_ReverseBytesV) {
     if (is_predicated_vector() && in(1)->is_predicated_vector() && in(2) == in(1)->in(2)) {
       return in(1)->in(1);
     } else {
-      // ReverseBytesV (ReverseBytesV X) =>  X
+      // ReverseBytesV (ReverseBytesV X) => X
       return in(1)->in(1);
     }
   }
@@ -1969,6 +1974,14 @@ Node* XorVNode::Ideal(PhaseGVN* phase, bool can_reshape) {
                                      bottom_type()->isa_vectmask() != NULL);
   }
   return NULL;
+}
+
+Node* VectorBlendNode::Identity(PhaseGVN* phase) {
+  // (VectorBlend X X MASK) => X
+  if (in(1) == in(2)) {
+    return in(1);
+  }
+  return this;
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -1449,6 +1449,7 @@ class VectorBlendNode : public VectorNode {
   }
 
   virtual int Opcode() const;
+  virtual Node* Identity(PhaseGVN* phase);
   Node* vec1() const { return in(1); }
   Node* vec2() const { return in(2); }
   Node* vec_mask() const { return in(3); }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -208,6 +208,8 @@ public class IRNode {
     public static final String VECTOR_UCAST_S2X = START + "VectorUCastS2X" + MID + END;
     public static final String VECTOR_UCAST_I2X = START + "VectorUCastI2X" + MID + END;
     public static final String VECTOR_REINTERPRET = START + "VectorReinterpret" + MID + END;
+    public static final String VECTOR_BLEND = START + "VectorBlend" + MID + END;
+    public static final String REVERSE_BYTES_V = START + "ReverseBytesV" + MID + END;
 
     public static final String FAST_LOCK   = START + "FastLock" + MID + END;
     public static final String FAST_UNLOCK = START + "FastUnlock" + MID + END;

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorReverseBytesTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorReverseBytesTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import compiler.lib.ir_framework.*;
+
+import java.util.Random;
+
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+
+/**
+ * @test
+ * @bug 8290485
+ * @key randomness
+ * @library /test/lib /
+ * @summary [vectorapi] REVERSE_BYTES for byte type should not emit any instructions
+ * @requires vm.compiler2.enabled
+ * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") | os.arch == "aarch64"
+ * @modules jdk.incubator.vector
+ *
+ * @run driver compiler.vectorapi.VectorReverseBytesTest
+ */
+
+public class VectorReverseBytesTest {
+    private static final VectorSpecies<Byte> B_SPECIES = ByteVector.SPECIES_MAX;
+
+    private static int LENGTH = 1024;
+    private static final Random RD = Utils.getRandomInstance();
+
+    private static byte[] input;
+    private static byte[] output;
+    private static boolean[] m;
+
+    static {
+        input = new byte[LENGTH];
+        output = new byte[LENGTH];
+        m = new boolean[LENGTH];
+
+        for (int i = 0; i < LENGTH; i++) {
+            input[i] = (byte) RD.nextInt(25);
+            m[i] = RD.nextBoolean();
+        }
+    }
+
+    @Test
+    @IR(failOn = IRNode.REVERSE_BYTES_V)
+    public static void testReverseBytesV() {
+        for (int i = 0; i < LENGTH; i += B_SPECIES.length()) {
+            ByteVector v = ByteVector.fromArray(B_SPECIES, input, i);
+            v.lanewise(VectorOperators.REVERSE_BYTES).intoArray(output, i);
+        }
+
+        // Verify results
+        for (int i = 0; i < LENGTH; i++) {
+            Asserts.assertEquals(input[i], output[i]);
+        }
+    }
+
+    @Test
+    @IR(failOn = IRNode.REVERSE_BYTES_V)
+    @IR(failOn = IRNode.VECTOR_BLEND)
+    public static void testReverseBytesVMasked() {
+        VectorMask<Byte> mask = VectorMask.fromArray(B_SPECIES, m, 0);
+        for (int i = 0; i < LENGTH; i += B_SPECIES.length()) {
+            ByteVector v = ByteVector.fromArray(B_SPECIES, input, i);
+            v.lanewise(VectorOperators.REVERSE_BYTES, mask).intoArray(output, i);
+        }
+
+        // Verify results
+        for (int i = 0; i < LENGTH; i++) {
+            Asserts.assertEquals(input[i], output[i]);
+        }
+    }
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("--add-modules=jdk.incubator.vector");
+    }
+}


### PR DESCRIPTION
The Vector API unary operation "`REVERSE_BYTES`" should not emit any instructions for byte vectors. The same to the relative masked operation. Currently it emits `"mov dst, src"` on aarch64 when the "`dst`" and "`src`" are not the same register. But for the masked "`REVERSE_BYTES`", the compiler will always generate a "`VectorBlend`" which I think is redundant, since the first and second vector input is the same one. Please see the generated codes for the masked "`REVERSE_BYTES`" for byte type with NEON:
```
  ldr q16, [x15, #16]            ; load the "src" vector
  mov v17.16b, v16.16b           ; reverse bytes "src"
  ldr q18, [x13, #16]
  neg v18.16b, v18.16b           ; load the vector mask
  bsl v18.16b, v17.16b, v16.16b  ; vector blend
```
The elements in register "`v17`" and "`v16`" are the same to each other, so the elements in result of "`bsl`" is the same to the original loaded values in "`v16`", no matter what the values in the vector mask are.

To improve this, we can add the igvn transformations for "`ReverseBytesV`" and "`VectorBlend`" in compiler. For "`ReverseBytesV`", it can return the vector input if the basic element type is `T_BYTE`. And for "`VectorBlend`", it can return the first input if the first and the second input are the same one.

Here is the performance data for the jmh benchmark [1] on ARM NEON:
```
Benchmark                         (size)  Mode  Cnt  Before    After    Units
ByteMaxVector.REVERSE_BYTES        1024  thrpt  15  19457.641 19516.124 ops/ms
ByteMaxVector.REVERSE_BYTESMasked  1024  thrpt  15  12498.416 20528.004 ops/ms
```
This patch may not have any influence to the non-masked "`REVERSE_BYTES`" on ARM NEON, because the backend may not emit any instruction for it before.

And here is the performance data on an x86 system:
```
Benchmark                         (size)  Mode  Cnt  Before    After    Units
ByteMaxVector.REVERSE_BYTES        1024  thrpt  15  19358.941 20012.047 ops/ms
ByteMaxVector.REVERSE_BYTESMasked  1024  thrpt  15  15759.788 20389.996 ops/ms
```
[1] https://github.com/openjdk/panama-vector/blob/vectorIntrinsics/test/micro/org/openjdk/bench/jdk/incubator/vector/operation/ByteMaxVector.java#L2201

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290485](https://bugs.openjdk.org/browse/JDK-8290485): [vector] REVERSE_BYTES for byte type should not emit any instructions


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9565/head:pull/9565` \
`$ git checkout pull/9565`

Update a local copy of the PR: \
`$ git checkout pull/9565` \
`$ git pull https://git.openjdk.org/jdk pull/9565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9565`

View PR using the GUI difftool: \
`$ git pr show -t 9565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9565.diff">https://git.openjdk.org/jdk/pull/9565.diff</a>

</details>
