### PR TITLE
8290917: x86: Memory-operand arithmetic instructions have too low costs

### DIFF
--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -7136,7 +7136,7 @@ instruct addI_eReg_mem(rRegI dst, memory src, eFlagsReg cr) %{
   match(Set dst (AddI dst (LoadI src)));
   effect(KILL cr);
 
-  ins_cost(125);
+  ins_cost(150);
   format %{ "ADD    $dst,$src" %}
   opcode(0x03);
   ins_encode( OpcP, RegMem( dst, src) );
@@ -7505,7 +7505,7 @@ instruct subI_eReg_mem(rRegI dst, memory src, eFlagsReg cr) %{
   match(Set dst (SubI dst (LoadI src)));
   effect(KILL cr);
 
-  ins_cost(125);
+  ins_cost(150);
   format %{ "SUB    $dst,$src" %}
   opcode(0x2B);
   ins_encode( OpcP, RegMem( dst, src) );
@@ -8178,7 +8178,7 @@ instruct andI_eReg_mem(rRegI dst, memory src, eFlagsReg cr) %{
   match(Set dst (AndI dst (LoadI src)));
   effect(KILL cr);
 
-  ins_cost(125);
+  ins_cost(150);
   format %{ "AND    $dst,$src" %}
   opcode(0x23);
   ins_encode( OpcP, RegMem( dst, src) );
@@ -8369,7 +8369,7 @@ instruct orI_eReg_mem(rRegI dst, memory src, eFlagsReg cr) %{
   match(Set dst (OrI dst (LoadI src)));
   effect(KILL cr);
 
-  ins_cost(125);
+  ins_cost(150);
   format %{ "OR     $dst,$src" %}
   opcode(0x0B);
   ins_encode( OpcP, RegMem( dst, src) );
@@ -8576,7 +8576,7 @@ instruct xorI_eReg_mem(rRegI dst, memory src, eFlagsReg cr) %{
   match(Set dst (XorI dst (LoadI src)));
   effect(KILL cr);
 
-  ins_cost(125);
+  ins_cost(150);
   format %{ "XOR    $dst,$src" %}
   opcode(0x33);
   ins_encode( OpcP, RegMem(dst, src) );

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -10206,6 +10206,7 @@ instruct andL_rReg_imm255(rRegL dst, rRegL src, immL_255 mask)
 
   format %{ "movzbl  $dst, $src\t# long & 0xFF" %}
   ins_encode %{
+    // movzbl zeroes out the upper 32-bit and does not need REX.W
     __ movzbl($dst$$Register, $src$$Register);
   %}
   ins_pipe(ialu_reg);
@@ -10216,8 +10217,9 @@ instruct andL_rReg_imm65535(rRegL dst, rRegL src, immL_65535 mask)
 %{
   match(Set dst (AndL src mask));
 
-  format %{ "movzwq  $dst, $src\t# long & 0xFFFF" %}
+  format %{ "movzwl  $dst, $src\t# long & 0xFFFF" %}
   ins_encode %{
+    // movzwl zeroes out the upper 32-bit and does not need REX.W
     __ movzwl($dst$$Register, $src$$Register);
   %}
   ins_pipe(ialu_reg);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -7667,7 +7667,7 @@ instruct addI_rReg_mem(rRegI dst, memory src, rFlagsReg cr)
   match(Set dst (AddI dst (LoadI src)));
   effect(KILL cr);
 
-  ins_cost(125); // XXX
+  ins_cost(150); // XXX
   format %{ "addl    $dst, $src\t# int" %}
   ins_encode %{
     __ addl($dst$$Register, $src$$Address);
@@ -7714,20 +7714,6 @@ instruct incI_rReg(rRegI dst, immI_1 src, rFlagsReg cr)
   ins_pipe(ialu_reg);
 %}
 
-instruct incI_mem(memory dst, immI_1 src, rFlagsReg cr)
-%{
-  predicate(UseIncDec);
-  match(Set dst (StoreI dst (AddI (LoadI dst) src)));
-  effect(KILL cr);
-
-  ins_cost(125); // XXX
-  format %{ "incl    $dst\t# int" %}
-  ins_encode %{
-    __ incrementl($dst$$Address);
-  %}
-  ins_pipe(ialu_mem_imm);
-%}
-
 // XXX why does that use AddI
 instruct decI_rReg(rRegI dst, immI_M1 src, rFlagsReg cr)
 %{
@@ -7740,21 +7726,6 @@ instruct decI_rReg(rRegI dst, immI_M1 src, rFlagsReg cr)
     __ decrementl($dst$$Register);
   %}
   ins_pipe(ialu_reg);
-%}
-
-// XXX why does that use AddI
-instruct decI_mem(memory dst, immI_M1 src, rFlagsReg cr)
-%{
-  predicate(UseIncDec);
-  match(Set dst (StoreI dst (AddI (LoadI dst) src)));
-  effect(KILL cr);
-
-  ins_cost(125); // XXX
-  format %{ "decl    $dst\t# int" %}
-  ins_encode %{
-    __ decrementl($dst$$Address);
-  %}
-  ins_pipe(ialu_mem_imm);
 %}
 
 instruct leaI_rReg_immI2_immI(rRegI dst, rRegI index, immI2 scale, immI disp)
@@ -7837,7 +7808,7 @@ instruct addL_rReg_mem(rRegL dst, memory src, rFlagsReg cr)
   match(Set dst (AddL dst (LoadL src)));
   effect(KILL cr);
 
-  ins_cost(125); // XXX
+  ins_cost(150); // XXX
   format %{ "addq    $dst, $src\t# long" %}
   ins_encode %{
     __ addq($dst$$Register, $src$$Address);
@@ -7884,20 +7855,6 @@ instruct incL_rReg(rRegI dst, immL1 src, rFlagsReg cr)
   ins_pipe(ialu_reg);
 %}
 
-instruct incL_mem(memory dst, immL1 src, rFlagsReg cr)
-%{
-  predicate(UseIncDec);
-  match(Set dst (StoreL dst (AddL (LoadL dst) src)));
-  effect(KILL cr);
-
-  ins_cost(125); // XXX
-  format %{ "incq    $dst\t# long" %}
-  ins_encode %{
-    __ incrementq($dst$$Address);
-  %}
-  ins_pipe(ialu_mem_imm);
-%}
-
 // XXX why does that use AddL
 instruct decL_rReg(rRegL dst, immL_M1 src, rFlagsReg cr)
 %{
@@ -7910,21 +7867,6 @@ instruct decL_rReg(rRegL dst, immL_M1 src, rFlagsReg cr)
     __ decrementq($dst$$Register);
   %}
   ins_pipe(ialu_reg);
-%}
-
-// XXX why does that use AddL
-instruct decL_mem(memory dst, immL_M1 src, rFlagsReg cr)
-%{
-  predicate(UseIncDec);
-  match(Set dst (StoreL dst (AddL (LoadL dst) src)));
-  effect(KILL cr);
-
-  ins_cost(125); // XXX
-  format %{ "decq    $dst\t# long" %}
-  ins_encode %{
-    __ decrementq($dst$$Address);
-  %}
-  ins_pipe(ialu_mem_imm);
 %}
 
 instruct leaL_rReg_immI2_immL32(rRegL dst, rRegL index, immI2 scale, immL32 disp)
@@ -8513,24 +8455,12 @@ instruct subI_rReg(rRegI dst, rRegI src, rFlagsReg cr)
   ins_pipe(ialu_reg_reg);
 %}
 
-instruct subI_rReg_imm(rRegI dst, immI src, rFlagsReg cr)
-%{
-  match(Set dst (SubI dst src));
-  effect(KILL cr);
-
-  format %{ "subl    $dst, $src\t# int" %}
-  ins_encode %{
-    __ subl($dst$$Register, $src$$constant);
-  %}
-  ins_pipe(ialu_reg);
-%}
-
 instruct subI_rReg_mem(rRegI dst, memory src, rFlagsReg cr)
 %{
   match(Set dst (SubI dst (LoadI src)));
   effect(KILL cr);
 
-  ins_cost(125);
+  ins_cost(150);
   format %{ "subl    $dst, $src\t# int" %}
   ins_encode %{
     __ subl($dst$$Register, $src$$Address);
@@ -8551,19 +8481,6 @@ instruct subI_mem_rReg(memory dst, rRegI src, rFlagsReg cr)
   ins_pipe(ialu_mem_reg);
 %}
 
-instruct subI_mem_imm(memory dst, immI src, rFlagsReg cr)
-%{
-  match(Set dst (StoreI dst (SubI (LoadI dst) src)));
-  effect(KILL cr);
-
-  ins_cost(125); // XXX
-  format %{ "subl    $dst, $src\t# int" %}
-  ins_encode %{
-    __ subl($dst$$Address, $src$$constant);
-  %}
-  ins_pipe(ialu_mem_imm);
-%}
-
 instruct subL_rReg(rRegL dst, rRegL src, rFlagsReg cr)
 %{
   match(Set dst (SubL dst src));
@@ -8576,24 +8493,12 @@ instruct subL_rReg(rRegL dst, rRegL src, rFlagsReg cr)
   ins_pipe(ialu_reg_reg);
 %}
 
-instruct subL_rReg_imm(rRegI dst, immL32 src, rFlagsReg cr)
-%{
-  match(Set dst (SubL dst src));
-  effect(KILL cr);
-
-  format %{ "subq    $dst, $src\t# long" %}
-  ins_encode %{
-    __ subq($dst$$Register, $src$$constant);
-  %}
-  ins_pipe(ialu_reg);
-%}
-
 instruct subL_rReg_mem(rRegL dst, memory src, rFlagsReg cr)
 %{
   match(Set dst (SubL dst (LoadL src)));
   effect(KILL cr);
 
-  ins_cost(125);
+  ins_cost(150);
   format %{ "subq    $dst, $src\t# long" %}
   ins_encode %{
     __ subq($dst$$Register, $src$$Address);
@@ -8612,19 +8517,6 @@ instruct subL_mem_rReg(memory dst, rRegL src, rFlagsReg cr)
     __ subq($dst$$Address, $src$$Register);
   %}
   ins_pipe(ialu_mem_reg);
-%}
-
-instruct subL_mem_imm(memory dst, immL32 src, rFlagsReg cr)
-%{
-  match(Set dst (StoreL dst (SubL (LoadL dst) src)));
-  effect(KILL cr);
-
-  ins_cost(125); // XXX
-  format %{ "subq    $dst, $src\t# long" %}
-  ins_encode %{
-    __ subq($dst$$Address, $src$$constant);
-  %}
-  ins_pipe(ialu_mem_imm);
 %}
 
 // Subtract from a pointer
@@ -8830,7 +8722,7 @@ instruct mulL_mem_imm(rRegL dst, memory src, immL32 imm, rFlagsReg cr)
   ins_pipe(ialu_reg_mem_alu0);
 %}
 
-instruct mulHiL_rReg(rdx_RegL dst, no_rax_RegL src, rax_RegL rax, rFlagsReg cr)
+instruct mulHiL_rReg(rdx_RegL dst, rRegL src, rax_RegL rax, rFlagsReg cr)
 %{
   match(Set dst (MulHiL src rax));
   effect(USE_KILL rax, KILL cr);
@@ -8843,7 +8735,7 @@ instruct mulHiL_rReg(rdx_RegL dst, no_rax_RegL src, rax_RegL rax, rFlagsReg cr)
   ins_pipe(ialu_reg_reg_alu0);
 %}
 
-instruct umulHiL_rReg(rdx_RegL dst, no_rax_RegL src, rax_RegL rax, rFlagsReg cr)
+instruct umulHiL_rReg(rdx_RegL dst, rRegL src, rax_RegL rax, rFlagsReg cr)
 %{
   match(Set dst (UMulHiL src rax));
   effect(USE_KILL rax, KILL cr);
@@ -8996,71 +8888,6 @@ instruct udivModL_rReg_divmod(rax_RegL rax, no_rax_rdx_RegL tmp, rdx_RegL rdx,
   ins_pipe(pipe_slow);
 %}
 
-
-//----------- DivL-By-Constant-Expansions--------------------------------------
-// DivI cases are handled by the compiler
-
-// Magic constant, reciprocal of 10
-instruct loadConL_0x6666666666666667(rRegL dst)
-%{
-  effect(DEF dst);
-
-  format %{ "movq    $dst, #0x666666666666667\t# Used in div-by-10" %}
-  ins_encode(load_immL(dst, 0x6666666666666667));
-  ins_pipe(ialu_reg);
-%}
-
-instruct mul_hi(rdx_RegL dst, no_rax_RegL src, rax_RegL rax, rFlagsReg cr)
-%{
-  effect(DEF dst, USE src, USE_KILL rax, KILL cr);
-
-  format %{ "imulq   rdx:rax, rax, $src\t# Used in div-by-10" %}
-  ins_encode %{
-    __ imulq($src$$Register);
-  %}
-  ins_pipe(ialu_reg_reg_alu0);
-%}
-
-instruct sarL_rReg_63(rRegL dst, rFlagsReg cr)
-%{
-  effect(USE_DEF dst, KILL cr);
-
-  format %{ "sarq    $dst, #63\t# Used in div-by-10" %}
-  ins_encode %{
-    __ sarq($dst$$Register, 63);
-  %}
-  ins_pipe(ialu_reg);
-%}
-
-instruct sarL_rReg_2(rRegL dst, rFlagsReg cr)
-%{
-  effect(USE_DEF dst, KILL cr);
-
-  format %{ "sarq    $dst, #2\t# Used in div-by-10" %}
-  ins_encode %{
-    __ sarq($dst$$Register, 2);
-  %}
-  ins_pipe(ialu_reg);
-%}
-
-instruct divL_10(rdx_RegL dst, no_rax_RegL src, immL10 div)
-%{
-  match(Set dst (DivL src div));
-
-  ins_cost((5+8)*100);
-  expand %{
-    rax_RegL rax;                     // Killed temp
-    rFlagsReg cr;                     // Killed
-    loadConL_0x6666666666666667(rax); // movq  rax, 0x6666666666666667
-    mul_hi(dst, src, rax, cr);        // mulq  rdx:rax <= rax * $src
-    sarL_rReg_63(src, cr);            // sarq  src, 63
-    sarL_rReg_2(dst, cr);             // sarq  rdx, 2
-    subL_rReg(dst, src, cr);          // subl  rdx, src
-  %}
-%}
-
-//-----------------------------------------------------------------------------
-
 instruct modI_rReg(rdx_RegI rdx, rax_RegI rax, no_rax_rdx_RegI div,
                    rFlagsReg cr)
 %{
@@ -9127,32 +8954,6 @@ instruct umodL_rReg(rdx_RegL rdx, rax_RegL rax, no_rax_rdx_RegL div, rFlagsReg c
 %}
 
 // Integer Shift Instructions
-// Shift Left by one
-instruct salI_rReg_1(rRegI dst, immI_1 shift, rFlagsReg cr)
-%{
-  match(Set dst (LShiftI dst shift));
-  effect(KILL cr);
-
-  format %{ "sall    $dst, $shift" %}
-  ins_encode %{
-    __ sall($dst$$Register, $shift$$constant);
-  %}
-  ins_pipe(ialu_reg);
-%}
-
-// Shift Left by one
-instruct salI_mem_1(memory dst, immI_1 shift, rFlagsReg cr)
-%{
-  match(Set dst (StoreI dst (LShiftI (LoadI dst) shift)));
-  effect(KILL cr);
-
-  format %{ "sall    $dst, $shift\t" %}
-  ins_encode %{
-    __ sall($dst$$Address, $shift$$constant);
-  %}
-  ins_pipe(ialu_mem_imm);
-%}
-
 // Shift Left by 8-bit immediate
 instruct salI_rReg_imm(rRegI dst, immI8 shift, rFlagsReg cr)
 %{
@@ -9231,32 +9032,6 @@ instruct salI_mem_rReg(rRegI dst, memory src, rRegI shift)
   ins_pipe(ialu_reg_mem);
 %}
 
-// Arithmetic shift right by one
-instruct sarI_rReg_1(rRegI dst, immI_1 shift, rFlagsReg cr)
-%{
-  match(Set dst (RShiftI dst shift));
-  effect(KILL cr);
-
-  format %{ "sarl    $dst, $shift" %}
-  ins_encode %{
-    __ sarl($dst$$Register, $shift$$constant);
-  %}
-  ins_pipe(ialu_reg);
-%}
-
-// Arithmetic shift right by one
-instruct sarI_mem_1(memory dst, immI_1 shift, rFlagsReg cr)
-%{
-  match(Set dst (StoreI dst (RShiftI (LoadI dst) shift)));
-  effect(KILL cr);
-
-  format %{ "sarl    $dst, $shift" %}
-  ins_encode %{
-    __ sarl($dst$$Address, $shift$$constant);
-  %}
-  ins_pipe(ialu_mem_imm);
-%}
-
 // Arithmetic Shift Right by 8-bit immediate
 instruct sarI_rReg_imm(rRegI dst, immI8 shift, rFlagsReg cr)
 %{
@@ -9332,32 +9107,6 @@ instruct sarI_mem_rReg(rRegI dst, memory src, rRegI shift)
     __ sarxl($dst$$Register, $src$$Address, $shift$$Register);
   %}
   ins_pipe(ialu_reg_mem);
-%}
-
-// Logical shift right by one
-instruct shrI_rReg_1(rRegI dst, immI_1 shift, rFlagsReg cr)
-%{
-  match(Set dst (URShiftI dst shift));
-  effect(KILL cr);
-
-  format %{ "shrl    $dst, $shift" %}
-  ins_encode %{
-    __ shrl($dst$$Register, $shift$$constant);
-  %}
-  ins_pipe(ialu_reg);
-%}
-
-// Logical shift right by one
-instruct shrI_mem_1(memory dst, immI_1 shift, rFlagsReg cr)
-%{
-  match(Set dst (StoreI dst (URShiftI (LoadI dst) shift)));
-  effect(KILL cr);
-
-  format %{ "shrl    $dst, $shift" %}
-  ins_encode %{
-    __ shrl($dst$$Address, $shift$$constant);
-  %}
-  ins_pipe(ialu_mem_imm);
 %}
 
 // Logical Shift Right by 8-bit immediate
@@ -9439,32 +9188,6 @@ instruct shrI_mem_rReg(rRegI dst, memory src, rRegI shift)
 %}
 
 // Long Shift Instructions
-// Shift Left by one
-instruct salL_rReg_1(rRegL dst, immI_1 shift, rFlagsReg cr)
-%{
-  match(Set dst (LShiftL dst shift));
-  effect(KILL cr);
-
-  format %{ "salq    $dst, $shift" %}
-  ins_encode %{
-    __ salq($dst$$Register, $shift$$constant);
-  %}
-  ins_pipe(ialu_reg);
-%}
-
-// Shift Left by one
-instruct salL_mem_1(memory dst, immI_1 shift, rFlagsReg cr)
-%{
-  match(Set dst (StoreL dst (LShiftL (LoadL dst) shift)));
-  effect(KILL cr);
-
-  format %{ "salq    $dst, $shift" %}
-  ins_encode %{
-    __ salq($dst$$Address, $shift$$constant);
-  %}
-  ins_pipe(ialu_mem_imm);
-%}
-
 // Shift Left by 8-bit immediate
 instruct salL_rReg_imm(rRegL dst, immI8 shift, rFlagsReg cr)
 %{
@@ -9543,32 +9266,6 @@ instruct salL_mem_rReg(rRegL dst, memory src, rRegI shift)
   ins_pipe(ialu_reg_mem);
 %}
 
-// Arithmetic shift right by one
-instruct sarL_rReg_1(rRegL dst, immI_1 shift, rFlagsReg cr)
-%{
-  match(Set dst (RShiftL dst shift));
-  effect(KILL cr);
-
-  format %{ "sarq    $dst, $shift" %}
-  ins_encode %{
-    __ sarq($dst$$Register, $shift$$constant);
-  %}
-  ins_pipe(ialu_reg);
-%}
-
-// Arithmetic shift right by one
-instruct sarL_mem_1(memory dst, immI_1 shift, rFlagsReg cr)
-%{
-  match(Set dst (StoreL dst (RShiftL (LoadL dst) shift)));
-  effect(KILL cr);
-
-  format %{ "sarq    $dst, $shift" %}
-  ins_encode %{
-    __ sarq($dst$$Address, $shift$$constant);
-  %}
-  ins_pipe(ialu_mem_imm);
-%}
-
 // Arithmetic Shift Right by 8-bit immediate
 instruct sarL_rReg_imm(rRegL dst, immI shift, rFlagsReg cr)
 %{
@@ -9645,32 +9342,6 @@ instruct sarL_mem_rReg(rRegL dst, memory src, rRegI shift)
     __ sarxq($dst$$Register, $src$$Address, $shift$$Register);
   %}
   ins_pipe(ialu_reg_mem);
-%}
-
-// Logical shift right by one
-instruct shrL_rReg_1(rRegL dst, immI_1 shift, rFlagsReg cr)
-%{
-  match(Set dst (URShiftL dst shift));
-  effect(KILL cr);
-
-  format %{ "shrq    $dst, $shift" %}
-  ins_encode %{
-    __ shrq($dst$$Register, $shift$$constant);
-  %}
-  ins_pipe(ialu_reg);
-%}
-
-// Logical shift right by one
-instruct shrL_mem_1(memory dst, immI_1 shift, rFlagsReg cr)
-%{
-  match(Set dst (StoreL dst (URShiftL (LoadL dst) shift)));
-  effect(KILL cr);
-
-  format %{ "shrq    $dst, $shift" %}
-  ins_encode %{
-    __ shrq($dst$$Address, $shift$$constant);
-  %}
-  ins_pipe(ialu_mem_imm);
 %}
 
 // Logical Shift Right by 8-bit immediate
@@ -10043,13 +9714,13 @@ instruct andI_rReg(rRegI dst, rRegI src, rFlagsReg cr)
 %}
 
 // And Register with Immediate 255
-instruct andI_rReg_imm255(rRegI dst, immI_255 src)
+instruct andI_rReg_imm255(rRegI dst, rRegI src, immI_255 mask)
 %{
-  match(Set dst (AndI dst src));
+  match(Set dst (AndI src mask));
 
-  format %{ "movzbl  $dst, $dst\t# int & 0xFF" %}
+  format %{ "movzbl  $dst, $src\t# int & 0xFF" %}
   ins_encode %{
-    __ movzbl($dst$$Register, $dst$$Register);
+    __ movzbl($dst$$Register, $src$$Register);
   %}
   ins_pipe(ialu_reg);
 %}
@@ -10067,13 +9738,13 @@ instruct andI2L_rReg_imm255(rRegL dst, rRegI src, immI_255 mask)
 %}
 
 // And Register with Immediate 65535
