### PR TITLE
8291021: JFR: Only one finished state in ChunkHeader class

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkHeader.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkHeader.java
@@ -57,7 +57,6 @@ public final class ChunkHeader {
     private long metadataPosition = 0;
     private long durationNanos;
     private long absoluteChunkEnd;
-    private boolean isFinished;
     private boolean finished;
     private boolean finalChunk;
 
@@ -154,9 +153,8 @@ public final class ChunkHeader {
                     Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Chunk: metadataPosition=" + metadataPosition);
                     this.durationNanos = durationNanos;
                     Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Chunk: durationNanos =" + durationNanos);
-                    isFinished = fileState2 == 0;
                     Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Chunk: generation=" + fileState2);
-                    Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Chunk: finished=" + isFinished);
+                    Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Chunk: finished=" + finished);
                     Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Chunk: fileSize=" + input.size());
                     this.finalChunk = (flagByte & MASK_FINAL_CHUNK) != 0;
                     Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Chunk: finalChunk=" + finalChunk);
@@ -197,7 +195,7 @@ public final class ChunkHeader {
     }
 
     public boolean isFinished() throws IOException {
-        return isFinished;
+        return finished;
     }
 
     public ChunkHeader nextHeader() throws IOException {


### PR DESCRIPTION
Could I have a review of PR that removes the field isFinished in the ChunkHeader class. It's sufficient with the finished field. 

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291021](https://bugs.openjdk.org/browse/JDK-8291021): JFR: Only one finished state in ChunkHeader class


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9639/head:pull/9639` \
`$ git checkout pull/9639`

Update a local copy of the PR: \
`$ git checkout pull/9639` \
`$ git pull https://git.openjdk.org/jdk pull/9639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9639`

View PR using the GUI difftool: \
`$ git pr show -t 9639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9639.diff">https://git.openjdk.org/jdk/pull/9639.diff</a>

</details>
