### PR TITLE
8289647: AssertionError during annotation processing of record related tests

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -1522,7 +1522,6 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
         public RecordComponent createRecordComponent(RecordComponent existing, JCVariableDecl var, List<JCAnnotation> annotations) {
             RecordComponent rc = null;
             if (existing != null) {
-                // Found a record component with an erroneous type: remove it and create a new one
                 recordComponents = List.filter(recordComponents, existing);
                 recordComponents = recordComponents.append(rc = new RecordComponent(var.sym, existing.originalAnnos, existing.isVarargs));
             } else {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -1503,10 +1503,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
             return null;
         }
 
-        /* creates a record component if non is related to the given variable and recreates a brand new one
-         * in other case
-         */
-        public RecordComponent createRecordComponent(JCVariableDecl var, List<JCAnnotation> annotations) {
+        public RecordComponent findRecordComponentToRemove(JCVariableDecl var) {
             RecordComponent toRemove = null;
             for (RecordComponent rc : recordComponents) {
                 /* it could be that a record erroneously declares two record components with the same name, in that
@@ -1516,11 +1513,18 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
                     toRemove = rc;
                 }
             }
+            return toRemove;
+        }
+
+        /* creates a record component if non is related to the given variable and recreates a brand new one
+         * in other case
+         */
+        public RecordComponent createRecordComponent(RecordComponent existing, JCVariableDecl var, List<JCAnnotation> annotations) {
             RecordComponent rc = null;
-            if (toRemove != null) {
+            if (existing != null) {
                 // Found a record component with an erroneous type: remove it and create a new one
-                recordComponents = List.filter(recordComponents, toRemove);
-                recordComponents = recordComponents.append(rc = new RecordComponent(var.sym, toRemove.originalAnnos, toRemove.isVarargs));
+                recordComponents = List.filter(recordComponents, existing);
+                recordComponents = recordComponents.append(rc = new RecordComponent(var.sym, existing.originalAnnos, existing.isVarargs));
             } else {
                 // Didn't find the record component: create one.
                 recordComponents = recordComponents.append(rc = new RecordComponent(var.sym, annotations));

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
@@ -997,9 +997,11 @@ public class TypeEnter implements Completer {
                      *  copying the original annotations from the record component to the corresponding field, again this applies
                      *  only if APs are present.
                      *
-                     *  We need to copy the annotations to the field so that annotations applicable only to the record component
-                     *  can be attributed as if declared in the field and then stored in the metadata associated to the record
-                     *  component.
+                     *  First, we find the record component by comparing its name and position with current field,
+                     *  if any, and we mark it. Then we copy the annotations to the field so that annotations applicable only to the record component
+                     *  can be attributed, as if declared in the field, and then stored in the metadata associated to the record
+                     *  component. The invariance we need to keep here is that record components must be scheduled for
+                     *  annotation only once during this process.
                      */
                     RecordComponent rc = sym.findRecordComponentToRemove(field);
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
@@ -981,9 +981,37 @@ public class TypeEnter implements Completer {
             ClassSymbol sym = tree.sym;
             if ((sym.flags_field & RECORD) != 0) {
                 List<JCVariableDecl> fields = TreeInfo.recordFields(tree);
-                memberEnter.memberEnter(fields, env);
+
                 for (JCVariableDecl field : fields) {
-                    sym.createRecordComponent(field,
+                    /** Some notes regarding the code below. Annotations applied to elements of a record header are propagated
+                     *  to other elements which, when applicable, not explicitly declared by the user: the canonical constructor,
+                     *  accessors, fields and record components. Of all these the only ones that can't be explicitly declared are
+                     *  the fields and the record components.
+                     *
+                     *  Now given that annotations are propagated to all possible targets  regardless of applicability,
+                     *  annotations not applicable to a given element should be removed. See Check::validateAnnotation. Once
+                     *  annotations are removed we could lose the whole picture, that's why original annotations are stored in
+                     *  the record component, see RecordComponent::originalAnnos, but there is no real AST representing a record
+                     *  component so if there is an annotation processing round it could be that we need to reenter a record for
+                     *  which we need to re-attribute its annotations. This is why one of the things the code below is doing is
+                     *  copying the original annotations from the record component to the corresponding field, again this applies
+                     *  only if APs are present.
+                     *
+                     *  We need to copy the annotations to the field so that annotations applicable only to the record component
+                     *  can be attributed as if declared in the field and then stored in the metadata associated to the record
+                     *  component.
+                     */
+                    RecordComponent rc = sym.findRecordComponentToRemove(field);
+
+                    if (rc != null && (rc.getOriginalAnnos().length() != field.mods.annotations.length())) {
+                        TreeCopier<JCTree> tc = new TreeCopier<>(make.at(field.pos));
+                        List<JCAnnotation> originalAnnos = tc.copy(rc.getOriginalAnnos());
+                        field.mods.annotations = originalAnnos;
+                    }
+
+                    memberEnter.memberEnter(field, env);
+
+                    sym.createRecordComponent(rc, field,
                             field.mods.annotations.isEmpty() ?
                                     List.nil() :
                                     new TreeCopier<JCTree>(make.at(field.pos)).copy(field.mods.annotations));
@@ -1229,37 +1257,10 @@ public class TypeEnter implements Completer {
                 memberEnter.memberEnter(equals, env);
             }
 
-            /** Some notes regarding the code below. Annotations applied to elements of a record header are propagated
-             *  to other elements which, when applicable, not explicitly declared by the user: the canonical constructor,
-             *  accessors, fields and record components. Of all these the only ones that can't be explicitly declared are
-             *  the fields and the record components.
-             *
-             *  Now given that annotations are propagated to all possible targets  regardless of applicability,
-             *  annotations not applicable to a given element should be removed. See Check::validateAnnotation. Once
-             *  annotations are removed we could lose the whole picture, that's why original annotations are stored in
-             *  the record component, see RecordComponent::originalAnnos, but there is no real AST representing a record
-             *  component so if there is an annotation processing round it could be that we need to reenter a record for
-             *  which we need to re-attribute its annotations. This is why one of the things the code below is doing is
-             *  copying the original annotations from the record component to the corresponding field, again this applies
-             *  only if APs are present.
-             *
-             *  We need to copy the annotations to the field so that annotations applicable only to the record component
-             *  can be attributed as if declared in the field and then stored in the metadata associated to the record
-             *  component.
-             */
+            // fields can't be varargs, lets remove the flag
             List<JCVariableDecl> recordFields = TreeInfo.recordFields(tree);
             for (JCVariableDecl field: recordFields) {
-                RecordComponent rec = tree.sym.getRecordComponent(field.sym);
-                TreeCopier<JCTree> tc = new TreeCopier<>(make.at(field.pos));
-                List<JCAnnotation> originalAnnos = tc.copy(rec.getOriginalAnnos());
-
                 field.mods.flags &= ~Flags.VARARGS;
-                if (originalAnnos.length() != field.mods.annotations.length()) {
-                    field.mods.annotations = originalAnnos;
-                    annotate.annotateLater(originalAnnos, env, field.sym, field.pos());
-                }
-
-                // also here
                 field.sym.flags_field &= ~Flags.VARARGS;
             }
             // now lets add the accessors

--- a/test/langtools/tools/javac/records/RecordCompilationTests.java
+++ b/test/langtools/tools/javac/records/RecordCompilationTests.java
@@ -25,7 +25,7 @@
  * RecordCompilationTests
  *
  * @test
- * @bug 8250629 8252307 8247352 8241151 8246774 8259025 8288130 8282714
+ * @bug 8250629 8252307 8247352 8241151 8246774 8259025 8288130 8282714 8289647
  * @summary Negative compilation tests, and positive compilation (smoke) tests for records
  * @library /lib/combo /tools/lib /tools/javac/lib
  * @modules


### PR DESCRIPTION
This PR fixes a situation where the same record component was entered *and* schedule for later annotation at the same time.

The test case of the original bug report was recreated as part of "RecordCompilationTests". I tested that it breaks with the expected assertion error mentioned on the original bug report, without the proposed changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289647](https://bugs.openjdk.org/browse/JDK-8289647): AssertionError during annotation processing of record related tests


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**) ⚠️ Review applies to [74fcc2a6](https://git.openjdk.org/jdk/pull/9570/files/74fcc2a693fca17a0b7a5437690175db1f6b4e19)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9570/head:pull/9570` \
`$ git checkout pull/9570`

Update a local copy of the PR: \
`$ git checkout pull/9570` \
`$ git pull https://git.openjdk.org/jdk pull/9570/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9570`

View PR using the GUI difftool: \
`$ git pr show -t 9570`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9570.diff">https://git.openjdk.org/jdk/pull/9570.diff</a>

</details>
