### PR TITLE
8290846: sun/tools/jstatd/JstatdTest* tests should use VM options

### DIFF
--- a/test/jdk/sun/tools/jstatd/JstatGCUtilParser.java
+++ b/test/jdk/sun/tools/jstatd/JstatGCUtilParser.java
@@ -43,9 +43,9 @@ public class JstatGCUtilParser {
     }
 
     public enum GcStatistics {
-        S0(GcStatisticsType.PERCENTAGE),
-        S1(GcStatisticsType.PERCENTAGE),
-        E(GcStatisticsType.PERCENTAGE),
+        S0(GcStatisticsType.PERCENTAGE_OR_DASH),
+        S1(GcStatisticsType.PERCENTAGE_OR_DASH),
+        E(GcStatisticsType.PERCENTAGE_OR_DASH),
         O(GcStatisticsType.PERCENTAGE),
         M(GcStatisticsType.PERCENTAGE_OR_DASH),
         CCS(GcStatisticsType.PERCENTAGE_OR_DASH),

--- a/test/jdk/sun/tools/jstatd/JstatdTest.java
+++ b/test/jdk/sun/tools/jstatd/JstatdTest.java
@@ -128,7 +128,6 @@ public final class JstatdTest {
      */
     private OutputAnalyzer runJps() throws Exception {
         JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("jps");
-        launcher.addVMArgs(Utils.getFilteredTestJavaOpts("-XX:+UsePerfData"));
         launcher.addVMArg("-XX:+UsePerfData");
         launcher.addToolArg(getDestination());
 
@@ -252,6 +251,7 @@ public final class JstatdTest {
      */
     private String[] getJstatdCmd() throws Exception {
         JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("jstatd");
+        launcher.addVMArgs(Utils.getTestJavaOpts());
         launcher.addVMArg("-XX:+UsePerfData");
         String testSrc = System.getProperty("test.src");
         if (port != null) {


### PR DESCRIPTION
Propagate test.vm.opts/test.java.opts to tested process. Also, accept the output of non-generation (ZGC) GC as valid.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290846](https://bugs.openjdk.org/browse/JDK-8290846): sun/tools/jstatd/JstatdTest* tests should use VM options


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9604/head:pull/9604` \
`$ git checkout pull/9604`

Update a local copy of the PR: \
`$ git checkout pull/9604` \
`$ git pull https://git.openjdk.org/jdk pull/9604/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9604`

View PR using the GUI difftool: \
`$ git pr show -t 9604`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9604.diff">https://git.openjdk.org/jdk/pull/9604.diff</a>

</details>
