### PR TITLE
8282666: nsk/jvmti/PopFrame/popframe004 failed with: TEST FAILED: 30 JVMTI events were generated by the function PopFrame()

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,7 @@ public class popframe004 {
 
         try {
             if (popFrameClsThr.isAlive())
-                popFrameClsThr.join(2000);
+                popFrameClsThr.join();
         } catch (InterruptedException e) {
             out.println("TEST INCOMPLETE: caught " + e);
             totRes = FAILED;


### PR DESCRIPTION
The nsk.jvmti test popframe004 is failing with the JVM args:
  `-Xcomp -XX:+CreateCoredumpOnCrash -ea -esa -XX:CompileThreshold=100 -XX:+UnlockExperimentalVMOptions -XX:-TieredCompilation`

The call to join() below should not have a timeout parameter.
```
        try {
            if (popFrameClsThr.isAlive())
                popFrameClsThr.join(2000);
        } catch (InterruptedException e) {
            out.println("TEST INCOMPLETE: caught " + e);
            totRes = FAILED;
        }
        if (popFrameClsThr.isAlive()) {
            out.println("TEST FAILED: thread with the method of " +
                "the popped frame is still alive");
            totRes = FAILED;
        } 
```
If the execution is slow by any reason (e.g. because of a compilation) then it causes the main thread to fail joining with the target thread which is why the test is failing with these symptoms.

This problem is hard to reproduce even in 1000's of runs on mach5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282666](https://bugs.openjdk.org/browse/JDK-8282666): nsk/jvmti/PopFrame/popframe004 failed with: TEST FAILED: 30 JVMTI events were generated by the function PopFrame()


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9689/head:pull/9689` \
`$ git checkout pull/9689`

Update a local copy of the PR: \
`$ git checkout pull/9689` \
`$ git pull https://git.openjdk.org/jdk pull/9689/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9689`

View PR using the GUI difftool: \
`$ git pr show -t 9689`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9689.diff">https://git.openjdk.org/jdk/pull/9689.diff</a>

</details>
