### PR TITLE
8292190: [IR Framework] Remove redundant regex matching for failing counts constraints

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/CountsRegexFailure.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/CountsRegexFailure.java
@@ -35,7 +35,8 @@ import java.util.List;
 class CountsRegexFailure extends RegexFailure {
     String failedComparison;
 
-    public CountsRegexFailure(String nodeRegex, int nodeId, long foundValue, Comparison<Long> comparison, List<String> matches) {
+    public CountsRegexFailure(String nodeRegex, int nodeId, int foundValue, Comparison<Integer> comparison,
+                              List<String> matches) {
         super(nodeRegex, nodeId, matches);
         this.failedComparison = "[found] " + foundValue + " " + comparison.getComparator() + " "
                                 + comparison.getGivenValue() + " [given]";


### PR DESCRIPTION
When checking a counts constraint, we are applying regex matching on the compilation output but only keep the count of all matches:

https://github.com/openjdk/jdk/blob/37d3146cca2c40dd53fcebd9cb78595f018b3489/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/Counts.java#L92-L96

If that does not match the expected count (L87) as stated in the IR rule (i.e. an IR matching failure), we reapply regex matching (L102) to get the matched output as well (used for the reporting):

https://github.com/openjdk/jdk/blob/37d3146cca2c40dd53fcebd9cb78595f018b3489/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/Counts.java#L85-L89

https://github.com/openjdk/jdk/blob/37d3146cca2c40dd53fcebd9cb78595f018b3489/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/Counts.java#L98-L103

This is not efficient and is now merged into a single regex matching application which is especially beneficial when matching on large compilation output strings (as for example seen in Valhalla IR tests).

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292190](https://bugs.openjdk.org/browse/JDK-8292190): [IR Framework] Remove redundant regex matching for failing counts constraints


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9831/head:pull/9831` \
`$ git checkout pull/9831`

Update a local copy of the PR: \
`$ git checkout pull/9831` \
`$ git pull https://git.openjdk.org/jdk pull/9831/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9831`

View PR using the GUI difftool: \
`$ git pr show -t 9831`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9831.diff">https://git.openjdk.org/jdk/pull/9831.diff</a>

</details>
