### PR TITLE
6227536: KeyGenerator.init() methods do not throw IllegalArgumentException for keysize == 0

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/HmacMD5KeyGenerator.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/HmacMD5KeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/com/sun/crypto/provider/HmacMD5KeyGenerator.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/HmacMD5KeyGenerator.java
@@ -89,7 +89,7 @@ public final class HmacMD5KeyGenerator extends KeyGeneratorSpi {
      */
     protected void engineInit(int keysize, SecureRandom random) {
 
-        if(keysize <= 0) {
+        if (keysize <= 0) {
             throw new IllegalArgumentException("keysize must not be <= 0 for SunJCE");
         }
 

--- a/src/java.base/share/classes/com/sun/crypto/provider/HmacMD5KeyGenerator.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/HmacMD5KeyGenerator.java
@@ -90,7 +90,8 @@ public final class HmacMD5KeyGenerator extends KeyGeneratorSpi {
     protected void engineInit(int keysize, SecureRandom random) {
 
         if (keysize <= 0) {
-            throw new IllegalArgumentException("keysize must not be <= 0 for SunJCE");
+            throw new IllegalArgumentException("keysize must not be <= 0 for " +
+                    "SunJCE");
         }
 
         this.keysize = (keysize+7) / 8;

--- a/src/java.base/share/classes/com/sun/crypto/provider/HmacMD5KeyGenerator.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/HmacMD5KeyGenerator.java
@@ -90,8 +90,7 @@ public final class HmacMD5KeyGenerator extends KeyGeneratorSpi {
     protected void engineInit(int keysize, SecureRandom random) {
 
         if (keysize <= 0) {
-            throw new IllegalArgumentException("keysize must not be <= 0 for " +
-                    "SunJCE");
+            throw new IllegalArgumentException("keysize must not be <= 0");
         }
 
         this.keysize = (keysize+7) / 8;

--- a/src/java.base/share/classes/com/sun/crypto/provider/HmacMD5KeyGenerator.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/HmacMD5KeyGenerator.java
@@ -88,6 +88,11 @@ public final class HmacMD5KeyGenerator extends KeyGeneratorSpi {
      * @param random the source of randomness for this key generator
      */
     protected void engineInit(int keysize, SecureRandom random) {
+
+        if(keysize <= 0) {
+            throw new IllegalArgumentException("keysize must not be <= 0 for SunJCE");
+        }
+
         this.keysize = (keysize+7) / 8;
         this.engineInit(random);
     }

--- a/src/java.base/share/classes/com/sun/crypto/provider/HmacSHA1KeyGenerator.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/HmacSHA1KeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/com/sun/crypto/provider/HmacSHA1KeyGenerator.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/HmacSHA1KeyGenerator.java
@@ -88,6 +88,11 @@ public final class HmacSHA1KeyGenerator extends KeyGeneratorSpi {
      * @param random the source of randomness for this key generator
      */
     protected void engineInit(int keysize, SecureRandom random) {
+
+        if(keysize <= 0) {
+            throw new IllegalArgumentException("keysize must not be <= 0 for SunJCE");
+        }
+
         this.keysize = (keysize+7) / 8;
         this.engineInit(random);
     }

--- a/src/java.base/share/classes/com/sun/crypto/provider/HmacSHA1KeyGenerator.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/HmacSHA1KeyGenerator.java
@@ -90,7 +90,8 @@ public final class HmacSHA1KeyGenerator extends KeyGeneratorSpi {
     protected void engineInit(int keysize, SecureRandom random) {
 
         if (keysize <= 0) {
-            throw new IllegalArgumentException("keysize must not be <= 0 for SunJCE");
+            throw new IllegalArgumentException("keysize must not be <= 0 for " +
+                    "SunJCE");
         }
 
         this.keysize = (keysize+7) / 8;

--- a/src/java.base/share/classes/com/sun/crypto/provider/HmacSHA1KeyGenerator.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/HmacSHA1KeyGenerator.java
@@ -89,7 +89,7 @@ public final class HmacSHA1KeyGenerator extends KeyGeneratorSpi {
      */
     protected void engineInit(int keysize, SecureRandom random) {
 
-        if(keysize <= 0) {
+        if (keysize <= 0) {
             throw new IllegalArgumentException("keysize must not be <= 0 for SunJCE");
         }
 

--- a/src/java.base/share/classes/com/sun/crypto/provider/HmacSHA1KeyGenerator.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/HmacSHA1KeyGenerator.java
@@ -90,8 +90,7 @@ public final class HmacSHA1KeyGenerator extends KeyGeneratorSpi {
     protected void engineInit(int keysize, SecureRandom random) {
 
         if (keysize <= 0) {
-            throw new IllegalArgumentException("keysize must not be <= 0 for " +
-                    "SunJCE");
+            throw new IllegalArgumentException("keysize must not be <= 0");
         }
 
         this.keysize = (keysize+7) / 8;

--- a/test/jdk/com/sun/crypto/provider/KeyGenerator/Test6227536.java
+++ b/test/jdk/com/sun/crypto/provider/KeyGenerator/Test6227536.java
@@ -52,7 +52,11 @@ public class Test6227536 {
 
         for (String keyGenToTest : test.keyGensToTest) {
 
-            System.out.println(testName + ": " + keyGenToTest + ((test.execute(keyGenToTest)) ? " Passed!" : " Failed!"));
+            if (test.execute(keyGenToTest)) {
+
+                System.out.println(testName + ": " + keyGenToTest + " Passed!");
+
+            }
 
         }
 

--- a/test/jdk/com/sun/crypto/provider/KeyGenerator/Test6227536.java
+++ b/test/jdk/com/sun/crypto/provider/KeyGenerator/Test6227536.java
@@ -23,10 +23,13 @@
 
 /*
  * @test
+ * @library /test/lib
  * @bug 6227536
  * @summary Verify HmacSHA1 and HmacMD5 KeyGenerators throw an Exception when a keysize of zero is requested
  * @author Kevin Driver
  */
+
+import jdk.test.lib.Utils;
 
 import javax.crypto.KeyGenerator;
 
@@ -35,17 +38,9 @@ public class Test6227536 {
     public boolean execute(String algo) throws Exception {
         KeyGenerator kg = KeyGenerator.getInstance(algo, "SunJCE");
 
-        try {
+        Utils.runAndCheckException(() -> kg.init(0), IllegalArgumentException.class);
 
-            kg.init(0);
-
-        } catch (IllegalArgumentException iae) {
-            // exception was thrown
-            return true;
-        }
-
-        // exception was not thrown
-        throw new Exception("expected exception not thrown by " + algo + "KeyGenerator");
+        return true;
     }
 
     public static void main (String[] args) throws Exception {

--- a/test/jdk/com/sun/crypto/provider/KeyGenerator/Test6227536.java
+++ b/test/jdk/com/sun/crypto/provider/KeyGenerator/Test6227536.java
@@ -25,7 +25,8 @@
  * @test
  * @library /test/lib
  * @bug 6227536
- * @summary Verify HmacSHA1 and HmacMD5 KeyGenerators throw an Exception when a keysize of zero is requested
+ * @summary Verify HmacSHA1 and HmacMD5 KeyGenerators throw an Exception when
+ *  a keysize of zero is requested
  * @author Kevin Driver
  */
 
@@ -35,26 +36,26 @@ import javax.crypto.KeyGenerator;
 
 public class Test6227536 {
 
+    String[] keyGensToTest = new String[]{"HmacSHA1", "HmacMD5"};
+
     public boolean execute(String algo) throws Exception {
         KeyGenerator kg = KeyGenerator.getInstance(algo, "SunJCE");
 
-        Utils.runAndCheckException(() -> kg.init(0), IllegalArgumentException.class);
+        Utils.runAndCheckException(() -> kg.init(0),
+                IllegalArgumentException.class);
 
         return true;
     }
 
-    public static void main (String[] args) throws Exception {
+    public static void main(String[] args) throws Exception {
         Test6227536 test = new Test6227536();
         String testName = test.getClass().getName();
-        if (test.execute("HmacSHA1")) {
-            System.out.println(testName + ": HmacSHA1 Passed!");
-        } else {
-            System.out.println(testName + ": HmacSHA1 Failed!");
+
+        for (String keyGenToTest : test.keyGensToTest) {
+
+            System.out.println(testName + ": " + keyGenToTest + ((test.execute(keyGenToTest)) ? " Passed!" : " Failed!"));
+
         }
-        if (test.execute("HmacMD5")) {
-            System.out.println(testName + ": HmacMD5 Passed!");
-        } else {
-            System.out.println(testName + ": HmacMD5 Failed!");
-        }
+
     }
 }

--- a/test/jdk/com/sun/crypto/provider/KeyGenerator/Test6227536.java
+++ b/test/jdk/com/sun/crypto/provider/KeyGenerator/Test6227536.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6227536
+ * @summary Verify HmacSHA1 and HmacMD5 KeyGenerators throw an Exception when a keysize of zero is requested
+ * @author Kevin Driver
+ */
+
+import javax.crypto.KeyGenerator;
+
+public class Test6227536 {
+
+    public boolean execute(String algo) throws Exception {
+        KeyGenerator kg = KeyGenerator.getInstance(algo, "SunJCE");
+
+        try {
+
+            kg.init(0);
+
+        } catch (IllegalArgumentException iae) {
+            // exception was thrown
+            return true;
+        }
+
+        // exception was not thrown
+        throw new Exception("expected exception not thrown by " + algo + "KeyGenerator");
+    }
+
+    public static void main (String[] args) throws Exception {
+        Test6227536 test = new Test6227536();
+        String testName = test.getClass().getName();
+        if (test.execute("HmacSHA1")) {
+            System.out.println(testName + ": HmacSHA1 Passed!");
+        } else {
+            System.out.println(testName + ": HmacSHA1 Failed!");
+        }
+        if (test.execute("HmacMD5")) {
+            System.out.println(testName + ": HmacMD5 Passed!");
+        } else {
+            System.out.println(testName + ": HmacMD5 Failed!");
+        }
+    }
+}

--- a/test/jdk/com/sun/crypto/provider/KeyGenerator/Test6227536.java
+++ b/test/jdk/com/sun/crypto/provider/KeyGenerator/Test6227536.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/crypto/provider/KeyGenerator/Test6227536.java
+++ b/test/jdk/com/sun/crypto/provider/KeyGenerator/Test6227536.java
@@ -27,7 +27,6 @@
  * @bug 6227536
  * @summary Verify HmacSHA1 and HmacMD5 KeyGenerators throw an Exception when
  *  a keysize of zero is requested
- * @author Kevin Driver
  */
 
 import jdk.test.lib.Utils;


### PR DESCRIPTION
As mentioned in the bug report, this issue *should not* be a framework-level issue, since potentially an individual provider could create a keysize of zero to have a certain significance. 

In the changes made here for `HmacMD5`- and `HmacSHA1`- `KeyGenerator`s, the check is for `keysize <= 0` and this message indicates this is a check characteristic to the `SunJCE` provider.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6227536](https://bugs.openjdk.org/browse/JDK-6227536): KeyGenerator.init() methods do not throw IllegalArgumentException for keysize == 0


### Reviewers
 * [Bradford Wetmore](https://openjdk.org/census#wetmore) (@bradfordwetmore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9679/head:pull/9679` \
`$ git checkout pull/9679`

Update a local copy of the PR: \
`$ git checkout pull/9679` \
`$ git pull https://git.openjdk.org/jdk pull/9679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9679`

View PR using the GUI difftool: \
`$ git pr show -t 9679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9679.diff">https://git.openjdk.org/jdk/pull/9679.diff</a>

</details>
