### PR TITLE
8291238: JDK can't be built without G1

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -255,10 +255,12 @@ void FileMapHeader::populate(FileMapInfo *info, size_t core_region_alignment,
       _heap_begin = CompressedOops::begin();
       _heap_end = CompressedOops::end();
     } else {
+#if INCLUDE_G1GC
       address start = (address)G1CollectedHeap::heap()->reserved().start();
       address end = (address)G1CollectedHeap::heap()->reserved().end();
       _heap_begin = HeapShared::to_requested_address(start);
       _heap_end = HeapShared::to_requested_address(end);
+#endif
     }
   }
   _compressed_oops = UseCompressedOops;
@@ -1522,7 +1524,9 @@ void FileMapInfo::write_region(int region, char* base, size_t size,
     if (UseCompressedOops) {
       mapping_offset = (size_t)CompressedOops::encode_not_null(cast_to_oop(base));
     } else {
+#if INCLUDE_G1GC
       mapping_offset = requested_base - (char*)G1CollectedHeap::heap()->reserved().start();
+#endif
     }
     assert(mapping_offset == (size_t)(uint32_t)mapping_offset, "must be 32-bit only");
   } else {


### PR DESCRIPTION
Please review this simple change for fixing build failure without G1.

The fix is by adding `#if INCLUDE_G1GC ... #endif` around some G1 specific code.

Passed builds-tier1 with G1GC disabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291238](https://bugs.openjdk.org/browse/JDK-8291238): JDK can't be built without G1


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9800/head:pull/9800` \
`$ git checkout pull/9800`

Update a local copy of the PR: \
`$ git checkout pull/9800` \
`$ git pull https://git.openjdk.org/jdk pull/9800/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9800`

View PR using the GUI difftool: \
`$ git pr show -t 9800`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9800.diff">https://git.openjdk.org/jdk/pull/9800.diff</a>

</details>
