### PR TITLE
8291725: Leftover marks when VM shutdown aborts bitmap clearing make mixed gc fail

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1271,6 +1271,22 @@ class G1MergeHeapRootsTask : public WorkerTask {
              "Bitmap should have no mark for region %u", hr->hrm_index());
     }
 
+    bool should_clear_region(HeapRegion* hr) const {
+      // The bitmap for young regions must obviously be clear as we never mark through them;
+      // old regions are only in the collection set after the concurrent cycle completed,
+      // so their bitmaps must also be clear except when the pause occurs during the
+      // Concurrent Cleanup for Next Mark phase. Only at that point the region's bitmap may
+      // contain marks while being in the collection set at the same time.
+      //
+      // There is one exception: shutdown might have aborted the Concurrent Cleanup for Next
+      // Mark phase midway, which might have also left stale marks in old generation regions.
+      // There might actually have been scheduled multiple collections, but at that point we do
+      // not care that much about performance and just do the work multiple times if needed.
+      return (_g1h->collector_state()->clearing_bitmap() ||
+              _g1h->concurrent_mark_is_terminating()) &&
+              hr->is_old();
+    }
+
   public:
     G1ClearBitmapClosure(G1CollectedHeap* g1h) : _g1h(g1h) { }
 
@@ -1279,13 +1295,7 @@ class G1MergeHeapRootsTask : public WorkerTask {
 
       // Evacuation failure uses the bitmap to record evacuation failed objects,
       // so the bitmap for the regions in the collection set must be cleared if not already.
-      //
-      // A clear bitmap is obvious for young regions as we never mark through them;
-      // old regions are only in the collection set after the concurrent cycle completed,
-      // so their bitmaps must also be clear except when the pause occurs during the
-      // concurrent bitmap clear. At that point the region's bitmap may contain marks
-      // while being in the collection set at the same time.
-      if (_g1h->collector_state()->clearing_bitmap() && hr->is_old()) {
+      if (should_clear_region(hr)) {
         _g1h->clear_bitmap_for_region(hr);
       } else {
         assert_bitmap_clear(hr, _g1h->concurrent_mark()->mark_bitmap());


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that removes stray bits on the mark bitmap during mixed gcs during shutdown?

So it may happen that after shutdown aborts the "Concurrent Cleanup for Next Mark" phase which leaves marks on the bitmaps (we want to shut down asap after all). However a mixed gc afterwards might notice these marks and in this case asserts, but in case of an evacuation failure might also trip over these additional marks.

Testing: tier1-5, I did not manage to reproduce this, but it's "obvious" given the failure mode, particularly because recently there has been a similar issue with full gc in [JDK-8274007](https://bugs.openjdk.org/browse/JDK-8274007)

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291725](https://bugs.openjdk.org/browse/JDK-8291725): Leftover marks when VM shutdown aborts bitmap clearing make mixed gc fail


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9735/head:pull/9735` \
`$ git checkout pull/9735`

Update a local copy of the PR: \
`$ git checkout pull/9735` \
`$ git pull https://git.openjdk.org/jdk pull/9735/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9735`

View PR using the GUI difftool: \
`$ git pr show -t 9735`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9735.diff">https://git.openjdk.org/jdk/pull/9735.diff</a>

</details>
