### PR TITLE
8292350: Use static methods for hashCode/toString primitives

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/ScreenMenu.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/ScreenMenu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -420,9 +420,9 @@ final class ScreenMenu extends Menu
             final KeyStroke ks = mi.getAccelerator();
             if (ks != null) hashCode ^= ks.hashCode();
 
-            hashCode ^= Boolean.valueOf(mi.isVisible()).hashCode();
-            hashCode ^= Boolean.valueOf(mi.isEnabled()).hashCode();
-            hashCode ^= Boolean.valueOf(mi.isSelected()).hashCode();
+            hashCode ^= Boolean.hashCode(mi.isVisible());
+            hashCode ^= Boolean.hashCode(mi.isEnabled());
+            hashCode ^= Boolean.hashCode(mi.isSelected());
 
         } else if (m instanceof JSeparator) {
             hashCode ^= "-".hashCode();

--- a/src/java.management/share/classes/javax/management/openmbean/ArrayType.java
+++ b/src/java.management/share/classes/javax/management/openmbean/ArrayType.java
@@ -745,7 +745,7 @@ public class ArrayType<T> extends OpenType<T> {
             int value = 0;
             value += dimension;
             value += elementType.hashCode();
-            value += Boolean.valueOf(primitiveArray).hashCode();
+            value += Boolean.hashCode(primitiveArray);
             myHashCode = Integer.valueOf(value);
         }
 

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/internal/WebRowSetXmlWriter.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/internal/WebRowSetXmlWriter.java
@@ -569,7 +569,7 @@ public class WebRowSetXmlWriter implements XmlWriter, Serializable {
     }
 
     private void writeBoolean(boolean b) throws java.io.IOException {
-        writer.write(Boolean.valueOf(b).toString());
+        writer.write(Boolean.toString(b));
     }
 
     private void writeFloat(float f) throws java.io.IOException {

--- a/src/jdk.hotspot.agent/share/classes/com/sun/java/swing/ui/WizardDlg.java
+++ b/src/jdk.hotspot.agent/share/classes/com/sun/java/swing/ui/WizardDlg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -149,7 +149,7 @@ public class WizardDlg extends JDialog
         this.panels = panels;
         panesPanel.removeAll();
         for(int i = 0; i < numCards; i++)
-            panesPanel.add((JPanel)panels.elementAt(i), (Integer.valueOf(i)).toString());
+            panesPanel.add((JPanel)panels.elementAt(i), Integer.toString(i));
 
         validate();
         enableBackNextButtons();


### PR DESCRIPTION
It's a bit shorter and clearer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292350](https://bugs.openjdk.org/browse/JDK-8292350): Use static methods for hashCode/toString primitives


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9816/head:pull/9816` \
`$ git checkout pull/9816`

Update a local copy of the PR: \
`$ git checkout pull/9816` \
`$ git pull https://git.openjdk.org/jdk pull/9816/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9816`

View PR using the GUI difftool: \
`$ git pr show -t 9816`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9816.diff">https://git.openjdk.org/jdk/pull/9816.diff</a>

</details>
