### PR TITLE
8290730: compiler/vectorization/TestAutoVecIntMinMax.java failed with "IRViolationException: There were one or multiple IR rule failures."

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -69,8 +69,6 @@ compiler/c2/Test8004741.java 8235801 generic-all
 
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all
 
-compiler/vectorization/TestAutoVecIntMinMax.java 8290730 generic-x64
-
 #############################################################################
 
 # :hotspot_gc

--- a/test/hotspot/jtreg/compiler/vectorization/TestAutoVecIntMinMax.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestAutoVecIntMinMax.java
@@ -33,8 +33,8 @@ import jdk.test.lib.Utils;
  * @summary Auto-vectorization enhancement for integer Math.max/Math.min operations
  * @library /test/lib /
  * @requires vm.compiler2.enabled
- * @requires (os.simpleArch == "x64" & ((vm.cpu.features ~= ".*avx.*")
- *           | (vm.cpu.features ~= ".*sse4.*"))) | os.arch == "aarch64" | os.arch == "riscv64"
+ * @requires (os.simpleArch == "x64" & (vm.opt.UseSSE == "null" | vm.opt.UseSSE > 3))
+ *           | os.arch == "aarch64" | os.arch == "riscv64"
  * @run driver compiler.c2.irTests.TestAutoVecIntMinMax
  */
 


### PR DESCRIPTION
… "IRViolationException: There were one or multiple IR rule failures."

The IR test - TestAutoVecIntMinMax.java was introduced in https://bugs.openjdk.org/browse/JDK-8288107 to test IR generation of MaxV and MinV nodes when the MinI/MaxI nodes are auto-vectorized.
However, the corresponding vector ISA support for min/max on x64 machines is only available in SSE versions > 3 and AVX.
The "@requires" annotation in the JTREG test has been modified to use the whitelisted flags instead.
Deleting the entry for this JTREG test in test/hotspot/jtreg/ProblemList.txt.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290730](https://bugs.openjdk.org/browse/JDK-8290730): compiler/vectorization/TestAutoVecIntMinMax.java failed with "IRViolationException: There were one or multiple IR rule failures."


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9610/head:pull/9610` \
`$ git checkout pull/9610`

Update a local copy of the PR: \
`$ git checkout pull/9610` \
`$ git pull https://git.openjdk.org/jdk pull/9610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9610`

View PR using the GUI difftool: \
`$ git pr show -t 9610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9610.diff">https://git.openjdk.org/jdk/pull/9610.diff</a>

</details>
