### PR TITLE
8286313 [macos] Voice over reads the boolean value as null in the JTable

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TableRowAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TableRowAccessibility.m
@@ -123,7 +123,14 @@ static jclass sjc_CAccessibility = NULL;
             if ([accessibilityName isEqualToString:@""]) {
                 accessibilityName = [cell accessibilityLabel];
             } else {
-                accessibilityName = [accessibilityName stringByAppendingFormat:@", %@", [cell accessibilityLabel]];
+                NSString *label = [cell accessibilityLabel];
+                if (label == nil) {
+                    id val = [cell accessibilityValue];
+                    if (val != nil) {
+                        label = [NSString stringWithFormat:@"%@", val];
+                    }
+                }
+                accessibilityName = [accessibilityName stringByAppendingFormat:@", %@", label];
             }
         }
         return accessibilityName;


### PR DESCRIPTION
I have a Table which is extended from AbstractTableModel with String, integer and Boolean values ( to represent checkbox). When the row is selected Voice over reads the Boolean value as null. 

@azuev-java @mrserb @prrace please review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286313](https://bugs.openjdk.org/browse/JDK-8286313): [macos] Voice over reads the boolean value as null in the JTable


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9629/head:pull/9629` \
`$ git checkout pull/9629`

Update a local copy of the PR: \
`$ git checkout pull/9629` \
`$ git pull https://git.openjdk.org/jdk pull/9629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9629`

View PR using the GUI difftool: \
`$ git pr show -t 9629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9629.diff">https://git.openjdk.org/jdk/pull/9629.diff</a>

</details>
