### PR TITLE
8289162: runtime/NMT/ThreadedMallocTestType.java should print out memory allocations to help debug

### DIFF
--- a/test/hotspot/jtreg/runtime/NMT/ThreadedMallocTestType.java
+++ b/test/hotspot/jtreg/runtime/NMT/ThreadedMallocTestType.java
@@ -61,6 +61,10 @@ public class ThreadedMallocTestType {
     allocThread.start();
     allocThread.join();
 
+		System.out.println("memAlloc1:"+memAlloc1);
+		System.out.println("memAlloc2:"+memAlloc2);
+		System.out.println("memAlloc3:"+memAlloc3);
+
     // Run 'jcmd <pid> VM.native_memory summary'
     pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "summary"});
     output = new OutputAnalyzer(pb.start());

--- a/test/hotspot/jtreg/runtime/NMT/ThreadedMallocTestType.java
+++ b/test/hotspot/jtreg/runtime/NMT/ThreadedMallocTestType.java
@@ -61,9 +61,9 @@ public class ThreadedMallocTestType {
     allocThread.start();
     allocThread.join();
 
-		System.out.println("memAlloc1:"+memAlloc1);
-		System.out.println("memAlloc2:"+memAlloc2);
-		System.out.println("memAlloc3:"+memAlloc3);
+    System.out.println("memAlloc1:"+memAlloc1);
+    System.out.println("memAlloc2:"+memAlloc2);
+    System.out.println("memAlloc3:"+memAlloc3);
 
     // Run 'jcmd <pid> VM.native_memory summary'
     pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "summary"});


### PR DESCRIPTION
To help debug [JDK-8286345](https://bugs.openjdk.org/browse/JDK-8286345) it would have been extremely useful to know the values of allocated memory pointers in `runtime/NMT/ThreadedMallocTestType.java`, so let's add those.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289162](https://bugs.openjdk.org/browse/JDK-8289162): runtime/NMT/ThreadedMallocTestType.java should print out memory allocations to help debug


### Reviewers
 * [Harold Seigel](https://openjdk.org/census#hseigel) (@hseigel - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9675/head:pull/9675` \
`$ git checkout pull/9675`

Update a local copy of the PR: \
`$ git checkout pull/9675` \
`$ git pull https://git.openjdk.org/jdk pull/9675/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9675`

View PR using the GUI difftool: \
`$ git pr show -t 9675`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9675.diff">https://git.openjdk.org/jdk/pull/9675.diff</a>

</details>
