### PR TITLE
8288204 GVN Crash: assert() failed: correct memory chain

### DIFF
--- a/src/hotspot/share/opto/arraycopynode.cpp
+++ b/src/hotspot/share/opto/arraycopynode.cpp
@@ -400,7 +400,7 @@ Node* ArrayCopyNode::array_copy_forward(PhaseGVN *phase,
       igvn->_worklist.push(adr_src);
       igvn->_worklist.push(adr_dest);
     }
-    return mm;
+    return phase->transform(mm);
   }
   return phase->C->top();
 }

--- a/test/hotspot/jtreg/compiler/c2/TestGVNCrash.java
+++ b/test/hotspot/jtreg/compiler/c2/TestGVNCrash.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/**
+ * @test
+ * @bug 8288204
+ * @summary GVN Crash: assert() failed: correct memory chain
+ *
+ * @run main/othervm -XX:CompileCommand=compileonly,compiler.c2.TestGVNCrash::test compiler.c2.TestGVNCrash
+ */
+
+package compiler.c2;
+
+public class TestGVNCrash {
+    public static int iField = 0;
+    public static double[] dArrFld = new double[256];
+    public static int[] iArrFld = new int[256];
+    public int[][] iArrFld1 = new int[256][256];
+
+    public void test() {
+        int x = 0;
+        for (int i = 0; i < 10; i++) {
+            do {
+                for (float j = 0; j < 0; j++) {
+                    iArrFld[x] = 3;
+                    iArrFld1[1][x] -= iField;
+                    dArrFld = new double[256];
+                    for (int k = 0; k < dArrFld.length; k++) {
+                        dArrFld[k] = (k % 2 == 0) ? k + 1 : k - 1;
+                    }
+                }
+            } while (++x < 5);
+            for (int j = 0; j < 100_000; j++) {
+                String s = "test";
+                s = s + s;
+                s = s + s;
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        TestGVNCrash t = new TestGVNCrash();
+        t.test();
+    }
+}


### PR DESCRIPTION
Hi can I have a review for this fix? LoadBNode::Ideal crashes after performing GVN right after EA. The bad IR is as follows:

![image](https://user-images.githubusercontent.com/5010047/183106710-3a518e5e-0b59-4c3c-aba4-8b6fcade3519.png)

The memory input of Load#971 is Phi#1109 and the address input of Load#971 is AddP whose object base is CheckCastPP#335:

The type of Phi#1109 is `byte[int:>=0]:exact+any *` while `byte[int:8]:NotNull:exact+any *,iid=177`  is the type of CheckCastPP#335 due to EA, they have different alias index, that's why we hit the assertion at L226:

https://github.com/openjdk/jdk/blob/b17a745d7f55941f02b0bdde83866aa5d32cce07/src/hotspot/share/opto/memnode.cpp#L207-L226
(t is `byte[int:>=0]:exact+any *`, t_adr is  `byte[int:8]:NotNull:exact+any *,iid=177`).



