### PR TITLE
8285836: sun/net/www/http/KeepAliveCache/KeepAliveProperty.java failed with "RuntimeException: Failed in server"

### DIFF
--- a/test/jdk/sun/net/www/http/KeepAliveCache/KeepAliveProperty.java
+++ b/test/jdk/sun/net/www/http/KeepAliveCache/KeepAliveProperty.java
@@ -171,6 +171,7 @@ public class KeepAliveProperty {
             if (!expectClose)
                 throw e;
         }
+        s.join();
 
         if (!pass)
             throw new RuntimeException("Failed in server");

--- a/test/jdk/sun/net/www/http/KeepAliveCache/KeepAliveProperty.java
+++ b/test/jdk/sun/net/www/http/KeepAliveCache/KeepAliveProperty.java
@@ -40,6 +40,7 @@ import static java.net.Proxy.NO_PROXY;
 public class KeepAliveProperty {
 
     static volatile boolean pass = false;
+    static Logger logger = Logger.getLogger("sun.net.www.protocol.http.HttpURLConnection");
 
     static class Server extends Thread {
         final ServerSocket server;
@@ -138,7 +139,6 @@ public class KeepAliveProperty {
 
     public static void main(String args[]) throws Exception {
         // exercise the logging code
-        Logger logger = Logger.getLogger("sun.net.www.protocol.http.HttpURLConnection");
         logger.setLevel(Level.FINEST);
         ConsoleHandler h = new ConsoleHandler();
         h.setLevel(Level.FINEST);


### PR DESCRIPTION
This patch fixes a race condition in KeepAliveProperty test. The client thread could read the `pass` field and fail the test before the server thread had a chance to set the field value to `true`. The fix adds an explicit wait for the server thread to complete.

Without this patch, the failure can be easily reproduced by adding a `Thread.sleep(100);` before `pass = !expectClose;`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285836](https://bugs.openjdk.org/browse/JDK-8285836): sun/net/www/http/KeepAliveCache/KeepAliveProperty.java failed with "RuntimeException: Failed in server"


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9700/head:pull/9700` \
`$ git checkout pull/9700`

Update a local copy of the PR: \
`$ git checkout pull/9700` \
`$ git pull https://git.openjdk.org/jdk pull/9700/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9700`

View PR using the GUI difftool: \
`$ git pr show -t 9700`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9700.diff">https://git.openjdk.org/jdk/pull/9700.diff</a>

</details>
