### PR TITLE
8291360: Create entry points to expose low-level class file information

### DIFF
--- a/make/data/hotspot-symbols/symbols-unix
+++ b/make/data/hotspot-symbols/symbols-unix
@@ -81,6 +81,7 @@ JVM_GetClassDeclaredConstructors
 JVM_GetClassDeclaredFields
 JVM_GetClassDeclaredMethods
 JVM_GetClassFieldsCount
+JVM_GetClassFileVersion
 JVM_GetClassInterfaces
 JVM_GetClassMethodsCount
 JVM_GetClassModifiers

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -1160,6 +1160,12 @@ JNIEXPORT void JNICALL
 JVM_VirtualThreadUnmountEnd(JNIEnv* env, jobject vthread, jboolean last_unmount);
 
 /*
+ * Value types support.
+ */
+JNIEXPORT jint JNICALL
+JVM_GetClassFileVersion(JNIEnv *env, jclass current);
+
+/*
  * This structure is used by the launcher to get the default thread
  * stack size from the VM using JNI_GetDefaultJavaVMInitArgs() with a
  * version of 1.1.  As it is not supported otherwise, it has been removed

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -1160,7 +1160,7 @@ JNIEXPORT void JNICALL
 JVM_VirtualThreadUnmountEnd(JNIEnv* env, jobject vthread, jboolean last_unmount);
 
 /*
- * Value types support.
+ * Core reflection support.
  */
 JNIEXPORT jint JNICALL
 JVM_GetClassFileVersion(JNIEnv *env, jclass current);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -4047,8 +4047,8 @@ JVM_END
 
 /*
  * Return the current class's class file version.  The low order 16 bits of the
- * the returned jint contains the class's major version.  The high order 16 bits
- * contains the class's minor version.
+ * returned jint contain the class's major version.  The high order 16 bits
+ * contain the class's minor version.
  */
 JVM_ENTRY(jint, JVM_GetClassFileVersion(JNIEnv* env, jclass current))
   oop mirror = JNIHandles::resolve_non_null(current);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -4044,3 +4044,22 @@ JVM_ENTRY(void, JVM_VirtualThreadUnmountEnd(JNIEnv* env, jobject vthread, jboole
   fatal("Should only be called with JVMTI enabled");
 #endif
 JVM_END
+
+/*
+ * Return the current class's class file version.  The low order 16 bits of the
+ * the returned jint contains the class's major version.  The high order 16 bits
+ * contains the class's minor version.
+ */
+JVM_ENTRY(jint, JVM_GetClassFileVersion(JNIEnv* env, jclass current))
+  oop mirror = JNIHandles::resolve_non_null(current);
+  if (java_lang_Class::is_primitive(mirror)) {
+    // return latest major version and minor version of 0.
+    return JVM_CLASSFILE_MAJOR_VERSION;
+  }
+  assert(!java_lang_Class::as_Klass(mirror)->is_array_klass(), "unexpected array class");
+
+  Klass* c = java_lang_Class::as_Klass(mirror);
+  assert(c->is_instance_klass(), "must be");
+  InstanceKlass* ik = InstanceKlass::cast(c);
+  return (ik->minor_version() << 16) | ik->major_version();
+JVM_END

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -4668,4 +4668,44 @@ public final class Class<T> implements java.io.Serializable,
     }
 
     private native Class<?>[] getPermittedSubclasses0();
+
+    /*
+     * Return the class's major and minor class file version packed into an int.
+     * The high order 16 bits contain the class's minor version.  The low order
+     * 16 bits contain the class's major version.
+     *
+     * If the class is an array type then the class file version of its component
+     * type is returned.  If the class is a primitive type then the latest class
+     * file major version is returned and zero is returned for the minor version.
+     */
+    private int getClassFileVersion() {
+        Class<?> component = this;
+        if (isArray()) {
+            do {
+                component = component.getComponentType();
+            } while (component.isArray());
+        }
+        return component.getClassFileVersion0();
+    }
+
+    private native int getClassFileVersion0();
+
+    /*
+     * Return the access flags as they were in the class's bytecode, including
+     * the original setting of ACC_SUPER.
+     *
+     * If the class is an array type then the access flags of the component type is
+     * returned.  If the class is a primitive then ACC_ABSTRACT | ACC_FINAL | ACC_PUBLIC.
+     */
+    private int getClassAccessFlagsRaw() {
+        Class<?> component = this;
+        if (isArray()) {
+            do {
+                component = component.getComponentType();
+            } while (component.isArray());
+        }
+        return component.getClassAccessFlagsRaw0();
+    }
+
+    private native int getClassAccessFlagsRaw0();
 }

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -4679,8 +4679,8 @@ public final class Class<T> implements java.io.Serializable,
      * file major version is returned and zero is returned for the minor version.
      */
     private int getClassFileVersion() {
-        Class<?> component = isArray() ? elementType() : this;
-        return component.getClassFileVersion0();
+        Class<?> c = isArray() ? elementType() : this;
+        return c.getClassFileVersion0();
     }
 
     private native int getClassFileVersion0();
