### PR TITLE
8292194: G1 nmethod entry barrier disarm value wraps around too early

### DIFF
--- a/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
@@ -105,8 +105,14 @@ public:
 void BarrierSetNMethod::arm_all_nmethods() {
   // Change to a new global GC phase. Doing this requires changing the thread-local
   // disarm value for all threads, to reflect the new GC phase.
+  // We wrap around at INT_MAX. That means that we assume nmethods won't have ABA
+  // problems in their nmethod disarm values after INT_MAX - 1 GCs. Every time a GC
+  // completes, ABA problems are removed, but if a concurrent GC is started and then
+  // aborted N times, that is when there could be ABA problems. If there are anything
+  // close to INT_MAX - 1 GCs starting without being able to finish, something is
+  // seriously wrong.
   ++_current_phase;
-  if (_current_phase == 4) {
+  if (_current_phase == INT_MAX) {
     _current_phase = 1;
   }
   BarrierSetNMethodArmClosure cl(_current_phase);


### PR DESCRIPTION
The disarm value for G1 nmethod entry barriers assumes that a concurrent GC can be aborted at most once. However, it can happen many times. In order to avoid ABA issues in the nmethod entry barriers, the limit for wrapping around and reusing numbers needs to be higher. This patch changes that point to INT_MAX as there is little point in using lower values.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292194](https://bugs.openjdk.org/browse/JDK-8292194): G1 nmethod entry barrier disarm value wraps around too early


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9822/head:pull/9822` \
`$ git checkout pull/9822`

Update a local copy of the PR: \
`$ git checkout pull/9822` \
`$ git pull https://git.openjdk.org/jdk pull/9822/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9822`

View PR using the GUI difftool: \
`$ git pr show -t 9822`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9822.diff">https://git.openjdk.org/jdk/pull/9822.diff</a>

</details>
