### PR TITLE
8292328 : AccessibleActionsTest.java test instruction for show popup on JLabel did not specify shift key

### DIFF
--- a/test/jdk/java/awt/a11y/AccessibleActionsTest.java
+++ b/test/jdk/java/awt/a11y/AccessibleActionsTest.java
@@ -57,7 +57,7 @@ public class AccessibleActionsTest extends AccessibleComponentTest {
             + "Check a11y actions.\n\n"
             + "Turn screen reader on, and Tab to the label.\n\n"
             + "Perform the VO action \"Press\" (VO+space)\n"
-            + "Perform the VO action \"Show menu\" (VO+m)\n\n"
+            + "Perform the VO action \"Show menu\" (VO+Shift+m)\n\n"
             + "If after the first action the text of the label has changed, and after the second action the menu appears  tab further and press PASS, otherwise press FAIL.";
 
     exceptionString = "AccessibleAction test failed!";


### PR DESCRIPTION
Corrected the test instruction to show the popup menu on JLabel when voice over is enabled .

@shurymury

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292328](https://bugs.openjdk.org/browse/JDK-8292328): AccessibleActionsTest.java test instruction for show popup on JLabel did not specify shift key


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9868/head:pull/9868` \
`$ git checkout pull/9868`

Update a local copy of the PR: \
`$ git checkout pull/9868` \
`$ git pull https://git.openjdk.org/jdk pull/9868/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9868`

View PR using the GUI difftool: \
`$ git pr show -t 9868`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9868.diff">https://git.openjdk.org/jdk/pull/9868.diff</a>

</details>
