### PR TITLE
8291828: Reduce runtime of java.util.stream microbenchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/java/util/stream/AllMatcher.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/AllMatcher.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongPredicate;
@@ -41,6 +44,9 @@ import java.util.stream.LongStream;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 public class AllMatcher {
 
     /**

--- a/test/micro/org/openjdk/bench/java/util/stream/AnyMatcher.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/AnyMatcher.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongPredicate;
@@ -41,6 +44,9 @@ import java.util.stream.LongStream;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 public class AnyMatcher {
 
     /**

--- a/test/micro/org/openjdk/bench/java/util/stream/Decomposition.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/Decomposition.java
@@ -24,13 +24,16 @@ package org.openjdk.bench.java.util.stream;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.stream.LongStream;
@@ -48,6 +51,9 @@ import java.util.stream.LongStream;
 @BenchmarkMode(Mode.SampleTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 public class Decomposition {
 
     @Param("1000")

--- a/test/micro/org/openjdk/bench/java/util/stream/NoneMatcher.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/NoneMatcher.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongPredicate;
@@ -43,6 +46,9 @@ import java.util.stream.LongStream;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 public class NoneMatcher {
 
     /**

--- a/test/micro/org/openjdk/bench/java/util/stream/Reducers.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/Reducers.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongBinaryOperator;
@@ -41,6 +44,9 @@ import java.util.stream.LongStream;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 public class Reducers {
 
     /**

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/AllMatch.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/AllMatch.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.ops.ref;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -39,6 +42,9 @@ import java.util.stream.LongStream;
  * Benchmark for allMatch() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class AllMatch {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/AllMatchShort.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/AllMatchShort.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.ops.ref;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -40,6 +43,9 @@ import java.util.stream.LongStream;
  * Focuses on short-circuiting behavior.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class AllMatchShort {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/AnyMatch.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/AnyMatch.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.ops.ref;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -39,6 +42,9 @@ import java.util.stream.LongStream;
  * Benchmark for anyMatch() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class AnyMatch {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/AnyMatchShort.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/AnyMatchShort.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.ops.ref;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -40,6 +43,9 @@ import java.util.stream.LongStream;
  * Focuses on short-circuiting behavior.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class AnyMatchShort {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/Filter.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/Filter.java
@@ -25,12 +25,15 @@ package org.openjdk.bench.java.util.stream.ops.ref;
 import org.openjdk.bench.java.util.stream.ops.LongAccumulator;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -40,6 +43,9 @@ import java.util.stream.LongStream;
  * Benchmark for filter() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class Filter {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/FindAny.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/FindAny.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.util.stream.ops.ref;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.stream.LongStream;
@@ -37,6 +40,9 @@ import java.util.stream.LongStream;
  * Benchmark for findAny() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class FindAny {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/FindFirst.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/FindFirst.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.util.stream.ops.ref;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.stream.LongStream;
@@ -37,6 +40,9 @@ import java.util.stream.LongStream;
  * Benchmark for findFirst() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class FindFirst {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/ForEach.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/ForEach.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.ops.ref;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
@@ -40,6 +43,9 @@ import java.util.stream.LongStream;
  * Benchmark for forEach() operations.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class ForEach {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/Limit.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/Limit.java
@@ -25,11 +25,14 @@ package org.openjdk.bench.java.util.stream.ops.ref;
 import org.openjdk.bench.java.util.stream.ops.LongAccumulator;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.stream.LongStream;
@@ -38,6 +41,9 @@ import java.util.stream.LongStream;
  * Benchmark for limit() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class Limit {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/Map.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/Map.java
@@ -25,12 +25,15 @@ package org.openjdk.bench.java.util.stream.ops.ref;
 import org.openjdk.bench.java.util.stream.ops.LongAccumulator;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -40,6 +43,9 @@ import java.util.stream.LongStream;
  * Benchmark for map() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class Map {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/NoneMatch.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/NoneMatch.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.ops.ref;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -39,6 +42,9 @@ import java.util.stream.LongStream;
  * Benchmark for noneMatch() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class NoneMatch {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/NoneMatchShort.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/NoneMatchShort.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.ops.ref;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -40,6 +43,9 @@ import java.util.stream.LongStream;
  * Focuses on short-circuiting behavior.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class NoneMatchShort {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/Reduce.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/Reduce.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.ops.ref;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.BinaryOperator;
@@ -39,7 +42,10 @@ import java.util.stream.LongStream;
  * Benchmark for reduce() operation.
  */
 @BenchmarkMode(Mode.Throughput)
-@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
+@OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class Reduce {
 

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/ReduceBase.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/ReduceBase.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.ops.ref;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.BinaryOperator;
@@ -39,6 +42,9 @@ import java.util.stream.LongStream;
  * Benchmark for reduce()-base operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class ReduceBase {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/SliceToList.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/SliceToList.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.util.stream.ops.ref;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -38,6 +41,9 @@ import java.util.stream.IntStream;
  * Benchmark for limit()/skip() operation in sized streams.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class SliceToList {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/Sorted.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/Sorted.java
@@ -25,12 +25,15 @@ package org.openjdk.bench.java.util.stream.ops.ref;
 import org.openjdk.bench.java.util.stream.ops.LongAccumulator;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.Comparator;
 import java.util.concurrent.TimeUnit;
@@ -40,6 +43,9 @@ import java.util.stream.LongStream;
  * Benchmark for sorted() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class Sorted {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/SortedUnique.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/SortedUnique.java
@@ -25,11 +25,14 @@ package org.openjdk.bench.java.util.stream.ops.ref;
 import org.openjdk.bench.java.util.stream.ops.LongAccumulator;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.stream.LongStream;
@@ -39,6 +42,9 @@ import java.util.stream.LongStream;
  * Sorts long range modulo power of two, then does unique elements.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class SortedUnique {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/UniqueElements.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/UniqueElements.java
@@ -25,11 +25,14 @@ package org.openjdk.bench.java.util.stream.ops.ref;
 import org.openjdk.bench.java.util.stream.ops.LongAccumulator;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.stream.LongStream;
@@ -38,6 +41,9 @@ import java.util.stream.LongStream;
  * Benchmark for uniqueElements() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class UniqueElements {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/AllMatch.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/AllMatch.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.ops.value;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongPredicate;
@@ -39,6 +42,9 @@ import java.util.stream.LongStream;
  * Benchmark for allMatch() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class AllMatch {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/AllMatchShort.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/AllMatchShort.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.ops.value;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongPredicate;
@@ -40,6 +43,9 @@ import java.util.stream.LongStream;
  * Focuses on short-circuiting behavior.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class AllMatchShort {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/AnyMatch.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/AnyMatch.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.ops.value;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongPredicate;
@@ -39,6 +42,9 @@ import java.util.stream.LongStream;
  * Benchmark for anyMatch() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class AnyMatch {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/AnyMatchShort.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/AnyMatchShort.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.ops.value;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongPredicate;
@@ -40,6 +43,9 @@ import java.util.stream.LongStream;
  * Focuses on short-circuiting behavior.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class AnyMatchShort {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/Filter.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/Filter.java
@@ -25,12 +25,15 @@ package org.openjdk.bench.java.util.stream.ops.value;
 import org.openjdk.bench.java.util.stream.ops.LongAccumulator;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongPredicate;
@@ -40,6 +43,9 @@ import java.util.stream.LongStream;
  * Benchmark for filter() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class Filter {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/FindAny.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/FindAny.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.util.stream.ops.value;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.stream.LongStream;
@@ -37,6 +40,9 @@ import java.util.stream.LongStream;
  * Benchmark for findAny() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class FindAny {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/FindFirst.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/FindFirst.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.util.stream.ops.value;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.stream.LongStream;
@@ -37,6 +40,9 @@ import java.util.stream.LongStream;
  * Benchmark for findFirst() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class FindFirst {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/ForEach.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/ForEach.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.ops.value;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
@@ -40,6 +43,9 @@ import java.util.stream.LongStream;
  * Benchmark for forEach() operations.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class ForEach {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/Limit.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/Limit.java
@@ -25,11 +25,14 @@ package org.openjdk.bench.java.util.stream.ops.value;
 import org.openjdk.bench.java.util.stream.ops.LongAccumulator;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.stream.LongStream;
@@ -38,6 +41,9 @@ import java.util.stream.LongStream;
  * Benchmark for limit() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class Limit {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/Map.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/Map.java
@@ -25,12 +25,15 @@ package org.openjdk.bench.java.util.stream.ops.value;
 import org.openjdk.bench.java.util.stream.ops.LongAccumulator;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongUnaryOperator;
@@ -40,6 +43,9 @@ import java.util.stream.LongStream;
  * Benchmark for map() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class Map {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/NoneMatch.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/NoneMatch.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.ops.value;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongPredicate;
@@ -39,6 +42,9 @@ import java.util.stream.LongStream;
  * Benchmark for noneMatch() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class NoneMatch {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/NoneMatchShort.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/NoneMatchShort.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.ops.value;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongPredicate;
@@ -40,6 +43,9 @@ import java.util.stream.LongStream;
  * Focuses on short-circuiting behavior.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class NoneMatchShort {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/Reduce.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/Reduce.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.ops.value;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongBinaryOperator;
@@ -39,6 +42,9 @@ import java.util.stream.LongStream;
  * Benchmark for reduce() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class Reduce {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/ReduceBase.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/ReduceBase.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.ops.value;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongBinaryOperator;
@@ -39,6 +42,9 @@ import java.util.stream.LongStream;
  * Benchmark for reduce()-base operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class ReduceBase {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/SizedCount.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/SizedCount.java
@@ -26,6 +26,8 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/SizedCount.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/SizedCount.java
@@ -26,8 +26,6 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
@@ -45,9 +43,9 @@ import java.util.stream.Stream;
 /**
  * Benchmark for count operation in sized streams.
  */
-@Fork(5)
-@Warmup(iterations = 10, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
-@Measurement(iterations = 20, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/SizedSum.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/SizedSum.java
@@ -26,8 +26,6 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
@@ -45,9 +43,9 @@ import java.util.stream.Stream;
 /**
  * Benchmark for sum operation in sized streams.
  */
-@Fork(5)
-@Warmup(iterations = 10, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
-@Measurement(iterations = 20, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/SizedSum.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/SizedSum.java
@@ -26,6 +26,8 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/SliceToArray.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/SliceToArray.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.util.stream.ops.value;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -38,6 +41,9 @@ import java.util.stream.IntStream;
  * Benchmark for limit()/skip() operation in sized streams.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class SliceToArray {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/Sorted.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/Sorted.java
@@ -25,11 +25,14 @@ package org.openjdk.bench.java.util.stream.ops.value;
 import org.openjdk.bench.java.util.stream.ops.LongAccumulator;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.stream.LongStream;
@@ -38,6 +41,9 @@ import java.util.stream.LongStream;
  * Benchmark for sorted() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class Sorted {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/SortedUnique.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/SortedUnique.java
@@ -25,11 +25,14 @@ package org.openjdk.bench.java.util.stream.ops.value;
 import org.openjdk.bench.java.util.stream.ops.LongAccumulator;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.stream.LongStream;
@@ -39,6 +42,9 @@ import java.util.stream.LongStream;
  * Sorts long range modulo power of two, then does unique elements.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class SortedUnique {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/value/UniqueElements.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/value/UniqueElements.java
@@ -25,11 +25,14 @@ package org.openjdk.bench.java.util.stream.ops.value;
 import org.openjdk.bench.java.util.stream.ops.LongAccumulator;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.stream.LongStream;
@@ -38,6 +41,9 @@ import java.util.stream.LongStream;
  * Benchmark for uniqueElements() operation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class UniqueElements {

--- a/test/micro/org/openjdk/bench/java/util/stream/pipeline/PipelineParMultiple.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/pipeline/PipelineParMultiple.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.util.stream.pipeline;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
@@ -41,6 +44,9 @@ import java.util.stream.LongStream;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 public class PipelineParMultiple {
 
     @Param("100000")

--- a/test/micro/org/openjdk/bench/java/util/stream/pipeline/PipelineSeqMultiple.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/pipeline/PipelineSeqMultiple.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.util.stream.pipeline;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
@@ -41,6 +44,9 @@ import java.util.stream.LongStream;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 public class PipelineSeqMultiple {
 
     @Param("100000")

--- a/test/micro/org/openjdk/bench/java/util/stream/pipeline/PipelineSetup.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/pipeline/PipelineSetup.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.util.stream.pipeline;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.stream.LongStream;
@@ -39,6 +42,9 @@ import java.util.stream.LongStream;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 public class PipelineSetup {
 
     /**

--- a/test/micro/org/openjdk/bench/java/util/stream/pipeline/Terminal.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/pipeline/Terminal.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.pipeline;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
@@ -44,6 +47,9 @@ import java.util.stream.LongStream;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 public class Terminal {
 
     /**

--- a/test/micro/org/openjdk/bench/java/util/stream/tasks/DictionaryWordValue/Bulk.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/tasks/DictionaryWordValue/Bulk.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.tasks.DictionaryWordValue;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.Arrays;
 import java.util.concurrent.RecursiveTask;
@@ -42,6 +45,9 @@ import java.util.function.Function;
  * Bulk scenario: searching max "wordValue" through the dictionary (array of strings).
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
 public class Bulk {

--- a/test/micro/org/openjdk/bench/java/util/stream/tasks/DictionaryWordValue/Lambda.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/tasks/DictionaryWordValue/Lambda.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.tasks.DictionaryWordValue;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -38,6 +41,9 @@ import java.util.concurrent.TimeUnit;
  * Bulk scenario: searching max "wordValue" through the dictionary (array of strings).
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
 public class Lambda {

--- a/test/micro/org/openjdk/bench/java/util/stream/tasks/IntegerDuplicate/Bulk.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/tasks/IntegerDuplicate/Bulk.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.util.stream.tasks.IntegerDuplicate;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -42,6 +45,9 @@ import java.util.stream.Stream;
  * This benchmark assesses flatMap() performance.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class Bulk {

--- a/test/micro/org/openjdk/bench/java/util/stream/tasks/IntegerDuplicate/Lambda.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/tasks/IntegerDuplicate/Lambda.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.util.stream.tasks.IntegerDuplicate;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,6 +42,9 @@ import java.util.concurrent.atomic.LongAdder;
  * This benchmark assesses flatMap() performance.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class Lambda {

--- a/test/micro/org/openjdk/bench/java/util/stream/tasks/IntegerMax/Bulk.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/tasks/IntegerMax/Bulk.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.tasks.IntegerMax;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.Arrays;
 import java.util.concurrent.RecursiveTask;
@@ -42,6 +45,9 @@ import java.util.function.BinaryOperator;
  * This test covers bulk infrastructure only. Refer to other tests for lambda-specific cases.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
 public class Bulk {

--- a/test/micro/org/openjdk/bench/java/util/stream/tasks/IntegerMax/Lambda.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/tasks/IntegerMax/Lambda.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.tasks.IntegerMax;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -40,6 +43,9 @@ import java.util.concurrent.TimeUnit;
  * This test covers lambda-specific solutions for the problem.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
 public class Lambda {

--- a/test/micro/org/openjdk/bench/java/util/stream/tasks/IntegerMax/Xtras.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/tasks/IntegerMax/Xtras.java
@@ -23,12 +23,15 @@
 package org.openjdk.bench.java.util.stream.tasks.IntegerMax;
 
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 
@@ -38,6 +41,9 @@ import java.util.concurrent.TimeUnit;
  * This test covers other interesting solutions for the original problem.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
 public class Xtras {

--- a/test/micro/org/openjdk/bench/java/util/stream/tasks/IntegerSum/Bulk.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/tasks/IntegerSum/Bulk.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.tasks.IntegerSum;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.Arrays;
 import java.util.concurrent.RecursiveTask;
@@ -42,6 +45,9 @@ import java.util.function.BinaryOperator;
  * This test covers bulk infrastructure only. Refer to other tests for lambda-specific cases.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
 public class Bulk {

--- a/test/micro/org/openjdk/bench/java/util/stream/tasks/IntegerSum/Lambda.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/tasks/IntegerSum/Lambda.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.tasks.IntegerSum;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -40,6 +43,9 @@ import java.util.concurrent.TimeUnit;
  * This test covers lambda-specific solutions for the problem.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
 public class Lambda {

--- a/test/micro/org/openjdk/bench/java/util/stream/tasks/PhoneCode/Bulk.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/tasks/PhoneCode/Bulk.java
@@ -25,10 +25,13 @@ package org.openjdk.bench.java.util.stream.tasks.PhoneCode;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -47,6 +50,9 @@ import static org.openjdk.bench.java.util.stream.tasks.PhoneCode.PhoneCodeProble
  * implementation.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.MINUTES)
 @State(Scope.Benchmark)
 public class Bulk {

--- a/test/micro/org/openjdk/bench/java/util/stream/tasks/PrimesFilter/t100/Bulk.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/tasks/PrimesFilter/t100/Bulk.java
@@ -25,10 +25,13 @@ package org.openjdk.bench.java.util.stream.tasks.PrimesFilter.t100;
 import org.openjdk.bench.java.util.stream.tasks.PrimesFilter.PrimesProblem;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -45,6 +48,9 @@ import java.util.stream.LongStream;
  * filter()...into() actions are benchmarked.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
 public class Bulk {

--- a/test/micro/org/openjdk/bench/java/util/stream/tasks/PrimesFilter/t100/Lambda.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/tasks/PrimesFilter/t100/Lambda.java
@@ -25,10 +25,13 @@ package org.openjdk.bench.java.util.stream.tasks.PrimesFilter.t100;
 import org.openjdk.bench.java.util.stream.tasks.PrimesFilter.PrimesProblem;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -41,6 +44,9 @@ import java.util.stream.LongStream;
  * filter()...into() actions are benchmarked.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
 public class Lambda {

--- a/test/micro/org/openjdk/bench/java/util/stream/tasks/PrimesFilter/t10000/Bulk.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/tasks/PrimesFilter/t10000/Bulk.java
@@ -25,10 +25,13 @@ package org.openjdk.bench.java.util.stream.tasks.PrimesFilter.t10000;
 import org.openjdk.bench.java.util.stream.tasks.PrimesFilter.PrimesProblem;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -45,6 +48,9 @@ import java.util.stream.LongStream;
  * filter()...into() actions are benchmarked.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
 public class Bulk {

--- a/test/micro/org/openjdk/bench/java/util/stream/tasks/PrimesFilter/t10000/Lambda.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/tasks/PrimesFilter/t10000/Lambda.java
@@ -25,10 +25,13 @@ package org.openjdk.bench.java.util.stream.tasks.PrimesFilter.t10000;
 import org.openjdk.bench.java.util.stream.tasks.PrimesFilter.PrimesProblem;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -41,6 +44,9 @@ import java.util.stream.LongStream;
  * filter()...into() actions are benchmarked.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
 public class Lambda {

--- a/test/micro/org/openjdk/bench/java/util/stream/tasks/PrimesSieve/Bulk.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/tasks/PrimesSieve/Bulk.java
@@ -24,12 +24,15 @@ package org.openjdk.bench.java.util.stream.tasks.PrimesSieve;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.Arrays;
 import java.util.concurrent.RecursiveTask;
@@ -43,6 +46,9 @@ import java.util.function.Predicate;
  * This test covers bulk infrastructure only. Refer to other tests for lambda-specific cases.
  */
 @BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
 public class Bulk {


### PR DESCRIPTION
These changes reduce the default run time from about 1 day 22 hours to about 6 hours with good stability we can use in weekly testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291828](https://bugs.openjdk.org/browse/JDK-8291828): Reduce runtime of java.util.stream microbenchmarks


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9733/head:pull/9733` \
`$ git checkout pull/9733`

Update a local copy of the PR: \
`$ git checkout pull/9733` \
`$ git pull https://git.openjdk.org/jdk pull/9733/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9733`

View PR using the GUI difftool: \
`$ git pr show -t 9733`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9733.diff">https://git.openjdk.org/jdk/pull/9733.diff</a>

</details>
