### PR TITLE
7189422: [macosx] Submenu's arrow have a wrong position

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaMenuPainter.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaMenuPainter.java
@@ -494,13 +494,15 @@ public class AquaMenuPainter {
         if (!isTopLevelMenu) {
             //    if ( GetSysDirection() < 0 ) hierRect.right = hierRect.left + w + 4;
             //    else hierRect.left = hierRect.right - w - 4;
-            arrowIconR.x = (viewR.width - arrowIconR.width) + 1;
-            arrowIconR.y = viewR.y + (labelR.height / 2) - (arrowIconR.height / 2) + 1;
 
-            checkIconR.y = viewR.y + (labelR.height / 2) - (checkIconR.height / 2);
+            arrowIconR.x = Math.abs((viewR.width - arrowIconR.width) + 1);
+            arrowIconR.y = Math.abs(viewR.y + (labelR.height / 2) - (arrowIconR.height / 2) + 1);
+
+            checkIconR.y = Math.abs(viewR.y + (labelR.height / 2) - (checkIconR.height / 2));
             checkIconR.x = 5;
 
             textR.width += 8;
+
         }
 
         /*System.out.println("Layout: " +horizontalAlignment+ " v=" +viewR+"  c="+checkIconR+" i="+

--- a/test/jdk/javax/swing/JMenu/TestSubMenuArrowPosition.java
+++ b/test/jdk/javax/swing/JMenu/TestSubMenuArrowPosition.java
@@ -21,12 +21,12 @@
  * questions.
  */
 
-/* 
+/*
  * @test
  * @bug 7189422
  * @key headful
  * @requires (os.family == "mac")
- * @summary Verifies arrow position in submenu with empty title 
+ * @summary Verifies arrow position in submenu with empty title
  * @run main TestSubMenuArrowPosition
  */
 
@@ -80,8 +80,8 @@ public class TestSubMenuArrowPosition {
 
             p = subMenu.getLocationOnScreen();
             BufferedImage img =
-                    robot.createScreenCapture(new Rectangle(p.x, p.y, 
-                                              subMenu.getWidth(), 
+                    robot.createScreenCapture(new Rectangle(p.x, p.y,
+                                              subMenu.getWidth(),
                                               subMenu.getHeight()));
 
             System.out.println("width " + img.getWidth() +
@@ -90,7 +90,7 @@ public class TestSubMenuArrowPosition {
                                                    img.getHeight() / 2));
             boolean passed = false;
             for (int x = img.getWidth() / 2; x < img.getWidth() - 1; ++x) {
-                System.out.println("x " + x + " rgb = " + 
+                System.out.println("x " + x + " rgb = " +
                                      Integer.toHexString(
                                       img.getRGB(x, img.getHeight() / 2)));
                 Color c = new Color(img.getRGB(x, img.getHeight() / 2));

--- a/test/jdk/javax/swing/JMenu/TestSubMenuArrowPosition.java
+++ b/test/jdk/javax/swing/JMenu/TestSubMenuArrowPosition.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* 
+ * @test
+ * @bug 7189422
+ * @key headful
+ * @requires (os.family == "mac")
+ * @summary Verifies arrow position in submenu with empty title 
+ * @run main TestSubMenuArrowPosition
+ */
+
+import java.io.File;
+import java.awt.event.InputEvent;
+import java.awt.image.BufferedImage;
+import java.awt.Color;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.SwingUtilities;
+import javax.imageio.ImageIO;
+
+public class TestSubMenuArrowPosition {
+
+    private static JFrame frame;
+    private static JMenu menu;
+    private static JMenu subMenu;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame();
+                JMenuBar menuBar = new JMenuBar();
+                menu = new JMenu("Test menu");
+                subMenu = new JMenu("");
+
+                menu.add(subMenu);
+                menuBar.add(menu);
+
+                frame.setJMenuBar(menuBar);
+                frame.setSize(300, 300);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            Point p = menu.getLocationOnScreen();
+            robot.mouseMove(p.x+5, p.y+5);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            p = subMenu.getLocationOnScreen();
+            BufferedImage img =
+                    robot.createScreenCapture(new Rectangle(p.x, p.y, 
+                                              subMenu.getWidth(), 
+                                              subMenu.getHeight()));
+
+            System.out.println("width " + img.getWidth() +
+                               " height " + img.getHeight());
+            Color prevColor = new Color(img.getRGB(img.getWidth() / 2,
+                                                   img.getHeight() / 2));
+            boolean passed = false;
+            for (int x = img.getWidth() / 2; x < img.getWidth() - 1; ++x) {
+                System.out.println("x " + x + " rgb = " + 
+                                     Integer.toHexString(
+                                      img.getRGB(x, img.getHeight() / 2)));
+                Color c = new Color(img.getRGB(x, img.getHeight() / 2));
+                if (!c.equals(prevColor)) {
+                    passed = true;
+                }
+                prevColor = c;
+            }
+            if (!passed) {
+                ImageIO.write(img, "png", new File("SimpleTest.png"));
+                throw new RuntimeException("Submenu's arrow have wrong position");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+
+    }
+}


### PR DESCRIPTION
Issue is Arrow in submenu with empty title have a wrong position in Aqua L&F as can be seen

<img width="94" alt="image" src="https://user-images.githubusercontent.com/43534309/183023538-de8e51b4-31e6-45d7-b2bd-35da5e29c1e8.png">


which is because the text being null/empty, `labelR` rectangle width/height is 0 so arrowIcon y coordinate becomes -ve as per the calculation in layoutMenuItem(). Although it seems logical to me to not show the arrow if submenu text is null, but
whereas for other L&F, it is shown as this 
for Metal
<img width="83" alt="image" src="https://user-images.githubusercontent.com/43534309/183022436-d9e8ebf1-98de-4cf6-bf43-3713357846e5.png">

for Nimbus
<img width="77" alt="image" src="https://user-images.githubusercontent.com/43534309/183022730-35d170b2-71c6-4231-9a03-880107dc49c6.png">

so the fix is made in Aqua L&F to show as other L&F as
<img width="92" alt="image" src="https://user-images.githubusercontent.com/43534309/183023030-7356086d-957c-4e0d-bd52-bdf3493a96b0.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7189422](https://bugs.openjdk.org/browse/JDK-7189422): [macosx] Submenu's arrow have a wrong position


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9769/head:pull/9769` \
`$ git checkout pull/9769`

Update a local copy of the PR: \
`$ git checkout pull/9769` \
`$ git pull https://git.openjdk.org/jdk pull/9769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9769`

View PR using the GUI difftool: \
`$ git pr show -t 9769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9769.diff">https://git.openjdk.org/jdk/pull/9769.diff</a>

</details>
