### PR TITLE
8292196: Reduce runtime of java.util.regex microbenchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/java/util/regex/Exponential.java
+++ b/test/micro/org/openjdk/bench/java/util/regex/Exponential.java
@@ -44,9 +44,9 @@ import java.util.regex.Pattern;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(1)
-@Warmup(iterations = 1)
-@Measurement(iterations = 4)
+@Fork(2)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Benchmark)
 public class Exponential {
     /** Run length of non-matching consecutive whitespace chars. */

--- a/test/micro/org/openjdk/bench/java/util/regex/PatternBench.java
+++ b/test/micro/org/openjdk/bench/java/util/regex/PatternBench.java
@@ -24,6 +24,7 @@ package org.openjdk.bench.java.util.regex;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -39,6 +40,9 @@ import java.util.regex.PatternSyntaxException;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class PatternBench {
 
@@ -71,36 +75,26 @@ public class PatternBench {
     }
 
     @Benchmark
-    @Warmup(iterations = 3)
-    @Measurement(iterations = 3)
     public long longStringGraphemeMatches() {
         return graphemePattern.matcher(flagsString.repeat(3)).results().count();
     }
 
     @Benchmark
-    @Warmup(iterations = 3)
-    @Measurement(iterations = 3)
     public int splitFlags() {
         return graphemeBoundaryPattern.split(flagsString).length;
     }
 
     @Benchmark
-    @Warmup(iterations = 3)
-    @Measurement(iterations = 3)
     public boolean canonicalJmodMatch() {
         return jmodCanonicalPattern.matcher(fileTestString).matches();
     }
 
     @Benchmark
-    @Warmup(iterations = 3)
-    @Measurement(iterations = 3)
     public boolean normalJmodMatch() {
         return jmodPattern.matcher(fileTestString).matches();
     }
 
     @Benchmark
-    @Warmup(iterations = 3)
-    @Measurement(iterations = 3)
     public boolean charPatternMatch() {
         return charPattern.matcher(charPatternStrings[0]).matches()
                 && charPattern.matcher(charPatternStrings[1]).matches()
@@ -108,8 +102,6 @@ public class PatternBench {
     }
 
     @Benchmark
-    @Warmup(iterations = 3)
-    @Measurement(iterations = 3)
     public boolean charPatternMatchWithCompile() {
         Pattern p = Pattern.compile(charPatternRegex);
         return p.matcher(charPatternStrings[0]).matches()
@@ -118,8 +110,6 @@ public class PatternBench {
     }
 
     @Benchmark
-    @Warmup(iterations = 3)
-    @Measurement(iterations = 3)
     public Pattern charPatternCompile() {
         return Pattern.compile(charPatternRegex);
     }

--- a/test/micro/org/openjdk/bench/java/util/regex/Primality.java
+++ b/test/micro/org/openjdk/bench/java/util/regex/Primality.java
@@ -45,12 +45,12 @@ import java.util.regex.Pattern;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(1)
-@Warmup(iterations = 1)
-@Measurement(iterations = 4)
+@Warmup(iterations = 2, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 3, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Benchmark)
 public class Primality {
     /** Number to be primality tested. */
-    @Param({"16", "17", "256", "257", "4096", "4099"})
+    @Param({"16", "17", /* "256", "257", */ "4096", "4099"})
     //  "64", "67", "1024", "1031", "16384", "16411"})
     int n;
 

--- a/test/micro/org/openjdk/bench/java/util/regex/Trim.java
+++ b/test/micro/org/openjdk/bench/java/util/regex/Trim.java
@@ -75,9 +75,9 @@ import java.util.regex.Pattern;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(1)
-@Warmup(iterations = 1)
-@Measurement(iterations = 4)
+@Fork(2)
+@Warmup(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Benchmark)
 public class Trim {
     /** Run length of non-matching consecutive whitespace chars. */


### PR DESCRIPTION
These changes reduce the run time to 45 minutes from about 1h40m with stability good enough for weekly promo build testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292196](https://bugs.openjdk.org/browse/JDK-8292196): Reduce runtime of java.util.regex microbenchmarks


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9861/head:pull/9861` \
`$ git checkout pull/9861`

Update a local copy of the PR: \
`$ git checkout pull/9861` \
`$ git pull https://git.openjdk.org/jdk pull/9861/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9861`

View PR using the GUI difftool: \
`$ git pr show -t 9861`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9861.diff">https://git.openjdk.org/jdk/pull/9861.diff</a>

</details>
