### PR TITLE
8292395: [testbug] VectorGatherScatterTest.java fails on SVE with -XX:MaxVectorSize=8 after JDK-8288397

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/VectorGatherScatterTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorGatherScatterTest.java
@@ -42,7 +42,7 @@ import jdk.test.lib.Utils;
  * @bug 8288397
  * @key randomness
  * @library /test/lib /
- * @requires vm.cpu.features ~= ".*sve.*"
+ * @requires vm.cpu.features ~= ".*sve.*" & (vm.opt.MaxVectorSize == "null" | vm.opt.MaxVectorSize >= 16)
  * @summary AArch64: Fix register issues in SVE backend match rules
  * @modules jdk.incubator.vector
  *


### PR DESCRIPTION
This test case was introduced in JDK-8288397 to check the misused
register issue for gather load/scatter store rules. `I_SPECIES` was set
intentionally as half of the length of `L_SPECIES` so as to trigger the
register issue.

However, if "-XX:MaxVectorSize=8" is specified from command line,
invalid vector size, i.e. 32-bit, is set for IntVector, leading to the
clinit failure, while initializing `I_SPECIES`.

To bypass this failure, we check "MaxVectorSize" option at the
"requires" annotation part in this patch, that is, we limit the minimal
value of "MaxVectorSize" as 16 bytes.

Testing:

1. We ran the test case on 512-bit SVE machine with 1) the default
MaxVectorSize, 2) MaxVectorSize=8 and 3) MaxVectorSize=16, and the test
passed. Note that in 2), this test case is actullay not selected since
the condition at the "requires" annotation is not satisfied.

2. We also manually checked that this patch doesn't change the
functionality of this test case, i.e. checking the register issue.