### PR TITLE
4797982: Setting negative size of JSplitPane divider leads to unexpected results.

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -418,7 +418,7 @@ public class JSplitPane extends JComponent implements Accessible
 
     /**
      * Sets the size of the divider.
-     * @implNote Divider sizes {@code newSize < 1} are ignored.
+     * Divider sizes {@code newSize < 1} are ignored.
      *
      * @param newSize an integer giving the size of the divider in pixels
      */

--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -418,13 +418,16 @@ public class JSplitPane extends JComponent implements Accessible
 
     /**
      * Sets the size of the divider.
+     * @implNote Divider sizes < 1 are ignored.
+     *           {@code SplitPane.dividerSize} L&amp;F specific value
+     *           will instead be used.
      *
      * @param newSize an integer giving the size of the divider in pixels
      */
     @BeanProperty(description
             = "The size of the divider.")
     public void setDividerSize(int newSize) {
-        if (newSize < 0) {
+        if (newSize <= 0) {
             return;
         }
         int           oldSize = dividerSize;

--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -418,9 +418,7 @@ public class JSplitPane extends JComponent implements Accessible
 
     /**
      * Sets the size of the divider.
-     * @implNote Divider sizes < 1 are ignored.
-     *           {@code SplitPane.dividerSize} L&amp;F specific value
-     *           will instead be used.
+     * @implNote Divider sizes {@code newSize < 1} are ignored.
      *
      * @param newSize an integer giving the size of the divider in pixels
      */

--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -418,14 +418,14 @@ public class JSplitPane extends JComponent implements Accessible
 
     /**
      * Sets the size of the divider.
-     * Divider sizes {@code newSize < 1} are ignored.
+     * Divider sizes {@code newSize < 0} are ignored.
      *
      * @param newSize an integer giving the size of the divider in pixels
      */
     @BeanProperty(description
             = "The size of the divider.")
     public void setDividerSize(int newSize) {
-        if (newSize <= 0) {
+        if (newSize < 0) {
             return;
         }
         int           oldSize = dividerSize;

--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -425,7 +425,7 @@ public class JSplitPane extends JComponent implements Accessible
             = "The size of the divider.")
     public void setDividerSize(int newSize) {
         if (newSize < 0) {
-            newSize = 0;
+            return;
         }
         int           oldSize = dividerSize;
 

--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -424,6 +424,9 @@ public class JSplitPane extends JComponent implements Accessible
     @BeanProperty(description
             = "The size of the divider.")
     public void setDividerSize(int newSize) {
+        if (newSize < 0) {
+            newSize = 0;
+        }
         int           oldSize = dividerSize;
 
         dividerSizeSet = true;

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -219,6 +219,9 @@ public class BasicSplitPaneDivider extends Container
      * Sets the size of the divider to {@code newSize}. That is
      * the width if the splitpane is {@code HORIZONTAL_SPLIT}, or
      * the height of {@code VERTICAL_SPLIT}.
+     * @implNote Divider sizes < 1 are ignored.
+     *           {@code SplitPane.dividerSize} L&amp;F specific value
+     *           will instead be used.
      *
      * @param newSize a new size
      */

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -219,12 +219,12 @@ public class BasicSplitPaneDivider extends Container
      * Sets the size of the divider to {@code newSize}. That is
      * the width if the splitpane is {@code HORIZONTAL_SPLIT}, or
      * the height of {@code VERTICAL_SPLIT}.
-     * Divider sizes {@code newSize < 1} are ignored.
+     * Divider sizes {@code newSize < 0} are ignored.
      *
      * @param newSize a new size
      */
     public void setDividerSize(int newSize) {
-        if (newSize <= 0) {
+        if (newSize < 0) {
             return;
         }
         dividerSize = newSize;

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -226,7 +226,7 @@ public class BasicSplitPaneDivider extends Container
      * @param newSize a new size
      */
     public void setDividerSize(int newSize) {
-        if (newSize < 0) {
+        if (newSize <= 0) {
             return;
         }
         dividerSize = newSize;

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -219,9 +219,7 @@ public class BasicSplitPaneDivider extends Container
      * Sets the size of the divider to {@code newSize}. That is
      * the width if the splitpane is {@code HORIZONTAL_SPLIT}, or
      * the height of {@code VERTICAL_SPLIT}.
-     * @implNote Divider sizes < 1 are ignored.
-     *           {@code SplitPane.dividerSize} L&amp;F specific value
-     *           will instead be used.
+     * @implNote Divider sizes {@code newSize < 1} are ignored.
      *
      * @param newSize a new size
      */

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -223,6 +223,9 @@ public class BasicSplitPaneDivider extends Container
      * @param newSize a new size
      */
     public void setDividerSize(int newSize) {
+        if (newSize < 0) {
+            return;
+        }
         dividerSize = newSize;
     }
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -219,7 +219,7 @@ public class BasicSplitPaneDivider extends Container
      * Sets the size of the divider to {@code newSize}. That is
      * the width if the splitpane is {@code HORIZONTAL_SPLIT}, or
      * the height of {@code VERTICAL_SPLIT}.
-     * @implNote Divider sizes {@code newSize < 1} are ignored.
+     * Divider sizes {@code newSize < 1} are ignored.
      *
      * @param newSize a new size
      */

--- a/test/jdk/javax/swing/JSplitPane/JSplitPaneTestNegDivSize.java
+++ b/test/jdk/javax/swing/JSplitPane/JSplitPaneTestNegDivSize.java
@@ -33,26 +33,39 @@ import javax.swing.JFrame;
 import javax.swing.JSplitPane;
 import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.plaf.basic.BasicSplitPaneUI;
 
 public class JSplitPaneTestNegDivSize {
 
-   private static volatile int divSize;
+    private static volatile int divSize;
+    private static volatile int basicDivSize;
+    private static JFrame frame;
+    private static JSplitPane sp;
 
-   public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws Exception {
         SwingUtilities.invokeAndWait(() -> {
-            JFrame frame = new JFrame();
-            frame.setSize(new Dimension(400,200));
-            frame.setVisible(true);
-            JSplitPane sp = new JSplitPane(JSplitPane.VERTICAL_SPLIT, true,
+            frame = new JFrame();
+            sp = new JSplitPane(JSplitPane.VERTICAL_SPLIT, true,
                     new JTextArea("I am top text area!"),
                     new JTextArea("I am bottom text area!"));
             frame.getContentPane().add(sp, BorderLayout.CENTER);
             sp.setDividerSize(-50);
             divSize = sp.getDividerSize();
-            System.out.println(divSize);
-            frame.dispose();
+            ((BasicSplitPaneUI)sp.getUI()).getDivider().setDividerSize(-50);
+            basicDivSize = ((BasicSplitPaneUI)sp.getUI()).getDivider().
+                                              getDividerSize();
+            frame.setSize(new Dimension(400,200));
+            frame.setVisible(true);
         });
-        if (divSize < 0) {
+        try {
+            Thread.sleep(1000);
+        } catch(Exception e){}
+        SwingUtilities.invokeAndWait(()->frame.dispose());
+        System.out.println(divSize);
+        System.out.println(basicDivSize);
+        System.out.println((Integer)UIManager.get("SplitPane.dividerSize"));
+        if (divSize < 0 || basicDivSize < 0) {
             throw new RuntimeException("Negative divider size");
         }
     }

--- a/test/jdk/javax/swing/JSplitPane/JSplitPaneTestNegDivSize.java
+++ b/test/jdk/javax/swing/JSplitPane/JSplitPaneTestNegDivSize.java
@@ -39,16 +39,16 @@ public class JSplitPaneTestNegDivSize {
    private static volatile int divSize;
 
    public static void main(String[] args) throws Exception {
-        SwingUtilities.invokeAndWait(() -> {	   
+        SwingUtilities.invokeAndWait(() -> {
             JFrame frame = new JFrame();
             frame.setSize(new Dimension(400,200));
             frame.setVisible(true);
             JSplitPane sp = new JSplitPane(JSplitPane.VERTICAL_SPLIT, true,
-                     new JTextArea("I am top text area!"),
-		     new JTextArea("I am bottom text area!"));
+                    new JTextArea("I am top text area!"),
+                    new JTextArea("I am bottom text area!"));
             frame.getContentPane().add(sp, BorderLayout.CENTER);
             sp.setDividerSize(-50);
-	    divSize = sp.getDividerSize();
+            divSize = sp.getDividerSize();
             System.out.println(divSize);
             frame.dispose();
         });

--- a/test/jdk/javax/swing/JSplitPane/JSplitPaneTestNegDivSize.java
+++ b/test/jdk/javax/swing/JSplitPane/JSplitPaneTestNegDivSize.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @key headful
+ * @bug 4797982
+ * @summary Verifies if negative size of JSplitPane divider can be set.
+ * @run main JSplitPaneTestNegDivSize
+ */
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import javax.swing.JFrame;
+import javax.swing.JSplitPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+
+public class JSplitPaneTestNegDivSize {
+
+   private static volatile int divSize;
+
+   public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {	   
+            JFrame frame = new JFrame();
+            frame.setSize(new Dimension(400,200));
+            frame.setVisible(true);
+            JSplitPane sp = new JSplitPane(JSplitPane.VERTICAL_SPLIT, true,
+                     new JTextArea("I am top text area!"),
+		     new JTextArea("I am bottom text area!"));
+            frame.getContentPane().add(sp, BorderLayout.CENTER);
+            sp.setDividerSize(-50);
+	    divSize = sp.getDividerSize();
+            System.out.println(divSize);
+            frame.dispose();
+        });
+        if (divSize < 0) {
+            throw new RuntimeException("Negative divider size");
+        }
+    }
+}


### PR DESCRIPTION
Setting JSplitPane divider size to negative value leads to unexpected results and is not desirable and seems to be not practical.
I guess we should return IAE but it might break existing app so fixed to clamp it to 0 incase negative value is tried to be set for divider size.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-4797982](https://bugs.openjdk.org/browse/JDK-4797982): Setting negative size of JSplitPane divider leads to unexpected results.
 * [JDK-8290992](https://bugs.openjdk.org/browse/JDK-8290992): Setting negative size of JSplitPane divider leads to unexpected results. (**CSR**)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**) ⚠️ Review applies to [40ddca94](https://git.openjdk.org/jdk/pull/9566/files/40ddca945eab79e5b384df8aea32a8808870a64c)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [ec9429aa](https://git.openjdk.org/jdk/pull/9566/files/ec9429aa346bb38710afd0aa5c06e97bbf23e801)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9566/head:pull/9566` \
`$ git checkout pull/9566`

Update a local copy of the PR: \
`$ git checkout pull/9566` \
`$ git pull https://git.openjdk.org/jdk pull/9566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9566`

View PR using the GUI difftool: \
`$ git pr show -t 9566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9566.diff">https://git.openjdk.org/jdk/pull/9566.diff</a>

</details>
