### PR TITLE
8291048: x86: compiler/c2/irTests/TestAutoVectorization2DArray.java fails with lower SSE

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestAutoVectorization2DArray.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestAutoVectorization2DArray.java
@@ -29,6 +29,7 @@ import compiler.lib.ir_framework.*;
  * @test
  * @bug 8279258
  * @summary Auto-vectorization enhancement for two-dimensional array operations
+ * @requires (os.arch != "x86" & os.arch != "i386") | vm.opt.UseSSE == "null" | vm.opt.UseSSE >= 2
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestAutoVectorization2DArray
  */


### PR DESCRIPTION
[JDK-8289801](https://bugs.openjdk.org/browse/JDK-8289801) whitelisted the UseSSE/UseAVX flags, but missed update in the test. So when we test x86_32 with lower SSE, it fails, as no `LoadVector`/etc nodes are getting emitted.

Additional testing: 
 - [x] Linux x86_32 fastdebug `c2/irTests` with `-XX:UseAVX=0 -XX:UseSSE=0` (now passes)
 - [x] Linux x86_32 fastdebug `c2/irTests` with `-XX:UseAVX=0 -XX:UseSSE=1` (now passes)
 - [x] Linux x86_32 fastdebug `c2/irTests` with `-XX:UseAVX=0 -XX:UseSSE=2` (still passes)
 - [x] Linux x86_32 fastdebug `c2/irTests` default (still passes)
 - [x] Linux x86_64 fastdebug `c2/irTests` with `-XX:UseAVX=0 -XX:UseSSE=0` (still passes)
 - [x] Linux x86_64 fastdebug `c2/irTests` with `-XX:UseAVX=0 -XX:UseSSE=1` (still passes)
 - [x] Linux x86_64 fastdebug `c2/irTests` with `-XX:UseAVX=0 -XX:UseSSE=2` (still passes)
 - [x] Linux x86_64 fastdebug `c2/irTests` default (still passes)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291048](https://bugs.openjdk.org/browse/JDK-8291048): x86: compiler/c2/irTests/TestAutoVectorization2DArray.java fails with lower SSE


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9646/head:pull/9646` \
`$ git checkout pull/9646`

Update a local copy of the PR: \
`$ git checkout pull/9646` \
`$ git pull https://git.openjdk.org/jdk pull/9646/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9646`

View PR using the GUI difftool: \
`$ git pr show -t 9646`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9646.diff">https://git.openjdk.org/jdk/pull/9646.diff</a>

</details>
