### PR TITLE
8290824: Use InputStream.readAllBytes() instead of explicit loops

### DIFF
--- a/src/java.base/share/classes/jdk/internal/module/ModuleHashes.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleHashes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,15 +115,11 @@ public final class ModuleHashes {
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalArgumentException(e);
         }
-        byte[] buf = new byte[32*1024];
         try (Stream<String> stream = reader.list()) {
             stream.sorted().forEach(rn -> {
                 md.update(rn.getBytes(StandardCharsets.UTF_8));
                 try (InputStream in = reader.open(rn).orElseThrow()) {
-                    int n;
-                    while ((n = in.read(buf)) > 0) {
-                        md.update(buf, 0, n);
-                    }
+                    md.update(in.readAllBytes());
                 } catch (IOException ioe) {
                     throw new UncheckedIOException(ioe);
                 }

--- a/src/java.base/share/classes/sun/security/provider/certpath/X509CertPath.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/X509CertPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package sun.security.provider.certpath;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.cert.CertificateEncodingException;
@@ -125,7 +126,7 @@ public class X509CertPath extends CertPath {
         // and the methods in the Sun JDK 1.4 implementation of ArrayList that
         // allow read-only access are thread-safe.
         this.certs = Collections.unmodifiableList(
-                new ArrayList<>((List<X509Certificate>)certs));
+                new ArrayList<X509Certificate>((List<X509Certificate>)certs));
     }
 
     /**
@@ -184,14 +185,14 @@ public class X509CertPath extends CertPath {
         }
 
         try {
-            DerInputStream dis = new DerInputStream(is.readAllBytes());
+            DerInputStream dis = new DerInputStream(readAllBytes(is));
             DerValue[] seq = dis.getSequence(3);
             if (seq.length == 0) {
-                return Collections.emptyList();
+                return Collections.<X509Certificate>emptyList();
             }
 
             certFac = CertificateFactory.getInstance("X.509");
-            certList = new ArrayList<>(seq.length);
+            certList = new ArrayList<X509Certificate>(seq.length);
 
             // append certs in reverse order (target to trust anchor)
             for (int i = seq.length-1; i >= 0; i--) {
@@ -227,7 +228,7 @@ public class X509CertPath extends CertPath {
             if (is.markSupported() == false) {
                 // Copy the entire input stream into an InputStream that does
                 // support mark
-                is = new ByteArrayInputStream(is.readAllBytes());
+                is = new ByteArrayInputStream(readAllBytes(is));
             }
             PKCS7 pkcs7 = new PKCS7(is);
 
@@ -237,7 +238,7 @@ public class X509CertPath extends CertPath {
                 certList = Arrays.asList(certArray);
             } else {
                 // no certs provided
-                certList = new ArrayList<>(0);
+                certList = new ArrayList<X509Certificate>(0);
             }
         } catch (IOException ioe) {
             throw new CertificateException("IOException parsing PKCS7 data: " +
@@ -248,6 +249,22 @@ public class X509CertPath extends CertPath {
         // and the methods in the Sun JDK 1.4 implementation of ArrayList that
         // allow read-only access are thread-safe.
         return Collections.unmodifiableList(certList);
+    }
+
+    /*
+     * Reads the entire contents of an InputStream into a byte array.
+     *
+     * @param is the InputStream to read from
+     * @return the bytes read from the InputStream
+     */
+    private static byte[] readAllBytes(InputStream is) throws IOException {
+        byte[] buffer = new byte[8192];
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(2048);
+        int n;
+        while ((n = is.read(buffer)) != -1) {
+            baos.write(buffer, 0, n);
+        }
+        return baos.toByteArray();
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/provider/certpath/X509CertPath.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/X509CertPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.provider.certpath;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.cert.CertificateEncodingException;
@@ -126,7 +125,7 @@ public class X509CertPath extends CertPath {
         // and the methods in the Sun JDK 1.4 implementation of ArrayList that
         // allow read-only access are thread-safe.
         this.certs = Collections.unmodifiableList(
-                new ArrayList<X509Certificate>((List<X509Certificate>)certs));
+                new ArrayList<>((List<X509Certificate>)certs));
     }
 
     /**
@@ -185,14 +184,14 @@ public class X509CertPath extends CertPath {
         }
 
         try {
-            DerInputStream dis = new DerInputStream(readAllBytes(is));
+            DerInputStream dis = new DerInputStream(is.readAllBytes());
             DerValue[] seq = dis.getSequence(3);
             if (seq.length == 0) {
-                return Collections.<X509Certificate>emptyList();
+                return Collections.emptyList();
             }
 
             certFac = CertificateFactory.getInstance("X.509");
-            certList = new ArrayList<X509Certificate>(seq.length);
+            certList = new ArrayList<>(seq.length);
 
             // append certs in reverse order (target to trust anchor)
             for (int i = seq.length-1; i >= 0; i--) {
@@ -228,7 +227,7 @@ public class X509CertPath extends CertPath {
             if (is.markSupported() == false) {
                 // Copy the entire input stream into an InputStream that does
                 // support mark
-                is = new ByteArrayInputStream(readAllBytes(is));
+                is = new ByteArrayInputStream(is.readAllBytes());
             }
             PKCS7 pkcs7 = new PKCS7(is);
 
@@ -238,7 +237,7 @@ public class X509CertPath extends CertPath {
                 certList = Arrays.asList(certArray);
             } else {
                 // no certs provided
-                certList = new ArrayList<X509Certificate>(0);
+                certList = new ArrayList<>(0);
             }
         } catch (IOException ioe) {
             throw new CertificateException("IOException parsing PKCS7 data: " +
@@ -257,15 +256,6 @@ public class X509CertPath extends CertPath {
      * @param is the InputStream to read from
      * @return the bytes read from the InputStream
      */
-    private static byte[] readAllBytes(InputStream is) throws IOException {
-        byte[] buffer = new byte[8192];
-        ByteArrayOutputStream baos = new ByteArrayOutputStream(2048);
-        int n;
-        while ((n = is.read(buffer)) != -1) {
-            baos.write(buffer, 0, n);
-        }
-        return baos.toByteArray();
-    }
 
     /**
      * Returns the encoded form of this certification path, using the

--- a/src/java.base/share/classes/sun/security/provider/certpath/X509CertPath.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/X509CertPath.java
@@ -250,13 +250,6 @@ public class X509CertPath extends CertPath {
         return Collections.unmodifiableList(certList);
     }
 
-    /*
-     * Reads the entire contents of an InputStream into a byte array.
-     *
-     * @param is the InputStream to read from
-     * @return the bytes read from the InputStream
-     */
-
     /**
      * Returns the encoded form of this certification path, using the
      * default encoding.


### PR DESCRIPTION
We can use `InputStream.readAllBytes()` in `ModuleHashes` and `X509CertPath`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290824](https://bugs.openjdk.org/browse/JDK-8290824): Use InputStream.readAllBytes() instead of explicit loops


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9596/head:pull/9596` \
`$ git checkout pull/9596`

Update a local copy of the PR: \
`$ git checkout pull/9596` \
`$ git pull https://git.openjdk.org/jdk pull/9596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9596`

View PR using the GUI difftool: \
`$ git pr show -t 9596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9596.diff">https://git.openjdk.org/jdk/pull/9596.diff</a>

</details>
