### PR TITLE
8292189: M-Let should be disabled by default

### DIFF
--- a/src/java.management/share/classes/javax/management/loading/MLet.java
+++ b/src/java.management/share/classes/javax/management/loading/MLet.java
@@ -754,6 +754,10 @@ public class MLet extends java.net.URLClassLoader
      public ObjectName preRegister(MBeanServer server, ObjectName name)
              throws Exception {
 
+         if (System.getProperty("com.sun.jmx.enableMLetRegistration") == null) {
+             throw new Exception("M-Let disabled: com.sun.jmx.enableMLetRegistration not set.");
+         }
+
          // Initialize local pointer to the MBean server
          setMBeanServer(server);
 

--- a/src/java.management/share/classes/javax/management/loading/MLet.java
+++ b/src/java.management/share/classes/javax/management/loading/MLet.java
@@ -751,11 +751,15 @@ public class MLet extends java.net.URLClassLoader
       * @exception java.lang.Exception This exception should be caught by the MBean server and re-thrown
       *as an MBeanRegistrationException.
       */
+     @SuppressWarnings("removal")
      public ObjectName preRegister(MBeanServer server, ObjectName name)
              throws Exception {
 
-         if (System.getProperty("com.sun.jmx.enableMLetRegistration") == null) {
-             throw new Exception("M-Let disabled: com.sun.jmx.enableMLetRegistration not set.");
+         String prop = AccessController.doPrivileged(new PrivilegedAction<String>() {
+                           public String run() { return System.getProperty("com.sun.jmx.enableMLetRegistration"); }
+                       });
+         if (!Boolean.parseBoolean(prop)) {
+             throw new UnsupportedOperationException("M-Let disabled: com.sun.jmx.enableMLetRegistration not set.");
          }
 
          // Initialize local pointer to the MBean server

--- a/test/jdk/javax/management/loading/GetMBeansFromURLTest.java
+++ b/test/jdk/javax/management/loading/GetMBeansFromURLTest.java
@@ -31,7 +31,7 @@
  *
  * @run clean GetMBeansFromURLTest
  * @run build GetMBeansFromURLTest
- * @run main GetMBeansFromURLTest
+ * @run main  GetMBeansFromURLTest
  */
 
 import javax.management.MBeanServer;
@@ -59,6 +59,8 @@ public class GetMBeansFromURLTest {
         // Register the MLet MBean with the MBeanServer
         //
         System.out.println("Register the MLet MBean");
+        // Set Property here, as test is on already in "othervm":
+        System.setProperty("com.sun.jmx.enableMLetRegistration", "true");
         ObjectName mletObjectName = new ObjectName("Test:type=MLet");
         mbs.registerMBean(mlet, mletObjectName);
 

--- a/test/jdk/javax/management/loading/GetMBeansFromURLTest.java
+++ b/test/jdk/javax/management/loading/GetMBeansFromURLTest.java
@@ -34,6 +34,7 @@
  * @run main  GetMBeansFromURLTest
  */
 
+import javax.management.MBeanRegistrationException;
 import javax.management.MBeanServer;
 import javax.management.MBeanServerFactory;
 import javax.management.ObjectName;
@@ -56,12 +57,27 @@ public class GetMBeansFromURLTest {
         System.out.println("Create the MLet");
         MLet mlet = new MLet();
 
-        // Register the MLet MBean with the MBeanServer
+        // Register the MLet MBean with the MBeanServer,
+        // first checking that registering fails by default:
         //
-        System.out.println("Register the MLet MBean");
-        // Set Property here, as test is on already in "othervm":
-        System.setProperty("com.sun.jmx.enableMLetRegistration", "true");
+        System.out.println("Register the MLet MBean (failure expected)");
         ObjectName mletObjectName = new ObjectName("Test:type=MLet");
+        boolean thrown = false;
+        try {
+            mbs.registerMBean(mlet, mletObjectName);
+        } catch (MBeanRegistrationException e) {
+            System.out.println("registerMBean threw expected Exception: " + e);
+            thrown = true;
+        }
+        if (!thrown) {
+            System.out.println("TEST FAILED: registerMBean: expected Exception not thrown.");
+            error = true;
+        }
+        // Register the MLet MBean with the MBeanServer,
+        // this time with the required property set:
+        //
+        System.out.println("Register the MLet MBean (with enabling property set)");
+        System.setProperty("com.sun.jmx.enableMLetRegistration", "true");
         mbs.registerMBean(mlet, mletObjectName);
 
         // Call getMBeansFromURL

--- a/test/jdk/javax/management/loading/GetMBeansFromURLTest.java
+++ b/test/jdk/javax/management/loading/GetMBeansFromURLTest.java
@@ -38,6 +38,7 @@ import javax.management.MBeanRegistrationException;
 import javax.management.MBeanServer;
 import javax.management.MBeanServerFactory;
 import javax.management.ObjectName;
+import javax.management.RuntimeMBeanException;
 import javax.management.ServiceNotFoundException;
 import javax.management.loading.MLet;
 
@@ -65,7 +66,7 @@ public class GetMBeansFromURLTest {
         boolean thrown = false;
         try {
             mbs.registerMBean(mlet, mletObjectName);
-        } catch (MBeanRegistrationException e) {
+        } catch (RuntimeMBeanException e) {
             System.out.println("registerMBean threw expected Exception: " + e);
             thrown = true;
         }

--- a/test/jdk/javax/management/loading/GetMBeansFromURLTest.java
+++ b/test/jdk/javax/management/loading/GetMBeansFromURLTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@
  * @run main  GetMBeansFromURLTest
  */
 
-import javax.management.MBeanRegistrationException;
 import javax.management.MBeanServer;
 import javax.management.MBeanServerFactory;
 import javax.management.ObjectName;

--- a/test/jdk/javax/management/loading/MLetCLR/MLetCommand.java
+++ b/test/jdk/javax/management/loading/MLetCLR/MLetCommand.java
@@ -31,7 +31,7 @@
  *
  * @run clean MLetCommand
  * @run build MLetCommand
- * @run main/othervm/java.security.policy=policy MLetCommand
+ * @run main/othervm/java.security.policy=policy -Dcom.sun.jmx.enableMLetRegistration=true MLetCommand
  */
 
 import javax.management.MBeanServer;

--- a/test/jdk/javax/management/loading/MletParserLocaleTest.java
+++ b/test/jdk/javax/management/loading/MletParserLocaleTest.java
@@ -29,7 +29,7 @@
  *
  * @run clean MletParserLocaleTest
  * @run build MletParserLocaleTest
- * @run main/othervm MletParserLocaleTest mlet4.html
+ * @run main/othervm -Dcom.sun.jmx.enableMLetRegistration=true MletParserLocaleTest mlet4.html
  */
 
 import java.io.File;

--- a/test/jdk/javax/management/loading/ParserInfiniteLoopTest.java
+++ b/test/jdk/javax/management/loading/ParserInfiniteLoopTest.java
@@ -32,9 +32,9 @@
  *
  * @run clean ParserInfiniteLoopTest
  * @run build ParserInfiniteLoopTest
- * @run main/othervm ParserInfiniteLoopTest mlet1.html
- * @run main/othervm ParserInfiniteLoopTest mlet2.html
- * @run main/othervm ParserInfiniteLoopTest mlet3.html
+ * @run main/othervm -Dcom.sun.jmx.enableMLetRegistration=true ParserInfiniteLoopTest mlet1.html
+ * @run main/othervm -Dcom.sun.jmx.enableMLetRegistration=true ParserInfiniteLoopTest mlet2.html
+ * @run main/othervm -Dcom.sun.jmx.enableMLetRegistration=true ParserInfiniteLoopTest mlet3.html
  */
 
 import java.io.File;


### PR DESCRIPTION
Add a requirement for the property "com.sun.jmx.enableMLetRegistration" to be set to "true" in order to register an M-Let.

Will create a CSR separately.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request to be approved

### Issues
 * [JDK-8292189](https://bugs.openjdk.org/browse/JDK-8292189): M-Let should be disabled by default
 * [JDK-8292295](https://bugs.openjdk.org/browse/JDK-8292295): M-Let should be disabled by default (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9852/head:pull/9852` \
`$ git checkout pull/9852`

Update a local copy of the PR: \
`$ git checkout pull/9852` \
`$ git pull https://git.openjdk.org/jdk pull/9852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9852`

View PR using the GUI difftool: \
`$ git pr show -t 9852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9852.diff">https://git.openjdk.org/jdk/pull/9852.diff</a>

</details>
