### PR TITLE
8291959: FileFontStrike#initNative does not properly initialize IG Table on Windows

### DIFF
--- a/src/java.desktop/windows/native/libfontmanager/lcdglyph.c
+++ b/src/java.desktop/windows/native/libfontmanager/lcdglyph.c
@@ -125,7 +125,7 @@ static unsigned char* getIGTable(int gamma) {
 JNIEXPORT jboolean JNICALL
     Java_sun_font_FileFontStrike_initNative(JNIEnv *env, jclass unused) {
 
-    memset(igLUTable, 0,  LCDLUTCOUNT);
+    memset(igLUTable, 0, sizeof igLUTable);
 
     return JNI_TRUE;
 }


### PR DESCRIPTION
FileFontStrike#initNative calls memset with LCDLUTCOUNT (the maximum length) as the number of bytes to zero out, which is incorrect as the elements are not 1 byte in size (unsigned char*), and will result in only part of the IG Table being correctly zeroed. This is more correctly resolved by passing sizeof igLUTable to memset instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291959](https://bugs.openjdk.org/browse/JDK-8291959): FileFontStrike#initNative does not properly initialize IG Table on Windows


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [4a074c93](https://git.openjdk.org/jdk/pull/9772/files/4a074c93be8ff95f99184fe0be52d7b235b3980a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9772/head:pull/9772` \
`$ git checkout pull/9772`

Update a local copy of the PR: \
`$ git checkout pull/9772` \
`$ git pull https://git.openjdk.org/jdk pull/9772/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9772`

View PR using the GUI difftool: \
`$ git pr show -t 9772`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9772.diff">https://git.openjdk.org/jdk/pull/9772.diff</a>

</details>
