### PR TITLE
8290969: DumpClassListCLDClosure incorrectly uses ResizeableResourceHashtable

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -164,7 +164,7 @@ class DumpClassListCLDClosure : public CLDClosure {
     if (!created) {
       return;
     }
-    if (_dumped_classes.maybe_grow(MAX_TABLE_SIZE)) {
+    if (_dumped_classes.maybe_grow()) {
       log_info(cds, hashtables)("Expanded _dumped_classes table to %d", _dumped_classes.table_size());
     }
     if (ik->java_super()) {
@@ -180,7 +180,7 @@ class DumpClassListCLDClosure : public CLDClosure {
 
 public:
   DumpClassListCLDClosure(fileStream* f)
-  : CLDClosure(), _dumped_classes(INITIAL_TABLE_SIZE) {
+  : CLDClosure(), _dumped_classes(INITIAL_TABLE_SIZE, MAX_TABLE_SIZE) {
     _stream = f;
   }
 


### PR DESCRIPTION
`ResizeableResourceHashtable` is an open hashing table which can be resized to improve search performance. It provides `maybe_grow(load_factor)` function for this purpose. To use this functionality an instance of `ResizeableResourceHashtable` must be correctly created and used:
- The non-zero maximum table size must be specified in the constructor.
- The default or a reasonable load factor must be used in `maybe_grow(load_factor)`.

`DumpClassListCLDClosure` does not meet these requirements:
- The maximum table size is not provided.
- The call of `maybe_grow(61333)` is used. The call will work when `number_of_entries > 61333*1987=121,868,671`. This does not look reasonable. 

This PR fixes DumpClassListCLDClosure to meet the requirements.
Tested with release/fastdebug builds:
- `gtest`: Passed.
- `tier1`: Passed.
- `test/hotspot/jtreg/runtime/cds`: Passed.

