### PR TITLE
8291056: Remove unused Generation::par_promote*()

### DIFF
--- a/src/hotspot/share/gc/shared/generation.cpp
+++ b/src/hotspot/share/gc/shared/generation.cpp
@@ -184,13 +184,6 @@ oop Generation::promote(oop obj, size_t obj_size) {
   return new_obj;
 }
 
-oop Generation::par_promote(int thread_num,
-                            oop obj, markWord m, size_t word_sz) {
-  // Could do a bad general impl here that gets a lock.  But no.
-  ShouldNotCallThis();
-  return NULL;
-}
-
 Space* Generation::space_containing(const void* p) const {
   GenerationIsInReservedClosure blk(p);
   // Cast away const

--- a/src/hotspot/share/gc/shared/generation.hpp
+++ b/src/hotspot/share/gc/shared/generation.hpp
@@ -267,20 +267,6 @@ class Generation: public CHeapObj<mtGC> {
   // avoid repeating the virtual call to retrieve it.
   virtual oop promote(oop obj, size_t obj_size);
 
-  // Thread "thread_num" (0 <= i < ParalleGCThreads) wants to promote
-  // object "obj", whose original mark word was "m", and whose size is
-  // "word_sz".  If possible, allocate space for "obj", copy obj into it
-  // (taking care to copy "m" into the mark word when done, since the mark
-  // word of "obj" may have been overwritten with a forwarding pointer, and
-  // also taking care to copy the klass pointer *last*.  Returns the new
-  // object if successful, or else NULL.
-  virtual oop par_promote(int thread_num, oop obj, markWord m, size_t word_sz);
-
-  // Informs the current generation that all par_promote_alloc's in the
-  // collection have been completed; any supporting data structures can be
-  // reset.  Default is to do nothing.
-  virtual void par_promote_alloc_done(int thread_num) {}
-
   // Informs the current generation that all oop_since_save_marks_iterates
   // performed by "thread_num" in the current collection, if any, have been
   // completed; any supporting data structures can be reset.  Default is to


### PR DESCRIPTION
Please review this trivial cleanup to remove unused Generation::par_promote() and Generation::par_promote_alloc_done() methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291056](https://bugs.openjdk.org/browse/JDK-8291056): Remove unused Generation::par_promote*()


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9648/head:pull/9648` \
`$ git checkout pull/9648`

Update a local copy of the PR: \
`$ git checkout pull/9648` \
`$ git pull https://git.openjdk.org/jdk pull/9648/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9648`

View PR using the GUI difftool: \
`$ git pr show -t 9648`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9648.diff">https://git.openjdk.org/jdk/pull/9648.diff</a>

</details>
