### PR TITLE
8291733: Remove JFR events that expose hashtable

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -2451,21 +2451,6 @@ void SystemDictionary::dump(outputStream *st, bool verbose) {
   }
 }
 
-TableStatistics SystemDictionary::placeholders_statistics() {
-  MutexLocker ml(SystemDictionary_lock);
-  return placeholders()->statistics_calculate();
-}
-
-TableStatistics SystemDictionary::loader_constraints_statistics() {
-  MutexLocker ml(SystemDictionary_lock);
-  return constraints()->statistics_calculate();
-}
-
-TableStatistics SystemDictionary::protection_domain_cache_statistics() {
-  MutexLocker ml(SystemDictionary_lock);
-  return pd_cache_table()->statistics_calculate();
-}
-
 // Utility for dumping dictionaries.
 SystemDictionaryDCmd::SystemDictionaryDCmd(outputStream* output, bool heap) :
                                  DCmdWithParser(output, heap),

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,6 @@ class ProtectionDomainCacheEntry;
 class GCTimer;
 class EventClassLoad;
 class Symbol;
-class TableStatistics;
 
 class SystemDictionary : AllStatic {
   friend class BootstrapInfo;
@@ -400,11 +399,6 @@ protected:
                                 bool defining, TRAPS);
   static void update_dictionary(unsigned int hash,
                                 InstanceKlass* k, Handle loader);
-
-public:
-  static TableStatistics placeholders_statistics();
-  static TableStatistics loader_constraints_statistics();
-  static TableStatistics protection_domain_cache_statistics();
 };
 
 #endif // SHARE_CLASSFILE_SYSTEMDICTIONARY_HPP

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -842,42 +842,6 @@
     <Field type="float" name="removalRate" label="Removal Rate" description="How many items were removed since last event (per second)" />
   </Event>
 
