### PR TITLE
8292062: misc javax/swing tests failing

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
@@ -724,6 +724,8 @@ public class SynthLookAndFeel extends BasicLookAndFeel {
         table.put("Menu.shortcutKeys",
                   new int[] {
                           SwingUtilities2.getSystemMnemonicKeyMask(),
+                          SwingUtilities2.setAltGraphMask(
+                             SwingUtilities2.getSystemMnemonicKeyMask())
                   });
 
         // enabled antialiasing depending on desktop settings

--- a/test/jdk/javax/swing/JList/4618767/JListSelectedElementTest.java
+++ b/test/jdk/javax/swing/JList/4618767/JListSelectedElementTest.java
@@ -50,7 +50,7 @@ import static javax.swing.UIManager.getInstalledLookAndFeels;
 /*
  * @test
  * @key headful
- * @bug 4618767
+ * @bug 4618767 8292062
  * @summary This test confirms that typing a letter while a JList has focus now makes the selection
  *          not jump to the item whose text starts with that letter if that typed letter is accompanied
  *          by modifier keys such as ALT or CTRL(eg: ALT+F).
@@ -117,8 +117,8 @@ public class JListSelectedElementTest {
                 }
 
                 // Now operate Menu using Mnemonics, different key combinations for different OSes.
-                // For most OSes it's ALT+F; on macOS it's ALT+CNTRL+F except for Nimbus LaF.
-                if (isMac && !laf.contains("Nimbus")) {
+                // For most OSes it's ALT+F; on macOS it's ALT+CNTRL+F.
+                if (isMac) {
                     hitKeys(KeyEvent.VK_ALT, KeyEvent.VK_CONTROL, FILE_MENU);
                 } else {
                     hitKeys(KeyEvent.VK_ALT, FILE_MENU);

--- a/test/jdk/javax/swing/JTree/4618767/JTreeSelectedElementTest.java
+++ b/test/jdk/javax/swing/JTree/4618767/JTreeSelectedElementTest.java
@@ -50,7 +50,7 @@ import static javax.swing.UIManager.getInstalledLookAndFeels;
 /*
  * @test
  * @key headful
- * @bug 4618767
+ * @bug 4618767 8292062
  * @summary This test confirms that typing a letter while a JTree has focus now makes the selection
  *          not jump to the item whose text starts with that letter if that typed letter is accompanied
  *          by modifier keys such as ALT or CTRL(eg: ALT+F).
@@ -107,8 +107,8 @@ public class JTreeSelectedElementTest {
                 }
 
                 // Now operate Menu using Mnemonics, different key combinations for different OSes.
-                // For most OSes it's ALT+F; on macOS it's ALT+CNTRL+F except for Nimbus LaF.
-                if (isMac && !laf.contains("Nimbus")) {
+                // For most OSes it's ALT+F; on macOS it's ALT+CNTRL+F.
+                if (isMac) {
                     hitKeys(KeyEvent.VK_ALT, KeyEvent.VK_CONTROL, FILE_MENU);
                 } else {
                     hitKeys(KeyEvent.VK_ALT, FILE_MENU);

--- a/test/jdk/javax/swing/event/RightAltKeyTest.java
+++ b/test/jdk/javax/swing/event/RightAltKeyTest.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @key headful
- * @bug 8194873
+ * @bug 8194873 8292062
  * @requires (os.family == "Windows")
  * @summary Checks that right ALT (ALT_GRAPH) key works on Swing components
  * @run main RightAltKeyTest


### PR DESCRIPTION
In [PR#9488](https://github.com/openjdk/jdk/pull/9488) https://git.openjdk.org/jdk/commit/b2f0cbdca109507e5f8e0c185f601c0c1e31f4fb
`CTRL+ALT` mnemonic support was added for Nimbus in macOS instead of `Alt`

so 2 of the 3 tests were failing after that, as it has workaround for non-support of CTRL+ALT mnemonic in macos for Nimbus L&F.
That workaround is now removed for the tests to now pass.

For RightAltKey test failure, we should have ALT_GRAPH mask for Menu.shortcutKeys also,
 as it is done for
https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLookAndFeel.java#L1101

so ALT_GRAPH support was added for Nimbus Menu.shortcutKeys

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292062](https://bugs.openjdk.org/browse/JDK-8292062): misc javax/swing tests failing


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9808/head:pull/9808` \
`$ git checkout pull/9808`

Update a local copy of the PR: \
`$ git checkout pull/9808` \
`$ git pull https://git.openjdk.org/jdk pull/9808/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9808`

View PR using the GUI difftool: \
`$ git pr show -t 9808`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9808.diff">https://git.openjdk.org/jdk/pull/9808.diff</a>

</details>
