### PR TITLE
8292347: Remove unused Type::is_ptr_to_boxing_obj

### DIFF
--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -280,9 +280,6 @@ public:
   bool is_ptr_to_narrowoop() const;
   bool is_ptr_to_narrowklass() const;
 
-  bool is_ptr_to_boxing_obj() const;
-
-
   // Convenience access
   float getf() const;
   double getd() const;
@@ -2033,12 +2030,6 @@ inline bool Type::is_floatingpoint() const {
       (_base == DoubleCon) || (_base == DoubleBot) )
     return true;
   return false;
-}
-
-inline bool Type::is_ptr_to_boxing_obj() const {
-  const TypeInstPtr* tp = isa_instptr();
-  return (tp != NULL) && (tp->offset() == 0) &&
-         tp->instance_klass()->is_box_klass();
 }
 
 


### PR DESCRIPTION
`Type::is_ptr_to_boxing_obj` is unused and should be removed.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292347](https://bugs.openjdk.org/browse/JDK-8292347): Remove unused Type::is_ptr_to_boxing_obj


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9873/head:pull/9873` \
`$ git checkout pull/9873`

Update a local copy of the PR: \
`$ git checkout pull/9873` \
`$ git pull https://git.openjdk.org/jdk pull/9873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9873`

View PR using the GUI difftool: \
`$ git pr show -t 9873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9873.diff">https://git.openjdk.org/jdk/pull/9873.diff</a>

</details>
