### PR TITLE
8291022: JFR: Reduce logging in ChunkHeader constructor

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkHeader.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkHeader.java
@@ -105,7 +105,7 @@ public final class ChunkHeader {
         ticksPerSecond = input.readRawLong();
         Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Chunk: ticksPerSecond=" + ticksPerSecond);
 
-        // File state and flag bit, updated by JVM and not reliable to read 
+        // File state and flag bit, updated by JVM and not reliable to read
         input.skipBytes(Integer.BYTES);
 
         refresh();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkHeader.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkHeader.java
@@ -89,21 +89,25 @@ public final class ChunkHeader {
         if (major != 1 && major != 2) {
             throw new IOException("File version " + major + "." + minor + ". Only Flight Recorder files of version 1.x and 2.x can be read by this JDK.");
         }
-        long c = input.readRawLong(); // chunk size
-        Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Chunk: chunkSize=" + c);
-        long cp = input.readRawLong(); // constant pool position
-        Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Chunk: constantPoolPosition=" + cp);
-        long mp = input.readRawLong(); // metadata position
-        Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Chunk: metadataPosition=" + mp);
-        chunkStartNanos = input.readRawLong(); // nanos since epoch
+        // Chunk size, constant pool position and metadata position are
+        // updated by JVM and not reliable to read
+        input.skipBytes(3 * Long.BYTES);
+
+        chunkStartNanos = input.readRawLong();
         Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Chunk: startNanos=" + chunkStartNanos);
-        durationNanos = input.readRawLong(); // duration nanos, not used
-        Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Chunk: durationNanos=" + durationNanos);
+
+        // Duration nanos, updated by JVM and not reliable to read
+        input.skipBytes(Long.BYTES);
+
         chunkStartTicks = input.readRawLong();
         Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Chunk: startTicks=" + chunkStartTicks);
+
         ticksPerSecond = input.readRawLong();
         Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Chunk: ticksPerSecond=" + ticksPerSecond);
-        input.readRawInt(); // ignore file state and flag bits
+
+        // File state and flag bit, updated by JVM and not reliable to read 
+        input.skipBytes(Integer.BYTES);
+
         refresh();
         input.position(absoluteEventStart);
     }


### PR DESCRIPTION
Could I have review of change that removes some unnecessary and unreliable logging.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291022](https://bugs.openjdk.org/browse/JDK-8291022): JFR: Reduce logging in ChunkHeader constructor


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9640/head:pull/9640` \
`$ git checkout pull/9640`

Update a local copy of the PR: \
`$ git checkout pull/9640` \
`$ git pull https://git.openjdk.org/jdk pull/9640/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9640`

View PR using the GUI difftool: \
`$ git pr show -t 9640`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9640.diff">https://git.openjdk.org/jdk/pull/9640.diff</a>

</details>
