### PR TITLE
8291289: gc/TestPLABAdaptToMinTLABSize fails after JDK-8289137

### DIFF
--- a/test/hotspot/jtreg/gc/TestPLABAdaptToMinTLABSize.java
+++ b/test/hotspot/jtreg/gc/TestPLABAdaptToMinTLABSize.java
@@ -27,6 +27,7 @@ package gc;
  * @test TestPLABAdaptToMinTLABSize
  * @bug 8289137
  * @summary Make sure that Young/OldPLABSize adapt to MinTLABSize setting.
+ * @requires vm.gc.Parallel | vm.gc.G1
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management


### PR DESCRIPTION
Hi all,

  can I get reviews for this change to the gc/TestPLABAdaptToMinTLABSize test to only let Parallel GC and G1 run the test as they are the only ones that use `Young/OldPLABSize` that is tested here?
The constraint function for these flags on other collectors always succeeds, so the failure tests with invalid options fail there.

Testing: local testing of all collectors, only Parallel and G1 succesfully complete them now

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291289](https://bugs.openjdk.org/browse/JDK-8291289): gc/TestPLABAdaptToMinTLABSize fails after JDK-8289137


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9654/head:pull/9654` \
`$ git checkout pull/9654`

Update a local copy of the PR: \
`$ git checkout pull/9654` \
`$ git pull https://git.openjdk.org/jdk pull/9654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9654`

View PR using the GUI difftool: \
`$ git pr show -t 9654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9654.diff">https://git.openjdk.org/jdk/pull/9654.diff</a>

</details>
