### PR TITLE
8292280: Unused field 'keyListener' in BasicRadioButtonUI

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicRadioButtonUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicRadioButtonUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,16 +26,11 @@
 package javax.swing.plaf.basic;
 
 import java.awt.*;
-import java.awt.event.*;
 import javax.swing.*;
-import javax.swing.border.*;
 import javax.swing.plaf.*;
 import javax.swing.text.View;
 import sun.swing.SwingUtilities2;
 import sun.awt.AppContext;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * RadioButtonUI implementation for BasicRadioButtonUI
@@ -54,8 +49,6 @@ public class BasicRadioButtonUI extends BasicToggleButtonUI
     private boolean defaults_initialized = false;
 
     private static final String propertyPrefix = "RadioButton" + ".";
-
-    private KeyListener keyListener = null;
 
     // ********************************
     //        Create PLAF
@@ -152,8 +145,6 @@ public class BasicRadioButtonUI extends BasicToggleButtonUI
         textRect.x = textRect.y = textRect.width = textRect.height = 0;
 
         Icon altIcon = b.getIcon();
-        Icon selectedIcon = null;
-        Icon disabledIcon = null;
 
         String text = SwingUtilities.layoutCompoundLabel(
             c, fm, b.getText(), altIcon != null ? altIcon : getDefaultIcon(),

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicRadioButtonUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicRadioButtonUI.java
@@ -145,6 +145,8 @@ public class BasicRadioButtonUI extends BasicToggleButtonUI
         textRect.x = textRect.y = textRect.width = textRect.height = 0;
 
         Icon altIcon = b.getIcon();
+        Icon selectedIcon = null;
+        Icon disabledIcon = null;
 
         String text = SwingUtilities.layoutCompoundLabel(
             c, fm, b.getText(), altIcon != null ? altIcon : getDefaultIcon(),


### PR DESCRIPTION
Field `keyListener` was added under [JDK-8033699](https://bugs.openjdk.org/browse/JDK-8033699). But then all its usages were removed in [JDK-8249548](https://bugs.openjdk.org/browse/JDK-8249548)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292280](https://bugs.openjdk.org/browse/JDK-8292280): Unused field 'keyListener' in BasicRadioButtonUI


### Reviewers
 * @stsypanov (no known github.com user name / role) ⚠️ Review applies to [f5957cd5](https://git.openjdk.org/jdk/pull/9832/files/f5957cd5285ef18c3ddb87fe573c8b953317e271)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9832/head:pull/9832` \
`$ git checkout pull/9832`

Update a local copy of the PR: \
`$ git checkout pull/9832` \
`$ git pull https://git.openjdk.org/jdk pull/9832/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9832`

View PR using the GUI difftool: \
`$ git pr show -t 9832`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9832.diff">https://git.openjdk.org/jdk/pull/9832.diff</a>

</details>
