### PR TITLE
8292318: Memory corruption in remove_dumptime_info

### DIFF
--- a/src/hotspot/share/classfile/systemDictionaryShared.hpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.hpp
@@ -168,15 +168,6 @@ private:
   static DumpTimeLambdaProxyClassDictionary* _dumptime_lambda_proxy_class_dictionary;
   static DumpTimeLambdaProxyClassDictionary* _cloned_dumptime_lambda_proxy_class_dictionary;
 
-  // Doesn't need to be cloned as it's not modified during dump time.
-  using SavedCpCacheEntriesTable = ResourceHashtable<
-    ConstantPoolCache*,
-    ConstantPoolCacheEntry*,
-    15889, // prime number
-    ResourceObj::C_HEAP,
-    mtClassShared>;
-  static SavedCpCacheEntriesTable* _saved_cpcache_entries_table;
-
   static ArchiveInfo _static_archive;
   static ArchiveInfo _dynamic_archive;
 
@@ -248,10 +239,8 @@ public:
     return ClassLoaderData::the_null_class_loader_data()->dictionary();
   }
 
-  static void set_saved_cpcache_entries(ConstantPoolCache* cpc, ConstantPoolCacheEntry* entries);
-  static ConstantPoolCacheEntry* get_saved_cpcache_entries_locked(ConstantPoolCache* k);
-  static void remove_saved_cpcache_entries(ConstantPoolCache* cpc);
-  static void remove_saved_cpcache_entries_locked(ConstantPoolCache* cpc);
+  static void set_resolution_info(InstanceKlass* k, DumpTimeResolutionInfo* res_info);
+  static DumpTimeResolutionInfo* get_resolution_info_locked(InstanceKlass* k);
 
   static void update_shared_entry(InstanceKlass* klass, int id);
   static void set_shared_class_misc_info(InstanceKlass* k, ClassFileStream* cfs);

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -576,8 +576,6 @@ void InstanceKlass::deallocate_record_components(ClassLoaderData* loader_data,
 // This function deallocates the metadata and C heap pointers that the
 // InstanceKlass points to.
 void InstanceKlass::deallocate_contents(ClassLoaderData* loader_data) {
-  SystemDictionaryShared::handle_class_unloading(this);
-
   // Orphan the mirror first, CMS thinks it's still live.
   if (java_mirror() != NULL) {
     java_lang_Class::set_klass(java_mirror(), NULL);
@@ -692,6 +690,8 @@ void InstanceKlass::deallocate_contents(ClassLoaderData* loader_data) {
     MetadataFactory::free_metadata(loader_data, annotations());
   }
   set_annotations(NULL);
+
+  SystemDictionaryShared::handle_class_unloading(this);
 }
 
 bool InstanceKlass::is_record() const {


### PR DESCRIPTION
In [JDK-8290833](https://bugs.openjdk.org/browse/JDK-8290833) (#9759), I added a table (`SystemDictionaryShared::_saved_cpcache_entries_table`) that remembers the initial state of a `ConstantPoolCache` during CDS dumping. This table is indexed with a `ConstantPoolCache*`

However, `ConstantPoolCache` has a complex lifecycle, especially with class redefinition. This makes it difficult to clean up the table. The crash reported in [the current bug](https://bugs.openjdk.org/browse/JDK-8292318) happened during clean up, probably because an `InstanceKlass` was still valid but its `ConstantPool` or `ConstantPoolCache` were not.

`DumpTimeClassInfo` is used to store various data required by CDS dumping. In this PR, I piggy-back the storage of the initial `ConstantPoolCache` states on `DumpTimeClassInfo`, so we don't need to worry about the lifecycles of `ConstantPoolCache` anymore.

See `DumpTimeClassInfo::set_resolution_info()` for the handling of class redefinition.

instanceKlass.cpp was reverted to the state before #9759.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292318](https://bugs.openjdk.org/browse/JDK-8292318): Memory corruption in remove_dumptime_info


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9883/head:pull/9883` \
`$ git checkout pull/9883`

Update a local copy of the PR: \
`$ git checkout pull/9883` \
`$ git pull https://git.openjdk.org/jdk pull/9883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9883`

View PR using the GUI difftool: \
`$ git pr show -t 9883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9883.diff">https://git.openjdk.org/jdk/pull/9883.diff</a>

</details>
