### PR TITLE
8291003: ARM32: constant_table.size assertion

### DIFF
--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -237,7 +237,7 @@ void MachConstantBaseNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const {
   Register r = as_Register(ra_->get_encode(this));
   CodeSection* consts_section = __ code()->consts();
   // constants section size is aligned according to the align_at_start settings of the next section
-  int consts_size = __ code()->insts()->align_at_start(consts_section->size());
+  int consts_size = CodeSection::align_at_start(consts_section->size(), CodeBuffer::SECT_INSTS);
   assert(constant_table.size() == consts_size, "must be: %d == %d", constant_table.size(), consts_size);
 
   // Materialize the constant table base.

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -236,7 +236,8 @@ void MachConstantBaseNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const {
 
   Register r = as_Register(ra_->get_encode(this));
   CodeSection* consts_section = __ code()->consts();
-  int consts_size = consts_section->align_at_start(consts_section->size());
+  // constants section size is aligned according to the align_at_start settings of the next section
+  int consts_size = __ code()->insts()->align_at_start(consts_section->size());
   assert(constant_table.size() == consts_size, "must be: %d == %d", constant_table.size(), consts_size);
 
   // Materialize the constant table base.

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -261,12 +261,12 @@ class CodeSection {
   // Slop between sections, used only when allocating temporary BufferBlob buffers.
   static csize_t end_slop()         { return MAX2((int)sizeof(jdouble), (int)CodeEntryAlignment); }
 
-  csize_t align_at_start(csize_t off, int section) const {
+  static csize_t align_at_start(csize_t off, int section) {
     return (csize_t) align_up(off, alignment(section));
   }
 
   csize_t align_at_start(csize_t off) const {
-    return (csize_t) align_up(off, alignment(_index));
+    return align_at_start(off, _index);
   }
 
   // Ensure there's enough space left in the current section.


### PR DESCRIPTION
This change fixes assertion condition as per the recent [JDK-8287373](https://bugs.openjdk.org/browse/JDK-8287373) change: the size of constants section is aligned up according to the settings of the next section (instructions section).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291003](https://bugs.openjdk.org/browse/JDK-8291003): ARM32: constant_table.size assertion


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9672/head:pull/9672` \
`$ git checkout pull/9672`

Update a local copy of the PR: \
`$ git checkout pull/9672` \
`$ git pull https://git.openjdk.org/jdk pull/9672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9672`

View PR using the GUI difftool: \
`$ git pr show -t 9672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9672.diff">https://git.openjdk.org/jdk/pull/9672.diff</a>

</details>
