### PR TITLE
8292119: ProblemList java/awt/image/multiresolution/MultiresolutionIconTest.java on linux-x64 and windows-all

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -468,6 +468,7 @@ java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java 8266243 macosx-
 java/awt/dnd/BadSerializationTest/BadSerializationTest.java 8277817 linux-x64,windows-x64
 java/awt/GraphicsDevice/CheckDisplayModes.java 8266242 macosx-aarch64
 java/awt/GraphicsDevice/DisplayModes/UnknownRefrshRateTest.java 8286436 macosx-aarch64
+java/awt/image/multiresolution/MultiresolutionIconTest.java 8291979 linux-x64,windows-all
 
 ############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList java/awt/image/multiresolution/MultiresolutionIconTest.java
on linux-x64 and windows-all

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292119](https://bugs.openjdk.org/browse/JDK-8292119): ProblemList java/awt/image/multiresolution/MultiresolutionIconTest.java on linux-x64 and windows-all


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9811/head:pull/9811` \
`$ git checkout pull/9811`

Update a local copy of the PR: \
`$ git checkout pull/9811` \
`$ git pull https://git.openjdk.org/jdk pull/9811/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9811`

View PR using the GUI difftool: \
`$ git pr show -t 9811`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9811.diff">https://git.openjdk.org/jdk/pull/9811.diff</a>

</details>
