### PR TITLE
8292304: [REDO] JDK-8289208 Test DrawRotatedStringUsingRotatedFont.java occasionally crashes on MacOS

### DIFF
--- a/src/java.desktop/share/classes/sun/java2d/Disposer.java
+++ b/src/java.desktop/share/classes/sun/java2d/Disposer.java
@@ -33,8 +33,8 @@ import java.lang.ref.PhantomReference;
 import java.lang.ref.WeakReference;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.ArrayList;
 import java.util.Hashtable;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 /**
  * This class is used for registering and disposing the native
@@ -145,7 +145,7 @@ public class Disposer implements Runnable {
                 Reference<?> obj = queue.remove();
                 obj.clear();
                 DisposerRecord rec = records.remove(obj);
-                rec.dispose();
+                safeDispose(rec);
                 obj = null;
                 rec = null;
                 clearDeferredRecords();
@@ -164,21 +164,23 @@ public class Disposer implements Runnable {
     public static interface PollDisposable {
     };
 
-    private static ArrayList<DisposerRecord> deferredRecords = null;
+    private static ConcurrentLinkedDeque<DisposerRecord> deferredRecords = new ConcurrentLinkedDeque<>();
+
+    private static void safeDispose(DisposerRecord rec) {
+        try {
+            rec.dispose();
+        } catch (final Exception e) {
+            System.out.println("Exception while disposing deferred rec.");
+        }
+    }
 
     private static void clearDeferredRecords() {
-        if (deferredRecords == null || deferredRecords.isEmpty()) {
-            return;
-        }
-        for (int i=0;i<deferredRecords.size(); i++) {
-            try {
-                DisposerRecord rec = deferredRecords.get(i);
-                rec.dispose();
-            } catch (Exception e) {
-                System.out.println("Exception while disposing deferred rec.");
+        while (!deferredRecords.isEmpty()) {
+            final DisposerRecord rec = deferredRecords.pollFirst();
+            if (rec != null) {
+                safeDispose(rec);
             }
         }
-        deferredRecords.clear();
     }
 
     /*
@@ -211,7 +213,7 @@ public class Disposer implements Runnable {
                 obj.clear();
                 DisposerRecord rec = records.remove(obj);
                 if (rec instanceof PollDisposable) {
-                    rec.dispose();
+                    safeDispose(rec);
                     obj = null;
                     rec = null;
                 } else {
@@ -219,10 +221,7 @@ public class Disposer implements Runnable {
                         continue;
                     }
                     deferred++;
-                    if (deferredRecords == null) {
-                      deferredRecords = new ArrayList<DisposerRecord>(5);
-                    }
-                    deferredRecords.add(rec);
+                    deferredRecords.offerLast(rec);
                 }
             }
         } catch (Exception e) {

--- a/test/jdk/java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java
+++ b/test/jdk/java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java
@@ -37,7 +37,8 @@ import static java.lang.Math.toRadians;
 
 /**
  * @test
- * @bug 8065373
+ * @bug 8065373 8289208
+ * @key headful
  * @summary Verifies that we get correct direction, when draw rotated string.
  * @author Sergey Bylokhov
  * @run main DrawRotatedStringUsingRotatedFont

--- a/test/jdk/sun/java2d/Disposer/TestDisposerRace.java
+++ b/test/jdk/sun/java2d/Disposer/TestDisposerRace.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2022, JetBrains s.r.o.. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.swing.SwingUtilities;
+
+import sun.java2d.Disposer;
+import sun.java2d.DisposerRecord;
+
+/**
+ * @test
+ * @bug 8289208
+ * @summary Verifies Disposer robustness in a multi-threaded environment.
+ * @run main/othervm -mx128m TestDisposerRace
+ * @modules java.desktop/sun.java2d
+ */
+public final class TestDisposerRace {
+    private static final AtomicInteger recordsCount = new AtomicInteger();
+    private static volatile boolean disposerDone = false;
+
+    public static void main(String[] args) throws Exception {
+        TestDisposerRace test = new TestDisposerRace();
+        test.run();
+
+        checkRecordsCountIsSane();
+        if (recordsCount.get() > 0) {
+            throw new RuntimeException("Some records (" + recordsCount + ") have not been disposed");
+        }
+    }
+
+    TestDisposerRace() {
+        addRecordsToDisposer(30_000);
+    }
+
+    void run() throws Exception {
+        generateOOME();
+        for (int i = 0; i < 1000; ++i) {
+            SwingUtilities.invokeAndWait(Disposer::pollRemove);
+            if (i % 10 == 0) {
+                // Adding records will race with the diposer trying to remove them
+                addRecordsToDisposer(1000);
+            }
+        }
+
+        Disposer.addObjectRecord(new Object(), new FinalDisposerRecord());
+
+        while (!disposerDone) {
+             generateOOME();
+        }
+    }
+
+    private static void checkRecordsCountIsSane() {
+        if (recordsCount.get() < 0) {
+            throw new RuntimeException("Disposed more records than were added");
+        }
+    }
+
+    private void addRecordsToDisposer(int count) {
+        checkRecordsCountIsSane();
+
+        recordsCount.addAndGet(count);
+
+        MyDisposerRecord disposerRecord = new MyDisposerRecord();
+        for (int i = 0; i < count; i++) {
+            Disposer.addObjectRecord(new Object(), disposerRecord);
+        }
+    }
+
+    class MyDisposerRecord implements DisposerRecord {
+        public void dispose() {
+            recordsCount.decrementAndGet();
+        }
+    }
+
+    class FinalDisposerRecord implements DisposerRecord {
+        public void dispose() {
+            disposerDone = true;
+        }
+    }
+
+    private static void giveGCAChance() {
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException ignored) {}
+    }
+
+    private static void generateOOME() throws Exception {
+        final List<Object> leak = new LinkedList<>();
+        try {
+            while (true) {
+                leak.add(new byte[1024 * 1024]);
+            }
+        } catch (OutOfMemoryError ignored) {}
+        giveGCAChance();
+    }
+}


### PR DESCRIPTION
See also the [original pull request](https://github.com/openjdk/jdk/pull/9362) where the change is explained and discussed in details.

Compared to the original version of this fix I
* changed the error reporting from `printStackTrace()` to `System.out.println()` as per @prrace request,
* fixed the test to use `AtomicInteger` for the counter of disposer records as `+=` and `--` operations on a `volatile int` do not guarantee value's integrity, which caused the test to often fail.

`test/jdk/sun/java2d/Disposer/TestDisposerRace.java` now passes successfully on MacOS and Linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292304](https://bugs.openjdk.org/browse/JDK-8292304): [REDO] JDK-8289208 Test DrawRotatedStringUsingRotatedFont.java occasionally crashes on MacOS


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9890/head:pull/9890` \
`$ git checkout pull/9890`

Update a local copy of the PR: \
`$ git checkout pull/9890` \
`$ git pull https://git.openjdk.org/jdk pull/9890/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9890`

View PR using the GUI difftool: \
`$ git pr show -t 9890`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9890.diff">https://git.openjdk.org/jdk/pull/9890.diff</a>

</details>
