### PR TITLE
8290814: Hide G1RootRegions behind G1ConcurrentMark

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -984,14 +984,6 @@ void G1CollectedHeap::print_heap_after_full_collection() {
 }
 
 bool G1CollectedHeap::abort_concurrent_cycle() {
-  // If we start the compaction before the CM threads finish
-  // scanning the root regions we might trip them over as we'll
-  // be moving objects / updating references. So let's wait until
-  // they are done. By telling them to abort, they should complete
-  // early.
-  _cm->root_regions()->abort();
-  _cm->root_regions()->wait_until_scan_finished();
-
   // Disable discovery and empty the discovered lists
   // for the CM ref processor.
   _ref_processor_cm->disable_discovery();
@@ -3278,7 +3270,7 @@ void G1CollectedHeap::retire_gc_alloc_region(HeapRegion* alloc_region,
 
   bool const during_im = collector_state()->in_concurrent_start_gc();
   if (during_im && allocated_bytes > 0) {
-    _cm->root_regions()->add(alloc_region->top_at_mark_start(), alloc_region->top());
+    _cm->add_root_region(alloc_region);
   }
   _hr_printer.retire(alloc_region);
 }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -285,6 +285,7 @@ class G1ConcurrentMark : public CHeapObj<mtGC> {
   friend class G1CMKeepAliveAndDrainClosure;
   friend class G1CMRefProcProxyTask;
   friend class G1CMRemarkTask;
+  friend class G1CMRootRegionScanTask;
   friend class G1CMTask;
   friend class G1ConcurrentMarkThread;
 
@@ -497,8 +498,6 @@ public:
   size_t partial_mark_stack_size_target() const { return _global_mark_stack.capacity() / 3; }
   bool mark_stack_empty() const                 { return _global_mark_stack.is_empty(); }
 
-  G1CMRootMemRegions* root_regions() { return &_root_regions; }
-
   void concurrent_cycle_start();
   // Abandon current marking iteration due to a Full GC.
   bool concurrent_cycle_abort();
@@ -557,9 +556,16 @@ public:
   // Scan all the root regions and mark everything reachable from
   // them.
   void scan_root_regions();
+  bool wait_until_root_region_scan_finished();
+  void add_root_region(HeapRegion* r);
+
+private:
+  G1CMRootMemRegions* root_regions() { return &_root_regions; }
 
   // Scan a single root MemRegion to mark everything reachable from it.
   void scan_root_region(const MemRegion* region, uint worker_id);
+
+public:
 
   // Do concurrent phase of marking, to a tentative transitive closure.
   void mark_from_roots();
@@ -608,7 +614,6 @@ private:
   void rebuild_and_scrub();
 
   uint needs_remembered_set_rebuild() const { return _needs_remembered_set_rebuild; }
-
 };
 
 // A class representing a marking task.

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -245,7 +245,7 @@ void G1YoungCollector::wait_for_root_region_scanning() {
   // root regions as it's the only way to ensure that all the
   // objects on them have been correctly scanned before we start
   // moving them during the GC.
-  bool waited = concurrent_mark()->root_regions()->wait_until_scan_finished();
+  bool waited = concurrent_mark()->wait_until_root_region_scan_finished();
   Tickspan wait_time;
   if (waited) {
     wait_time = (Ticks::now() - start);


### PR DESCRIPTION
Hi all,

  please review this cleanup that better encapsulates the `G1RootRegions` member of `G1ConcurrentMark` to be not directly accessible by non-concurrent mark related code. This is a preparatory change for [JDK-8289822](https://bugs.openjdk.org/browse/JDK-8289822) in that since the TAMSes are then owned by `G1ConcurrentMark`, there is the possibility to avoid allowing write access to these to non-G1ConcurrentMark classes as well.

[here](https://github.com/openjdk/jdk/compare/master...tschatzl:jdk:submit/8289822-move-tams?expand=1) you can see how that change could look like (also includes [JDK-8290357](https://bugs.openjdk.org/browse/JDK-8290357) that is also out for review).

Testing: tier1-3

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290814](https://bugs.openjdk.org/browse/JDK-8290814): Hide G1RootRegions behind G1ConcurrentMark


### Reviewers
 * [Sangheon Kim](https://openjdk.org/census#sangheki) (@sangheon - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9593/head:pull/9593` \
`$ git checkout pull/9593`

Update a local copy of the PR: \
`$ git checkout pull/9593` \
`$ git pull https://git.openjdk.org/jdk pull/9593/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9593`

View PR using the GUI difftool: \
`$ git pr show -t 9593`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9593.diff">https://git.openjdk.org/jdk/pull/9593.diff</a>

</details>
