### PR TITLE
8292338: aarch64: Use cbnz instruction in gen_continuation_enter when possible

### DIFF
--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -1050,8 +1050,7 @@ static void gen_continuation_enter(MacroAssembler* masm,
 
     fill_continuation_entry(masm);
 
-    __ cmp(c_rarg2, (u1)0);
-    __ br(Assembler::NE, call_thaw);
+    __ cbnz(c_rarg2, call_thaw);
 
     address mark = __ pc();
     __ trampoline_call(resolve);
@@ -1076,8 +1075,7 @@ static void gen_continuation_enter(MacroAssembler* masm,
 
   fill_continuation_entry(masm);
 
-  __ cmp(c_rarg2, (u1)0);
-  __ br(Assembler::NE, call_thaw);
+  __ cbnz(c_rarg2, call_thaw);
 
   address mark = __ pc();
   __ trampoline_call(resolve);


### PR DESCRIPTION
This is a trivial improvement for gen_continuation_enter on AArch64.
On AAch64, we can combine Compare and Branch on Zero/Nonzero into CBZ/CBNZ to save one instruction.
Tier1 tested with fastdebug build on aarch64-linux-gnu.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292338](https://bugs.openjdk.org/browse/JDK-8292338): aarch64: Use cbnz instruction in gen_continuation_enter when possible


### Reviewers
 * [Hao Sun](https://openjdk.org/census#haosun) (@shqking - Author)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9872/head:pull/9872` \
`$ git checkout pull/9872`

Update a local copy of the PR: \
`$ git checkout pull/9872` \
`$ git pull https://git.openjdk.org/jdk pull/9872/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9872`

View PR using the GUI difftool: \
`$ git pr show -t 9872`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9872.diff">https://git.openjdk.org/jdk/pull/9872.diff</a>

</details>
