### PR TITLE
8291926: ProblemList multiple tests in -Xcomp mode due to JDK-8291649

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -36,3 +36,8 @@ vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8265295 lin
 serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
 
 serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java 8288430 generic-all
+
+java/lang/Integer/BitTwiddle.java 8291649 generic-x64
+java/lang/Long/BitTwiddle.java    8291649 generic-x64
+java/util/zip/TestCRC32C.java     8291649 generic-x64
+java/util/zip/TestChecksum.java   8291649 generic-x64


### PR DESCRIPTION
A trivial fix to ProblemList multiple tests in -Xcomp mode due to JDK-8291649.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291926](https://bugs.openjdk.org/browse/JDK-8291926): ProblemList multiple tests in -Xcomp mode due to JDK-8291649


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9754/head:pull/9754` \
`$ git checkout pull/9754`

Update a local copy of the PR: \
`$ git checkout pull/9754` \
`$ git pull https://git.openjdk.org/jdk pull/9754/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9754`

View PR using the GUI difftool: \
`$ git pr show -t 9754`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9754.diff">https://git.openjdk.org/jdk/pull/9754.diff</a>

</details>
