### PR TITLE
JDK-8291878: NMT: Diagnostic malloc limits

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -4404,3 +4404,85 @@ bool Arguments::copy_expand_pid(const char* src, size_t srclen,
   *b = '\0';
   return (p == src_end); // return false if not all of the source was copied
 }
+
+bool Arguments::parse_malloc_limit_size(const char* s, size_t* out) {
+  julong limit = 0;
+  Arguments::ArgsRange range = parse_memory_size(s, &limit, 1, SIZE_MAX);
+  switch (range) {
+  case ArgsRange::arg_in_range: *out = (size_t)limit; return true;
+  case ArgsRange::arg_too_big: // only possible on 32-bit
+    vm_exit_during_initialization("MallocLimit: too large", s);
+    break;
+  case ArgsRange::arg_too_small:
+    vm_exit_during_initialization("MallocLimit: limit must be > 0");
+    break;
+  default:
+    // fall through
+    break;
+  }
+  return false;
+}
+
+// Helper for parse_malloc_limits
+void Arguments::parse_single_category_limit(char* expression, size_t limits[mt_number_of_types]) {
+  // <category>:<limit>
+  char* colon = ::strchr(expression, ':');
+  if (colon == nullptr) {
+    vm_exit_during_initialization("MallocLimit: colon missing", expression);
+  }
+  *colon = '\0';
+  MEMFLAGS f = NMTUtil::string_to_flag(expression);
+  if (f == mtNone) {
+    vm_exit_during_initialization("MallocLimit: invalid nmt category", expression);
+  }
+  if (parse_malloc_limit_size(colon + 1, limits + (int)f) == false) {
+    vm_exit_during_initialization("Invalid MallocLimit size", colon + 1);
+  }
+}
+
+// Parse diagnostic NMT switch "MallocLimit" and return the found limits.
+// 1) If option is not given, it will set all limits to 0 (aka "no limit").
+// 2) If option is given in the global form (-XX:MallocLimit=<size>), it
+//    will return the size in *total_limit.
+// 3) If option is given in its per-NMT-category form (-XX:MallocLimit=<category>:<size>[,<category>:<size>]),
+//    it will return all found limits in the limits array.
+// 4) If option is malformed, it will exit the VM.
+// For (2) and (3), limits not affected by the switch will be set to 0.
+void Arguments::parse_malloc_limits(size_t* total_limit, size_t limits[mt_number_of_types]) {
+
+  // Reset output to 0
+  *total_limit = 0;
+  for (int i = 0; i < mt_number_of_types; i ++) {
+    limits[i] = 0;
+  }
+
+  // We are done if the option is not given.
+  if (MallocLimit == nullptr) {
+    return;
+  }
+
+  // Global form?
+  if (parse_malloc_limit_size(MallocLimit, total_limit)) {
+    return;
+  }
+
+  // No. So it must be in category-specific form: MallocLimit=<nmt category>:<size>[,<nmt category>:<size> ..]
+  char* copy = os::strdup(MallocLimit);
+  if (copy == nullptr) {
+    vm_exit_out_of_memory(strlen(MallocLimit), OOM_MALLOC_ERROR, "MallocLimit");
+  }
+
+  char* p = copy, *q;
+  do {
+    q = p;
+    p = ::strchr(q, ',');
+    if (p != nullptr) {
+      *p = '\0';
+      p ++;
+    }
+    parse_single_category_limit(q, limits);
+  } while (p != nullptr);
+
+  os::free(copy);
+
+}

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -479,6 +479,10 @@ class Arguments : AllStatic {
                                          char** base_archive_path,
                                          char** top_archive_path) NOT_CDS_RETURN;
 
+  // Helpers for parse_malloc_limits
+  static bool parse_malloc_limit_size(const char* s, size_t* out);
+  static void parse_single_category_limit(char* expression, size_t limits[mt_number_of_types]);
+
  public:
   static int num_archives(const char* archive_path) NOT_CDS_RETURN_(0);
   // Parses the arguments, first phase
