### PR TITLE
JDK-8291734: Return accurate ACC_SUPER access flag for classes

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1346,16 +1346,18 @@ public final class Class<T> implements java.io.Serializable,
      * @since 20
      */
     public Set<AccessFlag> accessFlags() {
-        // This likely needs some refinement. Exploration of hidden
-        // classes, array classes.  Location.CLASS allows SUPER and
-        // AccessFlag.MODULE which INNER_CLASS forbids. INNER_CLASS
-        // allows PRIVATE, PROTECTED, and STATIC, which are not
-        // allowed on Location.CLASS.
-        return AccessFlag.maskToAccessFlags(getModifiers(),
-                                            (isMemberClass() || isLocalClass() ||
-                                             isAnonymousClass() || isArray()) ?
-                                            AccessFlag.Location.INNER_CLASS :
-                                            AccessFlag.Location.CLASS);
+        // Location.CLASS allows SUPER and AccessFlag.MODULE which
+        // INNER_CLASS forbids. INNER_CLASS allows PRIVATE, PROTECTED,
+        // and STATIC, which are not allowed on Location.CLASS.
+        // Use getClassAccessFlagsRaw to expose SUPER status.
+        var location = (isMemberClass() || isLocalClass() ||
+                        isAnonymousClass() || isArray()) ?
+            AccessFlag.Location.INNER_CLASS :
+            AccessFlag.Location.CLASS;
+        return AccessFlag.maskToAccessFlags((location == AccessFlag.Location.CLASS) ?
+                                            getClassAccessFlagsRaw() :
+                                            getModifiers(),
+                                            location);
     }
 
     /**

--- a/test/jdk/java/lang/reflect/AccessFlag/ClassAccessFlagTest.java
+++ b/test/jdk/java/lang/reflect/AccessFlag/ClassAccessFlagTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8266670
+ * @bug 8266670 8291734
  * @summary Test expected AccessFlag's on classes.
  */
 
@@ -46,16 +46,11 @@ import java.util.*;
  * return the Class object created from a module-info.class
  * file. Therefore, this test does not attempt to probe the setting of
  * that access flag.
- *
- * For a class, the VM must treat the class as if the ACC_SUPER bit
- * were set, but that bit is cleared by HotSpot when it is passed out
- * to the core reflection libraries. Therefore, this test does not
- * attempt to check whether or not AccessFlag.SUPER is set.
  */
-@ExpectedClassFlags("[PUBLIC, FINAL]")
+@ExpectedClassFlags("[PUBLIC, FINAL, SUPER]")
 public final class ClassAccessFlagTest {
     public static void main(String... args) {
-        // Top-level and axuillary classes; i.e. non-inner classes
+        // Top-level and auxiliary classes; i.e. non-inner classes
         Class<?>[] testClasses = {
             ClassAccessFlagTest.class,
             TestInterface.class,
@@ -226,7 +221,7 @@ public final class ClassAccessFlagTest {
 interface TestInterface {}
 
 
-@ExpectedClassFlags("[FINAL, ENUM]")
+@ExpectedClassFlags("[FINAL, SUPER, ENUM]")
 enum TestOuterEnum {
     INSTANCE;
 }


### PR DESCRIPTION
With the ACC_SUPER information now available from a private getClassAccessFlagsRaw() method, the 
 Set<AccessFlag> accessFlags() 
method can properly model that setting.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291734](https://bugs.openjdk.org/browse/JDK-8291734): Return accurate ACC_SUPER access flag for classes


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9799/head:pull/9799` \
`$ git checkout pull/9799`

Update a local copy of the PR: \
`$ git checkout pull/9799` \
`$ git pull https://git.openjdk.org/jdk pull/9799/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9799`

View PR using the GUI difftool: \
`$ git pr show -t 9799`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9799.diff">https://git.openjdk.org/jdk/pull/9799.diff</a>

</details>
