### PR TITLE
8287385: Suppress superficial unstable_if traps

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1861,9 +1861,8 @@ void Compile::process_for_post_loop_opts_igvn(PhaseIterGVN& igvn) {
 }
 
 void Compile::record_unstable_if_trap(UnstableIfTrap* trap) {
-  if (OptimizeUnstableIf) {
-    _unstable_if_traps.append(trap);
-  }
+  assert(OptimizeUnstableIf, "only valid OptimizeUnstableIf is on.");
+  _unstable_if_traps.append(trap);
 }
 
 void Compile::remove_useless_unstable_if_traps(Unique_Node_List& useful) {

--- a/src/hotspot/share/opto/parse.hpp
+++ b/src/hotspot/share/opto/parse.hpp
@@ -461,6 +461,7 @@ class Parse : public GraphKit {
   void merge_exception(int target_bci);
   // Helper: Merge the current mapping into the given basic block
   void merge_common(Block* target, int pnum);
+  bool unstable_if_merge(Block* target, SafePointNode* newin);
   // Helper functions for merging individual cells.
   PhiNode *ensure_phi(       int idx, bool nocreate = false);
   PhiNode *ensure_memory_phi(int idx, bool nocreate = false);

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -650,6 +650,21 @@ void Parse::do_all_blocks() {
         continue;
       }
 
+      if (OptimizeUnstableIf) {
+        // C2 is about to parse block, so the unstable_if traps associated with it
+        // are 'superficial'. suppress them.
+        auto unstable_if_traps = block->unstable_if_traps();
+        while (unstable_if_traps.length() > 0) {
+          UnstableIfTrap* trap = unstable_if_traps.pop();
+
+          trap->suppress(this, block);
+          CallStaticJavaNode* unc = trap->uncommon_trap();
+          unc->set_req(0, top());
+          record_for_igvn(unc);
+          //tty->print("mark dead: ");
+          //unc->dump();
+        }
+      }
       // Prepare to parse this block.
       load_state_from(block);
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestOptimizeUnstableIf.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestOptimizeUnstableIf.java
@@ -78,6 +78,22 @@ public class TestOptimizeUnstableIf {
         return x._value + y._value + z._value + i;
     }
 
+    @Test
+    @Arguments({Argument.RANDOM_EACH, Argument.TRUE})
+    @IR(failOn = {IRNode.MUL})
+    @IR(counts = {IRNode.UNSTABLE_IF_TRAP, "1"})
+    public static int superfical_if_constant(int x, boolean cond) {
+        int i = x;
+        if (cond) { // likely
+            i = 0;
+        }
+        // really complex iterations I made up
+        int y  = 42;
+        y = (int)(Math.sqrt(y) + (x * 0.1191837));
+        // if constant folding works, y will be dead and return 0;
+        return  i * y;
+    }
+
     @Check(test = "boxing_object")
     public void checkWithTestInfo(int result, TestInfo info) {
         if (info.isWarmUp()) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestOptimizeUnstableIf.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestOptimizeUnstableIf.java
@@ -54,6 +54,30 @@ public class TestOptimizeUnstableIf {
         return sum;
     }
 
+    // a custom "boxing" class
+    public static class Value {
+        public int _value;
+
+        public Value(int value) {
+          this._value = value;
+        }
+    }
+
+    @Test
+    @Arguments({Argument.TRUE, Argument.DEFAULT, Argument.RANDOM_EACH, Argument.RANDOM_EACH})
+    @IR(failOn = {IRNode.UNSTABLE_IF_TRAP})
+    public static int superficial_if(boolean cond, int i, int j, int k) {
+        Value x = new Value(i);
+        Value y = new Value(j);
+        Value z = new Value(k);
+
+        if (cond) { // likely
+            i++;
+        } // else section is superficial
+
+        return x._value + y._value + z._value + i;
+    }
+
     @Check(test = "boxing_object")
     public void checkWithTestInfo(int result, TestInfo info) {
         if (info.isWarmUp()) {


### PR DESCRIPTION
An unstable if trap is **superficial** if it can NOT prune any code. Sometimes, the else-section of program is empty. The superficial unstable_if traps not only complicate code shape but also consume codecache. C2 has to generate debuginfo for them. If the condition changed, HotSpot has to destroy the established nmethod and compile it again.  Our analysis shows that rough 20% unstable_if traps are superficial. 

The algorithm which can identify and suppress superficial unstable if traps derives from its definition.  A non-superficial unstable_if trap must prune some code. Parser skips parsing dead basic blocks(BBs). A trap is superficial if and only if its target BB is not dead! Or, it will be skipped(contradict from definition). As a result, we can suppress an unstable_if trap when c2 parse the target BB. This algorithm leaves alone those uncommon_traps do prune code. 

For example, C2  generates an uncommon_trap for the else if cond is very likely true. 
```
    public static int foo(boolean cond, int i) {
        Value x = new Value(0);
        Value y = new Value(1);
        Value z = new Value(i);

        if (cond) {
            i++;
        }
        return x._value + y._value + z._value + i;
    }
```

If we suppress this superficial unstable_if, the nmethod reduces from 608 bytes to 520 bytes, or -14.5%. Most of them come from "scopes data/pcs". It's because superficial unstable_if generates a trap like this
```
037     call,static  wrapper for: uncommon_trap(reason='unstable_if' action='reinterpret' debug_id='0')
        # SuperficialIfTrap::foo @ bci:29 (line 32) L[0]=_ L[1]=rsp + #4 L[2]=#ScObj0 L[3]=#ScObj1 L[4]=#ScObj2 STK[0]=rsp + #0
        # ScObj0 SuperficialIfTrap$Value={ [_value :0]=#0 }
        # ScObj1 SuperficialIfTrap$Value={ [_value :0]=#1 }
        # ScObj2 SuperficialIfTrap$Value={ [_value :0]=rsp + #4 }
        # OopMap {off=60/0x3c}
03c     stop    # ShouldNotReachHere
```

Here is the breakdown of nmethod, generated by '-XX:+PrintAssembly'
```
<-XX:-OptimizeUnstableIf>
Compiled method (c2)     346   17       4       SuperficialIfTrap::foo (53 bytes)
 total in heap  [0x00007f50f4970910,0x00007f50f4970b70] = 608
 relocation     [0x00007f50f4970a70,0x00007f50f4970a80] = 16
 main code      [0x00007f50f4970a80,0x00007f50f4970ad8] = 88
 stub code      [0x00007f50f4970ad8,0x00007f50f4970af0] = 24
 oops           [0x00007f50f4970af0,0x00007f50f4970b00] = 16
 metadata       [0x00007f50f4970b00,0x00007f50f4970b08] = 8
 scopes data    [0x00007f50f4970b08,0x00007f50f4970b38] = 48
 scopes pcs     [0x00007f50f4970b38,0x00007f50f4970b68] = 48
 dependencies   [0x00007f50f4970b68,0x00007f50f4970b70] = 8

<-XX:+OptimizeUnstableIf>
Compiled method (c2)     309   17       4       SuperficialIfTrap::foo (53 bytes)
 total in heap  [0x00007f4090970910,0x00007f4090970b18] = 520
 relocation     [0x00007f4090970a70,0x00007f4090970a80] = 16
 main code      [0x00007f4090970a80,0x00007f4090970ac8] = 72
 stub code      [0x00007f4090970ac8,0x00007f4090970ae0] = 24
 oops           [0x00007f4090970ae0,0x00007f4090970ae8] = 8
 scopes data    [0x00007f4090970ae8,0x00007f4090970af0] = 8
 scopes pcs     [0x00007f4090970af0,0x00007f4090970b10] = 32
 dependencies   [0x00007f4090970b10,0x00007f4090970b18] = 8
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287385](https://bugs.openjdk.org/browse/JDK-8287385): Suppress superficial unstable_if traps


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9601/head:pull/9601` \
`$ git checkout pull/9601`

Update a local copy of the PR: \
`$ git checkout pull/9601` \
`$ git pull https://git.openjdk.org/jdk pull/9601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9601`

View PR using the GUI difftool: \
`$ git pr show -t 9601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9601.diff">https://git.openjdk.org/jdk/pull/9601.diff</a>

</details>
