### PR TITLE
8292271 : Fix java/awt/PrintJob/PrintCheckboxTest/PrintCheckboxManualTest.java test

### DIFF
--- a/test/jdk/java/awt/PrintJob/PrintCheckboxTest/PrintCheckboxManualTest.java
+++ b/test/jdk/java/awt/PrintJob/PrintCheckboxTest/PrintCheckboxManualTest.java
@@ -60,18 +60,22 @@ public class PrintCheckboxManualTest
 
     public static void main(String[] args) throws InterruptedException,
             InvocationTargetException, IOException {
+
+        if (!isXToolkit()) {
+            throw new RuntimeException("XToolkit is not enabled, even though " +
+                    "test is executed on " + System.getProperty("os.name"));
+        }
         if (PrinterJob.lookupPrintServices().length == 0) {
             throw new SkippedException("Printer not configured or available."
                     + " Test cannot continue.");
         }
 
         String instruction = """
-               Linux or Solaris with XToolkit ONLY!
-               1. Click the 'Print' button on the frame,
-               2. Select a printer in the print dialog and proceed,
-               3. If the frame with checkbox and button on it is printed
-               successfully test PASSED else FAILED.
-               """;
+                1. Click the 'Print' button on the frame,
+                2. Select a printer in the print dialog and proceed,
+                3. If the frame with checkbox and button on it is printed
+                successfully test PASSED else FAILED.
+                """;
 
         Consumer<JEditorPane> testInstProvider = e -> {
             e.setContentType("text/plain");
@@ -84,8 +88,8 @@ public class PrintCheckboxManualTest
         EventQueue.invokeAndWait(PrintCheckboxManualTest::createTestUI);
 
         //this will block until user decision to pass or fail the test
-        TestResult  testResult = resultSupplier.get();
-        ManualTestFrame.handleResult(testResult,"PrintCheckboxManualTest");
+        TestResult testResult = resultSupplier.get();
+        ManualTestFrame.handleResult(testResult, "PrintCheckboxManualTest");
     }
 
     public static void createTestUI() {
@@ -129,6 +133,11 @@ public class PrintCheckboxManualTest
         f.add(b);
         f.setLocationRelativeTo(null);
         f.setVisible(true);
+    }
+
+    private static boolean isXToolkit() {
+        return Toolkit.getDefaultToolkit().getClass()
+                .getName().equals("sun.awt.X11.XToolkit");
     }
 }
 

--- a/test/jdk/java/awt/PrintJob/PrintCheckboxTest/PrintCheckboxManualTest.java
+++ b/test/jdk/java/awt/PrintJob/PrintCheckboxTest/PrintCheckboxManualTest.java
@@ -81,7 +81,7 @@ public class PrintCheckboxManualTest
         Supplier<TestResult> resultSupplier = ManualTestFrame.showUI(
                 "Tests PrintCheckboxManualTest",
                 "Wait until the Test UI is seen", testInstProvider);
-	 EventQueue.invokeAndWait(PrintCheckboxManualTest::createTestUI);
+	EventQueue.invokeAndWait(PrintCheckboxManualTest::createTestUI);
 
         //this will block until user decision to pass or fail the test
         TestResult  testResult = resultSupplier.get();

--- a/test/jdk/java/awt/PrintJob/PrintCheckboxTest/PrintCheckboxManualTest.java
+++ b/test/jdk/java/awt/PrintJob/PrintCheckboxTest/PrintCheckboxManualTest.java
@@ -81,7 +81,7 @@ public class PrintCheckboxManualTest
         Supplier<TestResult> resultSupplier = ManualTestFrame.showUI(
                 "Tests PrintCheckboxManualTest",
                 "Wait until the Test UI is seen", testInstProvider);
-	EventQueue.invokeAndWait(PrintCheckboxManualTest::createTestUI);
+        EventQueue.invokeAndWait(PrintCheckboxManualTest::createTestUI);
 
         //this will block until user decision to pass or fail the test
         TestResult  testResult = resultSupplier.get();

--- a/test/jdk/java/awt/PrintJob/PrintCheckboxTest/PrintCheckboxManualTest.java
+++ b/test/jdk/java/awt/PrintJob/PrintCheckboxTest/PrintCheckboxManualTest.java
@@ -38,6 +38,7 @@
 
 import java.awt.Button;
 import java.awt.Checkbox;
+import java.awt.EventQueue;
 import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.GridLayout;
@@ -80,7 +81,7 @@ public class PrintCheckboxManualTest
         Supplier<TestResult> resultSupplier = ManualTestFrame.showUI(
                 "Tests PrintCheckboxManualTest",
                 "Wait until the Test UI is seen", testInstProvider);
-        createTestUI();
+	 EventQueue.invokeAndWait(PrintCheckboxManualTest::createTestUI);
 
         //this will block until user decision to pass or fail the test
         TestResult  testResult = resultSupplier.get();

--- a/test/jdk/java/awt/PrintJob/PrintCheckboxTest/PrintCheckboxManualTest.java
+++ b/test/jdk/java/awt/PrintJob/PrintCheckboxTest/PrintCheckboxManualTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,82 +24,72 @@
 /*
   @test
   @bug 5045936 5055171
+  @key printer
+  @library /test/lib
+  @library /javax/accessibility/manual
+  @build lib.ManualTestFrame
+  @build lib.TestResult
+  @build jtreg.SkippedException
   @summary Tests that there is no ClassCastException thrown in printing
    checkbox and scrollbar with XAWT
-  @author art@sparc.spb.su
-  @run applet/manual=yesno PrintCheckboxManualTest.html
+  @requires (os.family == "linux" | os.family == "solaris")
+  @run main/manual PrintCheckboxManualTest
 */
 
-// Note there is no @ in front of test above.  This is so that the
-//  harness will not mistake this file as a test file.  It should
-//  only see the html file as a test file. (the harness runs all
-//  valid test files, so it would run this test twice if this file
-//  were valid as well as the html file.)
-// Also, note the area= after Your Name in the author tag.  Here, you
-//  should put which functional area the test falls in.  See the
-//  AWT-core home page -> test areas and/or -> AWT team  for a list of
-//  areas.
+import java.awt.Button;
+import java.awt.Checkbox;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.GridLayout;
+import java.awt.PrintJob;
+import java.awt.Scrollbar;
+import java.awt.Toolkit;
+import java.awt.print.PrinterJob;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import javax.swing.JEditorPane;
+import jtreg.SkippedException;
+import lib.ManualTestFrame;
+import lib.TestResult;
 
-
-
-import java.awt.*;
-import java.awt.event.*;
-
-
-//Manual tests should run as applet tests if possible because they
-// get their environments cleaned up, including AWT threads, any
-// test created threads, and any system resources used by the test
-// such as file descriptors.  (This is normally not a problem as
-// main tests usually run in a separate VM, however on some platforms
-// such as the Mac, separate VMs are not possible and non-applet
-// tests will cause problems).  Also, you don't have to worry about
-// synchronisation stuff in Applet tests the way you do in main
-// tests...
-
-
-public class PrintCheckboxManualTest extends Panel
+public class PrintCheckboxManualTest
 {
-    //Declare things used in the test, like buttons and labels here
-    Frame f;
 
-    public static void main(String[] args) {
-        PrintCheckboxManualTest a = new PrintCheckboxManualTest();
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException, IOException {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new SkippedException("Printer not configured or available."
+                    + " Test cannot continue.");
+        }
 
-        a.init();
-        a.start();
+        String instruction = """
+               Linux or Solaris with XToolkit ONLY!
+               1. Click the 'Print' button on the frame,
+               2. Select a printer in the print dialog and proceed,
+               3. If the frame with checkbox and button on it is printed
+               successfully test PASSED else FAILED.
+               """;
+
+        Consumer<JEditorPane> testInstProvider = e -> {
+            e.setContentType("text/plain");
+            e.setText(instruction);
+        };
+
+        Supplier<TestResult> resultSupplier = ManualTestFrame.showUI(
+                "Tests PrintCheckboxManualTest",
+                "Wait until the Test UI is seen", testInstProvider);
+        createTestUI();
+
+        //this will block until user decision to pass or fail the test
+        TestResult  testResult = resultSupplier.get();
+        ManualTestFrame.handleResult(testResult,"PrintCheckboxManualTest");
     }
 
-    public void init()
-    {
-        //Create instructions for the user here, as well as set up
-        // the environment -- set the layout manager, add buttons,
-        // etc.
-        this.setLayout (new BorderLayout ());
+    public static void createTestUI() {
 
-        String[] instructions =
-        {
-            "Linux or Solaris with XToolkit ONLY!",
-            "1. Click the 'Print' button on the frame",
-            "2. Select a printer in the print dialog and proceed",
-            "3. If the frame with checkbox and button on it is printed successfully test PASSED else FAILED"
-        };
-        Sysout.createDialogWithInstructions( instructions );
-
-    }//End  init()
-
-    public void start ()
-    {
-        //Get things going.  Request focus, set size, et cetera
-        setSize (200,200);
-        setVisible(true);
-        validate();
-
-        //What would normally go into main() will probably go here.
-        //Use System.out.println for diagnostic messages that you want
-        // to read after the test is done.
-        //Use Sysout.println for messages you want the tester to read.
-
-        f = new Frame("Print checkbox");
+        Frame f = new Frame("Print checkbox");
         f.setLayout(new GridLayout(2, 2));
         f.setSize(200, 100);
 
@@ -111,185 +101,33 @@ public class PrintCheckboxManualTest extends Panel
         f.add(sb);
 
         Button b = new Button("Print");
-        b.addActionListener(new ActionListener()
-        {
-        public void actionPerformed(ActionEvent ev)
-        {
-                PrintJob pj = Toolkit.getDefaultToolkit().getPrintJob(f, "PrintCheckboxManualTest", null);
-                if (pj != null)
+        b.addActionListener(ev -> {
+            PrintJob pj = Toolkit.getDefaultToolkit().getPrintJob(f, "PrintCheckboxManualTest", null);
+            if (pj != null)
+            {
+                try
                 {
-                        try
-                        {
-                                Graphics g = pj.getGraphics();
-                                f.printAll(g);
-                                g.dispose();
-                                pj.end();
-                                Sysout.println("Test PASSED");
-                        }
-                        catch (ClassCastException cce)
-                        {
-                                Sysout.println("Test FAILED: ClassCastException");
-//                              throw new RuntimeException("Test FAILED: ClassCastException", cce);
-                        }
-                        catch (Exception e)
-                        {
-                                Sysout.println("Test FAILED: unknown Exception");
-//                              throw new Error("Test FAILED: unknown exception", e);
-                        }
+                    Graphics g = pj.getGraphics();
+                    f.printAll(g);
+                    g.dispose();
+                    pj.end();
+                    System.out.println("Test PASSED");
                 }
-        }
+                catch (ClassCastException cce)
+                {
+                    System.out.println("Test FAILED: ClassCastException");
+                    throw new RuntimeException("Test FAILED: ClassCastException", cce);
+                }
+                catch (Exception e)
+                {
+                    System.out.println("Test FAILED: unknown Exception");
+                    throw new Error("Test FAILED: unknown exception", e);
+                }
+            }
         });
         f.add(b);
-
+        f.setLocationRelativeTo(null);
         f.setVisible(true);
-    }// start()
-
-    //The rest of this class is the actions which perform the test...
-
-    //Use Sysout.println to communicate with the user NOT System.out!!
-    //Sysout.println ("Something Happened!");
-
+    }
 }
 
-/* Place other classes related to the test after this line */
-
-
-
-
-
-/****************************************************
- Standard Test Machinery
- DO NOT modify anything below -- it's a standard
-  chunk of code whose purpose is to make user
-  interaction uniform, and thereby make it simpler
-  to read and understand someone else's test.
- ****************************************************/
-
-/**
- This is part of the standard test machinery.
- It creates a dialog (with the instructions), and is the interface
-  for sending text messages to the user.
- To print the instructions, send an array of strings to Sysout.createDialog
-  WithInstructions method.  Put one line of instructions per array entry.
- To display a message for the tester to see, simply call Sysout.println
-  with the string to be displayed.
- This mimics System.out.println but works within the test harness as well
-  as standalone.
- */
-
-class Sysout
-{
-    private static TestDialog dialog;
-
-    public static void createDialogWithInstructions( String[] instructions )
-    {
-        dialog = new TestDialog( new Frame(), "Instructions" );
-        dialog.printInstructions( instructions );
-        dialog.setVisible(true);
-        println( "Any messages for the tester will display here." );
-    }
-
-    public static void createDialog( )
-    {
-        dialog = new TestDialog( new Frame(), "Instructions" );
-        String[] defInstr = { "Instructions will appear here. ", "" } ;
-        dialog.printInstructions( defInstr );
-        dialog.setVisible(true);
-        println( "Any messages for the tester will display here." );
-    }
-
-
-    public static void printInstructions( String[] instructions )
-    {
-        dialog.printInstructions( instructions );
-    }
-
-
-    public static void println( String messageIn )
-    {
-        dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog
-{
-
-    TextArea instructionsText;
-    TextArea messageText;
-    int maxStringLength = 80;
-
-    //DO NOT call this directly, go through Sysout
-    public TestDialog( Frame frame, String name )
-    {
-        super( frame, name );
-        int scrollBoth = TextArea.SCROLLBARS_BOTH;
-        instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-        add( "North", instructionsText );
-
-        messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-        add("Center", messageText);
-
-        pack();
-
-        setVisible(true);
-    }// TestDialog()
-
-    //DO NOT call this directly, go through Sysout
-    public void printInstructions( String[] instructions )
-    {
-        //Clear out any current instructions
-        instructionsText.setText( "" );
-
-        //Go down array of instruction strings
-
-        String printStr, remainingStr;
-        for( int i=0; i < instructions.length; i++ )
-        {
-            //chop up each into pieces maxSringLength long
-            remainingStr = instructions[ i ];
-            while( remainingStr.length() > 0 )
-            {
-                //if longer than max then chop off first max chars to print
-                if( remainingStr.length() >= maxStringLength )
-                {
-                    //Try to chop on a word boundary
-                    int posOfSpace = remainingStr.
-                        lastIndexOf( ' ', maxStringLength - 1 );
-
-                    if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-                    printStr = remainingStr.substring( 0, posOfSpace + 1 );
-                    remainingStr = remainingStr.substring( posOfSpace + 1 );
-                }
-                //else just print
-                else
-                {
-                    printStr = remainingStr;
-                    remainingStr = "";
-                }
-
-                instructionsText.append( printStr + "\n" );
-
-            }// while
-
-        }// for
-
-    }//printInstructions()
-
-    //DO NOT call this directly, go through Sysout
-    public void displayMessage( String messageIn )
-    {
-        messageText.append( messageIn + "\n" );
-        System.out.println(messageIn);
-    }
-
-}// TestDialog  class


### PR DESCRIPTION
1) This test was failing due to yesno 
test result: Error. Parse Exception: Arguments to `manual' option not supported: yesno 
2) PrintCheckboxManualTest.html file was missing
3) Added os.family since test instruction says that its a linux and solair toolkit only test
4) Removed Sysout & TestDialog class &  added a better manual framework to show the instruction and test frame. 

@shurymury

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292271](https://bugs.openjdk.org/browse/JDK-8292271): Fix java/awt/PrintJob/PrintCheckboxTest/PrintCheckboxManualTest.java test


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9858/head:pull/9858` \
`$ git checkout pull/9858`

Update a local copy of the PR: \
`$ git checkout pull/9858` \
`$ git pull https://git.openjdk.org/jdk pull/9858/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9858`

View PR using the GUI difftool: \
`$ git pr show -t 9858`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9858.diff">https://git.openjdk.org/jdk/pull/9858.diff</a>

</details>
