### PR TITLE
8291822: ARM32: Build errors with GCC 11 in frame::saved_oop_result

### DIFF
--- a/src/hotspot/cpu/arm/frame_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.inline.hpp
@@ -196,6 +196,10 @@ inline JavaCallWrapper** frame::entry_frame_call_wrapper_addr() const {
 
 // Compiled frames
 
+// Register is a class, but it would be assigned numerical value.
+// "0" is assigned for rax. Thus we need to ignore -Wnonnull.
+PRAGMA_DIAG_PUSH
+PRAGMA_NONNULL_IGNORED
 inline oop frame::saved_oop_result(RegisterMap* map) const {
   oop* result_adr = (oop*) map->location(R0->as_VMReg(), nullptr);
   guarantee(result_adr != NULL, "bad register save location");
@@ -207,6 +211,7 @@ inline void frame::set_saved_oop_result(RegisterMap* map, oop obj) {
   guarantee(result_adr != NULL, "bad register save location");
   *result_adr = obj;
 }
+PRAGMA_DIAG_POP
 
 inline int frame::frame_size() const {
   return sender_sp() - sp();


### PR DESCRIPTION
Same workaround was applied for other platforms in JDK-8270083 and JDK-8271869

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291822](https://bugs.openjdk.org/browse/JDK-8291822): ARM32: Build errors with GCC 11 in frame::saved_oop_result


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [686e5507](https://git.openjdk.org/jdk/pull/9727/files/686e55075b5d16f346c2ed28d64abed216794b7a)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9727/head:pull/9727` \
`$ git checkout pull/9727`

Update a local copy of the PR: \
`$ git checkout pull/9727` \
`$ git pull https://git.openjdk.org/jdk pull/9727/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9727`

View PR using the GUI difftool: \
`$ git pr show -t 9727`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9727.diff">https://git.openjdk.org/jdk/pull/9727.diff</a>

</details>
