### PR TITLE
8291653

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1668,12 +1668,13 @@ bool G1RemSet::clean_card_before_refine(CardValue** const card_ptr_addr) {
     } else if (card_ptr != orig_card_ptr) {
       // Original card was inserted and an old card was evicted.
       start = _ct->addr_for(card_ptr);
-      r = _g1h->heap_region_containing(start);
+      r = _g1h->heap_region_containing_or_null(start);
 
       // Check whether the region formerly in the cache should be
       // ignored, as discussed earlier for the original card.  The
-      // region could have been freed while in the cache.
-      if (!r->is_old_or_humongous_or_archive()) {
+      // region could have been freed (or even uncommitted) while
+      // in the cache.
+      if (r == nullptr || !r->is_old_or_humongous_or_archive()) {
         return false;
       }
       *card_ptr_addr = card_ptr;


### PR DESCRIPTION
Hi all,

  can I have reviews for this wrong use of `G1CollectedHeap::heap_region_containing` in `G1RemSet::clean_card_before_refine()`?

If a card is evicted from the hot card cache it might also be located in an outdated (reclaimed) region (by Remark). So the call needs to explicitly consider that case and use `heap_region_containing_or_null` and appropriately check for that later.

This is only an issue in debug mode, because while still this is kind of an illegal request, the return value will always be a valid `HeapRegion` instance as we never deallocate them.

Testing: reproduced crashes with the given test case (1:5), no more crashes afterwards.

Thanks,
  Thomas