### PR TITLE
8291428: JFR: 'jfr print' displays incorrect timestamps during DST

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataDescriptor.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataDescriptor.java
@@ -190,6 +190,7 @@ public final class MetadataDescriptor {
     static final String ATTRIBUTE_ID = "id";
     static final String ATTRIBUTE_SIMPLE_TYPE = "simpleType";
     static final String ATTRIBUTE_GMT_OFFSET = "gmtOffset";
+    static final String ATTRIBUTE_DST = "dst";
     static final String ATTRIBUTE_LOCALE = "locale";
     static final String ELEMENT_TYPE = "class";
     static final String ELEMENT_SETTING = "setting";
@@ -205,6 +206,7 @@ public final class MetadataDescriptor {
     final List<EventType> eventTypes = new ArrayList<>();
     final Collection<Type> types = new ArrayList<>();
     long gmtOffset;
+    long dst;
     String locale;
     Element root;
     public long metadataId;
@@ -242,6 +244,10 @@ public final class MetadataDescriptor {
         return (int) gmtOffset;
     }
 
+    public int getDST() {
+        return (int) dst;
+    }
+
     public String getLocale() {
         return locale;
     }
@@ -254,7 +260,9 @@ public final class MetadataDescriptor {
     static void write(List<Type> types, DataOutput output) throws IOException {
         MetadataDescriptor m = new MetadataDescriptor();
         m.locale = Locale.getDefault().toString();
-        m.gmtOffset = TimeZone.getDefault().getRawOffset();
+        TimeZone tz = TimeZone.getDefault();
+        m.gmtOffset = tz.getRawOffset();
+        m.dst = tz.getDSTSavings();
         m.types.addAll(types);
         MetadataWriter w = new MetadataWriter(m);
         w.writeBinary(output);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataReader.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataReader.java
@@ -81,6 +81,7 @@ final class MetadataReader {
         buildEvenTypes();
         Element time = root.elements("region").get(0);
         descriptor.gmtOffset = time.attribute(MetadataDescriptor.ATTRIBUTE_GMT_OFFSET, 1);
+        descriptor.dst = time.attribute(MetadataDescriptor.ATTRIBUTE_DST, 0L);
         descriptor.locale = time.attribute(MetadataDescriptor.ATTRIBUTE_LOCALE, "");
         descriptor.root = root;
         if (Logger.shouldLog(LogTag.JFR_SYSTEM_PARSER, LogLevel.TRACE)) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataWriter.java
@@ -29,6 +29,7 @@ import static jdk.jfr.internal.MetadataDescriptor.ATTRIBUTE_CONSTANT_POOL;
 import static jdk.jfr.internal.MetadataDescriptor.ATTRIBUTE_DEFAULT_VALUE;
 import static jdk.jfr.internal.MetadataDescriptor.ATTRIBUTE_DIMENSION;
 import static jdk.jfr.internal.MetadataDescriptor.ATTRIBUTE_GMT_OFFSET;
+import static jdk.jfr.internal.MetadataDescriptor.ATTRIBUTE_DST;
 import static jdk.jfr.internal.MetadataDescriptor.ATTRIBUTE_ID;
 import static jdk.jfr.internal.MetadataDescriptor.ATTRIBUTE_LOCALE;
 import static jdk.jfr.internal.MetadataDescriptor.ATTRIBUTE_NAME;
@@ -72,6 +73,7 @@ final class MetadataWriter {
         Element region = new Element("region");
         region.addAttribute(ATTRIBUTE_LOCALE, descriptor.locale);
         region.addAttribute(ATTRIBUTE_GMT_OFFSET, descriptor.gmtOffset);
+        region.addAttribute(ATTRIBUTE_DST, descriptor.dst);
         root.add(region);
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
@@ -126,7 +126,7 @@ public final class ChunkParser {
             this.configuration = previous.configuration;
         }
         this.metadata = header.readMetadata(previousMetadata);
-        this.timeConverter = new TimeConverter(chunkHeader, metadata.getGMTOffset());
+        this.timeConverter = new TimeConverter(chunkHeader, metadata.getGMTOffset() + metadata.getDST());
         if (metadata != previousMetadata) {
             ParserFactory factory = new ParserFactory(metadata, constantLookups, timeConverter);
             parsers = factory.getParsers();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/TimeConverter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/TimeConverter.java
@@ -41,11 +41,11 @@ final class TimeConverter {
     private final double divisor;
     private final ZoneOffset zoneOffset;
 
-    TimeConverter(ChunkHeader chunkHeader, int rawOffset) {
+    TimeConverter(ChunkHeader chunkHeader, int offset) {
         this.startTicks = chunkHeader.getStartTicks();
         this.startNanos = chunkHeader.getStartNanos();
         this.divisor = chunkHeader.getTicksPerSecond() / 1000_000_000L;
-        this.zoneOffset = zoneOfSet(rawOffset);
+        this.zoneOffset = zoneOfSet(offset);
     }
 
     public long convertTimestamp(long ticks) {
@@ -60,11 +60,11 @@ final class TimeConverter {
         return zoneOffset;
     }
 
-    private ZoneOffset zoneOfSet(int rawOffset) {
+    private ZoneOffset zoneOfSet(int offset) {
         try {
-            return ZoneOffset.ofTotalSeconds(rawOffset / 1000);
+            return ZoneOffset.ofTotalSeconds(offset / 1000);
         } catch (DateTimeException dte) {
-            Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Could not create ZoneOffset from raw offset " + rawOffset);
+            Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Could not create ZoneOffset from raw offset " + offset);
         }
         return ZoneOffset.UTC;
     }


### PR DESCRIPTION
Could I have a review of change that fixes incorrect timestamp during DST. For details see issue.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291428](https://bugs.openjdk.org/browse/JDK-8291428): JFR: 'jfr print' displays incorrect timestamps during DST


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9666/head:pull/9666` \
`$ git checkout pull/9666`

Update a local copy of the PR: \
`$ git checkout pull/9666` \
`$ git pull https://git.openjdk.org/jdk pull/9666/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9666`

View PR using the GUI difftool: \
`$ git pr show -t 9666`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9666.diff">https://git.openjdk.org/jdk/pull/9666.diff</a>

</details>
