### PR TITLE
8291654: AArch64: assert from JDK-8287393 causes crashes

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -878,9 +878,6 @@ address MacroAssembler::trampoline_call(Address entry, CodeBuffer* cbuf,
     bool in_scratch_emit_size = false;
 #ifdef COMPILER2
     if (check_emit_size) {
-      assert(StubRoutines::aarch64::complete() &&
-             Thread::current()->is_Compiler_thread() &&
-             Compile::current()->output() != NULL, "not in output phase of C2 compilation");
       // We don't want to emit a trampoline if C2 is generating dummy
       // code during its branch shortening phase.
       CompileTask* task = ciEnv::current()->task();


### PR DESCRIPTION
https://github.com/openjdk/jdk/commit/6cbc234ad17c5a0c4b3d6ea76f807c27c1dc8330 adds an assert checking `in_scratch_emit_size` is set during the output phase of C2 compilation. The assert can fail if C1 uses `trampoline_call`.
The assert is not needed as the calculation of `in_scratch_emit_size` is short-circuited to false if it is C1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291654](https://bugs.openjdk.org/browse/JDK-8291654): AArch64: assert from JDK-8287393 causes crashes


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Xin Liu](https://openjdk.org/census#xliu) (@navyxliu - Committer)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9709/head:pull/9709` \
`$ git checkout pull/9709`

Update a local copy of the PR: \
`$ git checkout pull/9709` \
`$ git pull https://git.openjdk.org/jdk pull/9709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9709`

View PR using the GUI difftool: \
`$ git pr show -t 9709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9709.diff">https://git.openjdk.org/jdk/pull/9709.diff</a>

</details>
