### PR TITLE
8276561: URL$DefaultFactory::PREFIX should be static final

### DIFF
--- a/src/java.base/share/classes/java/net/URL.java
+++ b/src/java.base/share/classes/java/net/URL.java
@@ -1243,7 +1243,7 @@ public final class URL implements java.io.Serializable {
     private static final URLStreamHandlerFactory defaultFactory = new DefaultFactory();
 
     private static class DefaultFactory implements URLStreamHandlerFactory {
-        private static String PREFIX = "sun.net.www.protocol.";
+        private static final String PREFIX = "sun.net.www.protocol.";
 
         public URLStreamHandler createURLStreamHandler(String protocol) {
             // Avoid using reflection during bootstrap


### PR DESCRIPTION
Hi,

Could I get the following trivial code change reviewed please? Static analysis shows one 
static field declaration in java.net.URL that should be final.

Thanks,
Michael.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276561](https://bugs.openjdk.org/browse/JDK-8276561): URL$DefaultFactory::PREFIX should be static final


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - Committer)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9586/head:pull/9586` \
`$ git checkout pull/9586`

Update a local copy of the PR: \
`$ git checkout pull/9586` \
`$ git pull https://git.openjdk.org/jdk pull/9586/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9586`

View PR using the GUI difftool: \
`$ git pr show -t 9586`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9586.diff">https://git.openjdk.org/jdk/pull/9586.diff</a>

</details>
