### PR TITLE
8292016

### DIFF
--- a/src/java.base/macosx/native/libjli/java_md_macosx.m
+++ b/src/java.base/macosx/native/libjli/java_md_macosx.m
@@ -301,7 +301,7 @@ static void *apple_main (void *arg)
         main_fptr = (int (*)())dlsym(RTLD_DEFAULT, "main");
 #endif
         if (main_fptr == NULL) {
-            JLI_ReportErrorMessageSys("error locating main entrypoint\n");
+            JLI_ReportErrorMessageSys("error locating main entrypoint");
             exit(1);
         }
     }
@@ -346,11 +346,11 @@ static void MacOSXStartup(int argc, char *argv[]) {
     // Fire up the main thread
     pthread_t main_thr;
     if (pthread_create(&main_thr, NULL, &apple_main, &args) != 0) {
-        JLI_ReportErrorMessageSys("Could not create main thread: %s\n", strerror(errno));
+        JLI_ReportErrorMessageSys("Could not create main thread");
         exit(1);
     }
     if (pthread_detach(main_thr)) {
-        JLI_ReportErrorMessageSys("pthread_detach() failed: %s\n", strerror(errno));
+        JLI_ReportErrorMessageSys("pthread_detach() failed");
         exit(1);
     }
 

--- a/src/java.base/share/native/libjli/java.h
+++ b/src/java.base/share/native/libjli/java.h
@@ -136,7 +136,11 @@ void CreateExecutionEnvironment(int *argc, char ***argv,
 JNIEXPORT void JNICALL
 JLI_ReportErrorMessage(const char * message, ...);
 
-/* Reports a system error message to stderr or a window */
+/*
+ * Just like JLI_ReportErrorMessage, except that it concatenates the system
+ * error message if any, with a separator similar to std::perror. The error
+ * that was reported is cleared after this is called.
+ */
 JNIEXPORT void JNICALL
 JLI_ReportErrorMessageSys(const char * message, ...);
 

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -200,19 +200,23 @@ JLI_ReportErrorMessage(const char* fmt, ...) {
 JNIEXPORT void JNICALL
 JLI_ReportErrorMessageSys(const char* fmt, ...) {
     va_list vl;
-    char *emsg;
-
-    /*
-     * TODO: its safer to use strerror_r but is not available on
-     * Solaris 8. Until then....
-     */
-    emsg = strerror(errno);
-    if (emsg != NULL) {
-        fprintf(stderr, "%s\n", emsg);
-    }
 
     va_start(vl, fmt);
     vfprintf(stderr, fmt, vl);
+
+    if (errno != 0) {
+        /*
+         * Buffer size of 1024 copied from typical POSIX size used
+         * in strerror_r
+         */
+        char error[1024];
+        if(strerror_r(errno, error, sizeof error) == 0) {
+            fprintf(stderr, ": %s", error);
+        } else {
+        	fprintf(stderr, ": Java could not determine the underlying error");
+        }
+        errno = 0;
+    }
     fprintf(stderr, "\n");
     va_end(vl);
 }


### PR DESCRIPTION
Second attempt at resolving [JDK-8292016](https://bugs.openjdk.org/browse/JDK-8292016) with a less intrusive approach this time (Clearing the error after the call, which is done in other areas of the JDK as well)

Side note: While it might be preferred to remove this entirely, other areas of the JDK also use the same flawed logic, and removing this would simply push the issue elsewhere. Fixing this might result in a solution which can be used in those areas in the future.