### PR TITLE
8290780: AArch64: Crash in c2 nmethod running RunThese30M.java

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -148,7 +148,6 @@ extern "C" void disnm(intptr_t p);
 class RelocActions {
 protected:
   typedef int (*reloc_insn)(address insn_addr, address &target);
-  typedef int (*reloc_insn1)(address insn_addr, address &target);
 
   virtual reloc_insn adrpMem() = 0;
   virtual reloc_insn adrpAdd() = 0;
@@ -339,7 +338,6 @@ public:
     return 2;
   }
   static int adrpMovk_impl(address insn_addr, address &target) {
-    fprintf(stderr, "Patch adrp; movk: pc=%p, dest=%p\n", insn_addr, target);
     Instruction_aarch64::patch(insn_addr + sizeof (uint32_t), 20, 5, (uintptr_t)target >> 32);
     uintptr_t dest = (dest & 0xffffffffULL) | (uintptr_t(insn_addr) & 0xffff00000000ULL);
     target = address(dest);
@@ -469,7 +467,6 @@ public:
     ptrdiff_t byte_offset;
     if (offset_for(insn, insn3, byte_offset)) {
       target += byte_offset;
-      fprintf(stderr, "Decod adrp; movk: pc=%p, dest=%p\n", insn_addr, target);
       return 3;
     } else {
       return 2;
@@ -4615,7 +4612,7 @@ void MacroAssembler::adrp(Register reg1, const Address &dest, uint64_t &byte_off
   int64_t offset_low = dest_page - low_page;
   int64_t offset_high = dest_page - high_page;
 
-  //   assert(is_valid_AArch64_address(dest.target()), "bad address");
+  assert(is_valid_AArch64_address(dest.target()), "bad address");
   assert(dest.getMode() == Address::literal, "ADRP must be applied to a literal address");
 
   InstructionMark im(this);
@@ -4631,7 +4628,6 @@ void MacroAssembler::adrp(Register reg1, const Address &dest, uint64_t &byte_off
 
     _adrp(reg1, (address)adrp_target);
     movk(reg1, target >> 32, 32);
-    fprintf(stderr, "creat; movk: pc=%p, adrp_target=%p\n", pc(), (address)adrp_target);
   }
   byte_offset = (uint64_t)dest.target() & 0xfff;
 }

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -338,8 +338,9 @@ public:
     return 2;
   }
   static int adrpMovk_impl(address insn_addr, address &target) {
+    uintptr_t dest = uintptr_t(target);
     Instruction_aarch64::patch(insn_addr + sizeof (uint32_t), 20, 5, (uintptr_t)target >> 32);
-    uintptr_t dest = (dest & 0xffffffffULL) | (uintptr_t(insn_addr) & 0xffff00000000ULL);
+    dest = (dest & 0xffffffffULL) | (uintptr_t(insn_addr) & 0xffff00000000ULL);
     target = address(dest);
     return 2;
   }

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -6949,35 +6949,6 @@ class StubGenerator: public StubCodeGenerator {
 
     __ leave();
 
-#ifdef ASSERT
-    // {
-    //   // Stress relocs for adrp() by trying to reach a page beyond
-    //   // the range of a simple ADRP instruction.
-    //   ExternalAddress longWayAway(__ pc() - (1ll << 34));
-    //   if (! __ is_valid_AArch64_address(longWayAway.target())) {
-    //     longWayAway = ExternalAddress(__ pc() + (1ll << 34));
-    //   }
-    //   if (__ is_valid_AArch64_address(longWayAway.target())) {
-    //     uint64_t offset;
-    //     __ adrp(rscratch1, longWayAway, offset);
-    //     __ add(rscratch1, rscratch1, offset);
-    //   }
-    // }
-    {
-      ExternalAddress longWayAway((address)(size_t)os::vm_page_size() + 42);
-        uint64_t offset;
-        __ adrp(rscratch1, longWayAway, offset);
-        __ add(rscratch1, rscratch1, offset);
-    }
-    {
-        uint64_t offset;
-      ExternalAddress justOutOfReach(__ pc() - 4 * G - 4096);
-      fprintf(stderr, "adrp; movk: pc=%p, dest=%p\n", __ pc(), justOutOfReach.target());
-      __ adrp(rscratch1, justOutOfReach, offset);
-      __ add(rscratch1, rscratch1, offset);
-    }
-#endif // ASSERT
-
     // check for pending exceptions
 #ifdef ASSERT
     Label L;


### PR DESCRIPTION
Fix that masks the offsets used when adrp() is passed an unreachable destination. This reloc allows e.g. `adrp; movk; ldr` to access anywhere in the address space.

```
#  SIGSEGV (0xb) at pc=0x0000ffff55964edc, pid=2843096, tid=2850366
#
# JRE version: Java(TM) SE Runtime Environment (20.0+7) (fastdebug build 20-ea+7-377)
# Java VM: Java HotSpot(TM) 64-Bit Server VM (fastdebug 20-ea+7-377, compiled mode, sharing, compressed oops, compressed class ptrs, g1 gc, linux-aarch64)
# Problematic frame:
# J 91101 c2 java.io.ObjectOutputStream.enableReplaceObject(Z)Z java.base@20-ea (47 bytes) @ 0x0000ffff55964edc [0x0000ffff55964e80+0x000000000000005c]
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290780](https://bugs.openjdk.org/browse/JDK-8290780): AArch64: Crash in c2 nmethod running RunThese30M.java


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9615/head:pull/9615` \
`$ git checkout pull/9615`

Update a local copy of the PR: \
`$ git checkout pull/9615` \
`$ git pull https://git.openjdk.org/jdk pull/9615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9615`

View PR using the GUI difftool: \
`$ git pr show -t 9615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9615.diff">https://git.openjdk.org/jdk/pull/9615.diff</a>

</details>
