### PR TITLE
8290688: Optimize x86_64 nmethod entry barriers

### DIFF
--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
@@ -28,6 +28,8 @@
 // C2_MacroAssembler contains high-level macros for C2
 
  public:
+  void emit_entry_barrier_stub(C2EntryBarrierStub* stub) {}
+  static int entry_barrier_stub_size() { return 0; }
 
   void string_compare(Register str1, Register str2,
                       Register cnt1, Register cnt2, Register result,

--- a/src/hotspot/cpu/arm/c2_MacroAssembler_arm.hpp
+++ b/src/hotspot/cpu/arm/c2_MacroAssembler_arm.hpp
@@ -28,6 +28,9 @@
 // C2_MacroAssembler contains high-level macros for C2
 
  public:
+  void emit_entry_barrier_stub(C2EntryBarrierStub* stub) {}
+  static int entry_barrier_stub_size() { return 0; }
+
   // Compare char[] arrays aligned to 4 bytes.
   void char_arrays_equals(Register ary1, Register ary2,
                           Register limit, Register result,

--- a/src/hotspot/cpu/ppc/c2_MacroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/c2_MacroAssembler_ppc.hpp
@@ -28,6 +28,9 @@
 // C2_MacroAssembler contains high-level macros for C2
 
  public:
+  void emit_entry_barrier_stub(C2EntryBarrierStub* stub) {}
+  static int entry_barrier_stub_size() { return 0; }
+
   // Intrinsics for CompactStrings
   // Compress char[] to byte[] by compressing 16 bytes at once.
   void string_compress_16(Register src, Register dst, Register cnt,

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -36,6 +36,8 @@
                        VectorRegister vrs,
                        bool is_latin, Label& DONE);
  public:
+  void emit_entry_barrier_stub(C2EntryBarrierStub* stub) {}
+  static int entry_barrier_stub_size() { return 0; }
 
   void string_compare(Register str1, Register str2,
                       Register cnt1, Register cnt2, Register result,

--- a/src/hotspot/cpu/s390/c2_MacroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/c2_MacroAssembler_s390.hpp
@@ -29,6 +29,9 @@
 // C2_MacroAssembler contains high-level macros for C2
 
  public:
+  void emit_entry_barrier_stub(C2EntryBarrierStub* stub) {}
+  static int entry_barrier_stub_size() { return 0; }
+
   //-------------------------------------------
   // Special String Intrinsics Implementation.
   //-------------------------------------------

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -325,7 +325,8 @@ void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_by
   decrement(rsp, frame_size_in_bytes); // does not emit code for frame_size == 0
 
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-  bs->nmethod_entry_barrier(this);
+  // C1 code is not hot enough to micro optimize the nmethod entry barrier with an out-of-line stub
+  bs->nmethod_entry_barrier(this, NULL /* slow_path */, NULL /* continuation */);
 }
 
 

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -31,6 +31,9 @@ public:
   // C2 compiled method's prolog code.
   void verified_entry(int framesize, int stack_bang_size, bool fp_mode_24b, bool is_stub);
 
+  void emit_entry_barrier_stub(C2EntryBarrierStub* stub);
+  static int entry_barrier_stub_size();
+
   Assembler::AvxVectorLen vector_length_encoding(int vlen_in_bytes);
 
   // Code used by cmpFastLock and cmpFastUnlock mach instructions in .ad file.

--- a/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
@@ -309,19 +309,31 @@ void BarrierSetAssembler::incr_allocated_bytes(MacroAssembler* masm, Register th
 }
 
 #ifdef _LP64
-void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm) {
+void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slow_path, Label* continuation) {
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
   if (bs_nm == NULL) {
     return;
   }
-  Label continuation;
   Register thread = r15_thread;
   Address disarmed_addr(thread, in_bytes(bs_nm->thread_disarmed_offset()));
-  __ align(8);
+  // The immediate is the last 4 bytes, so if we align the start of the cmp
+  // instruction to 4 bytes, we know that the second half of it is also 4
+  // byte aligned, which means that the immediate will not cross a cache line
+  __ align(4);
+  uintptr_t before_cmp = (uintptr_t)__ pc();
   __ cmpl(disarmed_addr, 0);
-  __ jcc(Assembler::equal, continuation);
-  __ call(RuntimeAddress(StubRoutines::x86::method_entry_barrier()));
-  __ bind(continuation);
+  uintptr_t after_cmp = (uintptr_t)__ pc();
+  guarantee(after_cmp - before_cmp == 8, "Wrong assumed instruction length");
+
+  if (slow_path != NULL) {
+    __ jcc(Assembler::notEqual, *slow_path);
+    __ bind(*continuation);
+  } else {
+    Label done;
+    __ jccb(Assembler::equal, done);
+    __ call(RuntimeAddress(StubRoutines::x86::method_entry_barrier()));
+    __ bind(done);
+  }
 }
 #else
 void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm) {

--- a/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
@@ -336,7 +336,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
   }
 }
 #else
-void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slow_path, Label* continuation) {
+void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label*, Label*) {
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
   if (bs_nm == NULL) {
     return;

--- a/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
@@ -336,7 +336,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
   }
 }
 #else
