### PR TITLE
JDK-8289332: Auto-generate ids for user-defined headings

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlConfiguration.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlConfiguration.java
@@ -27,7 +27,6 @@ package jdk.javadoc.internal.doclets.formats.html;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -44,7 +43,6 @@ import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 
-import com.sun.source.util.DocTreePath;
 import jdk.javadoc.doclet.Doclet;
 import jdk.javadoc.doclet.DocletEnvironment;
 import jdk.javadoc.doclet.Reporter;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -172,7 +172,7 @@ public class HtmlDocletWriter {
 
     protected final HtmlIds htmlIds;
 
-    private final Set<String> headerIds = new HashSet<>();
+    private final Set<String> headingIds = new HashSet<>();
 
     /**
      * To check whether the repeated annotations is documented or not.
@@ -1682,7 +1682,7 @@ public class HtmlDocletWriter {
                 public Boolean visitStartElement(StartElementTree node, Content content) {
                     Content attrs = new ContentBuilder();
                     if (node.getName().toString().matches("(?i)h[1-6]") && !hasIdAttribute(node)) {
-                        generateHeaderId(node, trees, attrs);
+                        generateHeadingId(node, trees, attrs);
                     }
                     for (DocTree dt : node.getAttributes()) {
                         dt.accept(this, attrs);
@@ -1759,10 +1759,10 @@ public class HtmlDocletWriter {
 
     private boolean hasIdAttribute(StartElementTree node) {
         return node.getAttributes().stream().anyMatch(
-                dt -> equalsIgnoreCase(((AttributeTree)dt).getName(), "id"));
+                dt -> dt instanceof AttributeTree at && equalsIgnoreCase(at.getName(), "id"));
     }
 
-    private void generateHeaderId(StartElementTree node, List<? extends DocTree> trees, Content content) {
+    private void generateHeadingId(StartElementTree node, List<? extends DocTree> trees, Content content) {
         StringBuilder sb = new StringBuilder();
         String tagName = node.getName().toString().toLowerCase(Locale.ROOT);
         for (DocTree docTree : trees.subList(trees.indexOf(node) + 1, trees.size())) {
@@ -1782,22 +1782,8 @@ public class HtmlDocletWriter {
                 return; // Avoid generating id if embedded <a id=...> is present
             }
         }
-        String idValue = sb.toString()
-                .toLowerCase(Locale.ROOT)
-                .trim()
-                .replaceAll("[^\\w_-]+", "-");
-        if (!idValue.isEmpty()) {
-            // Make id unique
-            idValue = idValue + "-hdr";
-            if (!headerIds.add(idValue)) {
-                int counter = 1;
-                while (!headerIds.add(idValue + counter)) {
-                    counter++;
-                }
-                idValue = idValue + counter;
-            }
-            content.add("id=\"").add(idValue).add("\"");
-        }
+        HtmlId htmlId = htmlIds.forHeading(sb, headingIds);
+        content.add("id=\"").add(htmlId.name()).add("\"");
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlIds.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlIds.java
@@ -28,6 +28,7 @@ package jdk.javadoc.internal.doclets.formats.html;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.PackageElement;
@@ -510,5 +511,30 @@ public class HtmlIds {
      */
     public HtmlId forPage(Navigation.PageMode page) {
         return HtmlId.of(page.name().toLowerCase(Locale.ROOT).replace("_", "-"));
+    }
+
+    /**
+     * Returns an id for a heading in a doc comment. The id value is derived from the contents
+     * of the heading with additional checks to make it unique within its containing page.
+     *
+     * @param headingText the text contained by the heading
+     * @param headingIds the set of heading ids already generated for the current page
+     * @return a unique id value for the heading
+     */
+    public HtmlId forHeading(CharSequence headingText, Set<String> headingIds) {
+        String idValue = headingText.toString()
+                .toLowerCase(Locale.ROOT)
+                .trim()
+                .replaceAll("[^\\w_-]+", "-");
+        // Make id value unique
+        idValue = idValue + "-heading";
+        if (!headingIds.add(idValue)) {
+            int counter = 1;
+            while (!headingIds.add(idValue + counter)) {
+                counter++;
+            }
+            idValue = idValue + counter;
+        }
+        return HtmlId.of(idValue);
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java
+++ b/test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java
@@ -77,6 +77,8 @@ public class TestAutoHeaderId extends JavadocTester {
                          *
                          * <h3 style="color: red;" class="some-class">Other attributes</h3>
                          *
+                         * <h4></h4>
+                         *
                          * Last sentence.
                          */
                         public class C {
@@ -91,7 +93,7 @@ public class TestAutoHeaderId extends JavadocTester {
 
         checkOutput("p/C.html", true,
                 """
-                    <h2 id="first-header-hdr">First Header</h2>
+                    <h2 id="first-header-heading">First Header</h2>
                     """,
                 """
                     <h3 id="fixed-id-1">Header with ID</h3>
@@ -100,22 +102,25 @@ public class TestAutoHeaderId extends JavadocTester {
                     <h4><a id="fixed-id-2">Embedded A-Tag with ID</a></h4>
                     """,
                 """
-                    <h5 id="embedded-code-tag-hdr"><code>Embedded Code Tag</code></h5>
+                    <h5 id="embedded-code-tag-heading"><code>Embedded Code Tag</code></h5>
                     """,
                 """
-                    <h6 id="embedded-link-tag-hdr"><a href="C.html" title="class in p">Embedded Link Tag</a></h6>
+                    <h6 id="embedded-link-tag-heading"><a href="C.html" title="class in p">Embedded Link Tag</a></h6>
                     """,
                 """
-                    <h3 id="duplicate-text-hdr">Duplicate Text</h3>
+                    <h3 id="duplicate-text-heading">Duplicate Text</h3>
                     """,
                 """
-                    <h4 id="duplicate-text-hdr1">Duplicate Text</h4>
+                    <h4 id="duplicate-text-heading1">Duplicate Text</h4>
                     """,
                 """
-                    <h2 id="extra-chars-hdr">Extra (#*!. chars</h2>
+                    <h2 id="extra-chars-heading">Extra (#*!. chars</h2>
                     """,
                 """
-                    <h3 id="other-attributes-hdr" style="color: red;" class="some-class">Other attributes</h3>
+                    <h3 id="other-attributes-heading" style="color: red;" class="some-class">Other attributes</h3>
+                    """,
+                """    
+                    <h4 id="-heading"></h4>
                     """);
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java
+++ b/test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java
@@ -56,23 +56,23 @@ public class TestAutoHeaderId extends JavadocTester {
         tb.writeJavaFiles(src,
                 """
                         package p;
-                        /** 
+                        /**
                          * First sentence.
                          *
                          * <h2>First Header</h2>
-                         *     
+                         *
                          * <h3 id="fixed-id-1">Header with ID</h3>
                          *
                          * <h4><a id="fixed-id-2">Embedded A-Tag with ID</a></h4>
                          *
                          * <h5>{@code Embedded Code Tag}</h5>
-                         *     
+                         *
                          * <h6>{@linkplain C Embedded Link Tag}</h6>
-                         *     
+                         *
                          * <h3>Duplicate Text</h3>
-                         *     
+                         *
                          * <h4>Duplicate Text</h4>
-                         * 
+                         *
                          * <h2>Extra (#*!. chars</h2>
                          *
                          * <h3 style="color: red;" class="some-class">Other attributes</h3>
@@ -96,19 +96,19 @@ public class TestAutoHeaderId extends JavadocTester {
                 """
                     <h3 id="fixed-id-1">Header with ID</h3>
                     """,
-                """          
+                """
                     <h4><a id="fixed-id-2">Embedded A-Tag with ID</a></h4>
                     """,
-                """          
+                """
                     <h5 id="embedded-code-tag-hdr"><code>Embedded Code Tag</code></h5>
                     """,
-                """          
+                """
                     <h6 id="embedded-link-tag-hdr"><a href="C.html" title="class in p">Embedded Link Tag</a></h6>
                     """,
-                """          
+                """
                     <h3 id="duplicate-text-hdr">Duplicate Text</h3>
                     """,
-                """          
+                """
                     <h4 id="duplicate-text-hdr1">Duplicate Text</h4>
                     """,
                 """

--- a/test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java
+++ b/test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java
@@ -119,7 +119,7 @@ public class TestAutoHeaderId extends JavadocTester {
                 """
                     <h3 id="other-attributes-heading" style="color: red;" class="some-class">Other attributes</h3>
                     """,
-                """    
+                """
                     <h4 id="-heading"></h4>
                     """);
     }

--- a/test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java
+++ b/test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8289332
+ * @summary Auto-generate ids for user-defined headings
+ * @library /tools/lib ../../lib
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build javadoc.tester.* toolbox.ToolBox
+ * @run main TestAutoHeaderId
+ */
+
+import java.nio.file.Path;
+
+import toolbox.ToolBox;
+
+import javadoc.tester.JavadocTester;
+
+public class TestAutoHeaderId extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        TestAutoHeaderId tester = new TestAutoHeaderId();
+        tester.runTests();
+    }
+
+    private final ToolBox tb;
+
+    TestAutoHeaderId() {
+        tb = new ToolBox();
+    }
+
+    @Test
+    public void testAutoHeaderId(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                        package p;
+                        /** 
+                         * First sentence.
+                         *
+                         * <h2>First Header</h2>
+                         *     
+                         * <h3 id="fixed-id-1">Header with ID</h3>
+                         *
+                         * <h4><a id="fixed-id-2">Embedded A-Tag with ID</a></h4>
+                         *
+                         * <h5>{@code Embedded Code Tag}</h5>
+                         *     
+                         * <h6>{@linkplain C Embedded Link Tag}</h6>
+                         *     
+                         * <h3>Duplicate Text</h3>
+                         *     
+                         * <h4>Duplicate Text</h4>
+                         * 
+                         * <h2>Extra (#*!. chars</h2>
+                         *
+                         * <h3 style="color: red;" class="some-class">Other attributes</h3>
+                         *
+                         * Last sentence.
+                         */
+                        public class C {
+                            /** Comment. */
+                            C() { }
+                        }
+                        """);
+
+        javadoc("-d", base.resolve("api").toString(),
+                "-sourcepath", src.toString(),
+                "--no-platform-links", "p");
+
+        checkOutput("p/C.html", true,
+                """
+                    <h2 id="first-header-hdr">First Header</h2>
+                    """,
+                """
+                    <h3 id="fixed-id-1">Header with ID</h3>
+                    """,
+                """          
+                    <h4><a id="fixed-id-2">Embedded A-Tag with ID</a></h4>
+                    """,
+                """          
+                    <h5 id="embedded-code-tag-hdr"><code>Embedded Code Tag</code></h5>
+                    """,
+                """          
+                    <h6 id="embedded-link-tag-hdr"><a href="C.html" title="class in p">Embedded Link Tag</a></h6>
+                    """,
+                """          
+                    <h3 id="duplicate-text-hdr">Duplicate Text</h3>
+                    """,
+                """          
+                    <h4 id="duplicate-text-hdr1">Duplicate Text</h4>
+                    """,
+                """
+                    <h2 id="extra-chars-hdr">Extra (#*!. chars</h2>
+                    """,
+                """
+                    <h3 id="other-attributes-hdr" style="color: red;" class="some-class">Other attributes</h3>
+                    """);
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testIndexInDocFiles/TestIndexInDocFiles.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndexInDocFiles/TestIndexInDocFiles.java
@@ -100,13 +100,13 @@ public class TestIndexInDocFiles extends JavadocTester {
 
         checkOutput("doc-files/top-level-file.html", true,
                 """
-                    <h1 id="package-html-file-hdr">Package HTML file</h1>
+                    <h1 id="package-html-file-heading">Package HTML file</h1>
                     <span id="top-level-index" class="search-tag-result">top-level-index</span>
                     <code><span id="top.level.property" class="search-tag-result">top.level.property</span></code>
                     """);
         checkOutput("p/q/doc-files/package-file.html", true,
                 """
-                    <h1 id="package-html-file-hdr">Package HTML file</h1>
+                    <h1 id="package-html-file-heading">Package HTML file</h1>
                     <span id="package-index" class="search-tag-result">package-index</span>
                     <code><span id="package.property" class="search-tag-result">package.property</span></code>
                     """);
@@ -170,13 +170,13 @@ public class TestIndexInDocFiles extends JavadocTester {
 
         checkOutput("m.n/doc-files/module-file.html", true,
                 """
-                    <h1 id="module-html-file-hdr">Module HTML file</h1>
+                    <h1 id="module-html-file-heading">Module HTML file</h1>
                     <span id="module-index" class="search-tag-result">module-index</span>
                     <code><span id="module.property" class="search-tag-result">module.property</span></code>
                     """);
         checkOutput("m.n/p/q/doc-files/package-file.html", true,
                 """
-                    <h1 id="package-html-file-hdr">Package HTML file</h1>
+                    <h1 id="package-html-file-heading">Package HTML file</h1>
                     <span id="package-index" class="search-tag-result">package-index</span>
                     <code><span id="package.property" class="search-tag-result">package.property</span></code>
                     """);

--- a/test/langtools/jdk/javadoc/doclet/testIndexInDocFiles/TestIndexInDocFiles.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndexInDocFiles/TestIndexInDocFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,13 +100,13 @@ public class TestIndexInDocFiles extends JavadocTester {
 
         checkOutput("doc-files/top-level-file.html", true,
                 """
-                    <h1>Package HTML file</h1>
+                    <h1 id="package-html-file-hdr">Package HTML file</h1>
                     <span id="top-level-index" class="search-tag-result">top-level-index</span>
                     <code><span id="top.level.property" class="search-tag-result">top.level.property</span></code>
                     """);
         checkOutput("p/q/doc-files/package-file.html", true,
                 """
-                    <h1>Package HTML file</h1>
+                    <h1 id="package-html-file-hdr">Package HTML file</h1>
                     <span id="package-index" class="search-tag-result">package-index</span>
                     <code><span id="package.property" class="search-tag-result">package.property</span></code>
                     """);
@@ -170,13 +170,13 @@ public class TestIndexInDocFiles extends JavadocTester {
 
         checkOutput("m.n/doc-files/module-file.html", true,
                 """
-                    <h1>Module HTML file</h1>
+                    <h1 id="module-html-file-hdr">Module HTML file</h1>
                     <span id="module-index" class="search-tag-result">module-index</span>
                     <code><span id="module.property" class="search-tag-result">module.property</span></code>
                     """);
         checkOutput("m.n/p/q/doc-files/package-file.html", true,
                 """
-                    <h1>Package HTML file</h1>
+                    <h1 id="package-html-file-hdr">Package HTML file</h1>
                     <span id="package-index" class="search-tag-result">package-index</span>
                     <code><span id="package.property" class="search-tag-result">package.property</span></code>
                     """);


### PR DESCRIPTION
This is a simple change to automatically generate `id` attributes for HTML headers in documentation comments. 

I decided to leave the functionality in `HtmlDocletWriter` rather than moving it to `HtmlIds` because it uses the same helper methods as`commentTagsToContent`.

The value of the `id` attribute id derived from the content of the header tag with spaces and other non-word characters replaced by `-`. A `-hdr` suffix is appended to avoid collisions with other ids. If there are duplicate values an int counter is appended to make them unique.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289332](https://bugs.openjdk.org/browse/JDK-8289332): Auto-generate ids for user-defined headings


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9627/head:pull/9627` \
`$ git checkout pull/9627`

Update a local copy of the PR: \
`$ git checkout pull/9627` \
`$ git pull https://git.openjdk.org/jdk pull/9627/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9627`

View PR using the GUI difftool: \
`$ git pr show -t 9627`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9627.diff">https://git.openjdk.org/jdk/pull/9627.diff</a>

</details>
