### PR TITLE
6383195: javax.crypto.spec.PBEKeySpec is not thread safe

### DIFF
--- a/src/java.base/share/classes/javax/crypto/spec/PBEKeySpec.java
+++ b/src/java.base/share/classes/javax/crypto/spec/PBEKeySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/javax/crypto/spec/PBEKeySpec.java
+++ b/src/java.base/share/classes/javax/crypto/spec/PBEKeySpec.java
@@ -173,7 +173,7 @@ public class PBEKeySpec implements KeySpec {
      * Clears the internal copy of the password.
      *
      */
-    public final void clearPassword() {
+    public final synchronized void clearPassword() {
         if (password != null) {
             Arrays.fill(password, ' ');
             password = null;
@@ -191,7 +191,7 @@ public class PBEKeySpec implements KeySpec {
      * calling <code>clearPassword</code> method.
      * @return the password.
      */
-    public final char[] getPassword() {
+    public final synchronized char[] getPassword() {
         if (password == null) {
             throw new IllegalStateException("password has been cleared");
         }

--- a/test/jdk/javax/crypto/spec/PBEKeySpec/PBEKeySpecRacing.java
+++ b/test/jdk/javax/crypto/spec/PBEKeySpec/PBEKeySpecRacing.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6383195
+ * @summary javax.crypto.spec.PBEKeySpec is not thread safe
+ */
+
+/*
+ * Use one thread to clear the password, another to check the password state.
+ *
+ * If a partially cleared password is ever obtained, fail the test.
+ */
+import java.util.Arrays;
+import javax.crypto.spec.PBEKeySpec;
+
+public class PBEKeySpecRacing {
+    private static final int NUMTESTS = 1000;
+    private static final int PASSWORD_LEN = 25;
+
+    private static PBEKeySpec keySpec;
+
+    private static final char[] password;
+
+    static {
+        password = new char[PASSWORD_LEN];
+        Arrays.fill(password, 'A');
+    }
+
+    public static void main(String[] args) {
+        System.out.println("Testing: ");
+        for (int i = 0; i < NUMTESTS; i++) {
+            keySpec = new PBEKeySpec(password);
+            Thread reader = new Thread(() -> {
+                try {
+                    // Repeat until
+                    while (true) {
+                        char[] pbePass = keySpec.getPassword();
+                        if (!Arrays.equals(password, pbePass))
+                            throw new RuntimeException(
+                                    "Inconsistent Password: ");
+                    }
+                } catch (IllegalStateException e) {
+                    System.out.print(".");
+                }
+            });
+            Thread clearer = new Thread(() -> keySpec.clearPassword());
+            reader.start();
+            clearer.start();
+            try {
+                reader.join();
+                clearer.join();
+            } catch (InterruptedException e) {
+                // Swallow
+            }
+            // avoid long output lines.
+            if ((i % 80) == 79) {
+                System.out.println();
+            }
+        }
+        System.out.println("Test PASSED");
+    }
+}


### PR DESCRIPTION
Simple fix to a long-standing threading bug to help clear the bug backlog.  

Without the synchronized, the test case fails almost immediately.  

Running JPRT with tier1/tier2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6383195](https://bugs.openjdk.org/browse/JDK-6383195): javax.crypto.spec.PBEKeySpec is not thread safe


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**) ⚠️ Review applies to [13b296e4](https://git.openjdk.org/jdk/pull/9668/files/13b296e4589fe75b5850f936bb23015e94256623)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9668/head:pull/9668` \
`$ git checkout pull/9668`

Update a local copy of the PR: \
`$ git checkout pull/9668` \
`$ git pull https://git.openjdk.org/jdk pull/9668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9668`

View PR using the GUI difftool: \
`$ git pr show -t 9668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9668.diff">https://git.openjdk.org/jdk/pull/9668.diff</a>

</details>
