### PR TITLE
8290154: [JVMCI] partially implement JVMCI for RISC-V

### DIFF
--- a/make/autoconf/jvm-features.m4
+++ b/make/autoconf/jvm-features.m4
@@ -275,6 +275,8 @@ AC_DEFUN_ONCE([JVM_FEATURES_CHECK_JVMCI],
       AC_MSG_RESULT([yes])
     elif test "x$OPENJDK_TARGET_CPU" = "xaarch64"; then
       AC_MSG_RESULT([yes])
+    elif test "x$OPENJDK_TARGET_CPU" = "xriscv64"; then
+      AC_MSG_RESULT([yes])
     else
       AC_MSG_RESULT([no, $OPENJDK_TARGET_CPU])
       AVAILABLE=false

--- a/src/hotspot/cpu/riscv/jvmciCodeInstaller_riscv.cpp
+++ b/src/hotspot/cpu/riscv/jvmciCodeInstaller_riscv.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "jvmci/jvmciCodeInstaller.hpp"
+#include "jvmci/jvmciRuntime.hpp"
+#include "jvmci/jvmciCompilerToVM.hpp"
+#include "jvmci/jvmciJavaClasses.hpp"
+#include "oops/oop.inline.hpp"
+#include "runtime/handles.inline.hpp"
+#include "runtime/sharedRuntime.hpp"
+#include "vmreg_riscv.inline.hpp"
+
+jint CodeInstaller::pd_next_offset(NativeInstruction* inst, jint pc_offset, JVMCI_TRAPS) {
+  address pc = (address) inst;
+  if (inst->is_call() || inst->is_jal()) {
+    return pc_offset + NativeCall::instruction_size;
+  } else if (inst->is_jump()) {
+    return pc_offset + NativeJump::instruction_size;
+  } else if (inst->is_movptr()) {
+    return pc_offset + NativeMovConstReg::instruction_size;
+  } else if (inst->is_lui()) {
+    NativeCall* call = nativeCall_at(pc + NativeInstruction::instruction_size);
+    unsigned offset = 1;
+    while (!call->is_call()) {
+      call = nativeCall_at(pc + NativeInstruction::instruction_size * offset);
+      offset += 1;
+    }
+    return pc_offset + NativeInstruction::instruction_size * (offset + 1);
+  } else {
+    JVMCI_ERROR_0("unsupported type of instruction for call site");
+  }
+}
+
+void CodeInstaller::pd_patch_OopConstant(int pc_offset, Handle& obj, bool compressed, JVMCI_TRAPS) {
+  address pc = _instructions->start() + pc_offset;
+  jobject value = JNIHandles::make_local(obj());
+  int oop_index = _oop_recorder->find_index(value);
+  RelocationHolder rspec = oop_Relocation::spec(oop_index);
+  _instructions->relocate(pc, rspec);
+}
+
+void CodeInstaller::pd_patch_MetaspaceConstant(int pc_offset, HotSpotCompiledCodeStream* stream, u1 tag, JVMCI_TRAPS) {
+  address pc = _instructions->start() + pc_offset;
+  if (tag == PATCH_NARROW_KLASS) {
+    narrowKlass narrowOop = record_narrow_metadata_reference(_instructions, pc, stream, tag, JVMCI_CHECK);
+    JVMCI_event_3("relocating (narrow metaspace constant) at " PTR_FORMAT "/0x%x", p2i(pc), narrowOop);
+  } else {
+    NativeMovConstReg* move = nativeMovConstReg_at(pc);
+    void* reference = record_metadata_reference(_instructions, pc, stream, tag, JVMCI_CHECK);
+    move->set_data((intptr_t) reference);
+    JVMCI_event_3("relocating (metaspace constant) at " PTR_FORMAT "/" PTR_FORMAT, p2i(pc), p2i(reference));
+  }
+}
+
+void CodeInstaller::pd_patch_DataSectionReference(int pc_offset, int data_offset, JVMCI_TRAPS) {
+  address pc = _instructions->start() + pc_offset;
+  address dest = _constants->start() + data_offset;
+  _instructions->relocate(pc, section_word_Relocation::spec((address) dest, CodeBuffer::SECT_CONSTS));
+  JVMCI_event_3("relocating at " PTR_FORMAT " (+%d) with destination at %d", p2i(pc), pc_offset, data_offset);
+}
+
+void CodeInstaller::pd_relocate_ForeignCall(NativeInstruction* inst, jlong foreign_call_destination, JVMCI_TRAPS) {
+  address pc = (address) inst;
+  if (inst->is_call() || inst->is_jal()) {
+    NativeCall* call = nativeCall_at(pc);
+    call->set_destination((address) foreign_call_destination);
+    _instructions->relocate(call->instruction_address(), runtime_call_Relocation::spec());
+  } else if (inst->is_jump()) {
+    NativeJump* jump = nativeJump_at(pc);
+    jump->set_jump_destination((address) foreign_call_destination);
+    _instructions->relocate(jump->instruction_address(), runtime_call_Relocation::spec());
+  } else if (inst->is_lui()) {
+    NativeInstruction* nextInst;
+    unsigned offset = 0;
+    do {
+      offset += 1;
+      nextInst = nativeInstruction_at(pc + NativeInstruction::instruction_size * offset);
+    } while (!nextInst->is_call());
+    NativeCall* call = nativeCall_at(pc + NativeInstruction::instruction_size * offset);
+    call->set_destination((address) foreign_call_destination);
+    _instructions->relocate(call->instruction_address(), runtime_call_Relocation::spec());
+  } else {
+    JVMCI_ERROR("unknown call or jump instruction at " PTR_FORMAT, p2i(pc));
+  }
+  JVMCI_event_3("relocating (foreign call) at " PTR_FORMAT, p2i(inst));
+}
+
+void CodeInstaller::pd_relocate_JavaMethod(CodeBuffer &cbuf, methodHandle& method, jint pc_offset, JVMCI_TRAPS) {
+  Unimplemented();
+}
+
+void CodeInstaller::pd_relocate_poll(address pc, jint mark, JVMCI_TRAPS) {
+  Unimplemented();
+}
+
+// convert JVMCI register indices (as used in oop maps) to HotSpot registers
+VMReg CodeInstaller::get_hotspot_reg(jint jvmci_reg, JVMCI_TRAPS) {
+  if (jvmci_reg < RegisterImpl::number_of_registers) {
+    return as_Register(jvmci_reg)->as_VMReg();
+  } else {
+    jint floatRegisterNumber = jvmci_reg - RegisterImpl::number_of_registers;
+    if (floatRegisterNumber >= 0 && floatRegisterNumber < FloatRegisterImpl::number_of_registers) {
+      return as_FloatRegister(floatRegisterNumber)->as_VMReg();
+    }
+    JVMCI_ERROR_NULL("invalid register number: %d", jvmci_reg);
+  }
+}
+
+bool CodeInstaller::is_general_purpose_reg(VMReg hotspotRegister) {
+  return !hotspotRegister->is_FloatRegister();
+}

--- a/src/hotspot/cpu/riscv/jvmciCodeInstaller_riscv.cpp
+++ b/src/hotspot/cpu/riscv/jvmciCodeInstaller_riscv.cpp
@@ -108,11 +108,11 @@ void CodeInstaller::pd_relocate_poll(address pc, jint mark, JVMCI_TRAPS) {
 
 // convert JVMCI register indices (as used in oop maps) to HotSpot registers
 VMReg CodeInstaller::get_hotspot_reg(jint jvmci_reg, JVMCI_TRAPS) {
-  if (jvmci_reg < RegisterImpl::number_of_registers) {
+  if (jvmci_reg < Register::number_of_registers) {
     return as_Register(jvmci_reg)->as_VMReg();
   } else {
-    jint floatRegisterNumber = jvmci_reg - RegisterImpl::number_of_registers;
-    if (floatRegisterNumber >= 0 && floatRegisterNumber < FloatRegisterImpl::number_of_registers) {
+    jint floatRegisterNumber = jvmci_reg - Register::number_of_registers;
+    if (floatRegisterNumber >= 0 && floatRegisterNumber < FloatRegister::number_of_registers) {
       return as_FloatRegister(floatRegisterNumber)->as_VMReg();
     }
     JVMCI_ERROR_NULL("invalid register number: %d", jvmci_reg);

--- a/src/hotspot/cpu/riscv/jvmciCodeInstaller_riscv.cpp
+++ b/src/hotspot/cpu/riscv/jvmciCodeInstaller_riscv.cpp
@@ -115,10 +115,6 @@ VMReg CodeInstaller::get_hotspot_reg(jint jvmci_reg, JVMCI_TRAPS) {
     if (floatRegisterNumber >= 0 && floatRegisterNumber < FloatRegisterImpl::number_of_registers) {
       return as_FloatRegister(floatRegisterNumber)->as_VMReg();
     }
-    jint vectorRegisterNumber = floatRegisterNumber - FloatRegisterImpl::number_of_registers;
-    if (vectorRegisterNumber >= 0 && vectorRegisterNumber - VectorRegisterImpl::number_of_registers) {
-      return as_VectorRegister(vectorRegisterNumber)->as_VMReg();
-    }
     JVMCI_ERROR_NULL("invalid register number: %d", jvmci_reg);
   }
 }

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -65,6 +65,7 @@ class NativeInstruction {
   bool is_movptr()                          const { return is_movptr_at(addr_at(0));      }
   bool is_call()                            const { return is_call_at(addr_at(0));        }
   bool is_jump()                            const { return is_jump_at(addr_at(0));        }
+  bool is_lui()                             const { return is_lui_at(addr_at(0));         }
 
   static bool is_jal_at(address instr)        { assert_cond(instr != NULL); return extract_opcode(instr) == 0b1101111; }
   static bool is_jalr_at(address instr)       { assert_cond(instr != NULL); return extract_opcode(instr) == 0b1100111 && extract_funct3(instr) == 0b000; }

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -65,7 +65,6 @@ class NativeInstruction {
   bool is_movptr()                          const { return is_movptr_at(addr_at(0));      }
   bool is_call()                            const { return is_call_at(addr_at(0));        }
   bool is_jump()                            const { return is_jump_at(addr_at(0));        }
-  bool is_lui()                             const { return is_lui_at(addr_at(0));         }
 
   static bool is_jal_at(address instr)        { assert_cond(instr != NULL); return extract_opcode(instr) == 0b1101111; }
   static bool is_jalr_at(address instr)       { assert_cond(instr != NULL); return extract_opcode(instr) == 0b1100111 && extract_funct3(instr) == 0b000; }

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1984,7 +1984,7 @@ void SharedRuntime::generate_deopt_blob() {
     Label retaddr;
     __ set_last_Java_frame(sp, noreg, retaddr, t0);
 
-    __ lwu(c_rarg1, Address(xthread, in_bytes(JavaThread::pending_deoptimization_offset())));
+    __ lw(c_rarg1, Address(xthread, in_bytes(JavaThread::pending_deoptimization_offset())));
     __ mvw(t0, -1);
     __ sw(t0, Address(xthread, in_bytes(JavaThread::pending_deoptimization_offset())));
 

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -56,6 +56,9 @@
 #include "adfiles/ad_riscv.hpp"
 #include "opto/runtime.hpp"
 #endif
+#if INCLUDE_JVMCI
+#include "jvmci/jvmciJavaClasses.hpp"
+#endif
 
 #define __ masm->
 
@@ -208,6 +211,9 @@ void RegisterSaver::restore_live_registers(MacroAssembler* masm) {
 #ifdef COMPILER2
   __ pop_CPU_state(_save_vectors, Matcher::scalable_vector_reg_size(T_BYTE));
 #else
+#if !INCLUDE_JVMCI
+  assert(!_save_vectors, "vectors are generated only by C2 and JVMCI");
+#endif
   __ pop_CPU_state(_save_vectors);
 #endif
   __ leave();
@@ -506,6 +512,18 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm,
   // Will jump to the compiled code just as if compiled code was doing it.
   // Pre-load the register-jump target early, to schedule it better.
   __ ld(t1, Address(xmethod, in_bytes(Method::from_compiled_offset())));
+
+#if INCLUDE_JVMCI
+  if (EnableJVMCI) {
+    // check if this call should be routed towards a specific entry point
+    __ ld(t0, Address(xthread, in_bytes(JavaThread::jvmci_alternate_call_target_offset())));
+    Label no_alternative_target;
+    __ beqz(t0, no_alternative_target);
+    __ mv(t1, t0);
+    __ sd(zr, Address(xthread, in_bytes(JavaThread::jvmci_alternate_call_target_offset())));
+    __ bind(no_alternative_target);
+  }
+#endif // INCLUDE_JVMCI
 
   // Now generate the shuffle code.
   for (int i = 0; i < total_args_passed; i++) {
@@ -1875,6 +1893,11 @@ void SharedRuntime::generate_deopt_blob() {
   ResourceMark rm;
   // Setup code generation tools
   int pad = 0;
+#if INCLUDE_JVMCI
+  if (EnableJVMCI) {
+    pad += 512; // Increase the buffer size when compiling for JVMCI
+  }
+#endif
   CodeBuffer buffer("deopt_blob", 2048 + pad, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
   int frame_size_in_words = -1;
@@ -1926,6 +1949,12 @@ void SharedRuntime::generate_deopt_blob() {
   __ j(cont);
 
   int reexecute_offset = __ pc() - start;
+#if INCLUDE_JVMCI && !defined(COMPILER1)
+  if (EnableJVMCI && UseJVMCICompiler) {
+    // JVMCI does not use this kind of deoptimization
+    __ should_not_reach_here();
+  }
+#endif
 
   // Reexecute case
   // return address is the pc describes what bci to do re-execute at
@@ -1935,6 +1964,44 @@ void SharedRuntime::generate_deopt_blob() {
 
   __ mvw(xcpool, Deoptimization::Unpack_reexecute); // callee-saved
   __ j(cont);
+
+#if INCLUDE_JVMCI
+  Label after_fetch_unroll_info_call;
+  int implicit_exception_uncommon_trap_offset = 0;
+  int uncommon_trap_offset = 0;
+
+  if (EnableJVMCI) {
+    implicit_exception_uncommon_trap_offset = __ pc() - start;
+
+    __ ld(ra, Address(xthread, in_bytes(JavaThread::jvmci_implicit_exception_pc_offset())));
+    __ sd(zr, Address(xthread, in_bytes(JavaThread::jvmci_implicit_exception_pc_offset())));
+
+    uncommon_trap_offset = __ pc() - start;
+
+    // Save everything in sight.
+    reg_saver.save_live_registers(masm, 0, &frame_size_in_words);
+    // fetch_unroll_info needs to call last_java_frame()
+    Label retaddr;
+    __ set_last_Java_frame(sp, noreg, retaddr, t0);
+
+    __ lwu(c_rarg1, Address(xthread, in_bytes(JavaThread::pending_deoptimization_offset())));
+    __ mvw(t0, -1);
+    __ sw(t0, Address(xthread, in_bytes(JavaThread::pending_deoptimization_offset())));
+
+    __ mvw(xcpool, (int32_t)Deoptimization::Unpack_reexecute);
+    __ mv(c_rarg0, xthread);
+    __ orrw(c_rarg2, zr, xcpool); // exec mode
+    int32_t offset = 0;
+    __ la_patchable(t0, RuntimeAddress(CAST_FROM_FN_PTR(address, Deoptimization::uncommon_trap)), offset);
+    __ jalr(x1, t0, offset);
+    __ bind(retaddr);
+    oop_maps->add_gc_map( __ pc()-start, map->deep_copy());
+
+    __ reset_last_Java_frame(false);
+
+    __ j(after_fetch_unroll_info_call);
+  } // EnableJVMCI
+#endif // INCLUDE_JVMCI
 
   int exception_offset = __ pc() - start;
 
@@ -2028,6 +2095,12 @@ void SharedRuntime::generate_deopt_blob() {
   oop_maps->add_gc_map(__ pc() - start, map);
 
   __ reset_last_Java_frame(false);
+
+#if INCLUDE_JVMCI
+  if (EnableJVMCI) {
+    __ bind(after_fetch_unroll_info_call);
+  }
+#endif
 
   // Load UnrollBlock* into x15
   __ mv(x15, x10);
@@ -2184,6 +2257,12 @@ void SharedRuntime::generate_deopt_blob() {
   _deopt_blob = DeoptimizationBlob::create(&buffer, oop_maps, 0, exception_offset, reexecute_offset, frame_size_in_words);
   assert(_deopt_blob != NULL, "create deoptimization blob fail!");
   _deopt_blob->set_unpack_with_exception_in_tls_offset(exception_in_tls_offset);
+#if INCLUDE_JVMCI
+  if (EnableJVMCI) {
+    _deopt_blob->set_uncommon_trap_offset(uncommon_trap_offset);
+    _deopt_blob->set_implicit_exception_uncommon_trap_offset(implicit_exception_uncommon_trap_offset);
+  }
+#endif
 }
 
 // Number of stack slots between incoming argument block and the start of

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -342,6 +342,9 @@ class Deoptimization : AllStatic {
       return 0;
     }
   }
+  // In RISC-V, when this method is inlined, the condition behaves
+  // incorrectly if the nmethod is compiled by JVMCI, causing the
+  // method to return a negative index which is not -1
   static int RISCV64_ONLY(__attribute__ ((noinline))) trap_request_index(int trap_request) {
     if (trap_request < 0)
       return -1;

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -342,7 +342,7 @@ class Deoptimization : AllStatic {
       return 0;
     }
   }
-  static int trap_request_index(int trap_request) {
+  static int RISCV64_ONLY(__attribute__ ((noinline))) trap_request_index(int trap_request) {
     if (trap_request < 0)
       return -1;
     else

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -342,10 +342,7 @@ class Deoptimization : AllStatic {
       return 0;
     }
   }
-  // In RISC-V, when this method is inlined, the condition behaves
-  // incorrectly if the nmethod is compiled by JVMCI, causing the
-  // method to return a negative index which is not -1
-  static int RISCV64_ONLY(__attribute__ ((noinline))) trap_request_index(int trap_request) {
+  static int trap_request_index(int trap_request) {
     if (trap_request < 0)
       return -1;
     else

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.riscv64/src/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotJVMCIBackendFactory.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.riscv64/src/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotJVMCIBackendFactory.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.vm.ci.hotspot.riscv64;
+
+import static java.util.Collections.emptyMap;
+import static jdk.vm.ci.common.InitTimer.timer;
+
+import java.util.EnumSet;
+import java.util.Map;
+
+import jdk.vm.ci.riscv64.RISCV64;
+import jdk.vm.ci.riscv64.RISCV64.CPUFeature;
+import jdk.vm.ci.code.Architecture;
+import jdk.vm.ci.code.RegisterConfig;
+import jdk.vm.ci.code.TargetDescription;
+import jdk.vm.ci.code.stack.StackIntrospection;
+import jdk.vm.ci.common.InitTimer;
+import jdk.vm.ci.hotspot.HotSpotCodeCacheProvider;
+import jdk.vm.ci.hotspot.HotSpotConstantReflectionProvider;
+import jdk.vm.ci.hotspot.HotSpotJVMCIBackendFactory;
+import jdk.vm.ci.hotspot.HotSpotJVMCIRuntime;
+import jdk.vm.ci.hotspot.HotSpotMetaAccessProvider;
+import jdk.vm.ci.hotspot.HotSpotStackIntrospection;
+import jdk.vm.ci.meta.ConstantReflectionProvider;
+import jdk.vm.ci.runtime.JVMCIBackend;
+
+public class RISCV64HotSpotJVMCIBackendFactory implements HotSpotJVMCIBackendFactory {
+
+    private static EnumSet<RISCV64.CPUFeature> computeFeatures(RISCV64HotSpotVMConfig config) {
+        // Configure the feature set using the HotSpot flag settings.
+        Map<String, Long> constants = config.getStore().getConstants();
+        return HotSpotJVMCIBackendFactory.convertFeatures(CPUFeature.class, constants, config.vmVersionFeatures, emptyMap());
+    }
+
+    private static EnumSet<RISCV64.Flag> computeFlags(RISCV64HotSpotVMConfig config) {
+        EnumSet<RISCV64.Flag> flags = EnumSet.noneOf(RISCV64.Flag.class);
+
+        if (config.useConservativeFence) {
+            flags.add(RISCV64.Flag.UseConservativeFence);
+        }
+        if (config.avoidUnalignedAccesses) {
+            flags.add(RISCV64.Flag.AvoidUnalignedAccesses);
+        }
+        if (config.nearCpool) {
+            flags.add(RISCV64.Flag.NearCpool);
+        }
+        if (config.traceTraps) {
+            flags.add(RISCV64.Flag.TraceTraps);
+        }
+        if (config.useRVV) {
+            flags.add(RISCV64.Flag.UseRVV);
+        }
+        if (config.useRVC) {
+            flags.add(RISCV64.Flag.UseRVC);
+        }
+        if (config.useZba) {
+            flags.add(RISCV64.Flag.UseZba);
+        }
+        if (config.useZbb) {
+            flags.add(RISCV64.Flag.UseZbb);
+        }
+        if (config.useRVVForBigIntegerShiftIntrinsics) {
+            flags.add(RISCV64.Flag.UseRVVForBigIntegerShiftIntrinsics);
+        }
+
+        return flags;
+    }
+
+    private static TargetDescription createTarget(RISCV64HotSpotVMConfig config) {
+        final int stackFrameAlignment = 16;
+        final int implicitNullCheckLimit = 4096;
+        final boolean inlineObjects = true;
+        Architecture arch = new RISCV64(computeFeatures(config), computeFlags(config));
+        return new TargetDescription(arch, true, stackFrameAlignment, implicitNullCheckLimit, inlineObjects);
+    }
+
+    protected HotSpotConstantReflectionProvider createConstantReflection(HotSpotJVMCIRuntime runtime) {
+        return new HotSpotConstantReflectionProvider(runtime);
+    }
+
+    private static RegisterConfig createRegisterConfig(RISCV64HotSpotVMConfig config, TargetDescription target) {
+        boolean canUsePlatformRegister = config.linuxOs;
+        return new RISCV64HotSpotRegisterConfig(target, config.useCompressedOops, canUsePlatformRegister);
+    }
+
+    protected HotSpotCodeCacheProvider createCodeCache(HotSpotJVMCIRuntime runtime, TargetDescription target, RegisterConfig regConfig) {
+        return new HotSpotCodeCacheProvider(runtime, target, regConfig);
+    }
+
+    protected HotSpotMetaAccessProvider createMetaAccess(HotSpotJVMCIRuntime runtime) {
+        return new HotSpotMetaAccessProvider(runtime);
+    }
+
+    @Override
+    public String getArchitecture() {
+        return "riscv64";
+    }
+
+    @Override
+    public String toString() {
+        return "JVMCIBackend:" + getArchitecture();
+    }
+
+    @Override
+    @SuppressWarnings("try")
+    public JVMCIBackend createJVMCIBackend(HotSpotJVMCIRuntime runtime, JVMCIBackend host) {
+        assert host == null;
+        RISCV64HotSpotVMConfig config = new RISCV64HotSpotVMConfig(runtime.getConfigStore());
+        TargetDescription target = createTarget(config);
+
+        RegisterConfig regConfig;
+        HotSpotCodeCacheProvider codeCache;
+        ConstantReflectionProvider constantReflection;
+        HotSpotMetaAccessProvider metaAccess;
+        StackIntrospection stackIntrospection;
+        try (InitTimer t = timer("create providers")) {
+            try (InitTimer rt = timer("create MetaAccess provider")) {
+                metaAccess = createMetaAccess(runtime);
+            }
+            try (InitTimer rt = timer("create RegisterConfig")) {
+                regConfig = createRegisterConfig(config, target);
+            }
+            try (InitTimer rt = timer("create CodeCache provider")) {
+                codeCache = createCodeCache(runtime, target, regConfig);
+            }
+            try (InitTimer rt = timer("create ConstantReflection provider")) {
+                constantReflection = createConstantReflection(runtime);
+            }
+            try (InitTimer rt = timer("create StackIntrospection provider")) {
+                stackIntrospection = new HotSpotStackIntrospection(runtime);
+            }
+        }
+        try (InitTimer rt = timer("instantiate backend")) {
+            return createBackend(metaAccess, codeCache, constantReflection, stackIntrospection);
+        }
+    }
+
+    protected JVMCIBackend createBackend(HotSpotMetaAccessProvider metaAccess, HotSpotCodeCacheProvider codeCache, ConstantReflectionProvider constantReflection,
+                    StackIntrospection stackIntrospection) {
+        return new JVMCIBackend(metaAccess, codeCache, constantReflection, stackIntrospection);
+    }
+}

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.riscv64/src/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotJVMCIBackendFactory.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.riscv64/src/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotJVMCIBackendFactory.java
@@ -99,8 +99,7 @@ public class RISCV64HotSpotJVMCIBackendFactory implements HotSpotJVMCIBackendFac
     }
 
     private static RegisterConfig createRegisterConfig(RISCV64HotSpotVMConfig config, TargetDescription target) {
-        boolean canUsePlatformRegister = config.linuxOs;
-        return new RISCV64HotSpotRegisterConfig(target, config.useCompressedOops, canUsePlatformRegister);
+        return new RISCV64HotSpotRegisterConfig(target, config.useCompressedOops, config.linuxOs);
     }
 
     protected HotSpotCodeCacheProvider createCodeCache(HotSpotJVMCIRuntime runtime, TargetDescription target, RegisterConfig regConfig) {

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.riscv64/src/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotRegisterConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.riscv64/src/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotRegisterConfig.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.vm.ci.hotspot.riscv64;
+
+import static jdk.vm.ci.riscv64.RISCV64.x0;
+import static jdk.vm.ci.riscv64.RISCV64.x1;
+import static jdk.vm.ci.riscv64.RISCV64.x2;
+import static jdk.vm.ci.riscv64.RISCV64.x3;
+import static jdk.vm.ci.riscv64.RISCV64.x4;
+import static jdk.vm.ci.riscv64.RISCV64.x8;
+import static jdk.vm.ci.riscv64.RISCV64.x10;
+import static jdk.vm.ci.riscv64.RISCV64.x11;
+import static jdk.vm.ci.riscv64.RISCV64.x12;
+import static jdk.vm.ci.riscv64.RISCV64.x13;
+import static jdk.vm.ci.riscv64.RISCV64.x14;
+import static jdk.vm.ci.riscv64.RISCV64.x15;
+import static jdk.vm.ci.riscv64.RISCV64.x16;
+import static jdk.vm.ci.riscv64.RISCV64.x17;
+import static jdk.vm.ci.riscv64.RISCV64.x27;
+import static jdk.vm.ci.riscv64.RISCV64.f10;
+import static jdk.vm.ci.riscv64.RISCV64.f11;
+import static jdk.vm.ci.riscv64.RISCV64.f12;
+import static jdk.vm.ci.riscv64.RISCV64.f13;
+import static jdk.vm.ci.riscv64.RISCV64.f14;
+import static jdk.vm.ci.riscv64.RISCV64.f15;
+import static jdk.vm.ci.riscv64.RISCV64.f16;
+import static jdk.vm.ci.riscv64.RISCV64.f17;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import jdk.vm.ci.riscv64.RISCV64;
+import jdk.vm.ci.riscv64.RISCV64.CPUFeature;
+import jdk.vm.ci.code.Architecture;
+import jdk.vm.ci.code.CallingConvention;
+import jdk.vm.ci.code.CallingConvention.Type;
+import jdk.vm.ci.code.Register;
+import jdk.vm.ci.code.RegisterArray;
+import jdk.vm.ci.code.RegisterAttributes;
+import jdk.vm.ci.code.RegisterConfig;
+import jdk.vm.ci.code.StackSlot;
+import jdk.vm.ci.code.TargetDescription;
+import jdk.vm.ci.code.ValueKindFactory;
+import jdk.vm.ci.common.JVMCIError;
+import jdk.vm.ci.hotspot.HotSpotCallingConventionType;
+import jdk.vm.ci.meta.AllocatableValue;
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.JavaType;
+import jdk.vm.ci.meta.PlatformKind;
+import jdk.vm.ci.meta.Value;
+import jdk.vm.ci.meta.ValueKind;
+
+public class RISCV64HotSpotRegisterConfig implements RegisterConfig {
+
+    private final TargetDescription target;
+
+    private final RegisterArray allocatable;
+
+    /**
+     * The caller saved registers always include all parameter registers.
+     */
+    private final RegisterArray callerSaved;
+
+    private final boolean allAllocatableAreCallerSaved;
+
+    private final RegisterAttributes[] attributesMap;
+
+    @Override
+    public RegisterArray getAllocatableRegisters() {
+        return allocatable;
+    }
+
+    @Override
+    public RegisterArray filterAllocatableRegisters(PlatformKind kind, RegisterArray registers) {
+        ArrayList<Register> list = new ArrayList<>();
+        for (Register reg : registers) {
+            if (target.arch.canStoreValue(reg.getRegisterCategory(), kind)) {
+                list.add(reg);
+            }
+        }
+
+        return new RegisterArray(list);
+    }
+
+    @Override
+    public RegisterAttributes[] getAttributesMap() {
+        return attributesMap.clone();
+    }
+
+    private final RegisterArray javaGeneralParameterRegisters = new RegisterArray(x10, x11, x12, x13, x14, x15, x16, x17);
+    private final RegisterArray nativeGeneralParameterRegisters = new RegisterArray(x10, x11, x12, x13, x14, x15, x16, x17);
+    private final RegisterArray fpParameterRegisters = new RegisterArray(f10, f11, f12, f13, f14, f15, f16, f17);
+
+    public static final Register zero = x0;
+    public static final Register ra = x1;
+    public static final Register sp = x2;
+    public static final Register gp = x3;
+    public static final Register tp = x4;
+    public static final Register fp = x8;
+
+    private static final RegisterArray reservedRegisters = new RegisterArray(zero, ra, sp, gp, tp, fp);
+
+    private static RegisterArray initAllocatable(Architecture arch, boolean reserveForHeapBase) {
+        RegisterArray allRegisters = arch.getAvailableValueRegisters();
+        Register[] registers = new Register[allRegisters.size() - reservedRegisters.size() - (reserveForHeapBase ? 1 : 0)];
+        List<Register> reservedRegistersList = reservedRegisters.asList();
+
+        int idx = 0;
+        for (Register reg : allRegisters) {
+            if (reservedRegistersList.contains(reg)) {
+                // skip reserved registers
+                continue;
+            }
+            assert !(reg.equals(zero) || reg.equals(ra) || reg.equals(sp) || reg.equals(gp) || reg.equals(tp) || reg.equals(fp));
+            if (reserveForHeapBase && reg.equals(x27)) {
+                // skip heap base register
+                continue;
+            }
+
+            registers[idx++] = reg;
+        }
+
+        assert idx == registers.length;
+        return new RegisterArray(registers);
+    }
+
+    public RISCV64HotSpotRegisterConfig(TargetDescription target, boolean useCompressedOops, boolean linuxOs) {
+        this(target, initAllocatable(target.arch, useCompressedOops));
+    }
+
+    public RISCV64HotSpotRegisterConfig(TargetDescription target, RegisterArray allocatable) {
+        this.target = target;
+        this.allocatable = allocatable;
+
+        Set<Register> callerSaveSet = new HashSet<>();
+        allocatable.addTo(callerSaveSet);
+        fpParameterRegisters.addTo(callerSaveSet);
+        javaGeneralParameterRegisters.addTo(callerSaveSet);
+        nativeGeneralParameterRegisters.addTo(callerSaveSet);
+        callerSaved = new RegisterArray(callerSaveSet);
+
+        allAllocatableAreCallerSaved = true;
+        attributesMap = RegisterAttributes.createMap(this, RISCV64.allRegisters);
+    }
+
+    @Override
+    public RegisterArray getCallerSaveRegisters() {
+        return callerSaved;
+    }
+
+    @Override
+    public RegisterArray getCalleeSaveRegisters() {
+        return null;
+    }
+
+    @Override
+    public boolean areAllAllocatableRegistersCallerSaved() {
+        return allAllocatableAreCallerSaved;
+    }
+
+    @Override
+    public CallingConvention getCallingConvention(Type type, JavaType returnType, JavaType[] parameterTypes, ValueKindFactory<?> valueKindFactory) {
+        HotSpotCallingConventionType hotspotType = (HotSpotCallingConventionType) type;
+        if (type == HotSpotCallingConventionType.NativeCall) {
+            return callingConvention(nativeGeneralParameterRegisters, returnType, parameterTypes, hotspotType, valueKindFactory);
+        }
+        return callingConvention(javaGeneralParameterRegisters, returnType, parameterTypes, hotspotType, valueKindFactory);
+    }
+
+    @Override
+    public RegisterArray getCallingConventionRegisters(Type type, JavaKind kind) {
+        HotSpotCallingConventionType hotspotType = (HotSpotCallingConventionType) type;
+        switch (kind) {
+            case Boolean:
+            case Byte:
+            case Short:
+            case Char:
+            case Int:
+            case Long:
+            case Object:
+                return hotspotType == HotSpotCallingConventionType.NativeCall ? nativeGeneralParameterRegisters : javaGeneralParameterRegisters;
+            case Float:
+            case Double:
+                return fpParameterRegisters;
+            default:
+                throw JVMCIError.shouldNotReachHere();
+        }
+    }
+
+    private CallingConvention callingConvention(RegisterArray generalParameterRegisters, JavaType returnType, JavaType[] parameterTypes, HotSpotCallingConventionType type,
+                    ValueKindFactory<?> valueKindFactory) {
+        AllocatableValue[] locations = new AllocatableValue[parameterTypes.length];
+
+        int currentGeneral = 0;
+        int currentFP = 0;
+        int currentStackOffset = 0;
+
+        for (int i = 0; i < parameterTypes.length; i++) {
+            final JavaKind kind = parameterTypes[i].getJavaKind().getStackKind();
+
+            switch (kind) {
+                case Byte:
+                case Boolean:
+                case Short:
+                case Char:
+                case Int:
+                case Long:
+                case Object:
+                    if (currentGeneral < generalParameterRegisters.size()) {
+                        Register register = generalParameterRegisters.get(currentGeneral++);
+                        locations[i] = register.asValue(valueKindFactory.getValueKind(kind));
+                    }
+                    break;
+                case Float:
+                case Double:
+                    if (currentFP < fpParameterRegisters.size()) {
+                        Register register = fpParameterRegisters.get(currentFP++);
+                        locations[i] = register.asValue(valueKindFactory.getValueKind(kind));
+                    }
+                    break;
+                default:
+                    throw JVMCIError.shouldNotReachHere();
+            }
+
+            if (locations[i] == null) {
+                ValueKind<?> valueKind = valueKindFactory.getValueKind(kind);
+                locations[i] = StackSlot.get(valueKind, currentStackOffset, !type.out);
+                currentStackOffset += Math.max(valueKind.getPlatformKind().getSizeInBytes(), target.wordSize);
+            }
+        }
+
+        JavaKind returnKind = returnType == null ? JavaKind.Void : returnType.getJavaKind();
+        AllocatableValue returnLocation = returnKind == JavaKind.Void ? Value.ILLEGAL : getReturnRegister(returnKind).asValue(valueKindFactory.getValueKind(returnKind.getStackKind()));
+        return new CallingConvention(currentStackOffset, returnLocation, locations);
+    }
+
+    @Override
+    public Register getReturnRegister(JavaKind kind) {
+        switch (kind) {
+            case Boolean:
+            case Byte:
+            case Char:
+            case Short:
+            case Int:
+            case Long:
+            case Object:
+                return x10;
+            case Float:
+            case Double:
+                return f10;
+            case Void:
+            case Illegal:
+                return null;
+            default:
+                throw new UnsupportedOperationException("no return register for type " + kind);
+        }
+    }
+
+    @Override
+    public Register getFrameRegister() {
+        return x8;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Allocatable: " + getAllocatableRegisters() + "%n" + "CallerSave:  " + getCallerSaveRegisters() + "%n");
+    }
+}

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.riscv64/src/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.riscv64/src/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotVMConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.vm.ci.hotspot.riscv64;
+
+import jdk.vm.ci.hotspot.HotSpotVMConfigAccess;
+import jdk.vm.ci.hotspot.HotSpotVMConfigStore;
+import jdk.vm.ci.services.Services;
+
+public class RISCV64HotSpotVMConfig extends HotSpotVMConfigAccess {
+
+    RISCV64HotSpotVMConfig(HotSpotVMConfigStore config) {
+        super(config);
+    }
+
+    final boolean linuxOs = Services.getSavedProperty("os.name", "").startsWith("Linux");
+
+    final boolean useCompressedOops = getFlag("UseCompressedOops", Boolean.class);
+
+    // CPU Capabilities
+
+    /*
+     * These flags are set based on the corresponding command line flags.
+     */
+    final boolean useConservativeFence = getFlag("UseConservativeFence", Boolean.class);
+    final boolean avoidUnalignedAccesses = getFlag("AvoidUnalignedAccesses", Boolean.class);
+    final boolean nearCpool = getFlag("NearCpool", Boolean.class);
+    final boolean traceTraps = getFlag("TraceTraps", Boolean.class);
+    final boolean useRVV = getFlag("UseRVV", Boolean.class);
+    final boolean useRVC = getFlag("UseRVC", Boolean.class);
+    final boolean useZba = getFlag("UseZba", Boolean.class);
+    final boolean useZbb = getFlag("UseZbb", Boolean.class);
+    final boolean useRVVForBigIntegerShiftIntrinsics = getFlag("UseRVVForBigIntegerShiftIntrinsics", Boolean.class);
+
+    final long vmVersionFeatures = getFieldValue("Abstract_VM_Version::_features", Long.class, "uint64_t");
+
+    /*
+     * These flags are set if the corresponding support is in the hardware.
+     */
+    // Checkstyle: stop
+    // CPU feature flags are currently not available in VM_Version
+    // Checkstyle: resume
+
+}

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.riscv64/src/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.riscv64/src/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotVMConfig.java
@@ -26,7 +26,12 @@ import jdk.vm.ci.hotspot.HotSpotVMConfigAccess;
 import jdk.vm.ci.hotspot.HotSpotVMConfigStore;
 import jdk.vm.ci.services.Services;
 
-public class RISCV64HotSpotVMConfig extends HotSpotVMConfigAccess {
+/**
+ * Used to access native configuration details.
+ *
+ * All non-static, public fields in this class are so that they can be compiled as constants.
+ */
+class RISCV64HotSpotVMConfig extends HotSpotVMConfigAccess {
 
     RISCV64HotSpotVMConfig(HotSpotVMConfigStore config) {
         super(config);

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.riscv64/src/jdk/vm/ci/hotspot/riscv64/package-info.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.riscv64/src/jdk/vm/ci/hotspot/riscv64/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * The RISCV64 HotSpot specific portions of the JVMCI API.
+ */
+package jdk.vm.ci.hotspot.riscv64;

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.riscv64/src/jdk/vm/ci/riscv64/RISCV64.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.riscv64/src/jdk/vm/ci/riscv64/RISCV64.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.vm.ci.riscv64;
+
+import java.nio.ByteOrder;
+import java.util.EnumSet;
+
+import jdk.vm.ci.code.Architecture;
+import jdk.vm.ci.code.CPUFeatureName;
+import jdk.vm.ci.code.Register;
+import jdk.vm.ci.code.Register.RegisterCategory;
+import jdk.vm.ci.code.RegisterArray;
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.PlatformKind;
+
+public class RISCV64 extends Architecture {
+
+    public static final RegisterCategory CPU = new RegisterCategory("CPU");
+
+    // General purpose CPU registers
+    public static final Register x0 = new Register(0, 0, "x0", CPU);
+    public static final Register x1 = new Register(1, 1, "x1", CPU);
+    public static final Register x2 = new Register(2, 2, "x2", CPU);
+    public static final Register x3 = new Register(3, 3, "x3", CPU);
+    public static final Register x4 = new Register(4, 4, "x4", CPU);
+    public static final Register x5 = new Register(5, 5, "x5", CPU);
+    public static final Register x6 = new Register(6, 6, "x6", CPU);
+    public static final Register x7 = new Register(7, 7, "x7", CPU);
+    public static final Register x8 = new Register(8, 8, "x8", CPU);
+    public static final Register x9 = new Register(9, 9, "x9", CPU);
+    public static final Register x10 = new Register(10, 10, "x10", CPU);
+    public static final Register x11 = new Register(11, 11, "x11", CPU);
+    public static final Register x12 = new Register(12, 12, "x12", CPU);
+    public static final Register x13 = new Register(13, 13, "x13", CPU);
+    public static final Register x14 = new Register(14, 14, "x14", CPU);
+    public static final Register x15 = new Register(15, 15, "x15", CPU);
+    public static final Register x16 = new Register(16, 16, "x16", CPU);
+    public static final Register x17 = new Register(17, 17, "x17", CPU);
+    public static final Register x18 = new Register(18, 18, "x18", CPU);
+    public static final Register x19 = new Register(19, 19, "x19", CPU);
+    public static final Register x20 = new Register(20, 20, "x20", CPU);
+    public static final Register x21 = new Register(21, 21, "x21", CPU);
+    public static final Register x22 = new Register(22, 22, "x22", CPU);
+    public static final Register x23 = new Register(23, 23, "x23", CPU);
+    public static final Register x24 = new Register(24, 24, "x24", CPU);
+    public static final Register x25 = new Register(25, 25, "x25", CPU);
+    public static final Register x26 = new Register(26, 26, "x26", CPU);
+    public static final Register x27 = new Register(27, 27, "x27", CPU);
+    public static final Register x28 = new Register(28, 28, "x28", CPU);
+    public static final Register x29 = new Register(29, 29, "x29", CPU);
+    public static final Register x30 = new Register(30, 30, "x30", CPU);
+    public static final Register x31 = new Register(31, 31, "x31", CPU);
+
+    // @formatter:off
+    public static final RegisterArray cpuRegisters = new RegisterArray(
+        x0,  x1,  x2,  x3,  x4,  x5,  x6,  x7,
+        x8,  x9,  x10, x11, x12, x13, x14, x15,
+        x16, x17, x18, x19, x20, x21, x22, x23,
+        x24, x25, x26, x27, x28, x29, x30, x31
+    );
+    // @formatter:on
+
+    public static final RegisterCategory FP = new RegisterCategory("FP");
+
+    // Simd registers
+    public static final Register f0 = new Register(32, 0, "f0", FP);
+    public static final Register f1 = new Register(33, 1, "f1", FP);
+    public static final Register f2 = new Register(34, 2, "f2", FP);
+    public static final Register f3 = new Register(35, 3, "f3", FP);
+    public static final Register f4 = new Register(36, 4, "f4", FP);
+    public static final Register f5 = new Register(37, 5, "f5", FP);
+    public static final Register f6 = new Register(38, 6, "f6", FP);
+    public static final Register f7 = new Register(39, 7, "f7", FP);
+    public static final Register f8 = new Register(40, 8, "f8", FP);
+    public static final Register f9 = new Register(41, 9, "f9", FP);
+    public static final Register f10 = new Register(42, 10, "f10", FP);
+    public static final Register f11 = new Register(43, 11, "f11", FP);
+    public static final Register f12 = new Register(44, 12, "f12", FP);
+    public static final Register f13 = new Register(45, 13, "f13", FP);
+    public static final Register f14 = new Register(46, 14, "f14", FP);
+    public static final Register f15 = new Register(47, 15, "f15", FP);
+    public static final Register f16 = new Register(48, 16, "f16", FP);
+    public static final Register f17 = new Register(49, 17, "f17", FP);
+    public static final Register f18 = new Register(50, 18, "f18", FP);
+    public static final Register f19 = new Register(51, 19, "f19", FP);
+    public static final Register f20 = new Register(52, 20, "f20", FP);
+    public static final Register f21 = new Register(53, 21, "f21", FP);
+    public static final Register f22 = new Register(54, 22, "f22", FP);
+    public static final Register f23 = new Register(55, 23, "f23", FP);
+    public static final Register f24 = new Register(56, 24, "f24", FP);
+    public static final Register f25 = new Register(57, 25, "f25", FP);
+    public static final Register f26 = new Register(58, 26, "f26", FP);
+    public static final Register f27 = new Register(59, 27, "f27", FP);
+    public static final Register f28 = new Register(60, 28, "f28", FP);
+    public static final Register f29 = new Register(61, 29, "f29", FP);
+    public static final Register f30 = new Register(62, 30, "f30", FP);
+    public static final Register f31 = new Register(63, 31, "f31", FP);
+
+    // @formatter:off
+    public static final RegisterArray fpRegisters = new RegisterArray(
+        f0,  f1,  f2,  f3,  f4,  f5,  f6,  f7,
+        f8,  f9,  f10, f11, f12, f13, f14, f15,
+        f16, f17, f18, f19, f20, f21, f22, f23,
+        f24, f25, f26, f27, f28, f29, f30, f31
+    );
+    // @formatter:on
+
+    public static final RegisterCategory SIMD = new RegisterCategory("SIMD");
+
+    // Simd registers
+    public static final Register v0 = new Register(64, 0, "v0", SIMD);
+    public static final Register v1 = new Register(65, 1, "v1", SIMD);
+    public static final Register v2 = new Register(66, 2, "v2", SIMD);
+    public static final Register v3 = new Register(67, 3, "v3", SIMD);
+    public static final Register v4 = new Register(68, 4, "v4", SIMD);
+    public static final Register v5 = new Register(69, 5, "v5", SIMD);
+    public static final Register v6 = new Register(70, 6, "v6", SIMD);
+    public static final Register v7 = new Register(71, 7, "v7", SIMD);
+    public static final Register v8 = new Register(72, 8, "v8", SIMD);
+    public static final Register v9 = new Register(73, 9, "v9", SIMD);
+    public static final Register v10 = new Register(74, 10, "v10", SIMD);
+    public static final Register v11 = new Register(75, 11, "v11", SIMD);
+    public static final Register v12 = new Register(76, 12, "v12", SIMD);
+    public static final Register v13 = new Register(77, 13, "v13", SIMD);
+    public static final Register v14 = new Register(78, 14, "v14", SIMD);
+    public static final Register v15 = new Register(79, 15, "v15", SIMD);
+    public static final Register v16 = new Register(80, 16, "v16", SIMD);
+    public static final Register v17 = new Register(81, 17, "v17", SIMD);
+    public static final Register v18 = new Register(82, 18, "v18", SIMD);
+    public static final Register v19 = new Register(83, 19, "v19", SIMD);
+    public static final Register v20 = new Register(84, 20, "v20", SIMD);
+    public static final Register v21 = new Register(85, 21, "v21", SIMD);
+    public static final Register v22 = new Register(86, 22, "v22", SIMD);
+    public static final Register v23 = new Register(87, 23, "v23", SIMD);
+    public static final Register v24 = new Register(88, 24, "v24", SIMD);
+    public static final Register v25 = new Register(89, 25, "v25", SIMD);
+    public static final Register v26 = new Register(90, 26, "v26", SIMD);
+    public static final Register v27 = new Register(91, 27, "v27", SIMD);
+    public static final Register v28 = new Register(92, 28, "v28", SIMD);
+    public static final Register v29 = new Register(93, 29, "v29", SIMD);
+    public static final Register v30 = new Register(94, 30, "v30", SIMD);
+    public static final Register v31 = new Register(95, 31, "v31", SIMD);
+
+    // @formatter:off
+    public static final RegisterArray simdRegisters = new RegisterArray(
+        v0,  v1,  v2,  v3,  v4,  v5,  v6,  v7,
+        v8,  v9,  v10, v11, v12, v13, v14, v15,
+        v16, v17, v18, v19, v20, v21, v22, v23,
+        v24, v25, v26, v27, v28, v29, v30, v31
+    );
+    // @formatter:on
+
+    // @formatter:off
+    public static final RegisterArray allRegisters = new RegisterArray(
+        x0,  x1,  x2,  x3,  x4,  x5,  x6,  x7,
+        x8,  x9,  x10, x11, x12, x13, x14, x15,
+        x16, x17, x18, x19, x20, x21, x22, x23,
+        x24, x25, x26, x27, x28, x29, x30, x31,
+
+        f0,  f1,  f2,  f3,  f4,  f5,  f6,  f7,
+        f8,  f9,  f10, f11, f12, f13, f14, f15,
+        f16, f17, f18, f19, f20, f21, f22, f23,
+        f24, f25, f26, f27, f28, f29, f30, f31,
+
+        v0,  v1,  v2,  v3,  v4,  v5,  v6,  v7,
+        v8,  v9,  v10, v11, v12, v13, v14, v15,
+        v16, v17, v18, v19, v20, v21, v22, v23,
+        v24, v25, v26, v27, v28, v29, v30, v31
+    );
+    // @formatter:on
+
+    /**
+     * Basic set of CPU features mirroring what is returned from the mcpuid register. See:
+     * {@code VM_Version::cpuFeatureFlags}.
+     */
+    public enum CPUFeature implements CPUFeatureName {
+        I,
+        M,
+        A,
+        F,
+        D,
+        C,
+        V
+    }
+
+    private final EnumSet<CPUFeature> features;
+
+    /**
+     * Set of flags to control code emission.
+     */
+    public enum Flag {
+        UseConservativeFence,
+        AvoidUnalignedAccesses,
+        NearCpool,
+        TraceTraps,
+        UseRVV,
+        UseRVC,
+        UseZba,
+        UseZbb,
+        UseRVVForBigIntegerShiftIntrinsics
+    }
+
+    private final EnumSet<Flag> flags;
+
+    public RISCV64(EnumSet<CPUFeature> features, EnumSet<Flag> flags) {
+        super("riscv64", RISCV64Kind.QWORD, ByteOrder.LITTLE_ENDIAN, true, allRegisters, 0, 0, 8);
+        this.features = features;
+        this.flags = flags;
+    }
+
+    @Override
+    public EnumSet<CPUFeature> getFeatures() {
+        return features;
+    }
+
+    public EnumSet<Flag> getFlags() {
+        return flags;
+    }
+
+    @Override
+    public PlatformKind getPlatformKind(JavaKind javaKind) {
+        switch (javaKind) {
+            case Boolean:
+            case Byte:
+                return RISCV64Kind.BYTE;
+            case Short:
+            case Char:
+                return RISCV64Kind.WORD;
+            case Int:
+                return RISCV64Kind.DWORD;
+            case Long:
+            case Object:
+                return RISCV64Kind.QWORD;
+            case Float:
+                return RISCV64Kind.SINGLE;
+            case Double:
+                return RISCV64Kind.DOUBLE;
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public boolean canStoreValue(RegisterCategory category, PlatformKind platformKind) {
+        RISCV64Kind kind = (RISCV64Kind) platformKind;
+        if (kind.isInteger()) {
+            return category.equals(CPU);
+        } else if (kind.isFP()) {
+            return category.equals(FP);
+        } else if (kind.isSIMD()) {
+            return category.equals(SIMD);
+        }
+        return false;
+    }
+
+    @Override
+    public RISCV64Kind getLargestStorableKind(RegisterCategory category) {
+        if (category.equals(CPU)) {
+            return RISCV64Kind.QWORD;
+        } else if (category.equals(FP)) {
+            return RISCV64Kind.DOUBLE;
+        } else if (category.equals(SIMD)) {
+            return RISCV64Kind.V128_QWORD;
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.riscv64/src/jdk/vm/ci/riscv64/RISCV64.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.riscv64/src/jdk/vm/ci/riscv64/RISCV64.java
@@ -128,51 +128,6 @@ public class RISCV64 extends Architecture {
     );
     // @formatter:on
 
-    public static final RegisterCategory SIMD = new RegisterCategory("SIMD");
-
-    // Simd registers
-    public static final Register v0 = new Register(64, 0, "v0", SIMD);
-    public static final Register v1 = new Register(65, 1, "v1", SIMD);
-    public static final Register v2 = new Register(66, 2, "v2", SIMD);
-    public static final Register v3 = new Register(67, 3, "v3", SIMD);
-    public static final Register v4 = new Register(68, 4, "v4", SIMD);
-    public static final Register v5 = new Register(69, 5, "v5", SIMD);
-    public static final Register v6 = new Register(70, 6, "v6", SIMD);
-    public static final Register v7 = new Register(71, 7, "v7", SIMD);
-    public static final Register v8 = new Register(72, 8, "v8", SIMD);
-    public static final Register v9 = new Register(73, 9, "v9", SIMD);
-    public static final Register v10 = new Register(74, 10, "v10", SIMD);
-    public static final Register v11 = new Register(75, 11, "v11", SIMD);
-    public static final Register v12 = new Register(76, 12, "v12", SIMD);
-    public static final Register v13 = new Register(77, 13, "v13", SIMD);
-    public static final Register v14 = new Register(78, 14, "v14", SIMD);
-    public static final Register v15 = new Register(79, 15, "v15", SIMD);
-    public static final Register v16 = new Register(80, 16, "v16", SIMD);
-    public static final Register v17 = new Register(81, 17, "v17", SIMD);
-    public static final Register v18 = new Register(82, 18, "v18", SIMD);
-    public static final Register v19 = new Register(83, 19, "v19", SIMD);
-    public static final Register v20 = new Register(84, 20, "v20", SIMD);
-    public static final Register v21 = new Register(85, 21, "v21", SIMD);
-    public static final Register v22 = new Register(86, 22, "v22", SIMD);
-    public static final Register v23 = new Register(87, 23, "v23", SIMD);
-    public static final Register v24 = new Register(88, 24, "v24", SIMD);
-    public static final Register v25 = new Register(89, 25, "v25", SIMD);
-    public static final Register v26 = new Register(90, 26, "v26", SIMD);
-    public static final Register v27 = new Register(91, 27, "v27", SIMD);
-    public static final Register v28 = new Register(92, 28, "v28", SIMD);
-    public static final Register v29 = new Register(93, 29, "v29", SIMD);
-    public static final Register v30 = new Register(94, 30, "v30", SIMD);
-    public static final Register v31 = new Register(95, 31, "v31", SIMD);
-
-    // @formatter:off
-    public static final RegisterArray simdRegisters = new RegisterArray(
-        v0,  v1,  v2,  v3,  v4,  v5,  v6,  v7,
-        v8,  v9,  v10, v11, v12, v13, v14, v15,
-        v16, v17, v18, v19, v20, v21, v22, v23,
-        v24, v25, v26, v27, v28, v29, v30, v31
-    );
-    // @formatter:on
-
     // @formatter:off
     public static final RegisterArray allRegisters = new RegisterArray(
         x0,  x1,  x2,  x3,  x4,  x5,  x6,  x7,
@@ -183,12 +138,7 @@ public class RISCV64 extends Architecture {
         f0,  f1,  f2,  f3,  f4,  f5,  f6,  f7,
         f8,  f9,  f10, f11, f12, f13, f14, f15,
         f16, f17, f18, f19, f20, f21, f22, f23,
-        f24, f25, f26, f27, f28, f29, f30, f31,
-
-        v0,  v1,  v2,  v3,  v4,  v5,  v6,  v7,
-        v8,  v9,  v10, v11, v12, v13, v14, v15,
-        v16, v17, v18, v19, v20, v21, v22, v23,
-        v24, v25, v26, v27, v28, v29, v30, v31
+        f24, f25, f26, f27, f28, f29, f30, f31
     );
     // @formatter:on
 
@@ -270,8 +220,6 @@ public class RISCV64 extends Architecture {
             return category.equals(CPU);
         } else if (kind.isFP()) {
             return category.equals(FP);
-        } else if (kind.isSIMD()) {
-            return category.equals(SIMD);
         }
         return false;
     }
@@ -282,8 +230,6 @@ public class RISCV64 extends Architecture {
             return RISCV64Kind.QWORD;
         } else if (category.equals(FP)) {
             return RISCV64Kind.DOUBLE;
-        } else if (category.equals(SIMD)) {
-            return RISCV64Kind.V256_QWORD;
         } else {
             return null;
         }

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.riscv64/src/jdk/vm/ci/riscv64/RISCV64.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.riscv64/src/jdk/vm/ci/riscv64/RISCV64.java
@@ -33,6 +33,9 @@ import jdk.vm.ci.code.RegisterArray;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.PlatformKind;
 
+/**
+ * Represents the RISCV64 architecture.
+ */
 public class RISCV64 extends Architecture {
 
     public static final RegisterCategory CPU = new RegisterCategory("CPU");
@@ -280,7 +283,7 @@ public class RISCV64 extends Architecture {
         } else if (category.equals(FP)) {
             return RISCV64Kind.DOUBLE;
         } else if (category.equals(SIMD)) {
-            return RISCV64Kind.V128_QWORD;
+            return RISCV64Kind.V256_QWORD;
         } else {
             return null;
         }

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.riscv64/src/jdk/vm/ci/riscv64/RISCV64Kind.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.riscv64/src/jdk/vm/ci/riscv64/RISCV64Kind.java
@@ -108,7 +108,7 @@ public enum RISCV64Kind implements PlatformKind {
     }
 
     public boolean isFP() {
-        switch(this) {
+        switch (this) {
             case SINGLE:
             case DOUBLE:
                 return true;

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.riscv64/src/jdk/vm/ci/riscv64/RISCV64Kind.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.riscv64/src/jdk/vm/ci/riscv64/RISCV64Kind.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.vm.ci.riscv64;
+
+import jdk.vm.ci.meta.PlatformKind;
+
+public enum RISCV64Kind implements PlatformKind {
+
+    // scalar
+    BYTE(1),
+    WORD(2),
+    DWORD(4),
+    QWORD(8),
+    SINGLE(4),
+    DOUBLE(8),
+
+    // SIMD
+    V32_BYTE(4, BYTE),
+    V32_WORD(4, WORD),
+    V64_BYTE(8, BYTE),
+    V64_WORD(8, WORD),
+    V64_DWORD(8, DWORD),
+    V128_BYTE(16, BYTE),
+    V128_WORD(16, WORD),
+    V128_DWORD(16, DWORD),
+    V128_QWORD(16, QWORD),
+    V128_SINGLE(16, SINGLE),
+    V128_DOUBLE(16, DOUBLE),
+    V256_BYTE(32, BYTE),
+    V256_WORD(32, WORD),
+    V256_DWORD(32, DWORD),
+    V256_QWORD(32, QWORD),
+    V256_SINGLE(32, SINGLE),
+    V256_DOUBLE(32, DOUBLE);
+
+    // The maximum value of VLEN (the length of the vector registers) is 65536 according to the ISA.
+    // Thus those types are not enough to define all the possibilites.
+
+    private final int size;
+    private final int vectorLength;
+
+    private final RISCV64Kind scalar;
+    private final EnumKey<RISCV64Kind> key = new EnumKey<>(this);
+
+    RISCV64Kind(int size) {
+        this.size = size;
+        this.scalar = this;
+        this.vectorLength = 1;
+    }
+
+    RISCV64Kind(int size, RISCV64Kind scalar) {
+        this.size = size;
+        this.scalar = scalar;
+
+        assert size % scalar.size == 0;
+        this.vectorLength = size / scalar.size;
+    }
+
+    public RISCV64Kind getScalar() {
+        return scalar;
+    }
+
+    @Override
+    public int getSizeInBytes() {
+        return size;
+    }
+
+    @Override
+    public int getVectorLength() {
+        return vectorLength;
+    }
+
+    @Override
+    public Key getKey() {
+        return key;
+    }
+
+    public boolean isInteger() {
+        switch (this) {
+            case BYTE:
+            case WORD:
+            case DWORD:
+            case QWORD:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public boolean isFP() {
+        switch(this) {
+            case SINGLE:
+            case DOUBLE:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public boolean isSIMD() {
+        switch (this) {
+            case V32_BYTE:
+            case V32_WORD:
+            case V64_BYTE:
+            case V64_WORD:
+            case V64_DWORD:
+            case V128_BYTE:
+            case V128_WORD:
+            case V128_DWORD:
+            case V128_QWORD:
+            case V128_SINGLE:
+            case V128_DOUBLE:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    public char getTypeChar() {
+        switch (this) {
+            case BYTE:
+                return 'b';
+            case WORD:
+                return 'w';
+            case DWORD:
+                return 'd';
+            case QWORD:
+                return 'q';
+            case SINGLE:
+                return 'S';
+            case DOUBLE:
+                return 'D';
+            case V32_BYTE:
+            case V32_WORD:
+            case V64_BYTE:
+            case V64_WORD:
+            case V64_DWORD:
+            case V128_BYTE:
+            case V128_WORD:
+            case V128_DWORD:
+            case V128_QWORD:
+            case V128_SINGLE:
+            case V128_DOUBLE:
+                return 'v';
+            default:
+                return '-';
+        }
+    }
+
+}

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.riscv64/src/jdk/vm/ci/riscv64/RISCV64Kind.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.riscv64/src/jdk/vm/ci/riscv64/RISCV64Kind.java
@@ -32,29 +32,7 @@ public enum RISCV64Kind implements PlatformKind {
     DWORD(4),
     QWORD(8),
     SINGLE(4),
-    DOUBLE(8),
-
-    // SIMD
-    V32_BYTE(4, BYTE),
-    V32_WORD(4, WORD),
-    V64_BYTE(8, BYTE),
-    V64_WORD(8, WORD),
-    V64_DWORD(8, DWORD),
-    V128_BYTE(16, BYTE),
-    V128_WORD(16, WORD),
-    V128_DWORD(16, DWORD),
-    V128_QWORD(16, QWORD),
-    V128_SINGLE(16, SINGLE),
-    V128_DOUBLE(16, DOUBLE),
-    V256_BYTE(32, BYTE),
-    V256_WORD(32, WORD),
-    V256_DWORD(32, DWORD),
-    V256_QWORD(32, QWORD),
-    V256_SINGLE(32, SINGLE),
-    V256_DOUBLE(32, DOUBLE);
-
-    // The maximum value of VLEN (the length of the vector registers) is 65536 according to the ISA.
-    // Thus those types are not enough to define all the possibilites.
+    DOUBLE(8);
 
     private final int size;
     private final int vectorLength;
@@ -117,25 +95,6 @@ public enum RISCV64Kind implements PlatformKind {
         }
     }
 
-    public boolean isSIMD() {
-        switch (this) {
-            case V32_BYTE:
-            case V32_WORD:
-            case V64_BYTE:
-            case V64_WORD:
-            case V64_DWORD:
-            case V128_BYTE:
-            case V128_WORD:
-            case V128_DWORD:
-            case V128_QWORD:
-            case V128_SINGLE:
-            case V128_DOUBLE:
-                return true;
-            default:
-                return false;
-        }
-    }
-
     @Override
     public char getTypeChar() {
         switch (this) {
@@ -151,18 +110,6 @@ public enum RISCV64Kind implements PlatformKind {
                 return 'S';
             case DOUBLE:
                 return 'D';
-            case V32_BYTE:
-            case V32_WORD:
-            case V64_BYTE:
-            case V64_WORD:
-            case V64_DWORD:
-            case V128_BYTE:
-            case V128_WORD:
-            case V128_DWORD:
-            case V128_QWORD:
-            case V128_SINGLE:
-            case V128_DOUBLE:
-                return 'v';
             default:
                 return '-';
         }

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.riscv64/src/jdk/vm/ci/riscv64/package-info.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.riscv64/src/jdk/vm/ci/riscv64/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * The RISCV64 platform independent portions of the JVMCI API.
+ */
+package jdk.vm.ci.riscv64;

--- a/src/jdk.internal.vm.ci/share/classes/module-info.java
+++ b/src/jdk.internal.vm.ci/share/classes/module-info.java
@@ -39,5 +39,6 @@ module jdk.internal.vm.ci {
 
     provides jdk.vm.ci.hotspot.HotSpotJVMCIBackendFactory with
         jdk.vm.ci.hotspot.aarch64.AArch64HotSpotJVMCIBackendFactory,
-        jdk.vm.ci.hotspot.amd64.AMD64HotSpotJVMCIBackendFactory;
+        jdk.vm.ci.hotspot.amd64.AMD64HotSpotJVMCIBackendFactory,
+        jdk.vm.ci.hotspot.riscv64.RISCV64HotSpotJVMCIBackendFactory;
 }

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/CodeInstallationTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/CodeInstallationTest.java
@@ -24,12 +24,14 @@ package jdk.vm.ci.code.test;
 
 import jdk.vm.ci.aarch64.AArch64;
 import jdk.vm.ci.amd64.AMD64;
+import jdk.vm.ci.riscv64.RISCV64;
 import jdk.vm.ci.code.Architecture;
 import jdk.vm.ci.code.CodeCacheProvider;
 import jdk.vm.ci.code.InstalledCode;
 import jdk.vm.ci.code.TargetDescription;
 import jdk.vm.ci.code.test.aarch64.AArch64TestAssembler;
 import jdk.vm.ci.code.test.amd64.AMD64TestAssembler;
+import jdk.vm.ci.code.test.riscv64.RISCV64TestAssembler;
 import jdk.vm.ci.hotspot.HotSpotCodeCacheProvider;
 import jdk.vm.ci.hotspot.HotSpotCompiledCode;
 import jdk.vm.ci.hotspot.HotSpotJVMCIRuntime;
@@ -76,6 +78,8 @@ public class CodeInstallationTest {
             return new AMD64TestAssembler(codeCache, config);
         } else if (arch instanceof AArch64) {
             return new AArch64TestAssembler(codeCache, config);
+        } else if (arch instanceof RISCV64) {
+            return new RISCV64TestAssembler(codeCache, config);
         } else {
             Assert.fail("unsupported architecture");
             return null;

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/CodeInstallationTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/CodeInstallationTest.java
@@ -107,12 +107,9 @@ public class CodeInstallationTest {
             HotSpotCompiledCode code = asm.finish(resolvedMethod);
             InstalledCode installed = codeCache.addCode(resolvedMethod, code, null, null);
 
-            String str = ((HotSpotCodeCacheProvider) codeCache).disassemble(installed);
-                System.out.println(str);
-
             if (DEBUG) {
-                String str2 = ((HotSpotCodeCacheProvider) codeCache).disassemble(installed);
-                System.out.println(str2);
+                String str = ((HotSpotCodeCacheProvider) codeCache).disassemble(installed);
+                System.out.println(str);
             }
 
             Object expected = method.invoke(null, args);

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/CodeInstallationTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/CodeInstallationTest.java
@@ -107,9 +107,12 @@ public class CodeInstallationTest {
             HotSpotCompiledCode code = asm.finish(resolvedMethod);
             InstalledCode installed = codeCache.addCode(resolvedMethod, code, null, null);
 
-            if (DEBUG) {
-                String str = ((HotSpotCodeCacheProvider) codeCache).disassemble(installed);
+            String str = ((HotSpotCodeCacheProvider) codeCache).disassemble(installed);
                 System.out.println(str);
+
+            if (DEBUG) {
+                String str2 = ((HotSpotCodeCacheProvider) codeCache).disassemble(installed);
+                System.out.println(str2);
             }
 
             Object expected = method.invoke(null, args);

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/DataPatchTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/DataPatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @requires vm.jvmci
- * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64"
+ * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64" | vm.simpleArch == "riscv64"
  * @library /
  * @modules jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.meta
@@ -33,7 +33,8 @@
  *          jdk.internal.vm.ci/jdk.vm.ci.runtime
  *          jdk.internal.vm.ci/jdk.vm.ci.aarch64
  *          jdk.internal.vm.ci/jdk.vm.ci.amd64
- * @compile CodeInstallationTest.java DebugInfoTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java
+ *          jdk.internal.vm.ci/jdk.vm.ci.riscv64
+ * @compile CodeInstallationTest.java DebugInfoTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java riscv64/RISCV64TestAssembler.java
  * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseJVMCICompiler jdk.vm.ci.code.test.DataPatchTest
  */
 

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/InterpreterFrameSizeTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/InterpreterFrameSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @requires vm.jvmci
- * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64"
+ * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64" | vm.simpleArch == "riscv64"
  * @modules jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.code
  *          jdk.internal.vm.ci/jdk.vm.ci.code.site
@@ -33,7 +33,8 @@
  *          jdk.internal.vm.ci/jdk.vm.ci.common
  *          jdk.internal.vm.ci/jdk.vm.ci.aarch64
  *          jdk.internal.vm.ci/jdk.vm.ci.amd64
- * @compile CodeInstallationTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java
+ *          jdk.internal.vm.ci/jdk.vm.ci.riscv64
+ * @compile CodeInstallationTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java riscv64/RISCV64TestAssembler.java
  * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseJVMCICompiler jdk.vm.ci.code.test.InterpreterFrameSizeTest
  */
 

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/MaxOopMapStackOffsetTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/MaxOopMapStackOffsetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @requires vm.jvmci
- * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64"
+ * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64" | vm.simpleArch == "riscv64"
  * @library /
  * @modules jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.meta
@@ -34,7 +34,8 @@
  *          jdk.internal.vm.ci/jdk.vm.ci.runtime
  *          jdk.internal.vm.ci/jdk.vm.ci.aarch64
  *          jdk.internal.vm.ci/jdk.vm.ci.amd64
- * @compile CodeInstallationTest.java DebugInfoTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java
+ *          jdk.internal.vm.ci/jdk.vm.ci.riscv64
+ * @compile CodeInstallationTest.java DebugInfoTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java riscv64/RISCV64TestAssembler.java
  * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseJVMCICompiler jdk.vm.ci.code.test.MaxOopMapStackOffsetTest
  */
 

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @requires vm.jvmci
- * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64"
+ * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64" | vm.simpleArch == "riscv64"
  * @library /test/lib /
  * @modules jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.code
@@ -34,7 +34,8 @@
  *          jdk.internal.vm.ci/jdk.vm.ci.common
  *          jdk.internal.vm.ci/jdk.vm.ci.aarch64
  *          jdk.internal.vm.ci/jdk.vm.ci.amd64
- * @compile CodeInstallationTest.java TestHotSpotVMConfig.java NativeCallTest.java TestAssembler.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java
+ *          jdk.internal.vm.ci/jdk.vm.ci.riscv64
+ * @compile CodeInstallationTest.java TestHotSpotVMConfig.java NativeCallTest.java TestAssembler.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java riscv64/RISCV64TestAssembler.java
  * @run junit/othervm/native -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI  -Xbootclasspath/a:. jdk.vm.ci.code.test.NativeCallTest
  */
 package jdk.vm.ci.code.test;

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/SimpleCodeInstallationTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/SimpleCodeInstallationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @requires vm.jvmci
- * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64"
+ * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64" | vm.simpleArch == "riscv64"
  * @library /
  * @modules jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.meta
@@ -33,7 +33,8 @@
  *          jdk.internal.vm.ci/jdk.vm.ci.runtime
  *          jdk.internal.vm.ci/jdk.vm.ci.aarch64
  *          jdk.internal.vm.ci/jdk.vm.ci.amd64
- * @compile CodeInstallationTest.java DebugInfoTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java
+ *          jdk.internal.vm.ci/jdk.vm.ci.riscv64
+ * @compile CodeInstallationTest.java DebugInfoTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java riscv64/RISCV64TestAssembler.java
  * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseJVMCICompiler jdk.vm.ci.code.test.SimpleCodeInstallationTest
  */
 

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/SimpleDebugInfoTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/SimpleDebugInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @requires vm.jvmci
- * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64"
+ * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64" | vm.simpleArch == "riscv64"
  * @library /
  * @modules jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.meta
@@ -33,7 +33,8 @@
  *          jdk.internal.vm.ci/jdk.vm.ci.runtime
  *          jdk.internal.vm.ci/jdk.vm.ci.aarch64
  *          jdk.internal.vm.ci/jdk.vm.ci.amd64
- * @compile CodeInstallationTest.java DebugInfoTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java
+ *          jdk.internal.vm.ci/jdk.vm.ci.riscv64
+ * @compile CodeInstallationTest.java DebugInfoTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java riscv64/RISCV64TestAssembler.java
  * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseJVMCICompiler jdk.vm.ci.code.test.SimpleDebugInfoTest
  */
 

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/VirtualObjectDebugInfoTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/VirtualObjectDebugInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @requires vm.jvmci
- * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64"
+ * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64" | vm.simpleArch == "riscv64"
  * @library /
  * @modules jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.meta
@@ -33,7 +33,8 @@
  *          jdk.internal.vm.ci/jdk.vm.ci.runtime
  *          jdk.internal.vm.ci/jdk.vm.ci.aarch64
  *          jdk.internal.vm.ci/jdk.vm.ci.amd64
- * @compile CodeInstallationTest.java DebugInfoTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java
+ *          jdk.internal.vm.ci/jdk.vm.ci.riscv64
+ * @compile CodeInstallationTest.java DebugInfoTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java riscv64/RISCV64TestAssembler.java
  * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseJVMCICompiler jdk.vm.ci.code.test.VirtualObjectDebugInfoTest
  */
 

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/riscv64/RISCV64TestAssembler.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/riscv64/RISCV64TestAssembler.java
@@ -1,0 +1,494 @@
+/*
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.vm.ci.code.test.riscv64;
+
+import jdk.vm.ci.riscv64.RISCV64;
+import jdk.vm.ci.riscv64.RISCV64Kind;
+import jdk.vm.ci.code.CallingConvention;
+import jdk.vm.ci.code.CodeCacheProvider;
+import jdk.vm.ci.code.DebugInfo;
+import jdk.vm.ci.code.Register;
+import jdk.vm.ci.code.RegisterValue;
+import jdk.vm.ci.code.StackSlot;
+import jdk.vm.ci.code.site.ConstantReference;
+import jdk.vm.ci.code.site.DataSectionReference;
+import jdk.vm.ci.code.test.TestAssembler;
+import jdk.vm.ci.code.test.TestHotSpotVMConfig;
+import jdk.vm.ci.hotspot.HotSpotCallingConventionType;
+import jdk.vm.ci.hotspot.HotSpotConstant;
+import jdk.vm.ci.hotspot.HotSpotForeignCallTarget;
+import jdk.vm.ci.meta.AllocatableValue;
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.VMConstant;
+
+public class RISCV64TestAssembler extends TestAssembler {
+
+    private static final Register scratchRegister = RISCV64.x28;
+    private static final Register doubleScratch = RISCV64.f28;
+
+    public RISCV64TestAssembler(CodeCacheProvider codeCache, TestHotSpotVMConfig config) {
+        super(codeCache, config,
+              16 /* initialFrameSize */, 16 /* stackAlignment */,
+              RISCV64Kind.DWORD /* narrowOopKind */,
+              /* registers */
+              RISCV64.x0, RISCV64.x1, RISCV64.x2, RISCV64.x3,
+              RISCV64.x4, RISCV64.x5, RISCV64.x6, RISCV64.x7);
+    }
+
+    private static int instructionImmediate(int imm, int rs1, int funct, int rd, int opcode) {
+        return (imm << 20) | (rs1 << 15) | (funct << 12) | (rd << 7) | opcode;
+    }
+
+    private static int instructionRegister(int funct7, int rs2, int rs1, int funct3, int rd, int opcode) {
+        return (funct7 << 25) | (rs2 << 20) | (rs1 << 15) | (funct3 << 12) | (rd << 7) | opcode;
+    }
+
+    private void emitNop() {
+        code.emitInt(instructionImmediate(0, 0, 0b000, 0, 0b0010011));
+    }
+
+    private void emitAdd(Register Rd, Register Rn, Register Rm) {
+        // ADD
+        code.emitInt(instructionRegister(0b0000000, Rn.encoding, Rm.encoding, 0b000, Rd.encoding, 0b0110011));
+    }
+
+    private void emitAdd(Register Rd, Register Rn, int imm12) {
+        // ADDI
+        code.emitInt(instructionImmediate(imm12, Rn.encoding, 0b000, Rd.encoding, 0b0010011));
+    }
+
+    private void emitAddW(Register Rd, Register Rn, int imm12) {
+        // ADDIW
+        code.emitInt(instructionImmediate(imm12, Rn.encoding, 0b000, Rd.encoding, 0b0011011));
+    }
+
+    private void emitSub(Register Rd, Register Rn, int imm12) {
+        // SUBI
+        code.emitInt(instructionImmediate(-imm12, Rn.encoding, 0b000, Rd.encoding, 0b0010011));
+    }
+
+    private void emitSub(Register Rd, Register Rn, Register Rm) {
+        // SUB
+        code.emitInt(instructionRegister(0b0100000, Rn.encoding, Rm.encoding, 0b000, Rd.encoding, 0b0110011));
+    }
+
+    private void emitMv(Register Rd, Register Rn) {
+        // MV
+        code.emitInt(instructionRegister(0b0000000, Rn.encoding, 0, 0b000, Rd.encoding, 0b0110011));
+    }
+
+    private void emitShiftLeft(Register Rd, Register Rn, int shift) {
+        // SLLI
+        code.emitInt(instructionImmediate(shift, Rn.encoding, 0b001, Rd.encoding, 0b0010011));
+    }
+
+    private void emitLui(Register Rd, int imm20) {
+        // LUI
+        code.emitInt((imm20 << 12) | (Rd.encoding << 7) | 0b0110111);
+    }
+
+    private void emitAuipc(Register Rd, int imm20) {
+        // AUIPC
+        code.emitInt((imm20 << 12) | (Rd.encoding << 7) | 0b0010111);
+    }
+
+    private void emitLoadImmediate(Register Rd, int imm32) {
+        emitLui(Rd, (imm32 >> 12) & 0xfffff);
+        emitAddW(Rd, Rd, imm32 & 0xfff);
+    }
+
+    private void emitLoadRegister(Register Rt, RISCV64Kind kind, Register Rn, int offset) {
+        // LB/LH/LW/LD (immediate)
+        assert offset >= 0;
+        int size = 0;
+        int opc = 0;
+        switch (kind) {
+            case BYTE: size = 0b000; opc = 0b0000011; break;
+            case WORD: size = 0b001; opc = 0b0000011; break;
+            case DWORD: size = 0b010; opc = 0b0000011; break;
+            case QWORD: size = 0b011; opc = 0b0000011; break;
+            case SINGLE: size = 0b010; opc = 0b0000111; break;
+            case DOUBLE: size = 0b011; opc = 0b0000111; break;
+            default: throw new IllegalArgumentException();
+        }
+        code.emitInt((offset << 20) | (Rt.encoding << 15) | (size << 12) | (Rn.encoding << 7) | opc);
+    }
+
+    private void emitStoreRegister(Register Rt, RISCV64Kind kind, Register Rn, int offset) {
+        // SB/SH/SW/SD (immediate)
+        assert offset >= 0;
+        int size = 0;
+        int opc = 0;
+        switch (kind) {
+            case BYTE: size = 0b000; opc = 0b0100011; break;
+            case WORD: size = 0b001; opc = 0b0100011; break;
+            case DWORD: size = 0b010; opc = 0b0100011; break;
+            case QWORD: size = 0b011; opc = 0b0100011; break;
+            case SINGLE: size = 0b010; opc = 0b0100111; break;
+            case DOUBLE: size = 0b011; opc = 0b0100111; break;
+            default: throw new IllegalArgumentException();
+        }
+        code.emitInt(((offset >> 5) << 25) | (Rt.encoding << 20) | (Rn.encoding << 15) | (size << 12) | ((offset & 0x1f) << 7) | opc);
+    }
+
+    private void emitJalr(Register Rd, Register Rn, int imm) {
+        code.emitInt(instructionImmediate(imm, Rn.encoding, 0b000, Rd.encoding, 0b1100111));
+    }
+
+    private void emitFmv(Register Rd, RISCV64Kind kind, Register Rn) {
+        int funct = 0;
+        switch (kind) {
+            case SINGLE: funct = 0b1111000; break;
+            case DOUBLE: funct = 0b1111001; break;
+            default: throw new IllegalArgumentException();
+        }
+        code.emitInt(instructionRegister(funct, 0b00000, Rn.encoding, 0b000, Rd.encoding, 0b1010011));
+    }
+
+    @Override
+    public void emitGrowStack(int size) {
+        assert size % 16 == 0;
+        if (size > -4096 && size < 0) {
+            emitAdd(RISCV64.x2, RISCV64.x2, -size);
+        } else if (size == 0) {
+            // No-op
+        } else if (size < 4096) {
+            emitSub(RISCV64.x2, RISCV64.x2, size);
+        } else if (size < 65535) {
+            emitLoadImmediate(scratchRegister, size);
+            emitSub(RISCV64.x2, RISCV64.x2, scratchRegister);
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    public void emitPrologue() {
+        // Must be patchable by NativeJump::patch_verified_entry
+        emitNop();
+        emitNop();
+        emitGrowStack(32);
+        emitStoreRegister(RISCV64.x8, RISCV64Kind.QWORD, RISCV64.x2, 32);
+        emitMv(RISCV64.x8, RISCV64.x2);
+        setDeoptRescueSlot(newStackSlot(RISCV64Kind.QWORD));
+    }
+
+    @Override
+    public void emitEpilogue() {
+        recordMark(config.MARKID_DEOPT_HANDLER_ENTRY);
+        recordCall(new HotSpotForeignCallTarget(config.handleDeoptStub), 4*4, true, null);
+        emitCall(0xdeaddeaddeadL);
+    }
+
+    @Override
+    public void emitCallPrologue(CallingConvention cc, Object... prim) {
+        emitGrowStack(cc.getStackSize());
+        frameSize += cc.getStackSize();
+        AllocatableValue[] args = cc.getArguments();
+        for (int i = 0; i < args.length; i++) {
+            emitLoad(args[i], prim[i]);
+        }
+    }
+
+    @Override
+    public void emitCallEpilogue(CallingConvention cc) {
+        emitGrowStack(-cc.getStackSize());
+        frameSize -= cc.getStackSize();
+    }
+
+    @Override
+    public void emitCall(long addr) {
+        emitLoadPointer48(scratchRegister, addr);
+        emitJalr(scratchRegister, RISCV64.x1, 0);
+    }
+
+    @Override
+    public void emitLoad(AllocatableValue av, Object prim) {
+        if (av instanceof RegisterValue) {
+            Register reg = ((RegisterValue) av).getRegister();
+            if (prim instanceof Float) {
+                emitLoadFloat(reg, (Float) prim);
+            } else if (prim instanceof Double) {
+                emitLoadDouble(reg, (Double) prim);
+            } else if (prim instanceof Integer) {
+                emitLoadInt(reg, (Integer) prim);
+            } else if (prim instanceof Long) {
+                emitLoadLong(reg, (Long) prim);
+            }
+        } else if (av instanceof StackSlot) {
+            StackSlot slot = (StackSlot) av;
+            if (prim instanceof Float) {
+                emitFloatToStack(slot, emitLoadFloat(doubleScratch, (Float) prim));
+            } else if (prim instanceof Double) {
+                emitDoubleToStack(slot, emitLoadDouble(doubleScratch, (Double) prim));
+            } else if (prim instanceof Integer) {
+                emitIntToStack(slot, emitLoadInt(scratchRegister, (Integer) prim));
+            } else if (prim instanceof Long) {
+                emitLongToStack(slot, emitLoadLong(scratchRegister, (Long) prim));
+            } else {
+                assert false : "Unimplemented";
+            }
+        } else {
+            throw new IllegalArgumentException("Unknown value " + av);
+        }
+    }
+
+    private void emitLoadPointer48(Register ret, long addr) {
+        // 48-bit VA
+        assert (addr >> 48) == 0 : "invalid pointer" + Long.toHexString(addr);
+        emitLoadImmediate(ret, (int) ((addr >> 16) & 0xffffffff));
+        emitShiftLeft(ret, ret, 12);
+        emitAdd(ret, ret, (int) ((addr >> 4) & 0xfff));
+        emitShiftLeft(ret, ret, 4);
+        emitAdd(ret, ret, (int) (addr & 0xf));
+    }
+
+    private void emitLoadPointer32(Register ret, long addr) {
+        emitLui(ret, (int) ((addr >> 12) & 0xfffff));
+        emitAddW(ret, ret, (int) (addr & 0xfff));
+    }
+
+    @Override
+    public Register emitLoadPointer(HotSpotConstant c) {
+        recordDataPatchInCode(new ConstantReference((VMConstant) c));
+
+        Register ret = newRegister();
+        if (c.isCompressed()) {
+            emitLoadPointer32(ret, 0xdeaddead);
+        } else {
+            emitLoadPointer48(ret, 0xdeaddeaddeadL);
+        }
+        return ret;
+    }
+
+    @Override
+    public Register emitLoadPointer(Register b, int offset) {
+        Register ret = newRegister();
+        emitLoadRegister(ret, RISCV64Kind.QWORD, b, offset);
+        return ret;
+    }
+
+    @Override
+    public Register emitLoadNarrowPointer(DataSectionReference ref) {
+        recordDataPatchInCode(ref);
+
+        Register ret = newRegister();
+        emitAuipc(ret, 0xdead >> 12);
+        emitAdd(ret, ret, 0xdead & 0xfff);
+        emitLoadRegister(ret, RISCV64Kind.DWORD, ret, 0);
+        return ret;
+    }
+
+    @Override
+    public Register emitLoadPointer(DataSectionReference ref) {
+        recordDataPatchInCode(ref);
+
+        Register ret = newRegister();
+        emitAuipc(ret, 0xdead >> 12);
+        emitAdd(ret, ret, 0xdead & 0xfff);
+        emitLoadRegister(ret, RISCV64Kind.QWORD, ret, 0);
+        return ret;
+    }
+
+    private Register emitLoadDouble(Register reg, double c) {
+        DataSectionReference ref = new DataSectionReference();
+        ref.setOffset(data.position());
+        data.emitDouble(c);
+
+        recordDataPatchInCode(ref);
+        emitAuipc(scratchRegister, 0xdead >> 12);
+        emitAdd(scratchRegister, scratchRegister, 0xdead & 0xfff);
+        emitLoadRegister(scratchRegister, RISCV64Kind.QWORD, scratchRegister, 0);
+        emitFmv(reg, RISCV64Kind.DOUBLE, scratchRegister);
+        return reg;
+    }
+
+    private Register emitLoadFloat(Register reg, float c) {
+        DataSectionReference ref = new DataSectionReference();
+        ref.setOffset(data.position());
+        data.emitFloat(c);
+
+        recordDataPatchInCode(ref);
+        emitAuipc(scratchRegister, 0xdead >> 12);
+        emitAdd(scratchRegister, scratchRegister, 0xdead & 0xfff);
+        emitLoadRegister(scratchRegister, RISCV64Kind.DWORD, scratchRegister, 0);
+        emitFmv(reg, RISCV64Kind.SINGLE, scratchRegister);
+        return reg;
+    }
+
+    @Override
+    public Register emitLoadFloat(float c) {
+        Register ret = RISCV64.f10;
+        return emitLoadFloat(ret, c);
+    }
+
+    private Register emitLoadLong(Register reg, long c) {
+        emitLoadImmediate(reg, (int) ((c >> 32) & 0xffffffff));
+        emitShiftLeft(reg, reg, 12);
+        emitAdd(reg, reg, (int) ((c >> 20) & 0xfff));
+        emitShiftLeft(reg, reg, 12);
+        emitAdd(reg, reg, (int) ((c >> 8) & 0xfff));
+        emitShiftLeft(reg, reg, 8);
+        emitAdd(reg, reg, (int) (c & 0xff));
+        return reg;
+    }
+
+    @Override
+    public Register emitLoadLong(long c) {
+        Register ret = newRegister();
+        return emitLoadLong(ret, c);
+    }
+
+    private Register emitLoadInt(Register reg, int c) {
+        emitLoadImmediate(reg, c);
+        return reg;
+    }
+
+    @Override
+    public Register emitLoadInt(int c) {
+        Register ret = newRegister();
+        return emitLoadInt(ret, c);
+    }
+
+    @Override
+    public Register emitIntArg0() {
+        return codeCache.getRegisterConfig()
+            .getCallingConventionRegisters(HotSpotCallingConventionType.JavaCall, JavaKind.Int)
+            .get(0);
+    }
+
+    @Override
+    public Register emitIntArg1() {
+        return codeCache.getRegisterConfig()
+            .getCallingConventionRegisters(HotSpotCallingConventionType.JavaCall, JavaKind.Int)
+            .get(1);
+    }
+
+    @Override
+    public Register emitIntAdd(Register a, Register b) {
+        emitAdd(a, a, b);
+        return a;
+    }
+
+    @Override
+    public void emitTrap(DebugInfo info) {
+        // Dereference null pointer
+        emitAdd(scratchRegister, RISCV64.x0, 0);
+        recordImplicitException(info);
+        emitLoadRegister(RISCV64.x0, RISCV64Kind.QWORD, scratchRegister, 0);
+    }
+
+    @Override
+    public void emitIntRet(Register a) {
+        emitMv(RISCV64.x10, a);
+        emitMv(RISCV64.x2, RISCV64.x8);                                           // mov sp, x29
+        emitLoadRegister(RISCV64.x2, RISCV64Kind.QWORD, RISCV64.x8, 32);   // ld x8 32(sp)
+        emitLoadRegister(RISCV64.x2, RISCV64Kind.QWORD, RISCV64.x1, 48);   // ld x1 48(sp)
+        emitJalr(RISCV64.x0, RISCV64.x1, 0);                                       // ret
+    }
+
+    @Override
+    public void emitFloatRet(Register a) {
+        assert a == RISCV64.f10 : "Unimplemented move " + a;
+        emitMv(RISCV64.x2, RISCV64.x8);                                          // mov sp, x29
+        emitLoadRegister(RISCV64.x2, RISCV64Kind.QWORD, RISCV64.x8, 32);  // ld x8 32(sp)
+        emitLoadRegister(RISCV64.x2, RISCV64Kind.QWORD, RISCV64.x1, 48);  // ld x1 48(sp)
+        emitJalr(RISCV64.x0, RISCV64.x1, 0);                                      // ret
+    }
+
+    @Override
+    public void emitPointerRet(Register a) {
+        emitIntRet(a);
+    }
+
+    @Override
+    public StackSlot emitPointerToStack(Register a) {
+        return emitLongToStack(a);
+    }
+
+    @Override
+    public StackSlot emitNarrowPointerToStack(Register a) {
+        return emitIntToStack(a);
+    }
+
+    @Override
+    public Register emitUncompressPointer(Register compressed, long base, int shift) {
+        if (shift > 0) {
+            emitShiftLeft(compressed, compressed, shift);
+        }
+
+        if (base != 0) {
+            emitLoadLong(scratchRegister, base);
+            emitAdd(compressed, compressed, scratchRegister);
+        }
+
+        return compressed;
+    }
+
+    private StackSlot emitDoubleToStack(StackSlot slot, Register a) {
+        emitStoreRegister(a, RISCV64Kind.DOUBLE, RISCV64.x2, slot.getOffset(frameSize));
+        return slot;
+    }
+
+    @Override
+    public StackSlot emitDoubleToStack(Register a) {
+        StackSlot ret = newStackSlot(RISCV64Kind.DOUBLE);
+        return emitDoubleToStack(ret, a);
+    }
+
+    private StackSlot emitFloatToStack(StackSlot slot, Register a) {
+        emitStoreRegister(a, RISCV64Kind.SINGLE, RISCV64.x2, slot.getOffset(frameSize));
+        return slot;
+    }
+
+    @Override
+    public StackSlot emitFloatToStack(Register a) {
+        StackSlot ret = newStackSlot(RISCV64Kind.SINGLE);
+        return emitFloatToStack(ret, a);
+    }
+
+    private StackSlot emitIntToStack(StackSlot slot, Register a) {
+        emitStoreRegister(a, RISCV64Kind.DWORD, RISCV64.x2, slot.getOffset(frameSize));
+        return slot;
+    }
+
+    @Override
+    public StackSlot emitIntToStack(Register a) {
+        StackSlot ret = newStackSlot(RISCV64Kind.DWORD);
+        return emitIntToStack(ret, a);
+    }
+
+    private StackSlot emitLongToStack(StackSlot slot, Register a) {
+        emitStoreRegister(a, RISCV64Kind.QWORD, RISCV64.x2, slot.getOffset(frameSize));
+        return slot;
+    }
+
+    @Override
+    public StackSlot emitLongToStack(Register a) {
+        StackSlot ret = newStackSlot(RISCV64Kind.QWORD);
+        return emitLongToStack(ret, a);
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/riscv64/RISCV64TestAssembler.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/riscv64/RISCV64TestAssembler.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/riscv64/RISCV64TestAssembler.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/riscv64/RISCV64TestAssembler.java
@@ -137,7 +137,7 @@ public class RISCV64TestAssembler extends TestAssembler {
         lower = (lower << 52) >> 52;
         upper -= lower;
         upper = (int) upper;
-        emitLui(Rd, (int) (upper >> 12));
+        emitLui(Rd, ((int) (upper >> 12)) & 0xfffff);
         emitAddW(Rd, Rd, (int) lower);
     }
 
@@ -283,7 +283,7 @@ public class RISCV64TestAssembler extends TestAssembler {
         lower = (lower << 52) >> 52;
         upper -= lower;
         upper = (int) upper;
-        emitLui(ret, (int) (upper >> 12));
+        emitLui(ret, ((int) (upper >> 12)) & 0xfffff);
         emitAdd(ret, ret, (int) lower);
     }
 


### PR DESCRIPTION
This patch adds a partial JVMCI implementation for RISC-V, to allow using the GraalVM Native Image RISC-V LLVM backend, which does not use JVMCI for code emission.
It creates the jdk.vm.ci.riscv64 and jdk.vm.ci.hotspot.riscv64 packages, as well as implements a part of jvmciCodeInstaller_riscv64.cpp. To check for correctness, it enables JVMCI code installation tests on RISC-V. More testing is performed in Native Image.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (3 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 2 [Authors](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8290154](https://bugs.openjdk.org/browse/JDK-8290154): [JVMCI] partially implement JVMCI for RISC-V


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [8742b9b2](https://git.openjdk.org/jdk/pull/9587/files/8742b9b27a3467e7ce11f082cdf68f3244479332)
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - Committer) ⚠️ Review applies to [c3c6f651](https://git.openjdk.org/jdk/pull/9587/files/c3c6f651f52418eedfaed8971f4cae1c53da89fd)
 * [Yadong Wang](https://openjdk.org/census#yadongwang) (@yadongw - Author) ⚠️ Review applies to [225fee42](https://git.openjdk.org/jdk/pull/9587/files/225fee42a1892aa4c42572287d19e3b6315abf7a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9587/head:pull/9587` \
`$ git checkout pull/9587`

Update a local copy of the PR: \
`$ git checkout pull/9587` \
`$ git pull https://git.openjdk.org/jdk pull/9587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9587`

View PR using the GUI difftool: \
`$ git pr show -t 9587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9587.diff">https://git.openjdk.org/jdk/pull/9587.diff</a>

</details>