@@ -652,6 +656,16 @@ class Arguments : AllStatic {
   static void assert_is_dumping_archive() {
     assert(Arguments::is_dumping_archive(), "dump time only");
   }
+
+  // Parse diagnostic NMT switch "MallocLimit" and return the found limits.
+  // 1) If option is not given, it will set all limits to 0 (aka "no limit").
+  // 2) If option is given in the global form (-XX:MallocLimit=<size>), it
+  //    will return the size in *total_limit.
+  // 3) If option is given in its per-NMT-category form (-XX:MallocLimit=<category>:<size>[,<category>:<size>]),
+  //    it will return all found limits in the limits array.
+  // 4) If option is malformed, it will exit the VM.
+  // For (2) and (3), limits not affected by the switch will be set to 0.
+  static void parse_malloc_limits(size_t* total_limit, size_t limits[mt_number_of_types]);
 
   DEBUG_ONLY(static bool verify_special_jvm_flags(bool check_globals);)
 };

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1365,6 +1365,15 @@ const int ObjectAlignmentInBytes = 8;
           "allocate (for testing only)")                                    \
           range(0, max_uintx)                                               \
                                                                             \
+  product(ccstr, MallocLimit, nullptr, DIAGNOSTIC,                          \
+          "Limit malloc allocation size from hotspot (requires NMT). "      \
+          "Reaching the limit will trigger a fatal error."                  \
+          "Usage:"                                                          \
+          "- MallocLimit=<size> to set a total limit. "                     \
+          "- MallocLimit=<NMT category>:<size>[,<NMT category>:<size>..] "  \
+          "  to set one or more category-specific limits."                  \
+          "Example: -XX:MallocLimit=compiler:500m")                         \
+                                                                            \
   product(intx, TypeProfileWidth, 2,                                        \
           "Number of receiver types to record in call/cast profile")        \
           range(0, 8)                                                       \

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -189,11 +190,40 @@ class MallocMemorySummary : AllStatic {
   // Reserve memory for placement of MallocMemorySnapshot object
   static size_t _snapshot[CALC_OBJ_SIZE_IN_TYPE(MallocMemorySnapshot, size_t)];
 
+  // Malloc Limit handling (-XX:MallocLimit)
+  static size_t _limits_per_category[mt_number_of_types];
+  static size_t _total_limit;
+
+  static void initialize_limit_handling();
+  static void total_limit_reached(size_t size, size_t limit);
+  static void category_limit_reached(size_t size, size_t limit, MEMFLAGS flag);
+
+  static void check_limits_after_allocation(MEMFLAGS flag) {
+    // We can only either have a total limit or category specific limits,
+    // not both.
+    if (_total_limit != 0) {
+      size_t s = as_snapshot()->total();
+      if (s > _total_limit) {
+        total_limit_reached(s, _total_limit);
+      }
+    } else {
+      size_t per_cat_limit = _limits_per_category[(int)flag];
+      if (per_cat_limit > 0) {
+        const MallocMemory* mm = as_snapshot()->by_type(flag);
+        size_t s = mm->malloc_size() + mm->arena_size();
+        if (s > per_cat_limit) {
+          category_limit_reached(s, per_cat_limit, flag);
+        }
+      }
+    }
+  }
+
  public:
    static void initialize();
 
    static inline void record_malloc(size_t size, MEMFLAGS flag) {
      as_snapshot()->by_type(flag)->record_malloc(size);
+     check_limits_after_allocation(flag);
    }
 
    static inline void record_free(size_t size, MEMFLAGS flag) {
@@ -210,6 +240,7 @@ class MallocMemorySummary : AllStatic {
 
    static inline void record_arena_size_change(ssize_t size, MEMFLAGS flag) {
      as_snapshot()->by_type(flag)->record_arena_size_change(size);
+     check_limits_after_allocation(flag);
    }
 
    static void snapshot(MallocMemorySnapshot* s) {
@@ -234,6 +265,8 @@ class MallocMemorySummary : AllStatic {
   static MallocMemorySnapshot* as_snapshot() {
     return (MallocMemorySnapshot*)_snapshot;
   }
+
+  static void print_limits(outputStream* st);
 };
 
 

--- a/src/hotspot/share/services/memTracker.cpp
+++ b/src/hotspot/share/services/memTracker.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2028, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,6 +74,10 @@ void MemTracker::initialize() {
       log_warning(nmt)("NMT initialization failed. NMT disabled.");
       return;
     }
+  } else {
+    if (MallocLimit != nullptr) {
+      warning("MallocLimit will be ignored since NMT is disabled.");
+    }
   }
 
   NMTPreInit::pre_to_post();
@@ -110,6 +115,7 @@ void MemTracker::error_report(outputStream* output) {
     report(true, output, MemReporterBase::default_scale); // just print summary for error case.
     output->print("Preinit state:");
     NMTPreInit::print_state(output);
+    MallocMemorySummary::print_limits(output);
   }
 }
 
@@ -154,5 +160,6 @@ void MemTracker::tuning_statistics(outputStream* out) {
   out->cr();
   out->print_cr("Preinit state:");
   NMTPreInit::print_state(out);
+  MallocMemorySummary::print_limits(out);
   out->cr();
 }

--- a/src/hotspot/share/services/nmtCommon.cpp
+++ b/src/hotspot/share/services/nmtCommon.cpp
@@ -25,14 +25,14 @@
 #include "services/nmtCommon.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-#define MEMORY_TYPE_DECLARE_NAME(type, human_readable) \
-  human_readable,
-
 STATIC_ASSERT(NMT_off > NMT_unknown);
 STATIC_ASSERT(NMT_summary > NMT_off);
 STATIC_ASSERT(NMT_detail > NMT_summary);
 
-const char* NMTUtil::_memory_type_names[] = {
+#define MEMORY_TYPE_DECLARE_NAME(type, human_readable) \
+  { #type, human_readable },
+
+NMTUtil::S NMTUtil::_strings[] = {
   MEMORY_TYPES_DO(MEMORY_TYPE_DECLARE_NAME)
 };
 
@@ -85,4 +85,20 @@ NMT_TrackingLevel NMTUtil::parse_tracking_level(const char* s) {
     }
   }
   return NMT_unknown;
+}
+
+// Given a string, return associated flag. mtNone if name is invalid.
+// String can be either the human readable name or the
+// stringified enum (with or without leading "mt"). In all cases, case is ignored.
+MEMFLAGS NMTUtil::string_to_flag(const char* s) {
+  for (int i = 0; i < mt_number_of_types; i ++) {
+    assert(::strlen(_strings[i].enum_s) > 2, "Sanity"); // should always start with "mt"
+    if (::strcasecmp(_strings[i].human_readable, s) == 0 ||
+        ::strcasecmp(_strings[i].enum_s, s) == 0 ||
+        ::strcasecmp(_strings[i].enum_s + 2, s) == 0) // "mtXXX" -> match also "XXX" or "xxx"
+    {
+      return (MEMFLAGS)i;
+    }
+  }
+  return mtNone;
 }

--- a/src/hotspot/share/services/nmtCommon.hpp
+++ b/src/hotspot/share/services/nmtCommon.hpp
@@ -93,7 +93,7 @@ class NMTUtil : AllStatic {
 
   // Map memory type to human readable name
   static const char* flag_to_name(MEMFLAGS flag) {
-    return _memory_type_names[flag_to_index(flag)];
+    return _strings[flag_to_index(flag)].human_readable;
   }
 
   // Map an index to memory type
@@ -115,11 +115,20 @@ class NMTUtil : AllStatic {
   // string is not a valid level.
   static NMT_TrackingLevel parse_tracking_level(const char* s);
 
+  // Given a string, return associated flag. mtNone if name is invalid.
+  // String can be either the human readable name or the
+  // stringified enum (with or without leading "mt". In all cases, case is ignored.
+  static MEMFLAGS string_to_flag(const char* name);
+
   // Returns textual representation of a tracking level.
   static const char* tracking_level_to_string(NMT_TrackingLevel level);
 
  private:
-  static const char* _memory_type_names[mt_number_of_types];
+  struct S {
+    const char* enum_s; // e.g. "mtNMT"
+    const char* human_readable; // e.g. "Native Memory Tracking"
+  };
+  static S _strings[mt_number_of_types];
 };
 
 

--- a/test/hotspot/jtreg/runtime/NMT/MallocLimitTest.java
+++ b/test/hotspot/jtreg/runtime/NMT/MallocLimitTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test id=global_limit
+ * @summary Verify -XX:MallocLimit with a global limit
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @run driver MallocLimitTest global_limit
+ */
+
+/*
+ * @test id=compiler_limit
+ * @summary Verify -XX:MallocLimit with a compiler-specific limit (for "mtCompiler" category)
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @run driver MallocLimitTest compiler_limit
+ */
+
+/*
+ * @test id=test_multi_limit
+ * @summary Verify -XX:MallocLimit with multiple limits
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @run driver MallocLimitTest multi_limit
+ */
+
+/*
+ * @test id=test_valid_settings
+ * @summary Verify -XX:MallocLimit rejects invalid settings
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @run driver MallocLimitTest valid_settings
+ */
+
+/*
+ * @test id=test_invalid_settings
+ * @summary Verify -XX:MallocLimit rejects invalid settings
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @run driver MallocLimitTest invalid_settings
+ */
+
+/*
+ * @test id=test_limit_without_nmt
+ * @summary Verify that the VM warns if -XX:MallocLimit is given but NMT is disabled
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @run driver MallocLimitTest limit_without_nmt
+ */
+
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+public class MallocLimitTest {
+
+    private static ProcessBuilder processBuilderWithSetting(String... extra_settings) {
+        String[] vmargs = new String[] {
+            "-XX:+UnlockDiagnosticVMOptions", // MallocLimit is diagnostic
+            "-Xmx64m", "-XX:-CreateCoredumpOnCrash", "-Xlog:nmt",
+            "-XX:NativeMemoryTracking=summary"
+        };
+        String[] vmargs2 = new String[] { "-version" };
+        String[] both = Stream.concat(Stream.concat(Arrays.stream(vmargs), Arrays.stream(extra_settings)), Arrays.stream(vmargs2))
+                .toArray(String[]::new);
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(both);
+        return pb;
+    }
+
+    private static void test_global_limit() throws IOException {
+        long small_memory_size = 1024*1024; // 1m
+        ProcessBuilder pb = processBuilderWithSetting("-XX:MallocLimit=" + small_memory_size);
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.reportDiagnosticSummary();
+        output.shouldNotHaveExitValue(0);
+        output.shouldContain("[nmt] MallocLimit: total limit: " + small_memory_size);
+        String s = output.firstMatch(".*MallocLimit: reached limit \\(size: (\\d+), limit: " + small_memory_size + "\\).*", 1);
+        Asserts.assertNotNull(s);
+        long size = Long.parseLong(s);
+        Asserts.assertGreaterThan(size, small_memory_size);
+    }
+
+    private static void test_compiler_limit() throws IOException {
+        // Here, we count on the VM, running with -Xcomp and with 1m of arena space allowed, will start a compilation
+        // and then trip over the limit.
+        // If limit is too small, Compiler stops too early and we won't get a Retry file (see below, we check that).
+        // If limit is too large, we may not trigger it for java -version.
+        // 1m seems to work out fine.
+        long small_memory_size = 1024*1024; // 1m
+        ProcessBuilder pb = processBuilderWithSetting("-XX:MallocLimit=compiler:" + small_memory_size,
+                "-Xcomp" // make sure we hit the compiler category limit
+        );
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.reportDiagnosticSummary();
+        output.shouldNotHaveExitValue(0);
+        output.shouldContain("[nmt] MallocLimit: category \"Compiler\" limit: " + small_memory_size);
+        String s = output.firstMatch(".*MallocLimit: category \"Compiler\" reached limit \\(size: (\\d+), limit: " + small_memory_size + "\\).*", 1);
+        Asserts.assertNotNull(s);
+        long size = Long.parseLong(s);
+        output.shouldContain("Compiler replay data is saved as");
+        Asserts.assertGreaterThan(size, small_memory_size);
+    }
+
+    private static void test_multi_limit() throws IOException {
+        long small_memory_size = 1024; // 1k
+        ProcessBuilder pb = processBuilderWithSetting("-XX:MallocLimit=mtOther:2g,compiler:1g,internal:" + small_memory_size);
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.reportDiagnosticSummary();
+        output.shouldNotHaveExitValue(0);
+        output.shouldContain("[nmt] MallocLimit: category \"Compiler\" limit: 1073741824");
+        output.shouldContain("[nmt] MallocLimit: category \"Internal\" limit: " + small_memory_size);
+        output.shouldContain("[nmt] MallocLimit: category \"Other\" limit: 2147483648");
+        String s = output.firstMatch(".*MallocLimit: category \"Internal\" reached limit \\(size: (\\d+), limit: " + small_memory_size + "\\).*", 1);
+        long size = Long.parseLong(s);
+        Asserts.assertGreaterThan(size, small_memory_size);
+    }
+
+    private static void test_valid_setting(String setting, String... expected_output) throws IOException {
+        ProcessBuilder pb = processBuilderWithSetting("-XX:MallocLimit=" + setting);
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.reportDiagnosticSummary();
+        output.shouldHaveExitValue(0);
+        for (String expected : expected_output) {
+            output.shouldContain(expected);
+        }
+    }
+
+    private static void test_valid_settings() throws IOException {
+        // Test a number of valid settings.
+        test_valid_setting(
+                "2097152k",
+                "[nmt] MallocLimit: total limit: 2147483648",
+                "[nmt] NMT initialized: summary"
+        );
+        test_valid_setting(
+                "gc:1234567891,mtInternal:987654321,Object Monitors:1g",
+                "[0.001s][info][nmt] MallocLimit: category \"GC\" limit: 1234567891",
+                "[nmt] MallocLimit: category \"Internal\" limit: 987654321",
+                "[nmt] MallocLimit: category \"Object Monitors\" limit: 1073741824",
+                "[nmt] NMT initialized: summary"
+        );
+        // Set all categories individually:
+        test_valid_setting(
+                "JavaHeap:1024m,Class:1025m,Thread:1026m,ThreadStack:1027m,Code:1028m,GC:1029m,GCCardSet:1030m,Compiler:1031m,JVMCI:1032m," +
+                        "Internal:1033m,Other:1034m,Symbol:1035m,NMT:1036m,ClassShared:1037m,Chunk:1038m,Test:1039m,Tracing:1040m,Logging:1041m," +
+                        "Statistics:1042m,Arguments:1043m,Module:1044m,Safepoint:1045m,Synchronizer:1046m,Serviceability:1047m,Metaspace:1048m,StringDedup:1049m,ObjectMonitor:1050m",
+                "[nmt] MallocLimit: category \"Java Heap\" limit: 1073741824",
+                "[nmt] MallocLimit: category \"Class\" limit: 1074790400",
+                "[nmt] MallocLimit: category \"Thread\" limit: 1075838976",
+                "[nmt] MallocLimit: category \"Thread Stack\" limit: 1076887552",
+                "[nmt] MallocLimit: category \"Code\" limit: 1077936128",
+                "[nmt] MallocLimit: category \"GC\" limit: 1078984704",
+                "[nmt] MallocLimit: category \"GCCardSet\" limit: 1080033280",
+                "[nmt] MallocLimit: category \"Compiler\" limit: 1081081856",
+                "[nmt] MallocLimit: category \"JVMCI\" limit: 1082130432",
+                "[nmt] MallocLimit: category \"Internal\" limit: 1083179008",
+                "[nmt] MallocLimit: category \"Other\" limit: 1084227584",
+                "[nmt] MallocLimit: category \"Symbol\" limit: 1085276160",
+                "[nmt] MallocLimit: category \"Native Memory Tracking\" limit: 1086324736",
+                "[nmt] MallocLimit: category \"Shared class space\" limit: 1087373312",
+                "[nmt] MallocLimit: category \"Arena Chunk\" limit: 1088421888",
+                "[nmt] MallocLimit: category \"Test\" limit: 1089470464",
+                "[nmt] MallocLimit: category \"Tracing\" limit: 1090519040",
+                "[nmt] MallocLimit: category \"Logging\" limit: 1091567616",
+                "[nmt] MallocLimit: category \"Statistics\" limit: 1092616192",
+                "[nmt] MallocLimit: category \"Arguments\" limit: 1093664768",
+                "[nmt] MallocLimit: category \"Module\" limit: 1094713344",
+                "[nmt] MallocLimit: category \"Safepoint\" limit: 1095761920",
+                "[nmt] MallocLimit: category \"Synchronization\" limit: 1096810496",
+                "[nmt] MallocLimit: category \"Serviceability\" limit: 1097859072",
+                "[nmt] MallocLimit: category \"Metaspace\" limit: 1098907648",
+                "[nmt] MallocLimit: category \"String Deduplication\" limit: 1099956224",
+                "[nmt] MallocLimit: category \"Object Monitors\" limit: 1101004800",
+                "[nmt] NMT initialized: summary"
+        );
+    }
+
+    private static void test_invalid_setting(String setting, String expected_error) throws IOException {
+        ProcessBuilder pb = processBuilderWithSetting("-XX:MallocLimit=" + setting);
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.reportDiagnosticSummary();
+        output.shouldNotHaveExitValue(0);
+        output.shouldContain(expected_error);
+    }
+
+    private static void test_invalid_settings() throws IOException {
+        // Test a number of invalid settings the parser should catch. VM should abort in initialization.
+        test_invalid_setting("gc", "MallocLimit: colon missing: gc");
+        test_invalid_setting("gc:abc", "Invalid MallocLimit size: abc");
+        test_invalid_setting("abcd:10m", "MallocLimit: invalid nmt category: abcd");
+        test_invalid_setting("nmt:100m,abcd:10m", "MallocLimit: invalid nmt category: abcd");
+        test_invalid_setting("0", "MallocLimit: limit must be > 0");
+        test_invalid_setting("GC:0", "MallocLimit: limit must be > 0");
+    }
+
+    private static void test_limit_without_nmt() throws IOException {
+        ProcessBuilder pb = processBuilderWithSetting("-XX:NativeMemoryTracking=off", // overrides "summary" from processBuilderWithSetting()
+                "-XX:MallocLimit=3g");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.reportDiagnosticSummary();
+        output.shouldHaveExitValue(0); // Not a fatal error, just a warning
+        output.shouldContain("MallocLimit will be ignored since NMT is disabled");
+    }
+
+    public static void main(String args[]) throws Exception {
+
+        if (args[0].equals("global_limit")) {
+            test_global_limit();
+        } else if (args[0].equals("compiler_limit")) {
+            test_compiler_limit();
+        } else if (args[0].equals("multi_limit")) {
+            test_multi_limit();
+        } else if (args[0].equals("valid_settings")) {
+            test_valid_settings();
+        } else if (args[0].equals("invalid_settings")) {
+            test_invalid_settings();
+        } else if (args[0].equals("limit_without_nmt")) {
+            test_limit_without_nmt();
+        } else {
+            throw new RuntimeException("invalid test: " + args[0]);
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/NMT/MallocLimitTest.java
+++ b/test/hotspot/jtreg/runtime/NMT/MallocLimitTest.java
@@ -162,7 +162,7 @@ public class MallocLimitTest {
         );
         test_valid_setting(
                 "gc:1234567891,mtInternal:987654321,Object Monitors:1g",
-                "[0.001s][info][nmt] MallocLimit: category \"GC\" limit: 1234567891",
+                "[nmt] MallocLimit: category \"GC\" limit: 1234567891",
                 "[nmt] MallocLimit: category \"Internal\" limit: 987654321",
                 "[nmt] MallocLimit: category \"Object Monitors\" limit: 1073741824",
                 "[nmt] NMT initialized: summary"


### PR DESCRIPTION
This PR introduces malloc limits, similar to what `MallocMaxTestWords` was intending. `MallocMaxTestWords` is broken, but this one works fine since it is based on NMT. If this one is in, I'd like to remove `MallocMaxTestWords` or, if people really care, redirect it to the new switch.

----

Why this is useful:

We recently analyzed [JDK-8291919](https://bugs.openjdk.org/browse/JDK-8291919), a jdk11u-specific regression that caused a compiler arena to explode. We used to have such problems in the past a lot, when our CPU ports were young. They are rarer nowadays but still happen.

A switch to limit compiler-related mallocs would have been nice: something to cause the VM to stop with a fatal error in the compiler allocation path when the compiler arena size reached a certain point. I first tried `MallocMaxTestWords`, but that turned out to be broken since it does not de-account memory allocations.

We finally managed to get a retry file by reproducing the bug locally and ulimit-ing the virtual process size, but it was cumbersome. A simple switch like `MallocMaxTestWords` would have been much better.

In addition to customer scenarios like these, such a switch could be used to add sanity checks to compiler jtreg tests. Maybe we could have caught [JDK-8291919](https://bugs.openjdk.org/browse/JDK-8291919) before shipment.

-----

How it works:

Patch introduces a new diagnostic switch `-XX:MallocLimit`. That switch can be used in two ways:

1 impose a total global limit to the size hotspot is allowed to malloc: 
```
-XX:MallocLimit=<size>
```
2 impose a limit to a selected NMT category, or to multiple NMT categories: 
```
-XX:MallocLimit=<category>:<size>[,<category>:<size>...]
```

If the switch is set, and the VM mallocs more in total (1) or for the given category (2), it will now stop with a fatal error. That way we can e.g. limit compiler arenas to a certain maximum in situations where the compiler runs amok, and get a compiler retry file. See here, with an artificial compiler bug introduced:

```
thomas@starfish$ ./images/jdk/bin/java  -XX:NativeMemoryTracking=summary -XX:+UnlockDiagnosticVMOptions -XX:MallocLimit=compiler:1g -jar /shared/projects/spring-petclinic/target/spring-petclinic-2.5.0-SNAP
SHOT.jar
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (mallocTracker.cpp:146), pid=519822, tid=519836
#  guarantee(false) failed: MallocLimit: category "Compiler" reached limit (size: 1073765608, limit: 1073741824) 
#
...
# An error report file with more information is saved as:
# /shared/projects/openjdk/jdk-jdk/output-release/hs_err_pid519822.log
#
# Compiler replay data is saved as:
# /shared/projects/openjdk/jdk-jdk/output-release/replay_pid519822.log
#
```
-----

The patch:
- adds the option and its handling to NMT
- adds regression tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291878](https://bugs.openjdk.org/browse/JDK-8291878): NMT: Diagnostic malloc limits


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9778/head:pull/9778` \
`$ git checkout pull/9778`

Update a local copy of the PR: \
`$ git checkout pull/9778` \
`$ git pull https://git.openjdk.org/jdk pull/9778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9778`

View PR using the GUI difftool: \
`$ git pr show -t 9778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9778.diff">https://git.openjdk.org/jdk/pull/9778.diff</a>

</details>
