### PR TITLE
8291915: jpackage: use multiple Features in MSI installer

### DIFF
--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WinMsiBundler.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WinMsiBundler.java
@@ -512,6 +512,17 @@ public class WinMsiBundler  extends AbstractBundler {
             data.put("JpIsSystemWide", "yes");
         }
 
+        // Set the main launcher variable to use it from Shortcut and FileAssociations
+        final String mainLauncherLocation;
+        if (StandardBundlerParam.isRuntimeInstaller(params)) {
+            mainLauncherLocation = "";
+        } else {
+            Path appImageRoot = WIN_APP_IMAGE.fetchFrom(params);
+            var launchers = AppImageFile.getLaunchers(appImageRoot, params);
+            mainLauncherLocation = String.format("[INSTALLDIR]%s.exe", launchers.get(0).getName());
+        }
+        data.put("JpMainLauncherLocation", mainLauncherLocation);
+
         // Copy standard l10n files.
         for (String loc : Arrays.asList("en", "ja", "zh_CN")) {
             String fname = "MsiInstallerStrings_" + loc + ".wxl";

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixAppImageFragmentBuilder.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixAppImageFragmentBuilder.java
@@ -488,8 +488,7 @@ class WixAppImageFragmentBuilder extends WixFragmentBuilder {
             xml.writeAttribute("Name", launcherBasename);
             xml.writeAttribute("WorkingDirectory", INSTALLDIR.toString());
             xml.writeAttribute("Advertise", "no");
-            xml.writeAttribute("Target", String.format("[#%s]",
-                    Component.File.idOf(launcherPath)));
+            xml.writeAttribute("Target", "[ARPMAINLAUNCHERLOCATION]");
         });
     }
 
@@ -530,11 +529,17 @@ class WixAppImageFragmentBuilder extends WixFragmentBuilder {
                 xml.writeAttribute("Id", "open");
                 xml.writeAttribute("Command", "Open");
                 xml.writeAttribute("Argument", "\"%1\" %*");
-                xml.writeAttribute("TargetFile", Id.File.of(fa.launcherPath));
+                xml.writeAttribute("TargetProperty", "ARPMAINLAUNCHERLOCATION");
                 xml.writeEndElement(); // <Verb>
 
                 xml.writeEndElement(); // <Extension>
             }));
+        }
+        // Adding icon file Component to FA group because ICE69 warning becomes
+        // an error if Icon attribute value points to an .ico file that
+        // belongs to other Feature.
+        if (fa.iconPath != null) {
+            components.add("c" + Id.File.of(getInstalledFaIcoPath(fa)));
         }
 
         return components;

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/main.wxs
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/main.wxs
@@ -73,12 +73,19 @@
     <Directory Id="TARGETDIR" Name="SourceDir"/>
 
     <Feature Id="DefaultFeature" Title="!(loc.MainFeatureTitle)" Level="1">
-      <ComponentGroupRef Id="Shortcuts"/>
-      <ComponentGroupRef Id="Files"/>
-      <ComponentGroupRef Id="FileAssociations"/>
+      <Feature Id="DefaultFeature_Files" Title="!(loc.MainFeatureTitle) (Files)" Level="1">
+          <ComponentGroupRef Id="Files"/>
+      </Feature>
+      <Feature Id="DefaultFeature_Shortcuts" Title="!(loc.MainFeatureTitle) (Shortcuts)" Level="1">
+          <ComponentGroupRef Id="Shortcuts"/>
+      </Feature>
+      <Feature Id="DefaultFeature_FileAssociations" Title="!(loc.MainFeatureTitle) (File Associations)" Level="1">
+          <ComponentGroupRef Id="FileAssociations"/>
+      </Feature>
     </Feature>
 
     <CustomAction Id="JpSetARPINSTALLLOCATION" Property="ARPINSTALLLOCATION" Value="[INSTALLDIR]" />
+    <CustomAction Id="JpSetARPMAINLAUNCHERLOCATION" Property="ARPMAINLAUNCHERLOCATION" Value="$(var.JpMainLauncherLocation)" />
     <CustomAction Id="JpSetARPCOMMENTS" Property="ARPCOMMENTS" Value="$(var.JpAppDescription)" />
     <CustomAction Id="JpSetARPCONTACT" Property="ARPCONTACT" Value="$(var.JpAppVendor)" />
     <CustomAction Id="JpSetARPSIZE" Property="ARPSIZE" Value="$(var.JpAppSizeKb)" />
@@ -104,6 +111,7 @@
 
     <InstallExecuteSequence>
       <Custom Action="JpSetARPINSTALLLOCATION" After="CostFinalize">Not Installed</Custom>
