### PR TITLE
8291106: ZPlatformGranuleSizeShift is redundant

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/z/zGlobals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zGlobals_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/aarch64/gc/z/zGlobals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zGlobals_aarch64.hpp
@@ -24,7 +24,7 @@
 #ifndef CPU_AARCH64_GC_Z_ZGLOBALS_AARCH64_HPP
 #define CPU_AARCH64_GC_Z_ZGLOBALS_AARCH64_HPP
 
-const size_t ZPlatformGranuleSizeShift = 24; // 16MB
+const size_t ZPlatformGranuleSizeShift = 24;  // 16MB
 const size_t ZPlatformHeapViews        = 3;
 const size_t ZPlatformCacheLineSize    = 64;
 

--- a/src/hotspot/cpu/aarch64/gc/z/zGlobals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zGlobals_aarch64.hpp
@@ -24,7 +24,6 @@
 #ifndef CPU_AARCH64_GC_Z_ZGLOBALS_AARCH64_HPP
 #define CPU_AARCH64_GC_Z_ZGLOBALS_AARCH64_HPP
 
-const size_t ZPlatformGranuleSizeShift = 24;  // 16MB
 const size_t ZPlatformHeapViews        = 3;
 const size_t ZPlatformCacheLineSize    = 64;
 

--- a/src/hotspot/cpu/aarch64/gc/z/zGlobals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zGlobals_aarch64.hpp
@@ -24,7 +24,7 @@
 #ifndef CPU_AARCH64_GC_Z_ZGLOBALS_AARCH64_HPP
 #define CPU_AARCH64_GC_Z_ZGLOBALS_AARCH64_HPP
 
-const size_t ZPlatformGranuleSizeShift = 21; // 2MB
+const size_t ZPlatformGranuleSizeShift = 24; // 16MB
 const size_t ZPlatformHeapViews        = 3;
 const size_t ZPlatformCacheLineSize    = 64;
 

--- a/src/hotspot/cpu/ppc/gc/z/zGlobals_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/z/zGlobals_ppc.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2021, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/gc/z/zGlobals_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/z/zGlobals_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/gc/z/zGlobals_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/z/zGlobals_ppc.hpp
@@ -26,7 +26,6 @@
 #define CPU_PPC_GC_Z_ZGLOBALS_PPC_HPP
 
 #include "globalDefinitions_ppc.hpp"
-const size_t ZPlatformGranuleSizeShift = 21; // 2MB
 const size_t ZPlatformHeapViews        = 3;
 const size_t ZPlatformCacheLineSize    = DEFAULT_CACHE_LINE_SIZE;
 

--- a/src/hotspot/cpu/riscv/gc/z/zGlobals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/gc/z/zGlobals_riscv.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/riscv/gc/z/zGlobals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/gc/z/zGlobals_riscv.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/riscv/gc/z/zGlobals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/gc/z/zGlobals_riscv.hpp
@@ -26,7 +26,6 @@
 #ifndef CPU_RISCV_GC_Z_ZGLOBALS_RISCV_HPP
 #define CPU_RISCV_GC_Z_ZGLOBALS_RISCV_HPP
 
-const size_t ZPlatformGranuleSizeShift = 21; // 2MB
 const size_t ZPlatformHeapViews        = 3;
 const size_t ZPlatformCacheLineSize    = 64;
 

--- a/src/hotspot/cpu/x86/gc/z/zGlobals_x86.hpp
+++ b/src/hotspot/cpu/x86/gc/z/zGlobals_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/gc/z/zGlobals_x86.hpp
+++ b/src/hotspot/cpu/x86/gc/z/zGlobals_x86.hpp
@@ -24,7 +24,6 @@
 #ifndef CPU_X86_GC_Z_ZGLOBALS_X86_HPP
 #define CPU_X86_GC_Z_ZGLOBALS_X86_HPP
 
-const size_t ZPlatformGranuleSizeShift = 21; // 2MB
 const size_t ZPlatformHeapViews        = 3;
 const size_t ZPlatformCacheLineSize    = 64;
 

