### PR TITLE
8292016: Rework JLI_ReportErrorMessageSys

### DIFF
--- a/src/java.base/macosx/native/libjli/java_md_macosx.m
+++ b/src/java.base/macosx/native/libjli/java_md_macosx.m
@@ -346,11 +346,11 @@ static void MacOSXStartup(int argc, char *argv[]) {
     // Fire up the main thread
     pthread_t main_thr;
     if (pthread_create(&main_thr, NULL, &apple_main, &args) != 0) {
-        JLI_ReportErrorMessageSys("Could not create main thread: %s\n", strerror(errno));
+        JLI_ReportErrorMessageSys("Could not create main thread");
         exit(1);
     }
     if (pthread_detach(main_thr)) {
-        JLI_ReportErrorMessageSys("pthread_detach() failed: %s\n", strerror(errno));
+        JLI_ReportErrorMessageSys("pthread_detach() failed");
         exit(1);
     }
 

--- a/src/java.base/share/native/libjli/java.h
+++ b/src/java.base/share/native/libjli/java.h
@@ -136,7 +136,13 @@ void CreateExecutionEnvironment(int *argc, char ***argv,
 JNIEXPORT void JNICALL
 JLI_ReportErrorMessage(const char * message, ...);
 
-/* Reports a system error message to stderr or a window */
+/*
+ * Just like JLI_ReportErrorMessage, except that it also displays the system
+ * error message, if any, after the message passed to it by the caller.
+ * The system errors reported depend on the platform, the only guarantee
+ * is that the message passed to JLI_ReportErrorMessageSys will always be
+ * displayed first
+ */
 JNIEXPORT void JNICALL
 JLI_ReportErrorMessageSys(const char * message, ...);
 

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -205,12 +205,12 @@ JLI_ReportErrorMessageSys(const char* fmt, ...) {
     vfprintf(stderr, fmt, vl);
 
     /*
-     * TODO: its safer to use strerror_r but is not available on
-     * Solaris 8. Until then....
+     * Buffer of length 1024 copied from jni_util_md.c
      */
-    char* err = strerror(errno);
-    if (err != NULL) {
-        fprintf(stderr, "\n%s\n", err);
+    char buffer[1024];
+
+    if (strerror_r(errno, buffer, sizeof buffer) != 0) {
+        fprintf(stderr, " - %s\n", buffer);
     } else {
         fprintf(stderr, "\n");
     }

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -204,8 +204,10 @@ JLI_ReportErrorMessageSys(const char* fmt, ...) {
     va_start(vl, fmt);
     vfprintf(stderr, fmt, vl);
 
-    /* TODO: it's safer to use strerror_r, but it isn't available on
-       Solaris 8. Until then.... */
+    /*
+     * TODO: its safer to use strerror_r but is not available on
+     * Solaris 8. Until then....
+     */
     char* err = strerror(errno);
     if (err != NULL) {
         fprintf(stderr, "\n%s\n", err);

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -200,20 +200,23 @@ JLI_ReportErrorMessage(const char* fmt, ...) {
 JNIEXPORT void JNICALL
 JLI_ReportErrorMessageSys(const char* fmt, ...) {
     va_list vl;
-    char *emsg;
+
+    va_start(vl, fmt);
+    vfprintf(stderr, fmt, vl);
+
+    char *err;
 
     /*
      * TODO: its safer to use strerror_r but is not available on
      * Solaris 8. Until then....
      */
-    emsg = strerror(errno);
-    if (emsg != NULL) {
-        fprintf(stderr, "%s\n", emsg);
+    err = strerror(errno);
+    if (err != NULL) {
+        fprintf(stderr, "\n%s\n", err);
+    } else {
+    	fprintf(stderr, "\n");
     }
 
-    va_start(vl, fmt);
-    vfprintf(stderr, fmt, vl);
-    fprintf(stderr, "\n");
     va_end(vl);
 }
 

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -214,7 +214,7 @@ JLI_ReportErrorMessageSys(const char* fmt, ...) {
     if (err != NULL) {
         fprintf(stderr, "\n%s\n", err);
     } else {
-    	fprintf(stderr, "\n");
+        fprintf(stderr, "\n");
     }
 
     va_end(vl);

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -204,11 +204,13 @@ JLI_ReportErrorMessageSys(const char* fmt, ...) {
     va_start(vl, fmt);
     vfprintf(stderr, fmt, vl);
 
+    char *err;
+
     /*
      * TODO: its safer to use strerror_r but is not available on
      * Solaris 8. Until then....
      */
-    char* err = strerror(errno);
+    err = strerror(errno);
     if (err != NULL) {
         fprintf(stderr, "\n%s\n", err);
     } else {

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -204,13 +204,9 @@ JLI_ReportErrorMessageSys(const char* fmt, ...) {
     va_start(vl, fmt);
     vfprintf(stderr, fmt, vl);
 
-    char *err;
-
-    /*
-     * TODO: its safer to use strerror_r but is not available on
-     * Solaris 8. Until then....
-     */
-    err = strerror(errno);
+    /* TODO: it's safer to use strerror_r, but it isn't available on
+       Solaris 8. Until then.... */
+    char* err = strerror(errno);
     if (err != NULL) {
         fprintf(stderr, "\n%s\n", err);
     } else {

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -204,13 +204,11 @@ JLI_ReportErrorMessageSys(const char* fmt, ...) {
     va_start(vl, fmt);
     vfprintf(stderr, fmt, vl);
 
-    char *err;
-
     /*
      * TODO: its safer to use strerror_r but is not available on
      * Solaris 8. Until then....
      */
-    err = strerror(errno);
+    char *err = strerror(errno);
     if (err != NULL) {
         fprintf(stderr, "\n%s\n", err);
     } else {

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -208,7 +208,7 @@ JLI_ReportErrorMessageSys(const char* fmt, ...) {
      * TODO: its safer to use strerror_r but is not available on
      * Solaris 8. Until then....
      */
-    char *err = strerror(errno);
+    char* err = strerror(errno);
     if (err != NULL) {
         fprintf(stderr, "\n%s\n", err);
     } else {

--- a/src/java.base/windows/native/libjli/java_md.c
+++ b/src/java.base/windows/native/libjli/java_md.c
@@ -605,40 +605,35 @@ JLI_ReportErrorMessage(const char* fmt, ...) {
     va_end(vl);
 }
 
-/*
- * Just like JLI_ReportErrorMessage, except that it concatenates the system
- * error message if any, it's up to the calling routine to correctly
- * format the separation of the messages.
- */
 JNIEXPORT void JNICALL
 JLI_ReportErrorMessageSys(const char *fmt, ...)
 {
     va_list vl;
 
-    int save_errno = errno;
+    /* C runtime error that has no corresponding DOS error code */
+    char* crterr = strerror(errno);
     DWORD       errval;
     jboolean freeit = JNI_FALSE;
-    char  *errtext = NULL;
+    char  *winerr = NULL;
 
     va_start(vl, fmt);
 
     if ((errval = GetLastError()) != 0) {               /* Platform SDK / DOS Error */
         int n = FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM|
             FORMAT_MESSAGE_IGNORE_INSERTS|FORMAT_MESSAGE_ALLOCATE_BUFFER,
-            NULL, errval, 0, (LPTSTR)&errtext, 0, NULL);
-        if (errtext == NULL || n == 0) {                /* Paranoia check */
-            errtext = "";
+            NULL, errval, 0, (LPTSTR)&winerr, 0, NULL);
+        if (n == 0) {
+        	winerr = "Java could not correctly determine the native platform error";
             n = 0;
         } else {
             freeit = JNI_TRUE;
-            if (n > 2) {                                /* Drop final CR, LF */
-                if (errtext[n - 1] == '\n') n--;
-                if (errtext[n - 1] == '\r') n--;
-                errtext[n] = '\0';
+            /* Paranoia check */
+            if (winerr != NULL && n > 2) {                                /* Drop final CR, LF */
+                if (winerr[n - 1] == '\n') n--;
+                if (winerr[n - 1] == '\r') n--;
+                winerr[n] = '\0';
             }
         }
-    } else {   /* C runtime error that has no corresponding DOS error code */
-        errtext = strerror(save_errno);
     }
 
     if (IsJavaw()) {
@@ -646,16 +641,31 @@ JLI_ReportErrorMessageSys(const char *fmt, ...)
         int mlen;
         /* get the length of the string we need */
         int len = mlen =  _vscprintf(fmt, vl) + 1;
-        if (freeit) {
-           mlen += (int)JLI_StrLen(errtext);
+        if (crterr != NULL) {
+            mlen += 1 + (int) JLI_StrLen(crterr);
+        }
+
+        if (winerr != NULL) {
+            mlen += 2 + (int) JLI_StrLen(winerr);
+        } else {
+        	++mlen;
         }
 
         message = (char *)JLI_MemAlloc(mlen);
         _vsnprintf(message, len, fmt, vl);
         message[len]='\0';
 
-        if (freeit) {
-           JLI_StrCat(message, errtext);
+        if (crterr != NULL) {
+        	JLI_StrCat(message, '\n');
+            JLI_StrCat(message, crterr);
+        }
+
+        if (winerr != NULL) {
+        	JLI_StrCat(message, '\n');
+            JLI_StrCat(message, winerr);
+            JLI_StrCat(message, '\n');
+        } else {
+        	JLI_StrCat(message, '\n');
         }
 
         MessageBox(NULL, message, "Java Virtual Machine Launcher",
@@ -664,12 +674,17 @@ JLI_ReportErrorMessageSys(const char *fmt, ...)
         JLI_MemFree(message);
     } else {
         vfprintf(stderr, fmt, vl);
-        if (freeit) {
-           fprintf(stderr, "%s", errtext);
+        if (crterr != NULL) {
+           fprintf(stderr, "\nC Runtime Error: %s", crterr);
+        }
+        if (winerr != NULL) {
+        	fprintf(stderr, "\nWindows API Error: %s\n", winerr);
+        } else {
+        	fprintf(stderr, "\n");
         }
     }
     if (freeit) {
-        (void)LocalFree((HLOCAL)errtext);
+        (void)LocalFree((HLOCAL)winerr);
     }
     va_end(vl);
 }

--- a/src/java.base/windows/native/libjli/java_md.c
+++ b/src/java.base/windows/native/libjli/java_md.c
@@ -662,7 +662,7 @@ JLI_ReportErrorMessageSys(const char *fmt, ...)
 
         if (winerr != NULL) {
             /* Trailing null terminator */
-        	message[mlen - 1 - JLI_StrLen(winerr)] = '\n';
+            message[mlen - 1 - JLI_StrLen(winerr)] = '\n';
             JLI_StrCat(message, winerr);
         }
 

--- a/src/java.base/windows/native/libjli/java_md.c
+++ b/src/java.base/windows/native/libjli/java_md.c
@@ -646,7 +646,7 @@ JLI_ReportErrorMessageSys(const char *fmt, ...)
         }
 
         if (winerr != NULL) {
-            mlen += 2 + (int) JLI_StrLen(winerr);
+            mlen += 1 + (int) JLI_StrLen(winerr);
         } else {
             ++mlen;
         }
@@ -663,9 +663,8 @@ JLI_ReportErrorMessageSys(const char *fmt, ...)
         if (winerr != NULL) {
             JLI_StrCat(message, '\n');
             JLI_StrCat(message, winerr);
-            JLI_StrCat(message, '\n');
         } else {
-            JLI_StrCat(message, '\n');
+            JLI_StrCat(message, '\0');
         }
 
         MessageBox(NULL, message, "Java Virtual Machine Launcher",

--- a/src/java.base/windows/native/libjli/java_md.c
+++ b/src/java.base/windows/native/libjli/java_md.c
@@ -642,15 +642,13 @@ JLI_ReportErrorMessageSys(const char *fmt, ...)
         char *message;
         int mlen;
         /* Get the length of the string we need */
-        int len = mlen =  _vscprintf(fmt, vl) + 1;
+        int len = mlen = _vscprintf(fmt, vl) + 1;
         if (crterr != NULL) {
             mlen += 1 + (int) JLI_StrLen(crterr);
         }
 
         if (winerr != NULL) {
             mlen += 1 + (int) JLI_StrLen(winerr);
-        } else {
-            ++mlen;
         }
 
         message = (char *)JLI_MemAlloc(mlen);
@@ -658,15 +656,14 @@ JLI_ReportErrorMessageSys(const char *fmt, ...)
         message[len]='\0';
 
         if (crterr != NULL) {
-            JLI_StrCat(message, '\n');
+            message[len + 1] = '\n';
             JLI_StrCat(message, crterr);
         }
 
         if (winerr != NULL) {
-            JLI_StrCat(message, '\n');
+            /* Trailing null terminator */
+        	message[mlen - 1 - JLI_StrLen(winerr)] = '\n';
             JLI_StrCat(message, winerr);
-        } else {
-            JLI_StrCat(message, '\0');
         }
 
         MessageBox(NULL, message, "Java Virtual Machine Launcher",

--- a/src/java.base/windows/native/libjli/java_md.c
+++ b/src/java.base/windows/native/libjli/java_md.c
@@ -623,7 +623,7 @@ JLI_ReportErrorMessageSys(const char *fmt, ...)
             FORMAT_MESSAGE_IGNORE_INSERTS|FORMAT_MESSAGE_ALLOCATE_BUFFER,
             NULL, errval, 0, (LPTSTR)&winerr, 0, NULL);
         if (n == 0) {
-        	winerr = "Java could not correctly determine the native platform error";
+            winerr = "Java could not correctly determine the native platform error";
             n = 0;
         } else {
             freeit = JNI_TRUE;
@@ -648,7 +648,7 @@ JLI_ReportErrorMessageSys(const char *fmt, ...)
         if (winerr != NULL) {
             mlen += 2 + (int) JLI_StrLen(winerr);
         } else {
-        	++mlen;
+            ++mlen;
         }
 
         message = (char *)JLI_MemAlloc(mlen);
@@ -656,16 +656,16 @@ JLI_ReportErrorMessageSys(const char *fmt, ...)
         message[len]='\0';
 
         if (crterr != NULL) {
-        	JLI_StrCat(message, '\n');
+            JLI_StrCat(message, '\n');
             JLI_StrCat(message, crterr);
         }
 
         if (winerr != NULL) {
-        	JLI_StrCat(message, '\n');
+            JLI_StrCat(message, '\n');
             JLI_StrCat(message, winerr);
             JLI_StrCat(message, '\n');
         } else {
-        	JLI_StrCat(message, '\n');
+            JLI_StrCat(message, '\n');
         }
 
         MessageBox(NULL, message, "Java Virtual Machine Launcher",
@@ -675,12 +675,12 @@ JLI_ReportErrorMessageSys(const char *fmt, ...)
     } else {
         vfprintf(stderr, fmt, vl);
         if (crterr != NULL) {
-           fprintf(stderr, "\nC Runtime Error: %s", crterr);
+            fprintf(stderr, "\nC Runtime Error: %s", crterr);
         }
         if (winerr != NULL) {
-        	fprintf(stderr, "\nWindows API Error: %s\n", winerr);
+            fprintf(stderr, "\nWindows API Error: %s\n", winerr);
         } else {
-        	fprintf(stderr, "\n");
+            fprintf(stderr, "\n");
         }
     }
     if (freeit) {

--- a/src/java.base/windows/native/libjli/java_md.c
+++ b/src/java.base/windows/native/libjli/java_md.c
@@ -618,7 +618,8 @@ JLI_ReportErrorMessageSys(const char *fmt, ...)
 
     va_start(vl, fmt);
 
-    if ((errval = GetLastError()) != 0) {               /* Platform SDK / DOS Error */
+    /* Platform SDK / DOS Error */
+    if ((errval = GetLastError()) != 0) {
         int n = FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM|
             FORMAT_MESSAGE_IGNORE_INSERTS|FORMAT_MESSAGE_ALLOCATE_BUFFER,
             NULL, errval, 0, (LPTSTR)&winerr, 0, NULL);
@@ -628,7 +629,8 @@ JLI_ReportErrorMessageSys(const char *fmt, ...)
         } else {
             freeit = JNI_TRUE;
             /* Paranoia check */
-            if (winerr != NULL && n > 2) {                                /* Drop final CR, LF */
+            if (winerr != NULL && n > 2) {
+            	/* Drop final CR, LF */
                 if (winerr[n - 1] == '\n') n--;
                 if (winerr[n - 1] == '\r') n--;
                 winerr[n] = '\0';
@@ -639,7 +641,7 @@ JLI_ReportErrorMessageSys(const char *fmt, ...)
     if (IsJavaw()) {
         char *message;
         int mlen;
-        /* get the length of the string we need */
+        /* Get the length of the string we need */
         int len = mlen =  _vscprintf(fmt, vl) + 1;
         if (crterr != NULL) {
             mlen += 1 + (int) JLI_StrLen(crterr);

--- a/src/java.base/windows/native/libjli/java_md.c
+++ b/src/java.base/windows/native/libjli/java_md.c
@@ -630,7 +630,7 @@ JLI_ReportErrorMessageSys(const char *fmt, ...)
             freeit = JNI_TRUE;
             /* Paranoia check */
             if (winerr != NULL && n > 2) {
-            	/* Drop final CR, LF */
+                /* Drop final CR, LF */
                 if (winerr[n - 1] == '\n') n--;
                 if (winerr[n - 1] == '\r') n--;
                 winerr[n] = '\0';


### PR DESCRIPTION
JLI_ReportErrorMessageSys has a number of issues, as listed in the linked issue, since it's not widely used, it's easier to remove it and replace the areas it's called in with simpler calls to other error reporting functions:

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292016](https://bugs.openjdk.org/browse/JDK-8292016): Rework JLI_ReportErrorMessageSys


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9793/head:pull/9793` \
`$ git checkout pull/9793`

Update a local copy of the PR: \
`$ git checkout pull/9793` \
`$ git pull https://git.openjdk.org/jdk pull/9793/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9793`

View PR using the GUI difftool: \
`$ git pr show -t 9793`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9793.diff">https://git.openjdk.org/jdk/pull/9793.diff</a>

</details>