+      <Custom Action="JpSetARPMAINLAUNCHERLOCATION" After="CostFinalize">Not Installed</Custom>
       <Custom Action="JpSetARPCOMMENTS" After="CostFinalize">Not Installed</Custom>
       <Custom Action="JpSetARPCONTACT" After="CostFinalize">Not Installed</Custom>
       <Custom Action="JpSetARPSIZE" After="CostFinalize">Not Installed</Custom>

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.SecureRandom;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -64,6 +65,7 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
     public JPackageCommand() {
         prerequisiteActions = new Actions();
         verifyActions = new Actions();
+        installArguments = new ArrayList<>();
     }
 
     public JPackageCommand(JPackageCommand cmd) {
@@ -76,6 +78,7 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
         immutable = cmd.immutable;
         prerequisiteActions = new Actions(cmd.prerequisiteActions);
         verifyActions = new Actions(cmd.verifyActions);
+        installArguments = new ArrayList<>(cmd.installArguments);
     }
 
     JPackageCommand createImmutableCopy() {
@@ -178,8 +181,17 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
         return values.toArray(String[]::new);
     }
 
+    public List<String> getInstallArguments() {
+        return installArguments;
+    }
+
     public JPackageCommand addArguments(String name, Path value) {
         return addArguments(name, value.toString());
+    }
+
+    public JPackageCommand addInstallArguments(String... args) {
+        this.installArguments.addAll(Arrays.asList(args));
+        return this;
     }
 
     public boolean isImagePackageType() {
@@ -1060,6 +1072,7 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
     private boolean immutable;
     private final Actions prerequisiteActions;
     private final Actions verifyActions;
+    private final List<String> installArguments;
     private static boolean defaultWithToolProvider;
 
     private final static Map<String, PackageType> PACKAGE_TYPES = Functional.identity(

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
@@ -64,6 +64,8 @@ import static jdk.jpackage.test.PackageType.NATIVE;
 import static jdk.jpackage.test.PackageType.WINDOWS;
 import static jdk.jpackage.test.PackageType.WIN_EXE;
 import static jdk.jpackage.test.PackageType.WIN_MSI;
+import static jdk.jpackage.test.WindowsHelper.faFeatureInstalled;
+import static jdk.jpackage.test.WindowsHelper.filesFeatureInstalled;
 
 
 /**
@@ -265,7 +267,8 @@ public final class PackageTest extends RunnablePackageTest {
         }
 
         addInstallVerifier(cmd -> {
-            if (cmd.isFakeRuntime(noActionMsg) || cmd.isPackageUnpacked(noActionMsg)) {
+            if (cmd.isFakeRuntime(noActionMsg) || cmd.isPackageUnpacked(noActionMsg) ||
+                    !faFeatureInstalled(cmd)) {
                 return;
             }
 
@@ -618,10 +621,12 @@ public final class PackageTest extends RunnablePackageTest {
             }
             TKit.trace(String.format(formatString, cmd.getPrintableCommandLine()));
 
-            Optional.ofNullable(cmd.unpackedPackageDirectory()).ifPresent(
-                    unpackedDir -> {
-                        verifyRootCountInUnpackedPackage(cmd, unpackedDir);
-                    });
+            if (filesFeatureInstalled(cmd)) {
+                Optional.ofNullable(cmd.unpackedPackageDirectory()).ifPresent(
+                        unpackedDir -> {
+                            verifyRootCountInUnpackedPackage(cmd, unpackedDir);
+                        });
+            }
 
             if (!cmd.isRuntime()) {
                 if (WINDOWS.contains(cmd.packageType())
@@ -641,7 +646,9 @@ public final class PackageTest extends RunnablePackageTest {
                 LauncherAsServiceVerifier.verify(cmd);
             }
 
-            cmd.assertAppLayout();
+            if (filesFeatureInstalled(cmd)) {
+                cmd.assertAppLayout();
+            }
 
             installVerifiers.forEach(v -> v.accept(cmd));
         }

--- a/test/jdk/tools/jpackage/windows/WinFeaturesTest.java
+++ b/test/jdk/tools/jpackage/windows/WinFeaturesTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022, Red Hat Inc. and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.jpackage.internal.ApplicationLayout;
+import jdk.jpackage.test.FileAssociations;
+import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.PackageTest;
+import jdk.jpackage.test.PackageType;
+import jdk.jpackage.test.Annotations.Parameter;
+import jdk.jpackage.test.Annotations.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static jdk.jpackage.test.WindowsHelper.filesFeatureInstalled;
+
+/*
+ * @test
+ * @summary check that features can be installed separately
+ * @library ../helpers
+ * @key jpackagePlatformPackage
+ * @build jdk.jpackage.test.*
+ * @requires (os.family == "windows")
+ * @modules jdk.jpackage/jdk.jpackage.internal
+ * @compile WinFeaturesTest.java
+ * @run main/othervm/timeout=540 -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=WinFeaturesTest
+ */
+
+public class WinFeaturesTest {
+    @Test
+    @Parameter("DefaultFeature_Files")
+    @Parameter("DefaultFeature_FileAssociations")
+    @Parameter("DefaultFeature_Shortcuts")
+    public static void test(String feature) {
+        PackageTest packageTest = new PackageTest()
+                .forTypes(PackageType.WINDOWS)
+                .configureHelloApp()
+                .addInitializer(cmd -> {
+                    cmd.addArgument("--win-menu");
+                    cmd.addArgument("--win-shortcut");
+                    cmd.addInstallArguments(String.format("ADDLOCAL=%s", feature));
+                })
+                .addInstallVerifier(cmd -> {
+                    ApplicationLayout appLayout = cmd.appLayout();
+                    String launcherName = String.format("%s.exe", WinFeaturesTest.class.getName());
+                    Path launcherPath = appLayout.launchersDirectory().resolve(launcherName);
+                    if (filesFeatureInstalled(cmd)) {
+                        TKit.assertFileExists(launcherPath);
+                    } else if (!cmd.isPackageUnpacked()) { // ADDLOCAL is not supported with "msiexec /a"
+                        TKit.assertFalse(Files.exists(launcherPath), launcherPath.toString());
+                    }
+                });
+
+        Path icon = TKit.TEST_SRC_ROOT.resolve(Path.of("resources", "icon"
+                + TKit.ICON_SUFFIX));
+        icon = TKit.createRelativePathCopy(icon);
+        new FileAssociations("jptest1")
+                .setFilename("fa1")
+                .setIcon(icon)
+                .applyTo(packageTest);
+
+        packageTest.run();
+    }
+}


### PR DESCRIPTION
This change splits existing single Feature `DefaultFeature` into 3 different feautures:

 - `DefaultFeature_Files`: application and runtime files
 - `DefaultFeature_Shortcuts`: application Desktop and Start Menu shortcuts
 - `DefaultFeature_FileAssociations`: File Association components

These 3 Features are nested under the existing top-level Feature.

Currently the use of File references in Shortcuts and FileAssociations causes ICE69 MSI warnings like this one:

```
warning LGHT1076 : ICE69: Mismatched component reference. Entry 'reg12F3244EB2A37CCDB282E815ADFD174A' of the Registry table belongs to component 'cprogid9f99d1ff794e3df6bee07ba710a5501a'. However, the formatted string in column 'Value' references file 'file9846f81ce394345095918903022c1072' which belongs to component 'cfile9846f81ce394345095918903022c1072'. Components are in the same feature.
```

This warning seems to be completely harmless when the File, referenced from the Shortcut or Verb elements, belongs to the same Feature. Though, this warning becomes and error when the File belongs to other Feature.

To solve this problem for Shortcut and Verb - install-time `ARPMAINLAUNCHERLOCATION` is introduced, that points to the main application launcher in a form: `[INSTALLDIR]launcher.exe`. With such property no `ICE69` warnings are raised.

It appeared that such solution is not possible for the Shortcut Icon reference, that points to the icon file. Instead this icon file is additionally included into Shortcuts ComponentGroup. This way `ICE69` warning is raised (as before) instead of an error.

Added test uses `ADDLOCAL` options to test the installation of Features separately. To pass this option to installation handlers I've added it to `JPackageCommand`, this seemed to be the easiest way to pass it  without changing handler signatures.

It appeared, that default checks in `PackageTest` assume "all-or-nothing" installation scenario and contain non-trivial logic to determine which checks (files, desktop, FA) to run. I've iterated multiple times on this logic adding more flags (that can be controllable from the test itself) and ended up with helper methods in `WindowsHelper` that checks install arguments on `JPackageCommand` assuming `ADDLOCAL` and known Feature names there. This solution, while being the simplest of all attempts, is quite clunky, it may be better to introduce more fine-grained control over these checks from the test itself (such change is potentially disruptive to the test-suite).

It was also discovered, that `ADDLOCAL` option is not supported with `unpack` mode, and separate Features are not currently checked in this mode.

Testing:

 - `WinFeaturesTest` that installs and checks Features one by one
 - `FileAssociationsTest` and `WinShortcutTest` test runs with `install` enabled

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291915](https://bugs.openjdk.org/browse/JDK-8291915): jpackage: use multiple Features in MSI installer


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9751/head:pull/9751` \
`$ git checkout pull/9751`

Update a local copy of the PR: \
`$ git checkout pull/9751` \
`$ git pull https://git.openjdk.org/jdk pull/9751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9751`

View PR using the GUI difftool: \
`$ git pr show -t 9751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9751.diff">https://git.openjdk.org/jdk/pull/9751.diff</a>

</details>
