### PR TITLE
8291559: x86: compiler/vectorization/TestReverseBitsVector.java fails

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/TestReverseBitsVector.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestReverseBitsVector.java
@@ -25,6 +25,7 @@
  * @bug 8290034
  * @summary Auto-vectorization of Reverse bit operation.
  * @requires vm.compiler2.enabled
+ * @requires os.arch=="amd64" | os.arch=="x86_64"
  * @library /test/lib /
  * @run driver compiler.vectorization.TestReverseBitsVector
  */


### PR DESCRIPTION
See the bug report for reproducer. 

The test checks for `avx2`, but that is not enough for x86_32, as you can have `avx2` supported, but no `Reverse*` nodes emitted anyway. It seems the test is only viable on x86_64 anyway, so fix just gates the tests on that arch.

Additional testing:
 - [x] Affected test on Linux x86_32, now skipped
 - [x] Affected test on Linux x86_64, still passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291559](https://bugs.openjdk.org/browse/JDK-8291559): x86: compiler/vectorization/TestReverseBitsVector.java fails


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9685/head:pull/9685` \
`$ git checkout pull/9685`

Update a local copy of the PR: \
`$ git checkout pull/9685` \
`$ git pull https://git.openjdk.org/jdk pull/9685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9685`

View PR using the GUI difftool: \
`$ git pr show -t 9685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9685.diff">https://git.openjdk.org/jdk/pull/9685.diff</a>

</details>
