### PR TITLE
8292262: adjust timeouts in several M&M tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/load008/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/load008/TestDescription.java
@@ -45,7 +45,7 @@
  *          /test/lib
  * @comment generate and compile LoadableClassXXX classes
  * @run driver nsk.monitoring.stress.classload.GenClassesBuilder
- * @run main/othervm
+ * @run main/othervm/timeout=180
  *      -XX:-UseGCOverheadLimit
  *      nsk.monitoring.stress.classload.load001
  *      classes

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/load009/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/load009/TestDescription.java
@@ -45,7 +45,7 @@
  *          /test/lib
  * @comment generate and compile LoadableClassXXX classes
  * @run driver nsk.monitoring.stress.classload.GenClassesBuilder
- * @run main/othervm
+ * @run main/othervm/timeout=180
  *      -XX:-UseGCOverheadLimit
  *      nsk.monitoring.stress.classload.load001
  *      classes

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/unload002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/unload002/TestDescription.java
@@ -47,7 +47,7 @@
  *          /test/lib
  * @comment generate and compile LoadableClassXXX classes
  * @run driver nsk.monitoring.stress.classload.GenClassesBuilder
- * @run main/othervm
+ * @run main/othervm/timeout=180
  *      -XX:-UseGCOverheadLimit
  *      nsk.monitoring.stress.classload.unload001
  *      classes

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/unload008/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/unload008/TestDescription.java
@@ -47,7 +47,7 @@
  *          /test/lib
  * @comment generate and compile LoadableClassXXX classes
  * @run driver nsk.monitoring.stress.classload.GenClassesBuilder
- * @run main/othervm
+ * @run main/othervm/timeout=180
  *      -XX:-UseGCOverheadLimit
  *      nsk.monitoring.stress.classload.unload001
  *      classes


### PR DESCRIPTION
Trivial fixes to adjust timeouts in several M&M tests.

This fix is being tested in my jdk-20+10 stress testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292262](https://bugs.openjdk.org/browse/JDK-8292262): adjust timeouts in several M&M tests


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9847/head:pull/9847` \
`$ git checkout pull/9847`

Update a local copy of the PR: \
`$ git checkout pull/9847` \
`$ git pull https://git.openjdk.org/jdk pull/9847/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9847`

View PR using the GUI difftool: \
`$ git pr show -t 9847`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9847.diff">https://git.openjdk.org/jdk/pull/9847.diff</a>

</details>
