### PR TITLE
8290908: misc tests fail: assert(!thread->owns_locks()) failed: must release all locks when leaving VM

### DIFF
--- a/src/hotspot/share/prims/jvmtiEventController.cpp
+++ b/src/hotspot/share/prims/jvmtiEventController.cpp
@@ -891,10 +891,6 @@ JvmtiEventControllerPrivate::set_user_enabled(JvmtiEnvBase *env, JavaThread *thr
             thread==NULL? "ALL": JvmtiTrace::safe_get_thread_name(thread),
             enabled? "enabled" : "disabled", JvmtiTrace::event_name(event_type)));
 
-  if (event_type == JVMTI_EVENT_OBJECT_FREE) {
-    flush_object_free_events(env);
-  }
-
   if (thread == NULL && thread_oop_h() == NULL) {
     // NULL thread and NULL thread_oop now indicate setting globally instead
     // of setting thread specific since NULL thread by itself means an
@@ -1047,6 +1043,10 @@ JvmtiEventController::is_global_event(jvmtiEvent event_type) {
 void
 JvmtiEventController::set_user_enabled(JvmtiEnvBase *env, JavaThread *thread, oop thread_oop,
                                        jvmtiEvent event_type, bool enabled) {
+  if (event_type == JVMTI_EVENT_OBJECT_FREE) {
+    JvmtiEventControllerPrivate::flush_object_free_events(env);
+  }
+
   if (Threads::number_of_threads() == 0) {
     // during early VM start-up locks don't exist, but we are safely single threaded,
     // call the functionality without holding the JvmtiThreadState_lock.


### PR DESCRIPTION
This is a regression that has been introduced by the fix of:
[8256811](https://bugs.openjdk.org/browse/JDK-8256811): Delayed/missed jdwp class unloading events

This is the relevant comment from Zhengyu:
```
It is caused by [JDK-8256811](https://bugs.openjdk.org/browse/JDK-8256811), as JvmtiExport::post_object_free() call does not expect under any lock.

I think we can move following code outside of lock, as flush_obect_free_events() races ServiceThread's JvmtiTagMap::flush_all_object_free_events() call anyway.

  if (event_type == JVMTI_EVENT_OBJECT_FREE) {
    flush_object_free_events(env);
  }
```
The fix is as was suggested by Zhengyu above.
I was not able to reproduce JCK and nsk.jvmti test failures mentioned in the bug report.
However, this fix should address the problem as it moves the call to `flush_object_free_events(env)` out of a critical section with a lock.