### PR TITLE
8290718: Remove ALLOCATION_SUPER_CLASS_SPEC

### DIFF
--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -710,6 +710,12 @@ void Compilation::print_timers() {
 
 
 #ifndef PRODUCT
+void CompilationResourceObj::print() const       { print_on(tty); }
+
+void CompilationResourceObj::print_on(outputStream* st) const {
+  st->print_cr("CompilationResourceObj(" INTPTR_FORMAT ")", p2i(this));
+}
+
 void Compilation::compile_only_this_method() {
   ResourceMark rm;
   fileStream stream(os::fopen("c1_compile_only", "wt"));

--- a/src/hotspot/share/c1/c1_Compilation.hpp
+++ b/src/hotspot/share/c1/c1_Compilation.hpp
@@ -326,13 +326,19 @@ class InstructionMark: public StackObj {
 
 //----------------------------------------------------------------------
 // Base class for objects allocated by the compiler in the compilation arena
-class CompilationResourceObj ALLOCATION_SUPER_CLASS_SPEC {
+class CompilationResourceObj {
  public:
   void* operator new(size_t size) throw() { return Compilation::current()->arena()->Amalloc(size); }
   void* operator new(size_t size, Arena* arena) throw() {
     return arena->Amalloc(size);
   }
   void  operator delete(void* p) {} // nothing to do
+
+#ifndef PRODUCT
+  // Printing support
+  void print() const;
+  virtual void print_on(outputStream* st) const;
+#endif
 };
 
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2520,7 +2520,7 @@ public:
     if (occupied == 0) {
       tty->print_cr("  RSet is empty");
     } else {
-      hrrs->print();
+      tty->print_cr("hrrs " INTPTR_FORMAT, p2i(hrrs));
     }
     tty->print_cr("----------");
     return false;

--- a/src/hotspot/share/memory/allocation.cpp
+++ b/src/hotspot/share/memory/allocation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -239,15 +239,10 @@ ResourceObj::~ResourceObj() {
 // Non-product code
 
 #ifndef PRODUCT
-void AllocatedObj::print() const       { print_on(tty); }
-void AllocatedObj::print_value() const { print_value_on(tty); }
+void ResourceObj::print() const       { print_on(tty); }
 
-void AllocatedObj::print_on(outputStream* st) const {
-  st->print_cr("AllocatedObj(" INTPTR_FORMAT ")", p2i(this));
-}
-
-void AllocatedObj::print_value_on(outputStream* st) const {
-  st->print("AllocatedObj(" INTPTR_FORMAT ")", p2i(this));
+void ResourceObj::print_on(outputStream* st) const {
+  st->print_cr("ResourceObj(" INTPTR_FORMAT ")", p2i(this));
 }
 
 ReallocMark::ReallocMark() {

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -97,24 +97,6 @@ typedef AllocFailStrategy::AllocFailEnum AllocFailType;
 // char* ReallocateHeap(char *old, size_t size, MEMFLAGS flag, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
 // void FreeHeap(void* p);
 //
-// In non product mode we introduce a super class for all allocation classes
-// that supports printing.
-// We avoid the superclass in product mode to save space.
-
-#ifdef PRODUCT
-#define ALLOCATION_SUPER_CLASS_SPEC
-#else
-#define ALLOCATION_SUPER_CLASS_SPEC : public AllocatedObj
-class AllocatedObj {
- public:
-  // Printing support
-  void print() const;
-  void print_value() const;
-
-  virtual void print_on(outputStream* st) const;
-  virtual void print_value_on(outputStream* st) const;
-};
-#endif
 
 #define MEMORY_TYPES_DO(f)                                                           \
   /* Memory type by sub systems. It occupies lower byte. */                          \
@@ -192,7 +174,7 @@ char* ReallocateHeap(char *old,
 // handles NULL pointers
 void FreeHeap(void* p);
 
-template <MEMFLAGS F> class CHeapObj ALLOCATION_SUPER_CLASS_SPEC {
+template <MEMFLAGS F> class CHeapObj {
  public:
   ALWAYSINLINE void* operator new(size_t size) throw() {
     return (void*)AllocateHeap(size, F);
@@ -237,7 +219,7 @@ template <MEMFLAGS F> class CHeapObj ALLOCATION_SUPER_CLASS_SPEC {
 // Base class for objects allocated on the stack only.
 // Calling new or delete will result in fatal error.
 
-class StackObj ALLOCATION_SUPER_CLASS_SPEC {
+class StackObj {
  private:
   void* operator new(size_t size) throw();
   void* operator new [](size_t size) throw();
@@ -386,7 +368,7 @@ extern void resource_free_bytes( char *old, size_t size );
 // ResourceObj's can be allocated within other objects, but don't use
 // new or delete (allocation_type is unknown).  If new is used to allocate,
 // use delete to deallocate.
-class ResourceObj ALLOCATION_SUPER_CLASS_SPEC {
+class ResourceObj {
  public:
   enum allocation_type { STACK_OR_EMBEDDED = 0, RESOURCE_AREA, C_HEAP, ARENA, allocation_mask = 0x3 };
   static void set_allocation_type(address res, allocation_type type) NOT_DEBUG_RETURN;
@@ -438,6 +420,12 @@ protected:
   void* operator new [](size_t size, const std::nothrow_t& nothrow_constant) throw() = delete;
   void  operator delete(void* p);
   void  operator delete [](void* p) = delete;
+
+#ifndef PRODUCT
+  // Printing support
+  void print() const;
+  virtual void print_on(outputStream* st) const;
+#endif // PRODUCT
 };
 
 // One of the following macros must be used when allocating an array

--- a/src/hotspot/share/oops/stackChunkOop.cpp
+++ b/src/hotspot/share/oops/stackChunkOop.cpp
@@ -509,7 +509,7 @@ public:
     LogTarget(Trace, continuations) lt;
     if (lt.develop_is_enabled()) {
       LogStream ls(lt);
-      f.print_value_on(&ls);
+      f.print_on(&ls);
     }
     assert(f.pc() != nullptr,
            "young: %d num_frames: %d sp: " INTPTR_FORMAT " start: " INTPTR_FORMAT " end: " INTPTR_FORMAT,


### PR DESCRIPTION
This super class simply exists to have virtual functions for print() in non-product mode.  In CHeapObj objects, it creates a vptr that break deterministic archive creation when I change the type of ModuleEntry in upcoming work.
I moved the virtual print functions to ResourceObj and CompilationResourceObj since there are still several print functions called for those types.  Many were for the compilation types. Maybe someone should fix those someday.
Tested with tier1 on Oracle supported platforms and builds-only for others (ppc, s390, etc).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290718](https://bugs.openjdk.org/browse/JDK-8290718): Remove ALLOCATION_SUPER_CLASS_SPEC


### Reviewers
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9591/head:pull/9591` \
`$ git checkout pull/9591`

Update a local copy of the PR: \
`$ git checkout pull/9591` \
`$ git pull https://git.openjdk.org/jdk pull/9591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9591`

View PR using the GUI difftool: \
`$ git pr show -t 9591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9591.diff">https://git.openjdk.org/jdk/pull/9591.diff</a>

</details>
