### PR TITLE
4890041: Remove TAB and Shift TAB from Popup Menu in Motif Look & Feel

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/motif/MotifLookAndFeel.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/motif/MotifLookAndFeel.java
@@ -1229,8 +1229,6 @@ public class MotifLookAndFeel extends BasicLookAndFeel
             // selected.
             "PopupMenu.selectedWindowInputMapBindings", new Object[] {
                   "ESCAPE", "cancel",
-                     "TAB", "cancel",
-               "shift TAB", "cancel",
                     "DOWN", "selectNext",
                  "KP_DOWN", "selectNext",
                       "UP", "selectPrevious",


### PR DESCRIPTION
This is a cleanup of unneeded TAB and Shift TAB keybindings for PopupMenu.selectedWindowInputMapBindings which is consistent with other L&Fs as can be seen here

https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLookAndFeel.java#L1131

https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java#L702

https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKLookAndFeel.java#L806

No regression test added for this code cleanup

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-4890041](https://bugs.openjdk.org/browse/JDK-4890041): Remove TAB and Shift TAB from Popup Menu in Motif Look & Feel


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9609/head:pull/9609` \
`$ git checkout pull/9609`

Update a local copy of the PR: \
`$ git checkout pull/9609` \
`$ git pull https://git.openjdk.org/jdk pull/9609/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9609`

View PR using the GUI difftool: \
`$ git pr show -t 9609`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9609.diff">https://git.openjdk.org/jdk/pull/9609.diff</a>

</details>
