### PR TITLE
8292279: (fs) Use try-with-resources to release NativeBuffer

### DIFF
--- a/src/java.base/linux/classes/sun/nio/fs/LinuxDosFileAttributeView.java
+++ b/src/java.base/linux/classes/sun/nio/fs/LinuxDosFileAttributeView.java
@@ -212,8 +212,7 @@ class LinuxDosFileAttributeView
     private int getDosAttribute(int fd) throws UnixException {
         final int size = 24;
 
-        NativeBuffer buffer = NativeBuffers.getNativeBuffer(size);
-        try {
+        try (NativeBuffer buffer = NativeBuffers.getNativeBuffer(size)) {
             int len = LinuxNativeDispatcher
                 .fgetxattr(fd, DOS_XATTR_NAME_AS_BYTES, buffer.address(), size);
 
@@ -243,8 +242,6 @@ class LinuxDosFileAttributeView
             if (x.errno() == ENODATA)
                 return 0;
             throw x;
-        } finally {
-            buffer.release();
         }
     }
 
@@ -266,12 +263,9 @@ class LinuxDosFileAttributeView
             }
             if (newValue != oldValue) {
                 byte[] value = Util.toBytes("0x" + Integer.toHexString(newValue));
-                NativeBuffer buffer = NativeBuffers.asNativeBuffer(value);
-                try {
+                try (NativeBuffer buffer = NativeBuffers.asNativeBuffer(value)) {
                     LinuxNativeDispatcher.fsetxattr(fd, DOS_XATTR_NAME_AS_BYTES,
                         buffer.address(), value.length+1);
-                } finally {
-                    buffer.release();
                 }
             }
         } catch (UnixException x) {

--- a/src/java.base/linux/classes/sun/nio/fs/LinuxNativeDispatcher.java
+++ b/src/java.base/linux/classes/sun/nio/fs/LinuxNativeDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,13 +36,9 @@ class LinuxNativeDispatcher extends UnixNativeDispatcher {
     * FILE *setmntent(const char *filename, const char *type);
     */
     static long setmntent(byte[] filename, byte[] type) throws UnixException {
-        NativeBuffer pathBuffer = NativeBuffers.asNativeBuffer(filename);
-        NativeBuffer typeBuffer = NativeBuffers.asNativeBuffer(type);
-        try {
+        try (NativeBuffer pathBuffer = NativeBuffers.asNativeBuffer(filename);
+             NativeBuffer typeBuffer = NativeBuffers.asNativeBuffer(type)) {
             return setmntent0(pathBuffer.address(), typeBuffer.address());
-        } finally {
-            typeBuffer.release();
-            pathBuffer.release();
         }
     }
     private static native long setmntent0(long pathAddress, long typeAddress)
@@ -53,11 +49,8 @@ class LinuxNativeDispatcher extends UnixNativeDispatcher {
      */
 
     static int getmntent(long fp, UnixMountEntry entry, int buflen) throws UnixException {
-        NativeBuffer buffer = NativeBuffers.getNativeBuffer(buflen);
-        try {
+        try (NativeBuffer buffer = NativeBuffers.getNativeBuffer(buflen)) {
             return getmntent0(fp, entry, buffer.address(), buflen);
-        } finally {
-            buffer.release();
         }
     }
 

--- a/src/java.base/linux/classes/sun/nio/fs/LinuxWatchService.java
+++ b/src/java.base/linux/classes/sun/nio/fs/LinuxWatchService.java
@@ -250,15 +250,10 @@ class LinuxWatchService
             }
 
             // register with inotify (replaces existing mask if already registered)
-            int wd = -1;
-            try {
-                NativeBuffer buffer =
-                    NativeBuffers.asNativeBuffer(dir.getByteArrayForSysCalls());
-                try {
-                    wd = inotifyAddWatch(ifd, buffer.address(), mask);
-                } finally {
-                    buffer.release();
-                }
+            int wd;
+            try (NativeBuffer buffer =
+                 NativeBuffers.asNativeBuffer(dir.getByteArrayForSysCalls())) {
+                wd = inotifyAddWatch(ifd, buffer.address(), mask);
             } catch (UnixException x) {
                 if (x.errno() == ENOSPC) {
                     return new IOException("User limit of inotify watches reached");

--- a/src/java.base/macosx/classes/sun/nio/fs/BsdNativeDispatcher.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdNativeDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,11 +53,8 @@ class BsdNativeDispatcher extends UnixNativeDispatcher {
      * returns buf->f_mntonname (directory on which mounted)
      */
     static byte[] getmntonname(UnixPath path) throws UnixException {
-        NativeBuffer pathBuffer = copyToNativeBuffer(path);
-        try {
+        try (NativeBuffer pathBuffer = copyToNativeBuffer(path)) {
             return getmntonname0(pathBuffer.address());
-        } finally {
-            pathBuffer.release();
         }
     }
     static native byte[] getmntonname0(long pathAddress) throws UnixException;

--- a/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
@@ -337,13 +337,10 @@ abstract class UnixUserDefinedFileAttributeView
         throws UnixException
     {
         int size = fgetxattr(ofd, name, 0L, 0);
-        NativeBuffer buffer = NativeBuffers.getNativeBuffer(size);
-        try {
+        try (NativeBuffer buffer = NativeBuffers.getNativeBuffer(size)) {
             long address = buffer.address();
             size = fgetxattr(ofd, name, address, size);
             fsetxattr(nfd, name, address, size);
-        } finally {
-            buffer.release();
         }
     }
 }

--- a/src/java.base/windows/classes/sun/nio/fs/RegistryFileTypeDetector.java
+++ b/src/java.base/windows/classes/sun/nio/fs/RegistryFileTypeDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,18 +55,12 @@ public class RegistryFileTypeDetector
 
         // query HKEY_CLASSES_ROOT\<ext>
         String key = filename.substring(dot);
-        NativeBuffer keyBuffer = null;
-        NativeBuffer nameBuffer = null;
-        try {
-            keyBuffer = WindowsNativeDispatcher.asNativeBuffer(key);
-            nameBuffer = WindowsNativeDispatcher.asNativeBuffer("Content Type");
+        try (NativeBuffer keyBuffer = WindowsNativeDispatcher.asNativeBuffer(key);
+             NativeBuffer nameBuffer = WindowsNativeDispatcher.asNativeBuffer("Content Type")) {
             return queryStringValue(keyBuffer.address(), nameBuffer.address());
         } catch (WindowsException we) {
             we.rethrowAsIOException(file.toString());
             return null; // keep compiler happy
-        } finally {
-            nameBuffer.release();
-            keyBuffer.release();
         }
     }
 

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
@@ -263,8 +263,7 @@ class WindowsFileAttributes
     static WindowsFileAttributes readAttributes(long handle)
         throws WindowsException
     {
-        try (NativeBuffer buffer = NativeBuffers
-            .getNativeBuffer(SIZEOF_FILE_INFORMATION)) {
+        try (NativeBuffer buffer = NativeBuffers.getNativeBuffer(SIZEOF_FILE_INFORMATION)) {
             long address = buffer.address();
             GetFileInformationByHandle(handle, address);
 

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -263,9 +263,8 @@ class WindowsFileAttributes
     static WindowsFileAttributes readAttributes(long handle)
         throws WindowsException
     {
-        NativeBuffer buffer = NativeBuffers
-            .getNativeBuffer(SIZEOF_FILE_INFORMATION);
-        try {
+        try (NativeBuffer buffer = NativeBuffers
+            .getNativeBuffer(SIZEOF_FILE_INFORMATION)) {
             long address = buffer.address();
             GetFileInformationByHandle(handle, address);
 
@@ -275,18 +274,13 @@ class WindowsFileAttributes
                 .getInt(address + OFFSETOF_FILE_INFORMATION_ATTRIBUTES);
             if (isReparsePoint(fileAttrs)) {
                 int size = MAXIMUM_REPARSE_DATA_BUFFER_SIZE;
-                NativeBuffer reparseBuffer = NativeBuffers.getNativeBuffer(size);
-                try {
+                try (NativeBuffer reparseBuffer = NativeBuffers.getNativeBuffer(size)) {
                     DeviceIoControlGetReparsePoint(handle, reparseBuffer.address(), size);
                     reparseTag = (int)unsafe.getLong(reparseBuffer.address());
-                } finally {
-                    reparseBuffer.release();
                 }
             }
 
             return fromFileInformation(address, reparseTag);
-        } finally {
-            buffer.release();
         }
     }
 
@@ -300,9 +294,8 @@ class WindowsFileAttributes
             WindowsException firstException = null;
 
             // GetFileAttributesEx is the fastest way to read the attributes
-            NativeBuffer buffer =
-                NativeBuffers.getNativeBuffer(SIZEOF_FILE_ATTRIBUTE_DATA);
-            try {
+            try (NativeBuffer buffer =
+                NativeBuffers.getNativeBuffer(SIZEOF_FILE_ATTRIBUTE_DATA)) {
                 long address = buffer.address();
                 GetFileAttributesEx(path.getPathForWin32Calls(), address);
                 // if reparse point then file may be a sym link; otherwise
@@ -315,8 +308,6 @@ class WindowsFileAttributes
                 if (x.lastError() != ERROR_SHARING_VIOLATION)
                     throw x;
                 firstException = x;
-            } finally {
-                buffer.release();
             }
 
             // For sharing violations, fallback to FindFirstFile if the file
@@ -326,8 +317,7 @@ class WindowsFileAttributes
                 char last = search.charAt(search.length() -1);
                 if (last == ':' || last == '\\')
                     throw firstException;
-                buffer = getBufferForFindData();
-                try {
+                try (NativeBuffer buffer = getBufferForFindData()) {
                     long handle = FindFirstFile(search, buffer.address());
                     FindClose(handle);
                     WindowsFileAttributes attrs = fromFindData(buffer.address());
@@ -340,8 +330,6 @@ class WindowsFileAttributes
                     return attrs;
                 } catch (WindowsException ignore) {
                     throw firstException;
-                } finally {
-                    buffer.release();
                 }
             }
         }

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java
@@ -514,17 +514,12 @@ class WindowsFileCopy {
         try {
             int request = (DACL_SECURITY_INFORMATION |
                 OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION);
-            NativeBuffer buffer =
-                WindowsAclFileAttributeView.getFileSecurity(path, request);
-            try {
-                try {
-                    SetFileSecurity(target.getPathForWin32Calls(), request,
+            try (NativeBuffer buffer =
+                 WindowsAclFileAttributeView.getFileSecurity(path, request)) {
+                SetFileSecurity(target.getPathForWin32Calls(), request,
                         buffer.address());
-                } catch (WindowsException x) {
-                    x.rethrowAsIOException(target);
-                }
-            } finally {
-                buffer.release();
+            } catch (WindowsException x) {
+                x.rethrowAsIOException(target);
             }
         } finally {
             priv.drop();

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystemProvider.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystemProvider.java
@@ -33,8 +33,6 @@ import java.net.URI;
 import java.util.concurrent.ExecutorService;
 import java.io.*;
 import java.util.*;
-import java.security.AccessController;
-import jdk.internal.misc.Unsafe;
 import jdk.internal.util.StaticProperty;
 import sun.nio.ch.ThreadPool;
 import sun.security.util.SecurityConstants;
@@ -302,12 +300,11 @@ class WindowsFileSystemProvider
         // read security descriptor containing ACL (symlinks are followed)
         boolean hasRights = false;
         String target = WindowsLinkSupport.getFinalPath(file, true);
-        NativeBuffer aclBuffer = WindowsAclFileAttributeView
+        try (NativeBuffer aclBuffer = WindowsAclFileAttributeView
             .getFileSecurity(target,
                 DACL_SECURITY_INFORMATION
                 | OWNER_SECURITY_INFORMATION
-                | GROUP_SECURITY_INFORMATION);
-        try {
+                | GROUP_SECURITY_INFORMATION)) {
             hasRights = checkAccessMask(aclBuffer.address(), rights,
                 FILE_GENERIC_READ,
                 FILE_GENERIC_WRITE,
@@ -315,8 +312,6 @@ class WindowsFileSystemProvider
                 FILE_ALL_ACCESS);
         } catch (WindowsException exc) {
             exc.rethrowAsIOException(file);
-        } finally {
-            aclBuffer.release();
         }
         return hasRights;
     }

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsLinkSupport.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsLinkSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -269,8 +269,7 @@ class WindowsLinkSupport {
      */
     private static String readLinkImpl(long handle) throws IOException {
         int size = MAXIMUM_REPARSE_DATA_BUFFER_SIZE;
-        NativeBuffer buffer = NativeBuffers.getNativeBuffer(size);
-        try {
+        try (NativeBuffer buffer = NativeBuffers.getNativeBuffer(size)) {
             try {
                 DeviceIoControlGetReparsePoint(handle, buffer.address(), size);
             } catch (WindowsException x) {
@@ -334,8 +333,6 @@ class WindowsLinkSupport {
                 throw new IOException("Symbolic link target is invalid");
             }
             return target;
-        } finally {
-            buffer.release();
         }
     }
 

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsNativeDispatcher.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsNativeDispatcher.java
@@ -495,13 +495,10 @@ class WindowsNativeDispatcher {
     static VolumeInformation GetVolumeInformation(String root)
         throws WindowsException
     {
-        NativeBuffer buffer = asNativeBuffer(root);
-        try {
+        try (NativeBuffer buffer = asNativeBuffer(root)) {
             VolumeInformation info = new VolumeInformation();
             GetVolumeInformation0(buffer.address(), info);
             return info;
-        } finally {
-            buffer.release();
         }
     }
     static class VolumeInformation {
@@ -526,11 +523,8 @@ class WindowsNativeDispatcher {
      * )
      */
     static int GetDriveType(String root) throws WindowsException {
-        NativeBuffer buffer = asNativeBuffer(root);
-        try {
+        try (NativeBuffer buffer = asNativeBuffer(root)) {
             return GetDriveType0(buffer.address());
-        } finally {
-            buffer.release();
         }
     }
     private static native int GetDriveType0(long lpRoot) throws WindowsException;
@@ -546,13 +540,10 @@ class WindowsNativeDispatcher {
     static DiskFreeSpace GetDiskFreeSpaceEx(String path)
         throws WindowsException
     {
-        NativeBuffer buffer = asNativeBuffer(path);
-        try {
+        try (NativeBuffer buffer = asNativeBuffer(path)) {
             DiskFreeSpace space = new DiskFreeSpace();
             GetDiskFreeSpaceEx0(buffer.address(), space);
             return space;
-        } finally {
-            buffer.release();
         }
     }
 
@@ -568,13 +559,10 @@ class WindowsNativeDispatcher {
     static DiskFreeSpace GetDiskFreeSpace(String path)
         throws WindowsException
     {
-        NativeBuffer buffer = asNativeBuffer(path);
-        try {
+        try (NativeBuffer buffer = asNativeBuffer(path)) {
             DiskFreeSpace space = new DiskFreeSpace();
             GetDiskFreeSpace0(buffer.address(), space);
             return space;
-        } finally {
-            buffer.release();
         }
     }
 
@@ -609,11 +597,8 @@ class WindowsNativeDispatcher {
      * @return  lpFileName
      */
     static String GetVolumePathName(String path) throws WindowsException {
-        NativeBuffer buffer = asNativeBuffer(path);
-        try {
+        try (NativeBuffer buffer = asNativeBuffer(path)) {
             return GetVolumePathName0(buffer.address());
-        } finally {
-            buffer.release();
         }
     }
     private static native String GetVolumePathName0(long lpFileName)
@@ -653,12 +638,9 @@ class WindowsNativeDispatcher {
                                long pSecurityDescriptor,
                                int nLength) throws WindowsException
     {
-        NativeBuffer buffer = asNativeBuffer(path);
-        try {
+        try (NativeBuffer buffer = asNativeBuffer(path)) {
             return GetFileSecurity0(buffer.address(), requestedInformation,
                 pSecurityDescriptor, nLength);
-        } finally {
-            buffer.release();
         }
     }
     private static native int GetFileSecurity0(long lpFileName,
@@ -678,12 +660,9 @@ class WindowsNativeDispatcher {
                                 long pSecurityDescriptor)
         throws WindowsException
     {
-        NativeBuffer buffer = asNativeBuffer(path);
-        try {
+        try (NativeBuffer buffer = asNativeBuffer(path)) {
             // may be called with elevated privileges so always run on current thread
             SetFileSecurity0(buffer.address(), securityInformation, pSecurityDescriptor);
-        } finally {
-            buffer.release();
         }
     }
     static native void SetFileSecurity0(long lpFileName, int securityInformation,
@@ -835,11 +814,8 @@ class WindowsNativeDispatcher {
                                  long pSid,
                                  int cbSid) throws WindowsException
     {
-        NativeBuffer buffer = asNativeBuffer(accountName);
-        try {
+        try (NativeBuffer buffer = asNativeBuffer(accountName)) {
             return LookupAccountName0(buffer.address(), pSid, cbSid);
-        } finally {
-            buffer.release();
         }
     }
     private static native int LookupAccountName0(long lpAccountName, long pSid,
@@ -874,11 +850,8 @@ class WindowsNativeDispatcher {
     static long ConvertStringSidToSid(String sidString)
         throws WindowsException
     {
-        NativeBuffer buffer = asNativeBuffer(sidString);
-        try {
+        try (NativeBuffer buffer = asNativeBuffer(sidString)) {
             return ConvertStringSidToSid0(buffer.address());
-        } finally {
-            buffer.release();
         }
     }
     private static native long ConvertStringSidToSid0(long lpStringSid)
@@ -974,11 +947,8 @@ class WindowsNativeDispatcher {
     /**
      */
     static long LookupPrivilegeValue(String name) throws WindowsException {
-        NativeBuffer buffer = asNativeBuffer(name);
-        try {
+        try (NativeBuffer buffer = asNativeBuffer(name)) {
             return LookupPrivilegeValue0(buffer.address());
-        } finally {
-            buffer.release();
         }
     }
     private static native long LookupPrivilegeValue0(long lpName)
@@ -1036,13 +1006,9 @@ class WindowsNativeDispatcher {
     static void CreateHardLink(String newFile, String existingFile)
         throws WindowsException
     {
-        NativeBuffer newFileBuffer = asNativeBuffer(newFile);
-        NativeBuffer existingFileBuffer = asNativeBuffer(existingFile);
-        try {
+        try (NativeBuffer newFileBuffer = asNativeBuffer(newFile);
+             NativeBuffer existingFileBuffer = asNativeBuffer(existingFile)) {
             CreateHardLink0(newFileBuffer.address(), existingFileBuffer.address());
-        } finally {
-            existingFileBuffer.release();
-            newFileBuffer.release();
         }
     }
     private static native void CreateHardLink0(long newFileBuffer,
@@ -1057,11 +1023,8 @@ class WindowsNativeDispatcher {
      * )
      */
     static String GetFullPathName(String path) throws WindowsException {
-        NativeBuffer buffer = asNativeBuffer(path);
-        try {
+        try (NativeBuffer buffer = asNativeBuffer(path)) {
             return GetFullPathName0(buffer.address());
-        } finally {
-            buffer.release();
         }
     }
     private static native String GetFullPathName0(long pathAddress)

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsUserPrincipals.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsUserPrincipals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -140,7 +140,7 @@ class WindowsUserPrincipals {
         }
 
         // invoke LookupAccountName to get buffer size needed for SID
-        int size = 0;
+        int size;
         try {
             size = LookupAccountName(name, 0L, 0);
         } catch (WindowsException x) {
@@ -151,8 +151,7 @@ class WindowsUserPrincipals {
         assert size > 0;
 
         // allocate buffer and re-invoke LookupAccountName get SID
-        NativeBuffer sidBuffer = NativeBuffers.getNativeBuffer(size);
-        try {
+        try (NativeBuffer sidBuffer = NativeBuffers.getNativeBuffer(size)) {
             int newSize = LookupAccountName(name, sidBuffer.address(), size);
             if (newSize != size) {
                 // can this happen?
@@ -163,8 +162,6 @@ class WindowsUserPrincipals {
             return fromSid(sidBuffer.address());
         } catch (WindowsException x) {
             throw new IOException(name + ": " + x.errorString());
-        } finally {
-            sidBuffer.release();
         }
     }
 }


### PR DESCRIPTION
Since [JDK-8260966](https://bugs.openjdk.org/browse/JDK-8260966), NativeBuffer implements AutoCloseable interface.
Now we can use try-with-resources statements to simplify code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292279](https://bugs.openjdk.org/browse/JDK-8292279): (fs) Use try-with-resources to release NativeBuffer


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9794/head:pull/9794` \
`$ git checkout pull/9794`

Update a local copy of the PR: \
`$ git checkout pull/9794` \
`$ git pull https://git.openjdk.org/jdk pull/9794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9794`

View PR using the GUI difftool: \
`$ git pr show -t 9794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9794.diff">https://git.openjdk.org/jdk/pull/9794.diff</a>

</details>
