### PR TITLE
8291459: JVM crash with GenerateOopMap::error_work(char const*, __va_list_tag*)

### DIFF
--- a/src/hotspot/share/oops/generateOopMap.cpp
+++ b/src/hotspot/share/oops/generateOopMap.cpp
@@ -547,7 +547,13 @@ bool GenerateOopMap::jump_targets_do(BytecodeStream *bcs, jmpFct_t jmpFct, int *
     case Bytecodes::_ifnull:
     case Bytecodes::_ifnonnull:
       (*jmpFct)(this, bcs->dest(), data);
-      (*jmpFct)(this, bci + 3, data);
+      // Class files verified by the old verifier can have a conditional branch
+      // as their last bytecode, provided the conditional branch is unreachable
+      // during execution.  Check if this instruction is the method's last bytecode
+      // and, if so, don't call the jmpFct.
+      if (bci + 3 < method()->code_size()) {
+        (*jmpFct)(this, bci + 3, data);
+      }
       break;
 
     case Bytecodes::_goto:

--- a/test/hotspot/jtreg/runtime/GenerateOopMap/TestGenerateOopMapCrash.java
+++ b/test/hotspot/jtreg/runtime/GenerateOopMap/TestGenerateOopMapCrash.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8291459
+ * @summary Test that GenerateOopMap does not crash if last bytecode is a conditional branch
+ * @library /test/lib /
+ * @requires vm.flagless
+ * @compile if_icmpleIsLastOpcode.jasm
+ * @run driver compiler.linkage.TestGenerateOopMapCrash
+ */
+
+package compiler.linkage;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+// This test was copied from compiler test TestLinkageErrorInGenerateOopMap.java.
+public class TestGenerateOopMapCrash {
+
+    public static void main(String args[]) throws Exception {
+        if (args.length == 0) {
+            // Spawn new VM instance to execute test
+            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                    "-XX:-TieredCompilation",
+                    "-XX:CompileCommand=dontinline,compiler/linkage/if_icmpleIsLastOpcode.m*",
+                    "-XX:-CreateCoredumpOnCrash",
+                    "-Xmx64m",
+                    TestGenerateOopMapCrash.class.getName(),
+                    "run");
+            OutputAnalyzer output = new OutputAnalyzer(pb.start());
+            output.shouldHaveExitValue(0);
+        } else {
+            // Execute test
+            if_icmpleIsLastOpcode.test();
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/GenerateOopMap/if_icmpleIsLastOpcode.jasm
+++ b/test/hotspot/jtreg/runtime/GenerateOopMap/if_icmpleIsLastOpcode.jasm
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+// Old class file with a method whose last bytecode is an unreachable
+// conditional branch.
+public class compiler/linkage/if_icmpleIsLastOpcode version 49:0 {
+    public static Method m1:"()I" stack 1 locals 0 {
+        iconst_0;
+        ireturn;
+    }
+
+    public static Method m2:"(I)V" stack 1 locals 1 {
+        return;
+    }
+
+    public static Method test:"()V" stack 2 locals 1 {
+        iconst_0;
+        istore_0;
+        Loop: stack_frame_type append;
+        locals_map int;
+        iload_0;
+        invokestatic Method compiler/linkage/if_icmpleIsLastOpcode."m1":"()I";
+        invokestatic Method compiler/linkage/if_icmpleIsLastOpcode."m2":"(I)V";
+        iinc 0, 1;
+        ldc 100000;
+        if_icmple Loop;
+        return;
+        ldc 100000;
+        if_icmple Loop;
+    }
+}


### PR DESCRIPTION
The JVM fails when generating oop maps for method getAlphanumericCode(int) in bug_file/com/google/zxing/qrcode/encoder/Encoder.javap because the last bytecode in the method is an unreachable conditional branch at byecode index 11131:

      11124: ireturn
      11125: iinc          41, 1
      11128: iload         41
      11130: iconst_2
      11131: if_icmple     291

The class file (Encoder.class) containing getAlphanumericCode(int) has a class file version of 49.  So it is verified by the old verifier, which allows methods to end in a conditional branch provided that the conditional branch is unreachable during method execution.

This fix changes GenerateOopMap::jump_targets_do() to handle such methods.

The fix was tested by running the user's failing program, the new regression test, Mach5 tiers 1-2 on Linux, Mac OS, and Windows, Mach5 tiers 3-5 on Linu x64, and the JC Lang,VM, and API tests locally on Linux x64.

Please review.
Thanks, Harold