@@ -4693,8 +4693,8 @@ public final class Class<T> implements java.io.Serializable,
      * returned.  If the class is a primitive then ACC_ABSTRACT | ACC_FINAL | ACC_PUBLIC.
      */
     private int getClassAccessFlagsRaw() {
-        Class<?> component = isArray() ? elementType() : this;
-        return component.getClassAccessFlagsRaw0();
+        Class<?> c = isArray() ? elementType() : this;
+        return c.getClassAccessFlagsRaw0();
     }
 
     private native int getClassAccessFlagsRaw0();

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -4674,17 +4674,12 @@ public final class Class<T> implements java.io.Serializable,
      * The high order 16 bits contain the class's minor version.  The low order
      * 16 bits contain the class's major version.
      *
-     * If the class is an array type then the class file version of its component
+     * If the class is an array type then the class file version of its element
      * type is returned.  If the class is a primitive type then the latest class
      * file major version is returned and zero is returned for the minor version.
      */
     private int getClassFileVersion() {
-        Class<?> component = this;
-        if (isArray()) {
-            do {
-                component = component.getComponentType();
-            } while (component.isArray());
-        }
+        Class<?> component = isArray() ? elementType() : this;
         return component.getClassFileVersion0();
     }
 
@@ -4694,16 +4689,11 @@ public final class Class<T> implements java.io.Serializable,
      * Return the access flags as they were in the class's bytecode, including
      * the original setting of ACC_SUPER.
      *
-     * If the class is an array type then the access flags of the component type is
+     * If the class is an array type then the access flags of the element type is
      * returned.  If the class is a primitive then ACC_ABSTRACT | ACC_FINAL | ACC_PUBLIC.
      */
     private int getClassAccessFlagsRaw() {
-        Class<?> component = this;
-        if (isArray()) {
-            do {
-                component = component.getComponentType();
-            } while (component.isArray());
-        }
+        Class<?> component = isArray() ? elementType() : this;
         return component.getClassAccessFlagsRaw0();
     }
 

--- a/src/java.base/share/native/libjava/Class.c
+++ b/src/java.base/share/native/libjava/Class.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,6 +82,8 @@ static JNINativeMethod methods[] = {
     {"getRecordComponents0", "()[" RC,      (void *)&JVM_GetRecordComponents},
     {"isRecord0",            "()Z",         (void *)&JVM_IsRecord},
     {"getPermittedSubclasses0", "()[" CLS,  (void *)&JVM_GetPermittedSubclasses},
+    {"getClassFileVersion0", "()I",         (void *)&JVM_GetClassFileVersion},
+    {"getClassAccessFlagsRaw0", "()I",      (void *)&JVM_GetClassAccessFlags},
 };
 
 #undef OBJ

--- a/test/hotspot/jtreg/runtime/ClassFile/ClassAccessFlagsRawTest.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/ClassAccessFlagsRawTest.java
@@ -42,7 +42,7 @@ public class ClassAccessFlagsRawTest {
         int flags = (int)m.invoke(testClass);
         if (flags != expectedResult) {
             throw new RuntimeException(
-                "expected " + expectedResult + ", got " + flags + " for class " + className);
+                "expected 0x" + Integer.toHexString(expectedResult) + ", got 0x" + Integer.toHexString(flags) + " for class " + className);
         }
     }
 
