### PR TITLE
8290909: MemoryPoolMBean/isUsageThresholdExceeded tests failed with "isUsageThresholdExceeded() returned false, and is still false, while threshold = MMMMMMM and used peak = NNNNNNN" 

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryPoolMBean/isUsageThresholdExceeded/isexceeded001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryPoolMBean/isUsageThresholdExceeded/isexceeded001.java
@@ -68,7 +68,6 @@ public class isexceeded001 {
             long used = usage.getUsed();
             long max = usage.getMax();
             long peakUsed = peakUsage.getUsed();
-            long peakMax = peakUsage.getMax();
             long threshold = used + 1;
 
             if ( (max > -1) && (threshold > max) ) {
@@ -104,10 +103,9 @@ public class isexceeded001 {
             used = usage.getUsed();
             max = usage.getMax();
             peakUsed = peakUsage.getUsed();
-            peakMax = peakUsage.getMax();
 
             log.display("     used value is " + used     + "      max is " + max + " isExceeded = " + isExceeded);
-            log.display("peak used value is " + peakUsed + " peak max is " + peakMax);
+            log.display("peak used value is " + peakUsed);
             long thresholdCount = monitor.getUsageThresholdCount(pool);
             log.display("  threshold count  " + thresholdCount);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryPoolMBean/isUsageThresholdExceeded/isexceeded001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryPoolMBean/isUsageThresholdExceeded/isexceeded001.java
@@ -37,7 +37,7 @@ import javax.management.openmbean.CompositeData;
 
 public class isexceeded001 {
     private static boolean testFailed = false;
-    private static final int INCREMENT = 100 * 1024; // 100kb
+    private static final int INCREMENT = 100 * 1024 * 1024 ; // 100MB
     public static void main(String[] argv) {
         System.exit(Consts.JCK_STATUS_BASE + run(argv, System.out));
     }
@@ -54,17 +54,21 @@ public class isexceeded001 {
 
         for (int i = 0; i < pools.size(); i++) {
             Object pool = pools.get(i);
-            log.display(i + " pool " + monitor.getName(pool) + " of type: " + monitor.getType(pool));
-            if (!monitor.isUsageThresholdSupported(pool)) {
-                log.display("  does not support usage thresholds: skip");
+            // Skip non-heap pools, as they have unpredictable behaviour, or if
+            // usage threshold not supported:
+            if (monitor.getType(pool) != MemoryType.HEAP  || !monitor.isUsageThresholdSupported(pool)) {
                 continue;
             }
+            log.display(i + " pool " + monitor.getName(pool) + " of type: " + monitor.getType(pool));
 
             // Set a threshold that is greater than used value
             MemoryUsage usage = monitor.getUsage(pool);
+            MemoryUsage peakUsage = monitor.getPeakUsage(pool);
             boolean isExceeded = monitor.isUsageThresholdExceeded(pool);
             long used = usage.getUsed();
             long max = usage.getMax();
+            long peakUsed = peakUsage.getUsed();
+            long peakMax = peakUsage.getMax();
             long threshold = used + 1;
 
             if ( (max > -1) && (threshold > max) ) {
@@ -76,6 +80,7 @@ public class isexceeded001 {
 
             monitor.setUsageThreshold(pool, threshold);
             log.display("     used value is " + used     + "      max is " + max + " isExceeded = " + isExceeded);
+            log.display("peak used value is " + peakUsed);
             log.display("  threshold set to " + threshold);
             log.display("  threshold count  " + monitor.getUsageThresholdCount(pool));
 
@@ -95,23 +100,16 @@ public class isexceeded001 {
             // Fetch usage information: use peak usage in comparisons below, in case usage went up and then down.
             // Log used and peak used in case of failure.
             usage = monitor.getUsage(pool);
-            MemoryUsage peakUsage = monitor.getPeakUsage(pool);
+            peakUsage = monitor.getPeakUsage(pool);
             used = usage.getUsed();
             max = usage.getMax();
-            long peakUsed = usage.getUsed();
-            long peakMax = usage.getMax();
+            peakUsed = peakUsage.getUsed();
+            peakMax = peakUsage.getMax();
 
             log.display("     used value is " + used     + "      max is " + max + " isExceeded = " + isExceeded);
             log.display("peak used value is " + peakUsed + " peak max is " + peakMax);
-            log.display("  threshold set to " + threshold);
             long thresholdCount = monitor.getUsageThresholdCount(pool);
             log.display("  threshold count  " + thresholdCount);
-
-            // Test can be imprecise, particularly with CodeHeap: usage changes outside our control.
-            if (thresholdCount > 0 && monitor.getType(pool) != MemoryType.HEAP) {
-                log.display("  thresholdCount increasing outside our control for non-heap Pool: skip");
-                continue;
-            }
 
             // If peak used value is less than threshold, then isUsageThresholdExceeded()
             // is expected to return false.


### PR DESCRIPTION
This is test unstable when monitoring CodeHeap pools as they can change outside the test's control.
Attempting more heuristics to sense these unrelated changes just means we skip more pools.

The test design, making a Java allocation to affect a memory pool, shows it was intended for Java heap pools, so the test should focus on them.  If we make a larger allocation during the test we actually can observe a change in size in the old gen pools it monitors (new gen pools are not expected to have thresholds, so they are skipped).

There exist specific tests in test/hotspot/jtreg/compiler/codecache/jmx which are intended for non-heap pools, so we should skip them intentionally here in isUsageThresholdExceeded.

Other edits in the test to fix that the peak usage reported by the test was simply usage, not peak.  Fetch the usage and peak usage as near together as possible in the test.  At line 110 in the test, remove an attempt to skip pools we can't monitor (which was working, but does not cover all cases).


Example test log, showing allocation that hits the old gen and triggers the threshold set by the test:

----------System.out:(15/796)----------
...
5 pool G1 Old Gen of type: Heap memory
     used value is 1024000      max is 1038090240 isExceeded = false
peak used value is 1024000
  threshold set to 1024001
  threshold count  0
  reset peak usage. peak usage = 1024000 isExceeded = false
  Allocated heap.  isExceeded = true
     used value is 106930176      max is 1038090240 isExceeded = true
peak used value is 106930176 peak max is 1038090240
  threshold count  1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290909](https://bugs.openjdk.org/browse/JDK-8290909): MemoryPoolMBean/isUsageThresholdExceeded tests failed with "isUsageThresholdExceeded() returned false, and is still false, while threshold = MMMMMMM and used peak = NNNNNNN"


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9842/head:pull/9842` \
`$ git checkout pull/9842`

Update a local copy of the PR: \
`$ git checkout pull/9842` \
`$ git pull https://git.openjdk.org/jdk pull/9842/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9842`

View PR using the GUI difftool: \
`$ git pr show -t 9842`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9842.diff">https://git.openjdk.org/jdk/pull/9842.diff</a>

</details>
