### PR TITLE
8290704: x86: TemplateTable::_new should not call eden_allocate() without contiguous allocs enabled

### DIFF
--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -3981,7 +3981,7 @@ void TemplateTable::_new() {
       // initialize both the header and fields
       __ jmp(initialize_object);
     }
-  } else {
+  } else if (allow_shared_alloc) {
     // Allocation in the shared Eden, if allowed.
     //
     // rdx: instance size in bytes


### PR DESCRIPTION
I have been doing the thread register verification patches for better Loom debugging, and one of the failures it caught is calling `eden_allocate` with garbage thread register. That method actually shortcuts:

```
void BarrierSetAssembler::eden_allocate(MacroAssembler* masm,
                                        Register thread, Register obj,
                                        Register var_size_in_bytes,
                                        int con_size_in_bytes,
                                        Register t1,
                                        Label& slow_case) {
  ...
  if (!Universe::heap()->supports_inline_contig_alloc()) {
    __ jmp(slow_case);
```

...and does not use the thread. But it is still confusing. Other ports gate the calls to `eden_allocate` with `allow_shared_alloc`, x86 should do the same.

(This thing would be cleaner when/if we remove the support for contiguous inline allocs altogether, see [JDK-8290706](https://bugs.openjdk.org/browse/JDK-8290706)).

Additional testing:
 - [x] Linux x86_32 fastdebug `tier1`