### PR TITLE
8290041: ModuleDescriptor.hashCode is inconsistent

### DIFF
--- a/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
@@ -2627,7 +2627,7 @@ public class ModuleDescriptor
     private static int modsHashCode(Iterable<? extends Enum<?>> enums) {
         int h = 0;
         for (Enum<?> e : enums) {
-            h = h * 43 + Objects.hashCode(e.name());
+            h = h + Objects.hashCode(e.name()) * 43;
         }
         return h;
     }

--- a/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
@@ -2627,7 +2627,7 @@ public class ModuleDescriptor
     private static int modsHashCode(Iterable<? extends Enum<?>> enums) {
         int h = 0;
         for (Enum<?> e : enums) {
-            h = h + Objects.hashCode(e.name()) * 43;
+            h += e.name().hashCode();
         }
         return h;
     }

--- a/test/jdk/java/lang/module/ModuleDescriptorHashCodeTest.java
+++ b/test/jdk/java/lang/module/ModuleDescriptorHashCodeTest.java
@@ -24,6 +24,9 @@
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.module.ModuleDescriptor;
+import java.lang.module.ModuleDescriptor.Exports;
+import java.lang.module.ModuleDescriptor.Opens;
+import java.lang.module.ModuleDescriptor.Requires;
 import java.util.Set;
 
 import org.testng.annotations.Test;