-instruct andI_rReg_imm65535(rRegI dst, immI_65535 src)
+instruct andI_rReg_imm65535(rRegI dst, rRegI src, immI_65535 mask)
 %{
-  match(Set dst (AndI dst src));
+  match(Set dst (AndI src mask));
 
-  format %{ "movzwl  $dst, $dst\t# int & 0xFFFF" %}
+  format %{ "movzwl  $dst, $src\t# int & 0xFFFF" %}
   ins_encode %{
-    __ movzwl($dst$$Register, $dst$$Register);
+    __ movzwl($dst$$Register, $src$$Register);
   %}
   ins_pipe(ialu_reg);
 %}
@@ -10124,7 +9795,7 @@ instruct andI_rReg_mem(rRegI dst, memory src, rFlagsReg cr)
   match(Set dst (AndI dst (LoadI src)));
   effect(KILL cr);
 
-  ins_cost(125);
+  ins_cost(150);
   format %{ "andl    $dst, $src\t# int" %}
   ins_encode %{
     __ andl($dst$$Register, $src$$Address);
@@ -10322,7 +9993,7 @@ instruct orI_rReg_mem(rRegI dst, memory src, rFlagsReg cr)
   match(Set dst (OrI dst (LoadI src)));
   effect(KILL cr);
 
-  ins_cost(125);
+  ins_cost(150);
   format %{ "orl     $dst, $src\t# int" %}
   ins_encode %{
     __ orl($dst$$Register, $src$$Address);
@@ -10415,7 +10086,7 @@ instruct xorI_rReg_mem(rRegI dst, memory src, rFlagsReg cr)
   match(Set dst (XorI dst (LoadI src)));
   effect(KILL cr);
 
-  ins_cost(125);
+  ins_cost(150);
   format %{ "xorl    $dst, $src\t# int" %}
   ins_encode %{
     __ xorl($dst$$Register, $src$$Address);
@@ -10482,25 +10153,25 @@ instruct andL_rReg(rRegL dst, rRegL src, rFlagsReg cr)
 %}
 
 // And Register with Immediate 255
-instruct andL_rReg_imm255(rRegL dst, immL_255 src)
+instruct andL_rReg_imm255(rRegL dst, rRegL src, immL_255 mask)
 %{
-  match(Set dst (AndL dst src));
+  match(Set dst (AndL src mask));
 
-  format %{ "movzbq  $dst, $dst\t# long & 0xFF" %}
+  format %{ "movzbl  $dst, $src\t# long & 0xFF" %}
   ins_encode %{
-    __ movzbq($dst$$Register, $dst$$Register);
+    __ movzbl($dst$$Register, $src$$Register);
   %}
   ins_pipe(ialu_reg);
 %}
 
 // And Register with Immediate 65535
-instruct andL_rReg_imm65535(rRegL dst, immL_65535 src)
+instruct andL_rReg_imm65535(rRegL dst, rRegL src, immL_65535 mask)
 %{
-  match(Set dst (AndL dst src));
+  match(Set dst (AndL src mask));
 
-  format %{ "movzwq  $dst, $dst\t# long & 0xFFFF" %}
+  format %{ "movzwq  $dst, $src\t# long & 0xFFFF" %}
   ins_encode %{
-    __ movzwq($dst$$Register, $dst$$Register);
+    __ movzwl($dst$$Register, $src$$Register);
   %}
   ins_pipe(ialu_reg);
 %}
@@ -10524,7 +10195,7 @@ instruct andL_rReg_mem(rRegL dst, memory src, rFlagsReg cr)
   match(Set dst (AndL dst (LoadL src)));
   effect(KILL cr);
 
-  ins_cost(125);
+  ins_cost(150);
   format %{ "andq    $dst, $src\t# long" %}
   ins_encode %{
     __ andq($dst$$Register, $src$$Address);
@@ -10739,7 +10410,7 @@ instruct orL_rReg_mem(rRegL dst, memory src, rFlagsReg cr)
   match(Set dst (OrL dst (LoadL src)));
   effect(KILL cr);
 
-  ins_cost(125);
+  ins_cost(150);
   format %{ "orq     $dst, $src\t# long" %}
   ins_encode %{
     __ orq($dst$$Register, $src$$Address);
@@ -10836,7 +10507,7 @@ instruct xorL_rReg_mem(rRegL dst, memory src, rFlagsReg cr)
   match(Set dst (XorL dst (LoadL src)));
   effect(KILL cr);
 
-  ins_cost(125);
+  ins_cost(150);
   format %{ "xorq    $dst, $src\t# long" %}
   ins_encode %{
     __ xorq($dst$$Register, $src$$Address);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -3678,17 +3678,6 @@ operand no_rax_rdx_RegL()
   interface(REG_INTER);
 %}
 
-operand no_rax_RegL()
-%{
-  constraint(ALLOC_IN_RC(long_no_rax_rdx_reg));
-  match(RegL);
-  match(rRegL);
-  match(rdx_RegL);
-
-  format %{ %}
-  interface(REG_INTER);
-%}
-
 operand rax_RegL()
 %{
   constraint(ALLOC_IN_RC(long_rax_reg));

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -7703,6 +7703,20 @@ instruct incI_rReg(rRegI dst, immI_1 src, rFlagsReg cr)
   ins_pipe(ialu_reg);
 %}
 
+instruct incI_mem(memory dst, immI_1 src, rFlagsReg cr)
+%{
+  predicate(UseIncDec);
+  match(Set dst (StoreI dst (AddI (LoadI dst) src)));
+  effect(KILL cr);
+
+  ins_cost(125); // XXX
+  format %{ "incl    $dst\t# int" %}
+  ins_encode %{
+    __ incrementl($dst$$Address);
+  %}
+  ins_pipe(ialu_mem_imm);
+%}
+
 // XXX why does that use AddI
 instruct decI_rReg(rRegI dst, immI_M1 src, rFlagsReg cr)
 %{
@@ -7715,6 +7729,21 @@ instruct decI_rReg(rRegI dst, immI_M1 src, rFlagsReg cr)
     __ decrementl($dst$$Register);
   %}
   ins_pipe(ialu_reg);
+%}
+
+// XXX why does that use AddI
+instruct decI_mem(memory dst, immI_M1 src, rFlagsReg cr)
+%{
+  predicate(UseIncDec);
+  match(Set dst (StoreI dst (AddI (LoadI dst) src)));
+  effect(KILL cr);
+
+  ins_cost(125); // XXX
+  format %{ "decl    $dst\t# int" %}
+  ins_encode %{
+    __ decrementl($dst$$Address);
+  %}
+  ins_pipe(ialu_mem_imm);
 %}
 
 instruct leaI_rReg_immI2_immI(rRegI dst, rRegI index, immI2 scale, immI disp)
@@ -7844,6 +7873,20 @@ instruct incL_rReg(rRegI dst, immL1 src, rFlagsReg cr)
   ins_pipe(ialu_reg);
 %}
 
+instruct incL_mem(memory dst, immL1 src, rFlagsReg cr)
+%{
+  predicate(UseIncDec);
+  match(Set dst (StoreL dst (AddL (LoadL dst) src)));
+  effect(KILL cr);
+
+  ins_cost(125); // XXX
+  format %{ "incq    $dst\t# long" %}
+  ins_encode %{
+    __ incrementq($dst$$Address);
+  %}
+  ins_pipe(ialu_mem_imm);
+%}
+
 // XXX why does that use AddL
 instruct decL_rReg(rRegL dst, immL_M1 src, rFlagsReg cr)
 %{
@@ -7856,6 +7899,21 @@ instruct decL_rReg(rRegL dst, immL_M1 src, rFlagsReg cr)
     __ decrementq($dst$$Register);
   %}
   ins_pipe(ialu_reg);
+%}
+
+// XXX why does that use AddL
+instruct decL_mem(memory dst, immL_M1 src, rFlagsReg cr)
+%{
+  predicate(UseIncDec);
+  match(Set dst (StoreL dst (AddL (LoadL dst) src)));
+  effect(KILL cr);
+
+  ins_cost(125); // XXX
+  format %{ "decq    $dst\t# long" %}
+  ins_encode %{
+    __ decrementq($dst$$Address);
+  %}
+  ins_pipe(ialu_mem_imm);
 %}
 
 instruct leaL_rReg_immI2_immL32(rRegL dst, rRegL index, immI2 scale, immL32 disp)

--- a/test/micro/org/openjdk/bench/vm/compiler/x86/BasicRules.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/x86/BasicRules.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.vm.compiler.x86;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1, jvmArgsAppend = "-XX:-UseSuperWord")
+public class BasicRules {
+    static final int[] a = new int[1024];
+
+    @Benchmark
+    public void inc_mem() {
+        for (int i = 0; i < a.length; i++) {
+            a[i]++;
+        }
+    }
+
+    @Benchmark
+    public void add_mem_con(Blackhole bh) {
+        for (int i = 0; i < a.length; i++) {
+            bh.consume(a[i] + 100);
+        }
+    }
+}
+