-  <Event name="PlaceholderTableStatistics" category="Java Virtual Machine, Runtime, Tables" label="Placeholder Table Statistics" period="everyChunk">
-    <Field type="ulong" name="bucketCount" label="Bucket Count" description="Number of buckets" />
-    <Field type="ulong" name="entryCount" label="Entry Count" description="Number of all entries" />
-    <Field type="ulong" contentType="bytes" name="totalFootprint" label="Total Footprint" description="Total memory footprint (the table itself plus all of the entries)" />
-    <Field type="ulong" name="bucketCountMaximum" label="Maximum Bucket Count" description="The maximum bucket length (entries in a single bucket)" />
-    <Field type="float" name="bucketCountAverage" label="Average Bucket Count" description="The average bucket length" />
-    <Field type="float" name="bucketCountVariance" label="Bucket Count Variance" description="How far bucket lengths are spread out from their average value" />
-    <Field type="float" name="bucketCountStandardDeviation" label="Bucket Count Standard Deviation" description="How far bucket lengths are spread out from their mean (expected) value" />
-    <Field type="float" name="insertionRate" label="Insertion Rate" description="How many items were added since last event (per second)" />
-    <Field type="float" name="removalRate" label="Removal Rate" description="How many items were removed since last event (per second)" />
-  </Event>
-
-  <Event name="LoaderConstraintsTableStatistics" category="Java Virtual Machine, Runtime, Tables" label="Loader Constraints Table Statistics" period="everyChunk">
-    <Field type="ulong" name="bucketCount" label="Bucket Count" />
-    <Field type="ulong" name="entryCount" label="Entry Count" description="Number of all entries" />
-    <Field type="ulong" contentType="bytes" name="totalFootprint" label="Total Footprint" description="Total memory footprint (the table itself plus all of the entries)" />
-    <Field type="ulong" name="bucketCountMaximum" label="Maximum Bucket Count" description="The maximum bucket length (entries in a single bucket)" />
-    <Field type="float" name="bucketCountAverage" label="Average Bucket Count" description="The average bucket length" />
-    <Field type="float" name="bucketCountVariance" label="Bucket Count Variance" description="How far bucket lengths are spread out from their average value" />
-    <Field type="float" name="bucketCountStandardDeviation" label="Bucket Count Standard Deviation" description="How far bucket lengths are spread out from their mean (expected) value" />
-    <Field type="float" name="insertionRate" label="Insertion Rate" description="How many items were added since last event (per second)" />
-    <Field type="float" name="removalRate" label="Removal Rate" description="How many items were removed since last event (per second)" />
-  </Event>
-
-  <Event name="ProtectionDomainCacheTableStatistics" category="Java Virtual Machine, Runtime, Tables" label="Protection Domain Cache Table Statistics" period="everyChunk">
-    <Field type="ulong" name="bucketCount" label="Bucket Count" description="Number of buckets" />
-    <Field type="ulong" name="entryCount" label="Entry Count" description="Number of all entries" />
-    <Field type="ulong" contentType="bytes" name="totalFootprint" label="Total Footprint" description="Total memory footprint (the table itself plus all of the entries)" />
-    <Field type="ulong" name="bucketCountMaximum" label="Maximum Bucket Count" description="The maximum bucket length (entries in a single bucket)" />
-    <Field type="float" name="bucketCountAverage" label="Average Bucket Count" description="The average bucket length" />
-    <Field type="float" name="bucketCountVariance" label="Bucket Count Variance" description="How far bucket lengths are spread out from their average value" />
-    <Field type="float" name="bucketCountStandardDeviation" label="Bucket Count Standard Deviation" description="How far bucket lengths are spread out from their mean (expected) value" />
-    <Field type="float" name="insertionRate" label="Insertion Rate" description="How many items were added since last event (per second)" />
-    <Field type="float" name="removalRate" label="Removal Rate" description="How many items were removed since last event (per second)" />
-  </Event>
-
   <Event name="ThreadAllocationStatistics" category="Java Application, Statistics" label="Thread Allocation Statistics" period="everyChunk">
     <Field type="ulong" contentType="bytes" name="allocated" label="Allocated" description="Approximate number of bytes allocated since thread start" />
     <Field type="Thread" name="thread" label="Thread" />

--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -552,21 +552,6 @@ TRACE_REQUEST_FUNC(StringTableStatistics) {
   emit_table_statistics<EventStringTableStatistics>(statistics);
 }
 
