### PR TITLE
8290248: Implement MaxINode::Ideal transformation

### DIFF
--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -1082,6 +1082,85 @@ static bool can_overflow(const TypeInt* t, jint c) {
           (c > 0 && (java_add(t_hi, c) < t_hi)));
 }
 
+// Ideal transformations for MaxINode
+Node* MaxINode::Ideal(PhaseGVN* phase, bool can_reshape) {
+  // Force a right-spline graph
+  Node* l = in(1);
+  Node* r = in(2);
+  // Transform  MaxI1(MaxI2(a, b), c)  into  MaxI1(a, MaxI2(b, c))
+  // to force a right-spline graph for the rest of MaxINode::Ideal().
+  if (l->Opcode() == Op_MaxI) {
+    assert(l != l->in(1), "dead loop in MaxINode::Ideal");
+    r = phase->transform(new MaxINode(l->in(2), r));
+    l = l->in(1);
+    set_req_X(1, l, phase);
+    set_req_X(2, r, phase);
+    return this;
+  }
+
+  // Get left input & constant
+  Node* x = l;
+  jint x_off = 0;
+  if (x->Opcode() == Op_AddI && // Check for "x+c0" and collect constant
+      x->in(2)->is_Con()) {
+    const Type* t = x->in(2)->bottom_type();
+    if (t == Type::TOP) return NULL;  // No progress
+    x_off = t->is_int()->get_con();
+    x = x->in(1);
+  }
+
+  // Scan a right-spline-tree for MAXs
+  Node* y = r;
+  jint y_off = 0;
+  // Check final part of MAX tree
+  if (y->Opcode() == Op_AddI && // Check for "y+c1" and collect constant
+      y->in(2)->is_Con()) {
+    const Type* t = y->in(2)->bottom_type();
+    if (t == Type::TOP) return NULL;  // No progress
+    y_off = t->is_int()->get_con();
+    y = y->in(1);
+  }
+  if (x->_idx > y->_idx && r->Opcode() != Op_MaxI) {
+    swap_edges(1, 2);
+    return this;
+  }
+
+  const TypeInt* tx = phase->type(x)->isa_int();
+
+  if (r->Opcode() == Op_MaxI) {
+    assert(r != r->in(2), "dead loop in MaxINode::Ideal");
+    y = r->in(1);
+    // Check final part of MAX tree
+    if (y->Opcode() == Op_AddI &&// Check for "y+c1" and collect constant
+        y->in(2)->is_Con()) {
+      const Type* t = y->in(2)->bottom_type();
+      if (t == Type::TOP) return NULL;  // No progress
+      y_off = t->is_int()->get_con();
+      y = y->in(1);
+    }
+
+    if (x->_idx > y->_idx)
+      return new MaxINode(r->in(1), phase->transform(new MaxINode(l, r->in(2))));
+
+    // Transform MAX2(x + c0, MAX2(x + c1, z)) into MAX2(x + MAX2(c0, c1), z)
+    // if x == y and the additions can't overflow.
+    if (x == y && tx != NULL &&
+        !can_overflow(tx, x_off) &&
+        !can_overflow(tx, y_off)) {
+      return new MaxINode(phase->transform(new AddINode(x, phase->intcon(MAX2(x_off, y_off)))), r->in(2));
+    }
+  } else {
+    // Transform MAX2(x + c0, y + c1) into x + MAX2(c0, c1)
+    // if x == y and the additions can't overflow.
+    if (x == y && tx != NULL &&
+        !can_overflow(tx, x_off) &&
+        !can_overflow(tx, y_off)) {
+      return new AddINode(x, phase->intcon(MAX2(x_off, y_off)));
+    }
+  }
+ return NULL;
+}
+
 //=============================================================================
 //------------------------------Idealize---------------------------------------
 // MINs show up in range-check loop limit calculations.  Look for

--- a/src/hotspot/share/opto/addnode.hpp
+++ b/src/hotspot/share/opto/addnode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -299,6 +299,7 @@ public:
   virtual uint ideal_reg() const { return Op_RegI; }
   int max_opcode() const { return Op_MaxI; }
   int min_opcode() const { return Op_MinI; }
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
 };
 
 //------------------------------MinINode---------------------------------------

