### PR TITLE
8291358: Fix the "overridding" typo

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testExternalOverriddenMethod/pkg/XReader.java
+++ b/test/langtools/jdk/javadoc/doclet/testExternalOverriddenMethod/pkg/XReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@ import java.io.*;
 public abstract class XReader extends FilterReader implements DataInput {
 
    /**
-    * This tests overridding an external method.
+    * This tests overriding an external method.
     */
     public int read() throws IOException {
        return 'W';

--- a/test/langtools/jdk/javadoc/doclet/testVisibleMembers/TestVisibleMembers.java
+++ b/test/langtools/jdk/javadoc/doclet/testVisibleMembers/TestVisibleMembers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8025091 8198890
  * @summary Verify the presence visible members in the case of
- *          member hiding and overridding.
+ *          member hiding and overriding.
  * @library /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
  * @build javadoc.tester.* toolbox.ToolBox builder.ClassBuilder


### PR DESCRIPTION
Please review this trivial grammar fix. I checked that this `@summary` is not a summary of a commit in openjdk/jdk, so no harm in fixing it now:

    * @summary Verify the presence visible members in the case of
    *          member hiding and overriding.

That said, the `@summary` is still a broken sentence, which I'm not trying to fix beyond addressing the typo in question.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291358](https://bugs.openjdk.org/browse/JDK-8291358): Fix the "overridding" typo


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9660/head:pull/9660` \
`$ git checkout pull/9660`

Update a local copy of the PR: \
`$ git checkout pull/9660` \
`$ git pull https://git.openjdk.org/jdk pull/9660/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9660`

View PR using the GUI difftool: \
`$ git pr show -t 9660`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9660.diff">https://git.openjdk.org/jdk/pull/9660.diff</a>

</details>
