### PR TITLE
8282651: ZGC: vmTestbase/gc/ArrayJuggle/ tests fails intermittently with exit code 97

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle01/Juggle01.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle01/Juggle01.java
@@ -76,7 +76,7 @@ public class Juggle01 extends ThreadedGCTest implements GarbageProducerAware, Me
                 log.debug("Memory strategy: " + memoryStrategy);
                 long memory = runParams.getTestMemory();
                 int objectCount = memoryStrategy.getCount(memory);
-                objectSize = memoryStrategy.getSize(memory);
+                objectSize = memoryStrategy.getSize(memory) / runParams.getNumberOfThreads();
                 log.debug("Object count: " + objectCount);
                 log.debug("Object size: " + objectSize);
                 array = new Object[objectCount - 1];

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle01/Juggle01.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle01/Juggle01.java
@@ -31,14 +31,16 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp byteArr -ms low
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp byteArr
+ *      -ms low
  */
 
 package gc.ArrayJuggle.Juggle01;
 
-import jdk.test.whitebox.WhiteBox;
 import nsk.share.test.*;
 import nsk.share.gc.*;
 import nsk.share.gc.gp.*;
@@ -48,6 +50,9 @@ import nsk.share.gc.gp.*;
  * objects using given garbage producer and memory strategy.
  */
 public class Juggle01 extends ThreadedGCTest implements GarbageProducerAware, MemoryStrategyAware {
+        // Keep thread count to 4, intention is to juggle
+        // with multiple threads, not to overwhelm gc
+        private static int NUM_JUGGLE_THREADS = 4;
         private GarbageProducer garbageProducer;
         private MemoryStrategy memoryStrategy;
         private Object[] array;
@@ -70,8 +75,9 @@ public class Juggle01 extends ThreadedGCTest implements GarbageProducerAware, Me
                 log.debug("Garbage producer: " + garbageProducer);
                 log.debug("Memory strategy: " + memoryStrategy);
                 long memory = runParams.getTestMemory();
+                runParams.setNumberOfThreads(NUM_JUGGLE_THREADS);
                 int objectCount = memoryStrategy.getCount(memory);
-                objectSize = memoryStrategy.getSize(memory) / runParams.getNumberOfThreads();
+                objectSize = memoryStrategy.getSize(memory);
                 log.debug("Object count: " + objectCount);
                 log.debug("Object size: " + objectSize);
                 array = new Object[objectCount - 1];

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle01/Juggle01.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle01/Juggle01.java
@@ -57,12 +57,7 @@ public class Juggle01 extends ThreadedGCTest implements GarbageProducerAware, Me
                 public void run() {
                         synchronized (this) {
                                 int index = LocalRandom.nextInt(array.length);
-                                try {
-                                    array[index] = garbageProducer.create(objectSize);
-                                } catch (OutOfMemoryError e) {
-                                    // Do some cleanup for further juggling
-                                    WhiteBox.getWhiteBox().youngGC();
-                                }
+                                array[index] = garbageProducer.create(objectSize);
                         }
                 }
         }

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle02/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle02/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp byteArr -ms medium
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp byteArr -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle02/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle02/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp byteArr -ms medium
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp byteArr
+ *      -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle03/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle03/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp byteArr -ms high
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp byteArr -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle03/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle03/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp byteArr -ms high
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp byteArr
+ *      -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle04/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle04/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp byteArr -ms low
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp byteArr -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle04/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle04/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp byteArr -ms low
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp byteArr
+ *      -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle05/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle05/TestDescription.java
@@ -31,12 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
+ *      -XX:+HeapDumpOnOutOfMemoryError
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp booleanArr

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle05/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle05/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,12 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm
+ *      -Xbootclasspath/a:.
+ *      -XX:+UnlockDiagnosticVMOptions
+ *      -XX:+WhiteBoxAPI
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp booleanArr

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle06/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle06/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp booleanArr -ms high
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp booleanArr -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle06/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle06/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp booleanArr -ms high
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp booleanArr
+ *      -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle07/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle07/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp shortArr -ms low
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp shortArr
+ *      -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle07/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle07/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp shortArr -ms low
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp shortArr -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle08/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle08/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp shortArr -ms medium
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp shortArr
+ *      -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle08/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle08/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp shortArr -ms medium
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp shortArr -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle09/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle09/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp shortArr -ms high
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp shortArr
+ *      -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle09/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle09/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp shortArr -ms high
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp shortArr -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle10/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle10/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp charArr -ms low
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp charArr
+ *      -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle10/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle10/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp charArr -ms low
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp charArr -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle11/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle11/TestDescription.java
@@ -31,8 +31,12 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log -Djava.security.manager=allow gc.ArrayJuggle.Juggle01.Juggle01 -gp charArr -ms medium
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      -Djava.security.manager=allow
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp charArr
+ *      -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle11/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle11/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log -Djava.security.manager=allow gc.ArrayJuggle.Juggle01.Juggle01 -gp charArr -ms medium
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log -Djava.security.manager=allow gc.ArrayJuggle.Juggle01.Juggle01 -gp charArr -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle12/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle12/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp charArr -ms high
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp charArr
+ *      -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle12/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle12/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp charArr -ms high
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp charArr -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle13/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle13/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp intArr -ms low
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp intArr -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle13/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle13/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp intArr -ms low
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp intArr
+ *      -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle14/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle14/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp intArr -ms medium
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp intArr -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle14/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle14/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp intArr -ms medium
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp intArr
+ *      -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle15/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle15/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp intArr -ms high
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp intArr
+ *      -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle15/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle15/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp intArr -ms high
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp intArr -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle16/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle16/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp longArr -ms low
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp longArr
+ *      -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle16/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle16/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp longArr -ms low
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp longArr -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle17/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle17/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp longArr -ms medium
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp longArr -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle17/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle17/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp longArr -ms medium
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp longArr
+ *      -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle18/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle18/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp longArr -ms high
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp longArr
+ *      -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle18/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle18/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp longArr -ms high
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp longArr -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle19/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle19/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp floatArr -ms low
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp floatArr
+ *      -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle19/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle19/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp floatArr -ms low
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp floatArr -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle20/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle20/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp floatArr -ms medium
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp floatArr -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle20/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle20/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp floatArr -ms medium
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp floatArr
+ *      -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle21/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle21/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp floatArr -ms high
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp floatArr -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle21/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle21/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp floatArr -ms high
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp floatArr
+ *      -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle22/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle22/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp doubleArr -ms low
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp doubleArr
+ *      -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle22/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle22/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp doubleArr -ms low
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp doubleArr -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle23/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle23/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp doubleArr -ms medium
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp doubleArr -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle23/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle23/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp doubleArr -ms medium
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp doubleArr
+ *      -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle24/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle24/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp doubleArr -ms high
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp doubleArr
+ *      -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle24/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle24/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp doubleArr -ms high
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp doubleArr -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle25/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle25/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp objectArr -ms low
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp objectArr
+ *      -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle25/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle25/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp objectArr -ms low
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp objectArr -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle26/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle26/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp objectArr -ms medium
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp objectArr -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle26/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle26/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp objectArr -ms medium
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp objectArr
+ *      -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle27/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle27/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp objectArr -ms high
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp objectArr -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle27/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle27/TestDescription.java
@@ -31,8 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp objectArr -ms high
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp objectArr
+ *      -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle28/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle28/TestDescription.java
@@ -31,12 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
+ *      -XX:+HeapDumpOnOutOfMemoryError
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp hashed(doubleArr)

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle28/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle28/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,12 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm
+ *      -Xbootclasspath/a:.
+ *      -XX:+UnlockDiagnosticVMOptions
+ *      -XX:+WhiteBoxAPI
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp hashed(doubleArr)

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle29/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle29/TestDescription.java
@@ -31,12 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
+ *      -XX:+HeapDumpOnOutOfMemoryError
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp hashed(doubleArr)

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle29/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle29/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,12 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm
+ *      -Xbootclasspath/a:.
+ *      -XX:+UnlockDiagnosticVMOptions
+ *      -XX:+WhiteBoxAPI
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp hashed(doubleArr)

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle30/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle30/TestDescription.java
@@ -31,12 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
+ *      -XX:+HeapDumpOnOutOfMemoryError
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp hashed(doubleArr)

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle30/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle30/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,12 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm
+ *      -Xbootclasspath/a:.
+ *      -XX:+UnlockDiagnosticVMOptions
+ *      -XX:+WhiteBoxAPI
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp hashed(doubleArr)

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle31/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle31/TestDescription.java
@@ -31,12 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
+ *      -XX:+HeapDumpOnOutOfMemoryError
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp hashed(objectArr)

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle31/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle31/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,12 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm
+ *      -Xbootclasspath/a:.
+ *      -XX:+UnlockDiagnosticVMOptions
+ *      -XX:+WhiteBoxAPI
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp hashed(objectArr)

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle32/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle32/TestDescription.java
@@ -31,12 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
+ *      -XX:+HeapDumpOnOutOfMemoryError
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp hashed(objectArr)

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle32/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle32/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,12 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm
+ *      -Xbootclasspath/a:.
+ *      -XX:+UnlockDiagnosticVMOptions
+ *      -XX:+WhiteBoxAPI
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp hashed(objectArr)

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle33/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle33/TestDescription.java
@@ -31,12 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
+ *      -XX:+HeapDumpOnOutOfMemoryError
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp hashed(objectArr)

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle33/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle33/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,12 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm
+ *      -Xbootclasspath/a:.
+ *      -XX:+UnlockDiagnosticVMOptions
+ *      -XX:+WhiteBoxAPI
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp hashed(objectArr)

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle34/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle34/TestDescription.java
@@ -31,12 +31,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
+ *      -XX:+HeapDumpOnOutOfMemoryError
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp random(arrays)

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle34/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle34/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,12 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm
+ *      -Xbootclasspath/a:.
+ *      -XX:+UnlockDiagnosticVMOptions
+ *      -XX:+WhiteBoxAPI
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp random(arrays)


### PR DESCRIPTION
Fixing JuggleTests for OOME.
The JuggleTests continuously allocate memory and juggle them in various array positions. Over the course of allocation, heap might be fully filled, esp in high memory strategy. The test doesn't take into account OOME and run under the assumption that any freed memory would be immediately GCed. Immediate GC under memory stress is not guaranteed. Hence it is better to explicitly call WhiteBox API to do the job.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282651](https://bugs.openjdk.org/browse/JDK-8282651): ZGC: vmTestbase/gc/ArrayJuggle/ tests fails intermittently with exit code 97


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9645/head:pull/9645` \
`$ git checkout pull/9645`

Update a local copy of the PR: \
`$ git checkout pull/9645` \
`$ git pull https://git.openjdk.org/jdk pull/9645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9645`

View PR using the GUI difftool: \
`$ git pr show -t 9645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9645.diff">https://git.openjdk.org/jdk/pull/9645.diff</a>

</details>
