### PR TITLE
JDK-8290839: jdk/jfr/event/compiler/TestJitRestart.java failed with "RuntimeException: No JIT restart event found: expected true, was false"

### DIFF
--- a/test/jdk/jdk/jfr/event/compiler/TestJitRestart.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestJitRestart.java
@@ -95,7 +95,7 @@ public class TestJitRestart {
             }
         }
         // in some seldom cases we do not see the JitRestart event; but then
-        // do not fail (as long as no compilation happened before) 
+        // do not fail (as long as no compilation happened before)
         return true;
     }
 


### PR DESCRIPTION
In seldom cases the TestJitRestart.java JFR test failed because no Jitrestart event was seen in the test.
Dean Long suggested to change the test a bit "How about changing the test to look at CodeCacheFull, compilation, and JitRestart events. It can test that no compilation events happen after CodeCacheFull unless a JitRestart comes first. So it would be testing the order of events and not absolute counts."

So I adjusted the test (still succeeds after a JitRestart is seen, but in case it is not seen only fails in case of Compilation events after CodeCacheFull).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290839](https://bugs.openjdk.org/browse/JDK-8290839): jdk/jfr/event/compiler/TestJitRestart.java failed with "RuntimeException: No JIT restart event found: expected true, was false"


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9612/head:pull/9612` \
`$ git checkout pull/9612`

Update a local copy of the PR: \
`$ git checkout pull/9612` \
`$ git pull https://git.openjdk.org/jdk pull/9612/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9612`

View PR using the GUI difftool: \
`$ git pr show -t 9612`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9612.diff">https://git.openjdk.org/jdk/pull/9612.diff</a>

</details>
