### PR TITLE
8291893: riscv: remove fence.i used in user space

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.cpp
@@ -311,13 +311,6 @@ void Assembler::movptr(Register Rd, address addr) {
   addi(Rd, Rd, offset);
 }
 
-void Assembler::ifence() {
-  fence_i();
-  if (UseConservativeFence) {
-    fence(ir, ir);
-  }
-}
-
 #define INSN(NAME, NEG_INSN)                                                         \
   void Assembler::NAME(Register Rs, Register Rt, const address &dest) {              \
     NEG_INSN(Rt, Rs, dest);                                                          \

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -339,7 +339,6 @@ public:
   void movptr(Register Rd, address addr);
   void movptr_with_offset(Register Rd, address addr, int32_t &offset);
   void movptr(Register Rd, uintptr_t imm64);
-  void ifence();
   void j(const address &dest, Register temp = t0);
   void j(const Address &adr, Register temp = t0);
   void j(Label &l, Register temp = t0);
@@ -961,7 +960,6 @@ public:
     emit(insn);                                             \
   }
 
-  INSN(fence_i, 0b0001111, 0b001, 0b000000000000);
   INSN(ecall,   0b1110011, 0b000, 0b000000000000);
   INSN(_ebreak, 0b1110011, 0b000, 0b000000000001);
 

