### PR TITLE
8291992: [REDO2] ProblemList multiple tests in -Xcomp mode due to JDK-8291649

### DIFF
--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -29,3 +29,8 @@
 
 java/lang/invoke/MethodHandles/CatchExceptionTest.java 8146623 generic-all
 java/lang/ref/ReferenceEnqueue.java 8284236 generic-all
+
+java/lang/Integer/BitTwiddle.java 8291649 generic-x64
+java/lang/Long/BitTwiddle.java    8291649 generic-x64
+java/util/zip/TestCRC32C.java     8291649 generic-x64
+java/util/zip/TestChecksum.java   8291649 generic-x64


### PR DESCRIPTION
A trivial fix to ProblemList multiple tests in -Xcomp mode due to JDK-8291649.
Redoing this one with the correct ProblemList-Xcomp.txt file... 
and remembering to commit the correct file also.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291992](https://bugs.openjdk.org/browse/JDK-8291992): [REDO2] ProblemList multiple tests in -Xcomp mode due to JDK-8291649


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9786/head:pull/9786` \
`$ git checkout pull/9786`

Update a local copy of the PR: \
`$ git checkout pull/9786` \
`$ git pull https://git.openjdk.org/jdk pull/9786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9786`

View PR using the GUI difftool: \
`$ git pr show -t 9786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9786.diff">https://git.openjdk.org/jdk/pull/9786.diff</a>

</details>
