### PR TITLE
JDK-8290870: NMT: Increase MallocSiteTable size and allocate it only when needed

### DIFF
--- a/src/hotspot/share/services/mallocSiteTable.cpp
+++ b/src/hotspot/share/services/mallocSiteTable.cpp
@@ -29,7 +29,7 @@
 #include "services/mallocSiteTable.hpp"
 
 // Malloc site hashtable buckets
-MallocSiteHashtableEntry*  MallocSiteTable::_table[MallocSiteTable::table_size];
+MallocSiteHashtableEntry**  MallocSiteTable::_table = NULL;
 const NativeCallStack* MallocSiteTable::_hash_entry_allocation_stack = NULL;
 const MallocSiteHashtableEntry* MallocSiteTable::_hash_entry_allocation_site = NULL;
 
@@ -42,6 +42,12 @@ const MallocSiteHashtableEntry* MallocSiteTable::_hash_entry_allocation_site = N
  * time, it is in single-threaded mode from JVM perspective.
  */
 bool MallocSiteTable::initialize() {
+
+  ALLOW_C_FUNCTION(::calloc,
+                   _table = (MallocSiteHashtableEntry**)::calloc(table_size, sizeof(MallocSiteHashtableEntry*));)
+  if (_table == nullptr) {
+    return false;
+  }
 
   // Fake the call stack for hashtable entry allocation
   assert(NMT_TrackingStackDepth > 1, "At least one tracking stack");

--- a/src/hotspot/share/services/mallocSiteTable.hpp
+++ b/src/hotspot/share/services/mallocSiteTable.hpp
@@ -102,14 +102,7 @@ class MallocSiteTable : AllStatic {
   // be tuned if malloc activities changed significantly.
   // The statistics data can be obtained via Jcmd
   // jcmd <pid> VM.native_memory statistics.
-
-  // Currently, (number of buckets / number of entries) ratio is
-  // about 1 / 6
-  enum {
-    table_base_size = 128,   // The base size is calculated from statistics to give
-                             // table ratio around 1:6
-    table_size = (table_base_size * NMT_TrackingStackDepth - 1)
-  };
+  static const int table_size = 4099;
 
   // Table cannot be wider than a 16bit bucket idx can hold
 #define MAX_MALLOCSITE_TABLE_SIZE (USHRT_MAX - 1)
@@ -196,7 +189,7 @@ class MallocSiteTable : AllStatic {
  private:
   // The callsite hashtable. It has to be a static table,
   // since malloc call can come from C runtime linker.
-  static MallocSiteHashtableEntry*        _table[table_size];
+  static MallocSiteHashtableEntry**       _table;
   static const NativeCallStack*           _hash_entry_allocation_stack;
   static const MallocSiteHashtableEntry*  _hash_entry_allocation_site;
 };


### PR DESCRIPTION
MST size is too small. It was created with a very strict footprint limit, since it needed to be created statically and unconditionally.

However, [JDK-8256844](https://bugs.openjdk.org/browse/JDK-8256844) reworked NMT initialization and now we can move MST initialization to after argument parsing. Since it is only needed with -XX:NativeMemoryTracking=detail, it makes sense to only conditionally allocate it.

And therefore we can afford to make it larger.

At the moment, it is 511 entries wide. A typical VM run (release VM, reasonably complex scenario) comes to ~3000-6000 entries. Atm the median bucket chain length is 6-8, which is a lot.

Increasing table size to ~4000 drops median bucket chain length to 1, which is nice.

Example, spring petclinic boot up:

before:
```
Bucket chain length distribution:
unused: 1
longest: 14
median: 7
```

with table size 4099:
```
Bucket chain length distribution:
unused: 1751
longest: 5
median: 1
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290870](https://bugs.openjdk.org/browse/JDK-8290870): NMT: Increase MallocSiteTable size and allocate it only when needed


### Reviewers
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9613/head:pull/9613` \
`$ git checkout pull/9613`

Update a local copy of the PR: \
`$ git checkout pull/9613` \
`$ git pull https://git.openjdk.org/jdk pull/9613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9613`

View PR using the GUI difftool: \
`$ git pr show -t 9613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9613.diff">https://git.openjdk.org/jdk/pull/9613.diff</a>

</details>
