### PR TITLE
8290561: Coalesce incubator-module warnings for single-file source-code programs

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java
@@ -165,6 +165,7 @@ public class Modules extends JCTree.Visitor {
     private final String limitModsOpt;
     private final Set<String> extraLimitMods = new HashSet<>();
     private final String moduleVersionOpt;
+    private final boolean sourceLauncher;
 
     private final boolean lintOptions;
 
@@ -214,6 +215,7 @@ public class Modules extends JCTree.Visitor {
         addModsOpt = options.get(Option.ADD_MODULES);
         limitModsOpt = options.get(Option.LIMIT_MODULES);
         moduleVersionOpt = options.get(Option.MODULE_VERSION);
+        sourceLauncher = options.isSet("sourceLauncher");
     }
 
     int depth = -1;
@@ -1341,9 +1343,9 @@ public class Modules extends JCTree.Visitor {
                 .forEach(result::add);
         }
 
-        String incubatingModules = result.stream()
+        String incubatingModules = filterAlreadyWarnedIncubatorModules(result.stream()
                 .filter(msym -> msym.resolutionFlags.contains(ModuleResolutionFlags.WARN_INCUBATING))
-                .map(msym -> msym.name.toString())
+                .map(msym -> msym.name.toString()))
                 .collect(Collectors.joining(","));
 
         if (!incubatingModules.isEmpty()) {
@@ -1359,6 +1361,15 @@ public class Modules extends JCTree.Visitor {
         }
     }
     //where:
+        private Stream<String> filterAlreadyWarnedIncubatorModules(Stream<String> incubatingModules) {
+            if (!sourceLauncher) return incubatingModules;
+            Set<String> bootModules = ModuleLayer.boot()
+                                                 .modules()
+                                                 .stream()
+                                                 .map(Module::getName)
+                                                 .collect(Collectors.toSet());
+            return incubatingModules.filter(module -> !bootModules.contains(module));
+        }
         private static final Predicate<ModuleSymbol> IS_AUTOMATIC =
                 m -> (m.flags_field & Flags.AUTOMATIC_MODULE) != 0;
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/Main.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/Main.java
@@ -368,6 +368,7 @@ public class Main {
         javacOpts.add("-Xlint:deprecation");
         javacOpts.add("-Xlint:unchecked");
         javacOpts.add("-Xlint:-options");
+        javacOpts.add("-XDsourceLauncher");
         return javacOpts;
     }
 

--- a/test/langtools/tools/javac/launcher/SourceLauncherTest.java
+++ b/test/langtools/tools/javac/launcher/SourceLauncherTest.java
@@ -29,13 +29,22 @@
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.launcher
  *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.jdeps/com.sun.tools.classfile
  * @build toolbox.JavaTask toolbox.JavacTask toolbox.TestRunner toolbox.ToolBox
  * @run main SourceLauncherTest
  */
 
+import com.sun.tools.classfile.Attribute;
+import com.sun.tools.classfile.Attributes;
+import com.sun.tools.classfile.ClassFile;
+import com.sun.tools.classfile.ClassWriter;
+import com.sun.tools.classfile.ConstantPool;
+import com.sun.tools.classfile.ConstantPool.CPInfo;
+import com.sun.tools.classfile.ModuleResolution_attribute;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -45,6 +54,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.List;
 import java.util.Properties;
 import java.util.regex.Pattern;
@@ -654,6 +665,83 @@ public class SourceLauncherTest extends TestRunner {
                 "at Thrower.throwWhenZero(Thrower.java:8)",
                 "at Thrower.main(Thrower.java:4)");
     }
