### PR TITLE
8292077: G1 nmethod entry barriers don't keep oops alive

### DIFF
--- a/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
@@ -41,7 +41,6 @@
 #include "utilities/debug.hpp"
 
 class OopKeepaliveClosure : public OopClosure {
-private:
   CollectedHeap* _heap;
 
 public:
@@ -114,14 +113,8 @@ public:
 void BarrierSetNMethod::arm_all_nmethods() {
   // Change to a new global GC phase. Doing this requires changing the thread-local
   // disarm value for all threads, to reflect the new GC phase.
-  // We wrap around at INT_MAX. That means that we assume nmethods won't have ABA
-  // problems in their nmethod disarm values after INT_MAX - 1 GCs. Every time a GC
-  // completes, ABA problems are removed, but if a concurrent GC is started and then
-  // aborted N times, that is when there could be ABA problems. If there are anything
-  // close to INT_MAX - 1 GCs starting without being able to finish, something is
-  // seriously wrong.
   ++_current_phase;
-  if (_current_phase == INT_MAX) {
+  if (_current_phase == 4) {
     _current_phase = 1;
   }
   BarrierSetNMethodArmClosure cl(_current_phase);

--- a/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
@@ -63,8 +63,6 @@ bool BarrierSetNMethod::supports_entry_barrier(nmethod* nm) {
 bool BarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
   class OopKeepAliveClosure : public OopClosure {
   public:
-    OopKeepAliveClosure() {}
-
     virtual void do_oop(oop* p) {
       // Loads on nmethod oops are phantom strength. The intend of the load
       // is to just read the oop, and then explicitly keep it alive w.r.t.


### PR DESCRIPTION
The intention is that when G1 uses nmethod entry barriers (currently with --enable-preview to support Loom, but soon also with https://bugs.openjdk.org/browse/JDK-8290025), it keeps nmethod oops alive the first time an nmethod becomes on-stack during concurrent marking. The current code fails to do that, even though it intended to. That should be fixed.

There was code from loom to keep the oops alive by performing a phantom load. However, there is a quirk with the access API; if you don't assign the result of the load to something, the load won't be performed, and hence the oop won't be kept alive. I changed the code to use CollectedHeap::keep_alive explicitly instead of relying on side effects of a dummy load.
I also found that we assume G1 concurrent marking isn't aborted more than once. But that can happen. I made the assumption more conservative - surely if there are INT_MAX - 1 interrupted concurrent GCs in a row... something is very very wrong.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292077](https://bugs.openjdk.org/browse/JDK-8292077): G1 nmethod entry barriers don't keep oops alive


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [7f2f347e](https://git.openjdk.org/jdk/pull/9817/files/7f2f347e0949eb2d23ce4473f7676f43a5132700)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9817/head:pull/9817` \
`$ git checkout pull/9817`

Update a local copy of the PR: \
`$ git checkout pull/9817` \
`$ git pull https://git.openjdk.org/jdk pull/9817/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9817`

View PR using the GUI difftool: \
`$ git pr show -t 9817`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9817.diff">https://git.openjdk.org/jdk/pull/9817.diff</a>

</details>
