### PR TITLE
8292140: (fs) Needless instanceof check in RegistryFileTypeDetector

### DIFF
--- a/src/java.base/windows/classes/sun/nio/fs/RegistryFileTypeDetector.java
+++ b/src/java.base/windows/classes/sun/nio/fs/RegistryFileTypeDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 
 package sun.nio.fs;
 
-import java.nio.file.*;
+import java.nio.file.Path;
 import java.io.IOException;
 
 /**
@@ -41,9 +41,6 @@ public class RegistryFileTypeDetector
 
     @Override
     public String implProbeContentType(Path file) throws IOException {
-        if (!(file instanceof Path))
-            return null;
-
         // get file extension
         Path name = file.getFileName();
         if (name == null)


### PR DESCRIPTION
Type of `file` parameter is known to be `Path`. And `instanceof` only checks if it's `null` or not.
https://github.com/openjdk/jdk/blob/2712bc3f79990f27fe9a624a7a818ba1c2c74b67/src/java.base/windows/classes/sun/nio/fs/RegistryFileTypeDetector.java#L43-L46
Before `implProbeContentType` method  is called, parameter is checked for null in `sun.nio.fs.AbstractFileTypeDetector#probeContentType`. It means null check is redundant too.

https://github.com/openjdk/jdk/blob/eb8b789015c98cb5fe7ba788e71f3f6166884739/src/java.base/share/classes/sun/nio/fs/AbstractFileTypeDetector.java#L72-L75

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292140](https://bugs.openjdk.org/browse/JDK-8292140): (fs) Needless instanceof check in RegistryFileTypeDetector


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9797/head:pull/9797` \
`$ git checkout pull/9797`

Update a local copy of the PR: \
`$ git checkout pull/9797` \
`$ git pull https://git.openjdk.org/jdk pull/9797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9797`

View PR using the GUI difftool: \
`$ git pr show -t 9797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9797.diff">https://git.openjdk.org/jdk/pull/9797.diff</a>

</details>
