### PR TITLE
8291924: jpackage: l10n for Windows context menu label

### DIFF
--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixAppImageFragmentBuilder.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixAppImageFragmentBuilder.java
@@ -528,7 +528,7 @@ class WixAppImageFragmentBuilder extends WixFragmentBuilder {
 
                 xml.writeStartElement("Verb");
                 xml.writeAttribute("Id", "open");
-                xml.writeAttribute("Command", "Open");
+                xml.writeAttribute("Command", "!(loc.ContextMenuCommandLabel)");
                 xml.writeAttribute("Argument", "\"%1\" %*");
                 xml.writeAttribute("TargetFile", Id.File.of(fa.launcherPath));
                 xml.writeEndElement(); // <Verb>

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/MsiInstallerStrings_de.wxl
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/MsiInstallerStrings_de.wxl
@@ -12,4 +12,5 @@
   <String Id="ShortcutPromptDlgDesktopShortcutControlLabel">Desktopverknüpfung(en) erstellen</String>
   <String Id="ShortcutPromptDlgStartMenuShortcutControlLabel">Startmenüverknüpfung(en) erstellen</String>
   <String Id="InstallDirNotEmptyDlg_Title">[ProductName]-Setup</String>
+  <String Id="ContextMenuCommandLabel">Open with [ProductName]</String>
 </WixLocalization>

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/MsiInstallerStrings_de.wxl
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/MsiInstallerStrings_de.wxl
@@ -12,5 +12,4 @@
   <String Id="ShortcutPromptDlgDesktopShortcutControlLabel">Desktopverknüpfung(en) erstellen</String>
   <String Id="ShortcutPromptDlgStartMenuShortcutControlLabel">Startmenüverknüpfung(en) erstellen</String>
   <String Id="InstallDirNotEmptyDlg_Title">[ProductName]-Setup</String>
-  <String Id="ContextMenuCommandLabel">Mit [ProductName] öffnen</String>
 </WixLocalization>

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/MsiInstallerStrings_de.wxl
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/MsiInstallerStrings_de.wxl
@@ -12,4 +12,5 @@
   <String Id="ShortcutPromptDlgDesktopShortcutControlLabel">Desktopverknüpfung(en) erstellen</String>
   <String Id="ShortcutPromptDlgStartMenuShortcutControlLabel">Startmenüverknüpfung(en) erstellen</String>
   <String Id="InstallDirNotEmptyDlg_Title">[ProductName]-Setup</String>
+  <String Id="ContextMenuCommandLabel">Mit [ProductName] öffnen</String>
 </WixLocalization>

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/MsiInstallerStrings_en.wxl
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/MsiInstallerStrings_en.wxl
@@ -12,4 +12,5 @@
   <String Id="ShortcutPromptDlgDesktopShortcutControlLabel">Create desktop shortcut(s)</String>
   <String Id="ShortcutPromptDlgStartMenuShortcutControlLabel">Create start menu shortcut(s)</String>
   <String Id="InstallDirNotEmptyDlg_Title">[ProductName] Setup</String>
+  <String Id="ContextMenuCommandLabel">Open with [ProductName]</String>
 </WixLocalization>

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/MsiInstallerStrings_ja.wxl
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/MsiInstallerStrings_ja.wxl
@@ -12,5 +12,4 @@
   <String Id="ShortcutPromptDlgDesktopShortcutControlLabel">デスクトップ・ショートカットの作成</String>
   <String Id="ShortcutPromptDlgStartMenuShortcutControlLabel">スタート・メニューのショートカットの作成</String>
   <String Id="InstallDirNotEmptyDlg_Title">[ProductName]セットアップ</String>
-  <String Id="ContextMenuCommandLabel">[ProductName]で開く</String>
 </WixLocalization>

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/MsiInstallerStrings_ja.wxl
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/MsiInstallerStrings_ja.wxl
@@ -12,4 +12,5 @@
   <String Id="ShortcutPromptDlgDesktopShortcutControlLabel">デスクトップ・ショートカットの作成</String>
   <String Id="ShortcutPromptDlgStartMenuShortcutControlLabel">スタート・メニューのショートカットの作成</String>
   <String Id="InstallDirNotEmptyDlg_Title">[ProductName]セットアップ</String>
+  <String Id="ContextMenuCommandLabel">[ProductName]で開く</String>
 </WixLocalization>

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/MsiInstallerStrings_ja.wxl
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/MsiInstallerStrings_ja.wxl
@@ -12,4 +12,5 @@
   <String Id="ShortcutPromptDlgDesktopShortcutControlLabel">デスクトップ・ショートカットの作成</String>
   <String Id="ShortcutPromptDlgStartMenuShortcutControlLabel">スタート・メニューのショートカットの作成</String>
   <String Id="InstallDirNotEmptyDlg_Title">[ProductName]セットアップ</String>
+  <String Id="ContextMenuCommandLabel">Open with [ProductName]</String>
 </WixLocalization>

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/MsiInstallerStrings_zh_CN.wxl
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/MsiInstallerStrings_zh_CN.wxl
@@ -12,4 +12,5 @@
   <String Id="ShortcutPromptDlgDesktopShortcutControlLabel">创建桌面快捷方式</String>
   <String Id="ShortcutPromptDlgStartMenuShortcutControlLabel">创建开始菜单快捷方式</String>
   <String Id="InstallDirNotEmptyDlg_Title">[ProductName] 安装程序</String>
+  <String Id="ContextMenuCommandLabel">使用 [ProductName] 打开</String>
 </WixLocalization>

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/MsiInstallerStrings_zh_CN.wxl
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/MsiInstallerStrings_zh_CN.wxl
@@ -12,4 +12,5 @@
   <String Id="ShortcutPromptDlgDesktopShortcutControlLabel">创建桌面快捷方式</String>
   <String Id="ShortcutPromptDlgStartMenuShortcutControlLabel">创建开始菜单快捷方式</String>
   <String Id="InstallDirNotEmptyDlg_Title">[ProductName] 安装程序</String>
+  <String Id="ContextMenuCommandLabel">Open with [ProductName]</String>
 </WixLocalization>

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/MsiInstallerStrings_zh_CN.wxl
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/MsiInstallerStrings_zh_CN.wxl
@@ -12,5 +12,4 @@
   <String Id="ShortcutPromptDlgDesktopShortcutControlLabel">创建桌面快捷方式</String>
   <String Id="ShortcutPromptDlgStartMenuShortcutControlLabel">创建开始菜单快捷方式</String>
   <String Id="InstallDirNotEmptyDlg_Title">[ProductName] 安装程序</String>
-  <String Id="ContextMenuCommandLabel">使用 [ProductName] 打开</String>
 </WixLocalization>

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
@@ -285,13 +285,15 @@ public final class PackageTest extends RunnablePackageTest {
             });
 
             if (TKit.isWindows()) {
-                // verify context menu label in registry
+                // Verify context menu label in registry.
                 String progId = WindowsHelper.queryRegistryValue(
-                        "HKEY_LOCAL_MACHINE\\SOFTWARE\\Classes\\" + fa.getSuffix(), "");
+                        String.format("HKEY_LOCAL_MACHINE\\SOFTWARE\\Classes\\%s", fa.getSuffix()), "");
+                TKit.assertNotNull(progId, "context menu progId found");
                 String contextMenuLabel = WindowsHelper.queryRegistryValue(
-                        "HKEY_CLASSES_ROOT\\" + progId + "\\shell\\open", "");
+                        String.format("HKEY_CLASSES_ROOT\\%s\\shell\\open", progId), "");
                 TKit.assertNotNull(contextMenuLabel, "context menu label found");
