### PR TITLE
8287794: Reverse*VNode::Identity problem

### DIFF
--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1856,7 +1856,7 @@ static Node* reverse_operations_identity(Node* n, Node* in1) {
     return n;
   }
   if (n->Opcode() == in1->Opcode()) {
-    // OperationV (OperationV X , MASK) , MASK =>  X
+    // OperationV (OperationV X MASK) MASK =>  X
     if (n->is_predicated_vector() && in1->is_predicated_vector() && n->in(2) == in1->in(2)) {
       return in1->in(1);
     // OperationV (OperationV X) =>  X

--- a/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransforms.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransforms.java
@@ -37,7 +37,7 @@ import jdk.test.lib.Utils;
 /*
  * @test
  * @bug 8287794
- * @summary Test various reverse bytes ideal transforms.
+ * @summary Test various reverse bytes ideal transforms on X86(AVX2, AVX512) and AARCH64(NEON)
  * @requires vm.compiler2.enabled
  * @modules jdk.incubator.vector
  * @library /test/lib /
@@ -77,12 +77,12 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeature={"sve", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
+    @IR(applyIfCPUFeatureOr = {"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
     public void test_reversebytes_long_transform1(long[] lout, long[] linp) {
         VectorMask<Long> mask = VectorMask.fromLong(LSPECIES, 3);
         for (int i = 0; i < LSPECIES.loopBound(linp.length); i+=LSPECIES.length()) {
             LongVector.fromArray(LSPECIES, linp, i)
-                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .lanewise(VectorOperators.REVERSE_BYTES)
                      .lanewise(VectorOperators.REVERSE_BYTES, mask)
                      .intoArray(lout, i);
         }
@@ -96,13 +96,14 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr={"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
+    @IR(applyIfCPUFeatureOr = {"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
     public void test_reversebytes_long_transform2(long[] lout, long[] linp) {
-        VectorMask<Long> mask = VectorMask.fromLong(LSPECIES, 3);
+        VectorMask<Long> mask1 = VectorMask.fromLong(LSPECIES, 3);
+        VectorMask<Long> mask2 = VectorMask.fromLong(LSPECIES, 3);
         for (int i = 0; i < LSPECIES.loopBound(linp.length); i+=LSPECIES.length()) {
             LongVector.fromArray(LSPECIES, linp, i)
-                     .lanewise(VectorOperators.REVERSE_BYTES)
-                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask1)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask2)
                      .intoArray(lout, i);
         }
     }
@@ -115,14 +116,12 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr={"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
+    @IR(applyIfCPUFeatureOr = {"simd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
     public void test_reversebytes_long_transform3(long[] lout, long[] linp) {
-        VectorMask<Long> mask1 = VectorMask.fromLong(LSPECIES, 3);
-        VectorMask<Long> mask2 = VectorMask.fromLong(LSPECIES, 3);
         for (int i = 0; i < LSPECIES.loopBound(linp.length); i+=LSPECIES.length()) {
             LongVector.fromArray(LSPECIES, linp, i)
-                     .lanewise(VectorOperators.REVERSE_BYTES, mask1)
-                     .lanewise(VectorOperators.REVERSE_BYTES, mask2)
+                     .lanewise(VectorOperators.REVERSE_BYTES)
+                     .lanewise(VectorOperators.REVERSE_BYTES)
                      .intoArray(lout, i);
         }
     }
@@ -135,30 +134,12 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr={"simd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
-    public void test_reversebytes_long_transform4(long[] lout, long[] linp) {
-        for (int i = 0; i < LSPECIES.loopBound(linp.length); i+=LSPECIES.length()) {
-            LongVector.fromArray(LSPECIES, linp, i)
-                     .lanewise(VectorOperators.REVERSE_BYTES)
-                     .lanewise(VectorOperators.REVERSE_BYTES)
-                     .intoArray(lout, i);
-        }
-    }
-
-    @Run(test = {"test_reversebytes_long_transform4"}, mode = RunMode.STANDALONE)
-    public void kernel_test_reversebytes_long_transform4() {
-        for (int i = 0; i < ITERS; i++) {
-            test_reversebytes_long_transform4(lout, linp);
-        }
-    }
-
-    @Test
-    @IR(applyIfCPUFeature={"sve", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
+    @IR(applyIfCPUFeatureOr = {"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
     public void test_reversebytes_int_transform1(int[] iout, int[] iinp) {
         VectorMask<Integer> mask = VectorMask.fromLong(ISPECIES, 3);
         for (int i = 0; i < ISPECIES.loopBound(iinp.length); i+=ISPECIES.length()) {
             IntVector.fromArray(ISPECIES, iinp, i)
-                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .lanewise(VectorOperators.REVERSE_BYTES)
                      .lanewise(VectorOperators.REVERSE_BYTES, mask)
                      .intoArray(iout, i);
         }
@@ -172,13 +153,14 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr={"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
+    @IR(applyIfCPUFeatureOr = {"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
     public void test_reversebytes_int_transform2(int[] iout, int[] iinp) {
-        VectorMask<Integer> mask = VectorMask.fromLong(ISPECIES, 3);
+        VectorMask<Integer> mask1 = VectorMask.fromLong(ISPECIES, 3);
+        VectorMask<Integer> mask2 = VectorMask.fromLong(ISPECIES, 3);
         for (int i = 0; i < ISPECIES.loopBound(iinp.length); i+=ISPECIES.length()) {
             IntVector.fromArray(ISPECIES, iinp, i)
-                     .lanewise(VectorOperators.REVERSE_BYTES)
-                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask1)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask2)
                      .intoArray(iout, i);
         }
     }
@@ -191,14 +173,12 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr={"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
+    @IR(applyIfCPUFeatureOr = {"simd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
     public void test_reversebytes_int_transform3(int[] iout, int[] iinp) {
-        VectorMask<Integer> mask1 = VectorMask.fromLong(ISPECIES, 3);
-        VectorMask<Integer> mask2 = VectorMask.fromLong(ISPECIES, 3);
         for (int i = 0; i < ISPECIES.loopBound(iinp.length); i+=ISPECIES.length()) {
             IntVector.fromArray(ISPECIES, iinp, i)
-                     .lanewise(VectorOperators.REVERSE_BYTES, mask1)
-                     .lanewise(VectorOperators.REVERSE_BYTES, mask2)
+                     .lanewise(VectorOperators.REVERSE_BYTES)
+                     .lanewise(VectorOperators.REVERSE_BYTES)
                      .intoArray(iout, i);
         }
     }
@@ -211,30 +191,12 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr={"simd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
-    public void test_reversebytes_int_transform4(int[] iout, int[] iinp) {
-        for (int i = 0; i < ISPECIES.loopBound(iinp.length); i+=ISPECIES.length()) {
-            IntVector.fromArray(ISPECIES, iinp, i)
-                     .lanewise(VectorOperators.REVERSE_BYTES)
-                     .lanewise(VectorOperators.REVERSE_BYTES)
-                     .intoArray(iout, i);
-        }
-    }
-
-    @Run(test = {"test_reversebytes_int_transform4"}, mode = RunMode.STANDALONE)
-    public void kernel_test_reversebytes_int_transform4() {
-        for (int i = 0; i < ITERS; i++) {
-            test_reversebytes_int_transform4(iout, iinp);
-        }
-    }
-
-    @Test
-    @IR(applyIfCPUFeature={"sve", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
+    @IR(applyIfCPUFeatureOr = {"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
     public void test_reversebytes_short_transform1(short[] sout, short[] sinp) {
         VectorMask<Short> mask = VectorMask.fromLong(SSPECIES, 3);
         for (int i = 0; i < SSPECIES.loopBound(sinp.length); i+=SSPECIES.length()) {
             ShortVector.fromArray(SSPECIES, sinp, i)
-                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .lanewise(VectorOperators.REVERSE_BYTES)
                      .lanewise(VectorOperators.REVERSE_BYTES, mask)
                      .intoArray(sout, i);
         }
@@ -248,13 +210,14 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr={"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
+    @IR(applyIfCPUFeatureOr = {"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
     public void test_reversebytes_short_transform2(short[] sout, short[] sinp) {
-        VectorMask<Short> mask = VectorMask.fromLong(SSPECIES, 3);
+        VectorMask<Short> mask1 = VectorMask.fromLong(SSPECIES, 3);
+        VectorMask<Short> mask2 = VectorMask.fromLong(SSPECIES, 3);
         for (int i = 0; i < SSPECIES.loopBound(sinp.length); i+=SSPECIES.length()) {
             ShortVector.fromArray(SSPECIES, sinp, i)
-                     .lanewise(VectorOperators.REVERSE_BYTES)
-                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask1)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask2)
                      .intoArray(sout, i);
         }
     }
@@ -267,14 +230,12 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr={"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
+    @IR(applyIfCPUFeatureOr = {"simd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
     public void test_reversebytes_short_transform3(short[] sout, short[] sinp) {
-        VectorMask<Short> mask1 = VectorMask.fromLong(SSPECIES, 3);
-        VectorMask<Short> mask2 = VectorMask.fromLong(SSPECIES, 3);
         for (int i = 0; i < SSPECIES.loopBound(sinp.length); i+=SSPECIES.length()) {
             ShortVector.fromArray(SSPECIES, sinp, i)
-                     .lanewise(VectorOperators.REVERSE_BYTES, mask1)
-                     .lanewise(VectorOperators.REVERSE_BYTES, mask2)
+                     .lanewise(VectorOperators.REVERSE_BYTES)
+                     .lanewise(VectorOperators.REVERSE_BYTES)
                      .intoArray(sout, i);
         }
     }
@@ -283,24 +244,6 @@ public class TestReverseByteTransforms {
     public void kernel_test_reversebytes_short_transform3() {
         for (int i = 0; i < ITERS; i++) {
             test_reversebytes_short_transform3(sout, sinp);
-        }
-    }
-
-    @Test
-    @IR(applyIfCPUFeatureOr={"simd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
-    public void test_reversebytes_short_transform4(short[] sout, short[] sinp) {
-        for (int i = 0; i < SSPECIES.loopBound(sinp.length); i+=SSPECIES.length()) {
-            ShortVector.fromArray(SSPECIES, sinp, i)
-                     .lanewise(VectorOperators.REVERSE_BYTES)
-                     .lanewise(VectorOperators.REVERSE_BYTES)
-                     .intoArray(sout, i);
-        }
-    }
-
-    @Run(test = {"test_reversebytes_short_transform4"}, mode = RunMode.STANDALONE)
-    public void kernel_test_reversebytes_short_transform4() {
-        for (int i = 0; i < ITERS; i++) {
-            test_reversebytes_short_transform4(sout, sinp);
         }
     }
 }

--- a/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransforms.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransforms.java
@@ -77,7 +77,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeature={"sve", "true"}, failOn = {"ReverseBytesV"})
+    @IR(applyIfCPUFeature={"sve", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
     public void test_reversebytes_long_transform1(long[] lout, long[] linp) {
         VectorMask<Long> mask = VectorMask.fromLong(LSPECIES, 3);
         for (int i = 0; i < LSPECIES.loopBound(linp.length); i+=LSPECIES.length()) {
@@ -96,7 +96,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, counts = {"ReverseBytesV" , " > 0 "})
+    @IR(applyIfCPUFeatureOr={"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
     public void test_reversebytes_long_transform2(long[] lout, long[] linp) {
         VectorMask<Long> mask = VectorMask.fromLong(LSPECIES, 3);
         for (int i = 0; i < LSPECIES.loopBound(linp.length); i+=LSPECIES.length()) {
@@ -115,7 +115,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, counts = {"ReverseBytesV" , " > 0 "})
+    @IR(applyIfCPUFeatureOr={"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
     public void test_reversebytes_long_transform3(long[] lout, long[] linp) {
         VectorMask<Long> mask1 = VectorMask.fromLong(LSPECIES, 3);
         VectorMask<Long> mask2 = VectorMask.fromLong(LSPECIES, 3);
@@ -135,7 +135,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, failOn = {"ReverseBytesV"})
+    @IR(applyIfCPUFeatureOr={"simd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
     public void test_reversebytes_long_transform4(long[] lout, long[] linp) {
         for (int i = 0; i < LSPECIES.loopBound(linp.length); i+=LSPECIES.length()) {
             LongVector.fromArray(LSPECIES, linp, i)
@@ -153,7 +153,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeature={"sve", "true"}, failOn = {"ReverseBytesV"})
+    @IR(applyIfCPUFeature={"sve", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
     public void test_reversebytes_int_transform1(int[] iout, int[] iinp) {
         VectorMask<Integer> mask = VectorMask.fromLong(ISPECIES, 3);
         for (int i = 0; i < ISPECIES.loopBound(iinp.length); i+=ISPECIES.length()) {
@@ -172,7 +172,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, counts = {"ReverseBytesV" , " > 0 "})
+    @IR(applyIfCPUFeatureOr={"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
     public void test_reversebytes_int_transform2(int[] iout, int[] iinp) {
         VectorMask<Integer> mask = VectorMask.fromLong(ISPECIES, 3);
         for (int i = 0; i < ISPECIES.loopBound(iinp.length); i+=ISPECIES.length()) {
@@ -191,7 +191,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, counts = {"ReverseBytesV" , " > 0 "})
+    @IR(applyIfCPUFeatureOr={"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
     public void test_reversebytes_int_transform3(int[] iout, int[] iinp) {
         VectorMask<Integer> mask1 = VectorMask.fromLong(ISPECIES, 3);
         VectorMask<Integer> mask2 = VectorMask.fromLong(ISPECIES, 3);
@@ -211,7 +211,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, failOn = {"ReverseBytesV"})
+    @IR(applyIfCPUFeatureOr={"simd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
     public void test_reversebytes_int_transform4(int[] iout, int[] iinp) {
         for (int i = 0; i < ISPECIES.loopBound(iinp.length); i+=ISPECIES.length()) {
             IntVector.fromArray(ISPECIES, iinp, i)
@@ -229,7 +229,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeature={"sve", "true"}, failOn = {"ReverseBytesV"})
+    @IR(applyIfCPUFeature={"sve", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
     public void test_reversebytes_short_transform1(short[] sout, short[] sinp) {
         VectorMask<Short> mask = VectorMask.fromLong(SSPECIES, 3);
         for (int i = 0; i < SSPECIES.loopBound(sinp.length); i+=SSPECIES.length()) {
@@ -248,7 +248,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, counts = {"ReverseBytesV" , " > 0 "})
+    @IR(applyIfCPUFeatureOr={"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
     public void test_reversebytes_short_transform2(short[] sout, short[] sinp) {
         VectorMask<Short> mask = VectorMask.fromLong(SSPECIES, 3);
         for (int i = 0; i < SSPECIES.loopBound(sinp.length); i+=SSPECIES.length()) {
@@ -267,7 +267,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, counts = {"ReverseBytesV" , " > 0 "})
+    @IR(applyIfCPUFeatureOr={"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
     public void test_reversebytes_short_transform3(short[] sout, short[] sinp) {
         VectorMask<Short> mask1 = VectorMask.fromLong(SSPECIES, 3);
         VectorMask<Short> mask2 = VectorMask.fromLong(SSPECIES, 3);
@@ -287,7 +287,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, failOn = {"ReverseBytesV"})
+    @IR(applyIfCPUFeatureOr={"simd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
     public void test_reversebytes_short_transform4(short[] sout, short[] sinp) {
         for (int i = 0; i < SSPECIES.loopBound(sinp.length); i+=SSPECIES.length()) {
             ShortVector.fromArray(SSPECIES, sinp, i)

--- a/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransforms.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransforms.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import java.util.Random;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorSpecies;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.ShortVector;
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.LongVector;
+
+import compiler.lib.ir_framework.*;
+import jdk.test.lib.Utils;
+
+/*
+ * @test
+ * @bug 8287794
+ * @summary Test various reverse bytes ideal transforms.
+ * @requires vm.compiler2.enabled
+ * @modules jdk.incubator.vector
+ * @library /test/lib /
+ * @run driver compiler.vectorapi.TestReverseByteTransforms
+ */
+
+public class TestReverseByteTransforms {
+    static final VectorSpecies<Long> LSPECIES = LongVector.SPECIES_MAX;
+    static final VectorSpecies<Integer> ISPECIES = IntVector.SPECIES_MAX;
+    static final VectorSpecies<Short> SSPECIES = ShortVector.SPECIES_MAX;
+
+    static final int SIZE = 1024;
+    static final int ITERS = 50000;
+
+    static long [] lout = new long[SIZE];
+    static long [] linp = new long[SIZE];
+
+    static int [] iout = new int[SIZE];
+    static int [] iinp = new int[SIZE];
+
+    static short [] sout = new short[SIZE];
+    static short [] sinp = new short[SIZE];
+
+    static void init() {
+        Random r = new Random(1024);
+        for(int i = 0; i < SIZE; i++) {
+            linp[i] = r.nextLong();
+            iinp[i] = r.nextInt();
+            sinp[i] = (short)r.nextInt();
+        }
+    }
+
+    public static void main(String args[]) {
+        init();
+        TestFramework.runWithFlags("-XX:-TieredCompilation", "--add-modules=jdk.incubator.vector");
+        System.out.println("PASSED");
+    }
+
+    @Test
+    @IR(applyIfCPUFeature={"sve", "true"}, failOn = {"ReverseBytesV" , " > 0 "})
+    public void test_reversebytes_long_transform1(long[] lout, long[] linp) {
+        VectorMask<Long> mask = VectorMask.fromLong(LSPECIES, 3);
+        for (int i = 0; i < LSPECIES.loopBound(linp.length); i+=LSPECIES.length()) {
+            LongVector.fromArray(LSPECIES, linp, i)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .intoArray(lout, i);
+        }
+    }
+
+    @Run(test = {"test_reversebytes_long_transform1"}, mode = RunMode.STANDALONE)
+    public void kernel_test_reversebytes_long_transform1() {
+        for (int i = 0; i < ITERS; i++) {
+            test_reversebytes_long_transform1(lout, linp);
+        }
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, counts = {"ReverseBytesV" , " > 0 "})
+    public void test_reversebytes_long_transform2(long[] lout, long[] linp) {
+        VectorMask<Long> mask = VectorMask.fromLong(LSPECIES, 3);
+        for (int i = 0; i < LSPECIES.loopBound(linp.length); i+=LSPECIES.length()) {
+            LongVector.fromArray(LSPECIES, linp, i)
+                     .lanewise(VectorOperators.REVERSE_BYTES)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .intoArray(lout, i);
+        }
+    }
+
+    @Run(test = {"test_reversebytes_long_transform2"}, mode = RunMode.STANDALONE)
+    public void kernel_test_reversebytes_long_transform2() {
+        for (int i = 0; i < ITERS; i++) {
+            test_reversebytes_long_transform2(lout, linp);
+        }
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, counts = {"ReverseBytesV" , " > 0 "})
+    public void test_reversebytes_long_transform3(long[] lout, long[] linp) {
+        VectorMask<Long> mask1 = VectorMask.fromLong(LSPECIES, 3);
+        VectorMask<Long> mask2 = VectorMask.fromLong(LSPECIES, 3);
+        for (int i = 0; i < LSPECIES.loopBound(linp.length); i+=LSPECIES.length()) {
+            LongVector.fromArray(LSPECIES, linp, i)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask1)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask2)
+                     .intoArray(lout, i);
+        }
+    }
+
+    @Run(test = {"test_reversebytes_long_transform3"}, mode = RunMode.STANDALONE)
+    public void kernel_test_reversebytes_long_transform3() {
+        for (int i = 0; i < ITERS; i++) {
+            test_reversebytes_long_transform3(lout, linp);
+        }
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, failOn = {"ReverseBytesV" , " > 0 "})
+    public void test_reversebytes_long_transform4(long[] lout, long[] linp) {
+        for (int i = 0; i < LSPECIES.loopBound(linp.length); i+=LSPECIES.length()) {
+            LongVector.fromArray(LSPECIES, linp, i)
+                     .lanewise(VectorOperators.REVERSE_BYTES)
+                     .lanewise(VectorOperators.REVERSE_BYTES)
+                     .intoArray(lout, i);
+        }
+    }
+
+    @Run(test = {"test_reversebytes_long_transform4"}, mode = RunMode.STANDALONE)
+    public void kernel_test_reversebytes_long_transform4() {
+        for (int i = 0; i < ITERS; i++) {
+            test_reversebytes_long_transform4(lout, linp);
+        }
+    }
+
+    @Test
+    @IR(applyIfCPUFeature={"sve", "true"}, failOn = {"ReverseBytesV" , " > 0 "})
+    public void test_reversebytes_int_transform1(int[] iout, int[] iinp) {
+        VectorMask<Integer> mask = VectorMask.fromLong(ISPECIES, 3);
+        for (int i = 0; i < ISPECIES.loopBound(iinp.length); i+=ISPECIES.length()) {
+            IntVector.fromArray(ISPECIES, iinp, i)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .intoArray(iout, i);
+        }
+    }
+
+    @Run(test = {"test_reversebytes_int_transform1"}, mode = RunMode.STANDALONE)
+    public void kernel_test_reversebytes_int_transform1() {
+        for (int i = 0; i < ITERS; i++) {
+            test_reversebytes_int_transform1(iout, iinp);
+        }
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, counts = {"ReverseBytesV" , " > 0 "})
+    public void test_reversebytes_int_transform2(int[] iout, int[] iinp) {
+        VectorMask<Integer> mask = VectorMask.fromLong(ISPECIES, 3);
+        for (int i = 0; i < ISPECIES.loopBound(iinp.length); i+=ISPECIES.length()) {
+            IntVector.fromArray(ISPECIES, iinp, i)
+                     .lanewise(VectorOperators.REVERSE_BYTES)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .intoArray(iout, i);
+        }
+    }
+
+    @Run(test = {"test_reversebytes_int_transform2"}, mode = RunMode.STANDALONE)
+    public void kernel_test_reversebytes_int_transform2() {
+        for (int i = 0; i < ITERS; i++) {
+            test_reversebytes_int_transform2(iout, iinp);
+        }
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, counts = {"ReverseBytesV" , " > 0 "})
+    public void test_reversebytes_int_transform3(int[] iout, int[] iinp) {
+        VectorMask<Integer> mask1 = VectorMask.fromLong(ISPECIES, 3);
+        VectorMask<Integer> mask2 = VectorMask.fromLong(ISPECIES, 3);
+        for (int i = 0; i < ISPECIES.loopBound(iinp.length); i+=ISPECIES.length()) {
+            IntVector.fromArray(ISPECIES, iinp, i)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask1)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask2)
+                     .intoArray(iout, i);
+        }
+    }
+
+    @Run(test = {"test_reversebytes_int_transform3"}, mode = RunMode.STANDALONE)
+    public void kernel_test_reversebytes_int_transform3() {
+        for (int i = 0; i < ITERS; i++) {
+            test_reversebytes_int_transform3(iout, iinp);
+        }
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, failOn = {"ReverseBytesV" , " > 0 "})
+    public void test_reversebytes_int_transform4(int[] iout, int[] iinp) {
+        for (int i = 0; i < ISPECIES.loopBound(iinp.length); i+=ISPECIES.length()) {
+            IntVector.fromArray(ISPECIES, iinp, i)
+                     .lanewise(VectorOperators.REVERSE_BYTES)
+                     .lanewise(VectorOperators.REVERSE_BYTES)
+                     .intoArray(iout, i);
+        }
+    }
+
+    @Run(test = {"test_reversebytes_int_transform4"}, mode = RunMode.STANDALONE)
+    public void kernel_test_reversebytes_int_transform4() {
+        for (int i = 0; i < ITERS; i++) {
+            test_reversebytes_int_transform4(iout, iinp);
+        }
+    }
+
+    @Test
+    @IR(applyIfCPUFeature={"sve", "true"}, failOn = {"ReverseBytesV" , " > 0 "})
+    public void test_reversebytes_short_transform1(short[] sout, short[] sinp) {
+        VectorMask<Short> mask = VectorMask.fromLong(SSPECIES, 3);
+        for (int i = 0; i < SSPECIES.loopBound(sinp.length); i+=SSPECIES.length()) {
+            ShortVector.fromArray(SSPECIES, sinp, i)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .intoArray(sout, i);
+        }
+    }
+
+    @Run(test = {"test_reversebytes_short_transform1"}, mode = RunMode.STANDALONE)
+    public void kernel_test_reversebytes_short_transform1() {
+        for (int i = 0; i < ITERS; i++) {
+            test_reversebytes_short_transform1(sout, sinp);
+        }
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, counts = {"ReverseBytesV" , " > 0 "})
+    public void test_reversebytes_short_transform2(short[] sout, short[] sinp) {
+        VectorMask<Short> mask = VectorMask.fromLong(SSPECIES, 3);
+        for (int i = 0; i < SSPECIES.loopBound(sinp.length); i+=SSPECIES.length()) {
+            ShortVector.fromArray(SSPECIES, sinp, i)
+                     .lanewise(VectorOperators.REVERSE_BYTES)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .intoArray(sout, i);
+        }
+    }
+
+    @Run(test = {"test_reversebytes_short_transform2"}, mode = RunMode.STANDALONE)
+    public void kernel_test_reversebytes_short_transform2() {
+        for (int i = 0; i < ITERS; i++) {
+            test_reversebytes_short_transform2(sout, sinp);
+        }
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, counts = {"ReverseBytesV" , " > 0 "})
+    public void test_reversebytes_short_transform3(short[] sout, short[] sinp) {
+        VectorMask<Short> mask1 = VectorMask.fromLong(SSPECIES, 3);
+        VectorMask<Short> mask2 = VectorMask.fromLong(SSPECIES, 3);
+        for (int i = 0; i < SSPECIES.loopBound(sinp.length); i+=SSPECIES.length()) {
+            ShortVector.fromArray(SSPECIES, sinp, i)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask1)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask2)
+                     .intoArray(sout, i);
+        }
+    }
+
+    @Run(test = {"test_reversebytes_short_transform3"}, mode = RunMode.STANDALONE)
+    public void kernel_test_reversebytes_short_transform3() {
+        for (int i = 0; i < ITERS; i++) {
+            test_reversebytes_short_transform3(sout, sinp);
+        }
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, failOn = {"ReverseBytesV" , " > 0 "})
+    public void test_reversebytes_short_transform4(short[] sout, short[] sinp) {
+        for (int i = 0; i < SSPECIES.loopBound(sinp.length); i+=SSPECIES.length()) {
+            ShortVector.fromArray(SSPECIES, sinp, i)
+                     .lanewise(VectorOperators.REVERSE_BYTES)
+                     .lanewise(VectorOperators.REVERSE_BYTES)
+                     .intoArray(sout, i);
+        }
+    }
+
+    @Run(test = {"test_reversebytes_short_transform4"}, mode = RunMode.STANDALONE)
+    public void kernel_test_reversebytes_short_transform4() {
+        for (int i = 0; i < ITERS; i++) {
+            test_reversebytes_short_transform4(sout, sinp);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransforms.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransforms.java
@@ -77,7 +77,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeature={"sve", "true"}, failOn = {"ReverseBytesV" , " > 0 "})
+    @IR(applyIfCPUFeature={"sve", "true"}, failOn = {"ReverseBytesV"})
     public void test_reversebytes_long_transform1(long[] lout, long[] linp) {
         VectorMask<Long> mask = VectorMask.fromLong(LSPECIES, 3);
         for (int i = 0; i < LSPECIES.loopBound(linp.length); i+=LSPECIES.length()) {
@@ -135,7 +135,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, failOn = {"ReverseBytesV" , " > 0 "})
+    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, failOn = {"ReverseBytesV"})
     public void test_reversebytes_long_transform4(long[] lout, long[] linp) {
         for (int i = 0; i < LSPECIES.loopBound(linp.length); i+=LSPECIES.length()) {
             LongVector.fromArray(LSPECIES, linp, i)
@@ -153,7 +153,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeature={"sve", "true"}, failOn = {"ReverseBytesV" , " > 0 "})
+    @IR(applyIfCPUFeature={"sve", "true"}, failOn = {"ReverseBytesV"})
     public void test_reversebytes_int_transform1(int[] iout, int[] iinp) {
         VectorMask<Integer> mask = VectorMask.fromLong(ISPECIES, 3);
         for (int i = 0; i < ISPECIES.loopBound(iinp.length); i+=ISPECIES.length()) {
@@ -211,7 +211,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, failOn = {"ReverseBytesV" , " > 0 "})
+    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, failOn = {"ReverseBytesV"})
     public void test_reversebytes_int_transform4(int[] iout, int[] iinp) {
         for (int i = 0; i < ISPECIES.loopBound(iinp.length); i+=ISPECIES.length()) {
             IntVector.fromArray(ISPECIES, iinp, i)
@@ -229,7 +229,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeature={"sve", "true"}, failOn = {"ReverseBytesV" , " > 0 "})
+    @IR(applyIfCPUFeature={"sve", "true"}, failOn = {"ReverseBytesV"})
     public void test_reversebytes_short_transform1(short[] sout, short[] sinp) {
         VectorMask<Short> mask = VectorMask.fromLong(SSPECIES, 3);
         for (int i = 0; i < SSPECIES.loopBound(sinp.length); i+=SSPECIES.length()) {
@@ -287,7 +287,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, failOn = {"ReverseBytesV" , " > 0 "})
+    @IR(applyIfCPUFeatureOr={"sve", "true", "simd", "true", "avx2", "true"}, failOn = {"ReverseBytesV"})
     public void test_reversebytes_short_transform4(short[] sout, short[] sinp) {
         for (int i = 0; i < SSPECIES.loopBound(sinp.length); i+=SSPECIES.length()) {
             ShortVector.fromArray(SSPECIES, sinp, i)

--- a/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransformsSVE.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransformsSVE.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import java.util.Random;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorSpecies;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.ShortVector;
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.LongVector;
+
+import compiler.lib.ir_framework.*;
+import jdk.test.lib.Utils;
+
+/*
+ * @test
+ * @bug 8287794
+ * @summary Test various reverse bytes ideal transforms on AARCH64 SVE.
+ * @requires vm.compiler2.enabled
+ * @modules jdk.incubator.vector
+ * @requires vm.cpu.features ~= ".*sve.*"
+ * @library /test/lib /
+ * @run driver compiler.vectorapi.TestReverseByteTransformsSVE
+ */
+
+public class TestReverseByteTransformsSVE {
+    static final VectorSpecies<Long> LSPECIES = LongVector.SPECIES_MAX;
+    static final VectorSpecies<Integer> ISPECIES = IntVector.SPECIES_MAX;
+    static final VectorSpecies<Short> SSPECIES = ShortVector.SPECIES_MAX;
+
+    static final int SIZE = 1024;
+    static final int ITERS = 50000;
+
+    static long [] lout = new long[SIZE];
+    static long [] linp = new long[SIZE];
+
+    static int [] iout = new int[SIZE];
+    static int [] iinp = new int[SIZE];
+
+    static short [] sout = new short[SIZE];
+    static short [] sinp = new short[SIZE];
+
+    static void init() {
+        Random r = new Random(1024);
+        for(int i = 0; i < SIZE; i++) {
+            linp[i] = r.nextLong();
+            iinp[i] = r.nextInt();
+            sinp[i] = (short)r.nextInt();
+        }
+    }
+
+    public static void main(String args[]) {
+        init();
+        TestFramework.runWithFlags("-XX:-TieredCompilation", "--add-modules=jdk.incubator.vector");
+        System.out.println("PASSED");
+    }
+
+    @Test
+    @IR(applyIf = {"UseSVE", " > 0"}, failOn = {IRNode.REVERSE_BYTES_V})
+    public void test_reversebytes_long_transform(long[] lout, long[] linp) {
+        VectorMask<Long> mask = VectorMask.fromLong(LSPECIES, 3);
+        for (int i = 0; i < LSPECIES.loopBound(linp.length); i+=LSPECIES.length()) {
+            LongVector.fromArray(LSPECIES, linp, i)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .intoArray(lout, i);
+        }
+    }
+
+    @Run(test = {"test_reversebytes_long_transform"}, mode = RunMode.STANDALONE)
+    public void kernel_test_reversebytes_long_transform() {
+        for (int i = 0; i < ITERS; i++) {
+            test_reversebytes_long_transform(lout, linp);
+        }
+    }
+
+    @Test
+    @IR(applyIf = {"UseSVE", " > 0"}, failOn = {IRNode.REVERSE_BYTES_V})
+    public void test_reversebytes_int_transform(int[] iout, int[] iinp) {
+        VectorMask<Integer> mask = VectorMask.fromLong(ISPECIES, 3);
+        for (int i = 0; i < ISPECIES.loopBound(iinp.length); i+=ISPECIES.length()) {
+            IntVector.fromArray(ISPECIES, iinp, i)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .intoArray(iout, i);
+        }
+    }
+
+    @Run(test = {"test_reversebytes_int_transform"}, mode = RunMode.STANDALONE)
+    public void kernel_test_reversebytes_int_transform() {
+        for (int i = 0; i < ITERS; i++) {
+            test_reversebytes_int_transform(iout, iinp);
+        }
+    }
+
+    @Test
+    @IR(applyIf = {"UseSVE", " > 0"}, failOn = {IRNode.REVERSE_BYTES_V})
+    public void test_reversebytes_short_transform(short[] sout, short[] sinp) {
+        VectorMask<Short> mask = VectorMask.fromLong(SSPECIES, 3);
+        for (int i = 0; i < SSPECIES.loopBound(sinp.length); i+=SSPECIES.length()) {
+            ShortVector.fromArray(SSPECIES, sinp, i)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .lanewise(VectorOperators.REVERSE_BYTES, mask)
+                     .intoArray(sout, i);
+        }
+    }
+
+    @Run(test = {"test_reversebytes_short_transform"}, mode = RunMode.STANDALONE)
+    public void kernel_test_reversebytes_short_transform() {
+        for (int i = 0; i < ITERS; i++) {
+            test_reversebytes_short_transform(sout, sinp);
+        }
+    }
+}


### PR DESCRIPTION
Hi All,

- This bug fix patch fixes a missing case during reverse[bits|bytes] identity transformation.
- Unlike AARCH64(SVE), X86(AVX512) ISA has no direct instruction to reverse[bits|bytes] of a vector lane hence a predicated operation is supported through blend instruction.
- New IR framework based tests has been added to test transforms relevant to AVX2, AVX512 and SVE.

Kindly review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287794](https://bugs.openjdk.org/browse/JDK-8287794): Reverse*VNode::Identity problem


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [845b935d](https://git.openjdk.org/jdk/pull/9623/files/845b935d24179489eda97b173bc4232f8c07cd55)
 * [Xiaohong Gong](https://openjdk.org/census#xgong) (@XiaohongGong - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9623/head:pull/9623` \
`$ git checkout pull/9623`

Update a local copy of the PR: \
`$ git checkout pull/9623` \
`$ git pull https://git.openjdk.org/jdk pull/9623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9623`

View PR using the GUI difftool: \
`$ git pr show -t 9623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9623.diff">https://git.openjdk.org/jdk/pull/9623.diff</a>

</details>
