### PR TITLE
8292319: ProblemList 2 runtime/cds/appcds tests due to JDK-8292313

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -102,6 +102,9 @@ applications/jcstress/copy.java 8229852 linux-all
 
 containers/docker/TestJcmd.java 8278102 linux-all
 
+runtime/cds/appcds/WrongClasspath.java 8292313 generic-all 
+runtime/cds/appcds/dynamicArchive/WrongTopClasspath.java 8292313 generic-all
+
 #############################################################################
 
 # :hotspot_serviceability


### PR DESCRIPTION
A trivial fix to ProblemList 2 runtime/cds/appcds tests due to JDK-8292313.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292319](https://bugs.openjdk.org/browse/JDK-8292319): ProblemList 2 runtime/cds/appcds tests due to JDK-8292313


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9867/head:pull/9867` \
`$ git checkout pull/9867`

Update a local copy of the PR: \
`$ git checkout pull/9867` \
`$ git pull https://git.openjdk.org/jdk pull/9867/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9867`

View PR using the GUI difftool: \
`$ git pr show -t 9867`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9867.diff">https://git.openjdk.org/jdk/pull/9867.diff</a>

</details>
