### PR TITLE
8291650: Add delay to ClassUnloadEventTest before exiting to give time for JVM to send all events before VMDeath

### DIFF
--- a/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
+++ b/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
@@ -102,6 +102,13 @@ public class ClassUnloadEventTest {
         loader = null;
         // Trigger class unloading
         ClassUnloadCommon.triggerUnloading();
+
+        // Short delay to make sure all ClassUnloadEvents have been sent
+        // before VMDeathEvent is genareated.
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+        }
     }
 
     private static void runDebugger() throws Exception {


### PR DESCRIPTION
Near the end of the test, the debuggee forces a GC so ClassUnloadEvents will be generated, and then the debuggee immediately exits. However, the ClassUnloadEvents might not be sent out before the VMDeath is generated, and it prevents delivery of any more events. A short delay after the GC should give the JVM time to deliver the ClassUnloadEvents first.

Note, I was not able to reproduce this issue, so I'm not 100% sure this will fix it. It does turn up in CI testing, so this seems worth trying to see if we still see it during CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291650](https://bugs.openjdk.org/browse/JDK-8291650): Add delay to ClassUnloadEventTest before exiting to give time for JVM to send all events before VMDeath


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9708/head:pull/9708` \
`$ git checkout pull/9708`

Update a local copy of the PR: \
`$ git checkout pull/9708` \
`$ git pull https://git.openjdk.org/jdk pull/9708/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9708`

View PR using the GUI difftool: \
`$ git pr show -t 9708`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9708.diff">https://git.openjdk.org/jdk/pull/9708.diff</a>

</details>
