### PR TITLE
8290557: tools/jpackage/share/AddLauncherTest.java#id1 failed with "ERROR: Failed: Check icon file"

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LauncherIconVerifier.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LauncherIconVerifier.java
@@ -23,6 +23,7 @@
 
 package jdk.jpackage.test;
 
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -30,6 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import javax.imageio.ImageIO;
 
 public final class LauncherIconVerifier {
     public LauncherIconVerifier() {
@@ -100,13 +102,56 @@ public final class LauncherIconVerifier {
                         iconWorkDir, iconContainer, "expected");
                 Path extractedActualIcon = extractIconFromExecutable(iconWorkDir,
                         launcher, "actual");
-                TKit.assertTrue(-1 == Files.mismatch(extractedExpectedIcon,
-                        extractedActualIcon),
-                        String.format(
-                                "Check icon file [%s] of %s launcher is a copy of source icon file [%s]",
-                                extractedActualIcon,
-                                Optional.ofNullable(launcherName).orElse("main"),
-                                extractedExpectedIcon));
+
+                TKit.trace(String.format(
+                        "Check icon file [%s] of %s launcher is a copy of source icon file [%s]",
+                        extractedActualIcon,
+                        Optional.ofNullable(launcherName).orElse("main"),
+                        extractedExpectedIcon));
+
+                if (Files.mismatch(extractedExpectedIcon, extractedActualIcon)
+                        != -1) {
+                    // On Windows11 .NET API extracting icons from executables
+                    // produce slightly different output for the same icon.
+                    // To workaround it, compare pixels of images and if the
+                    // number of off pixels is below a threshold, assume
+                    // equality.
+                    BufferedImage expectedImg = ImageIO.read(
+                            extractedExpectedIcon.toFile());
+                    BufferedImage actualImg = ImageIO.read(
+                            extractedActualIcon.toFile());
+
+                    int w = expectedImg.getWidth();
+                    int h = expectedImg.getHeight();
+
+                    TKit.assertEquals(w, actualImg.getWidth(),
+                            "Check expected and actual icons have the same width");
+                    TKit.assertEquals(h, actualImg.getHeight(),
+                            "Check expected and actual icons have the same height");
+
+                    int diffPixelCount = 0;
+
+                    for (int i = 0; i != w; ++i) {
+                        for (int j = 0; j != h; ++j) {
+                            int expectedRGB = expectedImg.getRGB(i, j);
+                            int actualRGB = actualImg.getRGB(i, j);
+
+                            if (expectedRGB != actualRGB) {
+                                TKit.trace(String.format(
+                                        "Images mismatch at [%d, %d] pixel", i,
+                                        j));
+                                diffPixelCount++;
+                            }
+                        }
+                    }
+
+                    double threshold = 0.1;
+                    TKit.assertTrue(((double) diffPixelCount) / (w * h)
+                            < threshold,
+                            String.format(
+                                    "Check the number of mismatched pixels [%d] of [%d] is < [%f] threshold",
+                                    diffPixelCount, (w * h), threshold));
+                }
             });
         }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290557](https://bugs.openjdk.org/browse/JDK-8290557): tools/jpackage/share/AddLauncherTest.java#id1 failed with "ERROR: Failed: Check icon file"


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9618/head:pull/9618` \
`$ git checkout pull/9618`

Update a local copy of the PR: \
`$ git checkout pull/9618` \
`$ git pull https://git.openjdk.org/jdk pull/9618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9618`

View PR using the GUI difftool: \
`$ git pr show -t 9618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9618.diff">https://git.openjdk.org/jdk/pull/9618.diff</a>

</details>
