### PR TITLE
8288759: GCC 12 fails to compile signature.cpp due to -Wstringop-overread

### DIFF
--- a/src/hotspot/share/runtime/signature.cpp
+++ b/src/hotspot/share/runtime/signature.cpp
@@ -338,6 +338,11 @@ inline int SignatureStream::scan_type(BasicType type) {
 
   case T_ARRAY:
     while ((end < limit) && ((char)base[end] == JVM_SIGNATURE_ARRAY)) { end++; }
+    // If we discovered only the string of '[', this means something is wrong.
+    if (end >= limit) {
+      assert(false, "Invalid type detected");
+      return limit;
+    }
     _array_prefix = end - _end;  // number of '[' chars just skipped
     if (Signature::has_envelope(base[end])) {
       tem = (const u1 *) memchr(&base[end], JVM_SIGNATURE_ENDCLASS, limit - end);


### PR DESCRIPTION
Trying to compile with GCC 12.1.1 (current Fedora Rawhide) yields this failure:

```
In file included from /home/test/shipilev-jdk/src/hotspot/share/utilities/globalDefinitions_gcc.hpp:35,
                 from /home/test/shipilev-jdk/src/hotspot/share/utilities/globalDefinitions.hpp:35,
                 from /home/test/shipilev-jdk/src/hotspot/share/memory/allocation.hpp:29,
                 from /home/test/shipilev-jdk/src/hotspot/share/classfile/classLoaderData.hpp:28,
                 from /home/test/shipilev-jdk/src/hotspot/share/precompiled/precompiled.hpp:34:
In function 'const void* memchr(const void*, int, size_t)',
    inlined from 'int SignatureStream::scan_type(BasicType)' at /home/test/shipilev-jdk/src/hotspot/share/runtime/signature.cpp:343:32,
    inlined from 'void SignatureStream::next()' at /home/test/shipilev-jdk/src/hotspot/share/runtime/signature.cpp:373:19,
    inlined from 'void SignatureIterator::do_parameters_on(T*) [with T = Fingerprinter]' at /home/test/shipilev-jdk/src/hotspot/share/runtime/signature.hpp:635:41,
    inlined from 'void SignatureIterator::do_parameters_on(T*) [with T = Fingerprinter]' at /home/test/shipilev-jdk/src/hotspot/share/runtime/signature.hpp:629:6,
    inlined from 'void Fingerprinter::compute_fingerprint_and_return_type(bool)' at /home/test/shipilev-jdk/src/hotspot/share/runtime/signature.cpp:169:19:
/usr/include/string.h:102:27: error: 'void* __builtin_memchr(const void*, int, long unsigned int)' specified bound [18446744073709486082, 0] exceeds maximum object size 9223372036854775807 [-Werror=stringop-overread]
  102 |   return __builtin_memchr (__s, __c, __n);
      |          ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

As @kimbarrett says: "The warning is indicating an actual problem with the code. The while loop on line 338 may terminate with end == limit if the string consists of just a sequence of '[' and then ends. If the loop ends for that reason, we later read base[limit], invoking UB as limit is the length of base."

I propose we catch this corner case and return `limit` to fast-forward to the end of signature. I believe this is fine for the upstream code on that failure path, as the current behavior (UB, over-read) is even worse. The patch also asserts in debug builds, so that we know if we ever go there.

Additional testing:
 - [x] Linux x86_64 release build with GCC 12.1.1 (now passes)
 - [x] Linux x86_64 release build with GCC 9.4.0 (still passes)
 - [x] Linux x86_64 fastdebug build `tier1`
 - [x] Linux x86_64 fastdebug build `tier2`
 - [x] Linux x86_64 fastdebug build `tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288759](https://bugs.openjdk.org/browse/JDK-8288759): GCC 12 fails to compile signature.cpp due to -Wstringop-overread


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9711/head:pull/9711` \
`$ git checkout pull/9711`

Update a local copy of the PR: \
`$ git checkout pull/9711` \
`$ git pull https://git.openjdk.org/jdk pull/9711/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9711`

View PR using the GUI difftool: \
`$ git pr show -t 9711`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9711.diff">https://git.openjdk.org/jdk/pull/9711.diff</a>

</details>
