### PR TITLE
JDK-8292351: tty should always live

### DIFF
--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -429,7 +429,7 @@ stringStream::~stringStream() {
 // be (easily) postponed or omitted since it has ties to the JVM infrastructure.
 // The policy followed here is a compromise reached during review of JDK-8292351:
 // - pre-init: we silently swallow all output. We won't see anything, but at least won't crash
-// - post-exit: we write to a simple fdStream, but somewhat mimik the behavior of the real defaultStream
+// - post-exit: we write to a simple fdStream, but somewhat mimic the behavior of the real defaultStream
 static nullStream tty_preinit_stream;
 outputStream* tty = &tty_preinit_stream;
 
@@ -976,10 +976,11 @@ void ostream_exit() {
   ostream_exit_called = true;
   ClassListWriter::delete_classlist();
   // Make sure tty works after VM exit by assigning an always-on functioning fdStream.
-  if (tty != &tty_preinit_stream && tty != defaultStream::instance) {
-    delete tty;
-  }
+  outputStream* tmp = tty;
   tty = DisplayVMOutputToStderr ? fdStream::stdout_stream() : fdStream::stderr_stream();
+  if (tmp != &tty_preinit_stream && tmp != defaultStream::instance) {
+    delete tmp;
+  }
   delete defaultStream::instance;
   xtty = NULL;
   defaultStream::instance = NULL;

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -425,10 +425,10 @@ stringStream::~stringStream() {
 // The "real" tty is implemented by class defaultStream. But that cannot be used pre-VM-init
 // since its behavior depends on VM arguments that are not parsed yet. Therefore we point tty
 // to a simple always functioning stdout fdstream.
-static fdStream g_stdout_stream(os::get_fileno(stderr));
+static fdStream g_stderr_stream(os::get_fileno(stderr));
 
 xmlStream*   xtty;
-outputStream* tty = &g_stdout_stream;
+outputStream* tty = &g_stderr_stream;
 extern Mutex* tty_lock;
 
 #define EXTRACHARLEN   32
@@ -973,7 +973,7 @@ void ostream_exit() {
   if (defaultStream::instance != NULL) {
     delete defaultStream::instance;
   }
-  tty = &g_stdout_stream;
+  tty = &g_stderr_stream;
   xtty = NULL;
   defaultStream::instance = NULL;
 }

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -425,7 +425,7 @@ stringStream::~stringStream() {
 // The "real" tty is implemented by class defaultStream. But that cannot be used pre-VM-init
 // since its behavior depends on VM arguments that are not parsed yet. Therefore we point tty
 // to a simple always functioning stdout fdstream.
-static fdStream g_stdout_stream(os::get_fileno(stdout));
+static fdStream g_stdout_stream(os::get_fileno(stderr));
 
 xmlStream*   xtty;
 outputStream* tty = &g_stdout_stream;

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -424,7 +424,7 @@ stringStream::~stringStream() {
 // "tty" neeeds to be always valid since it may get used pre-VM-init and post-VM-cleanup.
 // The "real" tty is implemented by class defaultStream. But that cannot be used pre-VM-init
 // since its behavior depends on VM arguments that are not parsed yet. Therefore we point tty
-// to a simple always functioning stdout fdstream.
+// to a simple always functioning fdstream pointing to stderr.
 static fdStream g_stderr_stream(os::get_fileno(stderr));
 
 xmlStream*   xtty;

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -421,8 +421,14 @@ stringStream::~stringStream() {
   }
 }
 
+// "tty" neeeds to be always valid since it may get used pre-VM-init and post-VM-cleanup.
+// The "real" tty is implemented by class defaultStream. But that cannot be used pre-VM-init
+// since its behavior depends on VM arguments that are not parsed yet. Therefore we point tty
+// to a simple always functioning stdout fdstream.
+static fdStream g_stdout_stream(os::get_fileno(stdout));
+
 xmlStream*   xtty;
-outputStream* tty;
+outputStream* tty = &g_stdout_stream;
 extern Mutex* tty_lock;
 
 #define EXTRACHARLEN   32
@@ -967,7 +973,7 @@ void ostream_exit() {
   if (defaultStream::instance != NULL) {
     delete defaultStream::instance;
   }
-  tty = NULL;
+  tty = &g_stdout_stream;
   xtty = NULL;
   defaultStream::instance = NULL;
 }

--- a/src/hotspot/share/utilities/ostream.hpp
+++ b/src/hotspot/share/utilities/ostream.hpp
@@ -248,12 +248,25 @@ class fileStream : public outputStream {
 class fdStream : public outputStream {
  protected:
   int  _fd;
+  static fdStream _stdout_stream;
+  static fdStream _stderr_stream;
  public:
   fdStream(int fd = -1) : _fd(fd) { }
   bool is_open() const { return _fd != -1; }
   void set_fd(int fd) { _fd = fd; }
   int fd() const { return _fd; }
   virtual void write(const char* c, size_t len);
+  void flush() {};
+
+  // predefined streams for unbuffered IO to stdout, stderr
+  static fdStream* stdout_stream() { return &_stdout_stream; }
+  static fdStream* stderr_stream() { return &_stderr_stream; }
+};
+
+// A /dev/null equivalent stream
+class nullStream : public outputStream {
+public:
+  void write(const char* c, size_t len) {}
   void flush() {};
 };
 


### PR DESCRIPTION
The default stream object tty is used in many places but its lifetime is limited. It gets born not-quite at the beginning of VM initialization and dies in DestroyVM. This leaves time windows before VM initialization and after VM cleanup where logging to tty crashes.

This has been bugging me in the past, especially when wanting to use tty in code that runs very early (NMT preinit system, for example), and also causes problems for code that runs post-cleanup. Mostly this affects logging and error logging.

tty should always be safe to write to, and that is trivial to do.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292351](https://bugs.openjdk.org/browse/JDK-8292351): tty should always live


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [9d6a9082](https://git.openjdk.org/jdk/pull/9874/files/9d6a90824cf8491ef7df839b6022556ef176b79b)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9874/head:pull/9874` \
`$ git checkout pull/9874`

Update a local copy of the PR: \
`$ git checkout pull/9874` \
`$ git pull https://git.openjdk.org/jdk pull/9874/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9874`

View PR using the GUI difftool: \
`$ git pr show -t 9874`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9874.diff">https://git.openjdk.org/jdk/pull/9874.diff</a>

</details>
