### PR TITLE
JDK-8292072: NMT: repurpose Tracking overhead counter as global malloc counter

### DIFF
--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -66,25 +66,6 @@ size_t MemoryCounter::peak_size() const {
 }
 #endif
 
-// Total malloc invocation count
-size_t MallocMemorySnapshot::total_count() const {
-  size_t amount = 0;
-  for (int index = 0; index < mt_number_of_types; index ++) {
-    amount += _malloc[index].malloc_count();
-  }
-  return amount;
-}
-
-// Total malloc'd memory amount
-size_t MallocMemorySnapshot::total() const {
-  size_t amount = 0;
-  for (int index = 0; index < mt_number_of_types; index ++) {
-    amount += _malloc[index].malloc_size();
-  }
-  amount += _tracking_header.size() + total_arena();
-  return amount;
-}
-
 // Total malloc'd memory used by arenas
 size_t MallocMemorySnapshot::total_arena() const {
   size_t amount = 0;
@@ -100,6 +81,7 @@ void MallocMemorySnapshot::make_adjustment() {
   size_t arena_size = total_arena();
   int chunk_idx = NMTUtil::flag_to_index(mtChunk);
   _malloc[chunk_idx].record_free(arena_size);
+  _all_mallocs.deallocate(arena_size);
 }
 
 void MallocMemorySummary::initialize() {
@@ -127,7 +109,6 @@ void* MallocTracker::record_malloc(void* malloc_base, size_t size, MEMFLAGS flag
   assert(malloc_base != NULL, "precondition");
 
   MallocMemorySummary::record_malloc(size, flags);
-  MallocMemorySummary::record_new_malloc_header(sizeof(MallocHeader));
   uint32_t mst_marker = 0;
   if (MemTracker::tracking_level() == NMT_detail) {
     MallocSiteTable::allocation_at(stack, size, &mst_marker, flags);
@@ -162,7 +143,6 @@ void* MallocTracker::record_free(void* memblock) {
   header->assert_block_integrity();
 
   MallocMemorySummary::record_free(header->size(), header->flags());
-  MallocMemorySummary::record_free_malloc_header(sizeof(MallocHeader));
   if (MemTracker::tracking_level() == NMT_detail) {
     MallocSiteTable::deallocation_at(header->size(), header->mst_marker());
   }

--- a/src/hotspot/share/services/memBaseline.hpp
+++ b/src/hotspot/share/services/memBaseline.hpp
@@ -140,7 +140,7 @@ class MemBaseline {
   size_t malloc_tracking_overhead() const {
     assert(baseline_type() != Not_baselined, "Not yet baselined");
     MemBaseline* bl = const_cast<MemBaseline*>(this);
-    return bl->_malloc_memory_snapshot.malloc_overhead()->size();
+    return bl->_malloc_memory_snapshot.malloc_overhead();
   }
 
   MallocMemory* malloc_memory(MEMFLAGS flag) {

--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -157,8 +157,8 @@ void MemSummaryReporter::report_summary_of_type(MEMFLAGS flag,
     }
   } else if (flag == mtNMT) {
     // Count malloc headers in "NMT" category
-    reserved_amount  += _malloc_snapshot->malloc_overhead()->size();
-    committed_amount += _malloc_snapshot->malloc_overhead()->size();
+    reserved_amount  += _malloc_snapshot->malloc_overhead();
+    committed_amount += _malloc_snapshot->malloc_overhead();
   }
 
   if (amount_in_current_scale(reserved_amount) > 0) {
@@ -210,9 +210,9 @@ void MemSummaryReporter::report_summary_of_type(MEMFLAGS flag,
     }
 
     if (flag == mtNMT &&
-      amount_in_current_scale(_malloc_snapshot->malloc_overhead()->size()) > 0) {
+      amount_in_current_scale(_malloc_snapshot->malloc_overhead()) > 0) {
       out->print_cr("%27s (tracking overhead=" SIZE_FORMAT "%s)", " ",
-        amount_in_current_scale(_malloc_snapshot->malloc_overhead()->size()), scale);
+        amount_in_current_scale(_malloc_snapshot->malloc_overhead()), scale);
     } else if (flag == mtClass) {
       // Metadata information
       report_metadata(Metaspace::NonClassType);

--- a/test/hotspot/gtest/nmt/test_nmt_totals.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_totals.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+#include "memory/allocation.hpp"
+#include "runtime/os.hpp"
+#include "services/mallocTracker.hpp"
+#include "services/memTracker.hpp"
+#include "unittest.hpp"
+
+// convenience log. switch on if debugging tests. Don't use tty, plain stdio only.
+#define LOG(...) { printf(__VA_ARGS__); printf("\n"); fflush(stdout); }
+//#define LOG(...)
+
+static size_t get_total_malloc_invocs() {
+  return MallocMemorySummary::as_snapshot()->total_count();
+}
+
+static size_t get_total_malloc_size() {
+  return MallocMemorySummary::as_snapshot()->total();
+}
+
+static size_t get_malloc_overhead() {
+  return MallocMemorySummary::as_snapshot()->malloc_overhead();
+}
+
+struct totals_t { size_t n; size_t s; size_t ovrh; };
+
+static totals_t get_totals() {
+  totals_t tot;
+  tot.n = get_total_malloc_invocs();
+  tot.s = get_total_malloc_size();
+  tot.ovrh = get_malloc_overhead();
+  return tot;
+}
+
+// Concurrent code can malloc and free too, therefore we need to compare with a leeway factor
+#define compare_totals(t_real, t_expected) {                                  \
+  double leeway_factor = 0.33;                                                \
+  size_t leeway_n = (size_t)(((double)t_expected.n) * leeway_factor);         \
+  size_t leeway_s = (size_t)(((double)t_expected.s) * leeway_factor);         \
+  EXPECT_GE(t_real.n, t_expected.n - leeway_n);                               \
+  EXPECT_LE(t_real.n, t_expected.n + leeway_n);                               \
+  EXPECT_GE(t_real.s, t_expected.s - leeway_s);                               \
+  EXPECT_LE(t_real.s, t_expected.s + leeway_s);                               \
+  EXPECT_GE(t_real.ovrh, t_expected.ovrh - (leeway_n * sizeof(MallocHeader)));   \
+  EXPECT_LE(t_real.ovrh, t_expected.ovrh + (leeway_n * sizeof(MallocHeader)));   \
+  LOG("Deviation: n=" SSIZE_FORMAT ", s=" SSIZE_FORMAT ", ovrh=" SSIZE_FORMAT,   \
+      (ssize_t)t_real.n - (ssize_t)t_expected.n,                                 \
+      (ssize_t)t_real.s - (ssize_t)t_expected.s,                                 \
+      (ssize_t)t_real.ovrh - (ssize_t)t_expected.ovrh);                          \
+}
+
+TEST_VM(NMTNumbers, totals) {
+
+  if (!MemTracker::enabled()) {
+    // Skip test if NMT is disabled
+    return;
+  }
+
+  const totals_t t1 = get_totals();
+
+  LOG("t1: " SIZE_FORMAT " - " SIZE_FORMAT " - " SIZE_FORMAT, t1.n, t1.s, t1.ovrh);
+
+  static const int NUM_ALLOCS = 1024 * 16;
+  static const int ALLOC_SIZE = 1024;
+
+  void* p[NUM_ALLOCS];
+  for (int i = 0; i < NUM_ALLOCS; i ++) {
+    // spread over categories
+    int category = i % (mt_number_of_types - 1);
+    p[i] = NEW_C_HEAP_ARRAY(char, ALLOC_SIZE, (MEMFLAGS)category);
+  }
+
+  const totals_t t2 = get_totals();
+  LOG("t2: " SIZE_FORMAT " - " SIZE_FORMAT " - " SIZE_FORMAT, t2.n, t2.s, t2.ovrh);
+
+  totals_t t2_expected;
+  t2_expected.n = t1.n + NUM_ALLOCS;
+  t2_expected.s = t1.s + ALLOC_SIZE * NUM_ALLOCS;
+  t2_expected.ovrh = (t1.n + NUM_ALLOCS) * sizeof(MallocHeader);
+
+  LOG("t2 expected: " SIZE_FORMAT " - " SIZE_FORMAT " - " SIZE_FORMAT, t2_expected.n, t2_expected.s, t2_expected.ovrh);
+
+  compare_totals(t2, t2_expected);
+
+  for (int i = 0; i < NUM_ALLOCS; i ++) {
+    os::free(p[i]);
+  }
+
+  const totals_t t3 = get_totals();
+  LOG("t3: " SIZE_FORMAT " - " SIZE_FORMAT " - " SIZE_FORMAT, t3.n, t3.s, t3.ovrh);
+
+  compare_totals(t3, t1);
+
+}


### PR DESCRIPTION
I need a fast counter for global mallocs for [JDK-8291878](https://bugs.openjdk.org/browse/JDK-8291878). NMT does not keep a global counter, just category-specific counters. At the moment, `MallocMemorySummary::total()` iterates all these counters and adds them up, which is quite costly.

This patch makes `MallocMemorySummary::total()` fast by introducing a global malloc counter. However, we don't add a new counter, we just repurpose the tracking overhead counter. 

The tracking overhead counter gets updated on every malloc and counts number and size of all malloc headers. But malloc headers have always the same size. This patch uses the former overhead counter to count number and size of all mallocs. So now we have a global malloc counter, at no additional cost, and the overhead gets calculated from the number of total mallocs * constant header size.

---

Tests done:

- GHAs (which execute NMT jtreg + gtests tests in all modes)
- manual test (checking that tracking overhead numbers are the same as before)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292072](https://bugs.openjdk.org/browse/JDK-8292072): NMT: repurpose Tracking overhead counter as global malloc counter


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to [34dfad49](https://git.openjdk.org/jdk/pull/9804/files/34dfad49a15072cc727303b3ed13c1a00f5855cb)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9804/head:pull/9804` \
`$ git checkout pull/9804`

Update a local copy of the PR: \
`$ git checkout pull/9804` \
`$ git pull https://git.openjdk.org/jdk pull/9804/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9804`

View PR using the GUI difftool: \
`$ git pr show -t 9804`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9804.diff">https://git.openjdk.org/jdk/pull/9804.diff</a>

</details>