@@ -51,20 +51,28 @@ public class ClassAccessFlagsRawTest {
         m = cl.getDeclaredMethod("getClassAccessFlagsRaw", new Class[0]);
         m.setAccessible(true);
 
-        testIt("SUPERset", 33);    // ACC_SUPER 0x20 + ACC_PUBLIC 0x1
-        testIt("SUPERnotset", 1);  // ACC_PUBLIC 01
+        testIt("SUPERset", 0x21);  // ACC_SUPER 0x20 + ACC_PUBLIC 0x1
+        testIt("SUPERnotset", Modifier.PUBLIC);
 
         // test primitive array.  should return ACC_ABSTRACT | ACC_FINAL | ACC_PUBLIC.
         int flags = (int)m.invoke((new int[3]).getClass());
-        if (flags != 1041) {
-            throw new RuntimeException("expected 1041, got " + flags + " for primitive array");
+        if (flags != (Modifier.ABSTRACT | Modifier.FINAL | Modifier.PUBLIC)) {
+            throw new RuntimeException(
+                "expected 0x411, got 0x" + Integer.toHexString(flags) + " for primitive array");
         }
 
         // test object array.  should return flags of component.
         flags = (int)m.invoke((new SUPERnotset[2]).getClass());
-        if (flags != 1) {
-            throw new RuntimeException("expected 1, got " + flags + " for object array");
+        if (flags != Modifier.PUBLIC) {
+            throw new RuntimeException(
+                "expected 0x1, got 0x" + Integer.toHexString(flags) + " for object array");
         }
 
+        // test multi-dimensional object array.  should return flags of component.
+        flags = (int)m.invoke((new SUPERnotset[4][2]).getClass());
+        if (flags != Modifier.PUBLIC) {
+            throw new RuntimeException(
+                "expected 0x1, got 0x" + Integer.toHexString(flags) + " for object array");
+        }
     }
 }

--- a/test/hotspot/jtreg/runtime/ClassFile/ClassAccessFlagsRawTest.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/ClassAccessFlagsRawTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/**
+ * @test
+ * @bug 8291360
+ * @summary Test getting a class's raw access flags using java.lang.Class API
+ * @modules java.base/java.lang:open
+ * @compile classAccessFlagsRaw.jcod
+ * @run main/othervm ClassAccessFlagsRawTest
+ */
+
+import java.lang.reflect.*;
+
+public class ClassAccessFlagsRawTest {
+
+    static Method m;
+
+    public static void testIt(String className, int expectedResult) throws Exception {
+        Class<?> testClass = Class.forName(className);
+        int flags = (int)m.invoke(testClass);
+        if (flags != expectedResult) {
+            throw new RuntimeException(
+                "expected " + expectedResult + ", got " + flags + " for class " + className);
+        }
+    }
+
+    public static void main(String argv[]) throws Throwable {
+        Class<?> cl = java.lang.Class.class;
+        m = cl.getDeclaredMethod("getClassAccessFlagsRaw", new Class[0]);
+        m.setAccessible(true);
+
+        testIt("SUPERset", 33);    // ACC_SUPER 0x20 + ACC_PUBLIC 0x1
+        testIt("SUPERnotset", 1);  // ACC_PUBLIC 01
+
+        // test primitive array.  should return ACC_ABSTRACT | ACC_FINAL | ACC_PUBLIC.
+        int flags = (int)m.invoke((new int[3]).getClass());
+        if (flags != 1041) {
+            throw new RuntimeException("expected 1041, got " + flags + " for primitive array");
+        }
+
+        // test object array.  should return flags of component.
+        flags = (int)m.invoke((new SUPERnotset[2]).getClass());
+        if (flags != 1) {
+            throw new RuntimeException("expected 1, got " + flags + " for object array");
+        }
+
+    }
+}

--- a/test/hotspot/jtreg/runtime/ClassFile/ClassFileVersionTest.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/ClassFileVersionTest.java
@@ -41,8 +41,12 @@ public class ClassFileVersionTest {
         Class<?> testClass = Class.forName(className);
         int ver = (int)m.invoke(testClass);
         if (ver != expectedResult) {
+            int exp_minor = (expectedResult >> 16) & 0x0000FFFF;
+            int exp_major = expectedResult & 0x0000FFFF;
+            int got_minor = (ver >> 16) & 0x0000FFFF;
+            int got_major = ver & 0x0000FFFF;
             throw new RuntimeException(
-                "expected " + expectedResult + ", got " + ver + " for class " + className);
+                "Expected " + exp_major + ":" + exp_minor + " but got " + got_major + ":" + got_minor);
         }
     }
 