--- a/src/hotspot/cpu/riscv/compiledIC_riscv.cpp
+++ b/src/hotspot/cpu/riscv/compiledIC_riscv.cpp
@@ -69,8 +69,8 @@ address CompiledStaticCall::emit_to_interp_stub(CodeBuffer &cbuf, address mark) 
 #undef __
 
 int CompiledStaticCall::to_interp_stub_size() {
-  // fence_i + fence* + (lui, addi, slli, addi, slli, addi) + (lui, addi, slli, addi, slli) + jalr
-  return NativeFenceI::instruction_size() + 12 * NativeInstruction::instruction_size;
+  // (lui, addi, slli, addi, slli, addi) + (lui, addi, slli, addi, slli) + jalr
+  return 12 * NativeInstruction::instruction_size;
 }
 
 int CompiledStaticCall::to_trampoline_stub_size() {
@@ -98,7 +98,7 @@ void CompiledDirectStaticCall::set_to_interpreted(const methodHandle& callee, ad
 
   // Creation also verifies the object.
   NativeMovConstReg* method_holder
-    = nativeMovConstReg_at(stub + NativeFenceI::instruction_size());
+    = nativeMovConstReg_at(stub);
 #ifdef ASSERT
   NativeGeneralJump* jump = nativeGeneralJump_at(method_holder->next_instruction_address());
 
@@ -119,7 +119,7 @@ void CompiledDirectStaticCall::set_stub_to_clean(static_stub_Relocation* static_
   assert(CompiledICLocker::is_safe(stub), "mt unsafe call");
   // Creation also verifies the object.
   NativeMovConstReg* method_holder
-    = nativeMovConstReg_at(stub + NativeFenceI::instruction_size());
+    = nativeMovConstReg_at(stub);
   method_holder->set_data(0);
   NativeJump* jump = nativeJump_at(method_holder->next_instruction_address());
   jump->set_jump_destination((address)-1);
@@ -139,7 +139,7 @@ void CompiledDirectStaticCall::verify() {
   assert(stub != NULL, "no stub found for static call");
   // Creation also verifies the object.
   NativeMovConstReg* method_holder
-    = nativeMovConstReg_at(stub + NativeFenceI::instruction_size());
+    = nativeMovConstReg_at(stub);
   NativeJump* jump = nativeJump_at(method_holder->next_instruction_address());
 
   // Verify state.

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -88,8 +88,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, TraceTraps, false, "Trace all traps the signal handler")         \
   /* For now we're going to be safe and add the I/O bits to userspace fences. */ \
   product(bool, UseConservativeFence, true,                                      \
-          "Extend i for r and o for w in the pred/succ flags of fence;"          \
-          "Extend fence.i to fence.i + fence.")                                  \
+          "Extend i for r and o for w in the pred/succ flags of fence")          \
   product(bool, AvoidUnalignedAccesses, true,                                    \
           "Avoid generating unaligned memory accesses")                          \
   product(bool, UseRVV, false, EXPERIMENTAL, "Use RVV instructions")             \

--- a/src/hotspot/cpu/riscv/icache_riscv.cpp
+++ b/src/hotspot/cpu/riscv/icache_riscv.cpp
@@ -30,6 +30,14 @@
 #define __ _masm->
 
 static int icache_flush(address addr, int lines, int magic) {
+  // To make a store to instruction memory visible to all RISC-V harts,
+  // the writing hart has to execute a data FENCE before requesting that
+  // all remote RISC-V harts execute a FENCE.I.
+  //
+  // No sush assurance is defined at the interface level of the builtin
+  // method, and so we should make sure it works.
+  __asm__ volatile("fence rw, rw" : : : "memory");
+
   __builtin___clear_cache(addr, addr + (lines << ICache::log2_line_size));
   return magic;
 }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -46,9 +46,6 @@ class MacroAssembler: public Assembler {
 
   void safepoint_poll(Label& slow_path, bool at_return, bool acquire, bool in_nmethod);
 
-  // Place a fence.i after code may have been modified due to a safepoint.
-  void safepoint_ifence();
-
   // Alignment
   void align(int modulus, int extra_offset = 0);
 
@@ -836,9 +833,6 @@ private:
 
   void load_reserved(Register addr, enum operand_size size, Assembler::Aqrl acquire);
   void store_conditional(Register addr, Register new_val, enum operand_size size, Assembler::Aqrl release);
-
-  // Check the current thread doesn't need a cross modify fence.
-  void verify_cross_modify_fence_not_required() PRODUCT_RETURN;
 };
 
 #ifdef ASSERT

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -554,14 +554,6 @@ inline NativeMembar *NativeMembar_at(address addr) {
   return (NativeMembar*)addr;
 }
 
-class NativeFenceI : public NativeInstruction {
-public:
-  static inline int instruction_size() {
-    // 2 for fence.i + fence
-    return (UseConservativeFence ? 2 : 1) * NativeInstruction::instruction_size;
-  }
-};
-
 class NativePostCallNop: public NativeInstruction {
 public:
   bool check() const { return is_nop(); }

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -42,7 +42,6 @@
 // - - NativeIllegalInstruction
 // - - NativeCallTrampolineStub
 // - - NativeMembar
-// - - NativeFenceI
 
 // The base class for different kinds of native instruction abstractions.
 // Provides the primitive operations to manipulate code relative to this.

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -354,10 +354,6 @@ static void patch_callers_callsite(MacroAssembler *masm) {
   __ la_patchable(t0, RuntimeAddress(CAST_FROM_FN_PTR(address, SharedRuntime::fixup_callers_callsite)), offset);
   __ jalr(x1, t0, offset);
 
-  // Explicit fence.i required because fixup_callers_callsite may change the code
-  // stream.
-  __ safepoint_ifence();
-
   __ pop_CPU_state();
   // restore sp
   __ leave();

--- a/src/hotspot/os_cpu/linux_riscv/orderAccess_linux_riscv.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/orderAccess_linux_riscv.hpp
@@ -54,10 +54,6 @@ inline void OrderAccess::fence() {
 }
 
 inline void OrderAccess::cross_modify_fence_impl() {
-  asm volatile("fence.i" : : : "memory");
-  if (UseConservativeFence) {
-    asm volatile("fence ir, ir" : : : "memory");
-  }
 }
 
 #endif // OS_CPU_LINUX_RISCV_ORDERACCESS_LINUX_RISCV_HPP


### PR DESCRIPTION
The usage of fence.i is in-efficient or redundant in the current implementation of riscv port now. The riscv port has already followed the [RISC-V platform specification](https://github.com/riscv/riscv-platform-specs/blob/main/riscv-platform-spec.adoc): the write hart use the __builtin__clear_cache or the syscall riscv_flush_icache directly after modifying code in riscv port, to execute fence.i on local hart and other harts by IPI. That's because fence.i only synchronizes the local hart, and the OS can reschedule the user hart to a different physical hart after the fence.i.

"To order older stores before younger instruction fetches, user-level programs must use system supplied
library calls (e.g. GNU libc's __riscv_flush_icache, which invokes the Linux kernel's
corresponding vDSO routine), rather than executing the fence.i instruction directly."

What now seems unnecessary is that we also put fence.i in front of code that will be modifed concurrently, just like Aarch64 port. Because the icache flush syscall already provides the explicit icache synchronization between all harts, so that we can remove fence.i used in the read hart.
Details of the discussion can be found in https://mail.openjdk.org/pipermail/riscv-port-dev/2022-July/000571.html.

In contrast, the isb in aarch64 is not broadcast by the writing PE, so any other PE must perform its own isb synchronization after it knows that the instruction update is visible.

Tier1 of hotspot and jdk passed on unmatched.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291893](https://bugs.openjdk.org/browse/JDK-8291893): riscv: remove fence.i used in user space


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Vladimir Kempik](https://openjdk.org/census#vkempik) (@VladimirKempik - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9770/head:pull/9770` \
`$ git checkout pull/9770`

Update a local copy of the PR: \
`$ git checkout pull/9770` \
`$ git pull https://git.openjdk.org/jdk pull/9770/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9770`

View PR using the GUI difftool: \
`$ git pr show -t 9770`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9770.diff">https://git.openjdk.org/jdk/pull/9770.diff</a>

</details>