@@ -70,16 +73,14 @@ public class ModuleDescriptorHashCodeTest {
     @Test
     public void testOpensModifiersOrdering() throws Exception {
         // important to use Set.of() (i.e. backed by immutable set) to reproduce the issue
-        final Set<ModuleDescriptor.Opens.Modifier> mods1 = Set.of(
-                ModuleDescriptor.Opens.Modifier.SYNTHETIC, ModuleDescriptor.Opens.Modifier.MANDATED);
+        final Set<Opens.Modifier> mods1 = Set.of(Opens.Modifier.SYNTHETIC, Opens.Modifier.MANDATED);
         final ModuleDescriptor desc1 = createModuleDescriptor(mods1, null, null);
 
         // create the same module descriptor again and this time just change the order of the
         // "opens" modifiers' Set.
 
         // important to use Set.of() (i.e. backed by immutable set) to reproduce the issue
-        final Set<ModuleDescriptor.Opens.Modifier> mods2 = Set.of(
-                ModuleDescriptor.Opens.Modifier.MANDATED, ModuleDescriptor.Opens.Modifier.SYNTHETIC);
+        final Set<Opens.Modifier> mods2 = Set.of(Opens.Modifier.MANDATED, Opens.Modifier.SYNTHETIC);
         final ModuleDescriptor desc2 = createModuleDescriptor(mods2, null, null);
 
         // basic verification of the modifiers themselves before we check the module descriptors
@@ -103,16 +104,14 @@ public class ModuleDescriptorHashCodeTest {
     @Test
     public void testExportsModifiersOrdering() throws Exception {
         // important to use Set.of() (i.e. backed by immutable set) to reproduce the issue
-        final Set<ModuleDescriptor.Exports.Modifier> mods1 = Set.of(
-                ModuleDescriptor.Exports.Modifier.SYNTHETIC, ModuleDescriptor.Exports.Modifier.MANDATED);
+        final Set<Exports.Modifier> mods1 = Set.of(Exports.Modifier.SYNTHETIC, Exports.Modifier.MANDATED);
         final ModuleDescriptor desc1 = createModuleDescriptor(null, null, mods1);
 
         // create the same module descriptor again and this time just change the order of the
         // "exports" modifiers' Set.
 
         // important to use Set.of() (i.e. backed by immutable set) to reproduce the issue
-        final Set<ModuleDescriptor.Exports.Modifier> mods2 = Set.of(
-                ModuleDescriptor.Exports.Modifier.MANDATED, ModuleDescriptor.Exports.Modifier.SYNTHETIC);
+        final Set<Exports.Modifier> mods2 = Set.of(Exports.Modifier.MANDATED, Exports.Modifier.SYNTHETIC);
         final ModuleDescriptor desc2 = createModuleDescriptor(null, null, mods2);
 
         // basic verification of the modifiers themselves before we check the module descriptors
@@ -136,16 +135,14 @@ public class ModuleDescriptorHashCodeTest {
     @Test
     public void testRequiresModifiersOrdering() throws Exception {
         // important to use Set.of() (i.e. backed by immutable set) to reproduce the issue
-        final Set<ModuleDescriptor.Requires.Modifier> mods1 = Set.of(
-                ModuleDescriptor.Requires.Modifier.SYNTHETIC, ModuleDescriptor.Requires.Modifier.MANDATED);
+        final Set<Requires.Modifier> mods1 = Set.of(Requires.Modifier.SYNTHETIC, Requires.Modifier.MANDATED);
         final ModuleDescriptor desc1 = createModuleDescriptor(null, mods1, null);
 
         // create the same module descriptor again and this time just change the order of the
         // "exports" modifiers' Set.
 
         // important to use Set.of() (i.e. backed by immutable set) to reproduce the issue
-        final Set<ModuleDescriptor.Requires.Modifier> mods2 = Set.of(
-                ModuleDescriptor.Requires.Modifier.MANDATED, ModuleDescriptor.Requires.Modifier.SYNTHETIC);
+        final Set<Requires.Modifier> mods2 = Set.of(Requires.Modifier.MANDATED, Requires.Modifier.SYNTHETIC);
         final ModuleDescriptor desc2 = createModuleDescriptor(null, mods2, null);
 
         // basic verification of the modifiers themselves before we check the module descriptors
@@ -174,20 +171,20 @@ public class ModuleDescriptorHashCodeTest {
 
     // creates a module descriptor with passed (optional) opens/exports/requires modifiers
     private static ModuleDescriptor createModuleDescriptor(
-            Set<ModuleDescriptor.Opens.Modifier> opensModifiers,
-            Set<ModuleDescriptor.Requires.Modifier> reqsModifiers,
-            Set<ModuleDescriptor.Exports.Modifier> expsModifiers) {
+            Set<Opens.Modifier> opensModifiers,
+            Set<Requires.Modifier> reqsModifiers,
+            Set<Exports.Modifier> expsModifiers) {
 
-        final var mdb = ModuleDescriptor.newModule("foobar");
+        final ModuleDescriptor.Builder builder = ModuleDescriptor.newModule("foobar");
         if (opensModifiers != null) {
-            mdb.opens(opensModifiers, "a.p1", Set.of("a.m1"));
+            builder.opens(opensModifiers, "a.p1", Set.of("a.m1"));
         }
         if (reqsModifiers != null) {
-            mdb.requires(reqsModifiers, "a.m2");
+            builder.requires(reqsModifiers, "a.m2");
         }
         if (expsModifiers != null) {
-            mdb.exports(expsModifiers, "a.b.c", Set.of("a.m3"));
+            builder.exports(expsModifiers, "a.b.c", Set.of("a.m3"));
         }
-        return mdb.build();
+        return builder.build();
     }
 }

--- a/test/jdk/java/lang/module/ModuleDescriptorHashCodeTest.java
+++ b/test/jdk/java/lang/module/ModuleDescriptorHashCodeTest.java
@@ -68,28 +68,88 @@ public class ModuleDescriptorHashCodeTest {
      * descriptors, have the same hashcode.
      */
     @Test
-    public void testModifiersOrdering() throws Exception {
-        // create a module descriptor
-
+    public void testOpensModifiersOrdering() throws Exception {
         // important to use Set.of() (i.e. backed by immutable set) to reproduce the issue
-        final Set<ModuleDescriptor.Opens.Modifier> mod1 = Set.of(
+        final Set<ModuleDescriptor.Opens.Modifier> mods1 = Set.of(
                 ModuleDescriptor.Opens.Modifier.SYNTHETIC, ModuleDescriptor.Opens.Modifier.MANDATED);
-        final ModuleDescriptor desc1 = ModuleDescriptor.newModule("foobar")
-                .opens(mod1, "a.p1", Set.of("a.m1"))
-                .build();
+        final ModuleDescriptor desc1 = createModuleDescriptor(mods1, null, null);
 
         // create the same module descriptor again and this time just change the order of the
         // "opens" modifiers' Set.
 
         // important to use Set.of() (i.e. backed by immutable set) to reproduce the issue
-        final Set<ModuleDescriptor.Opens.Modifier> mod2 = Set.of(
+        final Set<ModuleDescriptor.Opens.Modifier> mods2 = Set.of(
                 ModuleDescriptor.Opens.Modifier.MANDATED, ModuleDescriptor.Opens.Modifier.SYNTHETIC);
-        final ModuleDescriptor desc2 = ModuleDescriptor.newModule("foobar")
-                .opens(mod2, "a.p1", Set.of("a.m1"))
-                .build();
+        final ModuleDescriptor desc2 = createModuleDescriptor(mods2, null, null);
 
         // basic verification of the modifiers themselves before we check the module descriptors
-        assertEquals(mod1, mod2, "Modifiers were expected to be equal");
+        assertEquals(mods1, mods2, "Modifiers were expected to be equal");
+
+        // now verify the module descriptors
+        assertEquals(desc1, desc2, "Module descriptors were expected to be equal");
+        assertEquals(desc1.compareTo(desc2), 0, "compareTo was expected to return" +
+                " 0 for module descriptors that are equal");
+        System.out.println(desc1 + " hashcode = " + desc1.hashCode());
+        System.out.println(desc2 + " hashcode = " + desc2.hashCode());
+        assertEquals(desc1.hashCode(), desc2.hashCode(), "Module descriptor hashcodes" +
+                " were expected to be equal");
+    }
+
+    /**
+     * Verifies that two "equal" module descriptors which only differ in the order of
+     * {@link ModuleDescriptor.Exports.Modifier exports modifiers}, that were used to construct the
+     * descriptors, have the same hashcode.
+     */
+    @Test
+    public void testExportsModifiersOrdering() throws Exception {
+        // important to use Set.of() (i.e. backed by immutable set) to reproduce the issue
+        final Set<ModuleDescriptor.Exports.Modifier> mods1 = Set.of(
+                ModuleDescriptor.Exports.Modifier.SYNTHETIC, ModuleDescriptor.Exports.Modifier.MANDATED);
+        final ModuleDescriptor desc1 = createModuleDescriptor(null, null, mods1);
+
+        // create the same module descriptor again and this time just change the order of the
+        // "exports" modifiers' Set.
+
+        // important to use Set.of() (i.e. backed by immutable set) to reproduce the issue
+        final Set<ModuleDescriptor.Exports.Modifier> mods2 = Set.of(
+                ModuleDescriptor.Exports.Modifier.MANDATED, ModuleDescriptor.Exports.Modifier.SYNTHETIC);
+        final ModuleDescriptor desc2 = createModuleDescriptor(null, null, mods2);
+
+        // basic verification of the modifiers themselves before we check the module descriptors
+        assertEquals(mods1, mods2, "Modifiers were expected to be equal");
+
+        // now verify the module descriptors
+        assertEquals(desc1, desc2, "Module descriptors were expected to be equal");
+        assertEquals(desc1.compareTo(desc2), 0, "compareTo was expected to return" +
+                " 0 for module descriptors that are equal");
+        System.out.println(desc1 + " hashcode = " + desc1.hashCode());
+        System.out.println(desc2 + " hashcode = " + desc2.hashCode());
+        assertEquals(desc1.hashCode(), desc2.hashCode(), "Module descriptor hashcodes" +
+                " were expected to be equal");
+    }
+
+    /**
+     * Verifies that two "equal" module descriptors which only differ in the order of
+     * {@link ModuleDescriptor.Requires.Modifier requires modifiers}, that were used to construct the
+     * descriptors, have the same hashcode.
+     */
+    @Test
+    public void testRequiresModifiersOrdering() throws Exception {
+        // important to use Set.of() (i.e. backed by immutable set) to reproduce the issue
+        final Set<ModuleDescriptor.Requires.Modifier> mods1 = Set.of(
+                ModuleDescriptor.Requires.Modifier.SYNTHETIC, ModuleDescriptor.Requires.Modifier.MANDATED);
+        final ModuleDescriptor desc1 = createModuleDescriptor(null, mods1, null);
+
+        // create the same module descriptor again and this time just change the order of the
+        // "exports" modifiers' Set.
+
+        // important to use Set.of() (i.e. backed by immutable set) to reproduce the issue
+        final Set<ModuleDescriptor.Requires.Modifier> mods2 = Set.of(
+                ModuleDescriptor.Requires.Modifier.MANDATED, ModuleDescriptor.Requires.Modifier.SYNTHETIC);
+        final ModuleDescriptor desc2 = createModuleDescriptor(null, mods2, null);
+
+        // basic verification of the modifiers themselves before we check the module descriptors
+        assertEquals(mods1, mods2, "Modifiers were expected to be equal");
 
         // now verify the module descriptors
         assertEquals(desc1, desc2, "Module descriptors were expected to be equal");
@@ -110,5 +170,24 @@ public class ModuleDescriptorHashCodeTest {
             // internally calls ModuleDescriptor.Builder
             return ModuleDescriptor.read(moduleInfo);
         }
+    }
+
+    // creates a module descriptor with passed (optional) opens/exports/requires modifiers
+    private static ModuleDescriptor createModuleDescriptor(
+            Set<ModuleDescriptor.Opens.Modifier> opensModifiers,
+            Set<ModuleDescriptor.Requires.Modifier> reqsModifiers,
+            Set<ModuleDescriptor.Exports.Modifier> expsModifiers) {
+
+        final var mdb = ModuleDescriptor.newModule("foobar");
+        if (opensModifiers != null) {
+            mdb.opens(opensModifiers, "a.p1", Set.of("a.m1"));
+        }
+        if (reqsModifiers != null) {
+            mdb.requires(reqsModifiers, "a.m2");
+        }
+        if (expsModifiers != null) {
+            mdb.exports(expsModifiers, "a.b.c", Set.of("a.m3"));
+        }
+        return mdb.build();
     }
 }


### PR DESCRIPTION
Can I please get a review of this change which proposes to fix https://bugs.openjdk.org/browse/JDK-8290041? 

As noted by the reporter, the current implementation is buggy since the calculation can result in a different value of the hashcode depending on the order of iteration of the `Modifier`s. The commit in this PR changes that computation to produce consistent result irrespective of the order in which the `Modifier`s (enum) is iterated upon.

A new test has been added which reproduces the issue and verifies the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290041](https://bugs.openjdk.org/browse/JDK-8290041): ModuleDescriptor.hashCode is inconsistent


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9790/head:pull/9790` \
`$ git checkout pull/9790`

Update a local copy of the PR: \
`$ git checkout pull/9790` \
`$ git pull https://git.openjdk.org/jdk pull/9790/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9790`

View PR using the GUI difftool: \
`$ git pr show -t 9790`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9790.diff">https://git.openjdk.org/jdk/pull/9790.diff</a>

</details>
