### PR TITLE
8292075: Remove deleted test compiler/rangechecks/TestRangeCheckHoistingScaledIV.java from ProblemList

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -47,7 +47,6 @@ compiler/ciReplay/TestSAServer.java 8029528 generic-all
 compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java 8225370 generic-all
 compiler/jvmci/compilerToVM/GetFlagValueTest.java 8204459 generic-all
 compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java 8262901 macosx-aarch64
-compiler/rangechecks/TestRangeCheckHoistingScaledIV.java 8291474 generic-ppc64le
 compiler/tiered/LevelTransitionTest.java 8067651 generic-all
 
 compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java 8190680 generic-all


### PR DESCRIPTION
Trivial change that deletes `compiler/rangechecks/TestRangeCheckHoistingScaledIV.java` from `test/hotspot/jtreg/ProblemList.txt`

JDK-8291597 deleted `TestRangeCheckHoistingScaledIV.java` but did not remove the ProblemList entry.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292075](https://bugs.openjdk.org/browse/JDK-8292075): Remove deleted test compiler/rangechecks/TestRangeCheckHoistingScaledIV.java from ProblemList


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Pengfei Li](https://openjdk.org/census#pli) (@pfustc - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9805/head:pull/9805` \
`$ git checkout pull/9805`

Update a local copy of the PR: \
`$ git checkout pull/9805` \
`$ git pull https://git.openjdk.org/jdk pull/9805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9805`

View PR using the GUI difftool: \
`$ git pr show -t 9805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9805.diff">https://git.openjdk.org/jdk/pull/9805.diff</a>

</details>
