### PR TITLE
8290806: Only add eager reclaim task to G1 post evacuate tasks if there were candidates

### DIFF
--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -670,7 +670,9 @@ G1PostEvacuateCollectionSetCleanupTask2::G1PostEvacuateCollectionSetCleanupTask2
 #if COMPILER2_OR_JVMCI
   add_serial_task(new UpdateDerivedPointersTask());
 #endif
-  add_serial_task(new EagerlyReclaimHumongousObjectsTask());
+  if (G1CollectedHeap::heap()->has_humongous_reclaim_candidates()) {
+    add_serial_task(new EagerlyReclaimHumongousObjectsTask());
+  }
 
   if (evac_failure_regions->evacuation_failed()) {
     add_parallel_task(new RestorePreservedMarksTask(per_thread_states->preserved_marks_set()));


### PR DESCRIPTION
Hi all,

  can I have reviews for this tiny optimization that does not enqueue the eager reclaim task if there were no eager reclaim candidates? This saves an iteration over all heap regions in applications that do not allocate humongous type arrays.

Testing: gha, gc/g1

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290806](https://bugs.openjdk.org/browse/JDK-8290806): Only add eager reclaim task to G1 post evacuate tasks if there were candidates


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Sangheon Kim](https://openjdk.org/census#sangheki) (@sangheon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9590/head:pull/9590` \
`$ git checkout pull/9590`

Update a local copy of the PR: \
`$ git checkout pull/9590` \
`$ git pull https://git.openjdk.org/jdk pull/9590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9590`

View PR using the GUI difftool: \
`$ git pr show -t 9590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9590.diff">https://git.openjdk.org/jdk/pull/9590.diff</a>

</details>
