### PR TITLE
8291626: Remove Mutex::contains as it is unused

### DIFF
--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -452,15 +452,6 @@ void Mutex::check_rank(Thread* thread) {
   }
 }
 
-bool Mutex::contains(Mutex* locks, Mutex* lock) {
-  for (; locks != NULL; locks = locks->next()) {
-    if (locks == lock) {
-      return true;
-    }
-  }
-  return false;
-}
-
 // Called immediately after lock acquisition or release as a diagnostic
 // to track the lock-set of the thread.
 // Rather like an EventListener for _owner (:>).

--- a/src/hotspot/share/runtime/mutex.hpp
+++ b/src/hotspot/share/runtime/mutex.hpp
@@ -108,7 +108,6 @@ class Mutex : public CHeapObj<mtSynchronizer> {
   Thread* _last_owner;           // the last thread to own the lock
   bool _skip_rank_check;         // read only by owner when doing rank checks
 
-  static bool contains(Mutex* locks, Mutex* lock);
   static Mutex* get_least_ranked_lock(Mutex* locks);
   Mutex* get_least_ranked_lock_besides_this(Mutex* locks);
   bool skip_rank_check() {


### PR DESCRIPTION
Hi,

Please review this PR removing some dead code.

Passed tier1-3 against commit with 2a1d9cf as parent, running tier1-2 on top of HEAD.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291626](https://bugs.openjdk.org/browse/JDK-8291626): Remove Mutex::contains as it is unused


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9701/head:pull/9701` \
`$ git checkout pull/9701`

Update a local copy of the PR: \
`$ git checkout pull/9701` \
`$ git pull https://git.openjdk.org/jdk pull/9701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9701`

View PR using the GUI difftool: \
`$ git pr show -t 9701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9701.diff">https://git.openjdk.org/jdk/pull/9701.diff</a>

</details>
