### PR TITLE
8291637: HttpClient default keep alive timeout not followed if server sends invalid value 

### DIFF
--- a/src/java.base/share/classes/java/net/URL.java
+++ b/src/java.base/share/classes/java/net/URL.java
@@ -1243,7 +1243,7 @@ public final class URL implements java.io.Serializable {
     private static final URLStreamHandlerFactory defaultFactory = new DefaultFactory();
 
     private static class DefaultFactory implements URLStreamHandlerFactory {
-        private static String PREFIX = "sun.net.www.protocol.";
+        private static final String PREFIX = "sun.net.www.protocol.";
 
         public URLStreamHandler createURLStreamHandler(String protocol) {
             // Avoid using reflection during bootstrap

--- a/src/java.base/share/classes/sun/net/www/http/HttpClient.java
+++ b/src/java.base/share/classes/sun/net/www/http/HttpClient.java
@@ -901,6 +901,11 @@ public class HttpClient extends NetworkClient {
                         /* default should be larger in case of proxy */
                         keepAliveConnections = p.findInt("max", usingProxy?50:5);
                         keepAliveTimeout = p.findInt("timeout", -1);
+                        if (keepAliveTimeout < -1) {
+                            // if the server specified a negative (invalid) value
+                            // then we set to -1, which is equivalent to no value
+                            keepAliveTimeout = -1;
+                        }
                     }
                 } else if (b[7] != '0') {
                     /*

--- a/test/jdk/sun/net/www/http/KeepAliveCache/B8291637.java
+++ b/test/jdk/sun/net/www/http/KeepAliveCache/B8291637.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8291637
+ * @run main/othervm -Dhttp.keepAlive.time.server=20 -esa -ea B8291637
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.*;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+
+public class B8291637 {
+    static CompletableFuture<Boolean> passed = new CompletableFuture<>();
+
+    static class Server extends Thread {
+        final ServerSocket serverSocket;
+        final int port;
+        volatile Socket s;
+
+        public Server() throws IOException {
+            serverSocket = new ServerSocket(0);
+            port = serverSocket.getLocalPort();
+            setDaemon(true);
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        public void close() {
+            try {
+                serverSocket.close();
+                s.close();
+            } catch (IOException e) {}
+        }
+
+        static void readRequest(Socket s) throws IOException {
+            InputStream is = s.getInputStream();
+            is.read();
+            while (is.available() > 0)
+                is.read();
+        }
+
+        public void run() {
+            try {
+                while (true) {
+                    s = serverSocket.accept();
+                    readRequest(s);
+                    OutputStream os = s.getOutputStream();
+                    String resp = "" +
+                            "HTTP/1.1 200 OK\r\n" +
+                            "Content-Length: 11\r\n" +
+                            "Connection: Keep-Alive\r\n" +
+                            "Keep-Alive: timeout=-10\r\n" + // invalid negative value
+                            "\r\n" +
+                            "Hello World";
+                    os.write(resp.getBytes(StandardCharsets.ISO_8859_1));
+                    os.flush();
+                    InputStream is = s.getInputStream();
+                    long l1 = System.currentTimeMillis();
+                    is.read();
+                    long l2 = System.currentTimeMillis();
+                    long diff = (l2 - l1) / 1000;
+                    /*
+                     * timeout is set to 20 seconds. If bug is still present
+                     * then the timeout will occur the first time the keep alive
+                     * thread wakes up which is after 5 seconds. This allows
+                     * very large leeway with slow running hardware.
+                     */
+                    if (diff < 19) {
+                        passed.complete(false);
+                    } else {
+                        passed.complete(true);
+                    }
+                    System.out.println("Time diff = " + diff);
+                }
+            } catch (IOException e) {
+                System.err.println("Server exception terminating");
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        Server server = new Server();
+        int port = server.getPort();
+        server.start();
+        URL url = new URL("http://127.0.0.1:" + Integer.toString(port) + "/");
+        HttpURLConnection urlc = (HttpURLConnection) url.openConnection();
+        InputStream i = urlc.getInputStream();
+        int c,count=0;
+        byte[] buf = new byte[256];
+        while ((c=i.read(buf)) != -1) {
+            count+=c;
+        }
+        i.close();
+        System.out.println("Read " + count );
+        if (!passed.get()) {
+            server.close();
+            throw new RuntimeException("Test failed");
+        } else {
+            server.close();
+            System.out.println("Test passed");
+        }
+    }
+}


### PR DESCRIPTION
Hi,

Some new keep alive tests are exposing some old bugs. In this case if the server sends an invalid timeout (say -20 seconds) we accept it creating a timeout in the past. So, the first time the keep alive thread wakes up it will close the connection.
The correct behavior is to ignore the invalid parameter and fallback to the default timeout or the timeout set by the relevant system property.

Thanks,
Michael

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Failed to retrieve information on issue `8291637`. Please make sure it exists and is accessible.

### Issue
 * ⚠️ Failed to retrieve information on issue `8291637`.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9750/head:pull/9750` \
`$ git checkout pull/9750`

Update a local copy of the PR: \
`$ git checkout pull/9750` \
`$ git pull https://git.openjdk.org/jdk pull/9750/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9750`

View PR using the GUI difftool: \
`$ git pr show -t 9750`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9750.diff">https://git.openjdk.org/jdk/pull/9750.diff</a>

</details>