+
+    @Test
+    public void testNoDuplicateIncubatorWarning(Path base) throws Exception {
+        Path module = base.resolve("lib");
+        Path moduleSrc = module.resolve("src");
+        Path moduleClasses = module.resolve("classes");
+        Files.createDirectories(moduleClasses);
+        tb.cleanDirectory(moduleClasses);
+        tb.writeJavaFiles(moduleSrc, "module test {}");
+        new JavacTask(tb)
+                .outdir(moduleClasses)
+                .files(tb.findJavaFiles(moduleSrc))
+                .run()
+                .writeAll();
+        markModuleAsIncubator(moduleClasses.resolve("module-info.class"));
+        tb.writeJavaFiles(base, "public class Main { public static void main(String... args) {}}");
+        String log = new JavaTask(tb)
+                .vmOptions("--module-path", moduleClasses.toString(),
+                           "--add-modules", "test")
+                .className(base.resolve("Main.java").toString())
+                .run(Task.Expect.SUCCESS)
+                .writeAll()
+                .getOutput(Task.OutputKind.STDERR);
+
+        int numberOfWarnings = log.split("WARNING").length - 1;
+
+        if (log.contains("warning:") || numberOfWarnings != 1) {
+            error("Unexpected warning in error output: " + log);
+        }
+
+        List<String> compileLog = new JavacTask(tb)
+                .options("--module-path", moduleClasses.toString(),
+                         "--add-modules", "test",
+                         "-XDrawDiagnostics",
+                         "-XDsourceLauncher",
+                         "-XDshould-stop.at=FLOW")
+                .files(base.resolve("Main.java").toString())
+                .run(Task.Expect.SUCCESS)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+
+        List<String> expectedOutput = List.of(
+                "- compiler.warn.incubating.modules: test",
+                "1 warning"
+        );
+
+        if (!expectedOutput.equals(compileLog)) {
+            error("Unexpected options : " + compileLog);
+        }
+    }
+        //where:
+        private static void markModuleAsIncubator(Path moduleInfoFile) throws Exception {
+            ClassFile cf = ClassFile.read(moduleInfoFile);
+            List<CPInfo> newPool = new ArrayList<>();
+            newPool.add(null);
+            cf.constant_pool.entries().forEach(newPool::add);
+            int moduleResolutionIndex = newPool.size();
+            newPool.add(new ConstantPool.CONSTANT_Utf8_info(Attribute.ModuleResolution));
+            Map<String, Attribute> newAttributes = new HashMap<>(cf.attributes.map);
+            newAttributes.put(Attribute.ModuleResolution,
+                              new ModuleResolution_attribute(moduleResolutionIndex,
+                                                             ModuleResolution_attribute.WARN_INCUBATING));
+            ClassFile newClassFile = new ClassFile(cf.magic,
+                                                   cf.minor_version,
+                                                   cf.major_version,
+                                                   new ConstantPool(newPool.toArray(new CPInfo[0])),
+                                                   cf.access_flags,
+                                                   cf.this_class,
+                                                   cf.super_class,
+                                                   cf.interfaces,
+                                                   cf.fields,
+                                                   cf.methods,
+                                                   new Attributes(newAttributes));
+            try (OutputStream out = Files.newOutputStream(moduleInfoFile)) {
+                new ClassWriter().write(newClassFile, out);
+            }
+        }
 
     Result run(Path file, List<String> runtimeArgs, List<String> appArgs) {
         List<String> args = new ArrayList<>();


### PR DESCRIPTION
Consider a trivial code like:
```
public class Main {
     public static void main(String... args) {}
}
```

And an execution like:
```
$ java --add-modules jdk.incubator.concurrent Main.java 
WARNING: Using incubator modules: jdk.incubator.concurrent
warning: using incubating module(s): jdk.incubator.concurrent
1 warning
```

Having two warnings (one from runtime, one from javac) seems unnecessary. The patch proposed herein tries to avoid the javac warning, keeping only the runtime one. The conditions under which an incubator module is ignored w.r.t. this warning are:

 * the boot Module layer has the module (hence, presumably, the runtime already provided the warning)
 * the javac run is (likely) from the source launcher. This is being done using a custom javac option, `-XDsourceLauncher` (which can possibly be used in other cases).

This is to avoid cases where we would incorrectly suppress the incubator warning, e.g. when `-XDsourceLauncher` would be passed on the command line.

There are other ways to attempt to detect javac invocations from the source launcher - a distinct file manager is used by the source launcher (but detection of the specific file manager does not feel in line with general javac approach); or use of the `jdk.internal.javac.source` system property set by the native launcher (but this is only set when `--source` option is used, as far as I know, and javac also typically does not check system properties).

Note that there is JDK-8290563 to improve the text of the javac warning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290561](https://bugs.openjdk.org/browse/JDK-8290561): Coalesce incubator-module warnings for single-file source-code programs


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9607/head:pull/9607` \
`$ git checkout pull/9607`

Update a local copy of the PR: \
`$ git checkout pull/9607` \
`$ git pull https://git.openjdk.org/jdk pull/9607/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9607`

View PR using the GUI difftool: \
`$ git pr show -t 9607`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9607.diff">https://git.openjdk.org/jdk/pull/9607.diff</a>

</details>
