### PR TITLE
8291825: java/time/nontestng/java/time/zone/CustomZoneNameTest.java fails if defaultLocale and defaultFormatLocale are different

### DIFF
--- a/test/jdk/java/time/nontestng/java/time/zone/zoneProvider/custom/CustomTimeZoneNameProvider.java
+++ b/test/jdk/java/time/nontestng/java/time/zone/zoneProvider/custom/CustomTimeZoneNameProvider.java
@@ -73,7 +73,7 @@ public class CustomTimeZoneNameProvider extends TimeZoneNameProvider {
     @Override
     public Locale[] getAvailableLocales() {
         return new Locale[]{
-            Locale.getDefault()
+            Locale.getDefault(Locale.Category.FORMAT)
         };
     }
 }


### PR DESCRIPTION
This patch fixes the test to use the same locale as the tested code

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291825](https://bugs.openjdk.org/browse/JDK-8291825): java/time/nontestng/java/time/zone/CustomZoneNameTest.java fails if defaultLocale and defaultFormatLocale are different


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9729/head:pull/9729` \
`$ git checkout pull/9729`

Update a local copy of the PR: \
`$ git checkout pull/9729` \
`$ git pull https://git.openjdk.org/jdk pull/9729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9729`

View PR using the GUI difftool: \
`$ git pr show -t 9729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9729.diff">https://git.openjdk.org/jdk/pull/9729.diff</a>

</details>
