### PR TITLE
8290707: runtime/cds/appcds/dynamicArchive/DynamicLambdaWithUseImplMethodHandle.java fails with "Can't find sun.hotspot.whitebox"

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicLambdaWithUseImplMethodHandle.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicLambdaWithUseImplMethodHandle.java
@@ -31,9 +31,9 @@
  * @build pkg1.BaseWithProtectedMethod
  * @build pkg2.Child
  * @build LambdaWithUseImplMethodHandleApp
- * @build sun.hotspot.WhiteBox
+ * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar test.jar pkg1.BaseWithProtectedMethod pkg2.Child LambdaWithUseImplMethodHandleApp
- * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. DynamicLambdaWithUseImplMethodHandle
  */
 


### PR DESCRIPTION
Hi all,

  can I have reviews for this trivial fix of the `sun.hotspot.whitebox` dependency in a test added recently?

Testing: local test

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290707](https://bugs.openjdk.org/browse/JDK-8290707): runtime/cds/appcds/dynamicArchive/DynamicLambdaWithUseImplMethodHandle.java fails with "Can't find sun.hotspot.whitebox"


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9568/head:pull/9568` \
`$ git checkout pull/9568`

Update a local copy of the PR: \
`$ git checkout pull/9568` \
`$ git pull https://git.openjdk.org/jdk pull/9568/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9568`

View PR using the GUI difftool: \
`$ git pr show -t 9568`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9568.diff">https://git.openjdk.org/jdk/pull/9568.diff</a>

</details>
