### PR TITLE
8289049: x86_32 build fails with GCC 11 due to newString646_US warning

### DIFF
--- a/src/java.base/share/native/libjava/jni_util.c
+++ b/src/java.base/share/native/libjava/jni_util.c
@@ -461,11 +461,14 @@ getString8859_1Chars(JNIEnv *env, jstring jstr)
 static jstring
 newString646_US(JNIEnv *env, const char *str)
 {
-    size_t len = (int)strlen(str);
+    int len = (int)strlen(str);
     jchar buf[512] = {0};
     jchar *str1;
     jstring result;
-    size_t i;
+    int i;
+
+    if ((*env)->EnsureLocalCapacity(env, 1) < 0)
+        return NULL;
 
     if (len > 512) {
         str1 = (jchar *)malloc(len * sizeof(jchar));

--- a/src/java.base/share/native/libjava/jni_util.c
+++ b/src/java.base/share/native/libjava/jni_util.c
@@ -461,11 +461,11 @@ getString8859_1Chars(JNIEnv *env, jstring jstr)
 static jstring
 newString646_US(JNIEnv *env, const char *str)
 {
-    int len = (int)strlen(str);
+    size_t len = (int)strlen(str);
     jchar buf[512] = {0};
     jchar *str1;
     jstring result;
-    int i;
+    size_t i;
 
     if (len > 512) {
         str1 = (jchar *)malloc(len * sizeof(jchar));


### PR DESCRIPTION
See bug report for reproducer and error message. The warning looks quite superficial, and I initially suspected that it complains about `int len = (int)strlen(str)` cast of `size_t`. But what is confusing is nearly the similar code in `newStringCp1252` (https://github.com/openjdk/jdk/blob/f5d1b5bda27c798347ae278cbf69725ed4be895c/src/java.base/share/native/libjava/jni_util.c#L533-L566) apparently does not produce the warning.

I propose we sync up unproblematic `newStringCp1252` and `newString646_US` implementation to dodge the warning.

Additional testing:
 - [x] Linux x86_32 build with GCC 11
 - [ ]  Linux x86_32 `tier1` test with GCC 9
 - [ ]  Linux x86_64 `tier1` test with GCC 9
