### PR TITLE
8290775: Some doc errors in DerOutputStream.java

### DIFF
--- a/src/java.base/share/classes/sun/security/util/DerOutputStream.java
+++ b/src/java.base/share/classes/sun/security/util/DerOutputStream.java
@@ -461,8 +461,8 @@ extends ByteArrayOutputStream implements DerEncoder {
      * @param s the string to write
      * @param stringTag one of the DER string tags that indicate which
      * encoding should be used to write the string out.
-     * @param charset the charset should be used corresponding to the
-     * above tag.
+     * @param charset the charset that should be used corresponding to
+     * the above tag.
      */
     private void writeString(String s, byte stringTag, Charset charset)
         throws IOException {

--- a/src/java.base/share/classes/sun/security/util/DerOutputStream.java
+++ b/src/java.base/share/classes/sun/security/util/DerOutputStream.java
@@ -175,7 +175,7 @@ extends ByteArrayOutputStream implements DerEncoder {
     /**
      * Marshals a DER integer on the output stream.
      *
-     * @param buf buffered data, which must be DER-encoded
+     * @param i the integer in bytes, equivalent to BigInteger::toByteArray.
      */
     public void putInteger(byte[] buf) throws IOException {
         write(DerValue.tag_Integer);
@@ -461,8 +461,8 @@ extends ByteArrayOutputStream implements DerEncoder {
      * @param s the string to write
      * @param stringTag one of the DER string tags that indicate which
      * encoding should be used to write the string out.
-     * @param charset the specified character set encodes a string into a
-     * sequence of bytes using
+     * @param charset the charset that is should use corresponding to the
+     * above tag.
      */
     private void writeString(String s, byte stringTag, Charset charset)
         throws IOException {

--- a/src/java.base/share/classes/sun/security/util/DerOutputStream.java
+++ b/src/java.base/share/classes/sun/security/util/DerOutputStream.java
@@ -66,7 +66,7 @@ extends ByteArrayOutputStream implements DerEncoder {
     public DerOutputStream(int size) { super(size); }
 
     /**
-     * Construct an DER output stream.
+     * Construct a DER output stream.
      */
     public DerOutputStream() { }
 
@@ -175,7 +175,7 @@ extends ByteArrayOutputStream implements DerEncoder {
     /**
      * Marshals a DER integer on the output stream.
      *
-     * @param i the integer in bytes, equivalent to BigInteger::toByteArray.
+     * @param buf the integer in bytes, equivalent to BigInteger::toByteArray.
      */
     public void putInteger(byte[] buf) throws IOException {
         write(DerValue.tag_Integer);

--- a/src/java.base/share/classes/sun/security/util/DerOutputStream.java
+++ b/src/java.base/share/classes/sun/security/util/DerOutputStream.java
@@ -461,7 +461,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      * @param s the string to write
      * @param stringTag one of the DER string tags that indicate which
      * encoding should be used to write the string out.
-     * @param charset the charset that is should use corresponding to the
+     * @param charset the charset should be used corresponding to the
      * above tag.
      */
     private void writeString(String s, byte stringTag, Charset charset)

--- a/src/java.base/share/classes/sun/security/util/DerOutputStream.java
+++ b/src/java.base/share/classes/sun/security/util/DerOutputStream.java
@@ -59,7 +59,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class DerOutputStream
 extends ByteArrayOutputStream implements DerEncoder {
     /**
-     * Construct an DER output stream.
+     * Construct a DER output stream.
      *
      * @param size how large a buffer to preallocate.
      */
@@ -71,7 +71,7 @@ extends ByteArrayOutputStream implements DerEncoder {
     public DerOutputStream() { }
 
     /**
-     * Writes tagged, pre-marshaled data.  This calcuates and encodes
+     * Writes tagged, pre-marshaled data.  This calculates and encodes
      * the length, so that the output data is the standard triple of
      * { tag, length, data } used by all DER values.
      *
@@ -175,7 +175,7 @@ extends ByteArrayOutputStream implements DerEncoder {
     /**
      * Marshals a DER integer on the output stream.
      *
-     * @param i the integer in bytes, equivalent to BigInteger::toByteArray.
+     * @param buf buffered data, which must be DER-encoded
      */
     public void putInteger(byte[] buf) throws IOException {
         write(DerValue.tag_Integer);
@@ -461,8 +461,8 @@ extends ByteArrayOutputStream implements DerEncoder {
      * @param s the string to write
      * @param stringTag one of the DER string tags that indicate which
      * encoding should be used to write the string out.
-     * @param enc the name of the encoder that should be used corresponding
-     * to the above tag.
+     * @param charset the specified character set encodes a string into a
+     * sequence of bytes using
      */
     private void writeString(String s, byte stringTag, Charset charset)
         throws IOException {


### PR DESCRIPTION
There are some doc errors in sun.security.util.DerOutputStream, like the followings,

```
/**
 * Private helper routine for writing DER encoded string values.
 * @param s the string to write
 * @param stringTag one of the DER string tags that indicate which
 * encoding should be used to write the string out.
 * @param enc the name of the encoder that should be used corresponding
 * to the above tag.
 */
private void writeString(String s, byte stringTag, Charset charset) throws IOException
```
The parameter is charset, but not enc.

```
/**
 * Marshals a DER integer on the output stream.
 *
 * @param i the integer in bytes, equivalent to BigInteger::toByteArray.
 */
public void putInteger(byte[] buf) throws IOException {
```
The parameter is buf, but not i.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290775](https://bugs.openjdk.org/browse/JDK-8290775): Some doc errors in DerOutputStream.java


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9585/head:pull/9585` \
`$ git checkout pull/9585`

Update a local copy of the PR: \
`$ git checkout pull/9585` \
`$ git pull https://git.openjdk.org/jdk pull/9585/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9585`

View PR using the GUI difftool: \
`$ git pr show -t 9585`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9585.diff">https://git.openjdk.org/jdk/pull/9585.diff</a>

</details>
