### PR TITLE
8290746: ProblemList compiler/vectorization/TestAutoVecIntMinMax.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -69,6 +69,7 @@ compiler/c2/Test8004741.java 8235801 generic-all
 
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all
 
+compiler/vectorization/TestAutoVecIntMinMax.java 8290730 generic-x64
 
 #############################################################################
 


### PR DESCRIPTION
In order to reduce the noise in the JDK20 CI, I'm ProblemListing test on x64: 

compiler/vectorization/TestAutoVecIntMinMax.java 

until JDK-8290730 is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290746](https://bugs.openjdk.org/browse/JDK-8290746): ProblemList compiler/vectorization/TestAutoVecIntMinMax.java


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9580/head:pull/9580` \
`$ git checkout pull/9580`

Update a local copy of the PR: \
`$ git checkout pull/9580` \
`$ git pull https://git.openjdk.org/jdk pull/9580/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9580`

View PR using the GUI difftool: \
`$ git pr show -t 9580`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9580.diff">https://git.openjdk.org/jdk/pull/9580.diff</a>

</details>
