### PR TITLE
8283276: java/io/ObjectStreamClass/ObjectStreamClassCaching.java fails with various GCs

### DIFF
--- a/test/jdk/java/io/ObjectStreamClass/ObjectStreamClassCaching.java
+++ b/test/jdk/java/io/ObjectStreamClass/ObjectStreamClassCaching.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 /*
- * @test id=with_G1GC
+ * @test id=G1
  * @requires vm.gc.G1
  * @bug 8277072
  * @library /test/lib/
@@ -40,7 +40,7 @@ import static org.testng.Assert.assertTrue;
  */
 
 /*
- * @test id=with_ParallelGC
+ * @test id=Parallel
  * @requires vm.gc.Parallel
  * @bug 8277072
  * @library /test/lib/
@@ -49,7 +49,7 @@ import static org.testng.Assert.assertTrue;
  */
 
 /*
- * @test id=with_ZGC
+ * @test id=Z
  * @requires vm.gc.Z
  * @bug 8277072
  * @library /test/lib/
@@ -58,7 +58,7 @@ import static org.testng.Assert.assertTrue;
  */
 
 /*
- * @test id=with_ShenandoahGC
+ * @test id=Shenandoah
  * @requires vm.gc.Shenandoah
  * @bug 8277072
  * @library /test/lib/
@@ -67,7 +67,7 @@ import static org.testng.Assert.assertTrue;
  */
 
 /*
- * @test id=with_SerialGC
+ * @test id=Serial
  * @requires vm.gc.Serial
  * @bug 8277072
  * @library /test/lib/
@@ -98,10 +98,8 @@ public class ObjectStreamClassCaching {
             oome = true;
         }
         assertFalse(oome, "WeakReference was not cleared although memory was pressed hard");
-        assertFalse(
-            ref1.refersTo(null),
-            "Cache lost entry together with WeakReference being cleared although memory was not under pressure"
-        );
+        assertFalse(ref1.refersTo(null),
+                    "Cache lost entry together with WeakReference being cleared although memory was not under pressure");
         System.gc();
         Thread.sleep(100L);
     }

--- a/test/jdk/java/io/ObjectStreamClass/ObjectStreamClassCaching.java
+++ b/test/jdk/java/io/ObjectStreamClass/ObjectStreamClassCaching.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,29 +30,86 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
-/* @test
+/*
+ * @test id=with_G1GC
+ * @requires vm.gc.G1
  * @bug 8277072
  * @library /test/lib/
- * @summary ObjectStreamClass caches keep ClassLoaders alive
- * @run testng/othervm -Xmx10m -XX:SoftRefLRUPolicyMSPerMB=1 ObjectStreamClassCaching
+ * @summary ObjectStreamClass caches keep ClassLoaders alive (G1 GC)
+ * @run testng/othervm -Xmx64m -XX:+UseG1GC ObjectStreamClassCaching
+ */
+
+/*
+ * @test id=with_ParallelGC
+ * @requires vm.gc.Parallel
+ * @bug 8277072
+ * @library /test/lib/
+ * @summary ObjectStreamClass caches keep ClassLoaders alive (Parallel GC)
+ * @run testng/othervm -Xmx64m -XX:+UseParallelGC ObjectStreamClassCaching
+ */
+
+/*
+ * @test id=with_ZGC
+ * @requires vm.gc.Z
+ * @bug 8277072
+ * @library /test/lib/
+ * @summary ObjectStreamClass caches keep ClassLoaders alive (Z GC)
+ * @run testng/othervm -Xmx64m -XX:+UseZGC ObjectStreamClassCaching
+ */
+
+/*
+ * @test id=with_ShenandoahGC
+ * @requires vm.gc.Shenandoah
+ * @bug 8277072
+ * @library /test/lib/
+ * @summary ObjectStreamClass caches keep ClassLoaders alive (Shenandoah GC)
+ * @run testng/othervm -Xmx64m -XX:+UseShenandoahGC ObjectStreamClassCaching
  */
 public class ObjectStreamClassCaching {
 
+    /**
+     * Test methods execute in same VM and are ordered by name.
+     * We test effectiveness 1st which is sensitive to previous allocations when ZGC is used.
+     */
     @Test
-    public void testCachingEffectiveness() throws Exception {
-        var ref = lookupObjectStreamClass(TestClass.class);
+    public void test1CacheEffectiveness() throws Exception {
+        var list = new ArrayList<>();
+        var ref1 = lookupObjectStreamClass(TestClass1.class);
+        var ref2 = newWeakRef();
+        boolean oome = false;
+        try {
+            while (!ref2.refersTo(null)) {
+                list.add(new byte[1024 * 1024 * 1]); // 1 MiB chunks
+                System.out.println("1MiB allocated...");
+                Thread.sleep(5L);
+            }
+        } catch (OutOfMemoryError e) {
+            // release
+            list = null;
+            oome = true;
+        }
+        assertFalse(oome, "WeakReference was not cleared although memory was pressed hard");
+        assertFalse(
+            ref1.refersTo(null),
+            "Cache lost entry together with WeakReference being cleared although memory was not under pressure"
+        );
         System.gc();
         Thread.sleep(100L);
-        // to trigger any ReferenceQueue processing...
-        lookupObjectStreamClass(AnotherTestClass.class);
-        assertFalse(ref.refersTo(null),
-                    "Cache lost entry although memory was not under pressure");
     }
 
     @Test
-    public void testCacheReleaseUnderMemoryPressure() throws Exception {
-        var ref = lookupObjectStreamClass(TestClass.class);
-        pressMemoryHard(ref);
+    public void test2CacheReleaseUnderMemoryPressure() throws Exception {
+        var list = new ArrayList<>();
+        var ref = lookupObjectStreamClass(TestClass2.class);
+        try {
+            while (!ref.refersTo(null)) {
+                list.add(new byte[1024 * 1024 * 4]); // 4 MiB chunks
+                System.out.println("4MiB allocated...");
+            }
+        } catch (OutOfMemoryError e) {
+            // release
+            list = null;
+        }
         System.gc();
         Thread.sleep(100L);
         assertTrue(ref.refersTo(null),
@@ -60,24 +117,18 @@ public class ObjectStreamClassCaching {
     }
 
     // separate method so that the looked-up ObjectStreamClass is not kept on stack
-    private static WeakReference<?> lookupObjectStreamClass(Class<?> cl) {
+    private static Reference<?> lookupObjectStreamClass(Class<?> cl) {
         return new WeakReference<>(ObjectStreamClass.lookup(cl));
     }
 
-    private static void pressMemoryHard(Reference<?> ref) {
-        try {
-            var list = new ArrayList<>();
-            while (!ref.refersTo(null)) {
-                list.add(new byte[1024 * 1024 * 64]); // 64 MiB chunks
-            }
-        } catch (OutOfMemoryError e) {
-            // release
-        }
+    // separate method so that the new Object() is not kept on stack
+    private static Reference<?> newWeakRef() {
+        return new WeakReference<>(new Object());
     }
-}
 
-class TestClass implements Serializable {
-}
+    static class TestClass1 implements Serializable {
+    }
 
-class AnotherTestClass implements Serializable {
+    static class TestClass2 implements Serializable {
+    }
 }

--- a/test/jdk/java/io/ObjectStreamClass/ObjectStreamClassCaching.java
+++ b/test/jdk/java/io/ObjectStreamClass/ObjectStreamClassCaching.java
@@ -65,6 +65,15 @@ import static org.testng.Assert.assertTrue;
  * @summary ObjectStreamClass caches keep ClassLoaders alive (Shenandoah GC)
  * @run testng/othervm -Xmx64m -XX:+UseShenandoahGC ObjectStreamClassCaching
  */
+
+/*
+ * @test id=with_SerialGC
+ * @requires vm.gc.Serial
+ * @bug 8277072
+ * @library /test/lib/
+ * @summary ObjectStreamClass caches keep ClassLoaders alive (Serial GC)
+ * @run testng/othervm -Xmx64m -XX:+UseSerialGC ObjectStreamClassCaching
+ */
 public class ObjectStreamClassCaching {
 
     /**


### PR DESCRIPTION
This is a continuation of effort from https://github.com/openjdk/jdk/pull/9533 to fix the ObjectStreamClassCaching test which is failing with various GCs != G1. The test class contains 2 test methods:
- test2CacheReleaseUnderMemoryPressure - this one was not logically changed at all - just one method was inlined
- test1CacheEffectiveness - this one now uses a different strategy which doesn't involve calling System.gc() in order to trigger reference processing in GC which is, as test failures reveal, sometimes to aggressive and triggers processing not only WeakReference(s) but also SoftReference(s). Instead, the test now gradually builds up memory pressure while checking what's happening to two WeakReference(s): ref1 - wrapping a cached ObjectStreamClass instance; and: ref2 - wrapping a new Object() instance. The "effectiveness" of caching is confirmed by verifying that weakly reachable new Object() referent of ref2 is GC-ed earlier than softly reachable ObjectStreamClass referent of ref1.
The test now contains several @run(s) with explicitly selected set of GC algorithms: G1, Parallel, ZGC, Shenandoah.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283276](https://bugs.openjdk.org/browse/JDK-8283276): java/io/ObjectStreamClass/ObjectStreamClassCaching.java fails with various GCs


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**) ⚠️ Review applies to [88f29edd](https://git.openjdk.org/jdk/pull/9684/files/88f29edd2f9b211c90ff059c506aef73fcd70846)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9684/head:pull/9684` \
`$ git checkout pull/9684`

Update a local copy of the PR: \
`$ git checkout pull/9684` \
`$ git pull https://git.openjdk.org/jdk pull/9684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9684`

View PR using the GUI difftool: \
`$ git pr show -t 9684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9684.diff">https://git.openjdk.org/jdk/pull/9684.diff</a>

</details>
