### PR TITLE
8292200: Add java/io/File/GetXSpace.java to Windows problem list

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -511,6 +511,7 @@ java/lang/instrument/RetransformBigClass.sh                     8065756 generic-
 
 java/io/pathNames/GeneralWin32.java                             8180264 windows-all
 java/io/File/createTempFile/SpecialTempFile.java                8274122 windows11
+java/io/File/GetXSpace.java                                     8291911 windows-all
 
 ############################################################################
 


### PR DESCRIPTION
Reduce the failure noise for now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292200](https://bugs.openjdk.org/browse/JDK-8292200): Add java/io/File/GetXSpace.java to Windows problem list


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9824/head:pull/9824` \
`$ git checkout pull/9824`

Update a local copy of the PR: \
`$ git checkout pull/9824` \
`$ git pull https://git.openjdk.org/jdk pull/9824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9824`

View PR using the GUI difftool: \
`$ git pr show -t 9824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9824.diff">https://git.openjdk.org/jdk/pull/9824.diff</a>

</details>
