### PR TITLE
8290709: Incorrect dominance error for unconditional pattern vs. null

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1720,8 +1720,6 @@ public class Attr extends JCTree.Visitor {
                             preview.checkSourceLevel(expr.pos(), Feature.CASE_NULL);
                             if (hasNullPattern) {
                                 log.error(label.pos(), Errors.DuplicateCaseLabel);
-                            } else if (wasUnconditionalPattern) {
-                                log.error(label.pos(), Errors.PatternDominated);
                             }
                             hasNullPattern = true;
                             attribExpr(expr, switchEnv, seltype);

--- a/test/langtools/tools/javac/patterns/CaseStructureTest.java
+++ b/test/langtools/tools/javac/patterns/CaseStructureTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8269146
+ * @bug 8269146 8290709
  * @summary Check compilation outcomes for various combinations of case label element.
  * @library /tools/lib /tools/javac/lib
  * @modules
@@ -119,16 +119,6 @@ public class CaseStructureTest extends ComboInstance<CaseStructureTest> {
             }
             if (patternCases > 0 && defaultCases > 0) {
                 shouldPass &= false;
-            }
-            if (!asCaseLabelElements) {
-                //as an edge case, `case <total-pattern>: case null:` is prohibited:
-                boolean seenPattern = false;
-                for (CaseLabel label : caseLabels) {
-                    switch (label) {
-                        case NULL: if (seenPattern) shouldPass = false; break;
-                        case PARENTHESIZED_PATTERN, TYPE_PATTERN: seenPattern = true; break;
-                    }
-                }
             }
             if (!(shouldPass ^ result.hasErrors())) {
                 throw new AssertionError("Unexpected result: shouldPass=" + shouldPass + ", actual: " + !result.hasErrors() + ", info: " + result.compilationInfo());

--- a/test/langtools/tools/javac/patterns/Domination.java
+++ b/test/langtools/tools/javac/patterns/Domination.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8262891
+ * @bug 8262891 8290709
  * @summary Check the pattern domination error are reported correctly.
  * @compile/fail/ref=Domination.out -XDrawDiagnostics --enable-preview -source ${jdk.version} Domination.java
  */
@@ -209,6 +209,13 @@ public class Domination {
         switch (o) {
             case R(int a) when true: return 1;
             case R(int a): return -1;
+        }
+    }
+
+    int testNotDominates2(Integer x) {
+        switch (x) {
+            case Integer i: return i;
+            case null : return -1;
         }
     }
 }

--- a/test/langtools/tools/javac/patterns/SwitchErrors.java
+++ b/test/langtools/tools/javac/patterns/SwitchErrors.java
@@ -154,12 +154,6 @@ public class SwitchErrors {
             case String s: break;
         }
     }
