### PR TITLE
8292026: Remove redundant allocations from DoubleByteEncoder

### DIFF
--- a/src/java.desktop/unix/classes/sun/font/DoubleByteEncoder.java
+++ b/src/java.desktop/unix/classes/sun/font/DoubleByteEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,6 @@
  * questions.
  */
 
-/*
- */
-
 package sun.font;
 
 import java.nio.ByteBuffer;
@@ -39,8 +36,8 @@ public abstract class DoubleByteEncoder
     extends CharsetEncoder
 {
 
-    private short[] index1;
-    private String[] index2;
+    private final short[] index1;
+    private final String[] index2;
 
     private final Surrogate.Parser sgp = new Surrogate.Parser();
 
@@ -102,8 +99,7 @@ public abstract class DoubleByteEncoder
                         return CoderResult.UNDERFLOW;
                     char c2 = sa[sp + 1];
 
-                    byte[] outputBytes = new byte[2];
-                    outputBytes = encodeSurrogate(c, c2);
+                    byte[] outputBytes = encodeSurrogate(c, c2);
 
                     if (outputBytes == null) {
                         return sgp.unmappableResult();
@@ -158,8 +154,7 @@ public abstract class DoubleByteEncoder
                     if ((surr = sgp.parse(c, src)) < 0)
                         return sgp.error();
                     char c2 = Surrogate.low(surr);
-                    byte[] outputBytes = new byte[2];
-                    outputBytes = encodeSurrogate(c, c2);
+                    byte[] outputBytes = encodeSurrogate(c, c2);
 
                     if (outputBytes == null) {
                         return sgp.unmappableResult();
@@ -204,7 +199,7 @@ public abstract class DoubleByteEncoder
     }
 
     protected CoderResult encodeLoop(CharBuffer src, ByteBuffer dst) {
-        if (true && src.hasArray() && dst.hasArray())
+        if (src.hasArray() && dst.hasArray())
             return encodeArrayLoop(src, dst);
         else
             return encodeBufferLoop(src, dst);


### PR DESCRIPTION
There are couple places where new byte array is allocated and then thrown away.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292026](https://bugs.openjdk.org/browse/JDK-8292026): Remove redundant allocations from DoubleByteEncoder


### Reviewers
 * @stsypanov (no known github.com user name / role)
 * @AJ1032480 (no known github.com user name / role)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9767/head:pull/9767` \
`$ git checkout pull/9767`

Update a local copy of the PR: \
`$ git checkout pull/9767` \
`$ git pull https://git.openjdk.org/jdk pull/9767/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9767`

View PR using the GUI difftool: \
`$ git pr show -t 9767`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9767.diff">https://git.openjdk.org/jdk/pull/9767.diff</a>

</details>
