### PR TITLE
8292022: Issues caused by Unary Plus Operator + and Shift Operators priority

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/BaseFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/BaseFileManager.java
@@ -432,7 +432,7 @@ public abstract class BaseFileManager implements JavaFileManager {
             ByteBuffer result =
                 (cached != null && cached.capacity() >= capacity)
                 ? cached.clear()
-                : ByteBuffer.allocate(capacity + capacity>>1);
+                : ByteBuffer.allocate(capacity + (capacity >> 1));
             cached = null;
             return result;
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/BaseFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/BaseFileManager.java
@@ -432,7 +432,7 @@ public abstract class BaseFileManager implements JavaFileManager {
             ByteBuffer result =
                 (cached != null && cached.capacity() >= capacity)
                 ? cached.clear()
-                : ByteBuffer.allocate(capacity + (capacity >> 1));
+                : ByteBuffer.allocate(capacity);
             cached = null;
             return result;
         }


### PR DESCRIPTION
(capacity + capacity>>1) The result of this expression is still capacity. So I guess what the author thought at the time might be (capacity + (capacity >> 1)), see https://bugs.openjdk.org/projects/JDK/issues/JDK-8292022

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292022](https://bugs.openjdk.org/browse/JDK-8292022): Issues caused by Unary Plus Operator + and Shift Operators priority


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9698/head:pull/9698` \
`$ git checkout pull/9698`

Update a local copy of the PR: \
`$ git checkout pull/9698` \
`$ git pull https://git.openjdk.org/jdk pull/9698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9698`

View PR using the GUI difftool: \
`$ git pr show -t 9698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9698.diff">https://git.openjdk.org/jdk/pull/9698.diff</a>

</details>
