### PR TITLE
8259687: JTabbedPane.setComponentAt doesn't hide previously visible tab component

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
@@ -1598,8 +1598,8 @@ public class JTabbedPane extends JComponent
             boolean selectedPage = (getSelectedIndex() == index);
 
             if (selectedPage) {
-                if (this.visComp != null &&
-                        !this.visComp.equals(component)) {
+                if (this.visComp != null && this.visComp.isVisible()
+                        && !this.visComp.equals(component)) {
                     // previous component visibility is set to false
                     this.visComp.setVisible(false);
                 }

--- a/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
@@ -1598,6 +1598,11 @@ public class JTabbedPane extends JComponent
             boolean selectedPage = (getSelectedIndex() == index);
 
             if (selectedPage) {
+                if (this.visComp != null &&
+                        !this.visComp.equals(component)) {
+                    // previous component visibility is set to false
+                    this.visComp.setVisible(false);
+                }
                 this.visComp = component;
             }
 

--- a/test/jdk/javax/swing/JTabbedPane/TabbedPaneBug.java
+++ b/test/jdk/javax/swing/JTabbedPane/TabbedPaneBug.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.AWTException;
+import java.awt.Color;
+import java.awt.Robot;
+import java.lang.reflect.InvocationTargetException;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @bug 8265586
+ * @key headful
+ * @summary Tests whether the
+ * @run main/othervm TabbedPaneBug
+ */
+public class TabbedPaneBug {
+
+    private static final int FIRST = 0;
+    private static final int SECOND = 1;
+    private static JFrame window;
+    private static JTabbedPane tabs;
+    private static final JPanel firstTab = new JPanel();
+    private static final JPanel secondTab = new JPanel();
+//    private static JLabel firstTab = new JLabel("First Contents");
+//    private static JLabel secondTab = new JLabel("Second Contents");
+
+    public static void main(String[] args) throws AWTException,
+            InterruptedException, InvocationTargetException {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(200);
+            SwingUtilities.invokeAndWait(() -> createAndShowGUI());
+
+            robot.waitForIdle();
+            robot.mouseMove(window.getWidth()/2, window.getHeight()/2);
+            robot.delay(500);
+            Color actualColor = robot.getPixelColor(window.getWidth()/2,
+                    window.getHeight()/2);
+            robot.delay(200);
+
+            if (actualColor.equals(Color.RED)) {
+                throw new RuntimeException("The second (selected) component" +
+                        " is not on the top!!");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (window != null) {
+                    window.dispose();
+                }
+            });
+        }
+
+    }
+
+    private static void createAndShowGUI() {
+        window = new JFrame("Tabbed Pane Bug");
+        tabs = new JTabbedPane();
+
+        firstTab.setBackground(Color.RED);
+        secondTab.setBackground(Color.GREEN);
+
+        tabs.addChangeListener((e) -> {
+            if (tabs.getSelectedComponent() == null) {
+                switch (tabs.getSelectedIndex()) {
+                    case FIRST:
+                        tabs.setComponentAt(tabs.getSelectedIndex(), firstTab);
+                        break;
+                    case SECOND:
+                        tabs.setComponentAt(tabs.getSelectedIndex(), secondTab);
+                        break;
+                    default:
+                }
+            }
+        });
+
+        tabs.addTab("First", null);
+        tabs.addTab("Second", null);
+
+        tabs.setSelectedIndex(SECOND);
+        window.add(tabs);
+        window.setSize(200, 200);
+        window.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        window.setVisible(true);
+    }
+}

--- a/test/jdk/javax/swing/JTabbedPane/TabbedPaneBug.java
+++ b/test/jdk/javax/swing/JTabbedPane/TabbedPaneBug.java
@@ -32,7 +32,7 @@ import javax.swing.SwingUtilities;
 
 /*
  * @test
- * @bug 8265586
+ * @bug 8259687
  * @key headful
  * @summary Tests whether the selected tab's component is on the top and visible.
  * @run main TabbedPaneBug

--- a/test/jdk/javax/swing/JTabbedPane/TabbedPaneBug.java
+++ b/test/jdk/javax/swing/JTabbedPane/TabbedPaneBug.java
@@ -34,8 +34,8 @@ import javax.swing.SwingUtilities;
  * @test
  * @bug 8265586
  * @key headful
- * @summary Tests whether the
- * @run main/othervm TabbedPaneBug
+ * @summary Tests whether the selected tab's component is on the top and visible.
+ * @run main TabbedPaneBug
  */
 public class TabbedPaneBug {
 
@@ -45,8 +45,6 @@ public class TabbedPaneBug {
     private static JTabbedPane tabs;
     private static final JPanel firstTab = new JPanel();
     private static final JPanel secondTab = new JPanel();
-//    private static JLabel firstTab = new JLabel("First Contents");
-//    private static JLabel secondTab = new JLabel("Second Contents");
 
     public static void main(String[] args) throws AWTException,
             InterruptedException, InvocationTargetException {


### PR DESCRIPTION
A simple change listener is used in JTabbedPane to lazily fill with components - this is done by adding the components to JTabbedPane using the `setComponentAt` in the change listener.

Previously, if the change listener was placed before calling `addTab()` , the previous visible component was overlapping with the current visible component. To fix it, the visibility of previous component is set to false before the current component's visibility is set to true in `setComponentAt`.

Following are the before and after fix screenshots-

![image](https://user-images.githubusercontent.com/95945681/181658303-ff3a7df7-5af6-4e76-a103-45d4d76480c3.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8259687](https://bugs.openjdk.org/browse/JDK-8259687): JTabbedPane.setComponentAt doesn't hide previously visible tab component


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9681/head:pull/9681` \
`$ git checkout pull/9681`

Update a local copy of the PR: \
`$ git checkout pull/9681` \
`$ git pull https://git.openjdk.org/jdk pull/9681/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9681`

View PR using the GUI difftool: \
`$ git pr show -t 9681`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9681.diff">https://git.openjdk.org/jdk/pull/9681.diff</a>

</details>