@@ -54,18 +58,33 @@ public class ClassFileVersionTest {
         testIt("Version64", 64);
         testIt("Version59", 59);
         // test minor version of 65535.
-        testIt("Version64_65535", -65472);  // -65472 = 0xFFFF0040
+        testIt("Version64_65535", 0xFFFF0040);  // 0xFFFF0040 = 64.65535
 
         // test primitive array.  should return latest version.
         int ver = (int)m.invoke((new int[3]).getClass());
         if (ver != 64) {
-            throw new RuntimeException("expected 64, got " + ver + " for primitive array");
+            int got_minor = (ver >> 16) & 0x0000FFFF;
+            int got_major = ver & 0x0000FFFF;
+            throw new RuntimeException(
+                "Expected 64:0, but got " + got_major + ":" + got_minor + " for primitive array");
         }
 
         // test object array.  should return class file version of component.
         ver = (int)m.invoke((new Version59[2]).getClass());
         if (ver != 59) {
-            throw new RuntimeException("expected 59, got " + ver + " for object array");
+            int got_minor = (ver >> 16) & 0x0000FFFF;
+            int got_major = ver & 0x0000FFFF;
+            throw new RuntimeException(
+                "Expected 59:0, but got " + got_major + ":" + got_minor + " for object array");
+        }
+
+        // test multi-dimensional object array.  should return class file version of component.
+        ver = (int)m.invoke((new Version59[3][2]).getClass());
+        if (ver != 59) {
+            int got_minor = (ver >> 16) & 0x0000FFFF;
+            int got_major = ver & 0x0000FFFF;
+            throw new RuntimeException(
+                "Expected 59:0, but got " + got_major + ":" + got_minor + " for object array");
         }
     }
 }