--- a/test/hotspot/jtreg/compiler/c2/irTests/MaxMinINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/MaxMinINodeIdealizationTests.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.c2.irTests;
+
+import jdk.test.lib.Asserts;
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8290248
+ * @summary Test that Ideal transformations of MaxINode and MinINode are
+ * being performed as expected.
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.MaxMinINodeIdealizationTests
+ */
+
+public class MaxMinINodeIdealizationTests {
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @Run(test = {"testMax1", "testMax2", "testMax3", "testMin1", "testMin2", "testMin3"})
+    public void runMethod() {
+        int a = RunInfo.getRandom().nextInt();
+        int min = Integer.MIN_VALUE;
+        int max = Integer.MAX_VALUE;
+
+        assertResult(a);
+        assertResult(0);
+        assertResult(min);
+        assertResult(max);
+    }
+
+    @DontCompile
+    public void assertResult(int a) {
+        Asserts.assertEQ(Math.max(((a >> 1) + 100), Math.max(((a >> 1) + 150), 200)), testMax1(a));
+        Asserts.assertEQ(Math.max(((a >> 1) + 10), ((a >> 1) + 11))                 , testMax2(a));
+        Asserts.assertEQ(Math.max(a, a)                                             , testMax3(a));
+
+        Asserts.assertEQ(Math.min(((a >> 1) + 100), Math.min(((a >> 1) + 150), 200)), testMin1(a));
+        Asserts.assertEQ(Math.min(((a >> 1) + 10), ((a >> 1) + 11))                 , testMin2(a));
+        Asserts.assertEQ(Math.min(a, a)                                             , testMin3(a));
+    }
+
+    // The transformations in test*1 and test*2 can happen only if the compiler has enough information
+    // to determine that the two addition operations can not overflow.
+
+    // Transform max(x + c0, max(y + c1, z)) to max(add(x, c2), z) if x == y, where c2 = MAX2(c0, c1).
+    // c0,c1,c2 are constants. x,y,z can be any valid c2 nodes. In this example, x and y are
+    // RShiftI nodes and z is a ConI.
+    @Test
+    @IR(counts = {IRNode.Max_I, "1",
+                  IRNode.ADD  , "1",
+                 })
+    public int testMax1(int i) {
+        return Math.max(((i >> 1) + 100), Math.max(((i >> 1) + 150), 200));
+    }
+
+    // Similarly, transform min(x + c0, min(y + c1, z)) to min(add(x, c2), z) if x == y, where c2 = MIN2(c0, c1).
+    @Test
+    @IR(counts = {IRNode.Min_I, "1",
+                  IRNode.ADD  , "1",
+                 })
+    public int testMin1(int i) {
+        return Math.min(((i >> 1) + 100), Math.min(((i >> 1) + 150), 200));
+    }
+
+    // Transform max(x + c0, y + c1) to add(x, c2) if x == y, where c2 = MAX2(c0, c1).
+    // c0,c1,c2 are constants. x and y can be any valid c2 nodes. If they are equal, this
+    // transformation would take place. In this example, x and y are same RShiftI nodes.
+    @Test
+    @IR(failOn = {IRNode.Max_I})
+    @IR(counts = {IRNode.ADD, "1"})
+    public int testMax2(int i) {
+        return Math.max((i >> 1) + 10, (i >> 1) + 11);
+    }
+
+    // Similarly, transform min(x + c0, y + c1) to add(x, c2) if x == y, where c2 = MIN2(c0, c1).
+    @Test
+    @IR(failOn = {IRNode.Min_I})
+    @IR(counts = {IRNode.ADD, "1"})
+    public int testMin2(int i) {
+        return Math.min((i >> 1) + 10, (i >> 1) + 11);
+    }
+
+    // Return the same node without generating a MaxINode/MinINode when a node is compared with itself.
+    // In this test, an integer is being compared with itself but it can be any valid c2 node.
+    @Test
+    @IR(failOn = {IRNode.Max_I})
+    public int testMax3(int i) {
+        return Math.max(i, i);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.Min_I})
+    public int testMin3(int i) {
+        return Math.min(i, i);
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -211,6 +211,8 @@ public class IRNode {
     public static final String VECTOR_BLEND = START + "VectorBlend" + MID + END;
     public static final String REVERSE_BYTES_V = START + "ReverseBytesV" + MID + END;
 
+    public static final String Min_I = START + "MinI" + MID + END;
+    public static final String Max_I = START + "MaxI" + MID + END;
     public static final String Min_V = START + "MinV" + MID + END;
     public static final String Max_V = START + "MaxV" + MID + END;
 


### PR DESCRIPTION
This patch implements Ideal transformations for MaxINode, which are
similar to the ones defined for MinINode to transform/optimize a couple
of commonly occuring patterns such as -

MaxI(x + c0, MaxI(y + c1, z)) ==> MaxI(AddI(x, MAX2(c0, c1)), z) when x
== y
MaxI(x + c0, y + c1) ==> AddI(x, MAX2(c0, c1)) when x == y

IR tests to test the Ideal transformations of both MaxI and MinI nodes
are also included in this patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290248](https://bugs.openjdk.org/browse/JDK-8290248): Implement MaxINode::Ideal transformation


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9703/head:pull/9703` \
`$ git checkout pull/9703`

Update a local copy of the PR: \
`$ git checkout pull/9703` \
`$ git pull https://git.openjdk.org/jdk pull/9703/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9703`

View PR using the GUI difftool: \
`$ git pr show -t 9703`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9703.diff">https://git.openjdk.org/jdk/pull/9703.diff</a>

</details>
