### PR TITLE
8291669: [REDO] Fix array range check hoisting for some scaled loop iv

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2771,7 +2771,9 @@ bool PhaseIdealLoop::is_scaled_iv(Node* exp, Node* iv, BasicType bt, jlong* p_sc
       // AddX(iv*K1, iv*K2) => iv*(K1+K2)
       jlong scale_sum = java_add(scale_l, scale_r);
       if (scale_sum > max_signed_integer(exp_bt) || scale_sum < min_signed_integer(exp_bt)) {
-        // Int scales may overflow as we are using jlong to compute.
+        // This logic is shared by int and long. For int, the result may overflow
+        // as we use jlong to compute so do the check here. Long result may also
+        // overflow but that's fine because result wraps.
         return false;
       }
       if (p_scale != NULL) {
@@ -2812,7 +2814,9 @@ bool PhaseIdealLoop::is_scaled_iv(Node* exp, Node* iv, BasicType bt, jlong* p_sc
         // SubX(iv*K1, iv*K2) => iv*(K1-K2)
         jlong scale_diff = java_subtract(scale_l, scale_r);
         if (scale_diff > max_signed_integer(exp_bt) || scale_diff < min_signed_integer(exp_bt)) {
-          // Int scales may overflow as we are using jlong to compute.
+          // This logic is shared by int and long. For int, the result may
+          // overflow as we use jlong to compute so do the check here. Long
+          // result may also overflow but that's fine because result wraps.
           return false;
         }
         if (p_scale != NULL) {

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2780,7 +2780,7 @@ bool PhaseIdealLoop::is_scaled_iv(Node* exp, Node* iv, BasicType bt, jlong* p_sc
         *p_scale = scale_sum;
       }
       if (p_short_scale != NULL) {
-        *p_short_scale = short_scale_l || short_scale_r;
+        *p_short_scale = short_scale_l && short_scale_r;
       }
       return true;
     }
@@ -2823,7 +2823,7 @@ bool PhaseIdealLoop::is_scaled_iv(Node* exp, Node* iv, BasicType bt, jlong* p_sc
           *p_scale = scale_diff;
         }
         if (p_short_scale != NULL) {
-          *p_short_scale = short_scale_l || short_scale_r;
+          *p_short_scale = short_scale_l && short_scale_r;
         }
         return true;
       }

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2770,7 +2770,7 @@ bool PhaseIdealLoop::is_scaled_iv(Node* exp, Node* iv, BasicType bt, jlong* p_sc
         is_scaled_iv(exp->in(2), iv, exp_bt, &scale_r, &short_scale_r, depth + 1)) {
       // AddX(iv*K1, iv*K2) => iv*(K1+K2)
       jlong scale_sum = java_add(scale_l, scale_r);
-      if (scale_sum > max_signed_integer(exp_bt) || scale_sum < min_signed_integer(exp_bt)) {
+      if (scale_sum > max_signed_integer(exp_bt) || scale_sum <= min_signed_integer(exp_bt)) {
         // This logic is shared by int and long. For int, the result may overflow
         // as we use jlong to compute so do the check here. Long result may also
         // overflow but that's fine because result wraps.
@@ -2813,7 +2813,7 @@ bool PhaseIdealLoop::is_scaled_iv(Node* exp, Node* iv, BasicType bt, jlong* p_sc
           is_scaled_iv(exp->in(2), iv, exp_bt, &scale_r, &short_scale_r, depth + 1)) {
         // SubX(iv*K1, iv*K2) => iv*(K1-K2)
         jlong scale_diff = java_subtract(scale_l, scale_r);
-        if (scale_diff > max_signed_integer(exp_bt) || scale_diff < min_signed_integer(exp_bt)) {
+        if (scale_diff > max_signed_integer(exp_bt) || scale_diff <= min_signed_integer(exp_bt)) {
           // This logic is shared by int and long. For int, the result may
           // overflow as we use jlong to compute so do the check here. Long
           // result may also overflow but that's fine because result wraps.

--- a/test/hotspot/jtreg/compiler/rangechecks/RangeCheckEliminationScaleNotOne.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/RangeCheckEliminationScaleNotOne.java
@@ -27,6 +27,7 @@
  * @summary C2: range check elimination may allow illegal out of bound access
  *
  * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:-UseLoopPredicate RangeCheckEliminationScaleNotOne
+ * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:+UseLoopPredicate RangeCheckEliminationScaleNotOne
  *
  */
 
@@ -73,6 +74,46 @@ public class RangeCheckEliminationScaleNotOne {
                 throw new RuntimeException("no AIOOB exception");
             }
         }
+
+        {
+            int[] array = new int[299];
+            boolean[] flags = new boolean[100];
+            Arrays.fill(flags, true);
+            flags[0] = false;
+            flags[1] = false;
+            for (int i = 0; i < 20_000; i++) {
+                test3(100, array, 1, flags);
+            }
+            boolean ex = false;
+            try {
+                test3(100, array, -8, flags);
+            } catch (ArrayIndexOutOfBoundsException aie) {
+                ex = true;
+            }
+            if (!ex) {
+                throw new RuntimeException("no AIOOB exception");
+            }
+        }
+
+        {
+            int[] array = new int[1000];
+            boolean[] flags = new boolean[100];
+            Arrays.fill(flags, true);
+            flags[0] = false;
+            flags[1] = false;
+            for (int i = 0; i < 20_000; i++) {
+                test4(100, array, 302, flags);
+            }
+            boolean ex = false;
+            try {
+                test4(100, array, 320, flags);
+            } catch (ArrayIndexOutOfBoundsException aie) {
+                ex = true;
+            }
+            if (!ex) {
+                throw new RuntimeException("no AIOOB exception");
+            }
+        }
     }
 
     private static int test1(int stop, int[] array, int offset, boolean[] flags) {
@@ -86,13 +127,34 @@ public class RangeCheckEliminationScaleNotOne {
         return res;
     }
 
-
     private static int test2(int stop, int[] array, int offset, boolean[] flags) {
         if (array == null) {}
         int res = 0;
         for (int i = 0; i < stop; i++) {
             if (flags[i]) {
                 res += array[-2 * i + offset];
+            }
+        }
+        return res;
+    }
+
+    private static int test3(int stop, int[] array, int offset, boolean[] flags) {
+        if (array == null) {}
+        int res = 0;
+        for (int i = 0; i < stop; i++) {
+            if (flags[i]) {
+                res += array[3 * i + offset];
+            }
+        }
+        return res;
+    }
+
+    private static int test4(int stop, int[] array, int offset, boolean[] flags) {
+        if (array == null) {}
+        int res = 0;
+        for (int i = 0; i < stop; i++) {
+            if (flags[i]) {
+                res += array[7 * i + offset];
             }
         }
         return res;

--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8289996
+ * @summary Test range check hoisting for some scaled iv at array index
+ * @library /test/lib /
+ * @requires vm.debug & vm.compiler2.enabled & (os.simpleArch == "x64" | os.arch == "aarch64")
+ * @modules jdk.incubator.vector
+ * @compile --enable-preview -source ${jdk.version} TestRangeCheckHoistingScaledIV.java
+ * @run main/othervm --enable-preview compiler.rangechecks.TestRangeCheckHoistingScaledIV
+ */
+
+package compiler.rangechecks;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteOrder;
+
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.VectorSpecies;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestRangeCheckHoistingScaledIV {
+
+    // Inner class for test loops
+    class Launcher {
+        private static final int SIZE = 16000;
+        private static final VectorSpecies<Byte> SPECIES = ByteVector.SPECIES_64;
+        private static final ByteOrder ORDER = ByteOrder.nativeOrder();
+
+        private static byte[] ta = new byte[SIZE];
+        private static byte[] tb = new byte[SIZE];
+
+        private static MemorySegment sa = MemorySegment.ofArray(ta);
+        private static MemorySegment sb = MemorySegment.ofArray(tb);
+
+        private static int count = 789;
+
+        // Normal array accesses with int range checks
+        public static void scaledIntIV() {
+            for (int i = 0; i < count; i += 2) {
+                tb[7 * i] = ta[3 * i];
+            }
+        }
+
+        // Memory segment accesses with long range checks
+        public static void scaledLongIV() {
+            for (long l = 0; l < count; l += 64) {
+                ByteVector v = ByteVector.fromMemorySegment(SPECIES, sa, l * 6, ORDER);
+                v.intoMemorySegment(sb, l * 15, ORDER);
+            }
+        }
+
+        public static void main(String[] args) {
+            for (int i = 0; i < 20000; i++) {
+                scaledIntIV();
+                scaledLongIV();
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "--enable-preview", "--add-modules", "jdk.incubator.vector",
+                "-Xbatch", "-XX:+TraceLoopPredicate", Launcher.class.getName());
+        OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
+        analyzer.shouldHaveExitValue(0);
+        analyzer.outputTo(System.out);
+
+        // Check if int range checks are hoisted
+        analyzer.stdoutShouldContain("rc_predicate init * 3");
+        analyzer.stdoutShouldContain("rc_predicate init * 7");
+
+        // Check if long range checks are hoisted
+        analyzer.stdoutShouldContain("rc_predicate init * 6");
+        analyzer.stdoutShouldContain("rc_predicate init * 15");
+    }
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/RangeCheckHoisting.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/RangeCheckHoisting.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class RangeCheckHoisting {
+
+    private static final int SIZE = 65536;
+
+    @Param("6789") private int count;
+
+    private static int[] a = new int[SIZE];
+    private static int[] b = new int[SIZE];
+
+    @Benchmark
+    public void ivScaled3() {
+        for (int i = 0; i < count; i++) {
+            b[3 * i] = a[3 * i];
+        }
+    }
+
+    @Benchmark
+    public void ivScaled7() {
+        for (int i = 0; i < count; i++) {
+            b[7 * i] = a[7 * i];
+        }
+    }
+}


### PR DESCRIPTION
This is a REDO of JDK-8289996. In previous patch, we defer some strength
reductions in Ideal functions of `Mul[I|L]Node` to post loop igvn phase
to fix a range check hoisting issue. More about previous patch can be
found in PR #9508, where we have described some details of the issue
we would like to fix.

Previous patch was backed out due to some jtreg failures found. We have
analyzed those failures one by one and found one of them exposes a real
performance regression. We see that deferring some strength reductions
to post loop igvn phase has too much impact. Some vector multiplication
will not be optimized to vector addition with vector shift after that
change. So in this REDO we propose the range check hoisting fix with a
different approach.

In this new patch, we add some recursive pattern matches for scaled loop
iv in function `PhaseIdealLoop::is_scaled_iv()`. These include matching
a sum or a difference of two scaled iv expressions. With this, all kinds
of Ideal-transformed scaled iv expressions can still be recognized. This
new approach only touches loop transformation code and hence has much
smaller impact. We have verified that this new approach applies to both
int range checks and long range checks.

Previously attached jtreg case fails on ppc64 because VectorAPI has no
vector intrinsics on ppc64 so there's no long range check to hoist. In
this patch, we limit the test architecture to x64 and AArch64.

Tested hotspot::hotspot_all_no_apps, jdk::tier1~3 and langtools::tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291669](https://bugs.openjdk.org/browse/JDK-8291669): [REDO] Fix array range check hoisting for some scaled loop iv


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**) ⚠️ Review applies to [02402795](https://git.openjdk.org/jdk/pull/9851/files/02402795a82c0429c56bdb2f730f813e8e2a8917)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9851/head:pull/9851` \
`$ git checkout pull/9851`

Update a local copy of the PR: \
`$ git checkout pull/9851` \
`$ git pull https://git.openjdk.org/jdk pull/9851/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9851`

View PR using the GUI difftool: \
`$ git pr show -t 9851`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9851.diff">https://git.openjdk.org/jdk/pull/9851.diff</a>

</details>
