### PR TITLE
8291081: Some sun/tools/jstatd/TestJstatd* tests fail with "Not a percentage\: 68.31\: expected true, was false"

### DIFF
--- a/test/jdk/sun/tools/jstatd/JstatGCUtilParser.java
+++ b/test/jdk/sun/tools/jstatd/JstatGCUtilParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import jdk.test.lib.Utils;
 public class JstatGCUtilParser {
 
     public enum GcStatisticsType {
-        INTEGER, DOUBLE, PERCENTAGE, PERCENTAGE_OR_DASH;
+        INTEGER, DOUBLE, PERCENTAGE, PERCENTAGE_OR_DASH, INTEGER_OR_DASH, DOUBLE_OR_DASH;
     }
 
     public enum GcStatistics {
@@ -49,12 +49,12 @@ public class JstatGCUtilParser {
         O(GcStatisticsType.PERCENTAGE),
         M(GcStatisticsType.PERCENTAGE_OR_DASH),
         CCS(GcStatisticsType.PERCENTAGE_OR_DASH),
-        YGC(GcStatisticsType.INTEGER),
-        YGCT(GcStatisticsType.DOUBLE),
-        FGC(GcStatisticsType.INTEGER),
-        FGCT(GcStatisticsType.DOUBLE),
-        CGC(GcStatisticsType.INTEGER),
-        CGCT(GcStatisticsType.DOUBLE),
+        YGC(GcStatisticsType.INTEGER_OR_DASH),
+        YGCT(GcStatisticsType.DOUBLE_OR_DASH),
+        FGC(GcStatisticsType.INTEGER_OR_DASH),
+        FGCT(GcStatisticsType.DOUBLE_OR_DASH),
+        CGC(GcStatisticsType.INTEGER_OR_DASH),
+        CGCT(GcStatisticsType.DOUBLE_OR_DASH),
         GCT(GcStatisticsType.DOUBLE);
 
         private final GcStatisticsType type;
@@ -93,17 +93,19 @@ public class JstatGCUtilParser {
             for (int i = 0; i < values().length; i++) {
                 GcStatisticsType type = values()[i].getType();
                 String value = valueArray[i].trim();
+                if ((type.equals(GcStatisticsType.PERCENTAGE_OR_DASH)
+                     || type.equals(GcStatisticsType.INTEGER_OR_DASH)
+                     || type.equals(GcStatisticsType.DOUBLE_OR_DASH))
+                    && value.equals("-")) {
+                    continue;
+                }
                 if (type.equals(GcStatisticsType.INTEGER)) {
                     NumberFormat.getInstance().parse(value).intValue();
-                    break;
+                    continue;
                 }
                 if (type.equals(GcStatisticsType.DOUBLE)) {
                     NumberFormat.getInstance().parse(value).doubleValue();
-                    break;
-                }
-                if (type.equals(GcStatisticsType.PERCENTAGE_OR_DASH) &&
-                        value.equals("-")) {
-                    break;
+                    continue;
                 }
                 double percentage = NumberFormat.getInstance().parse(value).doubleValue();
                 assertTrue(0 <= percentage && percentage <= 100,

--- a/test/jdk/sun/tools/jstatd/JstatGCUtilParser.java
+++ b/test/jdk/sun/tools/jstatd/JstatGCUtilParser.java
@@ -99,11 +99,13 @@ public class JstatGCUtilParser {
                     && value.equals("-")) {
                     continue;
                 }
-                if (type.equals(GcStatisticsType.INTEGER)) {
+                if (type.equals(GcStatisticsType.INTEGER)
+                    || type.equals(GcStatisticsType.INTEGER_OR_DASH)) {
                     NumberFormat.getInstance().parse(value).intValue();
                     continue;
                 }
-                if (type.equals(GcStatisticsType.DOUBLE)) {
+                if (type.equals(GcStatisticsType.DOUBLE)
+                    || type.equals(GcStatisticsType.DOUBLE_OR_DASH)) {
                     NumberFormat.getInstance().parse(value).doubleValue();
                     continue;
                 }

--- a/test/jdk/sun/tools/jstatd/JstatGCUtilParser.java
+++ b/test/jdk/sun/tools/jstatd/JstatGCUtilParser.java
@@ -109,7 +109,7 @@ public class JstatGCUtilParser {
                 }
                 double percentage = NumberFormat.getInstance().parse(value).doubleValue();
                 assertTrue(0 <= percentage && percentage <= 100,
-                        "Not a percentage: " + value);
+                        "Not a percentage. value: " + value + " percentage: " + percentage);
             }
         }
 

--- a/test/jdk/sun/tools/jstatd/JstatdTest.java
+++ b/test/jdk/sun/tools/jstatd/JstatdTest.java
@@ -49,7 +49,7 @@ import jdk.test.lib.thread.ProcessThread;
  * jps -J-XX:+UsePerfData hostname
  *
  * // run jstat and verify its output
- * jstat -J-XX:+UsePerfData -J-Duser.language=en -gcutil pid@hostname 250 5
+ * jstat -J-XX:+UsePerfData -gcutil pid@hostname 250 5
  *
  * // stop jstatd process and verify that no unexpected exceptions have been thrown
  * }
@@ -172,15 +172,14 @@ public final class JstatdTest {
     /**
      * Depending on test settings command line can look like:
      *
-     * jstat -J-XX:+UsePerfData -J-Duser.language=en -gcutil pid@hostname 250 5
-     * jstat -J-XX:+UsePerfData -J-Duser.language=en -gcutil pid@hostname:port 250 5
-     * jstat -J-XX:+UsePerfData -J-Duser.language=en -gcutil pid@hostname/serverName 250 5
-     * jstat -J-XX:+UsePerfData -J-Duser.language=en -gcutil pid@hostname:port/serverName 250 5
+     * jstat -J-XX:+UsePerfData -gcutil pid@hostname 250 5
+     * jstat -J-XX:+UsePerfData -gcutil pid@hostname:port 250 5
+     * jstat -J-XX:+UsePerfData -gcutil pid@hostname/serverName 250 5
+     * jstat -J-XX:+UsePerfData -gcutil pid@hostname:port/serverName 250 5
      */
     private OutputAnalyzer runJstat() throws Exception {
         JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("jstat");
         launcher.addVMArg("-XX:+UsePerfData");
-        launcher.addVMArg("-Duser.language=en");
         launcher.addToolArg("-gcutil");
         launcher.addToolArg(jstatdPid + "@" + getDestination());
         launcher.addToolArg(Integer.toString(JSTAT_GCUTIL_INTERVAL_MS));


### PR DESCRIPTION
The test should use the same locales in all processes, the default language should work fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291081](https://bugs.openjdk.org/browse/JDK-8291081): Some sun/tools/jstatd/TestJstatd* tests fail with "Not a percentage\: 68.31\: expected true, was false"


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to [2702a24a](https://git.openjdk.org/jdk/pull/9798/files/2702a24a9b2f4a3a4ef765ff186b15d91b02555a)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9798/head:pull/9798` \
`$ git checkout pull/9798`

Update a local copy of the PR: \
`$ git checkout pull/9798` \
`$ git pull https://git.openjdk.org/jdk pull/9798/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9798`

View PR using the GUI difftool: \
`$ git pr show -t 9798`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9798.diff">https://git.openjdk.org/jdk/pull/9798.diff</a>

</details>
