### PR TITLE
8290861: Remove unused field URLJarFile.BUF_SIZE

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/jar/URLJarFile.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/jar/URLJarFile.java
@@ -37,7 +37,6 @@ import java.util.zip.ZipEntry;
 import java.security.CodeSigner;
 import java.security.cert.Certificate;
 import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.security.PrivilegedExceptionAction;
 import java.security.PrivilegedActionException;
 import sun.net.www.ParseUtil;
@@ -53,8 +52,6 @@ public class URLJarFile extends JarFile {
 
     /* Controller of the Jar File's closing */
     private URLJarFileCloseController closeController = null;
-
-    private static int BUF_SIZE = 2048;
 
     private Manifest superMan;
     private Attributes superAttr;
@@ -165,7 +162,7 @@ public class URLJarFile extends JarFile {
     /* If close controller is set the notify the controller about the pending close */
     public void close() throws IOException {
         if (closeController != null) {
-                closeController.close(this);
+            closeController.close(this);
         }
         super.close();
     }
@@ -189,8 +186,8 @@ public class URLJarFile extends JarFile {
      * Given a URL, retrieves a JAR file, caches it to disk, and creates a
      * cached JAR file object.
      */
-     @SuppressWarnings("removal")
-     private static JarFile retrieve(final URL url, final URLJarFileCloseController closeController) throws IOException {
+    @SuppressWarnings("removal")
+    private static JarFile retrieve(final URL url, final URLJarFileCloseController closeController) throws IOException {
         /*
          * See if interface is set, then call retrieve function of the class
          * that implements URLJarFileCallBack interface (sun.plugin - to
@@ -253,7 +250,7 @@ public class URLJarFile extends JarFile {
 
         URLJarFileEntry(JarEntry je) {
             super(je);
-            this.je=je;
+            this.je = je;
         }
 
         public Attributes getAttributes() throws IOException {


### PR DESCRIPTION
Static field 'BUF_SIZE' in the class sun.net.[www.protocol.jar.URLJarFile](http://www.protocol.jar.urljarfile/) is unused and can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290861](https://bugs.openjdk.org/browse/JDK-8290861): Remove unused field URLJarFile.BUF_SIZE


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - Committer)
 * [Aleksei Efimov](https://openjdk.org/census#aefimov) (@AlekseiEfimov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9602/head:pull/9602` \
`$ git checkout pull/9602`

Update a local copy of the PR: \
`$ git checkout pull/9602` \
`$ git pull https://git.openjdk.org/jdk pull/9602/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9602`

View PR using the GUI difftool: \
`$ git pr show -t 9602`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9602.diff">https://git.openjdk.org/jdk/pull/9602.diff</a>

</details>
