### PR TITLE
8291952: riscv: Remove PRAGMA_NONNULL_IGNORED

### DIFF
--- a/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
@@ -275,13 +275,11 @@ inline intptr_t* frame::interpreter_frame_expression_stack() const {
 // Entry frames
 
 inline JavaCallWrapper** frame::entry_frame_call_wrapper_addr() const {
- return (JavaCallWrapper**)addr_at(entry_frame_call_wrapper_offset);
+  return (JavaCallWrapper**)addr_at(entry_frame_call_wrapper_offset);
 }
 
 
 // Compiled frames
-PRAGMA_DIAG_PUSH
-PRAGMA_NONNULL_IGNORED
 inline oop frame::saved_oop_result(RegisterMap* map) const {
   oop* result_adr = (oop *)map->location(x10->as_VMReg(), nullptr);
   guarantee(result_adr != NULL, "bad register save location");
@@ -293,7 +291,6 @@ inline void frame::set_saved_oop_result(RegisterMap* map, oop obj) {
   guarantee(result_adr != NULL, "bad register save location");
   *result_adr = obj;
 }
-PRAGMA_DIAG_POP
 
 inline const ImmutableOopMap* frame::get_oop_map() const {
   if (_cb == NULL) return NULL;


### PR DESCRIPTION
This is similar to: https://bugs.openjdk.org/browse/JDK-8291895
Because the bug that was warned about has now been fixed, the warnings are now superfluous.
Build with GCC 11.2.0.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291952](https://bugs.openjdk.org/browse/JDK-8291952): riscv: Remove PRAGMA_NONNULL_IGNORED


### Reviewers
 * [Yadong Wang](https://openjdk.org/census#yadongwang) (@yadongw - Author)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9766/head:pull/9766` \
`$ git checkout pull/9766`

Update a local copy of the PR: \
`$ git checkout pull/9766` \
`$ git pull https://git.openjdk.org/jdk pull/9766/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9766`

View PR using the GUI difftool: \
`$ git pr show -t 9766`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9766.diff">https://git.openjdk.org/jdk/pull/9766.diff</a>

</details>
