### PR TITLE
8291899: Zero VM is broken on MacOS after JDK-8290840 due to os::setup_fpu() is missing

### DIFF
--- a/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
+++ b/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
@@ -362,3 +362,5 @@ void os::current_thread_enable_wx(WXMode mode) {
   pthread_jit_write_protect_np(mode == WXExec);
 }
 #endif
+
+void os::setup_fpu() {}


### PR DESCRIPTION
Hi all,

Zero VM fails to build on MacOS after JDK-8290840 due to `os::setup_fpu()` is missing.
The fix just adds the definition of it for macos.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291899](https://bugs.openjdk.org/browse/JDK-8291899): Zero VM is broken on MacOS after JDK-8290840 due to os::setup_fpu() is missing


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9744/head:pull/9744` \
`$ git checkout pull/9744`

Update a local copy of the PR: \
`$ git checkout pull/9744` \
`$ git pull https://git.openjdk.org/jdk pull/9744/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9744`

View PR using the GUI difftool: \
`$ git pr show -t 9744`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9744.diff">https://git.openjdk.org/jdk/pull/9744.diff</a>

</details>
