### PR TITLE
8290059: Do not use std::thread in panama tests

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -53,6 +53,8 @@ BUILD_JDK_JTREG_EXECUTABLES_CFLAGS_exeJliLaunchTest := \
     -I$(TOPDIR)/src/java.base/$(OPENJDK_TARGET_OS_TYPE)/native/libjli \
     -I$(TOPDIR)/src/java.base/$(OPENJDK_TARGET_OS)/native/libjli
 
+TEST_LIB_NATIVE_SRC := $(TOPDIR)/test/lib/native
+
 # Platform specific setup
 ifeq ($(call isTargetOs, windows), true)
   BUILD_JDK_JTREG_EXCLUDE += libDirectIO.c libInheritedChannel.c \
@@ -67,26 +69,32 @@ ifeq ($(call isTargetOs, windows), true)
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerTest := $(LIBCXX) jvm.lib
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exerevokeall := advapi32.lib
   BUILD_JDK_JTREG_EXECUTABLES_CFLAGS_exeNullCallerTest := /EHsc
-  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libAsyncStackWalk := /EHsc
-  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libAsyncInvokers := /EHsc
-  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerUnnamed := /EHsc
-  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerModule := /EHsc
-  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLoaderLookupInvoker := /EHsc
-  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libAsyncStackWalk := $(LIBCXX)
-  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libAsyncInvokers := $(LIBCXX)
-  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerUnnamed := $(LIBCXX)
-  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerModule := $(LIBCXX)
-  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLoaderLookupInvoker := $(LIBCXX)
+
+  # java.lang.foreign tests
+  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libAsyncStackWalk := -I$(TEST_LIB_NATIVE_SRC)
+  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libLinkerInvokerUnnamed := -I$(TEST_LIB_NATIVE_SRC)
+  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libLinkerInvokerModule := -I$(TEST_LIB_NATIVE_SRC)
+  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libLoaderLookupInvoker := -I$(TEST_LIB_NATIVE_SRC)
+  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libAsyncInvokers := -I$(TEST_LIB_NATIVE_SRC)
+
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libTracePinnedThreads := jvm.lib
 else
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libstringPlatformChars := -ljava
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libDirectIO := -ljava
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libNativeThread := -pthread
-  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libAsyncStackWalk := $(LIBCXX) -pthread
-  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libAsyncInvokers := $(LIBCXX) -pthread
-  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerUnnamed := $(LIBCXX) -pthread
-  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerModule := $(LIBCXX) -pthread
-  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLoaderLookupInvoker := $(LIBCXX) -pthread
+
+  # java.lang.foreign tests
+  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libAsyncStackWalk := -I$(TEST_LIB_NATIVE_SRC)
+  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libAsyncStackWalk := -pthread
+  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libAsyncInvokers := -I$(TEST_LIB_NATIVE_SRC)
+  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libAsyncInvokers := -pthread
+  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libLinkerInvokerUnnamed := -I$(TEST_LIB_NATIVE_SRC)
+  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerUnnamed := -pthread
+  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libLinkerInvokerModule := -I$(TEST_LIB_NATIVE_SRC)
+  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerModule := -pthread
+  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libLoaderLookupInvoker := -I$(TEST_LIB_NATIVE_SRC)
+  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLoaderLookupInvoker := -pthread
+
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libExplicitAttach := -ljvm
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libExplicitAttach := -pthread
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libImplicitAttach := -pthread

--- a/test/jdk/java/foreign/enablenativeaccess/org/openjdk/foreigntest/libLinkerInvokerUnnamed.cpp
+++ b/test/jdk/java/foreign/enablenativeaccess/org/openjdk/foreigntest/libLinkerInvokerUnnamed.cpp
@@ -40,6 +40,6 @@ extern "C" {
     Java_org_openjdk_foreigntest_PanamaMainUnnamedModule_nativeLinker0(JNIEnv *env, jclass cls) {
         JavaVM* jvm;
         env->GetJavaVM(&jvm);
-        run_in_new_thread(call, jvm);
+        run_in_new_thread_and_join(call, jvm);
     }
 }

--- a/test/jdk/java/foreign/enablenativeaccess/org/openjdk/foreigntest/libLinkerInvokerUnnamed.cpp
+++ b/test/jdk/java/foreign/enablenativeaccess/org/openjdk/foreigntest/libLinkerInvokerUnnamed.cpp
@@ -23,9 +23,10 @@
  */
 
 #include "jni.h"
-#include <thread>
+#include "testlib_threads.h"
 
