### PR TITLE
8290943: Fix several IR test issues on SVE after JDK-8289801

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -217,6 +217,8 @@ public class IRNode {
     public static final String FAST_LOCK   = START + "FastLock" + MID + END;
     public static final String FAST_UNLOCK = START + "FastUnlock" + MID + END;
 
+    public static final String POPULATE_INDEX = START + "PopulateIndex" + MID + END;
+
     /**
      * Called by {@link IRMatcher} to merge special composite nodes together with additional user-defined input.
      */

--- a/test/hotspot/jtreg/compiler/vectorapi/AllBitsSetVectorMatchRuleTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/AllBitsSetVectorMatchRuleTest.java
@@ -42,7 +42,7 @@ import jdk.test.lib.Utils;
  * @key randomness
  * @library /test/lib /
  * @requires vm.compiler2.enabled
- * @requires vm.cpu.features ~= ".*simd.*" | vm.cpu.features ~= ".*sve.*"
+ * @requires vm.cpu.features ~= ".*simd.*"
  * @summary AArch64: [vector] Make all bits set vector sharable for match rules
  * @modules jdk.incubator.vector
  *

--- a/test/hotspot/jtreg/compiler/vectorization/TestPopCountVectorLong.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestPopCountVectorLong.java
@@ -25,7 +25,7 @@
 * @test
 * @summary Test vectorization of popcount for Long
 * @requires vm.compiler2.enabled
-* @requires vm.cpu.features ~= ".*avx512bw.*" | vm.cpu.features ~= ".*sve.*"
+* @requires vm.cpu.features ~= ".*avx512bw.*" | (vm.cpu.features ~= ".*sve.*" & (vm.opt.UseSVE == "null" | vm.opt.UseSVE > 0))
 * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
 * @library /test/lib /
 * @run driver compiler.vectorization.TestPopCountVectorLong

--- a/test/hotspot/jtreg/compiler/vectorization/TestPopulateIndex.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestPopulateIndex.java
@@ -27,7 +27,7 @@
 * @summary Test vectorization of loop induction variable usage in the loop
 * @requires vm.compiler2.enabled
 * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") |
-*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*sve.*")
+*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*sve.*" & (vm.opt.UseSVE == "null" | vm.opt.UseSVE > 0))
 * @library /test/lib /
 * @run driver compiler.vectorization.TestPopulateIndex
 */
@@ -60,7 +60,7 @@ public class TestPopulateIndex {
     }
 
     @Test
-    @IR(counts = {"PopulateIndex", ">= 1"})
+    @IR(counts = {IRNode.POPULATE_INDEX, "> 0"})
     public void indexArrayFill() {
         for (int i = 0; i < count; i++) {
             idx[i] = i;
@@ -78,7 +78,7 @@ public class TestPopulateIndex {
     }
 
     @Test
-    @IR(counts = {"PopulateIndex", ">= 1"})
+    @IR(counts = {IRNode.POPULATE_INDEX, "> 0"})
     public void exprWithIndex1() {
         for (int i = 0; i < count; i++) {
             dst[i] = src[i] * (i & 7);
@@ -96,7 +96,7 @@ public class TestPopulateIndex {
     }
 
     @Test
-    @IR(counts = {"PopulateIndex", ">= 1"})
+    @IR(counts = {IRNode.POPULATE_INDEX, "> 0"})
     public void exprWithIndex2() {
         for (int i = 0; i < count; i++) {
             f[i] = i * i + 100;


### PR DESCRIPTION
This patch was motivated by the test failure of
TestPopCountVectorLong.java on SVE with UseSVE=0 after JDK-8289801.

Both CPU feature CPU_SVE and VM option UseSVE should be checked to
determine whether the SVE codegen part is available.

Hence, 1) if one test case is designed to test multiple backends, we
should specify this full check in the "requires" annotation, e.g.,
TestPopCoundVectorLong.java. 2) if one test case is designed to test
only SVE backend, we may also specify UseSVE option to "runWithFlags()"
in "main" function and only check CPU feature in "requires" annotation
part, e.g., VectorMaskedNotTest.java[1].

This test failure can be easily resolved via adding the full check in
the "requires" annotation.

We further revisited all the SVE-oriented JTREG test cases and found two
potential issues.

1) AllBitsSetVectorMatchRuleTest.java
It's designed to test both NEON and SVE codegen. Since 1) ASIMD is the
mandatory feature on SVE platforms and 2) SVE codegen would be selected
by default on SVE platforms, it's no need to require SVE feature.

2) TestPopulateIndex.java
Similar to TestPopCountVectorLong.java, this case is expected to fail as
well on SVE with UseSVE=0. However, it didn't fail. The root cause is
that it's not correct to simply check the "PopulateIndex" string because
the test name i.e. TestPopulateIndex.java contains this string as well.
Instead, we turn to check IRNode name.

Testing:
We ran the following vector test cases on 1) NEON-only platform, 2) SVE
platform with UseSVE=0 specified, 3) SVE platform with UseSVE not
specified(default on), 4) x64 platform. All the test cases passed.

```
  hotspot:compiler/vectorapi
  jdk:jdk/incubator/vector
  hotspot:compiler/vectorization
```

[1] https://github.com/openjdk/jdk/blob/master/test/hotspot/jtreg/compiler/vectorapi/VectorMaskedNotTest.java#L116

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290943](https://bugs.openjdk.org/browse/JDK-8290943): Fix several IR test issues on SVE after JDK-8289801


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9653/head:pull/9653` \
`$ git checkout pull/9653`

Update a local copy of the PR: \
`$ git checkout pull/9653` \
`$ git pull https://git.openjdk.org/jdk pull/9653/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9653`

View PR using the GUI difftool: \
`$ git pr show -t 9653`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9653.diff">https://git.openjdk.org/jdk/pull/9653.diff</a>

</details>
