### PR TITLE
8291954: Use Optional.isEmpty instead of !Optional.isPresent in java.base

### DIFF
--- a/src/java.base/share/classes/java/lang/Runtime.java
+++ b/src/java.base/share/classes/java/lang/Runtime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -36,7 +36,6 @@ import java.util.Optional;
 import java.util.StringTokenizer;
 
 import jdk.internal.access.SharedSecrets;
-import jdk.internal.loader.NativeLibrary;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.Reflection;
 
@@ -1075,7 +1074,7 @@ public class Runtime {
                     m.group(VersionPattern.OPT_GROUP));
 
             // empty '+'
-            if (!build.isPresent()) {
+            if (build.isEmpty()) {
                 if (m.group(VersionPattern.PLUS_GROUP) != null) {
                     if (optional.isPresent()) {
                         if (pre.isPresent())
@@ -1087,7 +1086,7 @@ public class Runtime {
                             + " build or optional components: '" + s + "'");
                     }
                 } else {
-                    if (optional.isPresent() && !pre.isPresent()) {
+                    if (optional.isPresent() && pre.isEmpty()) {
                         throw new IllegalArgumentException("optional component"
                             + " must be preceded by a pre-release component"
                             + " or '+': '" + s + "'");
@@ -1353,11 +1352,11 @@ public class Runtime {
 
         private int comparePre(Version obj) {
             Optional<String> oPre = obj.pre();
-            if (!pre.isPresent()) {
+            if (pre.isEmpty()) {
                 if (oPre.isPresent())
                     return 1;
             } else {
-                if (!oPre.isPresent())
+                if (oPre.isEmpty())
                     return -1;
                 String val = pre.get();
                 String oVal = oPre.get();
@@ -1388,11 +1387,11 @@ public class Runtime {
 
         private int compareOptional(Version obj) {
             Optional<String> oOpt = obj.optional();
-            if (!optional.isPresent()) {
+            if (optional.isEmpty()) {
                 if (oOpt.isPresent())
                     return -1;
             } else {
-                if (!oOpt.isPresent())
+                if (oOpt.isEmpty())
                     return 1;
                 return optional.get().compareTo(oOpt.get());
             }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -6780,7 +6780,7 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
                     loopReturnType + ")");
         }
 
-        if (!pred.stream().filter(Objects::nonNull).findFirst().isPresent()) {
+        if (pred.stream().noneMatch(Objects::nonNull)) {
             throw newIllegalArgumentException("no predicate found", pred);
         }
         if (pred.stream().filter(Objects::nonNull).map(MethodHandle::type).map(MethodType::returnType).

--- a/src/java.base/share/classes/java/lang/module/Resolver.java
+++ b/src/java.base/share/classes/java/lang/module/Resolver.java
@@ -867,7 +867,7 @@ final class Resolver {
         Set<ModuleReference> result = new HashSet<>(beforeModules);
         for (ModuleReference mref : afterModules) {
             String name = mref.descriptor().name();
-            if (!beforeFinder.find(name).isPresent()
+            if (beforeFinder.find(name).isEmpty()
                     && findInParent(name) == null) {
                 result.add(mref);
             }

--- a/src/java.base/share/classes/java/util/Optional.java
+++ b/src/java.base/share/classes/java/util/Optional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,7 +212,7 @@ public final class Optional<T> {
      */
     public Optional<T> filter(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate);
-        if (!isPresent()) {
+        if (isEmpty()) {
             return this;
         } else {
             return predicate.test(value) ? this : empty();
@@ -254,7 +254,7 @@ public final class Optional<T> {
      */
     public <U> Optional<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper);
-        if (!isPresent()) {
+        if (isEmpty()) {
             return empty();
         } else {
             return Optional.ofNullable(mapper.apply(value));
@@ -282,7 +282,7 @@ public final class Optional<T> {
      */
     public <U> Optional<U> flatMap(Function<? super T, ? extends Optional<? extends U>> mapper) {
         Objects.requireNonNull(mapper);
-        if (!isPresent()) {
+        if (isEmpty()) {
             return empty();
         } else {
             @SuppressWarnings("unchecked")
@@ -331,7 +331,7 @@ public final class Optional<T> {
      * @since 9
      */
     public Stream<T> stream() {
-        if (!isPresent()) {
+        if (isEmpty()) {
             return Stream.empty();
         } else {
             return Stream.of(value);

--- a/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
@@ -38,7 +38,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -395,7 +394,7 @@ public final class ModuleBootstrap {
         if (isPatched) {
             patcher.patchedModules()
                     .stream()
-                    .filter(mn -> !cf.findModule(mn).isPresent())
+                    .filter(mn -> cf.findModule(mn).isEmpty())
                     .forEach(mn -> warnUnknownModule(PATCH_MODULE, mn));
         }
 
@@ -427,7 +426,7 @@ public final class ModuleBootstrap {
                     if (upgradeModulePath != null
                             && upgradeModulePath.find(name).isPresent())
                         fail(name + ": cannot be loaded from upgrade module path");
-                    if (!systemModuleFinder.find(name).isPresent())
+                    if (systemModuleFinder.find(name).isEmpty())
                         fail(name + ": cannot be loaded from application module path");
                 }
             }
@@ -658,7 +657,7 @@ public final class ModuleBootstrap {
             // the key is $MODULE
             String mn = e.getKey();
             Optional<Module> om = bootLayer.findModule(mn);
-            if (!om.isPresent()) {
+            if (om.isEmpty()) {
                 warnUnknownModule(ADD_READS, mn);
                 continue;
             }
@@ -728,7 +727,7 @@ public final class ModuleBootstrap {
             // The exporting module is in the boot layer
             Module m;
             Optional<Module> om = bootLayer.findModule(mn);
-            if (!om.isPresent()) {
+            if (om.isEmpty()) {
                 warnUnknownModule(option, mn);
                 continue;
             }

--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -726,7 +726,7 @@ public final class LauncherHelper {
         // main module is in the boot layer
         ModuleLayer layer = ModuleLayer.boot();
         Optional<Module> om = layer.findModule(mainModule);
-        if (!om.isPresent()) {
+        if (om.isEmpty()) {
             // should not happen
             throw new InternalError("Module " + mainModule + " not in boot Layer");
         }
@@ -735,7 +735,7 @@ public final class LauncherHelper {
         // get main class
         if (mainClass == null) {
             Optional<String> omc = m.getDescriptor().mainClass();
-            if (!omc.isPresent()) {
+            if (omc.isEmpty()) {
                 abort(null, "java.launcher.module.error1", mainModule);
             }
             mainClass = omc.get();
@@ -1023,7 +1023,7 @@ public final class LauncherHelper {
 
             // find the module with the FX launcher
             Optional<Module> om = ModuleLayer.boot().findModule(JAVAFX_GRAPHICS_MODULE_NAME);
-            if (!om.isPresent()) {
+            if (om.isEmpty()) {
                 abort(null, "java.launcher.cls.error5");
             }
 


### PR DESCRIPTION
I propose to replace usages of !Optional.isPresent() with Optional.isEmpty method.
It's makes code a bit easier to read.
Noticing negation before long chain of method calls is hard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291954](https://bugs.openjdk.org/browse/JDK-8291954): Use Optional.isEmpty instead of !Optional.isPresent in java.base


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9697/head:pull/9697` \
`$ git checkout pull/9697`

Update a local copy of the PR: \
`$ git checkout pull/9697` \
`$ git pull https://git.openjdk.org/jdk pull/9697/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9697`

View PR using the GUI difftool: \
`$ git pr show -t 9697`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9697.diff">https://git.openjdk.org/jdk/pull/9697.diff</a>

</details>
