### PR TITLE
8292233: Increase symtab hash table size

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/symtab.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/symtab.c
@@ -390,7 +390,7 @@ static struct symtab* build_symtab_internal(int fd, const char *filename, bool t
         goto bad;
       }
 
-      rslt = hcreate_r(n, symtab->hash_table);
+      rslt = hcreate_r(htab_sz, symtab->hash_table);
       // guarantee(rslt, "unexpected failure: hcreate_r");
 
       // shdr->sh_link points to the section that contains the actual strings


### PR DESCRIPTION
Resize the hash table to minimize collisions. The correct size was already calculated, but was not used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292233](https://bugs.openjdk.org/browse/JDK-8292233): Increase symtab hash table size


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9834/head:pull/9834` \
`$ git checkout pull/9834`

Update a local copy of the PR: \
`$ git checkout pull/9834` \
`$ git pull https://git.openjdk.org/jdk pull/9834/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9834`

View PR using the GUI difftool: \
`$ git pr show -t 9834`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9834.diff">https://git.openjdk.org/jdk/pull/9834.diff</a>

</details>
