### PR TITLE
JDK-8291823: IGV: Fix "Save selected groups"

### DIFF
--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/FolderNode.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/FolderNode.java
@@ -59,6 +59,10 @@ public class FolderNode extends AbstractNode {
             folder.getChangedEvent().addListener(this);
         }
 
+        public Folder getFolder() {
+            return folder;
+        }
+
         @Override
         protected Node[] createNodes(FolderElement e) {
             if (e instanceof InputGraph) {
@@ -148,5 +152,9 @@ public class FolderNode extends AbstractNode {
 
     public static GraphNode getGraphNode(InputGraph graph) {
         return graphNode.get(graph);
+    }
+
+    public Folder getFolder() {
+        return children.getFolder();
     }
 }

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/FolderNode.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/FolderNode.java
@@ -141,6 +141,11 @@ public class FolderNode extends AbstractNode {
         }
     }
 
+    public boolean isRootNode() {
+        Folder folder = getFolder();
+        return (folder != null && folder instanceof GraphDocument);
+    }
+
     @Override
     public Image getOpenedIcon(int i) {
         return getIcon(i);

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
@@ -37,8 +37,7 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
-import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
+import javax.swing.*;
 import javax.swing.border.Border;
 import org.openide.ErrorManager;
 import org.openide.actions.GarbageCollectAction;
@@ -71,6 +70,9 @@ public final class OutlineTopComponent extends TopComponent implements ExplorerM
     private FolderNode root;
     private Server server;
     private Server binaryServer;
+    private SaveAllAction saveAllAction;
+    private RemoveAllAction removeAllAction;
+
 
     private OutlineTopComponent() {
         initComponents();
@@ -94,25 +96,37 @@ public final class OutlineTopComponent extends TopComponent implements ExplorerM
     }
 
     private void initToolbar() {
-
         Toolbar toolbar = new Toolbar();
         Border b = (Border) UIManager.get("Nb.Editor.Toolbar.border"); //NOI18N
         toolbar.setBorder(b);
         this.add(toolbar, BorderLayout.NORTH);
 
         toolbar.add(ImportAction.get(ImportAction.class));
-
         toolbar.add(((NodeAction) SaveAsAction.get(SaveAsAction.class)).createContextAwareInstance(this.getLookup()));
-        toolbar.add(SaveAllAction.get(SaveAllAction.class));
+
+        saveAllAction = SaveAllAction.get(SaveAllAction.class);
+        saveAllAction.setEnabled(false);
+        toolbar.add(saveAllAction);
 
         toolbar.add(((NodeAction) RemoveAction.get(RemoveAction.class)).createContextAwareInstance(this.getLookup()));
-        toolbar.add(RemoveAllAction.get(RemoveAllAction.class));
+
+        removeAllAction = RemoveAllAction.get(RemoveAllAction.class);
+        removeAllAction.setEnabled(false);
+        toolbar.add(removeAllAction);
 
         toolbar.add(GarbageCollectAction.get(GarbageCollectAction.class).getToolbarPresenter());
 
         for (Toolbar tb : ToolbarPool.getDefault().getToolbars()) {
             tb.setVisible(false);
         }
+
+        document.getChangedEvent().addListener(g -> documentChanged());
+    }
+
+    private void documentChanged() {
+        boolean enableButton = !document.getElements().isEmpty();
+        saveAllAction.setEnabled(enableButton);
+        removeAllAction.setEnabled(enableButton);
     }
 
     private void initReceivers() {

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/ImportAction.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/ImportAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/ImportAction.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/ImportAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/RemoveAction.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/RemoveAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 
 package com.sun.hotspot.igv.coordinator.actions;
 
+import com.sun.hotspot.igv.coordinator.FolderNode;
 import javax.swing.Action;
 import org.openide.nodes.Node;
 import org.openide.util.HelpCtx;
@@ -72,6 +73,14 @@ public final class RemoveAction extends NodeAction {
 
     @Override
     protected boolean enable(Node[] nodes) {
-        return nodes.length > 0;
+        if (nodes.length > 0) {
+            for (Node n : nodes) {
+                if ((n instanceof FolderNode) && ((FolderNode) n).isRootNode()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/SaveAsAction.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/SaveAsAction.java
@@ -125,7 +125,7 @@ public final class SaveAsAction extends NodeAction {
     protected boolean enable(Node[] nodes) {
         if (nodes.length > 0) {
             for (Node n : nodes) {
-                if (!(n instanceof FolderNode)) {
+                if (!(n instanceof FolderNode) || ((FolderNode) n).isRootNode()) {
                     return false;
                 }
             }

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/SaveAsAction.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/SaveAsAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,9 @@
 
 package com.sun.hotspot.igv.coordinator.actions;
 
+import com.sun.hotspot.igv.coordinator.FolderNode;
+import com.sun.hotspot.igv.coordinator.OutlineTopComponent;
+import com.sun.hotspot.igv.data.Folder;
 import com.sun.hotspot.igv.data.GraphDocument;
 import com.sun.hotspot.igv.data.Group;
 import com.sun.hotspot.igv.data.serialization.Printer;
@@ -49,13 +52,18 @@ public final class SaveAsAction extends NodeAction {
 
     @Override
     protected void performAction(Node[] activatedNodes) {
-
+        final OutlineTopComponent component = OutlineTopComponent.findInstance();
         GraphDocument doc = new GraphDocument();
-        for (Node n : activatedNodes) {
-            Group group = n.getLookup().lookup(Group.class);
-            doc.addElement(group);
+        for (Node node : activatedNodes) {
+            if (node instanceof FolderNode) {
+                FolderNode folderNode = (FolderNode) node;
+                Folder folder = folderNode.getFolder();
+                if (folder instanceof Group) {
+                    Group group = (Group) folder;
+                    doc.addElement(group);
+                }
+            }
         }
-
         save(doc);
     }
 
@@ -115,12 +123,14 @@ public final class SaveAsAction extends NodeAction {
 
     @Override
     protected boolean enable(Node[] nodes) {
-
-        int cnt = 0;
-        for (Node n : nodes) {
-            cnt += n.getLookup().lookupAll(Group.class).size();
+        if (nodes.length > 0) {
+            for (Node n : nodes) {
+                if (!(n instanceof FolderNode)) {
+                    return false;
+                }
+            }
+            return true;
         }
-
-        return cnt > 0;
+        return false;
     }
 }


### PR DESCRIPTION
In IGV the button `Save selected groups to XML file...` is broken and never activated. 

*Before this fix* 
Bellow you can see the Outline with two selected groups, but the `Save selected groups to XML file...` button does not work:
<img width="307" alt="before_groups_selected" src="https://user-images.githubusercontent.com/71546117/182790122-ed272ed4-1cca-4d5c-ae2a-6c2f44fd3565.png">

*After this fix* 
Now the `Save selected groups to XML file...` button works if at least one groups is selected:
<img width="273" alt="groups_selected" src="https://user-images.githubusercontent.com/71546117/182790406-08d6366a-4351-49d4-959e-79948bc4984d.png">


*After this fix* 
The `Save selected groups to XML file...` button is greyed out if no groups are selected:
<img width="272" alt="no_groups_selected" src="https://user-images.githubusercontent.com/71546117/182792546-ef5169a8-d4d8-4981-aee1-af7e30895925.png">




*Before this fix* 
The `Save all groups to XML` and the `Remove all graphs and groups` buttons where available even if no graphs or groups were loaded:
<img width="306" alt="before_no_groups" src="https://user-images.githubusercontent.com/71546117/182791984-dbec8829-fd81-4ce8-aa05-2d2030f89bd3.png">

*After this fix* 
The `Save all groups to XML` and the `Remove all graphs and groups` buttons are greyed out if no graphs or groups are loaded:
<img width="271" alt="no_groups" src="https://user-images.githubusercontent.com/71546117/182792159-88b0fa32-89dd-4e02-a3a9-66bdc77ecf70.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291823](https://bugs.openjdk.org/browse/JDK-8291823): IGV: Fix "Save selected groups"


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9730/head:pull/9730` \
`$ git checkout pull/9730`

Update a local copy of the PR: \
`$ git checkout pull/9730` \
`$ git pull https://git.openjdk.org/jdk pull/9730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9730`

View PR using the GUI difftool: \
`$ git pr show -t 9730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9730.diff">https://git.openjdk.org/jdk/pull/9730.diff</a>

</details>