-    void nullAfterTotal(Object o) {
-        switch (o) {
-            case Object obj: break;
-            case null: break;
-        }
-    }
     void sealedNonAbstract(SealedNonAbstract obj) {
         switch (obj) {//does not cover SealedNonAbstract
             case A a -> {}

--- a/test/langtools/tools/javac/patterns/SwitchErrors.out
+++ b/test/langtools/tools/javac/patterns/SwitchErrors.out
@@ -6,7 +6,6 @@ SwitchErrors.java:28:18: compiler.err.prob.found.req: (compiler.misc.inconvertib
 SwitchErrors.java:29:18: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.String, int)
 SwitchErrors.java:30:18: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: int, java.lang.CharSequence)
 SwitchErrors.java:36:13: compiler.err.unconditional.pattern.and.default
-SwitchErrors.java:42:18: compiler.err.pattern.dominated
 SwitchErrors.java:42:24: compiler.err.unconditional.pattern.and.default
 SwitchErrors.java:48:18: compiler.err.unconditional.pattern.and.default
 SwitchErrors.java:54:18: compiler.err.duplicate.unconditional.pattern
@@ -27,22 +26,21 @@ SwitchErrors.java:137:28: compiler.err.flows.through.from.pattern
 SwitchErrors.java:143:18: compiler.err.flows.through.from.pattern
 SwitchErrors.java:148:27: compiler.err.flows.through.to.pattern
 SwitchErrors.java:154:18: compiler.err.flows.through.to.pattern
-SwitchErrors.java:160:18: compiler.err.pattern.dominated
-SwitchErrors.java:172:18: compiler.err.pattern.expected
-SwitchErrors.java:178:78: compiler.err.cant.resolve.location: kindname.variable, n, , , (compiler.misc.location: kindname.class, SwitchErrors, null)
-SwitchErrors.java:184:73: compiler.err.cant.resolve.location: kindname.variable, n, , , (compiler.misc.location: kindname.class, SwitchErrors, null)
-SwitchErrors.java:191:21: compiler.err.flows.through.to.pattern
-SwitchErrors.java:200:44: compiler.err.flows.through.from.pattern
-SwitchErrors.java:218:29: compiler.err.unconditional.pattern.and.default
-SwitchErrors.java:225:21: compiler.err.flows.through.to.pattern
-SwitchErrors.java:225:47: compiler.err.flows.through.from.pattern
-SwitchErrors.java:232:44: compiler.err.flows.through.from.pattern
-SwitchErrors.java:232:47: compiler.err.flows.through.from.pattern
-SwitchErrors.java:244:18: compiler.err.duplicate.unconditional.pattern
-SwitchErrors.java:249:18: compiler.err.prob.found.req: (compiler.misc.not.applicable.types: int, java.lang.Integer)
-SwitchErrors.java:254:18: compiler.err.type.found.req: int, (compiler.misc.type.req.class.array)
-SwitchErrors.java:267:24: compiler.err.flows.through.to.pattern
-SwitchErrors.java:281:37: compiler.err.flows.through.from.pattern
+SwitchErrors.java:166:18: compiler.err.pattern.expected
+SwitchErrors.java:172:78: compiler.err.cant.resolve.location: kindname.variable, n, , , (compiler.misc.location: kindname.class, SwitchErrors, null)
+SwitchErrors.java:178:73: compiler.err.cant.resolve.location: kindname.variable, n, , , (compiler.misc.location: kindname.class, SwitchErrors, null)
+SwitchErrors.java:185:21: compiler.err.flows.through.to.pattern
+SwitchErrors.java:194:44: compiler.err.flows.through.from.pattern
+SwitchErrors.java:212:29: compiler.err.unconditional.pattern.and.default
+SwitchErrors.java:219:21: compiler.err.flows.through.to.pattern
+SwitchErrors.java:219:47: compiler.err.flows.through.from.pattern
+SwitchErrors.java:226:44: compiler.err.flows.through.from.pattern
+SwitchErrors.java:226:47: compiler.err.flows.through.from.pattern
+SwitchErrors.java:238:18: compiler.err.duplicate.unconditional.pattern
+SwitchErrors.java:243:18: compiler.err.prob.found.req: (compiler.misc.not.applicable.types: int, java.lang.Integer)
+SwitchErrors.java:248:18: compiler.err.type.found.req: int, (compiler.misc.type.req.class.array)
+SwitchErrors.java:261:24: compiler.err.flows.through.to.pattern
+SwitchErrors.java:275:37: compiler.err.flows.through.from.pattern
 SwitchErrors.java:9:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:15:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:21:9: compiler.err.not.exhaustive.statement
@@ -53,8 +51,8 @@ SwitchErrors.java:86:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:91:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:97:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:104:9: compiler.err.not.exhaustive.statement
-SwitchErrors.java:164:9: compiler.err.not.exhaustive.statement
-SwitchErrors.java:237:9: compiler.err.not.exhaustive.statement
+SwitchErrors.java:158:9: compiler.err.not.exhaustive.statement
+SwitchErrors.java:231:9: compiler.err.not.exhaustive.statement
 - compiler.note.preview.filename: SwitchErrors.java, DEFAULT
 - compiler.note.preview.recompile
-57 errors
+55 errors

--- a/test/langtools/tools/javac/patterns/Switches.java
+++ b/test/langtools/tools/javac/patterns/Switches.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
 
 /*
  * @test
- * @bug 8262891 8268333 8268896 8269802 8269808 8270151 8269113 8277864
+ * @bug 8262891 8268333 8268896 8269802 8269808 8270151 8269113 8277864 8290709
  * @summary Check behavior of pattern switches.
  * @compile --enable-preview -source ${jdk.version} Switches.java
  * @run main/othervm --enable-preview Switches
@@ -94,6 +94,10 @@ public class Switches {
         assertEquals("a", deconstructExpression(new R("a")));
         assertEquals("1", deconstructExpression(new R(1)));
         assertEquals("other", deconstructExpression(""));
+        assertEquals("OK", totalPatternAndNull(Integer.valueOf(42)));
+        assertEquals("OK", totalPatternAndNull(null));
+        assertEquals("1", nullAfterTotal(Integer.valueOf(42)));
+        assertEquals("OK", nullAfterTotal(null));
     }
 
     void run(Function<Object, Integer> mapper) {
@@ -630,6 +634,20 @@ public class Switches {
             case R(String s) -> s;
             case R(Integer i) r -> r.o().toString();
             case Object x -> "other";
+        };
+    }
+
+    String totalPatternAndNull(Integer in) {
+        return switch (in) {
+            case -1: { yield "";}
+            case Integer i: case null: { yield "OK";}
+        };
+    }
+
+    String nullAfterTotal(Object o) {
+        return switch (o) {
+            case Object obj: { yield "1";}
+            case null: { yield "OK";}
         };
     }
 


### PR DESCRIPTION
The corresponding JLS rule (3rd preview feature of pattern switch) on unconditional patterns & null does not exist anymore:

Check:

- 2nd preview: https://cr.openjdk.java.net/~gbierman/jep420/jep420-20211208/specs/patterns-switch-jls.html#jls-14.11.1
- 3rd preview: https://cr.openjdk.java.net/~gbierman/jep427%2b405/jep427+405-20220601/specs/patterns-switch-record-patterns-jls.html#jls-14.11.1

Effectively, the following restriction was lifted:
```
A switch label that has a pattern case label element p that is total for the type of the selector expression of the enclosing switch statement or switch expression dominates a switch label that has a null case label element.
```

The corresponding neg-tests where now promoted as pos-tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290709](https://bugs.openjdk.org/browse/JDK-8290709): Incorrect dominance error for unconditional pattern vs. null


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9732/head:pull/9732` \
`$ git checkout pull/9732`

Update a local copy of the PR: \
`$ git checkout pull/9732` \
`$ git pull https://git.openjdk.org/jdk pull/9732/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9732`

View PR using the GUI difftool: \
`$ git pr show -t 9732`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9732.diff">https://git.openjdk.org/jdk/pull/9732.diff</a>

</details>