-                TKit.assertTrue(contextMenuLabel.startsWith("Open with"), "context menu label text");
+                String appName = cmd.getArgumentValue("--name");
+                TKit.assertTrue(String.format("Open with %s", appName).equals(contextMenuLabel), "context menu label text");
             }
         });
 

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
@@ -283,6 +283,16 @@ public final class PackageTest extends RunnablePackageTest {
                 HelloApp.verifyOutputFile(appOutput, expectedArgs,
                         Collections.emptyMap());
             });
+
+            if (TKit.isWindows()) {
+                // verify context menu label in registry
+                String progId = WindowsHelper.queryRegistryValue(
+                        "HKEY_LOCAL_MACHINE\\SOFTWARE\\Classes\\" + fa.getSuffix(), "");
+                String contextMenuLabel = WindowsHelper.queryRegistryValue(
+                        "HKEY_CLASSES_ROOT\\" + progId + "\\shell\\open", "");
+                TKit.assertNotNull(contextMenuLabel, "context menu label found");
+                TKit.assertTrue(contextMenuLabel.startsWith("Open with"), "context menu label text");
+            }
         });
 
         return this;

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
@@ -356,7 +356,7 @@ public class WindowsHelper {
         private final String name;
     }
 
-    private static String queryRegistryValue(String keyPath, String valueName) {
+    public static String queryRegistryValue(String keyPath, String valueName) {
         var status = Executor.of("reg", "query", keyPath, "/v", valueName)
                 .saveOutput()
                 .executeWithoutExitCodeCheck();

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
@@ -356,7 +356,7 @@ public class WindowsHelper {
         private final String name;
     }
 
-    public static String queryRegistryValue(String keyPath, String valueName) {
+    static String queryRegistryValue(String keyPath, String valueName) {
         var status = Executor.of("reg", "query", keyPath, "/v", valueName)
                 .saveOutput()
                 .executeWithoutExitCodeCheck();


### PR DESCRIPTION
This change adds `ContextMenuCommandLabel` l10n property for file association context menu label. It is a follow-up to [this PR comment](https://github.com/openjdk/jdk/pull/9224#issuecomment-1169286082).

Note, non-EN l10n values were filled using auto-translator and may need to be corrected.

To check the contents of the label, registry query is added to `PackageTest::addHelloAppFileAssociationsVerifier`.

Testing:

 - [x] ran `FileAssociationsTest` with `install` enabled

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291924](https://bugs.openjdk.org/browse/JDK-8291924): jpackage: l10n for Windows context menu label


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [227ad5d4](https://git.openjdk.org/jdk/pull/9753/files/227ad5d45be3161eb94df909e0ce5e0b738f34f8)
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9753/head:pull/9753` \
`$ git checkout pull/9753`

Update a local copy of the PR: \
`$ git checkout pull/9753` \
`$ git pull https://git.openjdk.org/jdk pull/9753/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9753`

View PR using the GUI difftool: \
`$ git pr show -t 9753`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9753.diff">https://git.openjdk.org/jdk/pull/9753.diff</a>

</details>
