### PR TITLE
8292313: 2 runtime/cds/appcds tests fail after JDK-8284313

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -102,9 +102,6 @@ applications/jcstress/copy.java 8229852 linux-all
 
 containers/docker/TestJcmd.java 8278102 linux-all
 
-runtime/cds/appcds/WrongClasspath.java 8292313 generic-all 
-runtime/cds/appcds/dynamicArchive/WrongTopClasspath.java 8292313 generic-all
-
 #############################################################################
 
 # :hotspot_serviceability

--- a/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary classpath mismatch between dump time and execution time
- * @requires vm.cds
+ * @requires vm.cds & vm.flagless
  * @library /test/lib
  * @compile test-classes/Hello.java
  * @compile test-classes/C2.java

--- a/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary classpath mismatch between dump time and execution time
- * @requires vm.cds & vm.flagless
+ * @requires vm.cds
  * @library /test/lib
  * @compile test-classes/Hello.java
  * @compile test-classes/C2.java
@@ -75,7 +75,7 @@ public class WrongClasspath {
     // message should be there.
     output = TestCommon.execAuto(
         "-cp", jars, "Hello");
-    output.shouldMatch(".warning..cds. A jar file is not the one used while building the shared archive file:.*jar2.jar")
+    output.shouldMatch("A jar file is not the one used while building the shared archive file:.*jar2.jar")
           .shouldMatch(".warning..cds.*jar2.jar timestamp has changed.");
   }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/WrongTopClasspath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/WrongTopClasspath.java
@@ -27,7 +27,7 @@ import java.io.File;
 /*
  * @test
  * @summary correct classpath for bottom archive, but bad classpath for top archive
- * @requires vm.cds & vm.flagless
+ * @requires vm.cds
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @build GenericTestApp jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar jdk.test.whitebox.WhiteBox
@@ -83,7 +83,7 @@ public class WrongTopClasspath extends DynamicArchiveTestBase {
                 "assertShared:java.lang.Object",  // base archive still useable
                 "assertNotShared:GenericTestApp") // but top archive is not useable
           .assertNormalExit(topArchiveMsg,
-                            "[warning][cds] shared class paths mismatch (hint: enable -Xlog:class+path=info to diagnose the failure)");
+                            "shared class paths mismatch (hint: enable -Xlog:class+path=info to diagnose the failure)");
 
         // modify the timestamp of appJar
         (new File(appJar.toString())).setLastModified(System.currentTimeMillis() + 2000);
@@ -97,7 +97,7 @@ public class WrongTopClasspath extends DynamicArchiveTestBase {
                 "assertNotShared:GenericTestApp") // but top archive is not useable
           .assertNormalExit(output -> {
               output.shouldContain(topArchiveMsg);
-              output.shouldMatch(".warning..cds. A jar file is not the one used while building the shared archive file:.*GenericTestApp.jar");
+              output.shouldMatch("A jar file is not the one used while building the shared archive file:.*GenericTestApp.jar");
               output.shouldMatch(".warning..cds.*GenericTestApp.jar timestamp has changed.");});
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/WrongTopClasspath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/WrongTopClasspath.java
@@ -27,7 +27,7 @@ import java.io.File;
 /*
  * @test
  * @summary correct classpath for bottom archive, but bad classpath for top archive
- * @requires vm.cds
+ * @requires vm.cds & vm.flagless
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @build GenericTestApp jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar jdk.test.whitebox.WhiteBox


### PR DESCRIPTION
The tests failed due to the presence of the -Xlog:cds flag. 

In the WrongTopClasspath.java test, it expects the following warning: 
`[warning][cds] shared class paths mismatch (hint: enable -Xlog:class+path=info to diagnose the failure) `

with -Xlog:cds enabled, the log statement becomes: 
`[info][cds] UseSharedSpaces: shared class paths mismatch (hint: enable -Xlog:class+path=info to diagnose the failure)` 

Since both tests are running in both Tiers 2 and 3 and the tests are not testing any of the VM flags settings in Tier4, I think we can simply add the following @requires to the tests: 
    vm.flagless

This message going to different channels (warning vs log) issue will be addressed in [JDK-8292269](https://bugs.openjdk.org/browse/JDK-8292269).

Passed tier2 testing and tested with `-Xlog:cds` locally on linux-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292313](https://bugs.openjdk.org/browse/JDK-8292313): 2 runtime/cds/appcds tests fail after JDK-8284313


### Reviewers
 * [Harold Seigel](https://openjdk.org/census#hseigel) (@hseigel - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9884/head:pull/9884` \
`$ git checkout pull/9884`

Update a local copy of the PR: \
`$ git checkout pull/9884` \
`$ git pull https://git.openjdk.org/jdk pull/9884/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9884`

View PR using the GUI difftool: \
`$ git pr show -t 9884`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9884.diff">https://git.openjdk.org/jdk/pull/9884.diff</a>

</details>
