### PR TITLE
8292082: Deprecate UseRTM* for removal

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -536,6 +536,10 @@ static SpecialFlag const special_jvm_flags[] = {
   { "DynamicDumpSharedSpaces",      JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
   { "RequireSharedSpaces",          JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
   { "UseSharedSpaces",              JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
+  { "UseRTMLocking",                JDK_Version::jdk(20), JDK_Version::jdk(21), JDK_Version::jdk(22) },
+  { "UseRTMDeopt",                  JDK_Version::jdk(20), JDK_Version::jdk(21), JDK_Version::jdk(22) },
+  { "UseRTMForStackLocks",          JDK_Version::jdk(20), JDK_Version::jdk(21), JDK_Version::undefined() },
+  { "UseRTMXendForLockBusy",        JDK_Version::jdk(20), JDK_Version::jdk(21), JDK_Version::undefined() },
 
   // --- Deprecated alias flags (see also aliased_jvm_flags) - sorted by obsolete_in then expired_in:
   { "DefaultMaxRAMFraction",        JDK_Version::jdk(8),  JDK_Version::undefined(), JDK_Version::undefined() },

--- a/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
@@ -67,6 +67,14 @@ public class VMDeprecatedOptions {
             {"CreateMinidumpOnCrash", "false"}
           }
         ));
+        if (Platform.isX86() || Platform.isX64() || Platform.isPPC()) {
+          deprecated.addAll(
+            Arrays.asList(new String[][] {
+              {"UseRTMLocking",         "false"},
+              {"UseRTMDeopt",           "false"},
+            })
+          );
+        }
         if (wb.isJFRIncluded()) {
             deprecated.add(new String[] {"FlightRecorder", "false"});
         }


### PR DESCRIPTION
HotSpot supports RTM (restricted transactional memory) to be used for locking and deoptimization. RTM has since been disabled in Intel processors due to security vulnerabilities [0] and IBM removed support for it since its Power 10 line. RTM adds unnecessarily to complexity and maintenance burden.

I would like to propose to deprecate the relevant flags for removal, and actually remove the flags and all related code in a later release, unless somebody comes up with a good reason and performance comparison to show that it's worth keeping.

[0] https://en.wikipedia.org/wiki/Transactional_Synchronization_Extensions#History_and_bugs

Testing:
 - [x] runtime/CommandLine/VMDeprecatedOptions.java
 - [x] tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request to be approved

### Issues
 * [JDK-8292082](https://bugs.openjdk.org/browse/JDK-8292082): Deprecate UseRTM* for removal
 * [JDK-8292096](https://bugs.openjdk.org/browse/JDK-8292096): Deprecate UseRTM* for removal (**CSR**)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9810/head:pull/9810` \
`$ git checkout pull/9810`

Update a local copy of the PR: \
`$ git checkout pull/9810` \
`$ git pull https://git.openjdk.org/jdk pull/9810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9810`

View PR using the GUI difftool: \
`$ git pr show -t 9810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9810.diff">https://git.openjdk.org/jdk/pull/9810.diff</a>

</details>