--- a/test/hotspot/jtreg/runtime/ClassFile/ClassFileVersionTest.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/ClassFileVersionTest.java
@@ -57,6 +57,7 @@ public class ClassFileVersionTest {
 
         testIt("Version64", 64);
         testIt("Version59", 59);
+        testIt("Version45_3", 0x3002D);  // 45.3
         // test minor version of 65535.
         testIt("Version64_65535", 0xFFFF0040);  // 0xFFFF0040 = 64.65535
 

--- a/test/hotspot/jtreg/runtime/ClassFile/ClassFileVersionTest.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/ClassFileVersionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/**
+ * @test
+ * @bug 8291360
+ * @summary Test getting the class file version for java.lang.Class API
+ * @modules java.base/java.lang:open
+ * @compile classFileVersions.jcod
+ * @run main/othervm --enable-preview ClassFileVersionTest
+ */
+
+import java.lang.reflect.*;
+
+public class ClassFileVersionTest {
+
+    static Method m;
+
+    public static void testIt(String className, int expectedResult) throws Exception {
+        Class<?> testClass = Class.forName(className);
+        int ver = (int)m.invoke(testClass);
+        if (ver != expectedResult) {
+            throw new RuntimeException(
+                "expected " + expectedResult + ", got " + ver + " for class " + className);
+        }
+    }
+
+    public static void main(String argv[]) throws Throwable {
+        Class<?> cl = java.lang.Class.class;
+        m = cl.getDeclaredMethod("getClassFileVersion", new Class[0]);
+        m.setAccessible(true);
+
+        testIt("Version64", 64);
+        testIt("Version59", 59);
+        // test minor version of 65535.
+        testIt("Version64_65535", -65472);  // -65472 = 0xFFFF0040
+
+        // test primitive array.  should return latest version.
+        int ver = (int)m.invoke((new int[3]).getClass());
+        if (ver != 64) {
+            throw new RuntimeException("expected 64, got " + ver + " for primitive array");
+        }
+
+        // test object array.  should return class file version of component.
+        ver = (int)m.invoke((new Version59[2]).getClass());
+        if (ver != 59) {
+            throw new RuntimeException("expected 59, got " + ver + " for object array");
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/ClassFile/ClassFileVersionTest.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/ClassFileVersionTest.java
@@ -46,7 +46,7 @@ public class ClassFileVersionTest {
             int got_minor = (ver >> 16) & 0x0000FFFF;
             int got_major = ver & 0x0000FFFF;
             throw new RuntimeException(
-                "Expected " + exp_major + ":" + exp_minor + " but got " + got_major + ":" + got_minor);
+                "Expected " + exp_minor + ":" + exp_major + " but got " + got_minor + ":" + got_major);
         }
     }
 
@@ -57,9 +57,9 @@ public class ClassFileVersionTest {
 
         testIt("Version64", 64);
         testIt("Version59", 59);
-        testIt("Version45_3", 0x3002D);  // 45.3
+        testIt("Version45_3", 0x3002D);  // 3:45
         // test minor version of 65535.
-        testIt("Version64_65535", 0xFFFF0040);  // 0xFFFF0040 = 64.65535
+        testIt("Version64_65535", 0xFFFF0040);  // 0xFFFF0040 = 65535:64
 
         // test primitive array.  should return latest version.
         int ver = (int)m.invoke((new int[3]).getClass());
@@ -67,7 +67,7 @@ public class ClassFileVersionTest {
             int got_minor = (ver >> 16) & 0x0000FFFF;
             int got_major = ver & 0x0000FFFF;
             throw new RuntimeException(
-                "Expected 64:0, but got " + got_major + ":" + got_minor + " for primitive array");
+                "Expected 0:64, but got " + got_minor + ":" + got_major + " for primitive array");
         }
 
         // test object array.  should return class file version of component.
@@ -76,7 +76,7 @@ public class ClassFileVersionTest {
             int got_minor = (ver >> 16) & 0x0000FFFF;
             int got_major = ver & 0x0000FFFF;
             throw new RuntimeException(
-                "Expected 59:0, but got " + got_major + ":" + got_minor + " for object array");
+                "Expected 0:59, but got " + got_minor + ":" + got_major + " for object array");
         }
 
         // test multi-dimensional object array.  should return class file version of component.
@@ -85,7 +85,7 @@ public class ClassFileVersionTest {
             int got_minor = (ver >> 16) & 0x0000FFFF;
             int got_major = ver & 0x0000FFFF;
             throw new RuntimeException(
-                "Expected 59:0, but got " + got_major + ":" + got_minor + " for object array");
+                "Expected 0:59, but got " + got_minor + ":" + got_major + " for object array");
         }
     }
 }

