### PR TITLE
Draft: Test GHA

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_neon.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_neon.ad
@@ -2391,6 +2391,41 @@ instruct vbsl16B(vecX dst, vecX src1, vecX src2)
   ins_pipe(vlogical128);
 %}
 
+// --------------------------------- VCMove ----------------------------
+
+instruct vcmove8B(vecD dst, vecD src1, vecD src2, immI cond, cmpOp copnd)
+%{
+  predicate(n->as_Vector()->length_in_bytes() == 8);
+  match(Set dst (CMoveVF (Binary copnd cond) (Binary src1 src2)));
+  format %{ "vcmoveD.$copnd  $dst, $src1, $src2\t# vector conditional move fp (8B)"%}
+  effect(TEMP_DEF dst);
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ neon_compare(as_FloatRegister($dst$$reg), bt, as_FloatRegister($src1$$reg),
+                    as_FloatRegister($src2$$reg), $cond$$constant, /*isQ*/ false);
+    __ bsl(as_FloatRegister($dst$$reg), __ T8B,
+           as_FloatRegister($src2$$reg), as_FloatRegister($src1$$reg));
+  %}
+  ins_pipe(vlogical64);
+%}
+
+instruct vcmove16B(vecX dst, vecX src1, vecX src2, immI cond, cmpOp copnd)
+%{
+  predicate(n->as_Vector()->length_in_bytes() == 16);
+  match(Set dst (CMoveVF (Binary copnd cond) (Binary src1 src2)));
+  match(Set dst (CMoveVD (Binary copnd cond) (Binary src1 src2)));
+  format %{ "vcmoveX.$copnd  $dst, $src1, $src2\t# vector conditional move fp (16B)"%}
+  effect(TEMP_DEF dst);
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ neon_compare(as_FloatRegister($dst$$reg), bt, as_FloatRegister($src1$$reg),
+                    as_FloatRegister($src2$$reg), $cond$$constant, /*isQ*/ true);
+    __ bsl(as_FloatRegister($dst$$reg), __ T16B,
+           as_FloatRegister($src2$$reg), as_FloatRegister($src1$$reg));
+  %}
+  ins_pipe(vlogical128);
+%}
+
 // --------------------------------- Load/store Mask ----------------------------
 
 instruct loadmask8B(vecD dst, vecD src  )

--- a/src/hotspot/cpu/aarch64/aarch64_sve.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_sve.ad
@@ -2306,6 +2306,25 @@ instruct vblend(vReg dst, vReg src1, vReg src2, pRegGov pg) %{
   ins_pipe(pipe_slow);
 %}
 
