### PR TITLE
8290669: Fix wording in sun.security.ec

### DIFF
--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECOperations.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECOperations.java
@@ -151,7 +151,7 @@ public class ECOperations {
         // and throw IntermediateValueException in the (unlikely) event
         // that the result is 0.
 
-        // Get 64 extra bits and reduce in to the nonce
+        // Get 64 extra bits and reduce into the nonce
         int seedBits = orderField.getSize().bitLength() + 64;
         if (seedBytes.length * 8 < seedBits) {
             throw new ProviderException("Incorrect seed length: " +

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/XECOperations.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/XECOperations.java
@@ -145,7 +145,7 @@ public class XECOperations {
 
     /**
      * Prune an encoded scalar value by modifying it in place. The extra
-     * high-order bits are masked off, the highest valid bit it set, and the
+     * high-order bits are masked off, the highest valid bit is set, and the
      * number is rounded down to a multiple of the cofactor.
      *
      * @param k an encoded scalar value

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAKeyPairGenerator.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAKeyPairGenerator.java
@@ -25,7 +25,6 @@
 
 package sun.security.ec.ed;
 
-//import java.security.*;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;


### PR DESCRIPTION
this patch fixes several wording in sun.security.ec

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290669](https://bugs.openjdk.org/browse/JDK-8290669): Fix wording in sun.security.ec


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9606/head:pull/9606` \
`$ git checkout pull/9606`

Update a local copy of the PR: \
`$ git checkout pull/9606` \
`$ git pull https://git.openjdk.org/jdk pull/9606/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9606`

View PR using the GUI difftool: \
`$ git pr show -t 9606`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9606.diff">https://git.openjdk.org/jdk/pull/9606.diff</a>

</details>
