### PR TITLE
8291970: Add TableStatistics get function to ResourceHashtable

### DIFF
--- a/src/hotspot/share/utilities/resourceHash.hpp
+++ b/src/hotspot/share/utilities/resourceHash.hpp
@@ -26,6 +26,8 @@
 #define SHARE_UTILITIES_RESOURCEHASH_HPP
 
 #include "memory/allocation.hpp"
+#include "utilities/numberSeq.hpp"
+#include "utilities/tableStatistics.hpp"
 
 template<typename K, typename V>
 class ResourceHashtableNode : public ResourceObj {
@@ -257,6 +259,26 @@ class ResourceHashtableBase : public STORAGE {
         }
       }
     }
+  }
+
+  template<typename Function>
+  TableStatistics statistics_calculate(Function size_function) const {
+    NumberSeq summary;
+    size_t literal_bytes = 0;
+    Node* const* bucket = table();
+    const unsigned sz = table_size();
+    while (bucket < bucket_at(sz)) {
+      Node* node = *bucket;
+      int count = 0;
+      while (node != NULL) {
+        literal_bytes += size_function(node->_key, node->_value);
+        count++;
+        node = node->_next;
+      }
+      summary.add((double)count);
+      ++bucket;
+    }
+    return TableStatistics(summary, literal_bytes, sizeof(Node*), sizeof(Node));
   }
 
 };

--- a/src/hotspot/share/utilities/tableStatistics.cpp
+++ b/src/hotspot/share/utilities/tableStatistics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,7 +91,7 @@ TableStatistics::TableStatistics() :
   _add_rate(0), _remove_rate(0) {
 }
 
-TableStatistics::TableStatistics(TableRateStatistics& rate_stats, NumberSeq summary, size_t literal_bytes, size_t bucket_bytes, size_t node_bytes) :
+TableStatistics::TableStatistics(NumberSeq summary, size_t literal_bytes, size_t bucket_bytes, size_t node_bytes) :
   _literal_bytes(literal_bytes),
   _number_of_buckets(0), _number_of_entries(0),
   _maximum_bucket_size(0), _average_bucket_size(0),
@@ -114,7 +114,12 @@ TableStatistics::TableStatistics(TableRateStatistics& rate_stats, NumberSeq summ
 
   _bucket_size = (_number_of_buckets <= 0) ? 0 : (_bucket_bytes / _number_of_buckets);
   _entry_size = (_number_of_entries <= 0) ? 0 : (_entry_bytes / _number_of_entries);
+}
 
+TableStatistics::TableStatistics(TableRateStatistics& rate_stats,
+                                  NumberSeq summary, size_t literal_bytes,
+                                  size_t bucket_bytes, size_t node_bytes) :
+  TableStatistics(summary, literal_bytes, bucket_bytes, node_bytes) {
 #if INCLUDE_JFR
   if (Jfr::is_recording()) {
     rate_stats.stamp();

--- a/src/hotspot/share/utilities/tableStatistics.hpp
+++ b/src/hotspot/share/utilities/tableStatistics.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,6 +82,7 @@ public:
   float _remove_rate;
 
   TableStatistics();
+  TableStatistics(NumberSeq summary, size_t literal_bytes, size_t bucket_bytes, size_t node_bytes);
   TableStatistics(TableRateStatistics& rate_stats, NumberSeq summary, size_t literal_bytes, size_t bucket_bytes, size_t node_bytes);
   ~TableStatistics();
 


### PR DESCRIPTION
Add a statistics_calculate function to ResourceHashtable so that we can use it for printing.  Also add a test.
Tested with tier1 on Oracle platforms (with and without product build).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291970](https://bugs.openjdk.org/browse/JDK-8291970): Add TableStatistics get function to ResourceHashtable


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9775/head:pull/9775` \
`$ git checkout pull/9775`

Update a local copy of the PR: \
`$ git checkout pull/9775` \
`$ git pull https://git.openjdk.org/jdk pull/9775/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9775`

View PR using the GUI difftool: \
`$ git pr show -t 9775`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9775.diff">https://git.openjdk.org/jdk/pull/9775.diff</a>

</details>
