### PR TITLE
8291060: OPEN_MAX is no longer the max limit on macOS >= 10.6 for RLIMIT_NOFILE

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1989,16 +1989,19 @@ jint os::init_2(void) {
     if (status != 0) {
       log_info(os)("os::init_2 getrlimit failed: %s", os::strerror(errno));
     } else {
+      // On macOS >= 10.6 if we define _DARWIN_UNLIMITED_STREAMS or _DARWIN_C_SOURCE
+      // (we define _DARWIN_C_SOURCE) we can ask for RLIM_INFINITY
       nbr_files.rlim_cur = nbr_files.rlim_max;
-
-#ifdef __APPLE__
-      // Darwin returns RLIM_INFINITY for rlim_max, but fails with EINVAL if
-      // you attempt to use RLIM_INFINITY. As per setrlimit(2), OPEN_MAX must
-      // be used instead
-      nbr_files.rlim_cur = MIN(OPEN_MAX, nbr_files.rlim_cur);
-#endif
-
       status = setrlimit(RLIMIT_NOFILE, &nbr_files);
+#ifdef __APPLE__
+      if (status != 0) {
+        // On macOS < 10.6 Darwin returns RLIM_INFINITY for rlim_max,
+        // but fails with EINVAL if you attempt to use RLIM_INFINITY.
+        // As per setrlimit(2), OPEN_MAX must be used instead.
+        nbr_files.rlim_cur = MIN(OPEN_MAX, nbr_files.rlim_cur);
+        status = setrlimit(RLIMIT_NOFILE, &nbr_files);
+      }
+#endif // #ifdef __APPLE__
       if (status != 0) {
         log_info(os)("os::init_2 setrlimit failed: %s", os::strerror(errno));
       }

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1989,19 +1989,19 @@ jint os::init_2(void) {
     if (status != 0) {
       log_info(os)("os::init_2 getrlimit failed: %s", os::strerror(errno));
     } else {
-      // On macOS >= 10.6 if we define _DARWIN_UNLIMITED_STREAMS or _DARWIN_C_SOURCE
-      // (we define _DARWIN_C_SOURCE) we can ask for RLIM_INFINITY
       nbr_files.rlim_cur = nbr_files.rlim_max;
       status = setrlimit(RLIMIT_NOFILE, &nbr_files);
 #ifdef __APPLE__
-      if (status != 0) {
-        // On macOS < 10.6 Darwin returns RLIM_INFINITY for rlim_max,
+      if (status != 0 && errno == EINVAL) {
+        // On macOS >= 10.6 if we define _DARWIN_UNLIMITED_STREAMS or _DARWIN_C_SOURCE
+        // (we define _DARWIN_C_SOURCE) we can ask for RLIM_INFINITY,
+        // however, on macOS < 10.6 Darwin returns RLIM_INFINITY for rlim_max,
         // but fails with EINVAL if you attempt to use RLIM_INFINITY.
         // As per setrlimit(2), OPEN_MAX must be used instead.
         nbr_files.rlim_cur = MIN(OPEN_MAX, nbr_files.rlim_cur);
         status = setrlimit(RLIMIT_NOFILE, &nbr_files);
       }
-#endif // #ifdef __APPLE__
+#endif // __APPLE__
       if (status != 0) {
         log_info(os)("os::init_2 setrlimit failed: %s", os::strerror(errno));
       }


### PR DESCRIPTION
On macOS we are currently using setrlimit(RLIMIT_NOFILE, OPEN_MAX) for MaxFDLimit (it's ON by default), but we can go higher than that. 

My own testing on macOS 12.3.1 reveals that we can ask for setrlimit(RLIMIT_NOFILE, RLIM_INFINITY), though in reality we will get back 32765, which is still more than OPEN_MAX (10240)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291060](https://bugs.openjdk.org/browse/JDK-8291060): OPEN_MAX is no longer the max limit on macOS >= 10.6 for RLIMIT_NOFILE


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9650/head:pull/9650` \
`$ git checkout pull/9650`

Update a local copy of the PR: \
`$ git checkout pull/9650` \
`$ git pull https://git.openjdk.org/jdk pull/9650/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9650`

View PR using the GUI difftool: \
`$ git pr show -t 9650`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9650.diff">https://git.openjdk.org/jdk/pull/9650.diff</a>

</details>
