### PR TITLE
8282642: vmTestbase/gc/gctests/LoadUnloadGC2/LoadUnloadGC2.java fails intermittently with exit code 1

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/LoadUnloadGC2/LoadUnloadGC2.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/LoadUnloadGC2/LoadUnloadGC2.java
@@ -47,13 +47,24 @@ import nsk.share.gc.gp.classload.*;
 import java.lang.reflect.Array;
 
 public class LoadUnloadGC2 extends GCTestBase {
+        private static int CYCLE = 1000;
         public void run() {
                 Stresser stresser = new Stresser(runParams.getStressOptions());
                 stresser.start(500000);
+                int iteration = 0;
                 try {
+                        GarbageProducer garbageProducer = new GeneratedClassProducer();
                         while (stresser.iteration()) {
-                                log.info("Iteration: " + stresser.getIteration());
-                                WhiteBox.getWhiteBox().fullGC();
+                                garbageProducer.create(512L);
+                                if(iteration++ > CYCLE) {
+                                    // Unload once every cycle.
+                                    iteration = 0;
+                                    garbageProducer = null;
+                                    // Perform GC so that
+                                    // class gets unloaded
+                                    WhiteBox.getWhiteBox().fullGC();
+                                    garbageProducer = new GeneratedClassProducer();
+                               }
                         }
                 } finally {
                         stresser.finish();

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/LoadUnloadGC2/LoadUnloadGC2.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/LoadUnloadGC2/LoadUnloadGC2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,11 +31,14 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -XX:-UseGCOverheadLimit gc.gctests.LoadUnloadGC2.LoadUnloadGC2
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI gc.gctests.LoadUnloadGC2.LoadUnloadGC2
  */
 
 package gc.gctests.LoadUnloadGC2;
 
+import jdk.test.whitebox.WhiteBox;
 import nsk.share.*;
 import nsk.share.test.*;
 import nsk.share.gc.*;
@@ -49,10 +52,8 @@ public class LoadUnloadGC2 extends GCTestBase {
                 stresser.start(500000);
                 try {
                         while (stresser.iteration()) {
-                                GarbageProducer garbageProducer = new GeneratedClassProducer();
                                 log.info("Iteration: " + stresser.getIteration());
-                                GarbageUtils.eatMemory(stresser, garbageProducer, 0);
-                                garbageProducer = null;
+                                WhiteBox.getWhiteBox().fullGC();
                         }
                 } finally {
                         stresser.finish();


### PR DESCRIPTION
LoadUnloadGC2 tests the Class unloading during GC. In order to trigger the GC, lots of memory is created at a short interval. Instead of GC getting triggered, the test quickly gets into OOME.
Using WhiteBox.fullGC is a cleaner and deterministic way to trigger GC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282642](https://bugs.openjdk.org/browse/JDK-8282642): vmTestbase/gc/gctests/LoadUnloadGC2/LoadUnloadGC2.java fails intermittently with exit code 1


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9628/head:pull/9628` \
`$ git checkout pull/9628`

Update a local copy of the PR: \
`$ git checkout pull/9628` \
`$ git pull https://git.openjdk.org/jdk pull/9628/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9628`

View PR using the GUI difftool: \
`$ git pr show -t 9628`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9628.diff">https://git.openjdk.org/jdk/pull/9628.diff</a>

</details>
