### PR TITLE
8292362: java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1 failed on some platforms

### DIFF
--- a/test/jdk/java/lang/Thread/jni/AttachCurrentThread/AttachTest.java
+++ b/test/jdk/java/lang/Thread/jni/AttachCurrentThread/AttachTest.java
@@ -36,7 +36,7 @@
 /**
  * @test
  * @summary Test native threads attaching implicitly to the VM by means of an upcall
- * @requires (os.family == "linux" | os.family == "mac") & (sun.arch.data.model == "64") & (os.arch == "amd64" | os.arch == "x86_64" | os.arch == "aarch64")
+ * @requires (os.family == "linux" | os.family == "mac") & (sun.arch.data.model == "64")
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} ImplicitAttach.java
  * @run main AttachTest --enable-preview --enable-native-access=ALL-UNNAMED ImplicitAttach 1

--- a/test/jdk/java/lang/Thread/jni/AttachCurrentThread/AttachTest.java
+++ b/test/jdk/java/lang/Thread/jni/AttachCurrentThread/AttachTest.java
@@ -36,7 +36,7 @@
 /**
  * @test
  * @summary Test native threads attaching implicitly to the VM by means of an upcall
- * @requires (os.family == "linux" | os.family == "mac") & (sun.arch.data.model == "64")
+ * @requires (os.family == "linux" | os.family == "mac") & (sun.arch.data.model == "64") & (os.arch == "amd64" | os.arch == "x86_64" | os.arch == "aarch64")
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} ImplicitAttach.java
  * @run main AttachTest --enable-preview --enable-native-access=ALL-UNNAMED ImplicitAttach 1

--- a/test/jdk/java/lang/Thread/jni/AttachCurrentThread/ImplicitAttach.java
+++ b/test/jdk/java/lang/Thread/jni/AttachCurrentThread/ImplicitAttach.java
@@ -45,7 +45,13 @@ public class ImplicitAttach {
         }
         latch = new CountDownLatch(threadCount);
 
-        Linker abi = Linker.nativeLinker();
+        Linker abi;
+        try {
+            abi = Linker.nativeLinker();
+        } catch (UnsupportedOperationException e) {
+            System.out.println("Test skipped, no native linker on this platform");
+            return;
+        }
 
         // stub to invoke callback
         MethodHandle callback = MethodHandles.lookup()


### PR DESCRIPTION
For example, java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1 failed on LoongArch64 (probably other platforms unsupported in src/java.base/share/classes/jdk/internal/foreign/CABI.java might have the same issue):
 
```
Exception in thread "main" java.lang.UnsupportedOperationException: Unsupported os, arch, or address size: Linux, loongarch64, 64
at java.base/jdk.internal.foreign.CABI.current(CABI.java:69)
at java.base/jdk.internal.foreign.abi.SharedUtils.getSystemLinker(SharedUtils.java:237)
at java.base/java.lang.foreign.Linker.nativeLinker(Linker.java:198)
at ImplicitAttach.main(ImplicitAttach.java:48)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292362](https://bugs.openjdk.org/browse/JDK-8292362): java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1 failed on some platforms


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Contributors
 * Alan Bateman `<alanb@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9877/head:pull/9877` \
`$ git checkout pull/9877`

Update a local copy of the PR: \
`$ git checkout pull/9877` \
`$ git pull https://git.openjdk.org/jdk pull/9877/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9877`

View PR using the GUI difftool: \
`$ git pr show -t 9877`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9877.diff">https://git.openjdk.org/jdk/pull/9877.diff</a>

</details>
