### PR TITLE
8290047: (fs) FileSystem.getPathMatcher does not check for ":" at last index

### DIFF
--- a/src/java.base/share/classes/java/nio/file/FileSystem.java
+++ b/src/java.base/share/classes/java/nio/file/FileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -304,7 +304,7 @@ public abstract class FileSystem
      * <blockquote><pre>
      * <i>syntax</i><b>:</b><i>pattern</i>
      * </pre></blockquote>
-     * where {@code ':'} stands for itself.
+     * where <i>syntax</i> must not be empty and {@code ':'} stands for itself.
      *
      * <p> A {@code FileSystem} implementation supports the "{@code glob}" and
      * "{@code regex}" syntaxes, and may support others. The value of the syntax

--- a/src/java.base/share/classes/java/nio/file/FileSystem.java
+++ b/src/java.base/share/classes/java/nio/file/FileSystem.java
@@ -304,7 +304,8 @@ public abstract class FileSystem
      * <blockquote><pre>
      * <i>syntax</i><b>:</b><i>pattern</i>
      * </pre></blockquote>
-     * where <i>syntax</i> must not be empty and {@code ':'} stands for itself.
+     * where <i>syntax</i> is the non-empty name of the syntax, <i>pattern</i>
+     * is a possibly-empty pattern string, and {@code ':'} stands for itself.
      *
      * <p> A {@code FileSystem} implementation supports the "{@code glob}" and
      * "{@code regex}" syntaxes, and may support others. The value of the syntax

