### PR TITLE
8291118: [vectorapi] Optimize the implementation of lanewise FIRST_NONZERO

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -759,11 +759,9 @@ public abstract class ByteVector extends AbstractVector<Byte> {
 
         if (opKind(op, VO_SPECIAL  | VO_SHIFT)) {
             if (op == FIRST_NONZERO) {
-                // FIXME: Support this in the JIT.
-                VectorMask<Byte> thisNZ
-                    = this.viewAsIntegralLanes().compare(NE, (byte) 0);
-                that = that.blend((byte) 0, thisNZ.cast(vspecies()));
-                op = OR_UNCHECKED;
+                VectorMask<Byte> mask
+                    = this.compare(EQ, (byte) 0);
+                return this.blend(that, mask);
             }
             if (opKind(op, VO_SHIFT)) {
                 // As per shift specification for Java, mask the shift count.
@@ -809,11 +807,9 @@ public abstract class ByteVector extends AbstractVector<Byte> {
 
         if (opKind(op, VO_SPECIAL  | VO_SHIFT)) {
             if (op == FIRST_NONZERO) {
-                // FIXME: Support this in the JIT.
-                VectorMask<Byte> thisNZ
-                    = this.viewAsIntegralLanes().compare(NE, (byte) 0);
-                that = that.blend((byte) 0, thisNZ.cast(vspecies()));
-                op = OR_UNCHECKED;
+                VectorMask<Byte> mask
+                    = this.compare(EQ, (byte) 0, m);
+                return this.blend(that, mask);
             }
             if (opKind(op, VO_SHIFT)) {
                 // As per shift specification for Java, mask the shift count.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -764,15 +764,9 @@ public abstract class DoubleVector extends AbstractVector<Double> {
 
         if (opKind(op, VO_SPECIAL )) {
             if (op == FIRST_NONZERO) {
-                // FIXME: Support this in the JIT.
-                VectorMask<Long> thisNZ
-                    = this.viewAsIntegralLanes().compare(NE, (long) 0);
-                that = that.blend((double) 0, thisNZ.cast(vspecies()));
-                op = OR_UNCHECKED;
-                // FIXME: Support OR_UNCHECKED on float/double also!
-                return this.viewAsIntegralLanes()
-                    .lanewise(op, that.viewAsIntegralLanes())
-                    .viewAsFloatingLanes();
+                VectorMask<Long> mask
+                    = this.viewAsIntegralLanes().compare(EQ, (long) 0);
+                return this.blend(that, mask.cast(vspecies()));
             }
         }
 
@@ -803,7 +797,10 @@ public abstract class DoubleVector extends AbstractVector<Double> {
 
         if (opKind(op, VO_SPECIAL )) {
             if (op == FIRST_NONZERO) {
-                return blend(lanewise(op, v), m);
+                LongVector bits = this.viewAsIntegralLanes();
+                VectorMask<Long> mask
+                    = bits.compare(EQ, (long) 0, m.cast(bits.vspecies()));
+                return this.blend(that, mask.cast(vspecies()));
             }
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -764,15 +764,9 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
         if (opKind(op, VO_SPECIAL )) {
             if (op == FIRST_NONZERO) {
-                // FIXME: Support this in the JIT.
-                VectorMask<Integer> thisNZ
-                    = this.viewAsIntegralLanes().compare(NE, (int) 0);
-                that = that.blend((float) 0, thisNZ.cast(vspecies()));
-                op = OR_UNCHECKED;
-                // FIXME: Support OR_UNCHECKED on float/double also!
-                return this.viewAsIntegralLanes()
-                    .lanewise(op, that.viewAsIntegralLanes())
-                    .viewAsFloatingLanes();
+                VectorMask<Integer> mask
+                    = this.viewAsIntegralLanes().compare(EQ, (int) 0);
+                return this.blend(that, mask.cast(vspecies()));
             }
         }
 
@@ -803,7 +797,10 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
         if (opKind(op, VO_SPECIAL )) {
             if (op == FIRST_NONZERO) {
-                return blend(lanewise(op, v), m);
+                IntVector bits = this.viewAsIntegralLanes();
+                VectorMask<Integer> mask
+                    = bits.compare(EQ, (int) 0, m.cast(bits.vspecies()));
+                return this.blend(that, mask.cast(vspecies()));
             }
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -759,11 +759,9 @@ public abstract class IntVector extends AbstractVector<Integer> {
 
         if (opKind(op, VO_SPECIAL  | VO_SHIFT)) {
             if (op == FIRST_NONZERO) {
-                // FIXME: Support this in the JIT.
-                VectorMask<Integer> thisNZ
-                    = this.viewAsIntegralLanes().compare(NE, (int) 0);
-                that = that.blend((int) 0, thisNZ.cast(vspecies()));
-                op = OR_UNCHECKED;
+                VectorMask<Integer> mask
+                    = this.compare(EQ, (int) 0);
+                return this.blend(that, mask);
             }
             if (opKind(op, VO_SHIFT)) {
                 // As per shift specification for Java, mask the shift count.
@@ -809,11 +807,9 @@ public abstract class IntVector extends AbstractVector<Integer> {
 
         if (opKind(op, VO_SPECIAL  | VO_SHIFT)) {
             if (op == FIRST_NONZERO) {
-                // FIXME: Support this in the JIT.
-                VectorMask<Integer> thisNZ
-                    = this.viewAsIntegralLanes().compare(NE, (int) 0);
-                that = that.blend((int) 0, thisNZ.cast(vspecies()));
-                op = OR_UNCHECKED;
+                VectorMask<Integer> mask
+                    = this.compare(EQ, (int) 0, m);
+                return this.blend(that, mask);
             }
             if (opKind(op, VO_SHIFT)) {
                 // As per shift specification for Java, mask the shift count.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -717,11 +717,9 @@ public abstract class LongVector extends AbstractVector<Long> {
 
         if (opKind(op, VO_SPECIAL  | VO_SHIFT)) {
             if (op == FIRST_NONZERO) {
-                // FIXME: Support this in the JIT.
-                VectorMask<Long> thisNZ
-                    = this.viewAsIntegralLanes().compare(NE, (long) 0);
-                that = that.blend((long) 0, thisNZ.cast(vspecies()));
-                op = OR_UNCHECKED;
+                VectorMask<Long> mask
+                    = this.compare(EQ, (long) 0);
+                return this.blend(that, mask);
             }
             if (opKind(op, VO_SHIFT)) {
                 // As per shift specification for Java, mask the shift count.
@@ -767,11 +765,9 @@ public abstract class LongVector extends AbstractVector<Long> {
 
         if (opKind(op, VO_SPECIAL  | VO_SHIFT)) {
             if (op == FIRST_NONZERO) {
-                // FIXME: Support this in the JIT.
-                VectorMask<Long> thisNZ
-                    = this.viewAsIntegralLanes().compare(NE, (long) 0);
-                that = that.blend((long) 0, thisNZ.cast(vspecies()));
-                op = OR_UNCHECKED;
+                VectorMask<Long> mask
+                    = this.compare(EQ, (long) 0, m);
+                return this.blend(that, mask);
             }
             if (opKind(op, VO_SHIFT)) {
                 // As per shift specification for Java, mask the shift count.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -759,11 +759,9 @@ public abstract class ShortVector extends AbstractVector<Short> {
 
         if (opKind(op, VO_SPECIAL  | VO_SHIFT)) {
             if (op == FIRST_NONZERO) {
-                // FIXME: Support this in the JIT.
-                VectorMask<Short> thisNZ
-                    = this.viewAsIntegralLanes().compare(NE, (short) 0);
-                that = that.blend((short) 0, thisNZ.cast(vspecies()));
-                op = OR_UNCHECKED;
+                VectorMask<Short> mask
+                    = this.compare(EQ, (short) 0);
+                return this.blend(that, mask);
             }
             if (opKind(op, VO_SHIFT)) {
                 // As per shift specification for Java, mask the shift count.
@@ -809,11 +807,9 @@ public abstract class ShortVector extends AbstractVector<Short> {
 
         if (opKind(op, VO_SPECIAL  | VO_SHIFT)) {
             if (op == FIRST_NONZERO) {
-                // FIXME: Support this in the JIT.
-                VectorMask<Short> thisNZ
-                    = this.viewAsIntegralLanes().compare(NE, (short) 0);
-                that = that.blend((short) 0, thisNZ.cast(vspecies()));
-                op = OR_UNCHECKED;
+                VectorMask<Short> mask
+                    = this.compare(EQ, (short) 0, m);
+                return this.blend(that, mask);
             }
             if (opKind(op, VO_SHIFT)) {
                 // As per shift specification for Java, mask the shift count.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -839,17 +839,9 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
         if (opKind(op, VO_SPECIAL {#if[!FP]? | VO_SHIFT})) {
             if (op == FIRST_NONZERO) {
-                // FIXME: Support this in the JIT.
-                VectorMask<$Boxbitstype$> thisNZ
-                    = this.viewAsIntegralLanes().compare(NE, ($bitstype$) 0);
-                that = that.blend(($type$) 0, thisNZ.cast(vspecies()));
-                op = OR_UNCHECKED;
-#if[FP]
-                // FIXME: Support OR_UNCHECKED on float/double also!
-                return this.viewAsIntegralLanes()
-                    .lanewise(op, that.viewAsIntegralLanes())
-                    .viewAsFloatingLanes();
-#end[FP]
+                VectorMask<$Boxbitstype$> mask
+                    = this{#if[FP]?.viewAsIntegralLanes()}.compare(EQ, ($bitstype$) 0);
+                return this.blend(that, mask{#if[FP]?.cast(vspecies())});
             }
 #if[BITWISE]
 #if[!FP]
@@ -900,13 +892,14 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         if (opKind(op, VO_SPECIAL {#if[!FP]? | VO_SHIFT})) {
             if (op == FIRST_NONZERO) {
 #if[FP]
-                return blend(lanewise(op, v), m);
+                $Bitstype$Vector bits = this.viewAsIntegralLanes();
+                VectorMask<$Boxbitstype$> mask
+                    = bits.compare(EQ, ($bitstype$) 0, m.cast(bits.vspecies()));
+                return this.blend(that, mask.cast(vspecies()));
 #else[FP]
-                // FIXME: Support this in the JIT.
-                VectorMask<$Boxbitstype$> thisNZ
-                    = this.viewAsIntegralLanes().compare(NE, ($bitstype$) 0);
-                that = that.blend(($type$) 0, thisNZ.cast(vspecies()));
-                op = OR_UNCHECKED;
+                VectorMask<$Boxtype$> mask
+                    = this.compare(EQ, ($type$) 0, m);
+                return this.blend(that, mask);
 #end[FP]
             }
 #if[BITWISE]


### PR DESCRIPTION
Vector API binary op "`FIRST_NONZERO`" represents the vector operation of "`a != 0 ? a : b`", which can be implemented with existing APIs like "`compare + blend`". The current implementation is more complex especially for the floating point type vectors. The main idea is:

```
1) mask = a.compare(0, ne);
2) b = b.blend(0, mask);
3) result = a | b;
```

And for the floating point types, it needs the vector reinterpretation between the floating point type and the relative integral type, since the final "`OR`" operation is only valid for bitwise integral types.

A simpler implementation is:

```
1) mask = a.compare(0, eq);
2) result = a.blend(b, mask);
```

This could save the final "`OR`" operation and the related reinterpretation between FP and integral types.

Here are the performance data of the "`FIRST_NONZERO`" benchmarks (please see the benchmark details for byte vector from [1]) on ARM NEON system:
```
Benchmark                          (size) Mode  Cnt  Before    After    Units
ByteMaxVector.FIRST_NONZERO         1024  thrpt  15 12107.422 18385.157 ops/ms
ByteMaxVector.FIRST_NONZEROMasked   1024  thrpt  15  9765.282 14739.775 ops/ms
DoubleMaxVector.FIRST_NONZERO       1024  thrpt  15  1798.545  2331.214 ops/ms
DoubleMaxVector.FIRST_NONZEROMasked 1024  thrpt  15  1211.838  1810.644 ops/ms
FloatMaxVector.FIRST_NONZERO        1024  thrpt  15  3491.924  4377.167 ops/ms
FloatMaxVector.FIRST_NONZEROMasked  1024  thrpt  15  2307.085  3606.576 ops/ms
IntMaxVector.FIRST_NONZERO          1024  thrpt  15  3602.727  5610.258 ops/ms
IntMaxVector.FIRST_NONZEROMasked    1024  thrpt  15  2726.843  4210.741 ops/ms
LongMaxVector.FIRST_NONZERO         1024  thrpt  15  1819.886  2974.655 ops/ms
LongMaxVector.FIRST_NONZEROMasked   1024  thrpt  15  1337.737  2315.094 ops/ms
ShortMaxVector.FIRST_NONZERO        1024  thrpt  15  6603.642  9586.320 ops/ms
ShortMaxVector.FIRST_NONZEROMasked  1024  thrpt  15  5222.006  7991.443 ops/ms
```
We can also observe the similar improvement on x86 system.

[1] https://github.com/openjdk/panama-vector/blob/vectorIntrinsics/test/micro/org/openjdk/bench/jdk/incubator/vector/operation/ByteMaxVector.java#L266

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291118](https://bugs.openjdk.org/browse/JDK-8291118): [vectorapi] Optimize the implementation of lanewise FIRST_NONZERO


### Reviewers
 * [Eric Liu](https://openjdk.org/census#eliu) (@theRealELiu - Author)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9683/head:pull/9683` \
`$ git checkout pull/9683`

Update a local copy of the PR: \
`$ git checkout pull/9683` \
`$ git pull https://git.openjdk.org/jdk pull/9683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9683`

View PR using the GUI difftool: \
`$ git pr show -t 9683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9683.diff">https://git.openjdk.org/jdk/pull/9683.diff</a>

</details>
