### PR TITLE
8291947: riscv: fail to build after JDK-8290840

### DIFF
--- a/src/hotspot/cpu/riscv/icache_riscv.cpp
+++ b/src/hotspot/cpu/riscv/icache_riscv.cpp
@@ -29,27 +29,8 @@
 
 #define __ _masm->
 
-// SYSCALL_RISCV_FLUSH_ICACHE is used to flush instruction cache. The "fence.i" instruction
-// only work on the current hart, so kernel provides the icache flush syscall to flush icache
-// on each hart. You can pass a flag to determine a global or local icache flush.
-static void icache_flush(long int start, long int end)
-{
-  const int SYSCALL_RISCV_FLUSH_ICACHE = 259;
-  register long int __a7 asm ("a7") = SYSCALL_RISCV_FLUSH_ICACHE;
-  register long int __a0 asm ("a0") = start;
-  register long int __a1 asm ("a1") = end;
-  // the flush can be applied to either all threads or only the current.
-  // 0 means a global icache flush, and the icache flush will be applied
-  // to other harts concurrently executing.
-  register long int __a2 asm ("a2") = 0;
-  __asm__ volatile ("ecall\n\t"
-                    : "+r" (__a0)
-                    : "r" (__a0), "r" (__a1), "r" (__a2), "r" (__a7)
-                    : "memory");
-}
-
 static int icache_flush(address addr, int lines, int magic) {
-  icache_flush((long int) addr, (long int) (addr + (lines << ICache::log2_line_size)));
+  __builtin___clear_cache(addr, addr + (lines << ICache::log2_line_size));
   return magic;
 }
 


### PR DESCRIPTION
[JDK-8290840](https://bugs.openjdk.org/browse/JDK-8290840) moved icache_flush from os_linux_riscv.cpp to icache_riscv.cpp, and we got 2 icache_flush there, and then caused a compilation error of "overloaded function with no contextual type information" in generate_icache_flush, which simply used the function name as a function address.

We put icache_flush in os files because it was just a linux implementation, and we saw some test failures on Hifive Unleashed when using the "portable" version of __builtin__clear_cache provided by compilers about 2 years ago. The problem doesn't exist anymore, so we can revert to the previous implementation of just using the builtin clear cache function.

Tier1 of hotspot and jdk passed on unmatched.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291947](https://bugs.openjdk.org/browse/JDK-8291947): riscv: fail to build after JDK-8290840


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9763/head:pull/9763` \
`$ git checkout pull/9763`

Update a local copy of the PR: \
`$ git checkout pull/9763` \
`$ git pull https://git.openjdk.org/jdk pull/9763/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9763`

View PR using the GUI difftool: \
`$ git pr show -t 9763`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9763.diff">https://git.openjdk.org/jdk/pull/9763.diff</a>

</details>
