### PR TITLE
8291840: Avoid JavaCalls for setting up _java_system_loader and _java_platform_loader

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -249,6 +249,8 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   bool is_builtin_class_loader_data() const;
   bool is_permanent_class_loader_data() const;
 
+  OopHandle class_loader_handle() const { return _class_loader; }
+
   // The Metaspace is created lazily so may be NULL.  This
   // method will allocate a Metaspace if needed.
   ClassLoaderMetaspace* metaspace_non_null();

--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -499,9 +499,11 @@ void Modules::define_archived_modules(Handle h_platform_loader, Handle h_system_
   }
 
   ClassLoaderData* platform_loader_data = SystemDictionary::register_loader(h_platform_loader);
+  SystemDictionary::set_platform_loader(platform_loader_data);
   ClassLoaderDataShared::restore_java_platform_loader_from_archive(platform_loader_data);
 
   ClassLoaderData* system_loader_data = SystemDictionary::register_loader(h_system_loader);
+  SystemDictionary::set_system_loader(system_loader_data);
   ClassLoaderDataShared::restore_java_system_loader_from_archive(system_loader_data);
 }
 

--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -509,7 +509,7 @@ void Modules::define_archived_modules(Handle h_platform_loader, Handle h_system_
   // However, if -Djava.system.class.loader=xxx is specified, java_platform_loader() would
   // be an instance of a user-defined class, so make sure this never happens.
   assert(Arguments::get_property("java.system.class.loader") == NULL,
-           "archived full module should have been disabled");
+           "archived full module should have been disabled if -Djava.system.class.loader is specified");
   ClassLoaderDataShared::restore_java_system_loader_from_archive(system_loader_data);
 }
 

--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -44,6 +44,7 @@
 #include "logging/logStream.hpp"
 #include "memory/resourceArea.hpp"
 #include "prims/jvmtiExport.hpp"
+#include "runtime/arguments.hpp"
 #include "runtime/globals_extension.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/javaCalls.hpp"
@@ -504,6 +505,11 @@ void Modules::define_archived_modules(Handle h_platform_loader, Handle h_system_
 
   ClassLoaderData* system_loader_data = SystemDictionary::register_loader(h_system_loader);
   SystemDictionary::set_system_loader(system_loader_data);
+  // system_loader_data here is always an instance of jdk.internal.loader.ClassLoader$AppClassLoader.
+  // However, if -Djava.system.class.loader=xxx is specified, java_platform_loader() would
+  // be an instance of a user-defined class, so make sure this never happens.
+  assert(Arguments::get_property("java.system.class.loader") == NULL,
+           "archived full module should have been disabled");
   ClassLoaderDataShared::restore_java_system_loader_from_archive(system_loader_data);
 }
 

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -133,6 +133,8 @@ class SystemDictionary : AllStatic {
                                                   const ClassLoadInfo& cl_info,
                                                   TRAPS);
 
+  static oop get_system_class_loader_impl(TRAPS);
+
  public:
   // Resolve either a hidden or normal class from a stream of bytes, based on ClassLoadInfo
   static InstanceKlass* resolve_from_stream(ClassFileStream* st,

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -218,6 +218,9 @@ public:
   // Register a new class loader
   static ClassLoaderData* register_loader(Handle class_loader, bool create_mirror_cld = false);
 
+  static void set_system_loader(ClassLoaderData *cld);
+  static void set_platform_loader(ClassLoaderData *cld);
+
   static Symbol* check_signature_loaders(Symbol* signature, Klass* klass_being_linked,
                                          Handle loader1, Handle loader2, bool is_method);
 

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -134,6 +134,7 @@ class SystemDictionary : AllStatic {
                                                   TRAPS);
 
   static oop get_system_class_loader_impl(TRAPS);
+  static oop get_platform_class_loader_impl(TRAPS);
 
  public:
   // Resolve either a hidden or normal class from a stream of bytes, based on ClassLoadInfo


### PR DESCRIPTION
Please review this small optimization for setting up the `_java_system_loader `and `_java_platform_loader`.

I saw startup perf improvements with HelloWorld on linux-x64 like the following:

```
instr delta =      -102248    -0.1226%
time  delta =       -0.125 ms -0.3507%
```

Passed tiers 1,2,3 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291840](https://bugs.openjdk.org/browse/JDK-8291840): Avoid JavaCalls for setting up _java_system_loader and _java_platform_loader


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9734/head:pull/9734` \
`$ git checkout pull/9734`

Update a local copy of the PR: \
`$ git checkout pull/9734` \
`$ git pull https://git.openjdk.org/jdk pull/9734/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9734`

View PR using the GUI difftool: \
`$ git pr show -t 9734`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9734.diff">https://git.openjdk.org/jdk/pull/9734.diff</a>

</details>
