### PR TITLE
8291953: Remove PTR32_FORMAT macros

### DIFF
--- a/src/hotspot/share/code/codeHeapState.cpp
+++ b/src/hotspot/share/code/codeHeapState.cpp
@@ -1398,14 +1398,14 @@ void CodeHeapState::print_usedSpace(outputStream* out, CodeHeap* heap) {
           ast->print(INTPTR_FORMAT, p2i(this_blob));
           ast->fill_to(19);
           //---<  blob offset from CodeHeap begin  >---
-          ast->print("(+" PTR32_FORMAT ")", (unsigned int)((char*)this_blob-low_bound));
+          ast->print("(+%u)", (unsigned int)((char*)this_blob-low_bound));
           ast->fill_to(33);
         } else {
           //---<  block address  >---
           ast->print(INTPTR_FORMAT, p2i(TopSizeArray[i].start));
           ast->fill_to(19);
           //---<  block offset from CodeHeap begin  >---
-          ast->print("(+" PTR32_FORMAT ")", (unsigned int)((char*)TopSizeArray[i].start-low_bound));
+          ast->print("(+%u)", (unsigned int)((char*)TopSizeArray[i].start-low_bound));
           ast->fill_to(33);
         }
 
@@ -1413,7 +1413,7 @@ void CodeHeapState::print_usedSpace(outputStream* out, CodeHeap* heap) {
         bool is_nmethod = TopSizeArray[i].nm_size > 0;
         if (is_nmethod) {
           //---<  nMethod size in hex  >---
-          ast->print(PTR32_FORMAT, TopSizeArray[i].nm_size);
+          ast->print("%u", TopSizeArray[i].nm_size);
           ast->print("(" SIZE_FORMAT_W(4) "K)", TopSizeArray[i].nm_size/K);
           ast->fill_to(51);
           ast->print("  %c", blobTypeChar[TopSizeArray[i].type]);
@@ -1431,7 +1431,7 @@ void CodeHeapState::print_usedSpace(outputStream* out, CodeHeap* heap) {
           ast->print("%s", TopSizeArray[i].blob_name);
         } else {
           //---<  block size in hex  >---
-          ast->print(PTR32_FORMAT, (unsigned int)(TopSizeArray[i].len<<log2_seg_size));
+          ast->print("%u", TopSizeArray[i].len<<log2_seg_size);
           ast->print("(" SIZE_FORMAT_W(4) "K)", (TopSizeArray[i].len<<log2_seg_size)/K);
           //---<  no compiler information  >---
           ast->fill_to(56);
@@ -2300,7 +2300,7 @@ void CodeHeapState::print_names(outputStream* out, CodeHeap* heap) {
         //---<  print line prefix (address and offset from CodeHeap start)  >---
         ast->print(INTPTR_FORMAT, p2i(this_blob));
         ast->fill_to(19);
-        ast->print("(+" PTR32_FORMAT ")", (unsigned int)((char*)this_blob-low_bound));
+        ast->print("(+%u)", (unsigned int)((char*)this_blob-low_bound));
         ast->fill_to(33);
 
         // access nmethod and Method fields only if we own the CodeCache_lock.
@@ -2313,7 +2313,7 @@ void CodeHeapState::print_names(outputStream* out, CodeHeap* heap) {
           int          hotness    = nm->hotness_counter();
           bool         get_name   = (cbType == nMethod_inuse) || (cbType == nMethod_notused);
           //---<  nMethod size in hex  >---
-          ast->print(PTR32_FORMAT, total_size);
+          ast->print("%u", total_size);
           ast->print("(" SIZE_FORMAT_W(4) "K)", total_size/K);
           //---<  compiler information  >---
           ast->fill_to(51);
@@ -2488,7 +2488,7 @@ void CodeHeapState::print_line_delim(outputStream* out, outputStream* ast, char*
 
     ast->print(INTPTR_FORMAT, p2i(low_bound + ix*granule_size));
     ast->fill_to(19);
-    ast->print("(+" PTR32_FORMAT "): |", (unsigned int)(ix*granule_size));
+    ast->print("(+%u): |", (unsigned int)(ix*granule_size));
   }
 }
 
@@ -2512,7 +2512,7 @@ void CodeHeapState::print_line_delim(outputStream* out, bufferedStream* ast, cha
 
     ast->print(INTPTR_FORMAT, p2i(low_bound + ix*granule_size));
     ast->fill_to(19);
-    ast->print("(+" PTR32_FORMAT "): |", (unsigned int)(ix*granule_size));
+    ast->print("(+%u): |", (unsigned int)(ix*granule_size));
   }
 }
 

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1900,7 +1900,7 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
   nmethodLocker nl(fr.pc());
 
   // Log a message
-  Events::log_deopt_message(current, "Uncommon trap: trap_request=" PTR32_FORMAT " fr.pc=" INTPTR_FORMAT " relative=" INTPTR_FORMAT,
+  Events::log_deopt_message(current, "Uncommon trap: trap_request=%d fr.pc=" INTPTR_FORMAT " relative=" INTPTR_FORMAT,
               trap_request, p2i(fr.pc()), fr.pc() - fr.cb()->code_begin());
 
   {

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -98,9 +98,6 @@ class oopDesc;
 #define INT32_FORMAT_W(width)  "%" #width PRId32
 #define UINT32_FORMAT_W(width) "%" #width PRIu32
 
-#define PTR32_FORMAT           "0x%08" PRIx32
-#define PTR32_FORMAT_W(width)  "0x%" #width PRIx32
-
 // Format 64-bit quantities.
 #define INT64_FORMAT           "%" PRId64
 #define UINT64_FORMAT          "%" PRIu64


### PR DESCRIPTION
Please review this change to remove the PTR32_FORMAT macro.

And the idea of hard-coded 32bit pointers is bad; we already have the
PTR_FORMAT macros that deal with the 32/64bit distinction for pointers, and
those should be used for such.

However, all uses of PTR32_FORMAT are actually with values that are real uint
values, not (converted) pointers. They should just use "%u" instead.  So we
can eliminate PTR32_FORMAT.

The unused PTR32_FORMAT_W is is also removed.

Testing:
mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291953](https://bugs.openjdk.org/browse/JDK-8291953): Remove PTR32_FORMAT macros


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9768/head:pull/9768` \
`$ git checkout pull/9768`

Update a local copy of the PR: \
`$ git checkout pull/9768` \
`$ git pull https://git.openjdk.org/jdk pull/9768/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9768`

View PR using the GUI difftool: \
`$ git pr show -t 9768`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9768.diff">https://git.openjdk.org/jdk/pull/9768.diff</a>

</details>
