### PR TITLE
6587699: Document DigestInputStream behavior when skip() or mark() / reset() is used

### DIFF
--- a/src/java.base/share/classes/java/security/DigestInputStream.java
+++ b/src/java.base/share/classes/java/security/DigestInputStream.java
@@ -51,6 +51,15 @@ import java.io.InputStream;
  * retain a handle onto the digest object, and clone it for each
  * digest to be computed, leaving the original digest untouched.
  *
+ * @implNote This implementation updates and only updates the message digest
+ *      with data actually read from the input stream when it is turned on.
+ *      This includes various {@code read} methods, {@code transferTo},
+ *      {@code readAllBytes}, and {@code readNBytes}. Specifically, data
+ *      bypassed by the {@code skip} method are ignored. On the other hand,
+ *      if the underlying stream supports the {@code mark} and
+ *      {@code reset} methods, and the same data is read again after
+ *      {@code reset}, then the message digest is updated again.
+ *
  * @see MessageDigest
  *
  * @see DigestOutputStream

--- a/src/java.base/share/classes/java/security/DigestInputStream.java
+++ b/src/java.base/share/classes/java/security/DigestInputStream.java
@@ -51,11 +51,12 @@ import java.io.InputStream;
  * retain a handle onto the digest object, and clone it for each
  * digest to be computed, leaving the original digest untouched.
  *
- * @implNote This implementation updates and only updates the message digest
- *      with data actually read from the input stream when it is turned on.
- *      This includes the various {@code read} methods, {@code transferTo},
- *      {@code readAllBytes}, and {@code readNBytes}. Especially, data
- *      bypassed by the {@code skip} method are ignored. On the other hand,
+ * @implNote This implementation only updates the message digest
+ *      with data actually read from the input stream when it is
+ *      {@linkplain #on(boolean) turned on}. This includes the various
+ *      {@code read} methods, {@code transferTo}, {@code readAllBytes},
+ *      and {@code readNBytes}. Please note that data bypassed by the
+ *      {@code skip} method are ignored. On the other hand,
  *      if the underlying stream supports the {@code mark} and
  *      {@code reset} methods, and the same data is read again after
  *      {@code reset}, then the message digest is updated again.

--- a/src/java.base/share/classes/java/security/DigestInputStream.java
+++ b/src/java.base/share/classes/java/security/DigestInputStream.java
@@ -53,8 +53,8 @@ import java.io.InputStream;
  *
  * @implNote This implementation updates and only updates the message digest
  *      with data actually read from the input stream when it is turned on.
- *      This includes various {@code read} methods, {@code transferTo},
- *      {@code readAllBytes}, and {@code readNBytes}. Specifically, data
+ *      This includes the various {@code read} methods, {@code transferTo},
+ *      {@code readAllBytes}, and {@code readNBytes}. Especially, data
  *      bypassed by the {@code skip} method are ignored. On the other hand,
  *      if the underlying stream supports the {@code mark} and
  *      {@code reset} methods, and the same data is read again after

--- a/test/jdk/java/security/DigestInputStream/TestSkipAndReset.java
+++ b/test/jdk/java/security/DigestInputStream/TestSkipAndReset.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.Asserts;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+
+/**
+ * @test
+ * @bug 6587699
+ * @summary Document DigestInputStream behavior when skip() or mark() / reset() is used
+ * @library /test/lib
+ */
+
+public class TestSkipAndReset {
+    public static void main(String[] args) throws Exception {
+        byte[] data = "1234567890".getBytes(StandardCharsets.UTF_8);
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        DigestInputStream dis = new DigestInputStream(new ByteArrayInputStream(data), md);
+
+        dis.read(); // read 1
+        dis.read(new byte[2], 0, 1); // read 2
+        dis.skip(3); // skip 3 4 5
+        dis.mark(10); // remember 5
+        dis.read(new byte[2]); // read 6 7
+        dis.skip(1); // skip 8
+        dis.read(); // read 9
+        dis.reset(); // back to 5
+        dis.readNBytes(3); // read 6 7 8
+        dis.reset(); // back to 5
+        dis.skip(2); // skip 6 7
+        dis.readAllBytes(); // read 8 9 0
+        dis.reset(); // back to 5
+        dis.skip(3); // skip 6 7 8
+        dis.transferTo(new ByteArrayOutputStream()); // read 9 0
+
+        byte[] hash = md.digest();
+        byte[] directHash = md.digest("1267967889090".getBytes(StandardCharsets.UTF_8));
+
+        Asserts.assertTrue(MessageDigest.isEqual(hash, directHash));
+    }
+}


### PR DESCRIPTION
Add an `@implNote` to clarify the behavior when these methods are called. A new test is added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-6587699](https://bugs.openjdk.org/browse/JDK-6587699): Document DigestInputStream behavior when skip() or mark() / reset() is used
 * [JDK-8291516](https://bugs.openjdk.org/browse/JDK-8291516): Document DigestInputStream behavior when skip() or mark() / reset() is used (**CSR**)


### Reviewers
 * [Bradford Wetmore](https://openjdk.org/census#wetmore) (@bradfordwetmore - **Reviewer**) ⚠️ Review applies to [a6304352](https://git.openjdk.org/jdk/pull/9667/files/a6304352b14418cf75aa0001c3faf3ed95d745df)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9667/head:pull/9667` \
`$ git checkout pull/9667`

Update a local copy of the PR: \
`$ git checkout pull/9667` \
`$ git pull https://git.openjdk.org/jdk pull/9667/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9667`

View PR using the GUI difftool: \
`$ git pr show -t 9667`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9667.diff">https://git.openjdk.org/jdk/pull/9667.diff</a>

</details>