--- a/test/micro/org/openjdk/bench/vm/compiler/x86/BasicRules.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/x86/BasicRules.java
@@ -29,21 +29,35 @@ import org.openjdk.jmh.infra.Blackhole;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
-@Fork(value = 1, jvmArgsAppend = "-XX:-UseSuperWord")
+@Fork(value = 3, jvmArgsAppend = "-XX:-UseSuperWord")
+@Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(time = 1, timeUnit = TimeUnit.SECONDS)
 public class BasicRules {
-    static final int[] a = new int[1024];
+    static final int[] INT_ARRAY = new int[1024];
+    static final long[] LONG_ARRAY = new long[1024];
 
     @Benchmark
-    public void inc_mem() {
-        for (int i = 0; i < a.length; i++) {
-            a[i]++;
+    public void andL_rReg_imm255(Blackhole bh) {
+        for (int i = 0; i < LONG_ARRAY.length; i++) {
+            long v = LONG_ARRAY[i];
+            bh.consume(v);
+            bh.consume(v & 0xFFL);
+        }
+    }
+
+    @Benchmark
+    public void andL_rReg_imm65535(Blackhole bh) {
+        for (int i = 0; i < LONG_ARRAY.length; i++) {
+            long v = LONG_ARRAY[i];
+            bh.consume(v);
+            bh.consume(v & 0xFFFFL);
         }
     }
 
     @Benchmark
     public void add_mem_con(Blackhole bh) {
-        for (int i = 0; i < a.length; i++) {
-            bh.consume(a[i] + 100);
+        for (int i = 0; i < INT_ARRAY.length; i++) {
+            bh.consume(INT_ARRAY[i] + 100);
         }
     }
 }

--- a/test/micro/org/openjdk/bench/vm/compiler/x86/BasicRules.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/x86/BasicRules.java
@@ -35,6 +35,8 @@ import org.openjdk.jmh.infra.Blackhole;
 public class BasicRules {
     static final int[] INT_ARRAY = new int[1024];
     static final long[] LONG_ARRAY = new long[1024];
+    static final int INT_IMM = 100;
+    static final long LONG_IMM = 100;
 
     @Benchmark
     public void andL_rReg_imm255(Blackhole bh) {
@@ -65,6 +67,62 @@ public class BasicRules {
     public void divL_10(Blackhole bh) {
         for (int i = 0; i < LONG_ARRAY.length; i++) {
             bh.consume(LONG_ARRAY[i] / 10L);
+        }
+    }
+
+    @Benchmark
+    public void salI_rReg_1(Blackhole bh) {
+        for (int i = 0; i < INT_ARRAY.length; i++) {
+            bh.consume(INT_ARRAY[i] << 1);
+        }
+    }
+
+    @Benchmark
+    public void sarI_rReg_1(Blackhole bh) {
+        for (int i = 0; i < INT_ARRAY.length; i++) {
+            bh.consume(INT_ARRAY[i] >> 1);
+        }
+    }
+
+    @Benchmark
+    public void shrI_rReg_1(Blackhole bh) {
+        for (int i = 0; i < INT_ARRAY.length; i++) {
+            bh.consume(INT_ARRAY[i] >>> 1);
+        }
+    }
+
+    @Benchmark
+    public void salL_rReg_1(Blackhole bh) {
+        for (int i = 0; i < LONG_ARRAY.length; i++) {
+            bh.consume(LONG_ARRAY[i] << 1);
+        }
+    }
+
+    @Benchmark
+    public void sarL_rReg_1(Blackhole bh) {
+        for (int i = 0; i < LONG_ARRAY.length; i++) {
+            bh.consume(LONG_ARRAY[i] >> 1);
+        }
+    }
+
+    @Benchmark
+    public void shrL_rReg_1(Blackhole bh) {
+        for (int i = 0; i < LONG_ARRAY.length; i++) {
+            bh.consume(LONG_ARRAY[i] >>> 1);
+        }
+    }
+
+    @Benchmark
+    public void subI_rReg_imm(Blackhole bh) {
+        for (int i = 0; i < INT_ARRAY.length; i++) {
+            bh.consume(INT_ARRAY[i] - INT_IMM);
+        }
+    }
+
+    @Benchmark
+    public void subL_rReg_imm(Blackhole bh) {
+        for (int i = 0; i < LONG_ARRAY.length; i++) {
+            bh.consume(LONG_ARRAY[i] - LONG_IMM);
         }
     }
 }

--- a/test/micro/org/openjdk/bench/vm/compiler/x86/BasicRules.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/x86/BasicRules.java
@@ -60,5 +60,12 @@ public class BasicRules {
             bh.consume(INT_ARRAY[i] + 100);
         }
     }
+
+    @Benchmark
+    public void divL_10(Blackhole bh) {
+        for (int i = 0; i < LONG_ARRAY.length; i++) {
+            bh.consume(LONG_ARRAY[i] / 10L);
+        }
+    }
 }
 

--- a/test/micro/org/openjdk/bench/vm/compiler/x86/LeaInstruction.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/x86/LeaInstruction.java
@@ -20,7 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.bench.vm.compiler;
+package org.openjdk.bench.vm.compiler.x86;
 
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;


### PR DESCRIPTION
The pattern `AddI (LoadI mem) imm` should be matched by a load followed by an add with constant, instead, it is currently matched as a constant load followed by an add with memory. The reason is that the cost of `addI_rReg_mem` is too low, this patch fixes this by increasing the cost of this fused instruction.

Testing: Manually run the test case in the JBS and look at the compiled code.

I also do some small clean-ups in x86_64.ad:

- The `mulHiL` rules have unnecessary constraints on the input registers, these can be removed. The `no_rax_RegL` operand as a consequence can also be removed.
- The rules involving long division by a constant can be removed because it has been covered by the optimiser during idealisation.
- The pattern `SubI src imm` and the likes never match because they are converted to `AddI src -imm` by the optimiser. As a result, these rules can be removed
- The rules involving shifting the argument by 1 are covered by and exactly the same as the corresponding rules of shifting by an immediate. As a result, they can be removed.
- Some rules involving and-ing with a bit mask have unnecessary constraints on the target register.

Please kindly review, thank you very much.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290917](https://bugs.openjdk.org/browse/JDK-8290917): x86: Memory-operand arithmetic instructions have too low costs


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**) ⚠️ Review applies to [ef4f3cf9](https://git.openjdk.org/jdk/pull/9791/files/ef4f3cf91e909b4508cff3c3f9728860aed1cd16)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9791/head:pull/9791` \
`$ git checkout pull/9791`

Update a local copy of the PR: \
`$ git checkout pull/9791` \
`$ git pull https://git.openjdk.org/jdk pull/9791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9791`

View PR using the GUI difftool: \
`$ git pr show -t 9791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9791.diff">https://git.openjdk.org/jdk/pull/9791.diff</a>

</details>
