### PR TITLE
JDK-8291901: IGV: Preference menu disappears after JDK-8288750

### DIFF
--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/resources/com/sun/hotspot/igv/coordinator/layer.xml
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/resources/com/sun/hotspot/igv/coordinator/layer.xml
@@ -158,6 +158,12 @@
         <folder name="RunProject_hidden"/>
         <folder name="Versioning_hidden"/>
 
+        <folder name="Options">
+            <file name="org-netbeans-modules-options-OptionsWindowAction.shadow">
+                <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-modules-options-OptionsWindowAction.instance"/>
+            </file>
+        </folder>
+
         <folder name="Window">
             <file name="OutlineAction.shadow">
                 <attr name="originalFile" stringvalue="Actions/Window/com-sun-hotspot-igv-coordinator-actions-OutlineAction.instance"/>


### PR DESCRIPTION
The `Options` menu is places by default in `Tools` in the menu bar. On macOS however the `Options` menu (called `Preference` on macOS) is placed in the macOS default application menu (`idealgraphvisualizer`) the options bar. Because the `Tools` menu was always empty on macOS it was removed in `JDK-8288750`. Unfortunately, this made the `Options` menu inaccessible on Linux. 


The problem is solved by putting the `Options` menu in a separate tab in the menu bar and keeping the `Tools` menu hidden:
![Options menu](https://user-images.githubusercontent.com/71546117/183050335-7523708a-6137-40dc-bc74-d89f3bf1fba1.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291901](https://bugs.openjdk.org/browse/JDK-8291901): IGV: Preference menu disappears after JDK-8288750


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9771/head:pull/9771` \
`$ git checkout pull/9771`

Update a local copy of the PR: \
`$ git checkout pull/9771` \
`$ git pull https://git.openjdk.org/jdk pull/9771/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9771`

View PR using the GUI difftool: \
`$ git pr show -t 9771`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9771.diff">https://git.openjdk.org/jdk/pull/9771.diff</a>

</details>
