### PR TITLE
8291957: Redundant import statements in sun.security.ec

### DIFF
--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECKeyPairGenerator.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECKeyPairGenerator.java
@@ -25,8 +25,6 @@
 
 package sun.security.ec;
 
-import java.io.IOException;
-import java.math.BigInteger;
 import java.security.*;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.ECGenParameterSpec;

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/SunEC.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/SunEC.java
@@ -31,19 +31,13 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivilegedAction;
 import java.security.Provider;
 import java.security.ProviderException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 
-import sun.security.ec.ed.EdDSAAlgorithmParameters;
 import sun.security.ec.ed.EdDSAKeyFactory;
 import sun.security.ec.ed.EdDSAKeyPairGenerator;
 import sun.security.ec.ed.EdDSASignature;
 import sun.security.util.CurveDB;
-import sun.security.util.KnownOIDs;
 import sun.security.util.NamedCurve;
 
 import static sun.security.util.SecurityConstants.PROVIDER_VER;

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/XDHPublicKeyImpl.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/XDHPublicKeyImpl.java
@@ -28,7 +28,6 @@ package sun.security.ec;
 import java.math.BigInteger;
 import java.security.InvalidKeyException;
 import java.security.KeyRep;
-import java.security.PublicKey;
 import java.security.interfaces.XECPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.NamedParameterSpec;


### PR DESCRIPTION
remove unused imports

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291957](https://bugs.openjdk.org/browse/JDK-8291957): Redundant import statements in sun.security.ec


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9792/head:pull/9792` \
`$ git checkout pull/9792`

Update a local copy of the PR: \
`$ git checkout pull/9792` \
`$ git pull https://git.openjdk.org/jdk pull/9792/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9792`

View PR using the GUI difftool: \
`$ git pr show -t 9792`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9792.diff">https://git.openjdk.org/jdk/pull/9792.diff</a>

</details>
