### PR TITLE
8290211: jdk/internal/vm/Continuation/Fuzz.java failed with "AssertionError: Failed to compile int Fuzz.com_int(int,int) in 5000ms"

### DIFF
--- a/test/jdk/jdk/internal/vm/Continuation/Fuzz.java
+++ b/test/jdk/jdk/internal/vm/Continuation/Fuzz.java
@@ -79,7 +79,7 @@ public class Fuzz implements Runnable {
     static final boolean VERBOSE = false;
 
     static float timeoutFactor = Float.parseFloat(System.getProperty("test.timeout.factor", "1.0"));
-    static final int COMPILATION_TIMEOUT = (int)(1_000 * timeoutFactor); // ms
+    static final int COMPILATION_TIMEOUT = (int)(5_000 * timeoutFactor); // ms
 
     static final Path TEST_DIR = Path.of(System.getProperty("test.src", "."));
 

--- a/test/jdk/jdk/internal/vm/Continuation/Fuzz.java
+++ b/test/jdk/jdk/internal/vm/Continuation/Fuzz.java
@@ -78,7 +78,8 @@ public class Fuzz implements Runnable {
     static final boolean RANDOM  = true;
     static final boolean VERBOSE = false;
 
-    static final int COMPILATION_TIMEOUT = 5_000; // ms
+    static float timeoutFactor = Float.parseFloat(System.getProperty("test.timeout.factor", "1.0"));
+    static final int COMPILATION_TIMEOUT = (int)(1_000 * timeoutFactor); // ms
 
     static final Path TEST_DIR = Path.of(System.getProperty("test.src", "."));
 


### PR DESCRIPTION
A trivial fix so that Continuation/Fuzz.java honors the timeoutFactor JTREG setting
when waiting for a compilation to finish.

This fix is being tested in my jdk-20+10 stress testing run.

The usual Mach5 timeoutFactor is 4.0 with slower configurations using a timeoutFactor
of 10.0. In my stress testing, I use release-bits: 4.0, fastdebug-bits: 6.0 and slowdebug-bits: 12.0.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290211](https://bugs.openjdk.org/browse/JDK-8290211): jdk/internal/vm/Continuation/Fuzz.java failed with "AssertionError: Failed to compile int Fuzz.com_int(int,int) in 5000ms"


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) ⚠️ Review applies to [bd9be934](https://git.openjdk.org/jdk/pull/9844/files/bd9be9348e98d1f9052024f9075d7b32c6c85c20)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [bd9be934](https://git.openjdk.org/jdk/pull/9844/files/bd9be9348e98d1f9052024f9075d7b32c6c85c20)
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9844/head:pull/9844` \
`$ git checkout pull/9844`

Update a local copy of the PR: \
`$ git checkout pull/9844` \
`$ git pull https://git.openjdk.org/jdk pull/9844/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9844`

View PR using the GUI difftool: \
`$ git pr show -t 9844`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9844.diff">https://git.openjdk.org/jdk/pull/9844.diff</a>

</details>