-void call(JavaVM *jvm) {
+void call(void* ctxt) {
+    JavaVM* jvm = (JavaVM*) ctxt;
     JNIEnv* env;
     jvm->AttachCurrentThread((void**)&env, NULL);
     jclass linkerClass = env->FindClass("java/lang/foreign/Linker");
@@ -39,7 +40,6 @@ extern "C" {
     Java_org_openjdk_foreigntest_PanamaMainUnnamedModule_nativeLinker0(JNIEnv *env, jclass cls) {
         JavaVM* jvm;
         env->GetJavaVM(&jvm);
-        std::thread thrd(call, jvm);
-        thrd.join();
+        run_async(call, jvm);
     }
 }

--- a/test/jdk/java/foreign/enablenativeaccess/org/openjdk/foreigntest/libLinkerInvokerUnnamed.cpp
+++ b/test/jdk/java/foreign/enablenativeaccess/org/openjdk/foreigntest/libLinkerInvokerUnnamed.cpp
@@ -40,6 +40,6 @@ extern "C" {
     Java_org_openjdk_foreigntest_PanamaMainUnnamedModule_nativeLinker0(JNIEnv *env, jclass cls) {
         JavaVM* jvm;
         env->GetJavaVM(&jvm);
-        run_async(call, jvm);
+        run_in_new_thread(call, jvm);
     }
 }

--- a/test/jdk/java/foreign/enablenativeaccess/panama_module/org/openjdk/foreigntest/libLinkerInvokerModule.cpp
+++ b/test/jdk/java/foreign/enablenativeaccess/panama_module/org/openjdk/foreigntest/libLinkerInvokerModule.cpp
@@ -40,6 +40,6 @@ extern "C" {
     Java_org_openjdk_foreigntest_PanamaMainJNI_nativeLinker0(JNIEnv *env, jclass cls) {
         JavaVM* jvm;
         env->GetJavaVM(&jvm);
-        run_async(call, jvm);
+        run_in_new_thread(call, jvm);
     }
 }

--- a/test/jdk/java/foreign/enablenativeaccess/panama_module/org/openjdk/foreigntest/libLinkerInvokerModule.cpp
+++ b/test/jdk/java/foreign/enablenativeaccess/panama_module/org/openjdk/foreigntest/libLinkerInvokerModule.cpp
@@ -23,9 +23,10 @@
  */
 
 #include "jni.h"
-#include <thread>
+#include "testlib_threads.h"
 
-void call(JavaVM *jvm) {
+void call(void* ctxt) {
+    JavaVM *jvm = (JavaVM*) ctxt;
     JNIEnv* env;
     jvm->AttachCurrentThread((void**)&env, NULL);
     jclass linkerClass = env->FindClass("java/lang/foreign/Linker");
@@ -39,7 +40,6 @@ extern "C" {
     Java_org_openjdk_foreigntest_PanamaMainJNI_nativeLinker0(JNIEnv *env, jclass cls) {
         JavaVM* jvm;
         env->GetJavaVM(&jvm);
-        std::thread thrd(call, jvm);
-        thrd.join();
+        run_async(call, jvm);
     }
 }

--- a/test/jdk/java/foreign/enablenativeaccess/panama_module/org/openjdk/foreigntest/libLinkerInvokerModule.cpp
+++ b/test/jdk/java/foreign/enablenativeaccess/panama_module/org/openjdk/foreigntest/libLinkerInvokerModule.cpp
@@ -40,6 +40,6 @@ extern "C" {
     Java_org_openjdk_foreigntest_PanamaMainJNI_nativeLinker0(JNIEnv *env, jclass cls) {
         JavaVM* jvm;
         env->GetJavaVM(&jvm);
-        run_in_new_thread(call, jvm);
+        run_in_new_thread_and_join(call, jvm);
     }
 }

--- a/test/jdk/java/foreign/libAsyncInvokers.cpp
+++ b/test/jdk/java/foreign/libAsyncInvokers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,27 +21,41 @@
  * questions.
  */
 
-#include <thread>
+#include "testlib_threads.h"
 
 #include "shared.h"
 
 template<typename CB>
+void proc_v(void* v_cb) {
+    ((CB) v_cb)();
+}
+
+template<typename CB>
 void launch_v(CB cb) {
-    std::thread thrd(cb);
-    thrd.join();
+    run_async(&proc_v<CB>, cb);
 }
 
 template<typename O, typename CB>
-void start(O& out, CB cb) {
-    out = cb();
+struct Context {
+    CB cb;
+    O o;
+};
+
+template<typename O, typename CB>
+void proc(void* context) {
+    Context<O, CB>* ctxt = (Context<O, CB>*) context;
+    ctxt->o = ctxt->cb();
 }
 
 template<typename O, typename CB>
 O launch(CB cb) {
-    O result;
-    std::thread thrd(&start<O, CB>, std::ref(result), cb);
-    thrd.join();
-    return result;
+    PROCEDURE target = &proc<O, CB>;
+    Context<O, CB> ctxt;
+    ctxt.cb = cb;
+
+    run_async(target, &ctxt);
+
+    return ctxt.o;
 }
 
 extern "C" {

--- a/test/jdk/java/foreign/libAsyncInvokers.cpp
+++ b/test/jdk/java/foreign/libAsyncInvokers.cpp
@@ -32,7 +32,7 @@ void proc_v(void* v_cb) {
 
 template<typename CB>
 void launch_v(CB cb) {
-    run_in_new_thread(&proc_v<CB>, (void*) cb);
+    run_in_new_thread_and_join(&proc_v<CB>, (void*) cb);
 }
 
 template<typename O, typename CB>
@@ -52,7 +52,7 @@ O launch(CB cb) {
     Context<O, CB> ctxt;
     ctxt.cb = cb;
 
-    run_in_new_thread(&proc<O, CB>, &ctxt);
+    run_in_new_thread_and_join(&proc<O, CB>, &ctxt);
 
     return ctxt.o;
 }

--- a/test/jdk/java/foreign/libAsyncInvokers.cpp
+++ b/test/jdk/java/foreign/libAsyncInvokers.cpp
@@ -32,7 +32,7 @@ void proc_v(void* v_cb) {
 
 template<typename CB>
 void launch_v(CB cb) {
-    run_async(&proc_v<CB>, cb);
+    run_async(&proc_v<CB>, (void*) cb);
 }
 
 template<typename O, typename CB>
@@ -49,11 +49,10 @@ void proc(void* context) {
 
 template<typename O, typename CB>
 O launch(CB cb) {
-    PROCEDURE target = &proc<O, CB>;
     Context<O, CB> ctxt;
     ctxt.cb = cb;
 
-    run_async(target, &ctxt);
+    run_async(&proc<O, CB>, &ctxt);
 
     return ctxt.o;
 }

--- a/test/jdk/java/foreign/libAsyncInvokers.cpp
+++ b/test/jdk/java/foreign/libAsyncInvokers.cpp
@@ -32,7 +32,7 @@ void proc_v(void* v_cb) {
 
 template<typename CB>
 void launch_v(CB cb) {
-    run_async(&proc_v<CB>, (void*) cb);
+    run_in_new_thread(&proc_v<CB>, (void*) cb);
 }
 
 template<typename O, typename CB>
@@ -52,7 +52,7 @@ O launch(CB cb) {
     Context<O, CB> ctxt;
     ctxt.cb = cb;
 
-    run_async(&proc<O, CB>, &ctxt);
+    run_in_new_thread(&proc<O, CB>, &ctxt);
 
     return ctxt.o;
 }

--- a/test/jdk/java/foreign/loaderLookup/libLoaderLookupInvoker.cpp
+++ b/test/jdk/java/foreign/loaderLookup/libLoaderLookupInvoker.cpp
@@ -47,7 +47,7 @@ extern "C" {
         env->GetJavaVM(&jvm);
         Context context;
         context.jvm = jvm;
-        run_in_new_thread(call, &context);
+        run_in_new_thread_and_join(call, &context);
         return context.res;
     }
 }

--- a/test/jdk/java/foreign/loaderLookup/libLoaderLookupInvoker.cpp
+++ b/test/jdk/java/foreign/loaderLookup/libLoaderLookupInvoker.cpp
@@ -23,18 +23,21 @@
  */
 
 #include "jni.h"
-#include <thread>
+#include "testlib_threads.h"
 
-jobject res;
+struct Context {
+    JavaVM* jvm;
+    jobject res;
+};
 
-jobject call(JavaVM *jvm) {
+void call(void* ctxt) {
+    Context* context = (Context*) ctxt;
     JNIEnv* env;
-    jvm->AttachCurrentThread((void**)&env, NULL);
+    context->jvm->AttachCurrentThread((void**)&env, NULL);
     jclass symbolLookupClass = env->FindClass("java/lang/foreign/SymbolLookup");
     jmethodID loaderLookupMethod = env->GetStaticMethodID(symbolLookupClass, "loaderLookup", "()Ljava/lang/foreign/SymbolLookup;");
-    res = env->NewGlobalRef(env->CallStaticObjectMethod(symbolLookupClass, loaderLookupMethod));
-    jvm->DetachCurrentThread();
-    return res;
+    context->res = env->NewGlobalRef(env->CallStaticObjectMethod(symbolLookupClass, loaderLookupMethod));
+    context->jvm->DetachCurrentThread();
 }
 
 extern "C" {
@@ -42,8 +45,9 @@ extern "C" {
     Java_TestLoaderLookupJNI_loaderLookup0(JNIEnv *env, jclass cls) {
         JavaVM* jvm;
         env->GetJavaVM(&jvm);
-        std::thread thrd(call, jvm);
-        thrd.join();
-        return res;
+        Context context;
+        context.jvm = jvm;
+        run_async(call, &context);
+        return context.res;
     }
 }

--- a/test/jdk/java/foreign/loaderLookup/libLoaderLookupInvoker.cpp
+++ b/test/jdk/java/foreign/loaderLookup/libLoaderLookupInvoker.cpp
@@ -47,7 +47,7 @@ extern "C" {
         env->GetJavaVM(&jvm);
         Context context;
         context.jvm = jvm;
-        run_async(call, &context);
+        run_in_new_thread(call, &context);
         return context.res;
     }
 }

--- a/test/jdk/java/foreign/stackwalk/libAsyncStackWalk.cpp
+++ b/test/jdk/java/foreign/stackwalk/libAsyncStackWalk.cpp
@@ -22,7 +22,7 @@
  *
  */
 
-#include <thread>
+#include "testlib_threads.h"
 
 #ifdef _WIN64
 #define EXPORT __declspec(dllexport)
@@ -30,15 +30,17 @@
 #define EXPORT
 #endif
 
-static void start(void (*cb)(void)) {
+typedef void (*CB_t)(void);
+
+static void start(void* ctxt) {
+    CB_t cb = (CB_t) ctxt;
     for (int i = 0; i < 25000; i++) {
         cb();
     }
 }
 
 extern "C" {
-EXPORT void asyncStackWalk(void (*cb)(void)) {
-    std::thread thrd(start, cb);
-    thrd.join();
+EXPORT void asyncStackWalk(CB_t cb) {
+    run_async(start, cb);
 }
 }

--- a/test/jdk/java/foreign/stackwalk/libAsyncStackWalk.cpp
+++ b/test/jdk/java/foreign/stackwalk/libAsyncStackWalk.cpp
@@ -41,6 +41,6 @@ static void start(void* ctxt) {
 
 extern "C" {
 EXPORT void asyncStackWalk(CB_t cb) {
-    run_in_new_thread(start, (void*) cb);
+    run_in_new_thread_and_join(start, (void*) cb);
 }
 }

--- a/test/jdk/java/foreign/stackwalk/libAsyncStackWalk.cpp
+++ b/test/jdk/java/foreign/stackwalk/libAsyncStackWalk.cpp
@@ -41,6 +41,6 @@ static void start(void* ctxt) {
 
 extern "C" {
 EXPORT void asyncStackWalk(CB_t cb) {
-    run_async(start, cb);
+    run_async(start, (void*) cb);
 }
 }

--- a/test/jdk/java/foreign/stackwalk/libAsyncStackWalk.cpp
+++ b/test/jdk/java/foreign/stackwalk/libAsyncStackWalk.cpp
@@ -41,6 +41,6 @@ static void start(void* ctxt) {
 
 extern "C" {
 EXPORT void asyncStackWalk(CB_t cb) {
-    run_async(start, (void*) cb);
+    run_in_new_thread(start, (void*) cb);
 }
 }

--- a/test/lib/native/testlib_threads.h
+++ b/test/lib/native/testlib_threads.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef TEST_LIB_NATIVE_THREAD_H
+#define TEST_LIB_NATIVE_THREAD_H
+
+// Header only library for using threads in tests
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifdef _WIN32
+
+#include <windows.h>
+typedef HANDLE THREAD_ID;
+
+#else // !_WIN32
+
+#include <unistd.h>
+#include <pthread.h>
+typedef pthread_t THREAD_ID;
+#endif // !_WIN32
+
+extern "C" {
+
+typedef void(*PROCEDURE)(void*);
+
+struct Helper {
+    PROCEDURE proc;
+    void* context;
+};
+
+#ifdef _WIN32
+static DWORD __stdcall procedure(void* ctxt) {
+#else // !windows
+void* procedure(void* ctxt) {
+#endif
+    Helper* helper = (Helper*)ctxt;
+    helper->proc(helper->context);
+    return 0;
+}
+
+void run_async(PROCEDURE proc, void* context) {
+    struct Helper helper;
+    helper.proc = proc;
+    helper.context = context;
+#ifdef _WIN32
+    HANDLE thread = CreateThread(NULL, 0, procedure, &helper, 0, NULL);
+    if (thread == NULL) {
+        perror("failed to create thread");
+    }
+    if (WaitForSingleObject(thread, INFINITE) != WAIT_OBJECT_0) {
+        perror("failed to join thread");
+    }
+#else
+    pthread_t thread;
+    int result = pthread_create(&thread, NULL, procedure, &helper);
+    if (result != 0) {
+        perror("failed to create thread");
+    }
+    if (pthread_join(thread, NULL) != 0) {
+        perror("failed to join thread");
+    }
+#endif
+}
+
+}
+
+#endif // TEST_LIB_NATIVE_THREAD_H

--- a/test/lib/native/testlib_threads.h
+++ b/test/lib/native/testlib_threads.h
@@ -65,7 +65,7 @@ void* procedure(void* ctxt) {
 
 // Run 'proc' in a newly started thread, passing 'context' to it
 // as an argument, and then join that thread.
-void run_in_new_thread(PROCEDURE proc, void* context) {
+void run_in_new_thread_and_join(PROCEDURE proc, void* context) {
     struct Helper helper;
     helper.proc = proc;
     helper.context = context;

--- a/test/lib/native/testlib_threads.h
+++ b/test/lib/native/testlib_threads.h
@@ -75,6 +75,8 @@ void run_in_new_thread(PROCEDURE proc, void* context) {
         fatal("failed to create thread", GetLastError());
     }
     if (WaitForSingleObject(thread, INFINITE) != WAIT_OBJECT_0) {
+        // Should be WAIT_FAILED, since this is not a mutex, and
+        // we set no timeout.
         fatal("failed to join thread", GetLastError());
     }
 #else

--- a/test/lib/native/testlib_threads.h
+++ b/test/lib/native/testlib_threads.h
@@ -30,16 +30,11 @@
 #include <stdio.h>
 
 #ifdef _WIN32
-
 #include <windows.h>
-typedef HANDLE THREAD_ID;
-
-#else // !_WIN32
-
+#else
 #include <unistd.h>
 #include <pthread.h>
-typedef pthread_t THREAD_ID;
-#endif // !_WIN32
+#endif
 
 extern "C" {
 
@@ -50,9 +45,14 @@ struct Helper {
     void* context;
 };
 
+static void fatal(const char* message) {
+    perror(message);
+    exit(-1);
+}
+
 #ifdef _WIN32
 static DWORD __stdcall procedure(void* ctxt) {
-#else // !windows
+#else
 void* procedure(void* ctxt) {
 #endif
     Helper* helper = (Helper*)ctxt;
@@ -67,19 +67,19 @@ void run_async(PROCEDURE proc, void* context) {
 #ifdef _WIN32
     HANDLE thread = CreateThread(NULL, 0, procedure, &helper, 0, NULL);
     if (thread == NULL) {
-        perror("failed to create thread");
+        fatal("failed to create thread");
     }
     if (WaitForSingleObject(thread, INFINITE) != WAIT_OBJECT_0) {
-        perror("failed to join thread");
+        fatal("failed to join thread");
     }
 #else
     pthread_t thread;
     int result = pthread_create(&thread, NULL, procedure, &helper);
     if (result != 0) {
-        perror("failed to create thread");
+        fatal("failed to create thread");
     }
     if (pthread_join(thread, NULL) != 0) {
-        perror("failed to join thread");
+        fatal("failed to join thread");
     }
 #endif
 }


### PR DESCRIPTION
This patch removes the use of std::thread from the `java.lang.foreign` tests, and switches to the OS specific thread APIs, in order to change things such as the stack size on some platforms where this is required in the future (see the JBS issue).

This is done by adding a small header-only library that exposes a function to run code in freshly spawned threads (`run_async`).

Testing: Running the affected tests on platforms that implement the linker.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290059](https://bugs.openjdk.org/browse/JDK-8290059): Do not use std::thread in panama tests


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [49e60f2d](https://git.openjdk.org/jdk/pull/9599/files/49e60f2d187476683d32fcab02714a4c56315529)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [49e60f2d](https://git.openjdk.org/jdk/pull/9599/files/49e60f2d187476683d32fcab02714a4c56315529)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [49e60f2d](https://git.openjdk.org/jdk/pull/9599/files/49e60f2d187476683d32fcab02714a4c56315529)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9599/head:pull/9599` \
`$ git checkout pull/9599`

Update a local copy of the PR: \
`$ git checkout pull/9599` \
`$ git pull https://git.openjdk.org/jdk pull/9599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9599`

View PR using the GUI difftool: \
`$ git pr show -t 9599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9599.diff">https://git.openjdk.org/jdk/pull/9599.diff</a>

</details>
