### PR TITLE
8291775: C2: assert(r != __null && r->is_Region()) failed: this phi must have a region

### DIFF
--- a/src/hotspot/share/opto/stringopts.cpp
+++ b/src/hotspot/share/opto/stringopts.cpp
@@ -261,10 +261,12 @@ void StringConcat::eliminate_unneeded_control() {
       Node* cmp = bol->in(1);
       assert(cmp->is_Cmp(), "unexpected if shape");
       if (cmp->in(1)->is_top() || cmp->in(2)->is_top()) {
-        // This region should lose its Phis and be optimized out by igvn but there's a chance the if folds to top first
-        // which then causes a reachable part of the graph to become dead.
+        // This region should lose its Phis. They are removed either in PhaseRemoveUseless (for data phis) or in IGVN
+        // (for memory phis). During IGVN, there is a chance that the If folds to top before the Region is processed
+        // which then causes a reachable part of the graph to become dead. To prevent this, set the boolean input of
+        // the If to a constant to nicely let the diamond Region/If fold away.
         Compile* C = _stringopts->C;
-        C->gvn_replace_by(n, iff->in(0));
+        C->gvn_replace_by(iff->in(1), _stringopts->gvn()->intcon(0));
       }
     }
   }

--- a/test/hotspot/jtreg/compiler/c2/Test7179138_1.java
+++ b/test/hotspot/jtreg/compiler/c2/Test7179138_1.java
@@ -31,6 +31,9 @@
  *      compiler.c2.Test7179138_1
  * @run main/othervm -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation
  *      -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN compiler.c2.Test7179138_1
+ * @run main/othervm -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:+AlwaysIncrementalInline
+ *      compiler.c2.Test7179138_1
  *
  * @author Skip Balk
  */


### PR DESCRIPTION
[JDK-8271341](https://bugs.openjdk.org/browse/JDK-8271341) fixed a case for string opts where a diamond `Region/If` in the middle of a chain of calls that are optimized out is not folded away correctly in IGVN, leading to a broken graph. The problem in the test case of JDK-8271341 was the following: 

One of the inputs of the `Cmp` nodes of the `If` is replaced by top (the data projection of the removed call into the `Cmp` node). During IGVN, top propagated too quickly to the `If` before the `Region/If` diamond could be folded away. As a result, the control flow below the `If` became dead. The fix was to eagerly fold the `Region/If` diamond in string opts by replacing the `Region` by the control input of the `If`  (see https://github.com/openjdk/jdk/pull/4944):

![Screenshot from 2022-08-15 11-24-31](https://user-images.githubusercontent.com/17833009/184611029-72852d8a-aaef-40bd-b792-a6e6fa1b33aa.png)

Replaced `396 Region` by control input of `If` (`330 IfTrue`):

![Screenshot from 2022-08-15 11-24-47](https://user-images.githubusercontent.com/17833009/184611053-678afd48-03c5-4c79-b14a-28ab7d5c1b5c.png)

The reason why we can rewire the phis to a non-region during string opts is because all phis are dead and will be removed. In the testcase of JDK-8271341, this is done in `PhaseRemoveUseless` because the data `424 Phi` has no users after string opts anymore. 

However, in the test case of this bug (actually the same test case but run with `-XX:+AlwaysIncrementalInline`), we have an additional memory phi which is actually dead but not removed by `PhaseRemoveUseless` because it still has other users at that point. The memory phi would eventually be removed during IGVN but the problem is that it is unexpected to process a phi with a non-region control input and we fail with the assertion in `PhiNode::Ideal()`.

The fix I propose is to not replace the `Region` node with the control input of the `If` as in JDK-8271341 but instead setting the boolean input of the `If` node to a constant (doesn't matter if 0 or 1 since the phis are dead anyways). If we then process the `If` or `IfTrue/IfFalse` before the `Region` in IGVN, we simply fold the node. This allows IGVN to safely remove a diamond `Region/If` without interference of top from string opts. The memory phi is eventually removed during IGVN.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291775](https://bugs.openjdk.org/browse/JDK-8291775): C2: assert(r != __null && r->is_Region()) failed: this phi must have a region


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9878/head:pull/9878` \
`$ git checkout pull/9878`

Update a local copy of the PR: \
`$ git checkout pull/9878` \
`$ git pull https://git.openjdk.org/jdk pull/9878/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9878`

View PR using the GUI difftool: \
`$ git pr show -t 9878`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9878.diff">https://git.openjdk.org/jdk/pull/9878.diff</a>

</details>
