### PR TITLE
8289002: Minimal x86_64 VM build fails with GCC 11: 'this' pointer is null

### DIFF
--- a/src/hotspot/share/services/diagnosticFramework.cpp
+++ b/src/hotspot/share/services/diagnosticFramework.cpp
@@ -463,9 +463,10 @@ void DCmdFactory::send_notification_internal(TRAPS) {
 
     Klass* k = Management::com_sun_management_internal_DiagnosticCommandImpl_klass(CHECK);
     if (k == nullptr) {
-      THROW_MSG(vmSymbols::java_lang_IllegalStateException(),
-                "DiagnosticCommandImpl is not available");
+      fatal("Should have the DiagnosticCommandImpl class");
+      return; // silence the compiler
     }
+
     InstanceKlass* dcmd_mbean_klass = InstanceKlass::cast(k);
 
     JavaValue result(T_OBJECT);

--- a/src/hotspot/share/services/diagnosticFramework.cpp
+++ b/src/hotspot/share/services/diagnosticFramework.cpp
@@ -462,6 +462,11 @@ void DCmdFactory::send_notification_internal(TRAPS) {
   if (notif) {
 
     Klass* k = Management::com_sun_management_internal_DiagnosticCommandImpl_klass(CHECK);
+    if (k == nullptr) {
+      // No management support in this VM.
+      THROW_MSG(vmSymbols::java_lang_IllegalStateException(),
+                "DiagnosticCommandImpl is not available");
+    }
     InstanceKlass* dcmd_mbean_klass = InstanceKlass::cast(k);
 
     JavaValue result(T_OBJECT);

--- a/src/hotspot/share/services/diagnosticFramework.cpp
+++ b/src/hotspot/share/services/diagnosticFramework.cpp
@@ -463,7 +463,6 @@ void DCmdFactory::send_notification_internal(TRAPS) {
 
     Klass* k = Management::com_sun_management_internal_DiagnosticCommandImpl_klass(CHECK);
     if (k == nullptr) {
-      // No management support in this VM.
       THROW_MSG(vmSymbols::java_lang_IllegalStateException(),
                 "DiagnosticCommandImpl is not available");
     }

--- a/src/hotspot/share/services/gcNotifier.cpp
+++ b/src/hotspot/share/services/gcNotifier.cpp
@@ -83,7 +83,7 @@ static Handle getGcInfoBuilder(GCMemoryManager *gcManager,TRAPS) {
 
   Klass* gcMBeanKlass = Management::com_sun_management_internal_GarbageCollectorExtImpl_klass(CHECK_NH);
 
-  instanceOop i = gcManager->get_memory_manager_instance(CHECK_NH);
+  instanceOop i = gcManager->get_memory_manager_instance(THREAD);
   instanceHandle ih(THREAD, i);
 
   JavaValue result(T_OBJECT);
@@ -201,7 +201,7 @@ void GCNotifier::sendNotificationInternal(TRAPS) {
     Handle objCause = java_lang_String::create_from_str(request->gcCause, CHECK);
     InstanceKlass* gc_mbean_klass = Management::com_sun_management_internal_GarbageCollectorExtImpl_klass(CHECK);
 
-    instanceOop gc_mbean = request->gcManager->get_memory_manager_instance(CHECK);
+    instanceOop gc_mbean = request->gcManager->get_memory_manager_instance(THREAD);
     instanceHandle gc_mbean_h(THREAD, gc_mbean);
     if (!gc_mbean_h->is_a(gc_mbean_klass)) {
       THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),

--- a/src/hotspot/share/services/gcNotifier.cpp
+++ b/src/hotspot/share/services/gcNotifier.cpp
@@ -83,7 +83,7 @@ static Handle getGcInfoBuilder(GCMemoryManager *gcManager,TRAPS) {
 
   Klass* gcMBeanKlass = Management::com_sun_management_internal_GarbageCollectorExtImpl_klass(CHECK_NH);
 
-  instanceOop i = gcManager->get_memory_manager_instance(THREAD);
+  instanceOop i = gcManager->get_memory_manager_instance(CHECK_NH);
   instanceHandle ih(THREAD, i);
 
   JavaValue result(T_OBJECT);
@@ -201,7 +201,7 @@ void GCNotifier::sendNotificationInternal(TRAPS) {
     Handle objCause = java_lang_String::create_from_str(request->gcCause, CHECK);
     InstanceKlass* gc_mbean_klass = Management::com_sun_management_internal_GarbageCollectorExtImpl_klass(CHECK);
 
-    instanceOop gc_mbean = request->gcManager->get_memory_manager_instance(THREAD);
+    instanceOop gc_mbean = request->gcManager->get_memory_manager_instance(CHECK);
     instanceHandle gc_mbean_h(THREAD, gc_mbean);
     if (!gc_mbean_h->is_a(gc_mbean_klass)) {
       THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),

--- a/src/hotspot/share/services/memoryManager.cpp
+++ b/src/hotspot/share/services/memoryManager.cpp
@@ -100,6 +100,11 @@ instanceOop MemoryManager::get_memory_manager_instance(TRAPS) {
       signature = vmSymbols::createMemoryManager_signature();
     }
 
+    if (k == nullptr) {
+      THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
+                 "This GCMemoryManager doesn't have a GarbageCollectorMXBean", NULL);
+    }
+
     InstanceKlass* ik = InstanceKlass::cast(k);
 
     JavaCalls::call_static(&result,

--- a/src/hotspot/share/services/memoryManager.cpp
+++ b/src/hotspot/share/services/memoryManager.cpp
@@ -101,8 +101,8 @@ instanceOop MemoryManager::get_memory_manager_instance(TRAPS) {
     }
 
     if (k == nullptr) {
-      THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
-                 "This GCMemoryManager doesn't have a GarbageCollectorMXBean", NULL);
+      fatal("Should have the ManagementFactoryHelper or GarbageCollectorExtImpl class");
+      return nullptr; // silence the compiler
     }
 
     InstanceKlass* ik = InstanceKlass::cast(k);


### PR DESCRIPTION
These build failures are specific to Minimal VM, because it disables "management" feature, and paths like these start to return NULL:

```
  static InstanceKlass* com_sun_management_internal_DiagnosticCommandImpl_klass(TRAPS)
      NOT_MANAGEMENT_RETURN_(NULL);
``` 

I propose we handle the `NULL`-s properly and throwing early when those are detected. We return/throw what similar code in the affected methods do. I went back and forth with the patch, and settled on throwing from `MemoryManager::get_memory_manager_instance`, and handling the exception at its uses.

Additional testing:
 - [x] Linux x86_64 fastdebug minimal build with GCC 11.3.0
 - [x]  Linux x86_64 fastdebug server with GCC 9.3.0, `tier1`
 - [x]  Linux x86_64 fastdebug server with GCC 9.3.0, `tier2`
 - [x]  Linux x86_64 fastdebug server with GCC 9.3.0, `hotspot_serviceability`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289002](https://bugs.openjdk.org/browse/JDK-8289002): Minimal x86_64 VM build fails with GCC 11: 'this' pointer is null


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9718/head:pull/9718` \
`$ git checkout pull/9718`

Update a local copy of the PR: \
`$ git checkout pull/9718` \
`$ git pull https://git.openjdk.org/jdk pull/9718/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9718`

View PR using the GUI difftool: \
`$ git pr show -t 9718`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9718.diff">https://git.openjdk.org/jdk/pull/9718.diff</a>

</details>
