### PR TITLE
8290687: serviceability/sa/TestClassDump.java could leave files owned by root on macOS

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestClassDump.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestClassDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.SA.SATestUtils;
+import jtreg.SkippedException;
 
 /**
  * @test
@@ -87,6 +88,10 @@ public class TestClassDump {
 
     public static void main(String[] args) throws Exception {
         SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
+        if (SATestUtils.needsPrivileges()) {
+            // This test will create files as root that cannot be easily deleted, so don't run.
+            throw new SkippedException("Cannot run this test on OSX if adding privileges is required.");
+        }
         LingeredApp theApp = null;
         try {
             theApp = LingeredApp.startApp();


### PR DESCRIPTION
Unless this test is run as root, it needs sudo privileges. If it gets them, the test runs fine, but leaves around files with root ownership so jtreg cannot delete them, and you see errors when "make clean" tries to delete them. It's best that we just don't run the test on OSX if sudo privileges.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290687](https://bugs.openjdk.org/browse/JDK-8290687): serviceability/sa/TestClassDump.java could leave files owned by root on macOS


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9579/head:pull/9579` \
`$ git checkout pull/9579`

Update a local copy of the PR: \
`$ git checkout pull/9579` \
`$ git pull https://git.openjdk.org/jdk pull/9579/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9579`

View PR using the GUI difftool: \
`$ git pr show -t 9579`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9579.diff">https://git.openjdk.org/jdk/pull/9579.diff</a>

</details>
