### PR TITLE
8291479: ProblemList compiler/rangechecks/TestRangeCheckHoistingScaledIV.java on ppc64le

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -47,6 +47,7 @@ compiler/ciReplay/TestSAServer.java 8029528 generic-all
 compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java 8225370 generic-all
 compiler/jvmci/compilerToVM/GetFlagValueTest.java 8204459 generic-all
 compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java 8262901 macosx-aarch64
+compiler/rangechecks/TestRangeCheckHoistingScaledIV.java 8291474 generic-ppc64le
 compiler/tiered/LevelTransitionTest.java 8067651 generic-all
 
 compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java 8190680 generic-all


### PR DESCRIPTION
ProblemListing compiler/rangechecks/TestRangeCheckHoistingScaledIV.java on ppc64le
It fails always.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291479](https://bugs.openjdk.org/browse/JDK-8291479): ProblemList compiler/rangechecks/TestRangeCheckHoistingScaledIV.java on ppc64le


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9674/head:pull/9674` \
`$ git checkout pull/9674`

Update a local copy of the PR: \
`$ git checkout pull/9674` \
`$ git pull https://git.openjdk.org/jdk pull/9674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9674`

View PR using the GUI difftool: \
`$ git pr show -t 9674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9674.diff">https://git.openjdk.org/jdk/pull/9674.diff</a>

</details>