--- a/src/java.base/share/classes/jdk/internal/jrtfs/JrtFileSystem.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/JrtFileSystem.java
@@ -175,7 +175,7 @@ class JrtFileSystem extends FileSystem {
     @Override
     public PathMatcher getPathMatcher(String syntaxAndInput) {
         int pos = syntaxAndInput.indexOf(':');
-        if (pos <= 0) {
+        if (pos <= 0 || pos == syntaxAndInput.length() - 1) {
             throw new IllegalArgumentException("pos is " + pos);
         }
         String syntax = syntaxAndInput.substring(0, pos);

--- a/src/java.base/share/classes/jdk/internal/jrtfs/JrtFileSystem.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/JrtFileSystem.java
@@ -176,7 +176,7 @@ class JrtFileSystem extends FileSystem {
     public PathMatcher getPathMatcher(String syntaxAndInput) {
         int pos = syntaxAndInput.indexOf(':');
         if (pos <= 0 || pos == syntaxAndInput.length() - 1) {
-            throw new IllegalArgumentException("pos is " + pos);
+            throw new IllegalArgumentException();
         }
         String syntax = syntaxAndInput.substring(0, pos);
         String input = syntaxAndInput.substring(pos + 1);

--- a/src/java.base/share/classes/jdk/internal/jrtfs/JrtFileSystem.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/JrtFileSystem.java
@@ -175,7 +175,7 @@ class JrtFileSystem extends FileSystem {
     @Override
     public PathMatcher getPathMatcher(String syntaxAndInput) {
         int pos = syntaxAndInput.indexOf(':');
-        if (pos <= 0 || pos == syntaxAndInput.length() - 1) {
+        if (pos <= 0) {
             throw new IllegalArgumentException();
         }
         String syntax = syntaxAndInput.substring(0, pos);

--- a/src/java.base/share/classes/jdk/internal/jrtfs/JrtFileSystem.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/JrtFileSystem.java
@@ -175,7 +175,7 @@ class JrtFileSystem extends FileSystem {
     @Override
     public PathMatcher getPathMatcher(String syntaxAndInput) {
         int pos = syntaxAndInput.indexOf(':');
-        if (pos <= 0 || pos == syntaxAndInput.length()) {
+        if (pos <= 0) {
             throw new IllegalArgumentException("pos is " + pos);
         }
         String syntax = syntaxAndInput.substring(0, pos);

--- a/src/java.base/unix/classes/sun/nio/ch/UnixAsynchronousSocketChannelImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/UnixAsynchronousSocketChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -741,10 +741,12 @@ class UnixAsynchronousSocketChannelImpl
                 return result;
             }
         } catch (Throwable x) {
+            System.out.println("Caught " + x);
             if (x instanceof ClosedChannelException)
                 x = new AsynchronousCloseException();
             exc = x;
         } finally {
+            System.out.println("finally");
             if (!pending)
                 enableWriting();
             end();

--- a/src/java.base/unix/classes/sun/nio/ch/UnixAsynchronousSocketChannelImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/UnixAsynchronousSocketChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -741,12 +741,10 @@ class UnixAsynchronousSocketChannelImpl
                 return result;
             }
         } catch (Throwable x) {
-            System.out.println("Caught " + x);
             if (x instanceof ClosedChannelException)
                 x = new AsynchronousCloseException();
             exc = x;
         } finally {
-            System.out.println("finally");
             if (!pending)
                 enableWriting();
             end();

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -281,7 +281,7 @@ abstract class UnixFileSystem
     @Override
     public PathMatcher getPathMatcher(String syntaxAndInput) {
         int pos = syntaxAndInput.indexOf(':');
-        if (pos <= 0 || pos == syntaxAndInput.length())
+        if (pos <= 0)
             throw new IllegalArgumentException();
         String syntax = syntaxAndInput.substring(0, pos);
         String input = syntaxAndInput.substring(pos+1);

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -281,7 +281,7 @@ abstract class UnixFileSystem
     @Override
     public PathMatcher getPathMatcher(String syntaxAndInput) {
         int pos = syntaxAndInput.indexOf(':');
-        if (pos <= 0 || pos == syntaxAndInput.length() - 1)
+        if (pos <= 0)
             throw new IllegalArgumentException();
         String syntax = syntaxAndInput.substring(0, pos);
         String input = syntaxAndInput.substring(pos+1);

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -281,7 +281,7 @@ abstract class UnixFileSystem
     @Override
     public PathMatcher getPathMatcher(String syntaxAndInput) {
         int pos = syntaxAndInput.indexOf(':');
-        if (pos <= 0)
+        if (pos <= 0 || pos == syntaxAndInput.length() - 1)
             throw new IllegalArgumentException();
         String syntax = syntaxAndInput.substring(0, pos);
         String input = syntaxAndInput.substring(pos+1);

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystem.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -261,7 +261,7 @@ class WindowsFileSystem
     @Override
     public PathMatcher getPathMatcher(String syntaxAndInput) {
         int pos = syntaxAndInput.indexOf(':');
-        if (pos <= 0 || pos == syntaxAndInput.length())
+        if (pos <= 0)
             throw new IllegalArgumentException();
         String syntax = syntaxAndInput.substring(0, pos);
         String input = syntaxAndInput.substring(pos+1);

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystem.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystem.java
@@ -261,7 +261,7 @@ class WindowsFileSystem
     @Override
     public PathMatcher getPathMatcher(String syntaxAndInput) {
         int pos = syntaxAndInput.indexOf(':');
-        if (pos <= 0)
+        if (pos <= 0 || pos == syntaxAndInput.length() - 1)
             throw new IllegalArgumentException();
         String syntax = syntaxAndInput.substring(0, pos);
         String input = syntaxAndInput.substring(pos+1);

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystem.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystem.java
@@ -261,7 +261,7 @@ class WindowsFileSystem
     @Override
     public PathMatcher getPathMatcher(String syntaxAndInput) {
         int pos = syntaxAndInput.indexOf(':');
-        if (pos <= 0 || pos == syntaxAndInput.length() - 1)
+        if (pos <= 0)
             throw new IllegalArgumentException();
         String syntax = syntaxAndInput.substring(0, pos);
         String input = syntaxAndInput.substring(pos+1);

--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -441,7 +441,7 @@ class ZipFileSystem extends FileSystem {
     @Override
     public PathMatcher getPathMatcher(String syntaxAndInput) {
         int pos = syntaxAndInput.indexOf(':');
-        if (pos <= 0 || pos == syntaxAndInput.length()) {
+        if (pos <= 0) {
             throw new IllegalArgumentException();
         }
         String syntax = syntaxAndInput.substring(0, pos);

--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -441,7 +441,7 @@ class ZipFileSystem extends FileSystem {
     @Override
     public PathMatcher getPathMatcher(String syntaxAndInput) {
         int pos = syntaxAndInput.indexOf(':');
-        if (pos <= 0) {
+        if (pos <= 0 || pos == syntaxAndInput.length() - 1) {
             throw new IllegalArgumentException();
         }
         String syntax = syntaxAndInput.substring(0, pos);

--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -441,7 +441,7 @@ class ZipFileSystem extends FileSystem {
     @Override
     public PathMatcher getPathMatcher(String syntaxAndInput) {
         int pos = syntaxAndInput.indexOf(':');
-        if (pos <= 0 || pos == syntaxAndInput.length() - 1) {
+        if (pos <= 0) {
             throw new IllegalArgumentException();
         }
         String syntax = syntaxAndInput.substring(0, pos);

--- a/test/jdk/java/nio/file/PathMatcher/Basic.java
+++ b/test/jdk/java/nio/file/PathMatcher/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4313887 6866397 8073445
+ * @bug 4313887 6866397 8073445 8290047
  * @summary Unit test for java.nio.file.PathMatcher
  */
 
@@ -65,6 +65,18 @@ public class Basic {
             failures++;
         } catch (PatternSyntaxException e) {
             System.out.println("Failed to compile ==> OKAY");
+        }
+    }
+
+    static void assertBadSyntaxAndPattern(String syntaxAndPattern) {
+        try {
+            FileSystems.getDefault().getPathMatcher(syntaxAndPattern);
+            System.out.printf("\"%s\" ==> no IllegalArgumentException%n",
+                              syntaxAndPattern);
+            failures++;
+        } catch (IllegalArgumentException iae) {
+            System.out.printf("IllegalArgumentException for \"%s\" ==> OKAY%n",
+                              syntaxAndPattern);
         }
     }
 
@@ -137,6 +149,8 @@ public class Basic {
         assertBadPattern("foo.html", "*{class,java");       // missing }
         assertBadPattern("foo.html", "*.{class,{.java}}");  // nested group
         assertBadPattern("foo.html", "*.html\\");           // nothing to escape
+        assertBadSyntaxAndPattern(":glob");                 // colon at head
+        assertBadSyntaxAndPattern("glob:");                 // colon at tail
 
         // platform specific
         if (System.getProperty("os.name").startsWith("Windows")) {

--- a/test/jdk/java/nio/file/PathMatcher/Basic.java
+++ b/test/jdk/java/nio/file/PathMatcher/Basic.java
@@ -68,18 +68,6 @@ public class Basic {
         }
     }
 
-    static void assertBadSyntaxAndPattern(String syntaxAndPattern) {
-        try {
-            FileSystems.getDefault().getPathMatcher(syntaxAndPattern);
-            System.out.printf("\"%s\" ==> no IllegalArgumentException%n",
-                              syntaxAndPattern);
-            failures++;
-        } catch (IllegalArgumentException iae) {
-            System.out.printf("IllegalArgumentException for \"%s\" ==> OKAY%n",
-                              syntaxAndPattern);
-        }
-    }
-
     static void assertRegExMatch(String path, String pattern) {
         System.out.format("Test regex pattern: %s", pattern);
         Path file = Paths.get(path);
@@ -96,6 +84,7 @@ public class Basic {
 
     public static void main(String[] args) {
         // basic
+        assertMatch("", "");
         assertMatch("foo.html", "foo.html");
         assertNotMatch("foo.html", "foo.htm");
         assertNotMatch("foo.html", "bar.html");
@@ -149,8 +138,13 @@ public class Basic {
         assertBadPattern("foo.html", "*{class,java");       // missing }
         assertBadPattern("foo.html", "*.{class,{.java}}");  // nested group
         assertBadPattern("foo.html", "*.html\\");           // nothing to escape
-        assertBadSyntaxAndPattern(":glob");                 // colon at head
-        assertBadSyntaxAndPattern("glob:");                 // colon at tail
+        try {
+            FileSystems.getDefault().getPathMatcher(":glob");
+            System.err.println("No IllegalArgumentException for \":glob\"");
+            failures++;
+        } catch (IllegalArgumentException iae) {
+            System.out.println("IllegalArgumentException for \":glob\" OKAY");
+        }
 
         // platform specific
         if (System.getProperty("os.name").startsWith("Windows")) {

--- a/test/jdk/jdk/internal/jrtfs/Basic.java
+++ b/test/jdk/jdk/internal/jrtfs/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8141521 8216553 8266291 8290047
  * @summary Basic test of jrt file system provider
  * @run testng Basic
  */
@@ -773,6 +774,20 @@ public class Basic {
         Path m = p.resolve("modules");
         Files.exists(m);
         assertTrue(wasDirectory == Files.isDirectory(p));
+    }
+
+    @DataProvider(name = "badSyntaxAndPattern")
+    private Object[][] badSyntaxAndPattern() {
+        return new Object[][] {
+            { ":glob"},
+            { "glob:"},
+        };
+    }
+
+    @Test(dataProvider = "badSyntaxAndPattern", expectedExceptions = IllegalArgumentException.class)
+    public void badSyntaxAndPatternTest(String syntaxAndPattern) {
+        FileSystem fs = FileSystems.getFileSystem(URI.create("jrt:/"));
+        PathMatcher pm = fs.getPathMatcher(syntaxAndPattern);
     }
 }
 

--- a/test/jdk/jdk/internal/jrtfs/Basic.java
+++ b/test/jdk/jdk/internal/jrtfs/Basic.java
@@ -780,11 +780,11 @@ public class Basic {
     private Object[][] badSyntaxAndPattern() {
         return new Object[][] {
             { ":glob"},
-            { "glob:"},
         };
     }
 
-    @Test(dataProvider = "badSyntaxAndPattern", expectedExceptions = IllegalArgumentException.class)
+    @Test(dataProvider = "badSyntaxAndPattern",
+          expectedExceptions = IllegalArgumentException.class)
     public void badSyntaxAndPatternTest(String syntaxAndPattern) {
         FileSystem fs = FileSystems.getFileSystem(URI.create("jrt:/"));
         PathMatcher pm = fs.getPathMatcher(syntaxAndPattern);

--- a/test/jdk/jdk/nio/zipfs/Basic.java
+++ b/test/jdk/jdk/nio/zipfs/Basic.java
@@ -121,8 +121,9 @@ public class Basic {
         }
         try {
             PathMatcher pm = fs.getPathMatcher("glob:");
-            throw new RuntimeException("IllegalArgumentException not thrown");
         } catch (IllegalArgumentException iae) {
+            iae.printStackTrace();
+            throw new RuntimeException("Unexpected IllegalArgumentException");
         }
 
         // Test: ClosedFileSystemException

--- a/test/jdk/jdk/nio/zipfs/Basic.java
+++ b/test/jdk/jdk/nio/zipfs/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.file.PathMatcher;
 import java.nio.file.ProviderMismatchException;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
@@ -42,7 +42,7 @@ import java.util.Map;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
 /**
  * @test
- * @bug 8038500 8040059 8150366 8150496 8147539
+ * @bug 8038500 8040059 8150366 8150496 8147539 8290047
  * @summary Basic test for zip provider
  *
  * @modules jdk.zipfs
@@ -89,7 +89,7 @@ public class Basic {
         // Test: copy file from zip file to current (scratch) directory
         Path source = fs.getPath("/META-INF/services/java.nio.file.spi.FileSystemProvider");
         if (Files.exists(source)) {
-            Path target = Paths.get(source.getFileName().toString());
+            Path target = Path.of(source.getFileName().toString());
             Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
             try {
                 long s1 = Files.readAttributes(source, BasicFileAttributes.class).size();
@@ -112,6 +112,18 @@ public class Basic {
               .register(FileSystems.getDefault().newWatchService(), ENTRY_CREATE);
             throw new RuntimeException("watch service is not supported");
         } catch (ProviderMismatchException x) { }
+
+        // Test: IllegalArgumentException
+        try {
+            PathMatcher pm = fs.getPathMatcher(":glob");
+            throw new RuntimeException("IllegalArgumentException not thrown");
+        } catch (IllegalArgumentException iae) {
+        }
+        try {
+            PathMatcher pm = fs.getPathMatcher("glob:");
+            throw new RuntimeException("IllegalArgumentException not thrown");
+        } catch (IllegalArgumentException iae) {
+        }
 
         // Test: ClosedFileSystemException
         fs.close();


### PR DESCRIPTION
For a `String` “s”, `s.indexOf(int)` can never return a value `>= s.length()` so change the check
```
        int pos = syntaxAndInput.indexOf(':');
        if (pos <= 0 || pos == syntaxAndInput.length())
```
to
```
        if (pos <= 0)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8290047](https://bugs.openjdk.org/browse/JDK-8290047): (fs) FileSystem.getPathMatcher does not check for ":" at last index
 * [JDK-8291730](https://bugs.openjdk.org/browse/JDK-8291730): (fs) FileSystem.getPathMatcher does not check for ":" at last index (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [291ef674](https://git.openjdk.org/jdk/pull/9595/files/291ef674e6d1975f94bef9e498f89fa34a1ee0eb)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to [b9de2604](https://git.openjdk.org/jdk/pull/9595/files/b9de2604b74c1082c6b0fa10435405120b971e93)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [b9de2604](https://git.openjdk.org/jdk/pull/9595/files/b9de2604b74c1082c6b0fa10435405120b971e93)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to [b9de2604](https://git.openjdk.org/jdk/pull/9595/files/b9de2604b74c1082c6b0fa10435405120b971e93)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9595/head:pull/9595` \
`$ git checkout pull/9595`

Update a local copy of the PR: \
`$ git checkout pull/9595` \
`$ git pull https://git.openjdk.org/jdk pull/9595/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9595`

View PR using the GUI difftool: \
`$ git pr show -t 9595`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9595.diff">https://git.openjdk.org/jdk/pull/9595.diff</a>

</details>