--- a/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
@@ -196,7 +196,7 @@ ZPhysicalMemoryBacking::ZPhysicalMemoryBacking(size_t max_capacity) :
 }
 
 int ZPhysicalMemoryBacking::create_mem_fd(const char* name) const {
-  assert(ZGranuleSize == 2  * M, "Granule size must match MFD_HUGE_2MB");
+  assert(ZGranuleSize == 2 * M, "Granule size must match MFD_HUGE_2MB");
 
   // Create file name
   char filename[PATH_MAX];

--- a/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
@@ -46,6 +46,9 @@
 #include <sys/statfs.h>
 #include <sys/types.h>
 #include <unistd.h>
+#ifdef AARCH64
+#include <linux/memfd.h>
+#endif
 
 //
 // Support for building on older Linux systems
@@ -196,14 +199,22 @@ ZPhysicalMemoryBacking::ZPhysicalMemoryBacking(size_t max_capacity) :
 }
 
 int ZPhysicalMemoryBacking::create_mem_fd(const char* name) const {
-  assert(ZGranuleSize == 2 * M, "Granule size must match MFD_HUGE_2MB");
+#ifdef AARCH64
+  assert(ZGranuleSize == 16 * M, "Granule size must match MFD_HUGE_16MB");
+#else
+  assert(ZGranuleSize == 2  * M, "Granule size must match MFD_HUGE_2MB");
+#endif
 
   // Create file name
   char filename[PATH_MAX];
   snprintf(filename, sizeof(filename), "%s%s", name, ZLargePages::is_explicit() ? ".hugetlb" : "");
 
   // Create file
+#ifdef AARCH64
+  const int extra_flags = ZLargePages::is_explicit() ? (MFD_HUGETLB | MFD_HUGE_16MB) : 0;
+#else
   const int extra_flags = ZLargePages::is_explicit() ? (MFD_HUGETLB | MFD_HUGE_2MB) : 0;
+#endif
   const int fd = ZSyscall::memfd_create(filename, MFD_CLOEXEC | extra_flags);
   if (fd == -1) {
     ZErrno err;

--- a/src/hotspot/share/gc/z/zGlobals.hpp
+++ b/src/hotspot/share/gc/z/zGlobals.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zGlobals.hpp
+++ b/src/hotspot/share/gc/z/zGlobals.hpp
@@ -42,11 +42,7 @@ const char*       ZGlobalPhaseToString();
 extern uint32_t   ZGlobalSeqNum;
 
 // Granule shift/size
-#ifdef AARCH64
-const size_t      ZGranuleSizeShift             = ZPlatformGranuleSizeShift;
-#else
 const size_t      ZGranuleSizeShift             = 21; // 2MB
-#endif
 const size_t      ZGranuleSize                  = (size_t)1 << ZGranuleSizeShift;
 
 // Number of heap views

--- a/src/hotspot/share/gc/z/zGlobals.hpp
+++ b/src/hotspot/share/gc/z/zGlobals.hpp
@@ -42,7 +42,11 @@ const char*       ZGlobalPhaseToString();
 extern uint32_t   ZGlobalSeqNum;
 
 // Granule shift/size
+#ifdef AARCH64
 const size_t      ZGranuleSizeShift             = ZPlatformGranuleSizeShift;
+#else
+const size_t      ZGranuleSizeShift             = 21; // 2MB
+#endif
 const size_t      ZGranuleSize                  = (size_t)1 << ZGranuleSizeShift;
 
 // Number of heap views


### PR DESCRIPTION
Hi,

When I am tunning `ZPageSizeSmall` to 16 MB from 2MB:

```
const size_t ZPlatformGranuleSizeShift          = 24; // 16MB

// Granule shift/size
const size_t      ZGranuleSizeShift             = ZPlatformGranuleSizeShift;

// Page size shifts
const size_t      ZPageSizeSmallShift           = ZGranuleSizeShift;

// Page sizes
const size_t      ZPageSizeSmall                = (size_t)1 << ZPageSizeSmallShift;
```

`zBitField` failed to work:

```
Internal Error
 (/home/zhaixiang/jdk/src/hotspot/share/gc/z/zBitField.hpp:76), pid=923047, tid=923069
#  assert(((ContainerType)value & (FieldMask << ValueShift)) == (ContainerType)value) failed: Invalid value
#
# JRE version: OpenJDK Runtime Environment (20.0) (fastdebug build 20-internal-adhoc.root.jdk)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 20-internal-adhoc.root.jdk, mixed mode, sharing, tiered, compressed class ptrs, z gc, linux-aarch64)
```

Perhaps `mask` also need to be adjusted:

```
static size_t object_index(oop obj) {
  const uintptr_t addr = ZOop::to_address(obj);
  const uintptr_t offset = ZAddress::offset(addr);
  const uintptr_t mask = ZGranuleSize - 1;
  return (offset & mask) >> ZObjectAlignmentSmallShift;
}
```

Back to the point: ZPlatformGranuleSizeShift is redundant due to it can not be modified, for example, `24`, so I removed the `ZPlatformGranuleSizeShift` from cpu backends, just keep it for debugging AArch64 to see the issue.

Please review my patch.

Thanks,
Leslie Zhai

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291106](https://bugs.openjdk.org/browse/JDK-8291106): ZPlatformGranuleSizeShift is redundant


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9582/head:pull/9582` \
`$ git checkout pull/9582`

Update a local copy of the PR: \
`$ git checkout pull/9582` \
`$ git pull https://git.openjdk.org/jdk pull/9582/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9582`

View PR using the GUI difftool: \
`$ git pr show -t 9582`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9582.diff">https://git.openjdk.org/jdk/pull/9582.diff</a>

</details>
