### PR TITLE
8291061: Improve thread safety of FileTime.toString and toInstant

### DIFF
--- a/src/java.base/share/classes/java/nio/file/attribute/FileTime.java
+++ b/src/java.base/share/classes/java/nio/file/attribute/FileTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -228,6 +228,7 @@ public final class FileTime
      * @since 1.8
      */
     public Instant toInstant() {
+        Instant instant = this.instant;
         if (instant == null) {
             long secs = 0L;
             int nanos = 0;
@@ -269,6 +270,8 @@ public final class FileTime
                 instant = Instant.MAX;
             else
                 instant = Instant.ofEpochSecond(secs, nanos);
+
+            this.instant = instant;
         }
         return instant;
     }
@@ -409,6 +412,7 @@ public final class FileTime
      */
     @Override
     public String toString() {
+        String valueAsString = this.valueAsString;
         if (valueAsString == null) {
             long secs = 0L;
             int  nanos = 0;
@@ -469,6 +473,7 @@ public final class FileTime
             }
             sb.append('Z');
             valueAsString = sb.toString();
+            this.valueAsString = valueAsString;
         }
         return valueAsString;
     }


### PR DESCRIPTION
We need to read fields `instant`/`valueAsString` once, as to dodge/resolve the data race on reading lazily-initialized fields.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291061](https://bugs.openjdk.org/browse/JDK-8291061): Improve thread safety of FileTime.toString and toInstant


### Reviewers
 * @stsypanov (no known github.com user name / role)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9608/head:pull/9608` \
`$ git checkout pull/9608`

Update a local copy of the PR: \
`$ git checkout pull/9608` \
`$ git pull https://git.openjdk.org/jdk pull/9608/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9608`

View PR using the GUI difftool: \
`$ git pr show -t 9608`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9608.diff">https://git.openjdk.org/jdk/pull/9608.diff</a>

</details>
