### PR TITLE
8290812: Add a test for ResourceHashtable

### DIFF
--- a/test/hotspot/gtest/utilities/test_resourceHash.cpp
+++ b/test/hotspot/gtest/utilities/test_resourceHash.cpp
@@ -299,7 +299,12 @@ class ResourceHashtableDeleteTest : public ::testing::Test {
         // NONCOPYABLE(TestValue)
         TestValue(Symbol* name) : _s(name) { _s->increment_refcount(); }
         TestValue(const TestValue& tv) { _s = tv.s(); _s->increment_refcount(); }
-        TestValue& operator=(const TestValue& tv) { _s = tv.s(); _s->increment_refcount(); return *this; }
+        TestValue& operator=(const TestValue& tv) {
+          if (&tv != this) {
+            _s = tv.s();
+            _s->increment_refcount();
+          }
+          return *this; }
         ~TestValue() { _s->decrement_refcount(); }
         Symbol* s() const { return _s; }
     };

--- a/test/hotspot/gtest/utilities/test_resourceHash.cpp
+++ b/test/hotspot/gtest/utilities/test_resourceHash.cpp
@@ -336,27 +336,27 @@ TEST_VM_F(ResourceHashtableDeleteTest, check_delete) {
   int s_orig_count = s->refcount();
   {
     TestValue tv(s);
-    // If you put a Symbol* as key in the ResourceHashtable, you must increment the
+    // If you use a Symbol* as key in the ResourceHashtable, you must increment the
     // refcount outside the hashtable functions.
     s->increment_refcount();
     _test_table.put(s, tv);
     ASSERT_EQ(s->refcount(), s_orig_count + 3) << "refcount incremented";
   }
   ASSERT_EQ(s->refcount(), s_orig_count + 2) << "refcount not copied";
-  // removing entry
+
   // Deleting this value from a hashtable calls the destructor!
   _test_table.remove(s);
   // Now decrement the refcount for s since it's no longer in the table.
   s->decrement_refcount();
-  // Removal should get make the refcount be the original refcount.
+  // Removal should make the refcount be the original refcount.
   ASSERT_EQ(s->refcount(), s_orig_count) << "refcount now decremented";
 
   TempNewSymbol d = SymbolTable::new_symbol("defghijklmnop");
   int d_orig_count = d->refcount();
   {
     TestValue tv(d);
-    // On the other hand, if the Key Symbol* is already a member of the entry, maybe it's not necessary
-    // to increment the refcount on the symbol.
+    // On the other hand, if the Key Symbol* is already a member of the entry, it's not strictly
+    // necessary to increment the refcount on the symbol.
     _test_table.put(d, tv);
     ASSERT_EQ(d->refcount(), d_orig_count + 2) << "refcount incremented";
   }
@@ -371,17 +371,18 @@ TEST_VM_F(ResourceHashtableDeleteTest, check_delete_ptr) {
   int s_orig_count = s->refcount();
   {
     TestValue* tv = new TestValue(s);
-    // If you put a Symbol* as key in the ResourceHashtable, you must increment the
+    // If you use a Symbol* as key in the ResourceHashtable, you must increment the
     // refcount outside the hashtable functions.
     s->increment_refcount();
     _ptr_test_table.put(s, tv);
     ASSERT_EQ(s->refcount(), s_orig_count + 2) << "refcount incremented";
   }
   ASSERT_EQ(s->refcount(), s_orig_count + 2) << "refcount not copied";
-  // removing entry
-  // Deleting this value from a hashtable calls the destructor!
+
+  // Deleting this value from a hashtable must call the destructor in the
+  // do_entry function.
   Deleter deleter;
   _ptr_test_table.unlink(&deleter);
-  // Removal should get make the refcount be the original refcount.
+  // Removal should make the refcount be the original refcount.
   ASSERT_EQ(s->refcount(), s_orig_count) << "refcount now decremented";
 }

--- a/test/hotspot/gtest/utilities/test_resourceHash.cpp
+++ b/test/hotspot/gtest/utilities/test_resourceHash.cpp
@@ -295,6 +295,8 @@ class ResourceHashtableDeleteTest : public ::testing::Test {
         Symbol* _s;
       public:
         // Never have ctors and dtors fix refcounts without copy ctors and assignment operators!
+        // Unless it's declared and used as a CHeapObj with
+        // NONCOPYABLE(TestValue)
         TestValue(Symbol* name) : _s(name) { _s->increment_refcount(); }
         TestValue(const TestValue& tv) { _s = tv.s(); _s->increment_refcount(); }
         TestValue& operator=(const TestValue& tv) { _s = tv.s(); _s->increment_refcount(); return *this; }

--- a/test/hotspot/gtest/utilities/test_resourceHash.cpp
+++ b/test/hotspot/gtest/utilities/test_resourceHash.cpp
@@ -351,7 +351,7 @@ class ResourceHashtableDeleteTest : public ::testing::Test {
 };
 
 TEST_VM_F(ResourceHashtableDeleteTest, check_delete) {
-  TempNewSymbol s = SymbolTable::new_symbol("abc");
+  TempNewSymbol s = SymbolTable::new_symbol("abcdefg");
   int s_orig_count = s->refcount();
   {
     TestValue tv(s);


### PR DESCRIPTION
I added a test for ResourceHashtable to show the interactions with it and Symbol* refcounting.
Tested with tier1 on Oracle platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290812](https://bugs.openjdk.org/browse/JDK-8290812): Add a test for ResourceHashtable


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [64f3338e](https://git.openjdk.org/jdk/pull/9603/files/64f3338e249f0412a90b5a396b6c6b9278d15e8d)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9603/head:pull/9603` \
`$ git checkout pull/9603`

Update a local copy of the PR: \
`$ git checkout pull/9603` \
`$ git pull https://git.openjdk.org/jdk pull/9603/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9603`

View PR using the GUI difftool: \
`$ git pr show -t 9603`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9603.diff">https://git.openjdk.org/jdk/pull/9603.diff</a>

</details>
