### PR TITLE
8284313: Improve warning messages when CDS archive fails to load

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -462,6 +462,11 @@ bool SharedClassPathEntry::validate(bool is_class_path) const {
     } else {
       FileMapInfo::fail_continue("A jar file is not the one used while building"
                                  " the shared archive file: %s", name);
+      if (_timestamp != st.st_mtime) {
+        log_warning(cds)("%s timestamp has changed.", name);
+      } else {
+        log_warning(cds)("%s size has changed.", name);
+      }
     }
   }
 
@@ -1052,7 +1057,11 @@ bool FileMapInfo::validate_shared_path_table() {
     assert(shared_path(0)->is_modules_image(), "first shared_path must be the modules image");
   } else {
     if (!validate_boot_class_paths() || !validate_app_class_paths(shared_app_paths_len)) {
-      fail_continue("shared class paths mismatch (hint: enable -Xlog:class+path=info to diagnose the failure)");
+      const char* mismatch_msg = "shared class paths mismatch (hint: enable -Xlog:class+path=info to diagnose the failure)";
+      fail_continue("%s", mismatch_msg);
+      if (!log_is_enabled(Info, cds) && !log_is_enabled(Info, class, path)) {
+        log_warning(cds)("%s", mismatch_msg);
+      }
       return false;
     }
   }

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -462,6 +462,10 @@ bool SharedClassPathEntry::validate(bool is_class_path) const {
     } else {
       FileMapInfo::fail_continue("A jar file is not the one used while building"
                                  " the shared archive file: %s", name);
+      if (!log_is_enabled(Info, cds)) {
+        log_warning(cds)("A jar file is not the one used while building"
+            " the shared archive file: %s", name);
+      }
       if (_timestamp != st.st_mtime) {
         log_warning(cds)("%s timestamp has changed.", name);
       } else {

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -460,11 +460,10 @@ bool SharedClassPathEntry::validate(bool is_class_path) const {
                                  "Timestamp mismatch" :
                                  "File size mismatch");
     } else {
-      FileMapInfo::fail_continue("A jar file is not the one used while building"
-                                 " the shared archive file: %s", name);
+      const char* bad_jar_msg = "A jar file is not the one used while building the shared archive file:";
+      FileMapInfo::fail_continue("%s %s", bad_jar_msg, name);
       if (!log_is_enabled(Info, cds)) {
-        log_warning(cds)("A jar file is not the one used while building"
-            " the shared archive file: %s", name);
+        log_warning(cds)("%s %s", bad_jar_msg, name);
       }
       if (_timestamp != st.st_mtime) {
         log_warning(cds)("%s timestamp has changed.", name);

--- a/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
@@ -54,7 +54,7 @@ public class WrongClasspath {
         .assertAbnormalExit(unableToUseMsg, mismatchMsg);
 
     // Run with -Xshare:auto and without CDS logging enabled, the mismatch message
-    // should stil be there.
+    // should still be there.
     OutputAnalyzer output = TestCommon.execAuto("Hello");
     output.shouldContain(mismatchMsg);
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
@@ -77,6 +77,7 @@ public class WrongClasspath {
     // message should be there.
     output = TestCommon.execAuto(
         "-cp", jars, "Hello");
-    output.shouldContain("jar2.jar timestamp has changed.");
+    output.shouldMatch(".warning..cds. A jar file is not the one used while building the shared archive file:.*jar2.jar")
+          .shouldMatch(".warning..cds.*jar2.jar timestamp has changed.");
   }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,8 @@ public class WrongClasspath {
 
   public static void main(String[] args) throws Exception {
     String appJar = JarBuilder.getOrCreateHelloJar();
+    String unableToUseMsg = "Unable to use shared archive";
+    String mismatchMsg = "shared class paths mismatch (hint: enable -Xlog:class+path=info to diagnose the failure)";
 
     // Dump an archive with a specified JAR file in -classpath
     TestCommon.testDump(appJar, TestCommon.list("Hello"));
@@ -49,8 +51,14 @@ public class WrongClasspath {
         /* "-cp", appJar, */ // <- uncomment this and the execution should succeed
         "-Xlog:cds",
         "Hello")
-        .assertAbnormalExit("Unable to use shared archive",
-                            "shared class paths mismatch");
+        .assertAbnormalExit(unableToUseMsg, mismatchMsg);
+
+    // Run with -Xshare:auto and without CDS logging enabled, the mismatch message
+    // should stil be there.
+    OutputAnalyzer output = TestCommon.execAuto(
+        /* "-cp", appJar, */ // <- uncomment this and the execution should succeed
+        "Hello");
+    output.shouldContain(mismatchMsg);
 
     // Dump CDS archive with 2 jars: -cp hello.jar:jar2.jar
     // Run with 2 jars but the second jar doesn't exist: -cp hello.jarjar2.jarx
@@ -60,7 +68,15 @@ public class WrongClasspath {
     TestCommon.testDump(jars, TestCommon.list("Hello", "pkg/C2"));
     TestCommon.run(
         "-cp", jars + "x", "Hello")
-        .assertAbnormalExit("Unable to use shared archive",
-                            "shared class paths mismatch");
+        .assertAbnormalExit(unableToUseMsg, mismatchMsg);
+
+    // modify the timestamp of the jar2
+    (new File(jar2.toString())).setLastModified(System.currentTimeMillis() + 2000);
+
+    // Run with -Xshare:auto and without CDS logging enabled, the "timestamp has changed"
+    // message should be there.
+    output = TestCommon.execAuto(
+        "-cp", jars, "Hello");
+    output.shouldContain("jar2.jar timestamp has changed.");
   }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
@@ -55,9 +55,7 @@ public class WrongClasspath {
 
     // Run with -Xshare:auto and without CDS logging enabled, the mismatch message
     // should stil be there.
-    OutputAnalyzer output = TestCommon.execAuto(
-        /* "-cp", appJar, */ // <- uncomment this and the execution should succeed
-        "Hello");
+    OutputAnalyzer output = TestCommon.execAuto("Hello");
     output.shouldContain(mismatchMsg);
 
     // Dump CDS archive with 2 jars: -cp hello.jar:jar2.jar

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/WrongTopClasspath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/WrongTopClasspath.java
@@ -95,6 +95,9 @@ public class WrongTopClasspath extends DynamicArchiveTestBase {
                 "-cp", appJar, mainClass,
                 "assertShared:java.lang.Object",  // base archive still useable
                 "assertNotShared:GenericTestApp") // but top archive is not useable
-          .assertNormalExit(topArchiveMsg, "GenericTestApp.jar timestamp has changed.");
+          .assertNormalExit(output -> {
+              output.shouldContain(topArchiveMsg);
+              output.shouldMatch(".warning..cds. A jar file is not the one used while building the shared archive file:.*GenericTestApp.jar");
+              output.shouldMatch(".warning..cds.*GenericTestApp.jar timestamp has changed.");});
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/WrongTopClasspath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/WrongTopClasspath.java
@@ -60,6 +60,8 @@ public class WrongTopClasspath extends DynamicArchiveTestBase {
                  "-cp", appJar, mainClass)
             .assertNormalExit();
 
+        String topArchiveMsg = "The top archive failed to load";
+
         // ... but try to load the top archive using "-cp WrongJar.jar".
         // Use -Xshare:auto so top archive can fail after base archive has succeeded,
         // but the app will continue to run.
@@ -71,6 +73,28 @@ public class WrongTopClasspath extends DynamicArchiveTestBase {
                 "-cp", wrongJar, mainClass,
                 "assertShared:java.lang.Object",  // base archive still useable
                 "assertNotShared:GenericTestApp") // but top archive is not useable
-          .assertNormalExit("The top archive failed to load");
+          .assertNormalExit(topArchiveMsg);
+
+        // Turn off all CDS logging, the "shared class paths mismatch" warning
+        // message should still be there.
+        run2_WB(baseArchiveName, topArchiveName,
+                "-Xshare:auto",
+                "-cp", wrongJar, mainClass,
+                "assertShared:java.lang.Object",  // base archive still useable
+                "assertNotShared:GenericTestApp") // but top archive is not useable
+          .assertNormalExit(topArchiveMsg,
+                            "[warning][cds] shared class paths mismatch (hint: enable -Xlog:class+path=info to diagnose the failure)");
+
+        // modify the timestamp of appJar
+        (new File(appJar.toString())).setLastModified(System.currentTimeMillis() + 2000);
+
+        // Without CDS logging enabled, the "timestamp has changed" message should
+        // be there.
+        run2_WB(baseArchiveName, topArchiveName,
+                "-Xshare:auto",
+                "-cp", appJar, mainClass,
+                "assertShared:java.lang.Object",  // base archive still useable
+                "assertNotShared:GenericTestApp") // but top archive is not useable
+          .assertNormalExit(topArchiveMsg, "GenericTestApp.jar timestamp has changed.");
     }
 }


### PR DESCRIPTION
Please review this change for adding more helpful messages when a CDS archive has failed to load without CDS logging being enabled.

e.g. warning for mismatch class paths between dump time and run time:
`[warning][cds] shared class paths mismatch (hint: enable -Xlog:class+path=info to diagnose the failure)`

warning if a timestamp of a jar file has been changed during run time:
`[warning][cds] app.jar timestamp has changed.`

Passed mach5 tiers 1,2,3 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284313](https://bugs.openjdk.org/browse/JDK-8284313): Improve warning messages when CDS archive fails to load


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to [64c7aa16](https://git.openjdk.org/jdk/pull/9823/files/64c7aa1614880559b51a450dc621d00ef6c517f4)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [08dc3a15](https://git.openjdk.org/jdk/pull/9823/files/08dc3a156b5eb0b7849b9f31647df1c6dd8aa79d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9823/head:pull/9823` \
`$ git checkout pull/9823`

Update a local copy of the PR: \
`$ git checkout pull/9823` \
`$ git pull https://git.openjdk.org/jdk pull/9823/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9823`

View PR using the GUI difftool: \
`$ git pr show -t 9823`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9823.diff">https://git.openjdk.org/jdk/pull/9823.diff</a>

</details>
