### PR TITLE
8292285: C2: remove unreachable block after NeverBranch-to-Goto conversion

### DIFF
--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -590,19 +590,24 @@ void PhaseCFG::convert_NeverBranch_to_Goto(Block *b) {
   b->_num_succs = 1;
   // remap successor's predecessors if necessary
   uint j;
-  for( j = 1; j < succ->num_preds(); j++)
-    if( succ->pred(j)->in(0) == bp )
+  for (j = 1; j < succ->num_preds(); j++) {
+    if (succ->pred(j)->in(0) == bp) {
       succ->head()->set_req(j, gto);
+    }
+  }
   // Kill alternate exit path
-  Block *dead = b->_succs[1-idx];
-  for( j = 1; j < dead->num_preds(); j++)
-    if( dead->pred(j)->in(0) == bp )
+  Block* dead = b->_succs[1 - idx];
+  for (j = 1; j < dead->num_preds(); j++) {
+    if (dead->pred(j)->in(0) == bp) {
       break;
+    }
+  }
   // Scan through block, yanking dead path from
   // all regions and phis.
   dead->head()->del_req(j);
-  for( int k = 1; dead->get_node(k)->is_Phi(); k++ )
+  for (int k = 1; dead->get_node(k)->is_Phi(); k++) {
     dead->get_node(k)->del_req(j);
+  }
   // If the fake exit block becomes unreachable, remove it from the block list.
   if (dead->num_preds() == 1) {
     for (uint i = 0; i < number_of_blocks(); i++) {

--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -610,8 +610,7 @@ void PhaseCFG::convert_NeverBranch_to_Goto(Block *b) {
       if (block == dead) {
         _blocks.remove(i);
       } else if (block->_pre_order > dead->_pre_order) {
-        // Adjust pre-order indices to avoid holes (whose absence is assumed
-        // e.g. by PhaseBlockLayout).
+        // Enforce contiguous pre-order indices (assumed by PhaseBlockLayout).
         block->_pre_order--;
       }
     }

--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -603,6 +603,20 @@ void PhaseCFG::convert_NeverBranch_to_Goto(Block *b) {
   dead->head()->del_req(j);
   for( int k = 1; dead->get_node(k)->is_Phi(); k++ )
     dead->get_node(k)->del_req(j);
+  // If the fake exit block becomes unreachable, remove it from the block list.
+  if (dead->num_preds() == 1) {
+    for (uint i = 0; i < number_of_blocks(); i++) {
+      Block* block = get_block(i);
+      if (block == dead) {
+        _blocks.remove(i);
+      } else if (block->_pre_order > dead->_pre_order) {
+        // Adjust pre-order indices to avoid holes (whose absence is assumed
+        // e.g. by PhaseBlockLayout).
+        block->_pre_order--;
+      }
+    }
+    _number_of_blocks--;
+  }
 }
 
 // Helper function to move block bx to the slot following b_index. Return


### PR DESCRIPTION
`NeverBranch` nodes introduce fake branches out of infinite loops to simplify intermediate optimizations that assume full reachability:
![before](https://user-images.githubusercontent.com/8792647/184355521-8b54725e-f7d2-4d37-a7ba-e0f7d1086421.png)
`PhaseCFG::convert_NeverBranch_to_Goto()` transforms such nodes into simple `Goto` nodes, removing the fake branch and thus making its destination block unreachable:
![after](https://user-images.githubusercontent.com/8792647/184355553-3b862832-7302-4de2-aa29-86d7da0d985a.png)
This changeset removes the unreachable destination block created by `PhaseCFG::convert_NeverBranch_to_Goto()` from the list of basic blocks:
![after-removal](https://user-images.githubusercontent.com/8792647/184355581-82038683-3f4f-4f4f-a8d7-16e507bfdf0c.png)
Removing unreachable blocks created by `PhaseCFG::convert_NeverBranch_to_Goto()` simplifies late control-flow analysis (for example, recomputing dominators during the output phase as required for late barrier analysis in Generational ZGC) and slightly reduces the size of the generated code.

#### Testing

- hs-tier1-3 (windows-x64, linux-x64, linux-aarch64, and macosx-x64; release and debug mode). The changeset does not introduce new test cases because it is already exercised by at least two existing ones (`compiler/inlining/StringConcatInfiniteLoop.java`, `compiler/loopopts/TestInfiniteLoopNotInnerMost.java`).
- fuzzing (~30 min. on each platform).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292285](https://bugs.openjdk.org/browse/JDK-8292285): C2: remove unreachable block after NeverBranch-to-Goto conversion


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [e633fbec](https://git.openjdk.org/jdk/pull/9853/files/e633fbecde2fc22357394775b70d8ac1ef0196c4)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [e633fbec](https://git.openjdk.org/jdk/pull/9853/files/e633fbecde2fc22357394775b70d8ac1ef0196c4)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9853/head:pull/9853` \
`$ git checkout pull/9853`

Update a local copy of the PR: \
`$ git checkout pull/9853` \
`$ git pull https://git.openjdk.org/jdk pull/9853/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9853`

View PR using the GUI difftool: \
`$ git pr show -t 9853`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9853.diff">https://git.openjdk.org/jdk/pull/9853.diff</a>

</details>
