### PR TITLE
[PATCH] Remove LESS/GREATER/EQUAL fields from java.text.Collator

### DIFF
--- a/src/java.base/share/classes/java/text/Collator.java
+++ b/src/java.base/share/classes/java/text/Collator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,6 @@ package java.text;
 import java.lang.ref.SoftReference;
 import java.text.spi.CollatorProvider;
 import java.util.Locale;
-import java.util.ResourceBundle;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import sun.util.locale.provider.LocaleProviderAdapter;
@@ -327,9 +326,8 @@ public abstract class Collator
      * rules.  false, otherwise.
      * @see java.text.Collator#compare
      */
-    public boolean equals(String source, String target)
-    {
-        return (compare(source, target) == Collator.EQUAL);
+    public boolean equals(String source, String target) {
+        return compare(source, target) == 0;
     }
 
     /**
@@ -492,26 +490,4 @@ public abstract class Collator
     private int decmp = 0;
     private static final ConcurrentMap<Locale, SoftReference<Collator>> cache
             = new ConcurrentHashMap<>();
-
-    //
-    // FIXME: These three constants should be removed.
-    //
-    /**
-     * LESS is returned if source string is compared to be less than target
-     * string in the compare() method.
-     * @see java.text.Collator#compare
-     */
-    static final int LESS = -1;
-    /**
-     * EQUAL is returned if source string is compared to be equal to target
-     * string in the compare() method.
-     * @see java.text.Collator#compare
-     */
-    static final int EQUAL = 0;
-    /**
-     * GREATER is returned if source string is compared to be greater than
-     * target string in the compare() method.
-     * @see java.text.Collator#compare
-     */
-    static final int GREATER = 1;
- }
+}

--- a/src/java.base/share/classes/java/text/RuleBasedCollationKey.java
+++ b/src/java.base/share/classes/java/text/RuleBasedCollationKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,14 +54,13 @@ final class RuleBasedCollationKey extends CollationKey {
      * zero if this is greater than target.
      * @see java.text.Collator#compare
      */
-    public int compareTo(CollationKey target)
-    {
+    public int compareTo(CollationKey target) {
         int result = key.compareTo(((RuleBasedCollationKey)(target)).key);
-        if (result <= Collator.LESS)
-            return Collator.LESS;
-        else if (result >= Collator.GREATER)
-            return Collator.GREATER;
-        return Collator.EQUAL;
+        if (result < 0)
+            return -1;
+        else if (result > 0)
+            return 1;
+        return 0;
     }
 
     /**

--- a/src/java.base/share/classes/java/text/RuleBasedCollator.java
+++ b/src/java.base/share/classes/java/text/RuleBasedCollator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,10 +37,6 @@
  */
 
 package java.text;
-
-import java.text.Normalizer;
-import java.util.Vector;
-import java.util.Locale;
 
 /**
  * The {@code RuleBasedCollator} class is a concrete subclass of
@@ -377,7 +373,7 @@ public class RuleBasedCollator extends Collator{
         // strengthResult, it overrides the last difference (if any) that
         // was found.
 
-        int result = Collator.EQUAL;
+        int result = 0;
 
         if (sourceCursor == null) {
             sourceCursor = getCollationElementIterator(source);
@@ -449,7 +445,7 @@ public class RuleBasedCollator extends Collator{
                     // The source's primary is ignorable, but the target's isn't.  We treat ignorables
                     // as a secondary difference, so remember that we found one.
                     if (checkSecTer) {
-                        result = Collator.GREATER;  // (strength is SECONDARY)
+                        result = 1;  // (strength is SECONDARY)
                         checkSecTer = false;
                     }
                     // Skip to the next source element, but don't fetch another target element.
@@ -459,7 +455,7 @@ public class RuleBasedCollator extends Collator{
                 {
                     // record differences - see the comment above.
                     if (checkSecTer) {
-                        result = Collator.LESS;  // (strength is SECONDARY)
+                        result = -1;  // (strength is SECONDARY)
                         checkSecTer = false;
                     }
                     // Skip to the next source element, but don't fetch another target element.
@@ -469,9 +465,9 @@ public class RuleBasedCollator extends Collator{
                     // orders are different because of the (pSOrder != pTOrder) test above.
                     // Record the difference and stop the comparison.
                     if (pSOrder < pTOrder) {
-                        return Collator.LESS;  // (strength is PRIMARY)
+                        return -1;  // (strength is PRIMARY)
                     } else {
-                        return Collator.GREATER;  // (strength is PRIMARY)
+                        return 1;  // (strength is PRIMARY)
                     }
                 }
             } else { // else of if ( pSOrder != pTOrder )
@@ -485,7 +481,7 @@ public class RuleBasedCollator extends Collator{
                     short secTOrder = CollationElementIterator.secondaryOrder(tOrder);
                     if (secSOrder != secTOrder) {
                         // there is a secondary difference
-                        result = (secSOrder < secTOrder) ? Collator.LESS : Collator.GREATER;
+                        result = (secSOrder < secTOrder) ? -1 : 1;
                                                 // (strength is SECONDARY)
                         checkSecTer = false;
                         // (even in french, only the first secondary difference within
@@ -497,7 +493,7 @@ public class RuleBasedCollator extends Collator{
                             short terTOrder = CollationElementIterator.tertiaryOrder(tOrder);
                             if (terSOrder != terTOrder) {
                                 // there is a tertiary difference
-                                result = (terSOrder < terTOrder) ? Collator.LESS : Collator.GREATER;
+                                result = (terSOrder < terTOrder) ? -1 : 1;
                                                 // (strength is TERTIARY)
                                 checkTertiary = false;
                             }
@@ -516,12 +512,12 @@ public class RuleBasedCollator extends Collator{
                 if (CollationElementIterator.primaryOrder(sOrder) != 0) {
                     // We found an additional non-ignorable base character in the source string.
                     // This is a primary difference, so the source is greater
-                    return Collator.GREATER; // (strength is PRIMARY)
+                    return 1; // (strength is PRIMARY)
                 }
                 else if (CollationElementIterator.secondaryOrder(sOrder) != 0) {
                     // Additional secondary elements mean the source string is greater
                     if (checkSecTer) {
-                        result = Collator.GREATER;  // (strength is SECONDARY)
+                        result = 1;  // (strength is SECONDARY)
                         checkSecTer = false;
                     }
                 }
@@ -533,11 +529,11 @@ public class RuleBasedCollator extends Collator{
                 if (CollationElementIterator.primaryOrder(tOrder) != 0)
                     // We found an additional non-ignorable base character in the target string.
                     // This is a primary difference, so the source is less
-                    return Collator.LESS; // (strength is PRIMARY)
+                    return -1; // (strength is PRIMARY)
                 else if (CollationElementIterator.secondaryOrder(tOrder) != 0) {
                     // Additional secondary elements in the target mean the source string is less
                     if (checkSecTer) {
-                        result = Collator.LESS;  // (strength is SECONDARY)
+                        result = -1;  // (strength is SECONDARY)
                         checkSecTer = false;
                     }
                 }


### PR DESCRIPTION
Apply FIXME comment.
This fields don't improve readability. Just confuses developers, who well aware of compareTo contracts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewers
 * @dambar240 (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9690/head:pull/9690` \
`$ git checkout pull/9690`

Update a local copy of the PR: \
`$ git checkout pull/9690` \
`$ git pull https://git.openjdk.org/jdk pull/9690/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9690`

View PR using the GUI difftool: \
`$ git pr show -t 9690`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9690.diff">https://git.openjdk.org/jdk/pull/9690.diff</a>

</details>
