### PR TITLE
8292244: Remove unnecessary include directories

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -730,7 +730,6 @@ ifeq ($(ENABLE_HEADLESS_ONLY), false)
 
   LIBSPLASHSCREEN_HEADER_DIRS += \
       libosxapp \
-      java.base:include \
       java.base:libjava \
       #
 

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -103,7 +103,6 @@ LIBAWT_EXTRA_HEADER_DIRS := \
     libmlib_image \
     include \
     java.base:libjava \
-    java.base:include \
     #
 
 LIBAWT_CFLAGS += -D__MEDIALIB_OLD_NAMES -D__USE_J2D_NAMES $(X_CFLAGS)
@@ -565,7 +564,6 @@ ifeq ($(call isTargetOs, windows), true)
       libawt/java2d \
       libawt/java2d/windows \
       libawt/windows \
-      java.base:include \
       java.base:libjava \
       #
 

--- a/make/modules/jdk.accessibility/Lib.gmk
+++ b/make/modules/jdk.accessibility/Lib.gmk
@@ -45,7 +45,6 @@ ifeq ($(call isTargetOs, windows), true)
             -DACCESSBRIDGE_ARCH_$2, \
         EXTRA_HEADER_DIRS := \
             include/bridge \
-            java.base:include \
             java.desktop:include, \
         LDFLAGS := $(LDFLAGS_JDKLIB), \
         LIBS := kernel32.lib user32.lib gdi32.lib \
@@ -72,8 +71,7 @@ ifeq ($(call isTargetOs, windows), true)
         CFLAGS := $(CFLAGS_JDKLIB) \
             -DACCESSBRIDGE_ARCH_$2, \
         EXTRA_HEADER_DIRS := \
-            include/bridge \
-            java.base:include, \
+            include/bridge, \
         LDFLAGS := $(LDFLAGS_JDKLIB) \
             -def:$(ACCESSIBILITY_SRCDIR)/libwindowsaccessbridge/WinAccessBridge.DEF, \
         LIBS := kernel32.lib user32.lib gdi32.lib \


### PR DESCRIPTION
Remove `java.base:include` from `EXTRA_HEADER_DIRS`.

The directory contains base versions of the files present in `<build>/support/modules_include/java.base`; the latter is automatically [included in every JDK library build](https://github.com/openjdk/jdk/blob/master/make/autoconf/flags-cflags.m4#L434).

Verified that:
- cl.exe command line contains `-I<stuff>/modules_include/java.base`
- Windows, Linux and Mac builds still pass


<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292244](https://bugs.openjdk.org/browse/JDK-8292244): Remove unnecessary include directories


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * @AJ1032480 (no known github.com user name / role)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9835/head:pull/9835` \
`$ git checkout pull/9835`

Update a local copy of the PR: \
`$ git checkout pull/9835` \
`$ git pull https://git.openjdk.org/jdk pull/9835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9835`

View PR using the GUI difftool: \
`$ git pr show -t 9835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9835.diff">https://git.openjdk.org/jdk/pull/9835.diff</a>

</details>
