### PR TITLE
8292226: Prepare make for better Link Time Optimization support

### DIFF
--- a/make/common/Utils.gmk
+++ b/make/common/Utils.gmk
@@ -367,6 +367,9 @@ isBuildCpu = \
 isBuildCpuArch = \
   $(strip $(if $(filter $(OPENJDK_BUILD_CPU_ARCH), $1), true, false))
 
+isCompiler = \
+  $(strip $(if $(filter $(TOOLCHAIN_TYPE), $1), true, false))
+
 ################################################################################
 # Converts a space separated list to a comma separated list.
 #

--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -170,7 +170,7 @@ endif
 
 ifeq ($(call check-jvm-feature, link-time-opt), true)
   ifeq ($(call isCompiler, gcc), true)
-    # NOTE: Disable automatic opimization level and let the explicit cflag control
+    # NOTE: Disable automatic optimization level and let the explicit cflag control
     # optimization level instead. This activates O3 on slowdebug builds, just
     # like the old build, but it's probably not right.
     JVM_OPTIMIZATION :=

--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -170,14 +170,9 @@ endif
 
 ifeq ($(call check-jvm-feature, link-time-opt), true)
   ifeq ($(call isCompiler, gcc), true)
-    ifneq ($(call check-jvm-feature, opt-size), true)
-      # NOTE: Disable automatic optimization level and let the explicit cflag control
-      # optimization level instead. This activates O3 on slowdebug builds, just
-      # like the old build, but it's probably not right.
-      JVM_OPTIMIZATION :=
-      JVM_CFLAGS_FEATURES += -O3
-      JVM_LDFLAGS_FEATURES += -O3
-    endif
+    # Set JVM_OPTIMIZATION directly so other jvm-feature flags can override it
+    # later on if desired
+    JVM_OPTIMIZATION := HIGHEST_JVM
     JVM_CFLAGS_FEATURES += -flto -fuse-linker-plugin
     JVM_LDFLAGS_FEATURES += -flto -fuse-linker-plugin -fno-strict-aliasing
   endif

--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -170,12 +170,16 @@ endif
 
 ifeq ($(call check-jvm-feature, link-time-opt), true)
   ifeq ($(call isCompiler, gcc), true)
-    # NOTE: Disable automatic optimization level and let the explicit cflag control
-    # optimization level instead. This activates O3 on slowdebug builds, just
-    # like the old build, but it's probably not right.
-    JVM_OPTIMIZATION :=
-    JVM_CFLAGS_FEATURES += -O3 -flto -fuse-linker-plugin
-    JVM_LDFLAGS_FEATURES += -O3 -flto -fuse-linker-plugin -fno-strict-aliasing
+    ifneq ($(call check-jvm-feature, opt-size), true)
+      # NOTE: Disable automatic optimization level and let the explicit cflag control
+      # optimization level instead. This activates O3 on slowdebug builds, just
+      # like the old build, but it's probably not right.
+      JVM_OPTIMIZATION :=
+      JVM_CFLAGS_FEATURES += -O3
+      JVM_LDFLAGS_FEATURES += -O3
+    endif
+    JVM_CFLAGS_FEATURES += -flto -fuse-linker-plugin
+    JVM_LDFLAGS_FEATURES += -flto -fuse-linker-plugin -fno-strict-aliasing
   endif
 endif
 

--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -169,10 +169,10 @@ endif
 ################################################################################
 
 ifeq ($(call check-jvm-feature, link-time-opt), true)
+  # Set JVM_OPTIMIZATION directly so other jvm-feature flags can override it
+  # later on if desired
+  JVM_OPTIMIZATION := HIGHEST_JVM
   ifeq ($(call isCompiler, gcc), true)
-    # Set JVM_OPTIMIZATION directly so other jvm-feature flags can override it
-    # later on if desired
-    JVM_OPTIMIZATION := HIGHEST_JVM
     JVM_CFLAGS_FEATURES += -flto -fuse-linker-plugin
     JVM_LDFLAGS_FEATURES += -flto -fuse-linker-plugin -fno-strict-aliasing
   endif

--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -169,12 +169,14 @@ endif
 ################################################################################
 
 ifeq ($(call check-jvm-feature, link-time-opt), true)
-  # NOTE: Disable automatic opimization level and let the explicit cflag control
-  # optimization level instead. This activates O3 on slowdebug builds, just
-  # like the old build, but it's probably not right.
-  JVM_OPTIMIZATION :=
-  JVM_CFLAGS_FEATURES += -O3 -flto
-  JVM_LDFLAGS_FEATURES += -O3 -flto -fuse-linker-plugin -fno-strict-aliasing
+  ifeq ($(call isCompiler, gcc), true)
+    # NOTE: Disable automatic opimization level and let the explicit cflag control
+    # optimization level instead. This activates O3 on slowdebug builds, just
+    # like the old build, but it's probably not right.
+    JVM_OPTIMIZATION :=
+    JVM_CFLAGS_FEATURES += -O3 -flto -fuse-linker-plugin
+    JVM_LDFLAGS_FEATURES += -O3 -flto -fuse-linker-plugin -fno-strict-aliasing
+  endif
 endif
 
 ifeq ($(call check-jvm-feature, opt-size), true)


### PR DESCRIPTION
The support for Link Time Optimization in the JDK's make system could do with some cleaning up, at the moment it simply assumes the compiler is gcc and sets the flags as such. Instead of introducing changes in bulk, as a first step, it would be good to simply supply the appropriate flags depending on the compiler and refine the flags for the one existing compiler with support for it. In practice the latter just means adding the proper -fuse-linker-plugin to gcc compile step when link-time-opt is specified, as without it the compiler generates both native code and information rich representation for Link Time Optimization. With this flag, native code generation is disabled and object files will contain only code required for Link Time Optimization, thus speeding up compile times as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292226](https://bugs.openjdk.org/browse/JDK-8292226): Prepare make for better Link Time Optimization support


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9829/head:pull/9829` \
`$ git checkout pull/9829`

Update a local copy of the PR: \
`$ git checkout pull/9829` \
`$ git pull https://git.openjdk.org/jdk pull/9829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9829`

View PR using the GUI difftool: \
`$ git pr show -t 9829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9829.diff">https://git.openjdk.org/jdk/pull/9829.diff</a>

</details>
