### PR TITLE
8291941: ProblemList java/lang/ProcessBuilder/PipelineLeaksFD.java on linux-all

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -494,6 +494,7 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java        8151492 generic-
 java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-x64
 java/lang/invoke/RicochetTest.java                              8251969 generic-all
+java/lang/ProcessBuilder/PipelineLeaksFD.java                   8291760 linux-all
 
 ############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList java/lang/ProcessBuilder/PipelineLeaksFD.java on linux-all.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291941](https://bugs.openjdk.org/browse/JDK-8291941): ProblemList java/lang/ProcessBuilder/PipelineLeaksFD.java on linux-all


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9757/head:pull/9757` \
`$ git checkout pull/9757`

Update a local copy of the PR: \
`$ git checkout pull/9757` \
`$ git pull https://git.openjdk.org/jdk pull/9757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9757`

View PR using the GUI difftool: \
`$ git pr show -t 9757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9757.diff">https://git.openjdk.org/jdk/pull/9757.diff</a>

</details>