-TRACE_REQUEST_FUNC(PlaceholderTableStatistics) {
-  TableStatistics statistics = SystemDictionary::placeholders_statistics();
-  emit_table_statistics<EventPlaceholderTableStatistics>(statistics);
-}
-
-TRACE_REQUEST_FUNC(LoaderConstraintsTableStatistics) {
-  TableStatistics statistics = SystemDictionary::loader_constraints_statistics();
-  emit_table_statistics<EventLoaderConstraintsTableStatistics>(statistics);
-}
-
-TRACE_REQUEST_FUNC(ProtectionDomainCacheTableStatistics) {
-  TableStatistics statistics = SystemDictionary::protection_domain_cache_statistics();
-  emit_table_statistics<EventProtectionDomainCacheTableStatistics>(statistics);
-}
-
 TRACE_REQUEST_FUNC(CompilerStatistics) {
   EventCompilerStatistics event;
   event.set_compileCount(CompileBroker::get_total_compile_count());

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -37,21 +37,6 @@
       <setting name="period">10 s</setting>
     </event>
 
-    <event name="jdk.PlaceholderTableStatistics">
-      <setting name="enabled">true</setting>
-      <setting name="period">10 s</setting>
-    </event>
-
-    <event name="jdk.LoaderConstraintsTableStatistics">
-      <setting name="enabled">true</setting>
-      <setting name="period">10 s</setting>
-    </event>
-
-    <event name="jdk.ProtectionDomainCacheTableStatistics">
-      <setting name="enabled">true</setting>
-      <setting name="period">10 s</setting>
-    </event>
-
     <event name="jdk.ThreadStart">
       <setting name="enabled">true</setting>
       <setting name="stackTrace">true</setting>

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -37,21 +37,6 @@
       <setting name="period">10 s</setting>
     </event>
 
-    <event name="jdk.PlaceholderTableStatistics">
-      <setting name="enabled">true</setting>
-      <setting name="period">10 s</setting>
-    </event>
-
-    <event name="jdk.LoaderConstraintsTableStatistics">
-      <setting name="enabled">true</setting>
-      <setting name="period">10 s</setting>
-    </event>
-
-    <event name="jdk.ProtectionDomainCacheTableStatistics">
-      <setting name="enabled">true</setting>
-      <setting name="period">10 s</setting>
-    </event>
-
     <event name="jdk.ThreadStart">
       <setting name="enabled">true</setting>
       <setting name="stackTrace">true</setting>

--- a/test/jdk/jdk/jfr/event/runtime/TestTableStatisticsEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestTableStatisticsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,18 +48,12 @@ public final class TestTableStatisticsEvent {
     try (Recording recording = new Recording()) {
       recording.enable(EventNames.SymbolTableStatistics);
       recording.enable(EventNames.StringTableStatistics);
-      recording.enable(EventNames.PlaceholderTableStatistics);
-      recording.enable(EventNames.LoaderConstraintsTableStatistics);
-      recording.enable(EventNames.ProtectionDomainCacheTableStatistics);
       recording.start();
       recording.stop();
 
       List<RecordedEvent> events = Events.fromRecording(recording);
       verifyTable(events, EventNames.SymbolTableStatistics);
       verifyTable(events, EventNames.StringTableStatistics);
-      verifyTable(events, EventNames.PlaceholderTableStatistics);
-      verifyTable(events, EventNames.LoaderConstraintsTableStatistics);
-      verifyTable(events, EventNames.ProtectionDomainCacheTableStatistics);
     }
   }
 

--- a/test/lib/jdk/test/lib/jfr/EventNames.java
+++ b/test/lib/jdk/test/lib/jfr/EventNames.java
@@ -82,9 +82,6 @@ public class EventNames {
     public final static String OldObjectSample = PREFIX + "OldObjectSample";
     public final static String SymbolTableStatistics = PREFIX + "SymbolTableStatistics";
     public final static String StringTableStatistics = PREFIX + "StringTableStatistics";
-    public final static String PlaceholderTableStatistics = PREFIX + "PlaceholderTableStatistics";
-    public final static String LoaderConstraintsTableStatistics = PREFIX + "LoaderConstraintsTableStatistics";
-    public final static String ProtectionDomainCacheTableStatistics = PREFIX + "ProtectionDomainCacheTableStatistics";
     public static final String RedefineClasses = PREFIX + "RedefineClasses";
     public static final String RetransformClasses = PREFIX + "RetransformClasses";
     public static final String ClassRedefinition = PREFIX + "ClassRedefinition";


### PR DESCRIPTION
There are JFR events for the Placeholders table, LoaderConstraintTable and ProtectionDomainCacheTable. These events expose implementation details for these tables that we'd rather not expose. A users visibility into these tables will not be helpful and it restricts our ability to make these a different (smaller) table or in the case of ProtectionDomain, not a table at all.

The Dictionary table (table of loaded classes) is useful from a users' perspective because it can be resized and we wanted to have events for the resizing. These other tables came along in that change.

Tested with tier1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291733](https://bugs.openjdk.org/browse/JDK-8291733): Remove JFR events that expose hashtable


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9714/head:pull/9714` \
`$ git checkout pull/9714`

Update a local copy of the PR: \
`$ git checkout pull/9714` \
`$ git pull https://git.openjdk.org/jdk pull/9714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9714`

View PR using the GUI difftool: \
`$ git pr show -t 9714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9714.diff">https://git.openjdk.org/jdk/pull/9714.diff</a>

</details>
