### PR TITLE
8244976: vmTestbase/nsk/jdi/Event/request/request001.java doesn' initialize eName

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/request/request001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/request/request001.java
@@ -550,13 +550,14 @@ public class request001 extends JDIBase {
                 } else {
                     log3("ERROR: else clause in detecting type of event1");
                     testExitCode = FAILED;
-                    throw new JDITestRuntimeException("** unexpected event **");
+                    throw new JDITestRuntimeException("** unexpected event ** " + event1);
                 }
-                log2("--------> got: " + event1.getClass().getName() + " index: " + index);
+                log2("--------> got: " + event1 + " index: " + index);
 
                 int flag = 1 << index;
                 if ((flagsCopy & flag) == 0) {
-                    log3("ERROR: event duplication. flafsCopy = " + Integer.toBinaryString(flagsCopy)
+                    log3("ERROR: event duplication. event " + event1
+                            + " flagsCopy = " + Integer.toBinaryString(flagsCopy)
                             + " flag = " + Integer.toBinaryString(flag));
                     testExitCode = FAILED;
                 } else {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/request/request001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/request/request001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -525,18 +525,14 @@ public class request001 extends JDIBase {
             log2(":::::::::vm.resume();");
             vm.resume();
 
-            Event  event1     = null;
-            int    flagsCopy  = flags;
-            String eName      = null;
-            int    index      = 0;
+            int flagsCopy = flags;
 
             log2("......getting and checking up on Events");
             for (int n4 = 0; n4 < namesRef.length(); n4++) {
-                int flag;
-
                 getEventSet();
-                event1 = eventIterator.nextEvent();
+                Event event1 = eventIterator.nextEvent();
 
+                int index;
                 if (event1 instanceof AccessWatchpointEvent) {
                     index = 0;
                 } else if (event1 instanceof ModificationWatchpointEvent ) {
@@ -554,11 +550,14 @@ public class request001 extends JDIBase {
                 } else {
                     log3("ERROR: else clause in detecting type of event1");
                     testExitCode = FAILED;
+                    throw new JDITestRuntimeException("** unexpected event **");
                 }
+                log2("--------> got: " + event1.getClass().getName() + " index: " + index);
 
-                flag = 1 << index;
+                int flag = 1 << index;
                 if ((flagsCopy & flag) == 0) {
-                    log3("ERROR: event duplication: " + eName);
+                    log3("ERROR: event duplication. flafsCopy = " + Integer.toBinaryString(flagsCopy)
+                            + " flag = " + Integer.toBinaryString(flag));
                     testExitCode = FAILED;
                 } else {
                     flagsCopy ^= flag;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventIterator/nextEvent/nextevent001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventIterator/nextEvent/nextevent001.java
@@ -540,13 +540,14 @@ public class nextevent001 extends JDIBase {
                 } else {
                     log3("ERROR: else clause in detecting type of event1");
                     testExitCode = FAILED;
-                    throw new JDITestRuntimeException("** unexpected event **");
+                    throw new JDITestRuntimeException("** unexpected event ** " + event1);
                 }
-                log2("--------> got: " + event1.getClass().getName() + " index: " + index);
+                log2("--------> got: " + event1 + " index: " + index);
 
                 int flag = 1 << index;
                 if ((flagsCopy & flag) == 0) {
-                    log3("ERROR: event duplication. flafsCopy = " + Integer.toBinaryString(flagsCopy)
+                    log3("ERROR: event duplication. event " + event1
+                            + " flagsCopy = " + Integer.toBinaryString(flagsCopy)
                             + " flag = " + Integer.toBinaryString(flag));
                     testExitCode = FAILED;
                 } else {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventIterator/nextEvent/nextevent001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventIterator/nextEvent/nextevent001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -514,18 +514,15 @@ public class nextevent001 extends JDIBase {
             log2(":::::::::vm.resume();");
             vm.resume();
 
-            Event  event1     = null;
-            int    flagsCopy  = flags;
-            String eName      = null;
-            int    index      = 0;
+            int flagsCopy = flags;
 
             log2("......getting and checking up on Events");
             for (int n4 = 0; n4 < namesRef.length(); n4++) {
-                int flag;
 
                 getEventSet();
-                event1 = eventIterator.nextEvent();
+                Event event1 = eventIterator.nextEvent();
 
+                int index;
                 if (event1 instanceof AccessWatchpointEvent) {
                     index = 0;
                 } else if (event1 instanceof ModificationWatchpointEvent ) {
@@ -543,11 +540,14 @@ public class nextevent001 extends JDIBase {
                 } else {
                     log3("ERROR: else clause in detecting type of event1");
                     testExitCode = FAILED;
+                    throw new JDITestRuntimeException("** unexpected event **");
                 }
+                log2("--------> got: " + event1.getClass().getName() + " index: " + index);
 
-                flag = 1 << index;
+                int flag = 1 << index;
                 if ((flagsCopy & flag) == 0) {
-                    log3("ERROR: event duplication: " + eName);
+                    log3("ERROR: event duplication. flafsCopy = " + Integer.toBinaryString(flagsCopy)
+                            + " flag = " + Integer.toBinaryString(flag));
                     testExitCode = FAILED;
                 } else {
                     flagsCopy ^= flag;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/LocatableEvent/thread/thread001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/LocatableEvent/thread/thread001.java
@@ -443,9 +443,9 @@ public class thread001 extends JDIBase {
                 } else {
                     log3("ERROR: else clause in detecting type of event1");
                     testExitCode = FAILED;
-                    throw new JDITestRuntimeException("** unexpected event **");
+                    throw new JDITestRuntimeException("** unexpected event ** " + event1);
                 }
-                log2("--------> got: " + event1.getClass().getName() + " index: " + index);
+                log2("--------> got: " + event1 + " index: " + index);
 
                 ThreadReference threadRef = ((LocatableEvent) event1).thread();
 
@@ -464,7 +464,8 @@ public class thread001 extends JDIBase {
 
                 int flag = 1 << index;
                 if ((flagsCopy & flag) == 0) {
-                    log3("ERROR: event duplication. flafsCopy = " + Integer.toBinaryString(flagsCopy)
+                    log3("ERROR: event duplication. event " + event1
+                            + " flagsCopy = " + Integer.toBinaryString(flagsCopy)
                             + " flag = " + Integer.toBinaryString(flag));
                     testExitCode = FAILED;
                 } else {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/LocatableEvent/thread/thread001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/LocatableEvent/thread/thread001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -417,45 +417,35 @@ public class thread001 extends JDIBase {
             log2(":::::::::vm.resume();");
             vm.resume();
 
-            Event   event1    = null;
             String threadName = null;
             int    flagsCopy  = flags;
-            String eName      = null;
 
             log2("......getting and checking up on Events");
             for (int n4 = 0; n4 < namesRef.length(); n4++) {
-                int flag;
-                int index;
                 getEventSet();
-                event1 = eventIterator.nextEvent();
+                Event event1 = eventIterator.nextEvent();
 
+                int index;
                 if (event1 instanceof AccessWatchpointEvent) {
-                    eName = "AccessWatchpointEvent";
                     index = 0;
                 } else if (event1 instanceof ModificationWatchpointEvent ) {
-                    eName = "ModificationWatchpointEvent";
                     index = 1;
                 } else if (event1 instanceof BreakpointEvent ) {
-                    eName = "BreakpointEvent";
                     index = 2;
                 } else if (event1 instanceof ExceptionEvent ) {
-                    eName = "ExceptionEvent";
                     index = 3;
                 } else if (event1 instanceof MethodEntryEvent ) {
-                    eName = "MethodEntryEvent";
                     index = 4;
                 } else if (event1 instanceof MethodExitEvent ) {
-                    eName = "MethodExitEvent";
                     index = 5;
                 } else if (event1 instanceof StepEvent ) {
-                    eName = "StepEvent";
                     index = 6;
                 } else {
                     log3("ERROR: else clause in detecting type of event1");
                     testExitCode = FAILED;
                     throw new JDITestRuntimeException("** unexpected event **");
                 }
-                log2("--------> got: " + eName);
+                log2("--------> got: " + event1.getClass().getName() + " index: " + index);
 
                 ThreadReference threadRef = ((LocatableEvent) event1).thread();
 
@@ -472,9 +462,10 @@ public class thread001 extends JDIBase {
                     log3("        thread's name == " + threadRef.name());
                 }
 
-                flag = 1 << index;
+                int flag = 1 << index;
                 if ((flagsCopy & flag) == 0) {
-                    log3("ERROR: event duplication: " + eName);
+                    log3("ERROR: event duplication. flafsCopy = " + Integer.toBinaryString(flagsCopy)
+                            + " flag = " + Integer.toBinaryString(flag));
                     testExitCode = FAILED;
                 } else {
                     flagsCopy ^= flag;


### PR DESCRIPTION
Fixed tests that use eName to print event name to print the class name. Plus some minor refactoring.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8244976](https://bugs.openjdk.org/browse/JDK-8244976): vmTestbase/nsk/jdi/Event/request/request001.java doesn' initialize eName


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [c6f79264](https://git.openjdk.org/jdk/pull/9624/files/c6f79264357807ffeab18b0ae7932b8b69cd4adb)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9624/head:pull/9624` \
`$ git checkout pull/9624`

Update a local copy of the PR: \
`$ git checkout pull/9624` \
`$ git pull https://git.openjdk.org/jdk pull/9624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9624`

View PR using the GUI difftool: \
`$ git pr show -t 9624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9624.diff">https://git.openjdk.org/jdk/pull/9624.diff</a>

</details>
