### PR TITLE
8290740: Catalog not used when the handler is null

### DIFF
--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogSupport.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ import org.xml.sax.InputSource;
 
 /**
  * @test
- * @bug 8158084 8162438 8162442 8166220 8166398
+ * @bug 8158084 8162438 8162442 8166220 8166398 8290740
  * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
  * @run testng/othervm -DrunSecMngr=true -Djava.security.manager=allow catalog.CatalogSupport
  * @run testng/othervm catalog.CatalogSupport
@@ -100,6 +100,17 @@ public class CatalogSupport extends CatalogSupportBase {
     @Test(dataProvider = "data_XIA")
     public void testXIncludeA(boolean setUseCatalog, boolean useCatalog, String catalog,
             String xml, MyHandler handler, String expected) throws Exception {
+        testXInclude(setUseCatalog, useCatalog, catalog, xml, handler, expected);
+    }
+
+    /*
+       Verifies that the Catalog is used when the handler is null. The test shall
+       run through without an Exception (that was thrown before the fix).
+    */
+    @Test(dataProvider = "data_XIA")
+    public void testXIncludeA_NullHandler(boolean setUseCatalog, boolean useCatalog, String catalog,
+            String xml, MyHandler handler, String expected) throws Exception {
+        handler = null;
         testXInclude(setUseCatalog, useCatalog, catalog, xml, handler, expected);
     }
 

--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogSupportBase.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogSupportBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -306,10 +306,13 @@ public class CatalogSupportBase {
     public void testXInclude(boolean setUseCatalog, boolean useCatalog, String catalog,
             String xml, MyHandler handler, String expected) throws Exception {
         SAXParser parser = getSAXParser(setUseCatalog, useCatalog, catalog);
-
         parser.parse(new InputSource(new StringReader(xml)), handler);
-        debugPrint("handler.result:" + handler.getResult());
-        Assert.assertEquals(handler.getResult().trim(), expected);
+        // the test verifies the result if handler != null, or no exception
+        // is thrown if handler == null.
+        if (handler != null) {
+            debugPrint("handler.result:" + handler.getResult());
+            Assert.assertEquals(handler.getResult().trim(), expected);
+        }
     }
 
     /*


### PR DESCRIPTION
Patch to make sure the Catalog is used even when the handler is null.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290740](https://bugs.openjdk.org/browse/JDK-8290740): Catalog not used when the handler is null


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9682/head:pull/9682` \
`$ git checkout pull/9682`

Update a local copy of the PR: \
`$ git checkout pull/9682` \
`$ git pull https://git.openjdk.org/jdk pull/9682/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9682`

View PR using the GUI difftool: \
`$ git pr show -t 9682`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9682.diff">https://git.openjdk.org/jdk/pull/9682.diff</a>

</details>