-void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm) {
+void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slow_path, Label* continuation) {
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
   if (bs_nm == NULL) {
     return;

--- a/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.hpp
@@ -68,7 +68,7 @@ public:
 
   virtual void barrier_stubs_init() {}
 
-  virtual void nmethod_entry_barrier(MacroAssembler* masm);
+  virtual void nmethod_entry_barrier(MacroAssembler* masm, Label* slow_path, Label* continuation);
   virtual void c2i_entry_barrier(MacroAssembler* masm);
 };
 

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -1518,7 +1518,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
 
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-  bs->nmethod_entry_barrier(masm);
+  bs->nmethod_entry_barrier(masm, NULL /* slow_path */, NULL /* continuation */);
 
   // Frame is now completed as far as size and linkage.
   int frame_complete = ((intptr_t)__ pc()) - start;

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -1744,7 +1744,8 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   __ subptr(rsp, stack_size - 2*wordSize);
 
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-  bs->nmethod_entry_barrier(masm);
+  // native wrapper is not hot enough to micro optimize the nmethod entry barrier with an out-of-line stub
+  bs->nmethod_entry_barrier(masm, NULL /* slow_path */, NULL /* continuation */);
 
   // Frame is now completed as far as size and linkage.
   int frame_complete = ((intptr_t)__ pc()) - start;

--- a/src/hotspot/share/opto/c2_MacroAssembler.hpp
+++ b/src/hotspot/share/opto/c2_MacroAssembler.hpp
@@ -29,6 +29,8 @@
 #include "asm/macroAssembler.inline.hpp"
 #include "utilities/macros.hpp"
 
+class C2EntryBarrierStub;
+
 class C2_MacroAssembler: public MacroAssembler {
  public:
   // creation

--- a/src/hotspot/share/opto/output.hpp
+++ b/src/hotspot/share/opto/output.hpp
@@ -40,6 +40,7 @@ class Arena;
 class Bundle;
 class Block;
 class Block_Array;
+class C2_MacroAssembler;
 class ciMethod;
 class Compile;
 class MachNode;
@@ -113,6 +114,30 @@ public:
   void emit(CodeBuffer& cb);
 };
 
+// We move non-hot code of the nmethod entry barrier to an out-of-line stub
+class C2EntryBarrierStub: public ResourceObj {
+  Label _slow_path;
+  Label _continuation;
+
+public:
+  C2EntryBarrierStub() :
+    _slow_path(),
+    _continuation() {}
+
+  Label& slow_path() { return _slow_path; }
+  Label& continuation() { return _continuation; }
+};
+
+class C2EntryBarrierStubTable {
+  C2EntryBarrierStub* _stub;
+
+public:
+  C2EntryBarrierStubTable() : _stub(NULL) {}
+  C2EntryBarrierStub* add_entry_barrier();
+  int estimate_stub_size() const;
+  void emit(CodeBuffer& cb);
+};
+
 class PhaseOutput : public Phase {
 private:
   // Instruction bits passed off to the VM
@@ -122,6 +147,7 @@ private:
   ExceptionHandlerTable  _handler_table;         // Table of native-code exception handlers
   ImplicitExceptionTable _inc_table;             // Table of implicit null checks in native code
   C2SafepointPollStubTable _safepoint_poll_table;// Table for safepoint polls
+  C2EntryBarrierStubTable _entry_barrier_table;  // Table for entry barrier stubs
   OopMapSet*             _oop_map_set;           // Table of oop maps (one for each safepoint location)
   BufferBlob*            _scratch_buffer_blob;   // For temporary code buffers.
   relocInfo*             _scratch_locs_memory;   // For temporary code buffers.
@@ -171,6 +197,9 @@ public:
 
   // Safepoint poll table
   C2SafepointPollStubTable* safepoint_poll_table() { return &_safepoint_poll_table; }
+
+  // Entry barrier table
+  C2EntryBarrierStubTable* entry_barrier_table() { return &_entry_barrier_table; }
 
   // Code emission iterator
   Block* block()   { return _block; }


### PR DESCRIPTION
The current x86_64 nmethod entry barrier is good, but it could be a bit better. In particular, this enhancement targets the following ideas.

1. The alignment of the cmp instruction is 8 bytes. However, we only patch 4 bytes and the instruction length is always 8 bytes. So if we align the start of the instruction to 4 bytes only, that is enough to ensure that the immediate part of the instruction is 4 byte aligned, which is all we need (cf. http://cr.openjdk.java.net/~jrose/jvm/hotspot-cmc.html).

2. Today the fast path (conditionally) jumps over a call to a stub. It is not uncommon for the branch not taken path being better optimized, making it favourable to move the call to a stub out-of-line. This has the additional benefit of not polluting the instruction caches at the nmethod entry with instructions not used in the fast path. A bit messy but we can do it for at least C2 code.

3. For C1 and native wrappers, I don't think they are hot enough to warrant the stub machinery. But at least the jump that jumps over the cold stuff, can be shortened. I can get behind that.

Before addressing this, turning nmethod entry barriers on with G1 (e.g. by enabling loom) leads to a regression in DaCapo tradesoap-large. With this enhancement, the regression goes away, so that the cost of nmethod entry barriers is not visible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290688](https://bugs.openjdk.org/browse/JDK-8290688): Optimize x86_64 nmethod entry barriers


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9569/head:pull/9569` \
`$ git checkout pull/9569`

Update a local copy of the PR: \
`$ git checkout pull/9569` \
`$ git pull https://git.openjdk.org/jdk pull/9569/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9569`

View PR using the GUI difftool: \
`$ git pr show -t 9569`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9569.diff">https://git.openjdk.org/jdk/pull/9569.diff</a>

</details>
