### PR TITLE
8292361: Build failure on PPC64 BE after JDK-8290840

### DIFF
--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -424,7 +424,7 @@ class os::Linux {
     return _nindex_to_node;
   }
 
-  void* resolve_function_descriptor(void* p);
+  static void* resolve_function_descriptor(void* p);
 };
 
 #endif // OS_LINUX_OS_LINUX_HPP


### PR DESCRIPTION
The only platform where this reproduces seems to be ppc64be. ppc64le builds fine.

```
* For target hotspot_variant-server_libjvm_objs_abstractInterpreter.o:
In file included from /home/buildbot/worker/build-jdkX-debian11/build/src/hotspot/share/runtime/os.inline.hpp:31,
                 from /home/buildbot/worker/build-jdkX-debian11/build/src/hotspot/cpu/ppc/macroAssembler_ppc.inline.hpp:37,
                 from /home/buildbot/worker/build-jdkX-debian11/build/src/hotspot/share/asm/macroAssembler.inline.hpp:30,
                 from /home/buildbot/worker/build-jdkX-debian11/build/src/hotspot/share/interpreter/abstractInterpreter.cpp:27:
/home/buildbot/worker/build-jdkX-debian11/build/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.inline.hpp: In static member function 'static void* os::resolve_function_descriptor(void*)':
/home/buildbot/worker/build-jdkX-debian11/build/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.inline.hpp:35:50: error: cannot call member function 'void* os::Linux::resolve_function_descriptor(void*)' without object
   35 |   return os::Linux::resolve_function_descriptor(p);
      |                                                  ^
```

I think we can make it go away if you make sure that `resolve_function_descriptor` is universally declared as `static`. `os_aix.hpp` and `os.hpp` already do that. This patch fixes the third declaration.

Additional testing:
 - [x] linux-x86_64-server-fastdebug build
 - [x] linux-x86_64-zero-fastdebug build
 - [x] linux-x86-server-fastdebug build
 - [x] linux-aarch64-server-fastdebug cross-build
 - [x] linux-arm-server-fastdebug cross-build
 - [x] linux-riscv64-server-fastdebug cross-build
 - [x] linux-s390x-server-fastdebug cross-build
 - [x] linux-ppc64le-server-fastdebug cross-build
 - [x] linux-ppc64-server-fastdebug cross-build (now passes)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292361](https://bugs.openjdk.org/browse/JDK-8292361): Build failure on PPC64 BE after JDK-8290840


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9876/head:pull/9876` \
`$ git checkout pull/9876`

Update a local copy of the PR: \
`$ git checkout pull/9876` \
`$ git pull https://git.openjdk.org/jdk pull/9876/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9876`

View PR using the GUI difftool: \
`$ git pr show -t 9876`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9876.diff">https://git.openjdk.org/jdk/pull/9876.diff</a>

</details>