+// vector conditional move
+
+instruct vcmove(vReg dst, vReg src1, vReg src2, pRegGov pg, immI cond, cmpOp copnd) %{
+  predicate(UseSVE > 0);
+  match(Set dst (CMoveVF (Binary copnd cond) (Binary src1 src2)));
+  match(Set dst (CMoveVD (Binary copnd cond) (Binary src1 src2)));
+  effect(TEMP pg);
+  format %{ "sve_cmove.$copnd $dst, $src1, $src2\t# vector conditional move fp (sve)" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
+    __ sve_compare(as_PRegister($pg$$reg), bt, ptrue, as_FloatRegister($src1$$reg),
+                   as_FloatRegister($src2$$reg), $cond$$constant);
+    __ sve_sel(as_FloatRegister($dst$$reg), size, as_PRegister($pg$$reg),
+               as_FloatRegister($src2$$reg), as_FloatRegister($src1$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 // vector store mask
 
 instruct vstoremaskB(vReg dst, pRegGov src, immI_1 size) %{

--- a/src/hotspot/cpu/aarch64/aarch64_sve_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_sve_ad.m4
@@ -1267,6 +1267,25 @@ instruct vblend(vReg dst, vReg src1, vReg src2, pRegGov pg) %{
   ins_pipe(pipe_slow);
 %}
 
+// vector conditional move
+
+instruct vcmove(vReg dst, vReg src1, vReg src2, pRegGov pg, immI cond, cmpOp copnd) %{
+  predicate(UseSVE > 0);
+  match(Set dst (CMoveVF (Binary copnd cond) (Binary src1 src2)));
+  match(Set dst (CMoveVD (Binary copnd cond) (Binary src1 src2)));
+  effect(TEMP pg);
+  format %{ "sve_cmove.$copnd $dst, $src1, $src2\t# vector conditional move fp (sve)" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
+    __ sve_compare(as_PRegister($pg$$reg), bt, ptrue, as_FloatRegister($src1$$reg),
+                   as_FloatRegister($src2$$reg), $cond$$constant);
+    __ sve_sel(as_FloatRegister($dst$$reg), size, as_PRegister($pg$$reg),
+               as_FloatRegister($src2$$reg), as_FloatRegister($src1$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 // vector store mask
 
 instruct vstoremaskB(vReg dst, pRegGov src, immI_1 size) %{

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -2359,14 +2359,26 @@ void Matcher::find_shared_post_visit(Node* n, uint opcode) {
     case Op_CMoveI:
     case Op_CMoveL:
     case Op_CMoveN:
-    case Op_CMoveP:
-    case Op_CMoveVF:
-    case Op_CMoveVD:  {
+    case Op_CMoveP: {
       // Restructure into a binary tree for Matching.  It's possible that
       // we could move this code up next to the graph reshaping for IfNodes
       // or vice-versa, but I do not want to debug this for Ladybird.
       // 10/2/2000 CNC.
       Node* pair1 = new BinaryNode(n->in(1), n->in(1)->in(1));
+      n->set_req(1, pair1);
+      Node* pair2 = new BinaryNode(n->in(2), n->in(3));
+      n->set_req(2, pair2);
+      n->del_req(3);
+      break;
+    }
+    case Op_CMoveVF:
+    case Op_CMoveVD: {
+      // Restructure into a binary tree for Matching:
+      // CMoveVF (Binary bool mask) (Binary src1 src2)
+      Node* in_cc = n->in(1);
+      assert(in_cc->is_Con(), "The condition input of cmove vector node must be a constant.");
+      Node* bol = new BoolNode(in_cc, (BoolTest::mask)in_cc->get_int());
+      Node* pair1 = new BinaryNode(bol, in_cc);
       n->set_req(1, pair1);
       Node* pair2 = new BinaryNode(n->in(2), n->in(3));
       n->set_req(2, pair2);

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2064,12 +2064,7 @@ bool SuperWord::implemented(Node_List* p) {
         opc = Op_RShiftI;
       }
       retValue = VectorNode::implemented(opc, size, velt_basic_type(p0));
-    }
-    if (!retValue) {
-      if (is_cmov_pack(p)) {
-        NOT_PRODUCT(if(is_trace_cmov()) {tty->print_cr("SWPointer::implemented: found cmpd pack"); print_pack(p);})
-        return true;
-      }
+      NOT_PRODUCT(if(retValue && is_trace_cmov() && is_cmov_pack(p)) {tty->print_cr("SWPointer::implemented: found cmpd pack"); print_pack(p);})
     }
   }
   return retValue;
@@ -2683,12 +2678,28 @@ bool SuperWord::output() {
           ShouldNotReachHere();
         }
 
-        int cond = (int)bol->as_Bool()->_test._test;
-        Node* in_cc  = _igvn.intcon(cond);
-        NOT_PRODUCT(if(is_trace_cmov()) {tty->print("SWPointer::output: created intcon in_cc node %d", in_cc->_idx); in_cc->dump();})
-        Node* cc = bol->clone();
-        cc->set_req(1, in_cc);
-        NOT_PRODUCT(if(is_trace_cmov()) {tty->print("SWPointer::output: created bool cc node %d", cc->_idx); cc->dump();})
+        BoolTest boltest = bol->as_Bool()->_test;
+        BoolTest::mask cond = boltest._test;
+        Node* cmp = bol->in(1);
+        // When the src order of cmp node and cmove node are the same:
+        // cmp: CmpD src1 src2
+        // bool: Bool cmp mask
+        // cmove: CMoveD bool scr1 src2
+        // =====> merged, equivalent to
+        // cmovev: CMoveVD mask src_vector1 src_vector2
+        //
+        // When the src order of cmp node and cmove node are different:
+        // cmp: CmpD src2 src1
+        // bool: Bool cmp mask
+        // cmove: CMoveD bool scr1 src2
+        // =====> merged, equivalent to
+        // cmovev: CMoveVD nagate(mask) src_vector1 src_vector2
+        if (cmp->in(2) == n->in(CMoveNode::IfFalse)) {
+          assert(cmp->in(1) == n->in(CMoveNode::IfTrue), "cmpnode and cmovenode don't share the same inputs.");
+          cond = boltest.negate();
+        }
+        Node* cc  = _igvn.intcon((int)cond);
+        NOT_PRODUCT(if(is_trace_cmov()) {tty->print("SWPointer::output: created intcon in_cc node %d", cc->_idx); cc->dump();})
 
         Node* src1 = vector_opd(p, 2); //2=CMoveNode::IfFalse
         if (src1 == NULL) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorConditionalMove.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorConditionalMove.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+import java.util.Random;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+
+/*
+ * @test
+ * @bug 8289422
+ * @key randomness
+ * @summary Auto-vectorization enhancement to support vector conditional move on AArch64
+ * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") | os.arch=="aarch64"
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.TestVectorConditionalMove
+ */
+
+public class TestVectorConditionalMove {
+    final private static int SIZE = 3000;
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    private static float[] floata = new float[SIZE];
+    private static float[] floatb = new float[SIZE];
+    private static float[] floatc = new float[SIZE];
+    private static double[] doublea = new double[SIZE];
+    private static double[] doubleb = new double[SIZE];
+    private static double[] doublec = new double[SIZE];
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("-XX:+UseCMoveUnconditionally", "-XX:+UseVectorCmov",
+                                   "-XX:CompileCommand=exclude,*.cmove*", "-XX:MaxVectorSize=32");
+    }
+
+    private float cmoveFloatGT(float a, float b) {
+        return (a > b) ? a : b;
+    }
+
+    private float cmoveFloatLT(float a, float b) {
+        return (a < b) ? a : b;
+    }
+
+    private double cmoveDoubleLE(double a, double b) {
+        return (a <= b) ? a : b;
+    }
+
+    private double cmoveDoubleGE(double a, double b) {
+        return (a >= b) ? a : b;
+    }
+
+    @Test
+    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.CMOVEVF, ">0", IRNode.STORE_VECTOR, ">0"})
+    private static void testCMoveVFGT(float[] a, float[] b, float[] c) {
+        for (int i = 0; i < a.length; i++) {
+            c[i] = (a[i] > b[i]) ? a[i] : b[i];
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.CMOVEVF, ">0", IRNode.STORE_VECTOR, ">0"})
+    private static void testCMoveVFLT(float[] a, float[] b, float[] c) {
+        for (int i = 0; i < a.length; i++) {
+            c[i] = (a[i] < b[i]) ? a[i] : b[i];
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.CMOVEVD, ">0", IRNode.STORE_VECTOR, ">0"})
+    private static void testCMoveVDLE(double[] a, double[] b, double[] c) {
+        for (int i = 0; i < a.length; i++) {
+            c[i] = (a[i] <= b[i]) ? a[i] : b[i];
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.CMOVEVD, ">0", IRNode.STORE_VECTOR, ">0"})
+    private static void testCMoveVDGE(double[] a, double[] b, double[] c) {
+        for (int i = 0; i < a.length; i++) {
+            c[i] = (a[i] >= b[i]) ? a[i] : b[i];
+        }
+    }
+
+    @Run(test = {"testCMoveVFGT", "testCMoveVFLT","testCMoveVDLE", "testCMoveVDGE"})
+    private void testCMove_runner() {
+        for (int i = 0; i < SIZE; i++) {
+            floata[i] = RANDOM.nextFloat();
+            floatb[i] = RANDOM.nextFloat();
+            doublea[i] = RANDOM.nextDouble();
+            doubleb[i] = RANDOM.nextDouble();
+        }
+
+        testCMoveVFGT(floata, floatb, floatc);
+        testCMoveVDLE(doublea, doubleb, doublec);
+        for (int i = 0; i < SIZE; i++) {
+            Asserts.assertEquals(floatc[i], cmoveFloatGT(floata[i], floatb[i]));
+            Asserts.assertEquals(doublec[i], cmoveDoubleLE(doublea[i], doubleb[i]));
+        }
+
+        testCMoveVFLT(floata, floatb, floatc);
+        testCMoveVDGE(doublea, doubleb, doublec);
+        for (int i = 0; i < SIZE; i++) {
+            Asserts.assertEquals(floatc[i], cmoveFloatLT(floata[i], floatb[i]));
+            Asserts.assertEquals(doublec[i], cmoveDoubleGE(doublea[i], doubleb[i]));
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -142,6 +142,8 @@ public class IRNode {
     public static final String SAFEPOINT = START + "SafePoint" + MID + END;
 
     public static final String CMOVEI = START + "CMoveI" + MID + END;
+    public static final String CMOVEVF = START + "CMoveVF" + MID + END;
+    public static final String CMOVEVD = START + "CMoveVD" + MID + END;
     public static final String ABS_I = START + "AbsI" + MID + END;
     public static final String ABS_L = START + "AbsL" + MID + END;
     public static final String ABS_F = START + "AbsF" + MID + END;

--- a/test/micro/org/openjdk/bench/vm/compiler/TypeVectorOperations.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/TypeVectorOperations.java
@@ -363,6 +363,22 @@ public abstract class TypeVectorOperations {
         }
     }
 
+    @Benchmark
+    @Fork(jvmArgsPrepend = {"-XX:+UseCMoveUnconditionally", "-XX:+UseVectorCmov"})
+    public void cmoveD() {
+        for (int i = 0; i < COUNT; i++) {
+            resD[i] = resD[i] < doubles[i] ? resD[i] : doubles[i];
+        }
+    }
+
+    @Benchmark
+    @Fork(jvmArgsPrepend = {"-XX:+UseCMoveUnconditionally", "-XX:+UseVectorCmov"})
+    public void cmoveF() {
+        for (int i = 0; i < COUNT; i++) {
+            resF[i] = resF[i] < floats[i] ? resF[i] : floats[i];
+        }
+    }
+
     @Fork(value = 1, jvmArgsPrepend = {
         "-XX:+UseSuperWord"
     })


### PR DESCRIPTION
```
// float[] a, float[] b, float[] c;
for (int i = 0; i < a.length; i++) {
    c[i] = (a[i] > b[i]) ? a[i] : b[i];
}
```

After JDK-8139340 and JDK-8192846, we hope to vectorize the case
above by enabling -XX:+UseCMoveUnconditionally and -XX:+UseVectorCmov.
But the transformation here[1] is going to optimize the BoolNode
with constant input to a constant and break the design logic of
cmove vector node[2]. We can't prevent all GVN transformation to
the BoolNode before matcher, so the patch keeps the condition input
as a constant while creating a cmove vector node, and then
restructures it into a binary tree before matching.

When the input order of original cmp node is different from the
input order of original cmove node, like:
```
// float[] a, float[] b, float[] c;
for (int i = 0; i < a.length; i++) {
    c[i] = (a[i] < b[i]) ? a[i] : b[i];
}
```
the patch negates the mask of the BoolNode before creating the
cmove vector node in SuperWord::output().

We can also use VectorNode::implemented() to consult if vector
conditional move is supported in the backend. So, the patch cleans
the related code in SuperWord::implemented().

With the patch, the performance uplift is:
(The micro-benchmark functions are included in the file
test/micro/org/openjdk/bench/vm/compiler/TypeVectorOperations.java)

AArch64:
Benchmark (length)  Mode  Cnt   uplift(ns/op)
cmoveD     523      avgt  15    68.89%
cmoveF     523      avgt  15    72.40%

X86:
Benchmark (length)  Mode  Cnt   uplift(ns/op)
cmoveD     523      avgt  15    73.12%
cmoveF     523      avgt  15    85.45%

[1]https://github.com/openjdk/jdk/blob/779b4e1d1959bc15a27492b7e2b951678e39cca8/src/hotspot/share/opto/subnode.cpp#L1310
[2]https://github.com/openjdk/jdk/blob/779b4e1d1959bc15a27492b7e2b951678e39cca8/src/hotspot/share/opto/matcher.cpp#L2365

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9670/head:pull/9670` \
`$ git checkout pull/9670`

Update a local copy of the PR: \
`$ git checkout pull/9670` \
`$ git pull https://git.openjdk.org/jdk pull/9670/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9670`

View PR using the GUI difftool: \
`$ git pr show -t 9670`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9670.diff">https://git.openjdk.org/jdk/pull/9670.diff</a>

</details>
