### PR TITLE
8292352: 32-bit Windows build failures after JDK-8290059

### DIFF
--- a/test/lib/native/testlib_threads.h
+++ b/test/lib/native/testlib_threads.h
@@ -54,7 +54,7 @@ static void fatal(const char* message, int code) {
 // Adapt from the callback type the OS API expects to
 // our OS-independent PROCEDURE type.
 #ifdef _WIN32
-static DWORD procedure(_In_ LPVOID ctxt) {
+DWORD WINAPI procedure(_In_ LPVOID ctxt) {
 #else
 void* procedure(void* ctxt) {
 #endif


### PR DESCRIPTION
The affected file was added by [JDK-8290059](https://bugs.openjdk.org/browse/JDK-8290059), and the code that fails the compilation is under `#ifdef _WIN32`, and it only (?) gets compiled for tests. Looks like we really need the "WINAPI" macro in the definition, so that we match the stdcall. See the example declaration in the [docs](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms686736(v=vs.85)).

Attn @JornVernee.

Additional testing:
 - [x] Windows x86_32 builds, `java/foreign` tests now pass
 - [x] Windows x86_64 builds, `java/foreign` tests still pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292352](https://bugs.openjdk.org/browse/JDK-8292352): 32-bit Windows build failures after JDK-8290059


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9875/head:pull/9875` \
`$ git checkout pull/9875`

Update a local copy of the PR: \
`$ git checkout pull/9875` \
`$ git pull https://git.openjdk.org/jdk pull/9875/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9875`

View PR using the GUI difftool: \
`$ git pr show -t 9875`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9875.diff">https://git.openjdk.org/jdk/pull/9875.diff</a>

</details>
