### PR TITLE
8292182: [TESTLIB] Enhance JAXPPolicyManager to setup required permissions for jtreg version 7 jar

### DIFF
--- a/test/jaxp/javax/xml/jaxp/libs/jaxp/library/JAXPPolicyManager.java
+++ b/test/jaxp/javax/xml/jaxp/libs/jaxp/library/JAXPPolicyManager.java
@@ -24,7 +24,6 @@ package jaxp.library;
 
 
 import java.net.URL;
-import java.nio.file.Path;
 import java.security.CodeSource;
 import java.security.Permission;
 import java.security.PermissionCollection;

--- a/test/jaxp/javax/xml/jaxp/libs/jaxp/library/JAXPPolicyManager.java
+++ b/test/jaxp/javax/xml/jaxp/libs/jaxp/library/JAXPPolicyManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@ package jaxp.library;
 
 
 import java.net.URL;
+import java.nio.file.Path;
 import java.security.CodeSource;
 import java.security.Permission;
 import java.security.PermissionCollection;
@@ -161,7 +162,7 @@ public class JAXPPolicyManager {
  */
 class TestPolicy extends Policy {
     private final static Set<String> TEST_JARS =
-         Set.of("jtreg.jar", "javatest.jar", "testng.jar", "jcommander.jar");
+         Set.of("jtreg.*jar", "javatest.*jar", "testng.*jar", "jcommander.*jar");
     private final PermissionCollection permissions = new Permissions();
 
     private ThreadLocal<Map<Integer, Permission>> transientPermissions = new ThreadLocal<>();
@@ -214,8 +215,9 @@ class TestPolicy extends Policy {
         CodeSource cs = (domain == null) ? null : domain.getCodeSource();
         URL loc = (cs == null) ? null : cs.getLocation();
         String path = (loc == null) ? null : loc.getPath();
-        return path != null && TEST_JARS.stream()
-                                .filter(path::endsWith)
+        String name = (path == null) ? null : path.substring(path.lastIndexOf('/') + 1);
+        return name != null && TEST_JARS.stream()
+                                .filter(name::matches)
                                 .findAny()
                                 .isPresent();
     }

--- a/test/jaxp/javax/xml/jaxp/libs/jaxp/library/JAXPPolicyManager.java
+++ b/test/jaxp/javax/xml/jaxp/libs/jaxp/library/JAXPPolicyManager.java
@@ -23,7 +23,9 @@
 package jaxp.library;
 
 
+import java.net.URI;
 import java.net.URL;
+import java.nio.file.Path;
 import java.security.CodeSource;
 import java.security.Permission;
 import java.security.PermissionCollection;
@@ -213,8 +215,8 @@ class TestPolicy extends Policy {
     private boolean isTestMachineryDomain(ProtectionDomain domain) {
         CodeSource cs = (domain == null) ? null : domain.getCodeSource();
         URL loc = (cs == null) ? null : cs.getLocation();
-        String path = (loc == null) ? null : loc.getPath();
-        String name = (path == null) ? null : path.substring(path.lastIndexOf('/') + 1);
+        URI uri = (loc == null) ? null : URI.create(loc.toString());
+        String name = (uri == null) ? null : Path.of(uri).getFileName().toString();
         return name != null && TEST_JARS.stream()
                                 .filter(name::matches)
                                 .findAny()


### PR DESCRIPTION
Enhance `JAXPPolicyManager` to setup required permissions for `jtreg` 7 by accept version information in JAR file names.

Find details in https://bugs.openjdk.org/browse/JDK-8292182

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292182](https://bugs.openjdk.org/browse/JDK-8292182): [TESTLIB] Enhance JAXPPolicyManager to setup required permissions for jtreg version 7 jar


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to [f2046e67](https://git.openjdk.org/jdk/pull/9857/files/f2046e670dd78f3bed483ac0d6a1b57303a7857b)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [f2046e67](https://git.openjdk.org/jdk/pull/9857/files/f2046e670dd78f3bed483ac0d6a1b57303a7857b)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [f2046e67](https://git.openjdk.org/jdk/pull/9857/files/f2046e670dd78f3bed483ac0d6a1b57303a7857b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9857/head:pull/9857` \
`$ git checkout pull/9857`

Update a local copy of the PR: \
`$ git checkout pull/9857` \
`$ git pull https://git.openjdk.org/jdk pull/9857/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9857`

View PR using the GUI difftool: \
`$ git pr show -t 9857`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9857.diff">https://git.openjdk.org/jdk/pull/9857.diff</a>

</details>
