### PR TITLE
4850101: Setting mnemonic to VK_F4 underlines the letter S in a button.

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
@@ -2073,18 +2073,8 @@ public class SwingUtilities implements SwingConstants
             return -1;
         }
 
-        if ((KeyEvent.getKeyText(mnemonic).equals("F1")) ||
-           (KeyEvent.getKeyText(mnemonic).equals("F2")) ||
-           (KeyEvent.getKeyText(mnemonic).equals("F3")) ||
-           (KeyEvent.getKeyText(mnemonic).equals("F4")) ||
-           (KeyEvent.getKeyText(mnemonic).equals("F5")) ||
-           (KeyEvent.getKeyText(mnemonic).equals("F6")) ||
-           (KeyEvent.getKeyText(mnemonic).equals("F7")) ||
-           (KeyEvent.getKeyText(mnemonic).equals("F8")) ||
-           (KeyEvent.getKeyText(mnemonic).equals("F9")) ||
-           (KeyEvent.getKeyText(mnemonic).equals("F10")) ||
-           (KeyEvent.getKeyText(mnemonic).equals("F11"))) {
-           return -1;
+        if (mnemonic >= 'a' && mnemonic <= 'z') {
+            return -1;
         }
 
         char uc = Character.toUpperCase((char)mnemonic);

--- a/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
@@ -2073,6 +2073,20 @@ public class SwingUtilities implements SwingConstants
             return -1;
         }
 
+        if ((KeyEvent.getKeyText(mnemonic).equals("F1")) ||
+           (KeyEvent.getKeyText(mnemonic).equals("F2")) ||
+           (KeyEvent.getKeyText(mnemonic).equals("F3")) ||
+           (KeyEvent.getKeyText(mnemonic).equals("F4")) ||
+           (KeyEvent.getKeyText(mnemonic).equals("F5")) ||
+           (KeyEvent.getKeyText(mnemonic).equals("F6")) ||
+           (KeyEvent.getKeyText(mnemonic).equals("F7")) ||
+           (KeyEvent.getKeyText(mnemonic).equals("F8")) ||
+           (KeyEvent.getKeyText(mnemonic).equals("F9")) ||
+           (KeyEvent.getKeyText(mnemonic).equals("F10")) ||
+           (KeyEvent.getKeyText(mnemonic).equals("F11"))) {
+           return -1;
+        }
+
         char uc = Character.toUpperCase((char)mnemonic);
         char lc = Character.toLowerCase((char)mnemonic);
 

--- a/test/jdk/javax/swing/JButton/TestMnemonicAction.java
+++ b/test/jdk/javax/swing/JButton/TestMnemonicAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/JButton/TestMnemonicAction.java
+++ b/test/jdk/javax/swing/JButton/TestMnemonicAction.java
@@ -23,6 +23,13 @@
  * questions.
  */
 
+/* @test
+ * @key headful
+ * @bug 4850101
+ * @summary Verifies if Setting mnemonic to VK_F4 underlines the letter S.
+ * @run main TestMnemonicAction
+ */
+
 import java.io.File;
 import java.awt.Dimension;
 import java.awt.Point;

--- a/test/jdk/javax/swing/JButton/TestMnemonicAction.java
+++ b/test/jdk/javax/swing/JButton/TestMnemonicAction.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.File;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+public class TestMnemonicAction {
+    private static JFrame f;
+    private static JButton b;
+
+    public static boolean compareBufferedImages(BufferedImage bufferedImage0,
+                                                BufferedImage bufferedImage1) {
+        int width = bufferedImage0.getWidth();
+        int height = bufferedImage0.getHeight();
+
+        if (width != bufferedImage1.getWidth() || height != bufferedImage1.getHeight()) {
+            return false;
+        }
+
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                if (bufferedImage0.getRGB(x, y) != bufferedImage1.getRGB(x, y)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        SwingUtilities.invokeAndWait(() -> {
+            f = new JFrame();
+            b = new JButton("Shutdown");
+            b.setMnemonic(KeyEvent.VK_F4);
+            b.setPreferredSize(new Dimension(100, 25));
+            b.setToolTipText("Shutdown");
+            f.getContentPane().add(b);
+            f.setDefaultCloseOperation(f.EXIT_ON_CLOSE);
+            f.setUndecorated(true);
+            f.setLocationRelativeTo(null);
+            f.pack();
+            f.setVisible(true);
+        });
+        Robot robot = new Robot();
+        robot.waitForIdle();
+        robot.delay(1000);
+        Point p = b.getLocationOnScreen();
+        BufferedImage imgmnemonic = robot.createScreenCapture(
+                        new Rectangle(p.x, p.y, b.getWidth(), b.getHeight()));
+        robot.delay(1000);
+        SwingUtilities.invokeAndWait(() -> {
+            if (f != null) {
+                f.dispose();
+            }
+        });
+        SwingUtilities.invokeAndWait(() -> {
+            f = new JFrame();
+            b = new JButton("Shutdown");
+            b.setPreferredSize(new Dimension(100, 25));
+            f.getContentPane().add(b);
+            f.setDefaultCloseOperation(f.EXIT_ON_CLOSE);
+            f.setUndecorated(true);
+            f.setLocationRelativeTo(null);
+            f.pack();
+            f.setVisible(true);
+        });
+        robot.waitForIdle();
+        robot.delay(1000);
+        p = b.getLocationOnScreen();
+        BufferedImage buttonimage = robot.createScreenCapture(
+                        new Rectangle(p.x, p.y, b.getWidth(), b.getHeight()));
+        robot.delay(1000);
+        SwingUtilities.invokeAndWait(() -> {
+            if (f != null) {
+                f.dispose();
+            }
+        });
+        if (!compareBufferedImages(imgmnemonic, buttonimage)) {
+            ImageIO.write(imgmnemonic, "png", new File("imgmnemonic.png"));
+            ImageIO.write(buttonimage, "png", new File("buttonimage.png"));
+            throw new RuntimeException("F4 mnemonic underlines S");
+        }
+    }
+}
+


### PR DESCRIPTION
It is seen that using VK_F4 in JButton's setMnemonic(int i), causes the letter 'S' in the JButton to be underlined if JButton's text has 'S' in its string.
This is because [**VK_F4**](https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/java/awt/event/KeyEvent.java#L506) keycode is 0x73 (115 in decimal) which happens to be value of lowercase [**'s'** ](https://www.cs.cmu.edu/~pattis/15-1XX/common/handouts/ascii.html) so as per the logic implemented in SwingUtilities.findDisplayedMnemonicIndex(), the first index of the character (either lowecasr or uppercase) is returned as a mnemonic, which gets underlined.

Fix is made to ignore Action Keys from VK_F1->VK_F11 as displayed mnemonic which corresponds to lowercase p->z

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-4850101](https://bugs.openjdk.org/browse/JDK-4850101): Setting mnemonic to VK_F4 underlines the letter S in a button.


### Reviewers
 * @AJ1032480 (no known github.com user name / role) ⚠️ Review applies to [9942d8bb](https://git.openjdk.org/jdk/pull/9712/files/9942d8bb92d5bfd778d884072540d93287252bde)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [9942d8bb](https://git.openjdk.org/jdk/pull/9712/files/9942d8bb92d5bfd778d884072540d93287252bde)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9712/head:pull/9712` \
`$ git checkout pull/9712`

Update a local copy of the PR: \
`$ git checkout pull/9712` \
`$ git pull https://git.openjdk.org/jdk pull/9712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9712`

View PR using the GUI difftool: \
`$ git pr show -t 9712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9712.diff">https://git.openjdk.org/jdk/pull/9712.diff</a>

</details>
