### PR TITLE
8260892: Compilation fails: lambda parameter not visible in body when generics involved

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -2940,7 +2940,7 @@ public class Attr extends JCTree.Visitor {
                     && ((tree.constructorType != null && inferenceContext.free(tree.constructorType))
                     || (tree.clazz.type != null && inferenceContext.free(tree.clazz.type)))) {
                 final ResultInfo resultInfoForClassDefinition = this.resultInfo;
-                Env<AttrContext> dupLocalEnv = localEnv.dup(localEnv.tree, localEnv.info.dup(localEnv.info.scope.dupUnshared()));
+                Env<AttrContext> dupLocalEnv = copyEnv(localEnv);
                 inferenceContext.addFreeTypeListener(List.of(tree.constructorType, tree.clazz.type),
                         instantiatedContext -> {
                             tree.constructorType = instantiatedContext.asInstType(tree.constructorType);

--- a/test/langtools/tools/javac/generics/diamond/ScopeCopyCanGetAlteredTest.java
+++ b/test/langtools/tools/javac/generics/diamond/ScopeCopyCanGetAlteredTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8260892
+ * @summary Compilation fails: lambda parameter not visible in body when generics involved
+ * @compile ScopeCopyCanGetAlteredTest.java
+ */
+
+import java.util.function.Function;
+import java.util.function.IntFunction;
+
+class ScopeCopyCanGetAlteredTest {
+    interface GenericOp<A> {
+        <B> A apply(IntFunction<B> func1, Function<B, A> func2);
+    }
+
+    static <A> GenericOp<A> foo(IntFunction<GenericOp<A>> f) {
+        return null;
+    }
+
+    static <A> GenericOp<A> bar() {
+        return foo((int arg) -> new GenericOp<>() {
+            @Override
+            public <B> A apply(IntFunction<B> func1, Function<B, A> func2) {
+                return func2.apply(func1.apply(arg));
+            }
+        });
+    }
+}


### PR DESCRIPTION
This bug is being produced because as the diamond expression can't be attributed until the inference has been done. A listener is registered in the corresponding inference context but the way the current environment is being copied into `dupLocalEnv` produces a copy that shares info with the outer lambda expression. The lambda expression removes the argument from the shared scope before the listener is fired and thus the error. The proposal is to use a different way to copy the environment into `dupLocalEnv` by producing a brand new scope.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8260892](https://bugs.openjdk.org/browse/JDK-8260892): Compilation fails: lambda parameter not visible in body when generics involved


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9710/head:pull/9710` \
`$ git checkout pull/9710`

Update a local copy of the PR: \
`$ git checkout pull/9710` \
`$ git pull https://git.openjdk.org/jdk pull/9710/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9710`

View PR using the GUI difftool: \
`$ git pr show -t 9710`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9710.diff">https://git.openjdk.org/jdk/pull/9710.diff</a>

</details>
