### PR TITLE
8292132: ProblemList jdk/internal/misc/TerminatingThreadLocal/TestTerminatingThreadLocal.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -496,6 +496,7 @@ java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-x64
 java/lang/invoke/RicochetTest.java                              8251969 generic-all
 java/lang/ProcessBuilder/PipelineLeaksFD.java                   8291760 linux-all
+jdk/internal/misc/TerminatingThreadLocal/TestTerminatingThreadLocal.java 8292051 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList jdk/internal/misc/TerminatingThreadLocal/TestTerminatingThreadLocal.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292132](https://bugs.openjdk.org/browse/JDK-8292132): ProblemList jdk/internal/misc/TerminatingThreadLocal/TestTerminatingThreadLocal.java


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9812/head:pull/9812` \
`$ git checkout pull/9812`

Update a local copy of the PR: \
`$ git checkout pull/9812` \
`$ git pull https://git.openjdk.org/jdk pull/9812/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9812`

View PR using the GUI difftool: \
`$ git pr show -t 9812`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9812.diff">https://git.openjdk.org/jdk/pull/9812.diff</a>

</details>
