### PR TITLE
[patch]: Optimize Preconditions outOfBoundsMessage

### DIFF
--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -96,9 +96,11 @@ $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
     BIN := $(MICROBENCHMARK_CLASSES), \
     JAVAC_FLAGS := --add-exports java.base/sun.security.util=ALL-UNNAMED \
         --add-exports java.base/sun.invoke.util=ALL-UNNAMED \
+        --add-exports java.base/jdk.internal.util=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.vm=ALL-UNNAMED \
         --enable-preview, \
     JAVA_FLAGS := --add-modules jdk.unsupported --limit-modules java.management \
+        --add-exports java.base/jdk.internal.util=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.vm=ALL-UNNAMED \
         --enable-preview, \
 ))

--- a/src/java.base/share/classes/jdk/internal/util/Preconditions.java
+++ b/src/java.base/share/classes/jdk/internal/util/Preconditions.java
@@ -217,39 +217,29 @@ public class Preconditions {
 
     private static String outOfBoundsMessage(String checkKind, List<? extends Number> args) {
         if (checkKind == null && args == null) {
-            return String.format("Range check failed");
+            return "Range check failed";
         } else if (checkKind == null) {
-            return String.format("Range check failed: %s", args);
+            return "Range check failed: " + args;
         } else if (args == null) {
-            return String.format("Range check failed: %s", checkKind);
+            return "Range check failed: " + checkKind;
         }
 
-        int argSize = 0;
+        int argSize;
         switch (checkKind) {
-            case "checkIndex":
-                argSize = 2;
-                break;
-            case "checkFromToIndex":
-            case "checkFromIndexSize":
-                argSize = 3;
-                break;
-            default:
+            case "checkIndex" -> argSize = 2;
+            case "checkFromToIndex", "checkFromIndexSize" -> argSize = 3;
+            default -> argSize = 0;
         }
 
         // Switch to default if fewer or more arguments than required are supplied
-        switch ((args.size() != argSize) ? "" : checkKind) {
-            case "checkIndex":
-                return String.format("Index %s out of bounds for length %s",
-                                     args.get(0), args.get(1));
-            case "checkFromToIndex":
-                return String.format("Range [%s, %s) out of bounds for length %s",
-                                     args.get(0), args.get(1), args.get(2));
-            case "checkFromIndexSize":
-                return String.format("Range [%s, %<s + %s) out of bounds for length %s",
-                                     args.get(0), args.get(1), args.get(2));
-            default:
-                return String.format("Range check failed: %s %s", checkKind, args);
-        }
+        return switch ((args.size() != argSize) ? "" : checkKind) {
+            case "checkIndex" -> "Index " + args.get(0) + " out of bounds for length " + args.get(1);
+            case "checkFromToIndex" -> "Range [" + args.get(0) + ", " + args.get(1)
+                    + ") out of bounds for length " + args.get(2);
+            case "checkFromIndexSize" -> "Range [" + args.get(0) + ", " + args.get(0) + " + " + args.get(1)
+                    + ") out of bounds for length " + args.get(2);
+            default -> "Range check failed: " + checkKind + " " + args;
+        };
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/util/Preconditions.java
+++ b/src/java.base/share/classes/jdk/internal/util/Preconditions.java
@@ -224,12 +224,11 @@ public class Preconditions {
             return "Range check failed: " + checkKind;
         }
 
-        int argSize;
-        switch (checkKind) {
-            case "checkIndex" -> argSize = 2;
-            case "checkFromToIndex", "checkFromIndexSize" -> argSize = 3;
-            default -> argSize = 0;
-        }
+        int argSize = switch (checkKind) {
+            case "checkIndex" -> 2;
+            case "checkFromToIndex", "checkFromIndexSize" -> 3;
+            default -> 0;
+        };
 
         // Switch to default if fewer or more arguments than required are supplied
         return switch ((args.size() != argSize) ? "" : checkKind) {

--- a/test/micro/org/openjdk/bench/jdk/internal/util/PreconditionsBench.java
+++ b/test/micro/org/openjdk/bench/jdk/internal/util/PreconditionsBench.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.jdk.internal.util;
+
+import jdk.internal.util.Preconditions;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(
+        value = 3,
+        jvmArgsAppend = {
+                "--add-exports", "java.base/jdk.internal.util=ALL-UNNAMED",
+                "--add-opens", "java.base/jdk.internal.util=ALL-UNNAMED"
+        })
+@State(Scope.Benchmark)
+public class PreconditionsBench {
+
+    @Benchmark
+    public int checkFromIndexSize() {
+        return Preconditions.checkFromIndexSize(0, 1, 2, Preconditions.AIOOBE_FORMATTER);
+    }
+
+    @Benchmark
+    public int checkFromIndexSizeThrows(final Blackhole bh) {
+        try {
+            return Preconditions.checkFromIndexSize(-1, -1, -1, Preconditions.AIOOBE_FORMATTER);
+        } catch (IndexOutOfBoundsException expected) {
+            bh.consume(expected);
+            return -1;
+        }
+    }
+
+    public static void main(String... args) throws Exception {
+        new Runner(new OptionsBuilder()
+                .include(PreconditionsBench.class.getSimpleName())
+                .shouldDoGC(true).build())
+            .run();
+    }
+}


### PR DESCRIPTION
I would like to propose a patch to improve the throughput for `jdk.internal.util.Preconditions.outOfBoundsMessage` which is used heavily for checking array index bounds, notably in `sun.security.provider` implementations and `AbstractStringBuilder` that utilize `Preconditions.checkFromIndexSize`. In cases where invalid inputs are provided and these checks fail, the current implementation uses expensive `String.format` that could be simplified and optimized with standard string concatenation where no special formatting is required.

Before:
```
Benchmark                                     Mode  Cnt        Score       Error   Units
PreconditionsBench.checkFromIndexSize        thrpt   15  1526125.991 ± 22883.285  ops/ms
PreconditionsBench.checkFromIndexSizeThrows  thrpt   15      418.862 ±    23.365  ops/ms
```

After:
```
Benchmark                                     Mode  Cnt        Score       Error   Units
PreconditionsBench.checkFromIndexSize        thrpt   15  1530809.049 ± 10784.193  ops/ms
PreconditionsBench.checkFromIndexSizeThrows  thrpt   15      608.061 ±     5.095  ops/ms
```

The primary motivator for this optimization is addressed in JDK 18+ via https://github.com/openjdk/jdk/commit/0e7288ffbf635b9fdb17e8017e9a4f673ca0501d which now performs a length check before calling `ArrayUtil.nullAndBoundsCheck` which calls `Preconditions.checkFromIndexSize` and avoids constructing `ArrayIndexOutOfBoundsException` when TLS read ciphers change (e.g. during handshake)

https://github.com/openjdk/jdk/blob/0e7288ffbf635b9fdb17e8017e9a4f673ca0501d/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java#L1437-L1448

Example stacktrace from OpenJDK 17.0.4.1:
```
java.lang.ArrayIndexOutOfBoundsException: Range [0, 0 + -16) out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:177)
	at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:174)
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:62)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckFromIndexSize(Preconditions.java:82)
	at java.base/jdk.internal.util.Preconditions.checkFromIndexSize(Preconditions.java:361)
	at java.base/sun.security.util.ArrayUtil.nullAndBoundsCheck(ArrayUtil.java:53)
	at java.base/com.sun.crypto.provider.GaloisCounterMode$GCMDecrypt.doFinal(GaloisCounterMode.java:1364)
	at java.base/com.sun.crypto.provider.GaloisCounterMode.engineDoFinal(GaloisCounterMode.java:406)
	at java.base/javax.crypto.Cipher.doFinal(Cipher.java:2088)
	at java.base/sun.security.ssl.SSLCipher$T13GcmReadCipherGenerator$GcmReadCipher.dispose(SSLCipher.java:1977)
	at java.base/sun.security.ssl.InputRecord.changeReadCiphers(InputRecord.java:125)
	at java.base/sun.security.ssl.Finished$T13FinishedConsumer.onConsumeFinished(Finished.java:1005)
	at java.base/sun.security.ssl.Finished$T13FinishedConsumer.consume(Finished.java:893)
	at java.base/sun.security.ssl.SSLHandshake.consume(SSLHandshake.java:396)
	at java.base/sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:480)
	at java.base/sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:458)
	at java.base/sun.security.ssl.TransportContext.dispatch(TransportContext.java:201)
	at java.base/sun.security.ssl.SSLTransport.decode(SSLTransport.java:172)
	at java.base/sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1505)
	at java.base/sun.security.ssl.SSLSocketImpl.readHandshakeRecord(SSLSocketImpl.java:1420)
	at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:455)
	at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:426)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9706/head:pull/9706` \
`$ git checkout pull/9706`

Update a local copy of the PR: \
`$ git checkout pull/9706` \
`$ git pull https://git.openjdk.org/jdk pull/9706/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9706`

View PR using the GUI difftool: \
`$ git pr show -t 9706`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9706.diff">https://git.openjdk.org/jdk/pull/9706.diff</a>

</details>