--- a/test/hotspot/jtreg/runtime/ClassFile/classAccessFlagsRaw.jcod
+++ b/test/hotspot/jtreg/runtime/ClassFile/classAccessFlagsRaw.jcod
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+// Class with ACC_SUPER set
+class SUPERset {
+  0xCAFEBABE;
+  0; // minor version
+  64; // version
+  [14] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    class #8; // #7     at 0x39
+    Utf8 "SUPERset"; // #8     at 0x3C
+    Utf8 "Code"; // #9     at 0x48
+    Utf8 "LineNumberTable"; // #10     at 0x4F
+    Utf8 "hi"; // #11     at 0x61
+    Utf8 "SourceFile"; // #12     at 0x66
+    Utf8 "SUPERset.java"; // #13     at 0x73
+  } // Constant Pool
+
+  0x0021; // access [ ACC_PUBLIC ACC_SUPER ]
+  #7;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [0] { // Fields
+  } // Fields
+
+  [2] { // Methods
+    {  // method at 0x90
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#9, 29) { // Code at 0x98
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0xAF
+              [1] { // line_number_table
+                0  1; //  at 0xBB
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0xBB
+      0x0009; // access
+      #11; // name_index       : hi
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#9, 25) { // Code at 0xC3
+          0; // max_stack
+          0; // max_locals
+          Bytes[1]{
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0xD6
+              [1] { // line_number_table
+                0  2; //  at 0xE2
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#12, 2) { // SourceFile at 0xE4
+      #13;
+    } // end SourceFile
+  } // Attributes
+} // end class SUPERset
+
+
+// Class with ACC_SUPER not set
+class SUPERnotset {
+  0xCAFEBABE;
+  0; // minor version
+  64; // version
+  [14] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    class #8; // #7     at 0x39
+    Utf8 "SUPERnotset"; // #8     at 0x3C
+    Utf8 "Code"; // #9     at 0x48
+    Utf8 "LineNumberTable"; // #10     at 0x4F
+    Utf8 "hi"; // #11     at 0x61
+    Utf8 "SourceFile"; // #12     at 0x66
+    Utf8 "SUPERnotset.java"; // #13     at 0x73
+  } // Constant Pool
+
+  0x0001; // access [ ACC_PUBLIC ]
+  #7;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [0] { // Fields
+  } // Fields
+
+  [2] { // Methods
+    {  // method at 0x90
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#9, 29) { // Code at 0x98
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0xAF
+              [1] { // line_number_table
+                0  1; //  at 0xBB
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0xBB
+      0x0009; // access
+      #11; // name_index       : hi
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#9, 25) { // Code at 0xC3
+          0; // max_stack
+          0; // max_locals
+          Bytes[1]{
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0xD6
+              [1] { // line_number_table
+                0  2; //  at 0xE2
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#12, 2) { // SourceFile at 0xE4
+      #13;
+    } // end SourceFile
+  } // Attributes
+} // end class SUPERnotset

--- a/test/hotspot/jtreg/runtime/ClassFile/classFileVersions.jcod
+++ b/test/hotspot/jtreg/runtime/ClassFile/classFileVersions.jcod
@@ -290,3 +290,93 @@ class Version64_65535 {
     } // end SourceFile
   } // Attributes
 } // end class Version64_65535
+
+
+// Class with major version 45 and minor version 3
+class Version45_3 {
+  0xCAFEBABE;
+  3; // minor version
+  45; // version
+  [14] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    class #8; // #7     at 0x39
+    Utf8 "Version45_3"; // #8     at 0x3C
+    Utf8 "Code"; // #9     at 0x48
+    Utf8 "LineNumberTable"; // #10     at 0x4F
+    Utf8 "hi"; // #11     at 0x61
+    Utf8 "SourceFile"; // #12     at 0x66
+    Utf8 "Version45_3.java"; // #13     at 0x73
+  } // Constant Pool
+
+  0x0021; // access [ ACC_PUBLIC ACC_SUPER ]
+  #7;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [0] { // Fields
+  } // Fields
+
+  [2] { // Methods
+    {  // method at 0x90
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#9, 29) { // Code at 0x98
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0xAF
+              [1] { // line_number_table
+                0  1; //  at 0xBB
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0xBB
+      0x0009; // access
+      #11; // name_index       : hi
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#9, 25) { // Code at 0xC3
+          0; // max_stack
+          0; // max_locals
+          Bytes[1]{
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0xD6
+              [1] { // line_number_table
+                0  2; //  at 0xE2
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#12, 2) { // SourceFile at 0xE4
+      #13;
+    } // end SourceFile
+  } // Attributes
+} // end class Version45_3

--- a/test/hotspot/jtreg/runtime/ClassFile/classFileVersions.jcod
+++ b/test/hotspot/jtreg/runtime/ClassFile/classFileVersions.jcod
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+// Class with major version 64 and minor version 0
+class Version64 {
+  0xCAFEBABE;
+  0; // minor version
+  64; // version
+  [14] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    class #8; // #7     at 0x39
+    Utf8 "Version64"; // #8     at 0x3C
+    Utf8 "Code"; // #9     at 0x48
+    Utf8 "LineNumberTable"; // #10     at 0x4F
+    Utf8 "hi"; // #11     at 0x61
+    Utf8 "SourceFile"; // #12     at 0x66
+    Utf8 "Version64.java"; // #13     at 0x73
+  } // Constant Pool
+
+  0x0021; // access [ ACC_PUBLIC ACC_SUPER ]
+  #7;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [0] { // Fields
+  } // Fields
+
+  [2] { // Methods
+    {  // method at 0x90
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#9, 29) { // Code at 0x98
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0xAF
+              [1] { // line_number_table
+                0  1; //  at 0xBB
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0xBB
+      0x0009; // access
+      #11; // name_index       : hi
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#9, 25) { // Code at 0xC3
+          0; // max_stack
+          0; // max_locals
+          Bytes[1]{
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0xD6
+              [1] { // line_number_table
+                0  2; //  at 0xE2
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#12, 2) { // SourceFile at 0xE4
+      #13;
+    } // end SourceFile
+  } // Attributes
+} // end class Version64
+
+
+// Class with major version 59 and minor version 0
+class Version59 {
+  0xCAFEBABE;
+  0; // minor version
+  59; // version
+  [14] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    class #8; // #7     at 0x39
+    Utf8 "Version59"; // #8     at 0x3C
+    Utf8 "Code"; // #9     at 0x48
+    Utf8 "LineNumberTable"; // #10     at 0x4F
+    Utf8 "hi"; // #11     at 0x61
+    Utf8 "SourceFile"; // #12     at 0x66
+    Utf8 "Version59.java"; // #13     at 0x73
+  } // Constant Pool
+
+  0x0021; // access [ ACC_PUBLIC ACC_SUPER ]
+  #7;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [0] { // Fields
+  } // Fields
+
+  [2] { // Methods
+    {  // method at 0x90
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#9, 29) { // Code at 0x98
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0xAF
+              [1] { // line_number_table
+                0  1; //  at 0xBB
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0xBB
+      0x0009; // access
+      #11; // name_index       : hi
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#9, 25) { // Code at 0xC3
+          0; // max_stack
+          0; // max_locals
+          Bytes[1]{
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0xD6
+              [1] { // line_number_table
+                0  2; //  at 0xE2
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#12, 2) { // SourceFile at 0xE4
+      #13;
+    } // end SourceFile
+  } // Attributes
+} // end class Version59
+
+
+// Class with major version 64 and minor version 65535
+class Version64_65535 {
+  0xCAFEBABE;
+  65535; // minor version
+  64; // version
+  [14] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    class #8; // #7     at 0x39
+    Utf8 "Version64_65535"; // #8     at 0x3C
+    Utf8 "Code"; // #9     at 0x48
+    Utf8 "LineNumberTable"; // #10     at 0x4F
+    Utf8 "hi"; // #11     at 0x61
+    Utf8 "SourceFile"; // #12     at 0x66
+    Utf8 "Version64_65535.java"; // #13     at 0x73
+  } // Constant Pool
+
+  0x0021; // access [ ACC_PUBLIC ACC_SUPER ]
+  #7;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [0] { // Fields
+  } // Fields
+
+  [2] { // Methods
+    {  // method at 0x90
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#9, 29) { // Code at 0x98
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0xAF
+              [1] { // line_number_table
+                0  1; //  at 0xBB
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0xBB
+      0x0009; // access
+      #11; // name_index       : hi
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#9, 25) { // Code at 0xC3
+          0; // max_stack
+          0; // max_locals
+          Bytes[1]{
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0xD6
+              [1] { // line_number_table
+                0  2; //  at 0xE2
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#12, 2) { // SourceFile at 0xE4
+      #13;
+    } // end SourceFile
+  } // Attributes
+} // end class Version64_65535


### PR DESCRIPTION
Please review this change to fix JDK-8291360.  This fix adds entry points getClassFileVersion() and getClassAccessFlagsRaw() to class java.lang.Class.  The new entry points return the current class's class file version and its raw access flags.

The fix was tested by running Mach5 tiers 1-2 on Linux, Mac OS, and Windows, and Mach5 tiers 1-3 on Linux x64.  Additionally, the JCK lang, vm, and api tests and new regression tests were run locally on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291360](https://bugs.openjdk.org/browse/JDK-8291360): Create entry points to expose low-level class file information


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to [941971dc](https://git.openjdk.org/jdk/pull/9688/files/941971dc6a6f8cc93bdb7f7497c2be10736ec494)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9688/head:pull/9688` \
`$ git checkout pull/9688`

Update a local copy of the PR: \
`$ git checkout pull/9688` \
`$ git pull https://git.openjdk.org/jdk pull/9688/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9688`

View PR using the GUI difftool: \
`$ git pr show -t 9688`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9688.diff">https://git.openjdk.org/jdk/pull/9688.diff</a>

</details>
