### PR TITLE
8292443: Weak CAS VarHandle/Unsafe tests should test always-failing cases

### DIFF
--- a/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestBoolean.java
+++ b/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestBoolean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,9 +212,16 @@ public class JdkInternalMiscUnsafeAccessTestBoolean {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetBooleanPlain(base, offset, true, false);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain boolean");
+            assertEquals(success, true, "success weakCompareAndSetPlain boolean");
             boolean x = UNSAFE.getBoolean(base, offset);
-            assertEquals(x, false, "weakCompareAndSetPlain boolean value");
+            assertEquals(x, false, "success weakCompareAndSetPlain boolean value");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetBooleanPlain(base, offset, true, false);
+            assertEquals(success, false, "failing weakCompareAndSetPlain boolean");
+            boolean x = UNSAFE.getBoolean(base, offset);
+            assertEquals(x, false, "failing weakCompareAndSetPlain boolean value");
         }
 
         {
@@ -222,9 +229,16 @@ public class JdkInternalMiscUnsafeAccessTestBoolean {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetBooleanAcquire(base, offset, false, true);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire boolean");
+            assertEquals(success, true, "success weakCompareAndSetAcquire boolean");
             boolean x = UNSAFE.getBoolean(base, offset);
-            assertEquals(x, true, "weakCompareAndSetAcquire boolean");
+            assertEquals(x, true, "success weakCompareAndSetAcquire boolean");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetBooleanAcquire(base, offset, false, false);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire boolean");
+            boolean x = UNSAFE.getBoolean(base, offset);
+            assertEquals(x, true, "failing weakCompareAndSetAcquire boolean value");
         }
 
         {
@@ -232,9 +246,16 @@ public class JdkInternalMiscUnsafeAccessTestBoolean {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetBooleanRelease(base, offset, true, false);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease boolean");
+            assertEquals(success, true, "success weakCompareAndSetRelease boolean");
             boolean x = UNSAFE.getBoolean(base, offset);
-            assertEquals(x, false, "weakCompareAndSetRelease boolean");
+            assertEquals(x, false, "success weakCompareAndSetRelease boolean");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetBooleanRelease(base, offset, true, false);
+            assertEquals(success, false, "failing weakCompareAndSetRelease boolean");
+            boolean x = UNSAFE.getBoolean(base, offset);
+            assertEquals(x, false, "failing weakCompareAndSetRelease boolean value");
         }
 
         {
@@ -242,9 +263,16 @@ public class JdkInternalMiscUnsafeAccessTestBoolean {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetBoolean(base, offset, false, true);
             }
-            assertEquals(success, true, "weakCompareAndSet boolean");
+            assertEquals(success, true, "success weakCompareAndSet boolean");
             boolean x = UNSAFE.getBoolean(base, offset);
-            assertEquals(x, true, "weakCompareAndSet boolean");
+            assertEquals(x, true, "success weakCompareAndSet boolean");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetBoolean(base, offset, false, false);
+            assertEquals(success, false, "failing weakCompareAndSet boolean");
+            boolean x = UNSAFE.getBoolean(base, offset);
+            assertEquals(x, true, "failing weakCompareAndSet boolean value");
         }
 
         UNSAFE.putBoolean(base, offset, false);

--- a/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestByte.java
+++ b/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestByte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -241,9 +241,16 @@ public class JdkInternalMiscUnsafeAccessTestByte {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetBytePlain(base, offset, (byte)0x01, (byte)0x23);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain byte");
+            assertEquals(success, true, "success weakCompareAndSetPlain byte");
             byte x = UNSAFE.getByte(base, offset);
-            assertEquals(x, (byte)0x23, "weakCompareAndSetPlain byte value");
+            assertEquals(x, (byte)0x23, "success weakCompareAndSetPlain byte value");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetBytePlain(base, offset, (byte)0x01, (byte)0x45);
+            assertEquals(success, false, "failing weakCompareAndSetPlain byte");
+            byte x = UNSAFE.getByte(base, offset);
+            assertEquals(x, (byte)0x23, "failing weakCompareAndSetPlain byte value");
         }
 
         {
@@ -251,9 +258,16 @@ public class JdkInternalMiscUnsafeAccessTestByte {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetByteAcquire(base, offset, (byte)0x23, (byte)0x01);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire byte");
+            assertEquals(success, true, "success weakCompareAndSetAcquire byte");
             byte x = UNSAFE.getByte(base, offset);
-            assertEquals(x, (byte)0x01, "weakCompareAndSetAcquire byte");
+            assertEquals(x, (byte)0x01, "success weakCompareAndSetAcquire byte");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetByteAcquire(base, offset, (byte)0x23, (byte)0x45);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire byte");
+            byte x = UNSAFE.getByte(base, offset);
+            assertEquals(x, (byte)0x01, "failing weakCompareAndSetAcquire byte value");
         }
 
         {
@@ -261,9 +275,16 @@ public class JdkInternalMiscUnsafeAccessTestByte {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetByteRelease(base, offset, (byte)0x01, (byte)0x23);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease byte");
+            assertEquals(success, true, "success weakCompareAndSetRelease byte");
             byte x = UNSAFE.getByte(base, offset);
-            assertEquals(x, (byte)0x23, "weakCompareAndSetRelease byte");
+            assertEquals(x, (byte)0x23, "success weakCompareAndSetRelease byte");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetByteRelease(base, offset, (byte)0x01, (byte)0x45);
+            assertEquals(success, false, "failing weakCompareAndSetRelease byte");
+            byte x = UNSAFE.getByte(base, offset);
+            assertEquals(x, (byte)0x23, "failing weakCompareAndSetRelease byte value");
         }
 
         {
@@ -271,9 +292,16 @@ public class JdkInternalMiscUnsafeAccessTestByte {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetByte(base, offset, (byte)0x23, (byte)0x01);
             }
-            assertEquals(success, true, "weakCompareAndSet byte");
+            assertEquals(success, true, "success weakCompareAndSet byte");
             byte x = UNSAFE.getByte(base, offset);
-            assertEquals(x, (byte)0x01, "weakCompareAndSet byte");
+            assertEquals(x, (byte)0x01, "success weakCompareAndSet byte");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetByte(base, offset, (byte)0x23, (byte)0x45);
+            assertEquals(success, false, "failing weakCompareAndSet byte");
+            byte x = UNSAFE.getByte(base, offset);
+            assertEquals(x, (byte)0x01, "failing weakCompareAndSet byte value");
         }
 
         UNSAFE.putByte(base, offset, (byte)0x23);

--- a/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestChar.java
+++ b/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestChar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -259,9 +259,16 @@ public class JdkInternalMiscUnsafeAccessTestChar {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetCharPlain(base, offset, '\u0123', '\u4567');
             }
-            assertEquals(success, true, "weakCompareAndSetPlain char");
+            assertEquals(success, true, "success weakCompareAndSetPlain char");
             char x = UNSAFE.getChar(base, offset);
-            assertEquals(x, '\u4567', "weakCompareAndSetPlain char value");
+            assertEquals(x, '\u4567', "success weakCompareAndSetPlain char value");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetCharPlain(base, offset, '\u0123', '\u89AB');
+            assertEquals(success, false, "failing weakCompareAndSetPlain char");
+            char x = UNSAFE.getChar(base, offset);
+            assertEquals(x, '\u4567', "failing weakCompareAndSetPlain char value");
         }
 
         {
@@ -269,9 +276,16 @@ public class JdkInternalMiscUnsafeAccessTestChar {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetCharAcquire(base, offset, '\u4567', '\u0123');
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire char");
+            assertEquals(success, true, "success weakCompareAndSetAcquire char");
             char x = UNSAFE.getChar(base, offset);
-            assertEquals(x, '\u0123', "weakCompareAndSetAcquire char");
+            assertEquals(x, '\u0123', "success weakCompareAndSetAcquire char");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetCharAcquire(base, offset, '\u4567', '\u89AB');
+            assertEquals(success, false, "failing weakCompareAndSetAcquire char");
+            char x = UNSAFE.getChar(base, offset);
+            assertEquals(x, '\u0123', "failing weakCompareAndSetAcquire char value");
         }
 
         {
@@ -279,9 +293,16 @@ public class JdkInternalMiscUnsafeAccessTestChar {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetCharRelease(base, offset, '\u0123', '\u4567');
             }
-            assertEquals(success, true, "weakCompareAndSetRelease char");
+            assertEquals(success, true, "success weakCompareAndSetRelease char");
             char x = UNSAFE.getChar(base, offset);
-            assertEquals(x, '\u4567', "weakCompareAndSetRelease char");
+            assertEquals(x, '\u4567', "success weakCompareAndSetRelease char");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetCharRelease(base, offset, '\u0123', '\u89AB');
+            assertEquals(success, false, "failing weakCompareAndSetRelease char");
+            char x = UNSAFE.getChar(base, offset);
+            assertEquals(x, '\u4567', "failing weakCompareAndSetRelease char value");
         }
 
         {
@@ -289,9 +310,16 @@ public class JdkInternalMiscUnsafeAccessTestChar {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetChar(base, offset, '\u4567', '\u0123');
             }
-            assertEquals(success, true, "weakCompareAndSet char");
+            assertEquals(success, true, "success weakCompareAndSet char");
             char x = UNSAFE.getChar(base, offset);
-            assertEquals(x, '\u0123', "weakCompareAndSet char");
+            assertEquals(x, '\u0123', "success weakCompareAndSet char");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetChar(base, offset, '\u4567', '\u89AB');
+            assertEquals(success, false, "failing weakCompareAndSet char");
+            char x = UNSAFE.getChar(base, offset);
+            assertEquals(x, '\u0123', "failing weakCompareAndSet char value");
         }
 
         UNSAFE.putChar(base, offset, '\u4567');

--- a/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestDouble.java
+++ b/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -241,9 +241,16 @@ public class JdkInternalMiscUnsafeAccessTestDouble {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetDoublePlain(base, offset, 1.0d, 2.0d);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain double");
+            assertEquals(success, true, "success weakCompareAndSetPlain double");
             double x = UNSAFE.getDouble(base, offset);
-            assertEquals(x, 2.0d, "weakCompareAndSetPlain double value");
+            assertEquals(x, 2.0d, "success weakCompareAndSetPlain double value");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetDoublePlain(base, offset, 1.0d, 3.0d);
+            assertEquals(success, false, "failing weakCompareAndSetPlain double");
+            double x = UNSAFE.getDouble(base, offset);
+            assertEquals(x, 2.0d, "failing weakCompareAndSetPlain double value");
         }
 
         {
@@ -251,9 +258,16 @@ public class JdkInternalMiscUnsafeAccessTestDouble {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetDoubleAcquire(base, offset, 2.0d, 1.0d);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire double");
+            assertEquals(success, true, "success weakCompareAndSetAcquire double");
             double x = UNSAFE.getDouble(base, offset);
-            assertEquals(x, 1.0d, "weakCompareAndSetAcquire double");
+            assertEquals(x, 1.0d, "success weakCompareAndSetAcquire double");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetDoubleAcquire(base, offset, 2.0d, 3.0d);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire double");
+            double x = UNSAFE.getDouble(base, offset);
+            assertEquals(x, 1.0d, "failing weakCompareAndSetAcquire double value");
         }
 
         {
@@ -261,9 +275,16 @@ public class JdkInternalMiscUnsafeAccessTestDouble {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetDoubleRelease(base, offset, 1.0d, 2.0d);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease double");
+            assertEquals(success, true, "success weakCompareAndSetRelease double");
             double x = UNSAFE.getDouble(base, offset);
-            assertEquals(x, 2.0d, "weakCompareAndSetRelease double");
+            assertEquals(x, 2.0d, "success weakCompareAndSetRelease double");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetDoubleRelease(base, offset, 1.0d, 3.0d);
+            assertEquals(success, false, "failing weakCompareAndSetRelease double");
+            double x = UNSAFE.getDouble(base, offset);
+            assertEquals(x, 2.0d, "failing weakCompareAndSetRelease double value");
         }
 
         {
@@ -271,9 +292,16 @@ public class JdkInternalMiscUnsafeAccessTestDouble {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetDouble(base, offset, 2.0d, 1.0d);
             }
-            assertEquals(success, true, "weakCompareAndSet double");
+            assertEquals(success, true, "success weakCompareAndSet double");
             double x = UNSAFE.getDouble(base, offset);
-            assertEquals(x, 1.0d, "weakCompareAndSet double");
+            assertEquals(x, 1.0d, "success weakCompareAndSet double");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetDouble(base, offset, 2.0d, 3.0d);
+            assertEquals(success, false, "failing weakCompareAndSet double");
+            double x = UNSAFE.getDouble(base, offset);
+            assertEquals(x, 1.0d, "failing weakCompareAndSet double value");
         }
 
         UNSAFE.putDouble(base, offset, 2.0d);

--- a/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestFloat.java
+++ b/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -241,9 +241,16 @@ public class JdkInternalMiscUnsafeAccessTestFloat {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetFloatPlain(base, offset, 1.0f, 2.0f);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain float");
+            assertEquals(success, true, "success weakCompareAndSetPlain float");
             float x = UNSAFE.getFloat(base, offset);
-            assertEquals(x, 2.0f, "weakCompareAndSetPlain float value");
+            assertEquals(x, 2.0f, "success weakCompareAndSetPlain float value");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetFloatPlain(base, offset, 1.0f, 3.0f);
+            assertEquals(success, false, "failing weakCompareAndSetPlain float");
+            float x = UNSAFE.getFloat(base, offset);
+            assertEquals(x, 2.0f, "failing weakCompareAndSetPlain float value");
         }
 
         {
@@ -251,9 +258,16 @@ public class JdkInternalMiscUnsafeAccessTestFloat {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetFloatAcquire(base, offset, 2.0f, 1.0f);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire float");
+            assertEquals(success, true, "success weakCompareAndSetAcquire float");
             float x = UNSAFE.getFloat(base, offset);
-            assertEquals(x, 1.0f, "weakCompareAndSetAcquire float");
+            assertEquals(x, 1.0f, "success weakCompareAndSetAcquire float");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetFloatAcquire(base, offset, 2.0f, 3.0f);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire float");
+            float x = UNSAFE.getFloat(base, offset);
+            assertEquals(x, 1.0f, "failing weakCompareAndSetAcquire float value");
         }
 
         {
@@ -261,9 +275,16 @@ public class JdkInternalMiscUnsafeAccessTestFloat {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetFloatRelease(base, offset, 1.0f, 2.0f);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease float");
+            assertEquals(success, true, "success weakCompareAndSetRelease float");
             float x = UNSAFE.getFloat(base, offset);
-            assertEquals(x, 2.0f, "weakCompareAndSetRelease float");
+            assertEquals(x, 2.0f, "success weakCompareAndSetRelease float");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetFloatRelease(base, offset, 1.0f, 3.0f);
+            assertEquals(success, false, "failing weakCompareAndSetRelease float");
+            float x = UNSAFE.getFloat(base, offset);
+            assertEquals(x, 2.0f, "failing weakCompareAndSetRelease float value");
         }
 
         {
@@ -271,9 +292,16 @@ public class JdkInternalMiscUnsafeAccessTestFloat {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetFloat(base, offset, 2.0f, 1.0f);
             }
-            assertEquals(success, true, "weakCompareAndSet float");
+            assertEquals(success, true, "success weakCompareAndSet float");
             float x = UNSAFE.getFloat(base, offset);
-            assertEquals(x, 1.0f, "weakCompareAndSet float");
+            assertEquals(x, 1.0f, "success weakCompareAndSet float");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetFloat(base, offset, 2.0f, 3.0f);
+            assertEquals(success, false, "failing weakCompareAndSet float");
+            float x = UNSAFE.getFloat(base, offset);
+            assertEquals(x, 1.0f, "failing weakCompareAndSet float value");
         }
 
         UNSAFE.putFloat(base, offset, 2.0f);

--- a/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestInt.java
+++ b/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -259,9 +259,16 @@ public class JdkInternalMiscUnsafeAccessTestInt {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetIntPlain(base, offset, 0x01234567, 0x89ABCDEF);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain int");
+            assertEquals(success, true, "success weakCompareAndSetPlain int");
             int x = UNSAFE.getInt(base, offset);
-            assertEquals(x, 0x89ABCDEF, "weakCompareAndSetPlain int value");
+            assertEquals(x, 0x89ABCDEF, "success weakCompareAndSetPlain int value");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetIntPlain(base, offset, 0x01234567, 0xCAFEBABE);
+            assertEquals(success, false, "failing weakCompareAndSetPlain int");
+            int x = UNSAFE.getInt(base, offset);
+            assertEquals(x, 0x89ABCDEF, "failing weakCompareAndSetPlain int value");
         }
 
         {
@@ -269,9 +276,16 @@ public class JdkInternalMiscUnsafeAccessTestInt {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetIntAcquire(base, offset, 0x89ABCDEF, 0x01234567);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire int");
+            assertEquals(success, true, "success weakCompareAndSetAcquire int");
             int x = UNSAFE.getInt(base, offset);
-            assertEquals(x, 0x01234567, "weakCompareAndSetAcquire int");
+            assertEquals(x, 0x01234567, "success weakCompareAndSetAcquire int");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetIntAcquire(base, offset, 0x89ABCDEF, 0xCAFEBABE);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire int");
+            int x = UNSAFE.getInt(base, offset);
+            assertEquals(x, 0x01234567, "failing weakCompareAndSetAcquire int value");
         }
 
         {
@@ -279,9 +293,16 @@ public class JdkInternalMiscUnsafeAccessTestInt {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetIntRelease(base, offset, 0x01234567, 0x89ABCDEF);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease int");
+            assertEquals(success, true, "success weakCompareAndSetRelease int");
             int x = UNSAFE.getInt(base, offset);
-            assertEquals(x, 0x89ABCDEF, "weakCompareAndSetRelease int");
+            assertEquals(x, 0x89ABCDEF, "success weakCompareAndSetRelease int");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetIntRelease(base, offset, 0x01234567, 0xCAFEBABE);
+            assertEquals(success, false, "failing weakCompareAndSetRelease int");
+            int x = UNSAFE.getInt(base, offset);
+            assertEquals(x, 0x89ABCDEF, "failing weakCompareAndSetRelease int value");
         }
 
         {
@@ -289,9 +310,16 @@ public class JdkInternalMiscUnsafeAccessTestInt {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetInt(base, offset, 0x89ABCDEF, 0x01234567);
             }
-            assertEquals(success, true, "weakCompareAndSet int");
+            assertEquals(success, true, "success weakCompareAndSet int");
             int x = UNSAFE.getInt(base, offset);
-            assertEquals(x, 0x01234567, "weakCompareAndSet int");
+            assertEquals(x, 0x01234567, "success weakCompareAndSet int");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetInt(base, offset, 0x89ABCDEF, 0xCAFEBABE);
+            assertEquals(success, false, "failing weakCompareAndSet int");
+            int x = UNSAFE.getInt(base, offset);
+            assertEquals(x, 0x01234567, "failing weakCompareAndSet int value");
         }
 
         UNSAFE.putInt(base, offset, 0x89ABCDEF);

--- a/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestLong.java
+++ b/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -259,9 +259,16 @@ public class JdkInternalMiscUnsafeAccessTestLong {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetLongPlain(base, offset, 0x0123456789ABCDEFL, 0xCAFEBABECAFEBABEL);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain long");
+            assertEquals(success, true, "success weakCompareAndSetPlain long");
             long x = UNSAFE.getLong(base, offset);
-            assertEquals(x, 0xCAFEBABECAFEBABEL, "weakCompareAndSetPlain long value");
+            assertEquals(x, 0xCAFEBABECAFEBABEL, "success weakCompareAndSetPlain long value");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetLongPlain(base, offset, 0x0123456789ABCDEFL, 0xDEADBEEFDEADBEEFL);
+            assertEquals(success, false, "failing weakCompareAndSetPlain long");
+            long x = UNSAFE.getLong(base, offset);
+            assertEquals(x, 0xCAFEBABECAFEBABEL, "failing weakCompareAndSetPlain long value");
         }
 
         {
@@ -269,9 +276,16 @@ public class JdkInternalMiscUnsafeAccessTestLong {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetLongAcquire(base, offset, 0xCAFEBABECAFEBABEL, 0x0123456789ABCDEFL);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire long");
+            assertEquals(success, true, "success weakCompareAndSetAcquire long");
             long x = UNSAFE.getLong(base, offset);
-            assertEquals(x, 0x0123456789ABCDEFL, "weakCompareAndSetAcquire long");
+            assertEquals(x, 0x0123456789ABCDEFL, "success weakCompareAndSetAcquire long");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetLongAcquire(base, offset, 0xCAFEBABECAFEBABEL, 0xDEADBEEFDEADBEEFL);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire long");
+            long x = UNSAFE.getLong(base, offset);
+            assertEquals(x, 0x0123456789ABCDEFL, "failing weakCompareAndSetAcquire long value");
         }
 
         {
@@ -279,9 +293,16 @@ public class JdkInternalMiscUnsafeAccessTestLong {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetLongRelease(base, offset, 0x0123456789ABCDEFL, 0xCAFEBABECAFEBABEL);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease long");
+            assertEquals(success, true, "success weakCompareAndSetRelease long");
             long x = UNSAFE.getLong(base, offset);
-            assertEquals(x, 0xCAFEBABECAFEBABEL, "weakCompareAndSetRelease long");
+            assertEquals(x, 0xCAFEBABECAFEBABEL, "success weakCompareAndSetRelease long");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetLongRelease(base, offset, 0x0123456789ABCDEFL, 0xDEADBEEFDEADBEEFL);
+            assertEquals(success, false, "failing weakCompareAndSetRelease long");
+            long x = UNSAFE.getLong(base, offset);
+            assertEquals(x, 0xCAFEBABECAFEBABEL, "failing weakCompareAndSetRelease long value");
         }
 
         {
@@ -289,9 +310,16 @@ public class JdkInternalMiscUnsafeAccessTestLong {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetLong(base, offset, 0xCAFEBABECAFEBABEL, 0x0123456789ABCDEFL);
             }
-            assertEquals(success, true, "weakCompareAndSet long");
+            assertEquals(success, true, "success weakCompareAndSet long");
             long x = UNSAFE.getLong(base, offset);
-            assertEquals(x, 0x0123456789ABCDEFL, "weakCompareAndSet long");
+            assertEquals(x, 0x0123456789ABCDEFL, "success weakCompareAndSet long");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetLong(base, offset, 0xCAFEBABECAFEBABEL, 0xDEADBEEFDEADBEEFL);
+            assertEquals(success, false, "failing weakCompareAndSet long");
+            long x = UNSAFE.getLong(base, offset);
+            assertEquals(x, 0x0123456789ABCDEFL, "failing weakCompareAndSet long value");
         }
 
         UNSAFE.putLong(base, offset, 0xCAFEBABECAFEBABEL);

--- a/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestObject.java
+++ b/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,9 +212,16 @@ public class JdkInternalMiscUnsafeAccessTestObject {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetReferencePlain(base, offset, "foo", "bar");
             }
-            assertEquals(success, true, "weakCompareAndSetPlain Object");
+            assertEquals(success, true, "success weakCompareAndSetPlain Object");
             Object x = UNSAFE.getReference(base, offset);
-            assertEquals(x, "bar", "weakCompareAndSetPlain Object value");
+            assertEquals(x, "bar", "success weakCompareAndSetPlain Object value");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetReferencePlain(base, offset, "foo", "baz");
+            assertEquals(success, false, "failing weakCompareAndSetPlain Object");
+            Object x = UNSAFE.getReference(base, offset);
+            assertEquals(x, "bar", "failing weakCompareAndSetPlain Object value");
         }
 
         {
@@ -222,9 +229,16 @@ public class JdkInternalMiscUnsafeAccessTestObject {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetReferenceAcquire(base, offset, "bar", "foo");
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire Object");
+            assertEquals(success, true, "success weakCompareAndSetAcquire Object");
             Object x = UNSAFE.getReference(base, offset);
-            assertEquals(x, "foo", "weakCompareAndSetAcquire Object");
+            assertEquals(x, "foo", "success weakCompareAndSetAcquire Object");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetReferenceAcquire(base, offset, "bar", "baz");
+            assertEquals(success, false, "failing weakCompareAndSetAcquire Object");
+            Object x = UNSAFE.getReference(base, offset);
+            assertEquals(x, "foo", "failing weakCompareAndSetAcquire Object value");
         }
 
         {
@@ -232,9 +246,16 @@ public class JdkInternalMiscUnsafeAccessTestObject {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetReferenceRelease(base, offset, "foo", "bar");
             }
-            assertEquals(success, true, "weakCompareAndSetRelease Object");
+            assertEquals(success, true, "success weakCompareAndSetRelease Object");
             Object x = UNSAFE.getReference(base, offset);
-            assertEquals(x, "bar", "weakCompareAndSetRelease Object");
+            assertEquals(x, "bar", "success weakCompareAndSetRelease Object");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetReferenceRelease(base, offset, "foo", "baz");
+            assertEquals(success, false, "failing weakCompareAndSetRelease Object");
+            Object x = UNSAFE.getReference(base, offset);
+            assertEquals(x, "bar", "failing weakCompareAndSetRelease Object value");
         }
 
         {
@@ -242,9 +263,16 @@ public class JdkInternalMiscUnsafeAccessTestObject {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetReference(base, offset, "bar", "foo");
             }
-            assertEquals(success, true, "weakCompareAndSet Object");
+            assertEquals(success, true, "success weakCompareAndSet Object");
             Object x = UNSAFE.getReference(base, offset);
-            assertEquals(x, "foo", "weakCompareAndSet Object");
+            assertEquals(x, "foo", "success weakCompareAndSet Object");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetReference(base, offset, "bar", "baz");
+            assertEquals(success, false, "failing weakCompareAndSet Object");
+            Object x = UNSAFE.getReference(base, offset);
+            assertEquals(x, "foo", "failing weakCompareAndSet Object value");
         }
 
         UNSAFE.putReference(base, offset, "bar");

--- a/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestShort.java
+++ b/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestShort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -259,9 +259,16 @@ public class JdkInternalMiscUnsafeAccessTestShort {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetShortPlain(base, offset, (short)0x0123, (short)0x4567);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain short");
+            assertEquals(success, true, "success weakCompareAndSetPlain short");
             short x = UNSAFE.getShort(base, offset);
-            assertEquals(x, (short)0x4567, "weakCompareAndSetPlain short value");
+            assertEquals(x, (short)0x4567, "success weakCompareAndSetPlain short value");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetShortPlain(base, offset, (short)0x0123, (short)0x89AB);
+            assertEquals(success, false, "failing weakCompareAndSetPlain short");
+            short x = UNSAFE.getShort(base, offset);
+            assertEquals(x, (short)0x4567, "failing weakCompareAndSetPlain short value");
         }
 
         {
@@ -269,9 +276,16 @@ public class JdkInternalMiscUnsafeAccessTestShort {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetShortAcquire(base, offset, (short)0x4567, (short)0x0123);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire short");
+            assertEquals(success, true, "success weakCompareAndSetAcquire short");
             short x = UNSAFE.getShort(base, offset);
-            assertEquals(x, (short)0x0123, "weakCompareAndSetAcquire short");
+            assertEquals(x, (short)0x0123, "success weakCompareAndSetAcquire short");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetShortAcquire(base, offset, (short)0x4567, (short)0x89AB);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire short");
+            short x = UNSAFE.getShort(base, offset);
+            assertEquals(x, (short)0x0123, "failing weakCompareAndSetAcquire short value");
         }
 
         {
@@ -279,9 +293,16 @@ public class JdkInternalMiscUnsafeAccessTestShort {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetShortRelease(base, offset, (short)0x0123, (short)0x4567);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease short");
+            assertEquals(success, true, "success weakCompareAndSetRelease short");
             short x = UNSAFE.getShort(base, offset);
-            assertEquals(x, (short)0x4567, "weakCompareAndSetRelease short");
+            assertEquals(x, (short)0x4567, "success weakCompareAndSetRelease short");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetShortRelease(base, offset, (short)0x0123, (short)0x89AB);
+            assertEquals(success, false, "failing weakCompareAndSetRelease short");
+            short x = UNSAFE.getShort(base, offset);
+            assertEquals(x, (short)0x4567, "failing weakCompareAndSetRelease short value");
         }
 
         {
@@ -289,9 +310,16 @@ public class JdkInternalMiscUnsafeAccessTestShort {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSetShort(base, offset, (short)0x4567, (short)0x0123);
             }
-            assertEquals(success, true, "weakCompareAndSet short");
+            assertEquals(success, true, "success weakCompareAndSet short");
             short x = UNSAFE.getShort(base, offset);
-            assertEquals(x, (short)0x0123, "weakCompareAndSet short");
+            assertEquals(x, (short)0x0123, "success weakCompareAndSet short");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSetShort(base, offset, (short)0x4567, (short)0x89AB);
+            assertEquals(success, false, "failing weakCompareAndSet short");
+            short x = UNSAFE.getShort(base, offset);
+            assertEquals(x, (short)0x0123, "failing weakCompareAndSet short value");
         }
 
         UNSAFE.putShort(base, offset, (short)0x4567);

--- a/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestBoolean.java
+++ b/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestBoolean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestByte.java
+++ b/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestByte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestChar.java
+++ b/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestChar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestDouble.java
+++ b/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestFloat.java
+++ b/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestInt.java
+++ b/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestLong.java
+++ b/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestObject.java
+++ b/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestShort.java
+++ b/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestShort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/unsafe/X-UnsafeAccessTest.java.template
+++ b/test/hotspot/jtreg/compiler/unsafe/X-UnsafeAccessTest.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -303,9 +303,16 @@ public class $Qualifier$UnsafeAccessTest$Type$ {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSet$MethodAffix$Plain(base, offset, $value1$, $value2$);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain $type$");
+            assertEquals(success, true, "success weakCompareAndSetPlain $type$");
             $type$ x = UNSAFE.get$MethodAffix$(base, offset);
-            assertEquals(x, $value2$, "weakCompareAndSetPlain $type$ value");
+            assertEquals(x, $value2$, "success weakCompareAndSetPlain $type$ value");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSet$MethodAffix$Plain(base, offset, $value1$, $value3$);
+            assertEquals(success, false, "failing weakCompareAndSetPlain $type$");
+            $type$ x = UNSAFE.get$MethodAffix$(base, offset);
+            assertEquals(x, $value2$, "failing weakCompareAndSetPlain $type$ value");
         }
 
         {
@@ -313,9 +320,16 @@ public class $Qualifier$UnsafeAccessTest$Type$ {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSet$MethodAffix$Acquire(base, offset, $value2$, $value1$);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire $type$");
+            assertEquals(success, true, "success weakCompareAndSetAcquire $type$");
             $type$ x = UNSAFE.get$MethodAffix$(base, offset);
-            assertEquals(x, $value1$, "weakCompareAndSetAcquire $type$");
+            assertEquals(x, $value1$, "success weakCompareAndSetAcquire $type$");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSet$MethodAffix$Acquire(base, offset, $value2$, $value3$);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire $type$");
+            $type$ x = UNSAFE.get$MethodAffix$(base, offset);
+            assertEquals(x, $value1$, "failing weakCompareAndSetAcquire $type$ value");
         }
 
         {
@@ -323,9 +337,16 @@ public class $Qualifier$UnsafeAccessTest$Type$ {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSet$MethodAffix$Release(base, offset, $value1$, $value2$);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease $type$");
+            assertEquals(success, true, "success weakCompareAndSetRelease $type$");
             $type$ x = UNSAFE.get$MethodAffix$(base, offset);
-            assertEquals(x, $value2$, "weakCompareAndSetRelease $type$");
+            assertEquals(x, $value2$, "success weakCompareAndSetRelease $type$");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSet$MethodAffix$Release(base, offset, $value1$, $value3$);
+            assertEquals(success, false, "failing weakCompareAndSetRelease $type$");
+            $type$ x = UNSAFE.get$MethodAffix$(base, offset);
+            assertEquals(x, $value2$, "failing weakCompareAndSetRelease $type$ value");
         }
 
         {
@@ -333,9 +354,16 @@ public class $Qualifier$UnsafeAccessTest$Type$ {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = UNSAFE.weakCompareAndSet$MethodAffix$(base, offset, $value2$, $value1$);
             }
-            assertEquals(success, true, "weakCompareAndSet $type$");
+            assertEquals(success, true, "success weakCompareAndSet $type$");
             $type$ x = UNSAFE.get$MethodAffix$(base, offset);
-            assertEquals(x, $value1$, "weakCompareAndSet $type$");
+            assertEquals(x, $value1$, "success weakCompareAndSet $type$");
+        }
+
+        {
+            boolean success = UNSAFE.weakCompareAndSet$MethodAffix$(base, offset, $value2$, $value3$);
+            assertEquals(success, false, "failing weakCompareAndSet $type$");
+            $type$ x = UNSAFE.get$MethodAffix$(base, offset);
+            assertEquals(x, $value1$, "failing weakCompareAndSet $type$ value");
         }
 
 #end[JdkInternalMisc]

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -506,9 +506,16 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetPlain(recv, true, false);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain boolean");
+            assertEquals(success, true, "success weakCompareAndSetPlain boolean");
             boolean x = (boolean) vh.get(recv);
-            assertEquals(x, false, "weakCompareAndSetPlain boolean value");
+            assertEquals(x, false, "success weakCompareAndSetPlain boolean value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain(recv, true, false);
+            assertEquals(success, false, "failing weakCompareAndSetPlain boolean");
+            boolean x = (boolean) vh.get(recv);
+            assertEquals(x, false, "failing weakCompareAndSetPlain boolean value");
         }
 
         {
@@ -516,9 +523,16 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetAcquire(recv, false, true);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire boolean");
+            assertEquals(success, true, "success weakCompareAndSetAcquire boolean");
             boolean x = (boolean) vh.get(recv);
-            assertEquals(x, true, "weakCompareAndSetAcquire boolean");
+            assertEquals(x, true, "success weakCompareAndSetAcquire boolean");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire(recv, false, false);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire boolean");
+            boolean x = (boolean) vh.get(recv);
+            assertEquals(x, true, "failing weakCompareAndSetAcquire boolean value");
         }
 
         {
@@ -526,9 +540,16 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetRelease(recv, true, false);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease boolean");
+            assertEquals(success, true, "success weakCompareAndSetRelease boolean");
             boolean x = (boolean) vh.get(recv);
-            assertEquals(x, false, "weakCompareAndSetRelease boolean");
+            assertEquals(x, false, "success weakCompareAndSetRelease boolean");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease(recv, true, false);
+            assertEquals(success, false, "failing weakCompareAndSetRelease boolean");
+            boolean x = (boolean) vh.get(recv);
+            assertEquals(x, false, "failing weakCompareAndSetRelease boolean value");
         }
 
         {
@@ -536,9 +557,16 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSet(recv, false, true);
             }
-            assertEquals(success, true, "weakCompareAndSet boolean");
+            assertEquals(success, true, "success weakCompareAndSet boolean");
             boolean x = (boolean) vh.get(recv);
-            assertEquals(x, true, "weakCompareAndSet boolean value");
+            assertEquals(x, true, "success weakCompareAndSet boolean value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet(recv, false, false);
+            assertEquals(success, false, "failing weakCompareAndSet boolean");
+            boolean x = (boolean) vh.get(recv);
+            assertEquals(x, true, "failing weakCompareAndSet boolean value");
         }
 
         // Compare set and get
@@ -766,9 +794,16 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetPlain(true, false);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain boolean");
+            assertEquals(success, true, "success weakCompareAndSetPlain boolean");
             boolean x = (boolean) vh.get();
-            assertEquals(x, false, "weakCompareAndSetPlain boolean value");
+            assertEquals(x, false, "success weakCompareAndSetPlain boolean value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain(true, false);
+            assertEquals(success, false, "failing weakCompareAndSetPlain boolean");
+            boolean x = (boolean) vh.get();
+            assertEquals(x, false, "failing weakCompareAndSetPlain boolean value");
         }
 
         {
@@ -776,9 +811,16 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetAcquire(false, true);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire boolean");
+            assertEquals(success, true, "success weakCompareAndSetAcquire boolean");
             boolean x = (boolean) vh.get();
-            assertEquals(x, true, "weakCompareAndSetAcquire boolean");
+            assertEquals(x, true, "success weakCompareAndSetAcquire boolean");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire(false, false);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire boolean");
+            boolean x = (boolean) vh.get();
+            assertEquals(x, true, "failing weakCompareAndSetAcquire boolean value");
         }
 
         {
@@ -786,9 +828,16 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetRelease(true, false);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease boolean");
+            assertEquals(success, true, "success weakCompareAndSetRelease boolean");
             boolean x = (boolean) vh.get();
-            assertEquals(x, false, "weakCompareAndSetRelease boolean");
+            assertEquals(x, false, "success weakCompareAndSetRelease boolean");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease(true, false);
+            assertEquals(success, false, "failing weakCompareAndSetRelease boolean");
+            boolean x = (boolean) vh.get();
+            assertEquals(x, false, "failing weakCompareAndSetRelease boolean value");
         }
 
         {
@@ -796,9 +845,16 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSet(false, true);
             }
-            assertEquals(success, true, "weakCompareAndSet boolean");
+            assertEquals(success, true, "success weakCompareAndSet boolean");
             boolean x = (boolean) vh.get();
-            assertEquals(x, true, "weakCompareAndSet boolean");
+            assertEquals(x, true, "success weakCompareAndSet boolean");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet(false, false);
+            assertEquals(success, false, "failing weakCompareAndSet boolean");
+            boolean x = (boolean) vh.get();
+            assertEquals(x, true, "failing weakCompareAndSet boolean value");
         }
 
         // Compare set and get
@@ -1029,9 +1085,16 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetPlain(array, i, true, false);
                 }
-                assertEquals(success, true, "weakCompareAndSetPlain boolean");
+                assertEquals(success, true, "success weakCompareAndSetPlain boolean");
                 boolean x = (boolean) vh.get(array, i);
-                assertEquals(x, false, "weakCompareAndSetPlain boolean value");
+                assertEquals(x, false, "success weakCompareAndSetPlain boolean value");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetPlain(array, i, true, false);
+                assertEquals(success, false, "failing weakCompareAndSetPlain boolean");
+                boolean x = (boolean) vh.get(array, i);
+                assertEquals(x, false, "failing weakCompareAndSetPlain boolean value");
             }
 
             {
@@ -1039,9 +1102,16 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetAcquire(array, i, false, true);
                 }
-                assertEquals(success, true, "weakCompareAndSetAcquire boolean");
+                assertEquals(success, true, "success weakCompareAndSetAcquire boolean");
                 boolean x = (boolean) vh.get(array, i);
-                assertEquals(x, true, "weakCompareAndSetAcquire boolean");
+                assertEquals(x, true, "success weakCompareAndSetAcquire boolean");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetAcquire(array, i, false, false);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire boolean");
+                boolean x = (boolean) vh.get(array, i);
+                assertEquals(x, true, "failing weakCompareAndSetAcquire boolean value");
             }
 
             {
@@ -1049,9 +1119,16 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetRelease(array, i, true, false);
                 }
-                assertEquals(success, true, "weakCompareAndSetRelease boolean");
+                assertEquals(success, true, "success weakCompareAndSetRelease boolean");
                 boolean x = (boolean) vh.get(array, i);
-                assertEquals(x, false, "weakCompareAndSetRelease boolean");
+                assertEquals(x, false, "success weakCompareAndSetRelease boolean");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetRelease(array, i, true, false);
+                assertEquals(success, false, "failing weakCompareAndSetRelease boolean");
+                boolean x = (boolean) vh.get(array, i);
+                assertEquals(x, false, "failing weakCompareAndSetRelease boolean value");
             }
 
             {
@@ -1059,9 +1136,16 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSet(array, i, false, true);
                 }
-                assertEquals(success, true, "weakCompareAndSet boolean");
+                assertEquals(success, true, "success weakCompareAndSet boolean");
                 boolean x = (boolean) vh.get(array, i);
-                assertEquals(x, true, "weakCompareAndSet boolean");
+                assertEquals(x, true, "success weakCompareAndSet boolean");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSet(array, i, false, false);
+                assertEquals(success, false, "failing weakCompareAndSet boolean");
+                boolean x = (boolean) vh.get(array, i);
+                assertEquals(x, true, "failing weakCompareAndSet boolean value");
             }
 
             // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessByte.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessByte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -484,9 +484,16 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetPlain(recv, (byte)0x01, (byte)0x23);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain byte");
+            assertEquals(success, true, "success weakCompareAndSetPlain byte");
             byte x = (byte) vh.get(recv);
-            assertEquals(x, (byte)0x23, "weakCompareAndSetPlain byte value");
+            assertEquals(x, (byte)0x23, "success weakCompareAndSetPlain byte value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain(recv, (byte)0x01, (byte)0x45);
+            assertEquals(success, false, "failing weakCompareAndSetPlain byte");
+            byte x = (byte) vh.get(recv);
+            assertEquals(x, (byte)0x23, "failing weakCompareAndSetPlain byte value");
         }
 
         {
@@ -494,9 +501,16 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetAcquire(recv, (byte)0x23, (byte)0x01);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire byte");
+            assertEquals(success, true, "success weakCompareAndSetAcquire byte");
             byte x = (byte) vh.get(recv);
-            assertEquals(x, (byte)0x01, "weakCompareAndSetAcquire byte");
+            assertEquals(x, (byte)0x01, "success weakCompareAndSetAcquire byte");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire(recv, (byte)0x23, (byte)0x45);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire byte");
+            byte x = (byte) vh.get(recv);
+            assertEquals(x, (byte)0x01, "failing weakCompareAndSetAcquire byte value");
         }
 
         {
@@ -504,9 +518,16 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetRelease(recv, (byte)0x01, (byte)0x23);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease byte");
+            assertEquals(success, true, "success weakCompareAndSetRelease byte");
             byte x = (byte) vh.get(recv);
-            assertEquals(x, (byte)0x23, "weakCompareAndSetRelease byte");
+            assertEquals(x, (byte)0x23, "success weakCompareAndSetRelease byte");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease(recv, (byte)0x01, (byte)0x45);
+            assertEquals(success, false, "failing weakCompareAndSetRelease byte");
+            byte x = (byte) vh.get(recv);
+            assertEquals(x, (byte)0x23, "failing weakCompareAndSetRelease byte value");
         }
 
         {
@@ -514,9 +535,16 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSet(recv, (byte)0x23, (byte)0x01);
             }
-            assertEquals(success, true, "weakCompareAndSet byte");
+            assertEquals(success, true, "success weakCompareAndSet byte");
             byte x = (byte) vh.get(recv);
-            assertEquals(x, (byte)0x01, "weakCompareAndSet byte value");
+            assertEquals(x, (byte)0x01, "success weakCompareAndSet byte value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet(recv, (byte)0x23, (byte)0x45);
+            assertEquals(success, false, "failing weakCompareAndSet byte");
+            byte x = (byte) vh.get(recv);
+            assertEquals(x, (byte)0x01, "failing weakCompareAndSet byte value");
         }
 
         // Compare set and get
@@ -760,9 +788,16 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetPlain((byte)0x01, (byte)0x23);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain byte");
+            assertEquals(success, true, "success weakCompareAndSetPlain byte");
             byte x = (byte) vh.get();
-            assertEquals(x, (byte)0x23, "weakCompareAndSetPlain byte value");
+            assertEquals(x, (byte)0x23, "success weakCompareAndSetPlain byte value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain((byte)0x01, (byte)0x45);
+            assertEquals(success, false, "failing weakCompareAndSetPlain byte");
+            byte x = (byte) vh.get();
+            assertEquals(x, (byte)0x23, "failing weakCompareAndSetPlain byte value");
         }
 
         {
@@ -770,9 +805,16 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetAcquire((byte)0x23, (byte)0x01);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire byte");
+            assertEquals(success, true, "success weakCompareAndSetAcquire byte");
             byte x = (byte) vh.get();
-            assertEquals(x, (byte)0x01, "weakCompareAndSetAcquire byte");
+            assertEquals(x, (byte)0x01, "success weakCompareAndSetAcquire byte");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire((byte)0x23, (byte)0x45);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire byte");
+            byte x = (byte) vh.get();
+            assertEquals(x, (byte)0x01, "failing weakCompareAndSetAcquire byte value");
         }
 
         {
@@ -780,9 +822,16 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetRelease((byte)0x01, (byte)0x23);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease byte");
+            assertEquals(success, true, "success weakCompareAndSetRelease byte");
             byte x = (byte) vh.get();
-            assertEquals(x, (byte)0x23, "weakCompareAndSetRelease byte");
+            assertEquals(x, (byte)0x23, "success weakCompareAndSetRelease byte");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease((byte)0x01, (byte)0x45);
+            assertEquals(success, false, "failing weakCompareAndSetRelease byte");
+            byte x = (byte) vh.get();
+            assertEquals(x, (byte)0x23, "failing weakCompareAndSetRelease byte value");
         }
 
         {
@@ -790,9 +839,16 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSet((byte)0x23, (byte)0x01);
             }
-            assertEquals(success, true, "weakCompareAndSet byte");
+            assertEquals(success, true, "success weakCompareAndSet byte");
             byte x = (byte) vh.get();
-            assertEquals(x, (byte)0x01, "weakCompareAndSet byte");
+            assertEquals(x, (byte)0x01, "success weakCompareAndSet byte");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet((byte)0x23, (byte)0x45);
+            assertEquals(success, false, "failing weakCompareAndSet byte");
+            byte x = (byte) vh.get();
+            assertEquals(x, (byte)0x01, "failing weakCompareAndSet byte value");
         }
 
         // Compare set and get
@@ -1039,9 +1095,16 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetPlain(array, i, (byte)0x01, (byte)0x23);
                 }
-                assertEquals(success, true, "weakCompareAndSetPlain byte");
+                assertEquals(success, true, "success weakCompareAndSetPlain byte");
                 byte x = (byte) vh.get(array, i);
-                assertEquals(x, (byte)0x23, "weakCompareAndSetPlain byte value");
+                assertEquals(x, (byte)0x23, "success weakCompareAndSetPlain byte value");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetPlain(array, i, (byte)0x01, (byte)0x45);
+                assertEquals(success, false, "failing weakCompareAndSetPlain byte");
+                byte x = (byte) vh.get(array, i);
+                assertEquals(x, (byte)0x23, "failing weakCompareAndSetPlain byte value");
             }
 
             {
@@ -1049,9 +1112,16 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetAcquire(array, i, (byte)0x23, (byte)0x01);
                 }
-                assertEquals(success, true, "weakCompareAndSetAcquire byte");
+                assertEquals(success, true, "success weakCompareAndSetAcquire byte");
                 byte x = (byte) vh.get(array, i);
-                assertEquals(x, (byte)0x01, "weakCompareAndSetAcquire byte");
+                assertEquals(x, (byte)0x01, "success weakCompareAndSetAcquire byte");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetAcquire(array, i, (byte)0x23, (byte)0x45);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire byte");
+                byte x = (byte) vh.get(array, i);
+                assertEquals(x, (byte)0x01, "failing weakCompareAndSetAcquire byte value");
             }
 
             {
@@ -1059,9 +1129,16 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetRelease(array, i, (byte)0x01, (byte)0x23);
                 }
-                assertEquals(success, true, "weakCompareAndSetRelease byte");
+                assertEquals(success, true, "success weakCompareAndSetRelease byte");
                 byte x = (byte) vh.get(array, i);
-                assertEquals(x, (byte)0x23, "weakCompareAndSetRelease byte");
+                assertEquals(x, (byte)0x23, "success weakCompareAndSetRelease byte");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetRelease(array, i, (byte)0x01, (byte)0x45);
+                assertEquals(success, false, "failing weakCompareAndSetRelease byte");
+                byte x = (byte) vh.get(array, i);
+                assertEquals(x, (byte)0x23, "failing weakCompareAndSetRelease byte value");
             }
 
             {
@@ -1069,9 +1146,16 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSet(array, i, (byte)0x23, (byte)0x01);
                 }
-                assertEquals(success, true, "weakCompareAndSet byte");
+                assertEquals(success, true, "success weakCompareAndSet byte");
                 byte x = (byte) vh.get(array, i);
-                assertEquals(x, (byte)0x01, "weakCompareAndSet byte");
+                assertEquals(x, (byte)0x01, "success weakCompareAndSet byte");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSet(array, i, (byte)0x23, (byte)0x45);
+                assertEquals(success, false, "failing weakCompareAndSet byte");
+                byte x = (byte) vh.get(array, i);
+                assertEquals(x, (byte)0x01, "failing weakCompareAndSet byte value");
             }
 
             // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessChar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -484,9 +484,16 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetPlain(recv, '\u0123', '\u4567');
             }
-            assertEquals(success, true, "weakCompareAndSetPlain char");
+            assertEquals(success, true, "success weakCompareAndSetPlain char");
             char x = (char) vh.get(recv);
-            assertEquals(x, '\u4567', "weakCompareAndSetPlain char value");
+            assertEquals(x, '\u4567', "success weakCompareAndSetPlain char value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain(recv, '\u0123', '\u89AB');
+            assertEquals(success, false, "failing weakCompareAndSetPlain char");
+            char x = (char) vh.get(recv);
+            assertEquals(x, '\u4567', "failing weakCompareAndSetPlain char value");
         }
 
         {
@@ -494,9 +501,16 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetAcquire(recv, '\u4567', '\u0123');
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire char");
+            assertEquals(success, true, "success weakCompareAndSetAcquire char");
             char x = (char) vh.get(recv);
-            assertEquals(x, '\u0123', "weakCompareAndSetAcquire char");
+            assertEquals(x, '\u0123', "success weakCompareAndSetAcquire char");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire(recv, '\u4567', '\u89AB');
+            assertEquals(success, false, "failing weakCompareAndSetAcquire char");
+            char x = (char) vh.get(recv);
+            assertEquals(x, '\u0123', "failing weakCompareAndSetAcquire char value");
         }
 
         {
@@ -504,9 +518,16 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetRelease(recv, '\u0123', '\u4567');
             }
-            assertEquals(success, true, "weakCompareAndSetRelease char");
+            assertEquals(success, true, "success weakCompareAndSetRelease char");
             char x = (char) vh.get(recv);
-            assertEquals(x, '\u4567', "weakCompareAndSetRelease char");
+            assertEquals(x, '\u4567', "success weakCompareAndSetRelease char");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease(recv, '\u0123', '\u89AB');
+            assertEquals(success, false, "failing weakCompareAndSetRelease char");
+            char x = (char) vh.get(recv);
+            assertEquals(x, '\u4567', "failing weakCompareAndSetRelease char value");
         }
 
         {
@@ -514,9 +535,16 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSet(recv, '\u4567', '\u0123');
             }
-            assertEquals(success, true, "weakCompareAndSet char");
+            assertEquals(success, true, "success weakCompareAndSet char");
             char x = (char) vh.get(recv);
-            assertEquals(x, '\u0123', "weakCompareAndSet char value");
+            assertEquals(x, '\u0123', "success weakCompareAndSet char value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet(recv, '\u4567', '\u89AB');
+            assertEquals(success, false, "failing weakCompareAndSet char");
+            char x = (char) vh.get(recv);
+            assertEquals(x, '\u0123', "failing weakCompareAndSet char value");
         }
 
         // Compare set and get
@@ -760,9 +788,16 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetPlain('\u0123', '\u4567');
             }
-            assertEquals(success, true, "weakCompareAndSetPlain char");
+            assertEquals(success, true, "success weakCompareAndSetPlain char");
             char x = (char) vh.get();
-            assertEquals(x, '\u4567', "weakCompareAndSetPlain char value");
+            assertEquals(x, '\u4567', "success weakCompareAndSetPlain char value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain('\u0123', '\u89AB');
+            assertEquals(success, false, "failing weakCompareAndSetPlain char");
+            char x = (char) vh.get();
+            assertEquals(x, '\u4567', "failing weakCompareAndSetPlain char value");
         }
 
         {
@@ -770,9 +805,16 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetAcquire('\u4567', '\u0123');
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire char");
+            assertEquals(success, true, "success weakCompareAndSetAcquire char");
             char x = (char) vh.get();
-            assertEquals(x, '\u0123', "weakCompareAndSetAcquire char");
+            assertEquals(x, '\u0123', "success weakCompareAndSetAcquire char");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire('\u4567', '\u89AB');
+            assertEquals(success, false, "failing weakCompareAndSetAcquire char");
+            char x = (char) vh.get();
+            assertEquals(x, '\u0123', "failing weakCompareAndSetAcquire char value");
         }
 
         {
@@ -780,9 +822,16 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetRelease('\u0123', '\u4567');
             }
-            assertEquals(success, true, "weakCompareAndSetRelease char");
+            assertEquals(success, true, "success weakCompareAndSetRelease char");
             char x = (char) vh.get();
-            assertEquals(x, '\u4567', "weakCompareAndSetRelease char");
+            assertEquals(x, '\u4567', "success weakCompareAndSetRelease char");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease('\u0123', '\u89AB');
+            assertEquals(success, false, "failing weakCompareAndSetRelease char");
+            char x = (char) vh.get();
+            assertEquals(x, '\u4567', "failing weakCompareAndSetRelease char value");
         }
 
         {
@@ -790,9 +839,16 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSet('\u4567', '\u0123');
             }
-            assertEquals(success, true, "weakCompareAndSet char");
+            assertEquals(success, true, "success weakCompareAndSet char");
             char x = (char) vh.get();
-            assertEquals(x, '\u0123', "weakCompareAndSet char");
+            assertEquals(x, '\u0123', "success weakCompareAndSet char");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet('\u4567', '\u89AB');
+            assertEquals(success, false, "failing weakCompareAndSet char");
+            char x = (char) vh.get();
+            assertEquals(x, '\u0123', "failing weakCompareAndSet char value");
         }
 
         // Compare set and get
@@ -1039,9 +1095,16 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetPlain(array, i, '\u0123', '\u4567');
                 }
-                assertEquals(success, true, "weakCompareAndSetPlain char");
+                assertEquals(success, true, "success weakCompareAndSetPlain char");
                 char x = (char) vh.get(array, i);
-                assertEquals(x, '\u4567', "weakCompareAndSetPlain char value");
+                assertEquals(x, '\u4567', "success weakCompareAndSetPlain char value");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetPlain(array, i, '\u0123', '\u89AB');
+                assertEquals(success, false, "failing weakCompareAndSetPlain char");
+                char x = (char) vh.get(array, i);
+                assertEquals(x, '\u4567', "failing weakCompareAndSetPlain char value");
             }
 
             {
@@ -1049,9 +1112,16 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetAcquire(array, i, '\u4567', '\u0123');
                 }
-                assertEquals(success, true, "weakCompareAndSetAcquire char");
+                assertEquals(success, true, "success weakCompareAndSetAcquire char");
                 char x = (char) vh.get(array, i);
-                assertEquals(x, '\u0123', "weakCompareAndSetAcquire char");
+                assertEquals(x, '\u0123', "success weakCompareAndSetAcquire char");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetAcquire(array, i, '\u4567', '\u89AB');
+                assertEquals(success, false, "failing weakCompareAndSetAcquire char");
+                char x = (char) vh.get(array, i);
+                assertEquals(x, '\u0123', "failing weakCompareAndSetAcquire char value");
             }
 
             {
@@ -1059,9 +1129,16 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetRelease(array, i, '\u0123', '\u4567');
                 }
-                assertEquals(success, true, "weakCompareAndSetRelease char");
+                assertEquals(success, true, "success weakCompareAndSetRelease char");
                 char x = (char) vh.get(array, i);
-                assertEquals(x, '\u4567', "weakCompareAndSetRelease char");
+                assertEquals(x, '\u4567', "success weakCompareAndSetRelease char");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetRelease(array, i, '\u0123', '\u89AB');
+                assertEquals(success, false, "failing weakCompareAndSetRelease char");
+                char x = (char) vh.get(array, i);
+                assertEquals(x, '\u4567', "failing weakCompareAndSetRelease char value");
             }
 
             {
@@ -1069,9 +1146,16 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSet(array, i, '\u4567', '\u0123');
                 }
-                assertEquals(success, true, "weakCompareAndSet char");
+                assertEquals(success, true, "success weakCompareAndSet char");
                 char x = (char) vh.get(array, i);
-                assertEquals(x, '\u0123', "weakCompareAndSet char");
+                assertEquals(x, '\u0123', "success weakCompareAndSet char");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSet(array, i, '\u4567', '\u89AB');
+                assertEquals(success, false, "failing weakCompareAndSet char");
+                char x = (char) vh.get(array, i);
+                assertEquals(x, '\u0123', "failing weakCompareAndSet char value");
             }
 
             // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -554,9 +554,16 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetPlain(recv, 1.0d, 2.0d);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain double");
+            assertEquals(success, true, "success weakCompareAndSetPlain double");
             double x = (double) vh.get(recv);
-            assertEquals(x, 2.0d, "weakCompareAndSetPlain double value");
+            assertEquals(x, 2.0d, "success weakCompareAndSetPlain double value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain(recv, 1.0d, 3.0d);
+            assertEquals(success, false, "failing weakCompareAndSetPlain double");
+            double x = (double) vh.get(recv);
+            assertEquals(x, 2.0d, "failing weakCompareAndSetPlain double value");
         }
 
         {
@@ -564,9 +571,16 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetAcquire(recv, 2.0d, 1.0d);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire double");
+            assertEquals(success, true, "success weakCompareAndSetAcquire double");
             double x = (double) vh.get(recv);
-            assertEquals(x, 1.0d, "weakCompareAndSetAcquire double");
+            assertEquals(x, 1.0d, "success weakCompareAndSetAcquire double");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire(recv, 2.0d, 3.0d);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire double");
+            double x = (double) vh.get(recv);
+            assertEquals(x, 1.0d, "failing weakCompareAndSetAcquire double value");
         }
 
         {
@@ -574,9 +588,16 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetRelease(recv, 1.0d, 2.0d);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease double");
+            assertEquals(success, true, "success weakCompareAndSetRelease double");
             double x = (double) vh.get(recv);
-            assertEquals(x, 2.0d, "weakCompareAndSetRelease double");
+            assertEquals(x, 2.0d, "success weakCompareAndSetRelease double");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease(recv, 1.0d, 3.0d);
+            assertEquals(success, false, "failing weakCompareAndSetRelease double");
+            double x = (double) vh.get(recv);
+            assertEquals(x, 2.0d, "failing weakCompareAndSetRelease double value");
         }
 
         {
@@ -584,9 +605,16 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSet(recv, 2.0d, 1.0d);
             }
-            assertEquals(success, true, "weakCompareAndSet double");
+            assertEquals(success, true, "success weakCompareAndSet double");
             double x = (double) vh.get(recv);
-            assertEquals(x, 1.0d, "weakCompareAndSet double value");
+            assertEquals(x, 1.0d, "success weakCompareAndSet double value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet(recv, 2.0d, 3.0d);
+            assertEquals(success, false, "failing weakCompareAndSet double");
+            double x = (double) vh.get(recv);
+            assertEquals(x, 1.0d, "failing weakCompareAndSet double value");
         }
 
         // Compare set and get
@@ -782,9 +810,16 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetPlain(1.0d, 2.0d);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain double");
+            assertEquals(success, true, "success weakCompareAndSetPlain double");
             double x = (double) vh.get();
-            assertEquals(x, 2.0d, "weakCompareAndSetPlain double value");
+            assertEquals(x, 2.0d, "success weakCompareAndSetPlain double value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain(1.0d, 3.0d);
+            assertEquals(success, false, "failing weakCompareAndSetPlain double");
+            double x = (double) vh.get();
+            assertEquals(x, 2.0d, "failing weakCompareAndSetPlain double value");
         }
 
         {
@@ -792,9 +827,16 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetAcquire(2.0d, 1.0d);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire double");
+            assertEquals(success, true, "success weakCompareAndSetAcquire double");
             double x = (double) vh.get();
-            assertEquals(x, 1.0d, "weakCompareAndSetAcquire double");
+            assertEquals(x, 1.0d, "success weakCompareAndSetAcquire double");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire(2.0d, 3.0d);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire double");
+            double x = (double) vh.get();
+            assertEquals(x, 1.0d, "failing weakCompareAndSetAcquire double value");
         }
 
         {
@@ -802,9 +844,16 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetRelease(1.0d, 2.0d);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease double");
+            assertEquals(success, true, "success weakCompareAndSetRelease double");
             double x = (double) vh.get();
-            assertEquals(x, 2.0d, "weakCompareAndSetRelease double");
+            assertEquals(x, 2.0d, "success weakCompareAndSetRelease double");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease(1.0d, 3.0d);
+            assertEquals(success, false, "failing weakCompareAndSetRelease double");
+            double x = (double) vh.get();
+            assertEquals(x, 2.0d, "failing weakCompareAndSetRelease double value");
         }
 
         {
@@ -812,9 +861,16 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSet(2.0d, 1.0d);
             }
-            assertEquals(success, true, "weakCompareAndSet double");
+            assertEquals(success, true, "success weakCompareAndSet double");
             double x = (double) vh.get();
-            assertEquals(x, 1.0d, "weakCompareAndSet double");
+            assertEquals(x, 1.0d, "success weakCompareAndSet double");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet(2.0d, 3.0d);
+            assertEquals(success, false, "failing weakCompareAndSet double");
+            double x = (double) vh.get();
+            assertEquals(x, 1.0d, "failing weakCompareAndSet double value");
         }
 
         // Compare set and get
@@ -1013,9 +1069,16 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetPlain(array, i, 1.0d, 2.0d);
                 }
-                assertEquals(success, true, "weakCompareAndSetPlain double");
+                assertEquals(success, true, "success weakCompareAndSetPlain double");
                 double x = (double) vh.get(array, i);
-                assertEquals(x, 2.0d, "weakCompareAndSetPlain double value");
+                assertEquals(x, 2.0d, "success weakCompareAndSetPlain double value");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetPlain(array, i, 1.0d, 3.0d);
+                assertEquals(success, false, "failing weakCompareAndSetPlain double");
+                double x = (double) vh.get(array, i);
+                assertEquals(x, 2.0d, "failing weakCompareAndSetPlain double value");
             }
 
             {
@@ -1023,9 +1086,16 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetAcquire(array, i, 2.0d, 1.0d);
                 }
-                assertEquals(success, true, "weakCompareAndSetAcquire double");
+                assertEquals(success, true, "success weakCompareAndSetAcquire double");
                 double x = (double) vh.get(array, i);
-                assertEquals(x, 1.0d, "weakCompareAndSetAcquire double");
+                assertEquals(x, 1.0d, "success weakCompareAndSetAcquire double");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetAcquire(array, i, 2.0d, 3.0d);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire double");
+                double x = (double) vh.get(array, i);
+                assertEquals(x, 1.0d, "failing weakCompareAndSetAcquire double value");
             }
 
             {
@@ -1033,9 +1103,16 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetRelease(array, i, 1.0d, 2.0d);
                 }
-                assertEquals(success, true, "weakCompareAndSetRelease double");
+                assertEquals(success, true, "success weakCompareAndSetRelease double");
                 double x = (double) vh.get(array, i);
-                assertEquals(x, 2.0d, "weakCompareAndSetRelease double");
+                assertEquals(x, 2.0d, "success weakCompareAndSetRelease double");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetRelease(array, i, 1.0d, 3.0d);
+                assertEquals(success, false, "failing weakCompareAndSetRelease double");
+                double x = (double) vh.get(array, i);
+                assertEquals(x, 2.0d, "failing weakCompareAndSetRelease double value");
             }
 
             {
@@ -1043,9 +1120,16 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSet(array, i, 2.0d, 1.0d);
                 }
-                assertEquals(success, true, "weakCompareAndSet double");
+                assertEquals(success, true, "success weakCompareAndSet double");
                 double x = (double) vh.get(array, i);
-                assertEquals(x, 1.0d, "weakCompareAndSet double");
+                assertEquals(x, 1.0d, "success weakCompareAndSet double");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSet(array, i, 2.0d, 3.0d);
+                assertEquals(success, false, "failing weakCompareAndSet double");
+                double x = (double) vh.get(array, i);
+                assertEquals(x, 1.0d, "failing weakCompareAndSet double value");
             }
 
             // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -554,9 +554,16 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetPlain(recv, 1.0f, 2.0f);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain float");
+            assertEquals(success, true, "success weakCompareAndSetPlain float");
             float x = (float) vh.get(recv);
-            assertEquals(x, 2.0f, "weakCompareAndSetPlain float value");
+            assertEquals(x, 2.0f, "success weakCompareAndSetPlain float value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain(recv, 1.0f, 3.0f);
+            assertEquals(success, false, "failing weakCompareAndSetPlain float");
+            float x = (float) vh.get(recv);
+            assertEquals(x, 2.0f, "failing weakCompareAndSetPlain float value");
         }
 
         {
@@ -564,9 +571,16 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetAcquire(recv, 2.0f, 1.0f);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire float");
+            assertEquals(success, true, "success weakCompareAndSetAcquire float");
             float x = (float) vh.get(recv);
-            assertEquals(x, 1.0f, "weakCompareAndSetAcquire float");
+            assertEquals(x, 1.0f, "success weakCompareAndSetAcquire float");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire(recv, 2.0f, 3.0f);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire float");
+            float x = (float) vh.get(recv);
+            assertEquals(x, 1.0f, "failing weakCompareAndSetAcquire float value");
         }
 
         {
@@ -574,9 +588,16 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetRelease(recv, 1.0f, 2.0f);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease float");
+            assertEquals(success, true, "success weakCompareAndSetRelease float");
             float x = (float) vh.get(recv);
-            assertEquals(x, 2.0f, "weakCompareAndSetRelease float");
+            assertEquals(x, 2.0f, "success weakCompareAndSetRelease float");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease(recv, 1.0f, 3.0f);
+            assertEquals(success, false, "failing weakCompareAndSetRelease float");
+            float x = (float) vh.get(recv);
+            assertEquals(x, 2.0f, "failing weakCompareAndSetRelease float value");
         }
 
         {
@@ -584,9 +605,16 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSet(recv, 2.0f, 1.0f);
             }
-            assertEquals(success, true, "weakCompareAndSet float");
+            assertEquals(success, true, "success weakCompareAndSet float");
             float x = (float) vh.get(recv);
-            assertEquals(x, 1.0f, "weakCompareAndSet float value");
+            assertEquals(x, 1.0f, "success weakCompareAndSet float value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet(recv, 2.0f, 3.0f);
+            assertEquals(success, false, "failing weakCompareAndSet float");
+            float x = (float) vh.get(recv);
+            assertEquals(x, 1.0f, "failing weakCompareAndSet float value");
         }
 
         // Compare set and get
@@ -782,9 +810,16 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetPlain(1.0f, 2.0f);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain float");
+            assertEquals(success, true, "success weakCompareAndSetPlain float");
             float x = (float) vh.get();
-            assertEquals(x, 2.0f, "weakCompareAndSetPlain float value");
+            assertEquals(x, 2.0f, "success weakCompareAndSetPlain float value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain(1.0f, 3.0f);
+            assertEquals(success, false, "failing weakCompareAndSetPlain float");
+            float x = (float) vh.get();
+            assertEquals(x, 2.0f, "failing weakCompareAndSetPlain float value");
         }
 
         {
@@ -792,9 +827,16 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetAcquire(2.0f, 1.0f);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire float");
+            assertEquals(success, true, "success weakCompareAndSetAcquire float");
             float x = (float) vh.get();
-            assertEquals(x, 1.0f, "weakCompareAndSetAcquire float");
+            assertEquals(x, 1.0f, "success weakCompareAndSetAcquire float");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire(2.0f, 3.0f);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire float");
+            float x = (float) vh.get();
+            assertEquals(x, 1.0f, "failing weakCompareAndSetAcquire float value");
         }
 
         {
@@ -802,9 +844,16 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetRelease(1.0f, 2.0f);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease float");
+            assertEquals(success, true, "success weakCompareAndSetRelease float");
             float x = (float) vh.get();
-            assertEquals(x, 2.0f, "weakCompareAndSetRelease float");
+            assertEquals(x, 2.0f, "success weakCompareAndSetRelease float");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease(1.0f, 3.0f);
+            assertEquals(success, false, "failing weakCompareAndSetRelease float");
+            float x = (float) vh.get();
+            assertEquals(x, 2.0f, "failing weakCompareAndSetRelease float value");
         }
 
         {
@@ -812,9 +861,16 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSet(2.0f, 1.0f);
             }
-            assertEquals(success, true, "weakCompareAndSet float");
+            assertEquals(success, true, "success weakCompareAndSet float");
             float x = (float) vh.get();
-            assertEquals(x, 1.0f, "weakCompareAndSet float");
+            assertEquals(x, 1.0f, "success weakCompareAndSet float");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet(2.0f, 3.0f);
+            assertEquals(success, false, "failing weakCompareAndSet float");
+            float x = (float) vh.get();
+            assertEquals(x, 1.0f, "failing weakCompareAndSet float value");
         }
 
         // Compare set and get
@@ -1013,9 +1069,16 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetPlain(array, i, 1.0f, 2.0f);
                 }
-                assertEquals(success, true, "weakCompareAndSetPlain float");
+                assertEquals(success, true, "success weakCompareAndSetPlain float");
                 float x = (float) vh.get(array, i);
-                assertEquals(x, 2.0f, "weakCompareAndSetPlain float value");
+                assertEquals(x, 2.0f, "success weakCompareAndSetPlain float value");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetPlain(array, i, 1.0f, 3.0f);
+                assertEquals(success, false, "failing weakCompareAndSetPlain float");
+                float x = (float) vh.get(array, i);
+                assertEquals(x, 2.0f, "failing weakCompareAndSetPlain float value");
             }
 
             {
@@ -1023,9 +1086,16 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetAcquire(array, i, 2.0f, 1.0f);
                 }
-                assertEquals(success, true, "weakCompareAndSetAcquire float");
+                assertEquals(success, true, "success weakCompareAndSetAcquire float");
                 float x = (float) vh.get(array, i);
-                assertEquals(x, 1.0f, "weakCompareAndSetAcquire float");
+                assertEquals(x, 1.0f, "success weakCompareAndSetAcquire float");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetAcquire(array, i, 2.0f, 3.0f);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire float");
+                float x = (float) vh.get(array, i);
+                assertEquals(x, 1.0f, "failing weakCompareAndSetAcquire float value");
             }
 
             {
@@ -1033,9 +1103,16 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetRelease(array, i, 1.0f, 2.0f);
                 }
-                assertEquals(success, true, "weakCompareAndSetRelease float");
+                assertEquals(success, true, "success weakCompareAndSetRelease float");
                 float x = (float) vh.get(array, i);
-                assertEquals(x, 2.0f, "weakCompareAndSetRelease float");
+                assertEquals(x, 2.0f, "success weakCompareAndSetRelease float");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetRelease(array, i, 1.0f, 3.0f);
+                assertEquals(success, false, "failing weakCompareAndSetRelease float");
+                float x = (float) vh.get(array, i);
+                assertEquals(x, 2.0f, "failing weakCompareAndSetRelease float value");
             }
 
             {
@@ -1043,9 +1120,16 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSet(array, i, 2.0f, 1.0f);
                 }
-                assertEquals(success, true, "weakCompareAndSet float");
+                assertEquals(success, true, "success weakCompareAndSet float");
                 float x = (float) vh.get(array, i);
-                assertEquals(x, 1.0f, "weakCompareAndSet float");
+                assertEquals(x, 1.0f, "success weakCompareAndSet float");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSet(array, i, 2.0f, 3.0f);
+                assertEquals(success, false, "failing weakCompareAndSet float");
+                float x = (float) vh.get(array, i);
+                assertEquals(x, 1.0f, "failing weakCompareAndSet float value");
             }
 
             // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -484,9 +484,16 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetPlain(recv, 0x01234567, 0x89ABCDEF);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain int");
+            assertEquals(success, true, "success weakCompareAndSetPlain int");
             int x = (int) vh.get(recv);
-            assertEquals(x, 0x89ABCDEF, "weakCompareAndSetPlain int value");
+            assertEquals(x, 0x89ABCDEF, "success weakCompareAndSetPlain int value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain(recv, 0x01234567, 0xCAFEBABE);
+            assertEquals(success, false, "failing weakCompareAndSetPlain int");
+            int x = (int) vh.get(recv);
+            assertEquals(x, 0x89ABCDEF, "failing weakCompareAndSetPlain int value");
         }
 
         {
@@ -494,9 +501,16 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetAcquire(recv, 0x89ABCDEF, 0x01234567);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire int");
+            assertEquals(success, true, "success weakCompareAndSetAcquire int");
             int x = (int) vh.get(recv);
-            assertEquals(x, 0x01234567, "weakCompareAndSetAcquire int");
+            assertEquals(x, 0x01234567, "success weakCompareAndSetAcquire int");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire(recv, 0x89ABCDEF, 0xCAFEBABE);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire int");
+            int x = (int) vh.get(recv);
+            assertEquals(x, 0x01234567, "failing weakCompareAndSetAcquire int value");
         }
 
         {
@@ -504,9 +518,16 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetRelease(recv, 0x01234567, 0x89ABCDEF);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease int");
+            assertEquals(success, true, "success weakCompareAndSetRelease int");
             int x = (int) vh.get(recv);
-            assertEquals(x, 0x89ABCDEF, "weakCompareAndSetRelease int");
+            assertEquals(x, 0x89ABCDEF, "success weakCompareAndSetRelease int");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease(recv, 0x01234567, 0xCAFEBABE);
+            assertEquals(success, false, "failing weakCompareAndSetRelease int");
+            int x = (int) vh.get(recv);
+            assertEquals(x, 0x89ABCDEF, "failing weakCompareAndSetRelease int value");
         }
 
         {
@@ -514,9 +535,16 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSet(recv, 0x89ABCDEF, 0x01234567);
             }
-            assertEquals(success, true, "weakCompareAndSet int");
+            assertEquals(success, true, "success weakCompareAndSet int");
             int x = (int) vh.get(recv);
-            assertEquals(x, 0x01234567, "weakCompareAndSet int value");
+            assertEquals(x, 0x01234567, "success weakCompareAndSet int value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet(recv, 0x89ABCDEF, 0xCAFEBABE);
+            assertEquals(success, false, "failing weakCompareAndSet int");
+            int x = (int) vh.get(recv);
+            assertEquals(x, 0x01234567, "failing weakCompareAndSet int value");
         }
 
         // Compare set and get
@@ -760,9 +788,16 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetPlain(0x01234567, 0x89ABCDEF);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain int");
+            assertEquals(success, true, "success weakCompareAndSetPlain int");
             int x = (int) vh.get();
-            assertEquals(x, 0x89ABCDEF, "weakCompareAndSetPlain int value");
+            assertEquals(x, 0x89ABCDEF, "success weakCompareAndSetPlain int value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain(0x01234567, 0xCAFEBABE);
+            assertEquals(success, false, "failing weakCompareAndSetPlain int");
+            int x = (int) vh.get();
+            assertEquals(x, 0x89ABCDEF, "failing weakCompareAndSetPlain int value");
         }
 
         {
@@ -770,9 +805,16 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetAcquire(0x89ABCDEF, 0x01234567);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire int");
+            assertEquals(success, true, "success weakCompareAndSetAcquire int");
             int x = (int) vh.get();
-            assertEquals(x, 0x01234567, "weakCompareAndSetAcquire int");
+            assertEquals(x, 0x01234567, "success weakCompareAndSetAcquire int");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire(0x89ABCDEF, 0xCAFEBABE);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire int");
+            int x = (int) vh.get();
+            assertEquals(x, 0x01234567, "failing weakCompareAndSetAcquire int value");
         }
 
         {
@@ -780,9 +822,16 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetRelease(0x01234567, 0x89ABCDEF);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease int");
+            assertEquals(success, true, "success weakCompareAndSetRelease int");
             int x = (int) vh.get();
-            assertEquals(x, 0x89ABCDEF, "weakCompareAndSetRelease int");
+            assertEquals(x, 0x89ABCDEF, "success weakCompareAndSetRelease int");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease(0x01234567, 0xCAFEBABE);
+            assertEquals(success, false, "failing weakCompareAndSetRelease int");
+            int x = (int) vh.get();
+            assertEquals(x, 0x89ABCDEF, "failing weakCompareAndSetRelease int value");
         }
 
         {
@@ -790,9 +839,16 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSet(0x89ABCDEF, 0x01234567);
             }
-            assertEquals(success, true, "weakCompareAndSet int");
+            assertEquals(success, true, "success weakCompareAndSet int");
             int x = (int) vh.get();
-            assertEquals(x, 0x01234567, "weakCompareAndSet int");
+            assertEquals(x, 0x01234567, "success weakCompareAndSet int");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet(0x89ABCDEF, 0xCAFEBABE);
+            assertEquals(success, false, "failing weakCompareAndSet int");
+            int x = (int) vh.get();
+            assertEquals(x, 0x01234567, "failing weakCompareAndSet int value");
         }
 
         // Compare set and get
@@ -1039,9 +1095,16 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetPlain(array, i, 0x01234567, 0x89ABCDEF);
                 }
-                assertEquals(success, true, "weakCompareAndSetPlain int");
+                assertEquals(success, true, "success weakCompareAndSetPlain int");
                 int x = (int) vh.get(array, i);
-                assertEquals(x, 0x89ABCDEF, "weakCompareAndSetPlain int value");
+                assertEquals(x, 0x89ABCDEF, "success weakCompareAndSetPlain int value");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetPlain(array, i, 0x01234567, 0xCAFEBABE);
+                assertEquals(success, false, "failing weakCompareAndSetPlain int");
+                int x = (int) vh.get(array, i);
+                assertEquals(x, 0x89ABCDEF, "failing weakCompareAndSetPlain int value");
             }
 
             {
@@ -1049,9 +1112,16 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetAcquire(array, i, 0x89ABCDEF, 0x01234567);
                 }
-                assertEquals(success, true, "weakCompareAndSetAcquire int");
+                assertEquals(success, true, "success weakCompareAndSetAcquire int");
                 int x = (int) vh.get(array, i);
-                assertEquals(x, 0x01234567, "weakCompareAndSetAcquire int");
+                assertEquals(x, 0x01234567, "success weakCompareAndSetAcquire int");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetAcquire(array, i, 0x89ABCDEF, 0xCAFEBABE);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire int");
+                int x = (int) vh.get(array, i);
+                assertEquals(x, 0x01234567, "failing weakCompareAndSetAcquire int value");
             }
 
             {
@@ -1059,9 +1129,16 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetRelease(array, i, 0x01234567, 0x89ABCDEF);
                 }
-                assertEquals(success, true, "weakCompareAndSetRelease int");
+                assertEquals(success, true, "success weakCompareAndSetRelease int");
                 int x = (int) vh.get(array, i);
-                assertEquals(x, 0x89ABCDEF, "weakCompareAndSetRelease int");
+                assertEquals(x, 0x89ABCDEF, "success weakCompareAndSetRelease int");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetRelease(array, i, 0x01234567, 0xCAFEBABE);
+                assertEquals(success, false, "failing weakCompareAndSetRelease int");
+                int x = (int) vh.get(array, i);
+                assertEquals(x, 0x89ABCDEF, "failing weakCompareAndSetRelease int value");
             }
 
             {
@@ -1069,9 +1146,16 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSet(array, i, 0x89ABCDEF, 0x01234567);
                 }
-                assertEquals(success, true, "weakCompareAndSet int");
+                assertEquals(success, true, "success weakCompareAndSet int");
                 int x = (int) vh.get(array, i);
-                assertEquals(x, 0x01234567, "weakCompareAndSet int");
+                assertEquals(x, 0x01234567, "success weakCompareAndSet int");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSet(array, i, 0x89ABCDEF, 0xCAFEBABE);
+                assertEquals(success, false, "failing weakCompareAndSet int");
+                int x = (int) vh.get(array, i);
+                assertEquals(x, 0x01234567, "failing weakCompareAndSet int value");
             }
 
             // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -484,9 +484,16 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetPlain(recv, 0x0123456789ABCDEFL, 0xCAFEBABECAFEBABEL);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain long");
+            assertEquals(success, true, "success weakCompareAndSetPlain long");
             long x = (long) vh.get(recv);
-            assertEquals(x, 0xCAFEBABECAFEBABEL, "weakCompareAndSetPlain long value");
+            assertEquals(x, 0xCAFEBABECAFEBABEL, "success weakCompareAndSetPlain long value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain(recv, 0x0123456789ABCDEFL, 0xDEADBEEFDEADBEEFL);
+            assertEquals(success, false, "failing weakCompareAndSetPlain long");
+            long x = (long) vh.get(recv);
+            assertEquals(x, 0xCAFEBABECAFEBABEL, "failing weakCompareAndSetPlain long value");
         }
 
         {
@@ -494,9 +501,16 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetAcquire(recv, 0xCAFEBABECAFEBABEL, 0x0123456789ABCDEFL);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire long");
+            assertEquals(success, true, "success weakCompareAndSetAcquire long");
             long x = (long) vh.get(recv);
-            assertEquals(x, 0x0123456789ABCDEFL, "weakCompareAndSetAcquire long");
+            assertEquals(x, 0x0123456789ABCDEFL, "success weakCompareAndSetAcquire long");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire(recv, 0xCAFEBABECAFEBABEL, 0xDEADBEEFDEADBEEFL);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire long");
+            long x = (long) vh.get(recv);
+            assertEquals(x, 0x0123456789ABCDEFL, "failing weakCompareAndSetAcquire long value");
         }
 
         {
@@ -504,9 +518,16 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetRelease(recv, 0x0123456789ABCDEFL, 0xCAFEBABECAFEBABEL);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease long");
+            assertEquals(success, true, "success weakCompareAndSetRelease long");
             long x = (long) vh.get(recv);
-            assertEquals(x, 0xCAFEBABECAFEBABEL, "weakCompareAndSetRelease long");
+            assertEquals(x, 0xCAFEBABECAFEBABEL, "success weakCompareAndSetRelease long");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease(recv, 0x0123456789ABCDEFL, 0xDEADBEEFDEADBEEFL);
+            assertEquals(success, false, "failing weakCompareAndSetRelease long");
+            long x = (long) vh.get(recv);
+            assertEquals(x, 0xCAFEBABECAFEBABEL, "failing weakCompareAndSetRelease long value");
         }
 
         {
@@ -514,9 +535,16 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSet(recv, 0xCAFEBABECAFEBABEL, 0x0123456789ABCDEFL);
             }
-            assertEquals(success, true, "weakCompareAndSet long");
+            assertEquals(success, true, "success weakCompareAndSet long");
             long x = (long) vh.get(recv);
-            assertEquals(x, 0x0123456789ABCDEFL, "weakCompareAndSet long value");
+            assertEquals(x, 0x0123456789ABCDEFL, "success weakCompareAndSet long value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet(recv, 0xCAFEBABECAFEBABEL, 0xDEADBEEFDEADBEEFL);
+            assertEquals(success, false, "failing weakCompareAndSet long");
+            long x = (long) vh.get(recv);
+            assertEquals(x, 0x0123456789ABCDEFL, "failing weakCompareAndSet long value");
         }
 
         // Compare set and get
@@ -760,9 +788,16 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetPlain(0x0123456789ABCDEFL, 0xCAFEBABECAFEBABEL);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain long");
+            assertEquals(success, true, "success weakCompareAndSetPlain long");
             long x = (long) vh.get();
-            assertEquals(x, 0xCAFEBABECAFEBABEL, "weakCompareAndSetPlain long value");
+            assertEquals(x, 0xCAFEBABECAFEBABEL, "success weakCompareAndSetPlain long value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain(0x0123456789ABCDEFL, 0xDEADBEEFDEADBEEFL);
+            assertEquals(success, false, "failing weakCompareAndSetPlain long");
+            long x = (long) vh.get();
+            assertEquals(x, 0xCAFEBABECAFEBABEL, "failing weakCompareAndSetPlain long value");
         }
 
         {
@@ -770,9 +805,16 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetAcquire(0xCAFEBABECAFEBABEL, 0x0123456789ABCDEFL);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire long");
+            assertEquals(success, true, "success weakCompareAndSetAcquire long");
             long x = (long) vh.get();
-            assertEquals(x, 0x0123456789ABCDEFL, "weakCompareAndSetAcquire long");
+            assertEquals(x, 0x0123456789ABCDEFL, "success weakCompareAndSetAcquire long");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire(0xCAFEBABECAFEBABEL, 0xDEADBEEFDEADBEEFL);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire long");
+            long x = (long) vh.get();
+            assertEquals(x, 0x0123456789ABCDEFL, "failing weakCompareAndSetAcquire long value");
         }
 
         {
@@ -780,9 +822,16 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetRelease(0x0123456789ABCDEFL, 0xCAFEBABECAFEBABEL);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease long");
+            assertEquals(success, true, "success weakCompareAndSetRelease long");
             long x = (long) vh.get();
-            assertEquals(x, 0xCAFEBABECAFEBABEL, "weakCompareAndSetRelease long");
+            assertEquals(x, 0xCAFEBABECAFEBABEL, "success weakCompareAndSetRelease long");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease(0x0123456789ABCDEFL, 0xDEADBEEFDEADBEEFL);
+            assertEquals(success, false, "failing weakCompareAndSetRelease long");
+            long x = (long) vh.get();
+            assertEquals(x, 0xCAFEBABECAFEBABEL, "failing weakCompareAndSetRelease long value");
         }
 
         {
@@ -790,9 +839,16 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSet(0xCAFEBABECAFEBABEL, 0x0123456789ABCDEFL);
             }
-            assertEquals(success, true, "weakCompareAndSet long");
+            assertEquals(success, true, "success weakCompareAndSet long");
             long x = (long) vh.get();
-            assertEquals(x, 0x0123456789ABCDEFL, "weakCompareAndSet long");
+            assertEquals(x, 0x0123456789ABCDEFL, "success weakCompareAndSet long");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet(0xCAFEBABECAFEBABEL, 0xDEADBEEFDEADBEEFL);
+            assertEquals(success, false, "failing weakCompareAndSet long");
+            long x = (long) vh.get();
+            assertEquals(x, 0x0123456789ABCDEFL, "failing weakCompareAndSet long value");
         }
 
         // Compare set and get
@@ -1039,9 +1095,16 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetPlain(array, i, 0x0123456789ABCDEFL, 0xCAFEBABECAFEBABEL);
                 }
-                assertEquals(success, true, "weakCompareAndSetPlain long");
+                assertEquals(success, true, "success weakCompareAndSetPlain long");
                 long x = (long) vh.get(array, i);
-                assertEquals(x, 0xCAFEBABECAFEBABEL, "weakCompareAndSetPlain long value");
+                assertEquals(x, 0xCAFEBABECAFEBABEL, "success weakCompareAndSetPlain long value");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetPlain(array, i, 0x0123456789ABCDEFL, 0xDEADBEEFDEADBEEFL);
+                assertEquals(success, false, "failing weakCompareAndSetPlain long");
+                long x = (long) vh.get(array, i);
+                assertEquals(x, 0xCAFEBABECAFEBABEL, "failing weakCompareAndSetPlain long value");
             }
 
             {
@@ -1049,9 +1112,16 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetAcquire(array, i, 0xCAFEBABECAFEBABEL, 0x0123456789ABCDEFL);
                 }
-                assertEquals(success, true, "weakCompareAndSetAcquire long");
+                assertEquals(success, true, "success weakCompareAndSetAcquire long");
                 long x = (long) vh.get(array, i);
-                assertEquals(x, 0x0123456789ABCDEFL, "weakCompareAndSetAcquire long");
+                assertEquals(x, 0x0123456789ABCDEFL, "success weakCompareAndSetAcquire long");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetAcquire(array, i, 0xCAFEBABECAFEBABEL, 0xDEADBEEFDEADBEEFL);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire long");
+                long x = (long) vh.get(array, i);
+                assertEquals(x, 0x0123456789ABCDEFL, "failing weakCompareAndSetAcquire long value");
             }
 
             {
@@ -1059,9 +1129,16 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetRelease(array, i, 0x0123456789ABCDEFL, 0xCAFEBABECAFEBABEL);
                 }
-                assertEquals(success, true, "weakCompareAndSetRelease long");
+                assertEquals(success, true, "success weakCompareAndSetRelease long");
                 long x = (long) vh.get(array, i);
-                assertEquals(x, 0xCAFEBABECAFEBABEL, "weakCompareAndSetRelease long");
+                assertEquals(x, 0xCAFEBABECAFEBABEL, "success weakCompareAndSetRelease long");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetRelease(array, i, 0x0123456789ABCDEFL, 0xDEADBEEFDEADBEEFL);
+                assertEquals(success, false, "failing weakCompareAndSetRelease long");
+                long x = (long) vh.get(array, i);
+                assertEquals(x, 0xCAFEBABECAFEBABEL, "failing weakCompareAndSetRelease long value");
             }
 
             {
@@ -1069,9 +1146,16 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSet(array, i, 0xCAFEBABECAFEBABEL, 0x0123456789ABCDEFL);
                 }
-                assertEquals(success, true, "weakCompareAndSet long");
+                assertEquals(success, true, "success weakCompareAndSet long");
                 long x = (long) vh.get(array, i);
-                assertEquals(x, 0x0123456789ABCDEFL, "weakCompareAndSet long");
+                assertEquals(x, 0x0123456789ABCDEFL, "success weakCompareAndSet long");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSet(array, i, 0xCAFEBABECAFEBABEL, 0xDEADBEEFDEADBEEFL);
+                assertEquals(success, false, "failing weakCompareAndSet long");
+                long x = (long) vh.get(array, i);
+                assertEquals(x, 0x0123456789ABCDEFL, "failing weakCompareAndSet long value");
             }
 
             // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessShort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -484,9 +484,16 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetPlain(recv, (short)0x0123, (short)0x4567);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain short");
+            assertEquals(success, true, "success weakCompareAndSetPlain short");
             short x = (short) vh.get(recv);
-            assertEquals(x, (short)0x4567, "weakCompareAndSetPlain short value");
+            assertEquals(x, (short)0x4567, "success weakCompareAndSetPlain short value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain(recv, (short)0x0123, (short)0x89AB);
+            assertEquals(success, false, "failing weakCompareAndSetPlain short");
+            short x = (short) vh.get(recv);
+            assertEquals(x, (short)0x4567, "failing weakCompareAndSetPlain short value");
         }
 
         {
@@ -494,9 +501,16 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetAcquire(recv, (short)0x4567, (short)0x0123);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire short");
+            assertEquals(success, true, "success weakCompareAndSetAcquire short");
             short x = (short) vh.get(recv);
-            assertEquals(x, (short)0x0123, "weakCompareAndSetAcquire short");
+            assertEquals(x, (short)0x0123, "success weakCompareAndSetAcquire short");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire(recv, (short)0x4567, (short)0x89AB);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire short");
+            short x = (short) vh.get(recv);
+            assertEquals(x, (short)0x0123, "failing weakCompareAndSetAcquire short value");
         }
 
         {
@@ -504,9 +518,16 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetRelease(recv, (short)0x0123, (short)0x4567);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease short");
+            assertEquals(success, true, "success weakCompareAndSetRelease short");
             short x = (short) vh.get(recv);
-            assertEquals(x, (short)0x4567, "weakCompareAndSetRelease short");
+            assertEquals(x, (short)0x4567, "success weakCompareAndSetRelease short");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease(recv, (short)0x0123, (short)0x89AB);
+            assertEquals(success, false, "failing weakCompareAndSetRelease short");
+            short x = (short) vh.get(recv);
+            assertEquals(x, (short)0x4567, "failing weakCompareAndSetRelease short value");
         }
 
         {
@@ -514,9 +535,16 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSet(recv, (short)0x4567, (short)0x0123);
             }
-            assertEquals(success, true, "weakCompareAndSet short");
+            assertEquals(success, true, "success weakCompareAndSet short");
             short x = (short) vh.get(recv);
-            assertEquals(x, (short)0x0123, "weakCompareAndSet short value");
+            assertEquals(x, (short)0x0123, "success weakCompareAndSet short value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet(recv, (short)0x4567, (short)0x89AB);
+            assertEquals(success, false, "failing weakCompareAndSet short");
+            short x = (short) vh.get(recv);
+            assertEquals(x, (short)0x0123, "failing weakCompareAndSet short value");
         }
 
         // Compare set and get
@@ -760,9 +788,16 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetPlain((short)0x0123, (short)0x4567);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain short");
+            assertEquals(success, true, "success weakCompareAndSetPlain short");
             short x = (short) vh.get();
-            assertEquals(x, (short)0x4567, "weakCompareAndSetPlain short value");
+            assertEquals(x, (short)0x4567, "success weakCompareAndSetPlain short value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain((short)0x0123, (short)0x89AB);
+            assertEquals(success, false, "failing weakCompareAndSetPlain short");
+            short x = (short) vh.get();
+            assertEquals(x, (short)0x4567, "failing weakCompareAndSetPlain short value");
         }
 
         {
@@ -770,9 +805,16 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetAcquire((short)0x4567, (short)0x0123);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire short");
+            assertEquals(success, true, "success weakCompareAndSetAcquire short");
             short x = (short) vh.get();
-            assertEquals(x, (short)0x0123, "weakCompareAndSetAcquire short");
+            assertEquals(x, (short)0x0123, "success weakCompareAndSetAcquire short");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire((short)0x4567, (short)0x89AB);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire short");
+            short x = (short) vh.get();
+            assertEquals(x, (short)0x0123, "failing weakCompareAndSetAcquire short value");
         }
 
         {
@@ -780,9 +822,16 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetRelease((short)0x0123, (short)0x4567);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease short");
+            assertEquals(success, true, "success weakCompareAndSetRelease short");
             short x = (short) vh.get();
-            assertEquals(x, (short)0x4567, "weakCompareAndSetRelease short");
+            assertEquals(x, (short)0x4567, "success weakCompareAndSetRelease short");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease((short)0x0123, (short)0x89AB);
+            assertEquals(success, false, "failing weakCompareAndSetRelease short");
+            short x = (short) vh.get();
+            assertEquals(x, (short)0x4567, "failing weakCompareAndSetRelease short value");
         }
 
         {
@@ -790,9 +839,16 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSet((short)0x4567, (short)0x0123);
             }
-            assertEquals(success, true, "weakCompareAndSet short");
+            assertEquals(success, true, "success weakCompareAndSet short");
             short x = (short) vh.get();
-            assertEquals(x, (short)0x0123, "weakCompareAndSet short");
+            assertEquals(x, (short)0x0123, "success weakCompareAndSet short");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet((short)0x4567, (short)0x89AB);
+            assertEquals(success, false, "failing weakCompareAndSet short");
+            short x = (short) vh.get();
+            assertEquals(x, (short)0x0123, "failing weakCompareAndSet short value");
         }
 
         // Compare set and get
@@ -1039,9 +1095,16 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetPlain(array, i, (short)0x0123, (short)0x4567);
                 }
-                assertEquals(success, true, "weakCompareAndSetPlain short");
+                assertEquals(success, true, "success weakCompareAndSetPlain short");
                 short x = (short) vh.get(array, i);
-                assertEquals(x, (short)0x4567, "weakCompareAndSetPlain short value");
+                assertEquals(x, (short)0x4567, "success weakCompareAndSetPlain short value");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetPlain(array, i, (short)0x0123, (short)0x89AB);
+                assertEquals(success, false, "failing weakCompareAndSetPlain short");
+                short x = (short) vh.get(array, i);
+                assertEquals(x, (short)0x4567, "failing weakCompareAndSetPlain short value");
             }
 
             {
@@ -1049,9 +1112,16 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetAcquire(array, i, (short)0x4567, (short)0x0123);
                 }
-                assertEquals(success, true, "weakCompareAndSetAcquire short");
+                assertEquals(success, true, "success weakCompareAndSetAcquire short");
                 short x = (short) vh.get(array, i);
-                assertEquals(x, (short)0x0123, "weakCompareAndSetAcquire short");
+                assertEquals(x, (short)0x0123, "success weakCompareAndSetAcquire short");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetAcquire(array, i, (short)0x4567, (short)0x89AB);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire short");
+                short x = (short) vh.get(array, i);
+                assertEquals(x, (short)0x0123, "failing weakCompareAndSetAcquire short value");
             }
 
             {
@@ -1059,9 +1129,16 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetRelease(array, i, (short)0x0123, (short)0x4567);
                 }
-                assertEquals(success, true, "weakCompareAndSetRelease short");
+                assertEquals(success, true, "success weakCompareAndSetRelease short");
                 short x = (short) vh.get(array, i);
-                assertEquals(x, (short)0x4567, "weakCompareAndSetRelease short");
+                assertEquals(x, (short)0x4567, "success weakCompareAndSetRelease short");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetRelease(array, i, (short)0x0123, (short)0x89AB);
+                assertEquals(success, false, "failing weakCompareAndSetRelease short");
+                short x = (short) vh.get(array, i);
+                assertEquals(x, (short)0x4567, "failing weakCompareAndSetRelease short value");
             }
 
             {
@@ -1069,9 +1146,16 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSet(array, i, (short)0x4567, (short)0x0123);
                 }
-                assertEquals(success, true, "weakCompareAndSet short");
+                assertEquals(success, true, "success weakCompareAndSet short");
                 short x = (short) vh.get(array, i);
-                assertEquals(x, (short)0x0123, "weakCompareAndSet short");
+                assertEquals(x, (short)0x0123, "success weakCompareAndSet short");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSet(array, i, (short)0x4567, (short)0x89AB);
+                assertEquals(success, false, "failing weakCompareAndSet short");
+                short x = (short) vh.get(array, i);
+                assertEquals(x, (short)0x0123, "failing weakCompareAndSet short value");
             }
 
             // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessString.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -583,9 +583,16 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetPlain(recv, "foo", "bar");
             }
-            assertEquals(success, true, "weakCompareAndSetPlain String");
+            assertEquals(success, true, "success weakCompareAndSetPlain String");
             String x = (String) vh.get(recv);
-            assertEquals(x, "bar", "weakCompareAndSetPlain String value");
+            assertEquals(x, "bar", "success weakCompareAndSetPlain String value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain(recv, "foo", "baz");
+            assertEquals(success, false, "failing weakCompareAndSetPlain String");
+            String x = (String) vh.get(recv);
+            assertEquals(x, "bar", "failing weakCompareAndSetPlain String value");
         }
 
         {
@@ -593,9 +600,16 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetAcquire(recv, "bar", "foo");
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire String");
+            assertEquals(success, true, "success weakCompareAndSetAcquire String");
             String x = (String) vh.get(recv);
-            assertEquals(x, "foo", "weakCompareAndSetAcquire String");
+            assertEquals(x, "foo", "success weakCompareAndSetAcquire String");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire(recv, "bar", "baz");
+            assertEquals(success, false, "failing weakCompareAndSetAcquire String");
+            String x = (String) vh.get(recv);
+            assertEquals(x, "foo", "failing weakCompareAndSetAcquire String value");
         }
 
         {
@@ -603,9 +617,16 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetRelease(recv, "foo", "bar");
             }
-            assertEquals(success, true, "weakCompareAndSetRelease String");
+            assertEquals(success, true, "success weakCompareAndSetRelease String");
             String x = (String) vh.get(recv);
-            assertEquals(x, "bar", "weakCompareAndSetRelease String");
+            assertEquals(x, "bar", "success weakCompareAndSetRelease String");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease(recv, "foo", "baz");
+            assertEquals(success, false, "failing weakCompareAndSetRelease String");
+            String x = (String) vh.get(recv);
+            assertEquals(x, "bar", "failing weakCompareAndSetRelease String value");
         }
 
         {
@@ -613,9 +634,16 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSet(recv, "bar", "foo");
             }
-            assertEquals(success, true, "weakCompareAndSet String");
+            assertEquals(success, true, "success weakCompareAndSet String");
             String x = (String) vh.get(recv);
-            assertEquals(x, "foo", "weakCompareAndSet String value");
+            assertEquals(x, "foo", "success weakCompareAndSet String value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet(recv, "bar", "baz");
+            assertEquals(success, false, "failing weakCompareAndSet String");
+            String x = (String) vh.get(recv);
+            assertEquals(x, "foo", "failing weakCompareAndSet String value");
         }
 
         // Compare set and get
@@ -795,9 +823,16 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetPlain("foo", "bar");
             }
-            assertEquals(success, true, "weakCompareAndSetPlain String");
+            assertEquals(success, true, "success weakCompareAndSetPlain String");
             String x = (String) vh.get();
-            assertEquals(x, "bar", "weakCompareAndSetPlain String value");
+            assertEquals(x, "bar", "success weakCompareAndSetPlain String value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain("foo", "baz");
+            assertEquals(success, false, "failing weakCompareAndSetPlain String");
+            String x = (String) vh.get();
+            assertEquals(x, "bar", "failing weakCompareAndSetPlain String value");
         }
 
         {
@@ -805,9 +840,16 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetAcquire("bar", "foo");
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire String");
+            assertEquals(success, true, "success weakCompareAndSetAcquire String");
             String x = (String) vh.get();
-            assertEquals(x, "foo", "weakCompareAndSetAcquire String");
+            assertEquals(x, "foo", "success weakCompareAndSetAcquire String");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire("bar", "baz");
+            assertEquals(success, false, "failing weakCompareAndSetAcquire String");
+            String x = (String) vh.get();
+            assertEquals(x, "foo", "failing weakCompareAndSetAcquire String value");
         }
 
         {
@@ -815,9 +857,16 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetRelease("foo", "bar");
             }
-            assertEquals(success, true, "weakCompareAndSetRelease String");
+            assertEquals(success, true, "success weakCompareAndSetRelease String");
             String x = (String) vh.get();
-            assertEquals(x, "bar", "weakCompareAndSetRelease String");
+            assertEquals(x, "bar", "success weakCompareAndSetRelease String");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease("foo", "baz");
+            assertEquals(success, false, "failing weakCompareAndSetRelease String");
+            String x = (String) vh.get();
+            assertEquals(x, "bar", "failing weakCompareAndSetRelease String value");
         }
 
         {
@@ -825,9 +874,16 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSet("bar", "foo");
             }
-            assertEquals(success, true, "weakCompareAndSet String");
+            assertEquals(success, true, "success weakCompareAndSet String");
             String x = (String) vh.get();
-            assertEquals(x, "foo", "weakCompareAndSet String");
+            assertEquals(x, "foo", "success weakCompareAndSet String");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet("bar", "baz");
+            assertEquals(success, false, "failing weakCompareAndSet String");
+            String x = (String) vh.get();
+            assertEquals(x, "foo", "failing weakCompareAndSet String value");
         }
 
         // Compare set and get
@@ -1010,9 +1066,16 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetPlain(array, i, "foo", "bar");
                 }
-                assertEquals(success, true, "weakCompareAndSetPlain String");
+                assertEquals(success, true, "success weakCompareAndSetPlain String");
                 String x = (String) vh.get(array, i);
-                assertEquals(x, "bar", "weakCompareAndSetPlain String value");
+                assertEquals(x, "bar", "success weakCompareAndSetPlain String value");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetPlain(array, i, "foo", "baz");
+                assertEquals(success, false, "failing weakCompareAndSetPlain String");
+                String x = (String) vh.get(array, i);
+                assertEquals(x, "bar", "failing weakCompareAndSetPlain String value");
             }
 
             {
@@ -1020,9 +1083,16 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetAcquire(array, i, "bar", "foo");
                 }
-                assertEquals(success, true, "weakCompareAndSetAcquire String");
+                assertEquals(success, true, "success weakCompareAndSetAcquire String");
                 String x = (String) vh.get(array, i);
-                assertEquals(x, "foo", "weakCompareAndSetAcquire String");
+                assertEquals(x, "foo", "success weakCompareAndSetAcquire String");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetAcquire(array, i, "bar", "baz");
+                assertEquals(success, false, "failing weakCompareAndSetAcquire String");
+                String x = (String) vh.get(array, i);
+                assertEquals(x, "foo", "failing weakCompareAndSetAcquire String value");
             }
 
             {
@@ -1030,9 +1100,16 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetRelease(array, i, "foo", "bar");
                 }
-                assertEquals(success, true, "weakCompareAndSetRelease String");
+                assertEquals(success, true, "success weakCompareAndSetRelease String");
                 String x = (String) vh.get(array, i);
-                assertEquals(x, "bar", "weakCompareAndSetRelease String");
+                assertEquals(x, "bar", "success weakCompareAndSetRelease String");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetRelease(array, i, "foo", "baz");
+                assertEquals(success, false, "failing weakCompareAndSetRelease String");
+                String x = (String) vh.get(array, i);
+                assertEquals(x, "bar", "failing weakCompareAndSetRelease String value");
             }
 
             {
@@ -1040,9 +1117,16 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSet(array, i, "bar", "foo");
                 }
-                assertEquals(success, true, "weakCompareAndSet String");
+                assertEquals(success, true, "success weakCompareAndSet String");
                 String x = (String) vh.get(array, i);
-                assertEquals(x, "foo", "weakCompareAndSet String");
+                assertEquals(x, "foo", "success weakCompareAndSet String");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSet(array, i, "bar", "baz");
+                assertEquals(success, false, "failing weakCompareAndSet String");
+                String x = (String) vh.get(array, i);
+                assertEquals(x, "foo", "failing weakCompareAndSet String value");
             }
 
             // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsChar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1082,9 +1082,16 @@ public class VarHandleTestByteArrayAsDouble extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetPlain(array, i, VALUE_1, VALUE_2);
                     }
-                    assertEquals(success, true, "weakCompareAndSetPlain double");
+                    assertEquals(success, true, "success weakCompareAndSetPlain double");
                     double x = (double) vh.get(array, i);
-                    assertEquals(x, VALUE_2, "weakCompareAndSetPlain double value");
+                    assertEquals(x, VALUE_2, "success weakCompareAndSetPlain double value");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetPlain(array, i, VALUE_1, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetPlain double");
+                    double x = (double) vh.get(array, i);
+                    assertEquals(x, VALUE_2, "failing weakCompareAndSetPlain double value");
                 }
 
                 {
@@ -1092,9 +1099,16 @@ public class VarHandleTestByteArrayAsDouble extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetAcquire(array, i, VALUE_2, VALUE_1);
                     }
-                    assertEquals(success, true, "weakCompareAndSetAcquire double");
+                    assertEquals(success, true, "success weakCompareAndSetAcquire double");
                     double x = (double) vh.get(array, i);
-                    assertEquals(x, VALUE_1, "weakCompareAndSetAcquire double");
+                    assertEquals(x, VALUE_1, "success weakCompareAndSetAcquire double");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetAcquire(array, i, VALUE_2, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetAcquire double");
+                    double x = (double) vh.get(array, i);
+                    assertEquals(x, VALUE_1, "failing weakCompareAndSetAcquire double value");
                 }
 
                 {
@@ -1102,9 +1116,16 @@ public class VarHandleTestByteArrayAsDouble extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetRelease(array, i, VALUE_1, VALUE_2);
                     }
-                    assertEquals(success, true, "weakCompareAndSetRelease double");
+                    assertEquals(success, true, "success weakCompareAndSetRelease double");
                     double x = (double) vh.get(array, i);
-                    assertEquals(x, VALUE_2, "weakCompareAndSetRelease double");
+                    assertEquals(x, VALUE_2, "success weakCompareAndSetRelease double");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetRelease(array, i, VALUE_1, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetRelease double");
+                    double x = (double) vh.get(array, i);
+                    assertEquals(x, VALUE_2, "failing weakCompareAndSetRelease double value");
                 }
 
                 {
@@ -1112,9 +1133,16 @@ public class VarHandleTestByteArrayAsDouble extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSet(array, i, VALUE_2, VALUE_1);
                     }
-                    assertEquals(success, true, "weakCompareAndSet double");
+                    assertEquals(success, true, "success weakCompareAndSet double");
                     double x = (double) vh.get(array, i);
-                    assertEquals(x, VALUE_1, "weakCompareAndSet double");
+                    assertEquals(x, VALUE_1, "success weakCompareAndSet double");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSet(array, i, VALUE_2, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSet double");
+                    double x = (double) vh.get(array, i);
+                    assertEquals(x, VALUE_1, "failing weakCompareAndSet double value");
                 }
 
                 // Compare set and get
@@ -1255,9 +1283,16 @@ public class VarHandleTestByteArrayAsDouble extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetPlain(array, i, VALUE_1, VALUE_2);
                     }
-                    assertEquals(success, true, "weakCompareAndSetPlain double");
+                    assertEquals(success, true, "success weakCompareAndSetPlain double");
                     double x = (double) vh.get(array, i);
-                    assertEquals(x, VALUE_2, "weakCompareAndSetPlain double value");
+                    assertEquals(x, VALUE_2, "success weakCompareAndSetPlain double value");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetPlain(array, i, VALUE_1, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetPlain double");
+                    double x = (double) vh.get(array, i);
+                    assertEquals(x, VALUE_2, "failing weakCompareAndSetPlain double value");
                 }
 
                 {
@@ -1265,9 +1300,16 @@ public class VarHandleTestByteArrayAsDouble extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetAcquire(array, i, VALUE_2, VALUE_1);
                     }
-                    assertEquals(success, true, "weakCompareAndSetAcquire double");
+                    assertEquals(success, true, "success weakCompareAndSetAcquire double");
                     double x = (double) vh.get(array, i);
-                    assertEquals(x, VALUE_1, "weakCompareAndSetAcquire double");
+                    assertEquals(x, VALUE_1, "success weakCompareAndSetAcquire double");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetAcquire(array, i, VALUE_2, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetAcquire double");
+                    double x = (double) vh.get(array, i);
+                    assertEquals(x, VALUE_1, "failing weakCompareAndSetAcquire double value");
                 }
 
                 {
@@ -1275,9 +1317,16 @@ public class VarHandleTestByteArrayAsDouble extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetRelease(array, i, VALUE_1, VALUE_2);
                     }
-                    assertEquals(success, true, "weakCompareAndSetRelease double");
+                    assertEquals(success, true, "success weakCompareAndSetRelease double");
                     double x = (double) vh.get(array, i);
-                    assertEquals(x, VALUE_2, "weakCompareAndSetRelease double");
+                    assertEquals(x, VALUE_2, "success weakCompareAndSetRelease double");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetRelease(array, i, VALUE_1, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetRelease double");
+                    double x = (double) vh.get(array, i);
+                    assertEquals(x, VALUE_2, "failing weakCompareAndSetRelease double value");
                 }
 
                 {
@@ -1285,9 +1334,16 @@ public class VarHandleTestByteArrayAsDouble extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSet(array, i, VALUE_2, VALUE_1);
                     }
-                    assertEquals(success, true, "weakCompareAndSet double");
+                    assertEquals(success, true, "success weakCompareAndSet double");
                     double x = (double) vh.get(array, i);
-                    assertEquals(x, VALUE_1, "weakCompareAndSet double");
+                    assertEquals(x, VALUE_1, "success weakCompareAndSet double");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSet(array, i, VALUE_2, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSet double");
+                    double x = (double) vh.get(array, i);
+                    assertEquals(x, VALUE_1, "failing weakCompareAndSet double value");
                 }
 
                 // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1082,9 +1082,16 @@ public class VarHandleTestByteArrayAsFloat extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetPlain(array, i, VALUE_1, VALUE_2);
                     }
-                    assertEquals(success, true, "weakCompareAndSetPlain float");
+                    assertEquals(success, true, "success weakCompareAndSetPlain float");
                     float x = (float) vh.get(array, i);
-                    assertEquals(x, VALUE_2, "weakCompareAndSetPlain float value");
+                    assertEquals(x, VALUE_2, "success weakCompareAndSetPlain float value");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetPlain(array, i, VALUE_1, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetPlain float");
+                    float x = (float) vh.get(array, i);
+                    assertEquals(x, VALUE_2, "failing weakCompareAndSetPlain float value");
                 }
 
                 {
@@ -1092,9 +1099,16 @@ public class VarHandleTestByteArrayAsFloat extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetAcquire(array, i, VALUE_2, VALUE_1);
                     }
-                    assertEquals(success, true, "weakCompareAndSetAcquire float");
+                    assertEquals(success, true, "success weakCompareAndSetAcquire float");
                     float x = (float) vh.get(array, i);
-                    assertEquals(x, VALUE_1, "weakCompareAndSetAcquire float");
+                    assertEquals(x, VALUE_1, "success weakCompareAndSetAcquire float");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetAcquire(array, i, VALUE_2, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetAcquire float");
+                    float x = (float) vh.get(array, i);
+                    assertEquals(x, VALUE_1, "failing weakCompareAndSetAcquire float value");
                 }
 
                 {
@@ -1102,9 +1116,16 @@ public class VarHandleTestByteArrayAsFloat extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetRelease(array, i, VALUE_1, VALUE_2);
                     }
-                    assertEquals(success, true, "weakCompareAndSetRelease float");
+                    assertEquals(success, true, "success weakCompareAndSetRelease float");
                     float x = (float) vh.get(array, i);
-                    assertEquals(x, VALUE_2, "weakCompareAndSetRelease float");
+                    assertEquals(x, VALUE_2, "success weakCompareAndSetRelease float");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetRelease(array, i, VALUE_1, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetRelease float");
+                    float x = (float) vh.get(array, i);
+                    assertEquals(x, VALUE_2, "failing weakCompareAndSetRelease float value");
                 }
 
                 {
@@ -1112,9 +1133,16 @@ public class VarHandleTestByteArrayAsFloat extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSet(array, i, VALUE_2, VALUE_1);
                     }
-                    assertEquals(success, true, "weakCompareAndSet float");
+                    assertEquals(success, true, "success weakCompareAndSet float");
                     float x = (float) vh.get(array, i);
-                    assertEquals(x, VALUE_1, "weakCompareAndSet float");
+                    assertEquals(x, VALUE_1, "success weakCompareAndSet float");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSet(array, i, VALUE_2, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSet float");
+                    float x = (float) vh.get(array, i);
+                    assertEquals(x, VALUE_1, "failing weakCompareAndSet float value");
                 }
 
                 // Compare set and get
@@ -1255,9 +1283,16 @@ public class VarHandleTestByteArrayAsFloat extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetPlain(array, i, VALUE_1, VALUE_2);
                     }
-                    assertEquals(success, true, "weakCompareAndSetPlain float");
+                    assertEquals(success, true, "success weakCompareAndSetPlain float");
                     float x = (float) vh.get(array, i);
-                    assertEquals(x, VALUE_2, "weakCompareAndSetPlain float value");
+                    assertEquals(x, VALUE_2, "success weakCompareAndSetPlain float value");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetPlain(array, i, VALUE_1, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetPlain float");
+                    float x = (float) vh.get(array, i);
+                    assertEquals(x, VALUE_2, "failing weakCompareAndSetPlain float value");
                 }
 
                 {
@@ -1265,9 +1300,16 @@ public class VarHandleTestByteArrayAsFloat extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetAcquire(array, i, VALUE_2, VALUE_1);
                     }
-                    assertEquals(success, true, "weakCompareAndSetAcquire float");
+                    assertEquals(success, true, "success weakCompareAndSetAcquire float");
                     float x = (float) vh.get(array, i);
-                    assertEquals(x, VALUE_1, "weakCompareAndSetAcquire float");
+                    assertEquals(x, VALUE_1, "success weakCompareAndSetAcquire float");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetAcquire(array, i, VALUE_2, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetAcquire float");
+                    float x = (float) vh.get(array, i);
+                    assertEquals(x, VALUE_1, "failing weakCompareAndSetAcquire float value");
                 }
 
                 {
@@ -1275,9 +1317,16 @@ public class VarHandleTestByteArrayAsFloat extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetRelease(array, i, VALUE_1, VALUE_2);
                     }
-                    assertEquals(success, true, "weakCompareAndSetRelease float");
+                    assertEquals(success, true, "success weakCompareAndSetRelease float");
                     float x = (float) vh.get(array, i);
-                    assertEquals(x, VALUE_2, "weakCompareAndSetRelease float");
+                    assertEquals(x, VALUE_2, "success weakCompareAndSetRelease float");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetRelease(array, i, VALUE_1, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetRelease float");
+                    float x = (float) vh.get(array, i);
+                    assertEquals(x, VALUE_2, "failing weakCompareAndSetRelease float value");
                 }
 
                 {
@@ -1285,9 +1334,16 @@ public class VarHandleTestByteArrayAsFloat extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSet(array, i, VALUE_2, VALUE_1);
                     }
-                    assertEquals(success, true, "weakCompareAndSet float");
+                    assertEquals(success, true, "success weakCompareAndSet float");
                     float x = (float) vh.get(array, i);
-                    assertEquals(x, VALUE_1, "weakCompareAndSet float");
+                    assertEquals(x, VALUE_1, "success weakCompareAndSet float");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSet(array, i, VALUE_2, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSet float");
+                    float x = (float) vh.get(array, i);
+                    assertEquals(x, VALUE_1, "failing weakCompareAndSet float value");
                 }
 
                 // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1266,9 +1266,16 @@ public class VarHandleTestByteArrayAsInt extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetPlain(array, i, VALUE_1, VALUE_2);
                     }
-                    assertEquals(success, true, "weakCompareAndSetPlain int");
+                    assertEquals(success, true, "success weakCompareAndSetPlain int");
                     int x = (int) vh.get(array, i);
-                    assertEquals(x, VALUE_2, "weakCompareAndSetPlain int value");
+                    assertEquals(x, VALUE_2, "success weakCompareAndSetPlain int value");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetPlain(array, i, VALUE_1, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetPlain int");
+                    int x = (int) vh.get(array, i);
+                    assertEquals(x, VALUE_2, "failing weakCompareAndSetPlain int value");
                 }
 
                 {
@@ -1276,9 +1283,16 @@ public class VarHandleTestByteArrayAsInt extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetAcquire(array, i, VALUE_2, VALUE_1);
                     }
-                    assertEquals(success, true, "weakCompareAndSetAcquire int");
+                    assertEquals(success, true, "success weakCompareAndSetAcquire int");
                     int x = (int) vh.get(array, i);
-                    assertEquals(x, VALUE_1, "weakCompareAndSetAcquire int");
+                    assertEquals(x, VALUE_1, "success weakCompareAndSetAcquire int");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetAcquire(array, i, VALUE_2, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetAcquire int");
+                    int x = (int) vh.get(array, i);
+                    assertEquals(x, VALUE_1, "failing weakCompareAndSetAcquire int value");
                 }
 
                 {
@@ -1286,9 +1300,16 @@ public class VarHandleTestByteArrayAsInt extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetRelease(array, i, VALUE_1, VALUE_2);
                     }
-                    assertEquals(success, true, "weakCompareAndSetRelease int");
+                    assertEquals(success, true, "success weakCompareAndSetRelease int");
                     int x = (int) vh.get(array, i);
-                    assertEquals(x, VALUE_2, "weakCompareAndSetRelease int");
+                    assertEquals(x, VALUE_2, "success weakCompareAndSetRelease int");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetRelease(array, i, VALUE_1, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetRelease int");
+                    int x = (int) vh.get(array, i);
+                    assertEquals(x, VALUE_2, "failing weakCompareAndSetRelease int value");
                 }
 
                 {
@@ -1296,9 +1317,16 @@ public class VarHandleTestByteArrayAsInt extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSet(array, i, VALUE_2, VALUE_1);
                     }
-                    assertEquals(success, true, "weakCompareAndSet int");
+                    assertEquals(success, true, "success weakCompareAndSet int");
                     int x = (int) vh.get(array, i);
-                    assertEquals(x, VALUE_1, "weakCompareAndSet int");
+                    assertEquals(x, VALUE_1, "success weakCompareAndSet int");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSet(array, i, VALUE_2, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSet int");
+                    int x = (int) vh.get(array, i);
+                    assertEquals(x, VALUE_1, "failing weakCompareAndSet int value");
                 }
 
                 // Compare set and get
@@ -1549,9 +1577,16 @@ public class VarHandleTestByteArrayAsInt extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetPlain(array, i, VALUE_1, VALUE_2);
                     }
-                    assertEquals(success, true, "weakCompareAndSetPlain int");
+                    assertEquals(success, true, "success weakCompareAndSetPlain int");
                     int x = (int) vh.get(array, i);
-                    assertEquals(x, VALUE_2, "weakCompareAndSetPlain int value");
+                    assertEquals(x, VALUE_2, "success weakCompareAndSetPlain int value");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetPlain(array, i, VALUE_1, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetPlain int");
+                    int x = (int) vh.get(array, i);
+                    assertEquals(x, VALUE_2, "failing weakCompareAndSetPlain int value");
                 }
 
                 {
@@ -1559,9 +1594,16 @@ public class VarHandleTestByteArrayAsInt extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetAcquire(array, i, VALUE_2, VALUE_1);
                     }
-                    assertEquals(success, true, "weakCompareAndSetAcquire int");
+                    assertEquals(success, true, "success weakCompareAndSetAcquire int");
                     int x = (int) vh.get(array, i);
-                    assertEquals(x, VALUE_1, "weakCompareAndSetAcquire int");
+                    assertEquals(x, VALUE_1, "success weakCompareAndSetAcquire int");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetAcquire(array, i, VALUE_2, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetAcquire int");
+                    int x = (int) vh.get(array, i);
+                    assertEquals(x, VALUE_1, "failing weakCompareAndSetAcquire int value");
                 }
 
                 {
@@ -1569,9 +1611,16 @@ public class VarHandleTestByteArrayAsInt extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetRelease(array, i, VALUE_1, VALUE_2);
                     }
-                    assertEquals(success, true, "weakCompareAndSetRelease int");
+                    assertEquals(success, true, "success weakCompareAndSetRelease int");
                     int x = (int) vh.get(array, i);
-                    assertEquals(x, VALUE_2, "weakCompareAndSetRelease int");
+                    assertEquals(x, VALUE_2, "success weakCompareAndSetRelease int");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetRelease(array, i, VALUE_1, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetRelease int");
+                    int x = (int) vh.get(array, i);
+                    assertEquals(x, VALUE_2, "failing weakCompareAndSetRelease int value");
                 }
 
                 {
@@ -1579,9 +1628,16 @@ public class VarHandleTestByteArrayAsInt extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSet(array, i, VALUE_2, VALUE_1);
                     }
-                    assertEquals(success, true, "weakCompareAndSet int");
+                    assertEquals(success, true, "success weakCompareAndSet int");
                     int x = (int) vh.get(array, i);
-                    assertEquals(x, VALUE_1, "weakCompareAndSet int");
+                    assertEquals(x, VALUE_1, "success weakCompareAndSet int");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSet(array, i, VALUE_2, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSet int");
+                    int x = (int) vh.get(array, i);
+                    assertEquals(x, VALUE_1, "failing weakCompareAndSet int value");
                 }
 
                 // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1266,9 +1266,16 @@ public class VarHandleTestByteArrayAsLong extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetPlain(array, i, VALUE_1, VALUE_2);
                     }
-                    assertEquals(success, true, "weakCompareAndSetPlain long");
+                    assertEquals(success, true, "success weakCompareAndSetPlain long");
                     long x = (long) vh.get(array, i);
-                    assertEquals(x, VALUE_2, "weakCompareAndSetPlain long value");
+                    assertEquals(x, VALUE_2, "success weakCompareAndSetPlain long value");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetPlain(array, i, VALUE_1, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetPlain long");
+                    long x = (long) vh.get(array, i);
+                    assertEquals(x, VALUE_2, "failing weakCompareAndSetPlain long value");
                 }
 
                 {
@@ -1276,9 +1283,16 @@ public class VarHandleTestByteArrayAsLong extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetAcquire(array, i, VALUE_2, VALUE_1);
                     }
-                    assertEquals(success, true, "weakCompareAndSetAcquire long");
+                    assertEquals(success, true, "success weakCompareAndSetAcquire long");
                     long x = (long) vh.get(array, i);
-                    assertEquals(x, VALUE_1, "weakCompareAndSetAcquire long");
+                    assertEquals(x, VALUE_1, "success weakCompareAndSetAcquire long");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetAcquire(array, i, VALUE_2, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetAcquire long");
+                    long x = (long) vh.get(array, i);
+                    assertEquals(x, VALUE_1, "failing weakCompareAndSetAcquire long value");
                 }
 
                 {
@@ -1286,9 +1300,16 @@ public class VarHandleTestByteArrayAsLong extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetRelease(array, i, VALUE_1, VALUE_2);
                     }
-                    assertEquals(success, true, "weakCompareAndSetRelease long");
+                    assertEquals(success, true, "success weakCompareAndSetRelease long");
                     long x = (long) vh.get(array, i);
-                    assertEquals(x, VALUE_2, "weakCompareAndSetRelease long");
+                    assertEquals(x, VALUE_2, "success weakCompareAndSetRelease long");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetRelease(array, i, VALUE_1, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetRelease long");
+                    long x = (long) vh.get(array, i);
+                    assertEquals(x, VALUE_2, "failing weakCompareAndSetRelease long value");
                 }
 
                 {
@@ -1296,9 +1317,16 @@ public class VarHandleTestByteArrayAsLong extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSet(array, i, VALUE_2, VALUE_1);
                     }
-                    assertEquals(success, true, "weakCompareAndSet long");
+                    assertEquals(success, true, "success weakCompareAndSet long");
                     long x = (long) vh.get(array, i);
-                    assertEquals(x, VALUE_1, "weakCompareAndSet long");
+                    assertEquals(x, VALUE_1, "success weakCompareAndSet long");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSet(array, i, VALUE_2, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSet long");
+                    long x = (long) vh.get(array, i);
+                    assertEquals(x, VALUE_1, "failing weakCompareAndSet long value");
                 }
 
                 // Compare set and get
@@ -1549,9 +1577,16 @@ public class VarHandleTestByteArrayAsLong extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetPlain(array, i, VALUE_1, VALUE_2);
                     }
-                    assertEquals(success, true, "weakCompareAndSetPlain long");
+                    assertEquals(success, true, "success weakCompareAndSetPlain long");
                     long x = (long) vh.get(array, i);
-                    assertEquals(x, VALUE_2, "weakCompareAndSetPlain long value");
+                    assertEquals(x, VALUE_2, "success weakCompareAndSetPlain long value");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetPlain(array, i, VALUE_1, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetPlain long");
+                    long x = (long) vh.get(array, i);
+                    assertEquals(x, VALUE_2, "failing weakCompareAndSetPlain long value");
                 }
 
                 {
@@ -1559,9 +1594,16 @@ public class VarHandleTestByteArrayAsLong extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetAcquire(array, i, VALUE_2, VALUE_1);
                     }
-                    assertEquals(success, true, "weakCompareAndSetAcquire long");
+                    assertEquals(success, true, "success weakCompareAndSetAcquire long");
                     long x = (long) vh.get(array, i);
-                    assertEquals(x, VALUE_1, "weakCompareAndSetAcquire long");
+                    assertEquals(x, VALUE_1, "success weakCompareAndSetAcquire long");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetAcquire(array, i, VALUE_2, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetAcquire long");
+                    long x = (long) vh.get(array, i);
+                    assertEquals(x, VALUE_1, "failing weakCompareAndSetAcquire long value");
                 }
 
                 {
@@ -1569,9 +1611,16 @@ public class VarHandleTestByteArrayAsLong extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetRelease(array, i, VALUE_1, VALUE_2);
                     }
-                    assertEquals(success, true, "weakCompareAndSetRelease long");
+                    assertEquals(success, true, "success weakCompareAndSetRelease long");
                     long x = (long) vh.get(array, i);
-                    assertEquals(x, VALUE_2, "weakCompareAndSetRelease long");
+                    assertEquals(x, VALUE_2, "success weakCompareAndSetRelease long");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetRelease(array, i, VALUE_1, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetRelease long");
+                    long x = (long) vh.get(array, i);
+                    assertEquals(x, VALUE_2, "failing weakCompareAndSetRelease long value");
                 }
 
                 {
@@ -1579,9 +1628,16 @@ public class VarHandleTestByteArrayAsLong extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSet(array, i, VALUE_2, VALUE_1);
                     }
-                    assertEquals(success, true, "weakCompareAndSet long");
+                    assertEquals(success, true, "success weakCompareAndSet long");
                     long x = (long) vh.get(array, i);
-                    assertEquals(x, VALUE_1, "weakCompareAndSet long");
+                    assertEquals(x, VALUE_1, "success weakCompareAndSet long");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSet(array, i, VALUE_2, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSet long");
+                    long x = (long) vh.get(array, i);
+                    assertEquals(x, VALUE_1, "failing weakCompareAndSet long value");
                 }
 
                 // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,9 +212,16 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, true, false);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain boolean");
+            assertEquals(success, true, "success weakCompareAndSetPlain boolean");
             boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, false, "weakCompareAndSetPlain boolean value");
+            assertEquals(x, false, "success weakCompareAndSetPlain boolean value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, true, false);
+            assertEquals(success, false, "failing weakCompareAndSetPlain boolean");
+            boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, false, "failing weakCompareAndSetPlain boolean value");
         }
 
         {
@@ -222,9 +229,16 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, false, true);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire boolean");
+            assertEquals(success, true, "success weakCompareAndSetAcquire boolean");
             boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, true, "weakCompareAndSetAcquire boolean");
+            assertEquals(x, true, "success weakCompareAndSetAcquire boolean");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, false, false);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire boolean");
+            boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, true, "failing weakCompareAndSetAcquire boolean value");
         }
 
         {
@@ -232,9 +246,16 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, true, false);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease boolean");
+            assertEquals(success, true, "success weakCompareAndSetRelease boolean");
             boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, false, "weakCompareAndSetRelease boolean");
+            assertEquals(x, false, "success weakCompareAndSetRelease boolean");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, true, false);
+            assertEquals(success, false, "failing weakCompareAndSetRelease boolean");
+            boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, false, "failing weakCompareAndSetRelease boolean value");
         }
 
         {
@@ -242,9 +263,16 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, false, true);
             }
-            assertEquals(success, true, "weakCompareAndSet boolean");
+            assertEquals(success, true, "success weakCompareAndSet boolean");
             boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, true, "weakCompareAndSet boolean");
+            assertEquals(x, true, "success weakCompareAndSet boolean");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, false, false);
+            assertEquals(success, false, "failing weakCompareAndSet boolean");
+            boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, true, "failing weakCompareAndSet boolean value");
         }
 
         // Compare set and get
@@ -446,9 +474,16 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(true, false);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain boolean");
+            assertEquals(success, true, "success weakCompareAndSetPlain boolean");
             boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, false, "weakCompareAndSetPlain boolean value");
+            assertEquals(x, false, "success weakCompareAndSetPlain boolean value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(true, false);
+            assertEquals(success, false, "failing weakCompareAndSetPlain boolean");
+            boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, false, "failing weakCompareAndSetPlain boolean value");
         }
 
         {
@@ -456,9 +491,16 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(false, true);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire boolean");
+            assertEquals(success, true, "success weakCompareAndSetAcquire boolean");
             boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, true, "weakCompareAndSetAcquire boolean");
+            assertEquals(x, true, "success weakCompareAndSetAcquire boolean");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(false, false);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire boolean");
+            boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, true, "failing weakCompareAndSetAcquire boolean value");
         }
 
         {
@@ -466,9 +508,16 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(true, false);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease boolean");
+            assertEquals(success, true, "success weakCompareAndSetRelease boolean");
             boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, false, "weakCompareAndSetRelease boolean");
+            assertEquals(x, false, "success weakCompareAndSetRelease boolean");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(true, false);
+            assertEquals(success, false, "failing weakCompareAndSetRelease boolean");
+            boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, false, "failing weakCompareAndSetRelease boolean value");
         }
 
         {
@@ -476,9 +525,16 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(false, true);
             }
-            assertEquals(success, true, "weakCompareAndSet boolean");
+            assertEquals(success, true, "success weakCompareAndSet boolean");
             boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, true, "weakCompareAndSet boolean");
+            assertEquals(x, true, "success weakCompareAndSet boolean");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(false, false);
+            assertEquals(success, false, "failing weakCompareAndSet boolean");
+            boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, true, "failing weakCompareAndSetRe boolean value");
         }
 
         // Compare set and get
@@ -705,9 +761,16 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, true, false);
                 }
-                assertEquals(success, true, "weakCompareAndSetPlain boolean");
+                assertEquals(success, true, "success weakCompareAndSetPlain boolean");
                 boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, false, "weakCompareAndSetPlain boolean value");
+                assertEquals(x, false, "success weakCompareAndSetPlain boolean value");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, true, false);
+                assertEquals(success, false, "failing weakCompareAndSetPlain boolean");
+                boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, false, "failing weakCompareAndSetPlain boolean value");
             }
 
             {
@@ -715,9 +778,16 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, false, true);
                 }
-                assertEquals(success, true, "weakCompareAndSetAcquire boolean");
+                assertEquals(success, true, "success weakCompareAndSetAcquire boolean");
                 boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, true, "weakCompareAndSetAcquire boolean");
+                assertEquals(x, true, "success weakCompareAndSetAcquire boolean");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, false, false);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire boolean");
+                boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, true, "failing weakCompareAndSetAcquire boolean value");
             }
 
             {
@@ -725,9 +795,16 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, true, false);
                 }
-                assertEquals(success, true, "weakCompareAndSetRelease boolean");
+                assertEquals(success, true, "success weakCompareAndSetRelease boolean");
                 boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, false, "weakCompareAndSetRelease boolean");
+                assertEquals(x, false, "success weakCompareAndSetRelease boolean");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, true, false);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire boolean");
+                boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, false, "failing weakCompareAndSetAcquire boolean value");
             }
 
             {
@@ -735,9 +812,16 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, false, true);
                 }
-                assertEquals(success, true, "weakCompareAndSet boolean");
+                assertEquals(success, true, "success weakCompareAndSet boolean");
                 boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, true, "weakCompareAndSet boolean");
+                assertEquals(x, true, "success weakCompareAndSet boolean");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, false, false);
+                assertEquals(success, false, "failing weakCompareAndSet boolean");
+                boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, true, "failing weakCompareAndSet boolean value");
             }
 
             // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,9 +212,16 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, (byte)0x01, (byte)0x23);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain byte");
+            assertEquals(success, true, "success weakCompareAndSetPlain byte");
             byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, (byte)0x23, "weakCompareAndSetPlain byte value");
+            assertEquals(x, (byte)0x23, "success weakCompareAndSetPlain byte value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, (byte)0x01, (byte)0x45);
+            assertEquals(success, false, "failing weakCompareAndSetPlain byte");
+            byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, (byte)0x23, "failing weakCompareAndSetPlain byte value");
         }
 
         {
@@ -222,9 +229,16 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, (byte)0x23, (byte)0x01);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire byte");
+            assertEquals(success, true, "success weakCompareAndSetAcquire byte");
             byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, (byte)0x01, "weakCompareAndSetAcquire byte");
+            assertEquals(x, (byte)0x01, "success weakCompareAndSetAcquire byte");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, (byte)0x23, (byte)0x45);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire byte");
+            byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, (byte)0x01, "failing weakCompareAndSetAcquire byte value");
         }
 
         {
@@ -232,9 +246,16 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, (byte)0x01, (byte)0x23);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease byte");
+            assertEquals(success, true, "success weakCompareAndSetRelease byte");
             byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, (byte)0x23, "weakCompareAndSetRelease byte");
+            assertEquals(x, (byte)0x23, "success weakCompareAndSetRelease byte");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, (byte)0x01, (byte)0x45);
+            assertEquals(success, false, "failing weakCompareAndSetRelease byte");
+            byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, (byte)0x23, "failing weakCompareAndSetRelease byte value");
         }
 
         {
@@ -242,9 +263,16 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, (byte)0x23, (byte)0x01);
             }
-            assertEquals(success, true, "weakCompareAndSet byte");
+            assertEquals(success, true, "success weakCompareAndSet byte");
             byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, (byte)0x01, "weakCompareAndSet byte");
+            assertEquals(x, (byte)0x01, "success weakCompareAndSet byte");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, (byte)0x23, (byte)0x45);
+            assertEquals(success, false, "failing weakCompareAndSet byte");
+            byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, (byte)0x01, "failing weakCompareAndSet byte value");
         }
 
         // Compare set and get
@@ -468,9 +496,16 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact((byte)0x01, (byte)0x23);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain byte");
+            assertEquals(success, true, "success weakCompareAndSetPlain byte");
             byte x = (byte) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, (byte)0x23, "weakCompareAndSetPlain byte value");
+            assertEquals(x, (byte)0x23, "success weakCompareAndSetPlain byte value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact((byte)0x01, (byte)0x45);
+            assertEquals(success, false, "failing weakCompareAndSetPlain byte");
+            byte x = (byte) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, (byte)0x23, "failing weakCompareAndSetPlain byte value");
         }
 
         {
@@ -478,9 +513,16 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact((byte)0x23, (byte)0x01);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire byte");
+            assertEquals(success, true, "success weakCompareAndSetAcquire byte");
             byte x = (byte) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, (byte)0x01, "weakCompareAndSetAcquire byte");
+            assertEquals(x, (byte)0x01, "success weakCompareAndSetAcquire byte");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact((byte)0x23, (byte)0x45);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire byte");
+            byte x = (byte) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, (byte)0x01, "failing weakCompareAndSetAcquire byte value");
         }
 
         {
@@ -488,9 +530,16 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact((byte)0x01, (byte)0x23);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease byte");
+            assertEquals(success, true, "success weakCompareAndSetRelease byte");
             byte x = (byte) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, (byte)0x23, "weakCompareAndSetRelease byte");
+            assertEquals(x, (byte)0x23, "success weakCompareAndSetRelease byte");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact((byte)0x01, (byte)0x45);
+            assertEquals(success, false, "failing weakCompareAndSetRelease byte");
+            byte x = (byte) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, (byte)0x23, "failing weakCompareAndSetRelease byte value");
         }
 
         {
@@ -498,9 +547,16 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact((byte)0x23, (byte)0x01);
             }
-            assertEquals(success, true, "weakCompareAndSet byte");
+            assertEquals(success, true, "success weakCompareAndSet byte");
             byte x = (byte) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, (byte)0x01, "weakCompareAndSet byte");
+            assertEquals(x, (byte)0x01, "success weakCompareAndSet byte");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact((byte)0x23, (byte)0x45);
+            assertEquals(success, false, "failing weakCompareAndSet byte");
+            byte x = (byte) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, (byte)0x01, "failing weakCompareAndSetRe byte value");
         }
 
         // Compare set and get
@@ -749,9 +805,16 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, (byte)0x01, (byte)0x23);
                 }
-                assertEquals(success, true, "weakCompareAndSetPlain byte");
+                assertEquals(success, true, "success weakCompareAndSetPlain byte");
                 byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, (byte)0x23, "weakCompareAndSetPlain byte value");
+                assertEquals(x, (byte)0x23, "success weakCompareAndSetPlain byte value");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, (byte)0x01, (byte)0x45);
+                assertEquals(success, false, "failing weakCompareAndSetPlain byte");
+                byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, (byte)0x23, "failing weakCompareAndSetPlain byte value");
             }
 
             {
@@ -759,9 +822,16 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, (byte)0x23, (byte)0x01);
                 }
-                assertEquals(success, true, "weakCompareAndSetAcquire byte");
+                assertEquals(success, true, "success weakCompareAndSetAcquire byte");
                 byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, (byte)0x01, "weakCompareAndSetAcquire byte");
+                assertEquals(x, (byte)0x01, "success weakCompareAndSetAcquire byte");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, (byte)0x23, (byte)0x45);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire byte");
+                byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, (byte)0x01, "failing weakCompareAndSetAcquire byte value");
             }
 
             {
@@ -769,9 +839,16 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, (byte)0x01, (byte)0x23);
                 }
-                assertEquals(success, true, "weakCompareAndSetRelease byte");
+                assertEquals(success, true, "success weakCompareAndSetRelease byte");
                 byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, (byte)0x23, "weakCompareAndSetRelease byte");
+                assertEquals(x, (byte)0x23, "success weakCompareAndSetRelease byte");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, (byte)0x01, (byte)0x45);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire byte");
+                byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, (byte)0x23, "failing weakCompareAndSetAcquire byte value");
             }
 
             {
@@ -779,9 +856,16 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, (byte)0x23, (byte)0x01);
                 }
-                assertEquals(success, true, "weakCompareAndSet byte");
+                assertEquals(success, true, "success weakCompareAndSet byte");
                 byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, (byte)0x01, "weakCompareAndSet byte");
+                assertEquals(x, (byte)0x01, "success weakCompareAndSet byte");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, (byte)0x23, (byte)0x45);
+                assertEquals(success, false, "failing weakCompareAndSet byte");
+                byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, (byte)0x01, "failing weakCompareAndSet byte value");
             }
 
             // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,9 +212,16 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, '\u0123', '\u4567');
             }
-            assertEquals(success, true, "weakCompareAndSetPlain char");
+            assertEquals(success, true, "success weakCompareAndSetPlain char");
             char x = (char) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, '\u4567', "weakCompareAndSetPlain char value");
+            assertEquals(x, '\u4567', "success weakCompareAndSetPlain char value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, '\u0123', '\u89AB');
+            assertEquals(success, false, "failing weakCompareAndSetPlain char");
+            char x = (char) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, '\u4567', "failing weakCompareAndSetPlain char value");
         }
 
         {
@@ -222,9 +229,16 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, '\u4567', '\u0123');
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire char");
+            assertEquals(success, true, "success weakCompareAndSetAcquire char");
             char x = (char) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, '\u0123', "weakCompareAndSetAcquire char");
+            assertEquals(x, '\u0123', "success weakCompareAndSetAcquire char");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, '\u4567', '\u89AB');
+            assertEquals(success, false, "failing weakCompareAndSetAcquire char");
+            char x = (char) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, '\u0123', "failing weakCompareAndSetAcquire char value");
         }
 
         {
@@ -232,9 +246,16 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, '\u0123', '\u4567');
             }
-            assertEquals(success, true, "weakCompareAndSetRelease char");
+            assertEquals(success, true, "success weakCompareAndSetRelease char");
             char x = (char) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, '\u4567', "weakCompareAndSetRelease char");
+            assertEquals(x, '\u4567', "success weakCompareAndSetRelease char");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, '\u0123', '\u89AB');
+            assertEquals(success, false, "failing weakCompareAndSetRelease char");
+            char x = (char) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, '\u4567', "failing weakCompareAndSetRelease char value");
         }
 
         {
@@ -242,9 +263,16 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, '\u4567', '\u0123');
             }
-            assertEquals(success, true, "weakCompareAndSet char");
+            assertEquals(success, true, "success weakCompareAndSet char");
             char x = (char) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, '\u0123', "weakCompareAndSet char");
+            assertEquals(x, '\u0123', "success weakCompareAndSet char");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, '\u4567', '\u89AB');
+            assertEquals(success, false, "failing weakCompareAndSet char");
+            char x = (char) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, '\u0123', "failing weakCompareAndSet char value");
         }
 
         // Compare set and get
@@ -468,9 +496,16 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact('\u0123', '\u4567');
             }
-            assertEquals(success, true, "weakCompareAndSetPlain char");
+            assertEquals(success, true, "success weakCompareAndSetPlain char");
             char x = (char) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, '\u4567', "weakCompareAndSetPlain char value");
+            assertEquals(x, '\u4567', "success weakCompareAndSetPlain char value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact('\u0123', '\u89AB');
+            assertEquals(success, false, "failing weakCompareAndSetPlain char");
+            char x = (char) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, '\u4567', "failing weakCompareAndSetPlain char value");
         }
 
         {
@@ -478,9 +513,16 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact('\u4567', '\u0123');
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire char");
+            assertEquals(success, true, "success weakCompareAndSetAcquire char");
             char x = (char) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, '\u0123', "weakCompareAndSetAcquire char");
+            assertEquals(x, '\u0123', "success weakCompareAndSetAcquire char");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact('\u4567', '\u89AB');
+            assertEquals(success, false, "failing weakCompareAndSetAcquire char");
+            char x = (char) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, '\u0123', "failing weakCompareAndSetAcquire char value");
         }
 
         {
@@ -488,9 +530,16 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact('\u0123', '\u4567');
             }
-            assertEquals(success, true, "weakCompareAndSetRelease char");
+            assertEquals(success, true, "success weakCompareAndSetRelease char");
             char x = (char) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, '\u4567', "weakCompareAndSetRelease char");
+            assertEquals(x, '\u4567', "success weakCompareAndSetRelease char");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact('\u0123', '\u89AB');
+            assertEquals(success, false, "failing weakCompareAndSetRelease char");
+            char x = (char) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, '\u4567', "failing weakCompareAndSetRelease char value");
         }
 
         {
@@ -498,9 +547,16 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact('\u4567', '\u0123');
             }
-            assertEquals(success, true, "weakCompareAndSet char");
+            assertEquals(success, true, "success weakCompareAndSet char");
             char x = (char) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, '\u0123', "weakCompareAndSet char");
+            assertEquals(x, '\u0123', "success weakCompareAndSet char");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact('\u4567', '\u89AB');
+            assertEquals(success, false, "failing weakCompareAndSet char");
+            char x = (char) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, '\u0123', "failing weakCompareAndSetRe char value");
         }
 
         // Compare set and get
@@ -749,9 +805,16 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, '\u0123', '\u4567');
                 }
-                assertEquals(success, true, "weakCompareAndSetPlain char");
+                assertEquals(success, true, "success weakCompareAndSetPlain char");
                 char x = (char) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, '\u4567', "weakCompareAndSetPlain char value");
+                assertEquals(x, '\u4567', "success weakCompareAndSetPlain char value");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, '\u0123', '\u89AB');
+                assertEquals(success, false, "failing weakCompareAndSetPlain char");
+                char x = (char) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, '\u4567', "failing weakCompareAndSetPlain char value");
             }
 
             {
@@ -759,9 +822,16 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, '\u4567', '\u0123');
                 }
-                assertEquals(success, true, "weakCompareAndSetAcquire char");
+                assertEquals(success, true, "success weakCompareAndSetAcquire char");
                 char x = (char) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, '\u0123', "weakCompareAndSetAcquire char");
+                assertEquals(x, '\u0123', "success weakCompareAndSetAcquire char");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, '\u4567', '\u89AB');
+                assertEquals(success, false, "failing weakCompareAndSetAcquire char");
+                char x = (char) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, '\u0123', "failing weakCompareAndSetAcquire char value");
             }
 
             {
@@ -769,9 +839,16 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, '\u0123', '\u4567');
                 }
-                assertEquals(success, true, "weakCompareAndSetRelease char");
+                assertEquals(success, true, "success weakCompareAndSetRelease char");
                 char x = (char) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, '\u4567', "weakCompareAndSetRelease char");
+                assertEquals(x, '\u4567', "success weakCompareAndSetRelease char");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, '\u0123', '\u89AB');
+                assertEquals(success, false, "failing weakCompareAndSetAcquire char");
+                char x = (char) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, '\u4567', "failing weakCompareAndSetAcquire char value");
             }
 
             {
@@ -779,9 +856,16 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, '\u4567', '\u0123');
                 }
-                assertEquals(success, true, "weakCompareAndSet char");
+                assertEquals(success, true, "success weakCompareAndSet char");
                 char x = (char) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, '\u0123', "weakCompareAndSet char");
+                assertEquals(x, '\u0123', "success weakCompareAndSet char");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, '\u4567', '\u89AB');
+                assertEquals(success, false, "failing weakCompareAndSet char");
+                char x = (char) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, '\u0123', "failing weakCompareAndSet char value");
             }
 
             // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,9 +212,16 @@ public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, 1.0d, 2.0d);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain double");
+            assertEquals(success, true, "success weakCompareAndSetPlain double");
             double x = (double) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, 2.0d, "weakCompareAndSetPlain double value");
+            assertEquals(x, 2.0d, "success weakCompareAndSetPlain double value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, 1.0d, 3.0d);
+            assertEquals(success, false, "failing weakCompareAndSetPlain double");
+            double x = (double) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, 2.0d, "failing weakCompareAndSetPlain double value");
         }
 
         {
@@ -222,9 +229,16 @@ public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, 2.0d, 1.0d);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire double");
+            assertEquals(success, true, "success weakCompareAndSetAcquire double");
             double x = (double) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, 1.0d, "weakCompareAndSetAcquire double");
+            assertEquals(x, 1.0d, "success weakCompareAndSetAcquire double");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, 2.0d, 3.0d);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire double");
+            double x = (double) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, 1.0d, "failing weakCompareAndSetAcquire double value");
         }
 
         {
@@ -232,9 +246,16 @@ public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, 1.0d, 2.0d);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease double");
+            assertEquals(success, true, "success weakCompareAndSetRelease double");
             double x = (double) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, 2.0d, "weakCompareAndSetRelease double");
+            assertEquals(x, 2.0d, "success weakCompareAndSetRelease double");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, 1.0d, 3.0d);
+            assertEquals(success, false, "failing weakCompareAndSetRelease double");
+            double x = (double) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, 2.0d, "failing weakCompareAndSetRelease double value");
         }
 
         {
@@ -242,9 +263,16 @@ public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, 2.0d, 1.0d);
             }
-            assertEquals(success, true, "weakCompareAndSet double");
+            assertEquals(success, true, "success weakCompareAndSet double");
             double x = (double) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, 1.0d, "weakCompareAndSet double");
+            assertEquals(x, 1.0d, "success weakCompareAndSet double");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, 2.0d, 3.0d);
+            assertEquals(success, false, "failing weakCompareAndSet double");
+            double x = (double) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, 1.0d, "failing weakCompareAndSet double value");
         }
 
         // Compare set and get
@@ -390,9 +418,16 @@ public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(1.0d, 2.0d);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain double");
+            assertEquals(success, true, "success weakCompareAndSetPlain double");
             double x = (double) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, 2.0d, "weakCompareAndSetPlain double value");
+            assertEquals(x, 2.0d, "success weakCompareAndSetPlain double value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(1.0d, 3.0d);
+            assertEquals(success, false, "failing weakCompareAndSetPlain double");
+            double x = (double) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, 2.0d, "failing weakCompareAndSetPlain double value");
         }
 
         {
@@ -400,9 +435,16 @@ public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(2.0d, 1.0d);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire double");
+            assertEquals(success, true, "success weakCompareAndSetAcquire double");
             double x = (double) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, 1.0d, "weakCompareAndSetAcquire double");
+            assertEquals(x, 1.0d, "success weakCompareAndSetAcquire double");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(2.0d, 3.0d);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire double");
+            double x = (double) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, 1.0d, "failing weakCompareAndSetAcquire double value");
         }
 
         {
@@ -410,9 +452,16 @@ public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(1.0d, 2.0d);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease double");
+            assertEquals(success, true, "success weakCompareAndSetRelease double");
             double x = (double) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, 2.0d, "weakCompareAndSetRelease double");
+            assertEquals(x, 2.0d, "success weakCompareAndSetRelease double");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(1.0d, 3.0d);
+            assertEquals(success, false, "failing weakCompareAndSetRelease double");
+            double x = (double) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, 2.0d, "failing weakCompareAndSetRelease double value");
         }
 
         {
@@ -420,9 +469,16 @@ public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(2.0d, 1.0d);
             }
-            assertEquals(success, true, "weakCompareAndSet double");
+            assertEquals(success, true, "success weakCompareAndSet double");
             double x = (double) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, 1.0d, "weakCompareAndSet double");
+            assertEquals(x, 1.0d, "success weakCompareAndSet double");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(2.0d, 3.0d);
+            assertEquals(success, false, "failing weakCompareAndSet double");
+            double x = (double) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, 1.0d, "failing weakCompareAndSetRe double value");
         }
 
         // Compare set and get
@@ -593,9 +649,16 @@ public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, 1.0d, 2.0d);
                 }
-                assertEquals(success, true, "weakCompareAndSetPlain double");
+                assertEquals(success, true, "success weakCompareAndSetPlain double");
                 double x = (double) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, 2.0d, "weakCompareAndSetPlain double value");
+                assertEquals(x, 2.0d, "success weakCompareAndSetPlain double value");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, 1.0d, 3.0d);
+                assertEquals(success, false, "failing weakCompareAndSetPlain double");
+                double x = (double) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, 2.0d, "failing weakCompareAndSetPlain double value");
             }
 
             {
@@ -603,9 +666,16 @@ public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, 2.0d, 1.0d);
                 }
-                assertEquals(success, true, "weakCompareAndSetAcquire double");
+                assertEquals(success, true, "success weakCompareAndSetAcquire double");
                 double x = (double) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, 1.0d, "weakCompareAndSetAcquire double");
+                assertEquals(x, 1.0d, "success weakCompareAndSetAcquire double");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, 2.0d, 3.0d);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire double");
+                double x = (double) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, 1.0d, "failing weakCompareAndSetAcquire double value");
             }
 
             {
@@ -613,9 +683,16 @@ public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, 1.0d, 2.0d);
                 }
-                assertEquals(success, true, "weakCompareAndSetRelease double");
+                assertEquals(success, true, "success weakCompareAndSetRelease double");
                 double x = (double) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, 2.0d, "weakCompareAndSetRelease double");
+                assertEquals(x, 2.0d, "success weakCompareAndSetRelease double");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, 1.0d, 3.0d);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire double");
+                double x = (double) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, 2.0d, "failing weakCompareAndSetAcquire double value");
             }
 
             {
@@ -623,9 +700,16 @@ public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, 2.0d, 1.0d);
                 }
-                assertEquals(success, true, "weakCompareAndSet double");
+                assertEquals(success, true, "success weakCompareAndSet double");
                 double x = (double) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, 1.0d, "weakCompareAndSet double");
+                assertEquals(x, 1.0d, "success weakCompareAndSet double");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, 2.0d, 3.0d);
+                assertEquals(success, false, "failing weakCompareAndSet double");
+                double x = (double) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, 1.0d, "failing weakCompareAndSet double value");
             }
 
             // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,9 +212,16 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, 1.0f, 2.0f);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain float");
+            assertEquals(success, true, "success weakCompareAndSetPlain float");
             float x = (float) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, 2.0f, "weakCompareAndSetPlain float value");
+            assertEquals(x, 2.0f, "success weakCompareAndSetPlain float value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, 1.0f, 3.0f);
+            assertEquals(success, false, "failing weakCompareAndSetPlain float");
+            float x = (float) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, 2.0f, "failing weakCompareAndSetPlain float value");
         }
 
         {
@@ -222,9 +229,16 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, 2.0f, 1.0f);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire float");
+            assertEquals(success, true, "success weakCompareAndSetAcquire float");
             float x = (float) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, 1.0f, "weakCompareAndSetAcquire float");
+            assertEquals(x, 1.0f, "success weakCompareAndSetAcquire float");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, 2.0f, 3.0f);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire float");
+            float x = (float) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, 1.0f, "failing weakCompareAndSetAcquire float value");
         }
 
         {
@@ -232,9 +246,16 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, 1.0f, 2.0f);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease float");
+            assertEquals(success, true, "success weakCompareAndSetRelease float");
             float x = (float) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, 2.0f, "weakCompareAndSetRelease float");
+            assertEquals(x, 2.0f, "success weakCompareAndSetRelease float");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, 1.0f, 3.0f);
+            assertEquals(success, false, "failing weakCompareAndSetRelease float");
+            float x = (float) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, 2.0f, "failing weakCompareAndSetRelease float value");
         }
 
         {
@@ -242,9 +263,16 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, 2.0f, 1.0f);
             }
-            assertEquals(success, true, "weakCompareAndSet float");
+            assertEquals(success, true, "success weakCompareAndSet float");
             float x = (float) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, 1.0f, "weakCompareAndSet float");
+            assertEquals(x, 1.0f, "success weakCompareAndSet float");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, 2.0f, 3.0f);
+            assertEquals(success, false, "failing weakCompareAndSet float");
+            float x = (float) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, 1.0f, "failing weakCompareAndSet float value");
         }
 
         // Compare set and get
@@ -390,9 +418,16 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(1.0f, 2.0f);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain float");
+            assertEquals(success, true, "success weakCompareAndSetPlain float");
             float x = (float) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, 2.0f, "weakCompareAndSetPlain float value");
+            assertEquals(x, 2.0f, "success weakCompareAndSetPlain float value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(1.0f, 3.0f);
+            assertEquals(success, false, "failing weakCompareAndSetPlain float");
+            float x = (float) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, 2.0f, "failing weakCompareAndSetPlain float value");
         }
 
         {
@@ -400,9 +435,16 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(2.0f, 1.0f);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire float");
+            assertEquals(success, true, "success weakCompareAndSetAcquire float");
             float x = (float) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, 1.0f, "weakCompareAndSetAcquire float");
+            assertEquals(x, 1.0f, "success weakCompareAndSetAcquire float");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(2.0f, 3.0f);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire float");
+            float x = (float) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, 1.0f, "failing weakCompareAndSetAcquire float value");
         }
 
         {
@@ -410,9 +452,16 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(1.0f, 2.0f);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease float");
+            assertEquals(success, true, "success weakCompareAndSetRelease float");
             float x = (float) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, 2.0f, "weakCompareAndSetRelease float");
+            assertEquals(x, 2.0f, "success weakCompareAndSetRelease float");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(1.0f, 3.0f);
+            assertEquals(success, false, "failing weakCompareAndSetRelease float");
+            float x = (float) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, 2.0f, "failing weakCompareAndSetRelease float value");
         }
 
         {
@@ -420,9 +469,16 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(2.0f, 1.0f);
             }
-            assertEquals(success, true, "weakCompareAndSet float");
+            assertEquals(success, true, "success weakCompareAndSet float");
             float x = (float) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, 1.0f, "weakCompareAndSet float");
+            assertEquals(x, 1.0f, "success weakCompareAndSet float");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(2.0f, 3.0f);
+            assertEquals(success, false, "failing weakCompareAndSet float");
+            float x = (float) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, 1.0f, "failing weakCompareAndSetRe float value");
         }
 
         // Compare set and get
@@ -593,9 +649,16 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, 1.0f, 2.0f);
                 }
-                assertEquals(success, true, "weakCompareAndSetPlain float");
+                assertEquals(success, true, "success weakCompareAndSetPlain float");
                 float x = (float) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, 2.0f, "weakCompareAndSetPlain float value");
+                assertEquals(x, 2.0f, "success weakCompareAndSetPlain float value");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, 1.0f, 3.0f);
+                assertEquals(success, false, "failing weakCompareAndSetPlain float");
+                float x = (float) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, 2.0f, "failing weakCompareAndSetPlain float value");
             }
 
             {
@@ -603,9 +666,16 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, 2.0f, 1.0f);
                 }
-                assertEquals(success, true, "weakCompareAndSetAcquire float");
+                assertEquals(success, true, "success weakCompareAndSetAcquire float");
                 float x = (float) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, 1.0f, "weakCompareAndSetAcquire float");
+                assertEquals(x, 1.0f, "success weakCompareAndSetAcquire float");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, 2.0f, 3.0f);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire float");
+                float x = (float) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, 1.0f, "failing weakCompareAndSetAcquire float value");
             }
 
             {
@@ -613,9 +683,16 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, 1.0f, 2.0f);
                 }
-                assertEquals(success, true, "weakCompareAndSetRelease float");
+                assertEquals(success, true, "success weakCompareAndSetRelease float");
                 float x = (float) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, 2.0f, "weakCompareAndSetRelease float");
+                assertEquals(x, 2.0f, "success weakCompareAndSetRelease float");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, 1.0f, 3.0f);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire float");
+                float x = (float) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, 2.0f, "failing weakCompareAndSetAcquire float value");
             }
 
             {
@@ -623,9 +700,16 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, 2.0f, 1.0f);
                 }
-                assertEquals(success, true, "weakCompareAndSet float");
+                assertEquals(success, true, "success weakCompareAndSet float");
                 float x = (float) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, 1.0f, "weakCompareAndSet float");
+                assertEquals(x, 1.0f, "success weakCompareAndSet float");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, 2.0f, 3.0f);
+                assertEquals(success, false, "failing weakCompareAndSet float");
+                float x = (float) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, 1.0f, "failing weakCompareAndSet float value");
             }
 
             // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,9 +212,16 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, 0x01234567, 0x89ABCDEF);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain int");
+            assertEquals(success, true, "success weakCompareAndSetPlain int");
             int x = (int) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, 0x89ABCDEF, "weakCompareAndSetPlain int value");
+            assertEquals(x, 0x89ABCDEF, "success weakCompareAndSetPlain int value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, 0x01234567, 0xCAFEBABE);
+            assertEquals(success, false, "failing weakCompareAndSetPlain int");
+            int x = (int) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, 0x89ABCDEF, "failing weakCompareAndSetPlain int value");
         }
 
         {
@@ -222,9 +229,16 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, 0x89ABCDEF, 0x01234567);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire int");
+            assertEquals(success, true, "success weakCompareAndSetAcquire int");
             int x = (int) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, 0x01234567, "weakCompareAndSetAcquire int");
+            assertEquals(x, 0x01234567, "success weakCompareAndSetAcquire int");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, 0x89ABCDEF, 0xCAFEBABE);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire int");
+            int x = (int) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, 0x01234567, "failing weakCompareAndSetAcquire int value");
         }
 
         {
@@ -232,9 +246,16 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, 0x01234567, 0x89ABCDEF);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease int");
+            assertEquals(success, true, "success weakCompareAndSetRelease int");
             int x = (int) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, 0x89ABCDEF, "weakCompareAndSetRelease int");
+            assertEquals(x, 0x89ABCDEF, "success weakCompareAndSetRelease int");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, 0x01234567, 0xCAFEBABE);
+            assertEquals(success, false, "failing weakCompareAndSetRelease int");
+            int x = (int) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, 0x89ABCDEF, "failing weakCompareAndSetRelease int value");
         }
 
         {
@@ -242,9 +263,16 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, 0x89ABCDEF, 0x01234567);
             }
-            assertEquals(success, true, "weakCompareAndSet int");
+            assertEquals(success, true, "success weakCompareAndSet int");
             int x = (int) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, 0x01234567, "weakCompareAndSet int");
+            assertEquals(x, 0x01234567, "success weakCompareAndSet int");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, 0x89ABCDEF, 0xCAFEBABE);
+            assertEquals(success, false, "failing weakCompareAndSet int");
+            int x = (int) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, 0x01234567, "failing weakCompareAndSet int value");
         }
 
         // Compare set and get
@@ -468,9 +496,16 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(0x01234567, 0x89ABCDEF);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain int");
+            assertEquals(success, true, "success weakCompareAndSetPlain int");
             int x = (int) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, 0x89ABCDEF, "weakCompareAndSetPlain int value");
+            assertEquals(x, 0x89ABCDEF, "success weakCompareAndSetPlain int value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(0x01234567, 0xCAFEBABE);
+            assertEquals(success, false, "failing weakCompareAndSetPlain int");
+            int x = (int) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, 0x89ABCDEF, "failing weakCompareAndSetPlain int value");
         }
 
         {
@@ -478,9 +513,16 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(0x89ABCDEF, 0x01234567);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire int");
+            assertEquals(success, true, "success weakCompareAndSetAcquire int");
             int x = (int) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, 0x01234567, "weakCompareAndSetAcquire int");
+            assertEquals(x, 0x01234567, "success weakCompareAndSetAcquire int");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(0x89ABCDEF, 0xCAFEBABE);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire int");
+            int x = (int) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, 0x01234567, "failing weakCompareAndSetAcquire int value");
         }
 
         {
@@ -488,9 +530,16 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(0x01234567, 0x89ABCDEF);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease int");
+            assertEquals(success, true, "success weakCompareAndSetRelease int");
             int x = (int) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, 0x89ABCDEF, "weakCompareAndSetRelease int");
+            assertEquals(x, 0x89ABCDEF, "success weakCompareAndSetRelease int");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(0x01234567, 0xCAFEBABE);
+            assertEquals(success, false, "failing weakCompareAndSetRelease int");
+            int x = (int) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, 0x89ABCDEF, "failing weakCompareAndSetRelease int value");
         }
 
         {
@@ -498,9 +547,16 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(0x89ABCDEF, 0x01234567);
             }
-            assertEquals(success, true, "weakCompareAndSet int");
+            assertEquals(success, true, "success weakCompareAndSet int");
             int x = (int) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, 0x01234567, "weakCompareAndSet int");
+            assertEquals(x, 0x01234567, "success weakCompareAndSet int");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(0x89ABCDEF, 0xCAFEBABE);
+            assertEquals(success, false, "failing weakCompareAndSet int");
+            int x = (int) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, 0x01234567, "failing weakCompareAndSetRe int value");
         }
 
         // Compare set and get
@@ -749,9 +805,16 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, 0x01234567, 0x89ABCDEF);
                 }
-                assertEquals(success, true, "weakCompareAndSetPlain int");
+                assertEquals(success, true, "success weakCompareAndSetPlain int");
                 int x = (int) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, 0x89ABCDEF, "weakCompareAndSetPlain int value");
+                assertEquals(x, 0x89ABCDEF, "success weakCompareAndSetPlain int value");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, 0x01234567, 0xCAFEBABE);
+                assertEquals(success, false, "failing weakCompareAndSetPlain int");
+                int x = (int) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, 0x89ABCDEF, "failing weakCompareAndSetPlain int value");
             }
 
             {
@@ -759,9 +822,16 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, 0x89ABCDEF, 0x01234567);
                 }
-                assertEquals(success, true, "weakCompareAndSetAcquire int");
+                assertEquals(success, true, "success weakCompareAndSetAcquire int");
                 int x = (int) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, 0x01234567, "weakCompareAndSetAcquire int");
+                assertEquals(x, 0x01234567, "success weakCompareAndSetAcquire int");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, 0x89ABCDEF, 0xCAFEBABE);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire int");
+                int x = (int) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, 0x01234567, "failing weakCompareAndSetAcquire int value");
             }
 
             {
@@ -769,9 +839,16 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, 0x01234567, 0x89ABCDEF);
                 }
-                assertEquals(success, true, "weakCompareAndSetRelease int");
+                assertEquals(success, true, "success weakCompareAndSetRelease int");
                 int x = (int) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, 0x89ABCDEF, "weakCompareAndSetRelease int");
+                assertEquals(x, 0x89ABCDEF, "success weakCompareAndSetRelease int");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, 0x01234567, 0xCAFEBABE);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire int");
+                int x = (int) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, 0x89ABCDEF, "failing weakCompareAndSetAcquire int value");
             }
 
             {
@@ -779,9 +856,16 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, 0x89ABCDEF, 0x01234567);
                 }
-                assertEquals(success, true, "weakCompareAndSet int");
+                assertEquals(success, true, "success weakCompareAndSet int");
                 int x = (int) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, 0x01234567, "weakCompareAndSet int");
+                assertEquals(x, 0x01234567, "success weakCompareAndSet int");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, 0x89ABCDEF, 0xCAFEBABE);
+                assertEquals(success, false, "failing weakCompareAndSet int");
+                int x = (int) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, 0x01234567, "failing weakCompareAndSet int value");
             }
 
             // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,9 +212,16 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, 0x0123456789ABCDEFL, 0xCAFEBABECAFEBABEL);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain long");
+            assertEquals(success, true, "success weakCompareAndSetPlain long");
             long x = (long) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, 0xCAFEBABECAFEBABEL, "weakCompareAndSetPlain long value");
+            assertEquals(x, 0xCAFEBABECAFEBABEL, "success weakCompareAndSetPlain long value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, 0x0123456789ABCDEFL, 0xDEADBEEFDEADBEEFL);
+            assertEquals(success, false, "failing weakCompareAndSetPlain long");
+            long x = (long) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, 0xCAFEBABECAFEBABEL, "failing weakCompareAndSetPlain long value");
         }
 
         {
@@ -222,9 +229,16 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, 0xCAFEBABECAFEBABEL, 0x0123456789ABCDEFL);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire long");
+            assertEquals(success, true, "success weakCompareAndSetAcquire long");
             long x = (long) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, 0x0123456789ABCDEFL, "weakCompareAndSetAcquire long");
+            assertEquals(x, 0x0123456789ABCDEFL, "success weakCompareAndSetAcquire long");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, 0xCAFEBABECAFEBABEL, 0xDEADBEEFDEADBEEFL);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire long");
+            long x = (long) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, 0x0123456789ABCDEFL, "failing weakCompareAndSetAcquire long value");
         }
 
         {
@@ -232,9 +246,16 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, 0x0123456789ABCDEFL, 0xCAFEBABECAFEBABEL);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease long");
+            assertEquals(success, true, "success weakCompareAndSetRelease long");
             long x = (long) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, 0xCAFEBABECAFEBABEL, "weakCompareAndSetRelease long");
+            assertEquals(x, 0xCAFEBABECAFEBABEL, "success weakCompareAndSetRelease long");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, 0x0123456789ABCDEFL, 0xDEADBEEFDEADBEEFL);
+            assertEquals(success, false, "failing weakCompareAndSetRelease long");
+            long x = (long) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, 0xCAFEBABECAFEBABEL, "failing weakCompareAndSetRelease long value");
         }
 
         {
@@ -242,9 +263,16 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, 0xCAFEBABECAFEBABEL, 0x0123456789ABCDEFL);
             }
-            assertEquals(success, true, "weakCompareAndSet long");
+            assertEquals(success, true, "success weakCompareAndSet long");
             long x = (long) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, 0x0123456789ABCDEFL, "weakCompareAndSet long");
+            assertEquals(x, 0x0123456789ABCDEFL, "success weakCompareAndSet long");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, 0xCAFEBABECAFEBABEL, 0xDEADBEEFDEADBEEFL);
+            assertEquals(success, false, "failing weakCompareAndSet long");
+            long x = (long) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, 0x0123456789ABCDEFL, "failing weakCompareAndSet long value");
         }
 
         // Compare set and get
@@ -468,9 +496,16 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(0x0123456789ABCDEFL, 0xCAFEBABECAFEBABEL);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain long");
+            assertEquals(success, true, "success weakCompareAndSetPlain long");
             long x = (long) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, 0xCAFEBABECAFEBABEL, "weakCompareAndSetPlain long value");
+            assertEquals(x, 0xCAFEBABECAFEBABEL, "success weakCompareAndSetPlain long value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(0x0123456789ABCDEFL, 0xDEADBEEFDEADBEEFL);
+            assertEquals(success, false, "failing weakCompareAndSetPlain long");
+            long x = (long) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, 0xCAFEBABECAFEBABEL, "failing weakCompareAndSetPlain long value");
         }
 
         {
@@ -478,9 +513,16 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(0xCAFEBABECAFEBABEL, 0x0123456789ABCDEFL);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire long");
+            assertEquals(success, true, "success weakCompareAndSetAcquire long");
             long x = (long) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, 0x0123456789ABCDEFL, "weakCompareAndSetAcquire long");
+            assertEquals(x, 0x0123456789ABCDEFL, "success weakCompareAndSetAcquire long");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(0xCAFEBABECAFEBABEL, 0xDEADBEEFDEADBEEFL);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire long");
+            long x = (long) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, 0x0123456789ABCDEFL, "failing weakCompareAndSetAcquire long value");
         }
 
         {
@@ -488,9 +530,16 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(0x0123456789ABCDEFL, 0xCAFEBABECAFEBABEL);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease long");
+            assertEquals(success, true, "success weakCompareAndSetRelease long");
             long x = (long) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, 0xCAFEBABECAFEBABEL, "weakCompareAndSetRelease long");
+            assertEquals(x, 0xCAFEBABECAFEBABEL, "success weakCompareAndSetRelease long");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(0x0123456789ABCDEFL, 0xDEADBEEFDEADBEEFL);
+            assertEquals(success, false, "failing weakCompareAndSetRelease long");
+            long x = (long) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, 0xCAFEBABECAFEBABEL, "failing weakCompareAndSetRelease long value");
         }
 
         {
@@ -498,9 +547,16 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(0xCAFEBABECAFEBABEL, 0x0123456789ABCDEFL);
             }
-            assertEquals(success, true, "weakCompareAndSet long");
+            assertEquals(success, true, "success weakCompareAndSet long");
             long x = (long) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, 0x0123456789ABCDEFL, "weakCompareAndSet long");
+            assertEquals(x, 0x0123456789ABCDEFL, "success weakCompareAndSet long");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(0xCAFEBABECAFEBABEL, 0xDEADBEEFDEADBEEFL);
+            assertEquals(success, false, "failing weakCompareAndSet long");
+            long x = (long) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, 0x0123456789ABCDEFL, "failing weakCompareAndSetRe long value");
         }
 
         // Compare set and get
@@ -749,9 +805,16 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, 0x0123456789ABCDEFL, 0xCAFEBABECAFEBABEL);
                 }
-                assertEquals(success, true, "weakCompareAndSetPlain long");
+                assertEquals(success, true, "success weakCompareAndSetPlain long");
                 long x = (long) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, 0xCAFEBABECAFEBABEL, "weakCompareAndSetPlain long value");
+                assertEquals(x, 0xCAFEBABECAFEBABEL, "success weakCompareAndSetPlain long value");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, 0x0123456789ABCDEFL, 0xDEADBEEFDEADBEEFL);
+                assertEquals(success, false, "failing weakCompareAndSetPlain long");
+                long x = (long) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, 0xCAFEBABECAFEBABEL, "failing weakCompareAndSetPlain long value");
             }
 
             {
@@ -759,9 +822,16 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, 0xCAFEBABECAFEBABEL, 0x0123456789ABCDEFL);
                 }
-                assertEquals(success, true, "weakCompareAndSetAcquire long");
+                assertEquals(success, true, "success weakCompareAndSetAcquire long");
                 long x = (long) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, 0x0123456789ABCDEFL, "weakCompareAndSetAcquire long");
+                assertEquals(x, 0x0123456789ABCDEFL, "success weakCompareAndSetAcquire long");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, 0xCAFEBABECAFEBABEL, 0xDEADBEEFDEADBEEFL);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire long");
+                long x = (long) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, 0x0123456789ABCDEFL, "failing weakCompareAndSetAcquire long value");
             }
 
             {
@@ -769,9 +839,16 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, 0x0123456789ABCDEFL, 0xCAFEBABECAFEBABEL);
                 }
-                assertEquals(success, true, "weakCompareAndSetRelease long");
+                assertEquals(success, true, "success weakCompareAndSetRelease long");
                 long x = (long) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, 0xCAFEBABECAFEBABEL, "weakCompareAndSetRelease long");
+                assertEquals(x, 0xCAFEBABECAFEBABEL, "success weakCompareAndSetRelease long");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, 0x0123456789ABCDEFL, 0xDEADBEEFDEADBEEFL);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire long");
+                long x = (long) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, 0xCAFEBABECAFEBABEL, "failing weakCompareAndSetAcquire long value");
             }
 
             {
@@ -779,9 +856,16 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, 0xCAFEBABECAFEBABEL, 0x0123456789ABCDEFL);
                 }
-                assertEquals(success, true, "weakCompareAndSet long");
+                assertEquals(success, true, "success weakCompareAndSet long");
                 long x = (long) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, 0x0123456789ABCDEFL, "weakCompareAndSet long");
+                assertEquals(x, 0x0123456789ABCDEFL, "success weakCompareAndSet long");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, 0xCAFEBABECAFEBABEL, 0xDEADBEEFDEADBEEFL);
+                assertEquals(success, false, "failing weakCompareAndSet long");
+                long x = (long) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, 0x0123456789ABCDEFL, "failing weakCompareAndSet long value");
             }
 
             // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,9 +212,16 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, (short)0x0123, (short)0x4567);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain short");
+            assertEquals(success, true, "success weakCompareAndSetPlain short");
             short x = (short) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, (short)0x4567, "weakCompareAndSetPlain short value");
+            assertEquals(x, (short)0x4567, "success weakCompareAndSetPlain short value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, (short)0x0123, (short)0x89AB);
+            assertEquals(success, false, "failing weakCompareAndSetPlain short");
+            short x = (short) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, (short)0x4567, "failing weakCompareAndSetPlain short value");
         }
 
         {
@@ -222,9 +229,16 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, (short)0x4567, (short)0x0123);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire short");
+            assertEquals(success, true, "success weakCompareAndSetAcquire short");
             short x = (short) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, (short)0x0123, "weakCompareAndSetAcquire short");
+            assertEquals(x, (short)0x0123, "success weakCompareAndSetAcquire short");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, (short)0x4567, (short)0x89AB);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire short");
+            short x = (short) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, (short)0x0123, "failing weakCompareAndSetAcquire short value");
         }
 
         {
@@ -232,9 +246,16 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, (short)0x0123, (short)0x4567);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease short");
+            assertEquals(success, true, "success weakCompareAndSetRelease short");
             short x = (short) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, (short)0x4567, "weakCompareAndSetRelease short");
+            assertEquals(x, (short)0x4567, "success weakCompareAndSetRelease short");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, (short)0x0123, (short)0x89AB);
+            assertEquals(success, false, "failing weakCompareAndSetRelease short");
+            short x = (short) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, (short)0x4567, "failing weakCompareAndSetRelease short value");
         }
 
         {
@@ -242,9 +263,16 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, (short)0x4567, (short)0x0123);
             }
-            assertEquals(success, true, "weakCompareAndSet short");
+            assertEquals(success, true, "success weakCompareAndSet short");
             short x = (short) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, (short)0x0123, "weakCompareAndSet short");
+            assertEquals(x, (short)0x0123, "success weakCompareAndSet short");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, (short)0x4567, (short)0x89AB);
+            assertEquals(success, false, "failing weakCompareAndSet short");
+            short x = (short) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, (short)0x0123, "failing weakCompareAndSet short value");
         }
 
         // Compare set and get
@@ -468,9 +496,16 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact((short)0x0123, (short)0x4567);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain short");
+            assertEquals(success, true, "success weakCompareAndSetPlain short");
             short x = (short) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, (short)0x4567, "weakCompareAndSetPlain short value");
+            assertEquals(x, (short)0x4567, "success weakCompareAndSetPlain short value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact((short)0x0123, (short)0x89AB);
+            assertEquals(success, false, "failing weakCompareAndSetPlain short");
+            short x = (short) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, (short)0x4567, "failing weakCompareAndSetPlain short value");
         }
 
         {
@@ -478,9 +513,16 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact((short)0x4567, (short)0x0123);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire short");
+            assertEquals(success, true, "success weakCompareAndSetAcquire short");
             short x = (short) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, (short)0x0123, "weakCompareAndSetAcquire short");
+            assertEquals(x, (short)0x0123, "success weakCompareAndSetAcquire short");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact((short)0x4567, (short)0x89AB);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire short");
+            short x = (short) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, (short)0x0123, "failing weakCompareAndSetAcquire short value");
         }
 
         {
@@ -488,9 +530,16 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact((short)0x0123, (short)0x4567);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease short");
+            assertEquals(success, true, "success weakCompareAndSetRelease short");
             short x = (short) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, (short)0x4567, "weakCompareAndSetRelease short");
+            assertEquals(x, (short)0x4567, "success weakCompareAndSetRelease short");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact((short)0x0123, (short)0x89AB);
+            assertEquals(success, false, "failing weakCompareAndSetRelease short");
+            short x = (short) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, (short)0x4567, "failing weakCompareAndSetRelease short value");
         }
 
         {
@@ -498,9 +547,16 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact((short)0x4567, (short)0x0123);
             }
-            assertEquals(success, true, "weakCompareAndSet short");
+            assertEquals(success, true, "success weakCompareAndSet short");
             short x = (short) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, (short)0x0123, "weakCompareAndSet short");
+            assertEquals(x, (short)0x0123, "success weakCompareAndSet short");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact((short)0x4567, (short)0x89AB);
+            assertEquals(success, false, "failing weakCompareAndSet short");
+            short x = (short) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, (short)0x0123, "failing weakCompareAndSetRe short value");
         }
 
         // Compare set and get
@@ -749,9 +805,16 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, (short)0x0123, (short)0x4567);
                 }
-                assertEquals(success, true, "weakCompareAndSetPlain short");
+                assertEquals(success, true, "success weakCompareAndSetPlain short");
                 short x = (short) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, (short)0x4567, "weakCompareAndSetPlain short value");
+                assertEquals(x, (short)0x4567, "success weakCompareAndSetPlain short value");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, (short)0x0123, (short)0x89AB);
+                assertEquals(success, false, "failing weakCompareAndSetPlain short");
+                short x = (short) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, (short)0x4567, "failing weakCompareAndSetPlain short value");
             }
 
             {
@@ -759,9 +822,16 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, (short)0x4567, (short)0x0123);
                 }
-                assertEquals(success, true, "weakCompareAndSetAcquire short");
+                assertEquals(success, true, "success weakCompareAndSetAcquire short");
                 short x = (short) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, (short)0x0123, "weakCompareAndSetAcquire short");
+                assertEquals(x, (short)0x0123, "success weakCompareAndSetAcquire short");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, (short)0x4567, (short)0x89AB);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire short");
+                short x = (short) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, (short)0x0123, "failing weakCompareAndSetAcquire short value");
             }
 
             {
@@ -769,9 +839,16 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, (short)0x0123, (short)0x4567);
                 }
-                assertEquals(success, true, "weakCompareAndSetRelease short");
+                assertEquals(success, true, "success weakCompareAndSetRelease short");
                 short x = (short) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, (short)0x4567, "weakCompareAndSetRelease short");
+                assertEquals(x, (short)0x4567, "success weakCompareAndSetRelease short");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, (short)0x0123, (short)0x89AB);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire short");
+                short x = (short) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, (short)0x4567, "failing weakCompareAndSetAcquire short value");
             }
 
             {
@@ -779,9 +856,16 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, (short)0x4567, (short)0x0123);
                 }
-                assertEquals(success, true, "weakCompareAndSet short");
+                assertEquals(success, true, "success weakCompareAndSet short");
                 short x = (short) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, (short)0x0123, "weakCompareAndSet short");
+                assertEquals(x, (short)0x0123, "success weakCompareAndSet short");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, (short)0x4567, (short)0x89AB);
+                assertEquals(success, false, "failing weakCompareAndSet short");
+                short x = (short) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, (short)0x0123, "failing weakCompareAndSet short value");
             }
 
             // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,9 +212,16 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, "foo", "bar");
             }
-            assertEquals(success, true, "weakCompareAndSetPlain String");
+            assertEquals(success, true, "success weakCompareAndSetPlain String");
             String x = (String) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, "bar", "weakCompareAndSetPlain String value");
+            assertEquals(x, "bar", "success weakCompareAndSetPlain String value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, "foo", "baz");
+            assertEquals(success, false, "failing weakCompareAndSetPlain String");
+            String x = (String) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, "bar", "failing weakCompareAndSetPlain String value");
         }
 
         {
@@ -222,9 +229,16 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, "bar", "foo");
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire String");
+            assertEquals(success, true, "success weakCompareAndSetAcquire String");
             String x = (String) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, "foo", "weakCompareAndSetAcquire String");
+            assertEquals(x, "foo", "success weakCompareAndSetAcquire String");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, "bar", "baz");
+            assertEquals(success, false, "failing weakCompareAndSetAcquire String");
+            String x = (String) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, "foo", "failing weakCompareAndSetAcquire String value");
         }
 
         {
@@ -232,9 +246,16 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, "foo", "bar");
             }
-            assertEquals(success, true, "weakCompareAndSetRelease String");
+            assertEquals(success, true, "success weakCompareAndSetRelease String");
             String x = (String) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, "bar", "weakCompareAndSetRelease String");
+            assertEquals(x, "bar", "success weakCompareAndSetRelease String");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, "foo", "baz");
+            assertEquals(success, false, "failing weakCompareAndSetRelease String");
+            String x = (String) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, "bar", "failing weakCompareAndSetRelease String value");
         }
 
         {
@@ -242,9 +263,16 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, "bar", "foo");
             }
-            assertEquals(success, true, "weakCompareAndSet String");
+            assertEquals(success, true, "success weakCompareAndSet String");
             String x = (String) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, "foo", "weakCompareAndSet String");
+            assertEquals(x, "foo", "success weakCompareAndSet String");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, "bar", "baz");
+            assertEquals(success, false, "failing weakCompareAndSet String");
+            String x = (String) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, "foo", "failing weakCompareAndSet String value");
         }
 
         // Compare set and get
@@ -368,9 +396,16 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact("foo", "bar");
             }
-            assertEquals(success, true, "weakCompareAndSetPlain String");
+            assertEquals(success, true, "success weakCompareAndSetPlain String");
             String x = (String) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, "bar", "weakCompareAndSetPlain String value");
+            assertEquals(x, "bar", "success weakCompareAndSetPlain String value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact("foo", "baz");
+            assertEquals(success, false, "failing weakCompareAndSetPlain String");
+            String x = (String) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, "bar", "failing weakCompareAndSetPlain String value");
         }
 
         {
@@ -378,9 +413,16 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact("bar", "foo");
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire String");
+            assertEquals(success, true, "success weakCompareAndSetAcquire String");
             String x = (String) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, "foo", "weakCompareAndSetAcquire String");
+            assertEquals(x, "foo", "success weakCompareAndSetAcquire String");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact("bar", "baz");
+            assertEquals(success, false, "failing weakCompareAndSetAcquire String");
+            String x = (String) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, "foo", "failing weakCompareAndSetAcquire String value");
         }
 
         {
@@ -388,9 +430,16 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact("foo", "bar");
             }
-            assertEquals(success, true, "weakCompareAndSetRelease String");
+            assertEquals(success, true, "success weakCompareAndSetRelease String");
             String x = (String) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, "bar", "weakCompareAndSetRelease String");
+            assertEquals(x, "bar", "success weakCompareAndSetRelease String");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact("foo", "baz");
+            assertEquals(success, false, "failing weakCompareAndSetRelease String");
+            String x = (String) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, "bar", "failing weakCompareAndSetRelease String value");
         }
 
         {
@@ -398,9 +447,16 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact("bar", "foo");
             }
-            assertEquals(success, true, "weakCompareAndSet String");
+            assertEquals(success, true, "success weakCompareAndSet String");
             String x = (String) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, "foo", "weakCompareAndSet String");
+            assertEquals(x, "foo", "success weakCompareAndSet String");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact("bar", "baz");
+            assertEquals(success, false, "failing weakCompareAndSet String");
+            String x = (String) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, "foo", "failing weakCompareAndSetRe String value");
         }
 
         // Compare set and get
@@ -549,9 +605,16 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, "foo", "bar");
                 }
-                assertEquals(success, true, "weakCompareAndSetPlain String");
+                assertEquals(success, true, "success weakCompareAndSetPlain String");
                 String x = (String) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, "bar", "weakCompareAndSetPlain String value");
+                assertEquals(x, "bar", "success weakCompareAndSetPlain String value");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, "foo", "baz");
+                assertEquals(success, false, "failing weakCompareAndSetPlain String");
+                String x = (String) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, "bar", "failing weakCompareAndSetPlain String value");
             }
 
             {
@@ -559,9 +622,16 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, "bar", "foo");
                 }
-                assertEquals(success, true, "weakCompareAndSetAcquire String");
+                assertEquals(success, true, "success weakCompareAndSetAcquire String");
                 String x = (String) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, "foo", "weakCompareAndSetAcquire String");
+                assertEquals(x, "foo", "success weakCompareAndSetAcquire String");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, "bar", "baz");
+                assertEquals(success, false, "failing weakCompareAndSetAcquire String");
+                String x = (String) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, "foo", "failing weakCompareAndSetAcquire String value");
             }
 
             {
@@ -569,9 +639,16 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, "foo", "bar");
                 }
-                assertEquals(success, true, "weakCompareAndSetRelease String");
+                assertEquals(success, true, "success weakCompareAndSetRelease String");
                 String x = (String) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, "bar", "weakCompareAndSetRelease String");
+                assertEquals(x, "bar", "success weakCompareAndSetRelease String");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, "foo", "baz");
+                assertEquals(success, false, "failing weakCompareAndSetAcquire String");
+                String x = (String) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, "bar", "failing weakCompareAndSetAcquire String value");
             }
 
             {
@@ -579,9 +656,16 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, "bar", "foo");
                 }
-                assertEquals(success, true, "weakCompareAndSet String");
+                assertEquals(success, true, "success weakCompareAndSet String");
                 String x = (String) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, "foo", "weakCompareAndSet String");
+                assertEquals(x, "foo", "success weakCompareAndSet String");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, "bar", "baz");
+                assertEquals(success, false, "failing weakCompareAndSet String");
+                String x = (String) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, "foo", "failing weakCompareAndSet String value");
             }
 
             // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestAccess.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestAccess.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -726,9 +726,16 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetPlain(recv, $value1$, $value2$);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain $type$");
+            assertEquals(success, true, "success weakCompareAndSetPlain $type$");
             $type$ x = ($type$) vh.get(recv);
-            assertEquals(x, $value2$, "weakCompareAndSetPlain $type$ value");
+            assertEquals(x, $value2$, "success weakCompareAndSetPlain $type$ value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain(recv, $value1$, $value3$);
+            assertEquals(success, false, "failing weakCompareAndSetPlain $type$");
+            $type$ x = ($type$) vh.get(recv);
+            assertEquals(x, $value2$, "failing weakCompareAndSetPlain $type$ value");
         }
 
         {
@@ -736,9 +743,16 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetAcquire(recv, $value2$, $value1$);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire $type$");
+            assertEquals(success, true, "success weakCompareAndSetAcquire $type$");
             $type$ x = ($type$) vh.get(recv);
-            assertEquals(x, $value1$, "weakCompareAndSetAcquire $type$");
+            assertEquals(x, $value1$, "success weakCompareAndSetAcquire $type$");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire(recv, $value2$, $value3$);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire $type$");
+            $type$ x = ($type$) vh.get(recv);
+            assertEquals(x, $value1$, "failing weakCompareAndSetAcquire $type$ value");
         }
 
         {
@@ -746,9 +760,16 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetRelease(recv, $value1$, $value2$);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease $type$");
+            assertEquals(success, true, "success weakCompareAndSetRelease $type$");
             $type$ x = ($type$) vh.get(recv);
-            assertEquals(x, $value2$, "weakCompareAndSetRelease $type$");
+            assertEquals(x, $value2$, "success weakCompareAndSetRelease $type$");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease(recv, $value1$, $value3$);
+            assertEquals(success, false, "failing weakCompareAndSetRelease $type$");
+            $type$ x = ($type$) vh.get(recv);
+            assertEquals(x, $value2$, "failing weakCompareAndSetRelease $type$ value");
         }
 
         {
@@ -756,9 +777,16 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSet(recv, $value2$, $value1$);
             }
-            assertEquals(success, true, "weakCompareAndSet $type$");
+            assertEquals(success, true, "success weakCompareAndSet $type$");
             $type$ x = ($type$) vh.get(recv);
-            assertEquals(x, $value1$, "weakCompareAndSet $type$ value");
+            assertEquals(x, $value1$, "success weakCompareAndSet $type$ value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet(recv, $value2$, $value3$);
+            assertEquals(success, false, "failing weakCompareAndSet $type$");
+            $type$ x = ($type$) vh.get(recv);
+            assertEquals(x, $value1$, "failing weakCompareAndSet $type$ value");
         }
 
         // Compare set and get
@@ -1103,9 +1131,16 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetPlain($value1$, $value2$);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain $type$");
+            assertEquals(success, true, "success weakCompareAndSetPlain $type$");
             $type$ x = ($type$) vh.get();
-            assertEquals(x, $value2$, "weakCompareAndSetPlain $type$ value");
+            assertEquals(x, $value2$, "success weakCompareAndSetPlain $type$ value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain($value1$, $value3$);
+            assertEquals(success, false, "failing weakCompareAndSetPlain $type$");
+            $type$ x = ($type$) vh.get();
+            assertEquals(x, $value2$, "failing weakCompareAndSetPlain $type$ value");
         }
 
         {
@@ -1113,9 +1148,16 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetAcquire($value2$, $value1$);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire $type$");
+            assertEquals(success, true, "success weakCompareAndSetAcquire $type$");
             $type$ x = ($type$) vh.get();
-            assertEquals(x, $value1$, "weakCompareAndSetAcquire $type$");
+            assertEquals(x, $value1$, "success weakCompareAndSetAcquire $type$");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire($value2$, $value3$);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire $type$");
+            $type$ x = ($type$) vh.get();
+            assertEquals(x, $value1$, "failing weakCompareAndSetAcquire $type$ value");
         }
 
         {
@@ -1123,9 +1165,16 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSetRelease($value1$, $value2$);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease $type$");
+            assertEquals(success, true, "success weakCompareAndSetRelease $type$");
             $type$ x = ($type$) vh.get();
-            assertEquals(x, $value2$, "weakCompareAndSetRelease $type$");
+            assertEquals(x, $value2$, "success weakCompareAndSetRelease $type$");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease($value1$, $value3$);
+            assertEquals(success, false, "failing weakCompareAndSetRelease $type$");
+            $type$ x = ($type$) vh.get();
+            assertEquals(x, $value2$, "failing weakCompareAndSetRelease $type$ value");
         }
 
         {
@@ -1133,9 +1182,16 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = vh.weakCompareAndSet($value2$, $value1$);
             }
-            assertEquals(success, true, "weakCompareAndSet $type$");
+            assertEquals(success, true, "success weakCompareAndSet $type$");
             $type$ x = ($type$) vh.get();
-            assertEquals(x, $value1$, "weakCompareAndSet $type$");
+            assertEquals(x, $value1$, "success weakCompareAndSet $type$");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet($value2$, $value3$);
+            assertEquals(success, false, "failing weakCompareAndSet $type$");
+            $type$ x = ($type$) vh.get();
+            assertEquals(x, $value1$, "failing weakCompareAndSet $type$ value");
         }
 
         // Compare set and get
@@ -1483,9 +1539,16 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetPlain(array, i, $value1$, $value2$);
                 }
-                assertEquals(success, true, "weakCompareAndSetPlain $type$");
+                assertEquals(success, true, "success weakCompareAndSetPlain $type$");
                 $type$ x = ($type$) vh.get(array, i);
-                assertEquals(x, $value2$, "weakCompareAndSetPlain $type$ value");
+                assertEquals(x, $value2$, "success weakCompareAndSetPlain $type$ value");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetPlain(array, i, $value1$, $value3$);
+                assertEquals(success, false, "failing weakCompareAndSetPlain $type$");
+                $type$ x = ($type$) vh.get(array, i);
+                assertEquals(x, $value2$, "failing weakCompareAndSetPlain $type$ value");
             }
 
             {
@@ -1493,9 +1556,16 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetAcquire(array, i, $value2$, $value1$);
                 }
-                assertEquals(success, true, "weakCompareAndSetAcquire $type$");
+                assertEquals(success, true, "success weakCompareAndSetAcquire $type$");
                 $type$ x = ($type$) vh.get(array, i);
-                assertEquals(x, $value1$, "weakCompareAndSetAcquire $type$");
+                assertEquals(x, $value1$, "success weakCompareAndSetAcquire $type$");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetAcquire(array, i, $value2$, $value3$);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire $type$");
+                $type$ x = ($type$) vh.get(array, i);
+                assertEquals(x, $value1$, "failing weakCompareAndSetAcquire $type$ value");
             }
 
             {
@@ -1503,9 +1573,16 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSetRelease(array, i, $value1$, $value2$);
                 }
-                assertEquals(success, true, "weakCompareAndSetRelease $type$");
+                assertEquals(success, true, "success weakCompareAndSetRelease $type$");
                 $type$ x = ($type$) vh.get(array, i);
-                assertEquals(x, $value2$, "weakCompareAndSetRelease $type$");
+                assertEquals(x, $value2$, "success weakCompareAndSetRelease $type$");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetRelease(array, i, $value1$, $value3$);
+                assertEquals(success, false, "failing weakCompareAndSetRelease $type$");
+                $type$ x = ($type$) vh.get(array, i);
+                assertEquals(x, $value2$, "failing weakCompareAndSetRelease $type$ value");
             }
 
             {
@@ -1513,9 +1590,16 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = vh.weakCompareAndSet(array, i, $value2$, $value1$);
                 }
-                assertEquals(success, true, "weakCompareAndSet $type$");
+                assertEquals(success, true, "success weakCompareAndSet $type$");
                 $type$ x = ($type$) vh.get(array, i);
-                assertEquals(x, $value1$, "weakCompareAndSet $type$");
+                assertEquals(x, $value1$, "success weakCompareAndSet $type$");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSet(array, i, $value2$, $value3$);
+                assertEquals(success, false, "failing weakCompareAndSet $type$");
+                $type$ x = ($type$) vh.get(array, i);
+                assertEquals(x, $value1$, "failing weakCompareAndSet $type$ value");
             }
 
             // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestByteArrayView.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestByteArrayView.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1627,9 +1627,16 @@ public class VarHandleTestByteArrayAs$Type$ extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetPlain(array, i, VALUE_1, VALUE_2);
                     }
-                    assertEquals(success, true, "weakCompareAndSetPlain $type$");
+                    assertEquals(success, true, "success weakCompareAndSetPlain $type$");
                     $type$ x = ($type$) vh.get(array, i);
-                    assertEquals(x, VALUE_2, "weakCompareAndSetPlain $type$ value");
+                    assertEquals(x, VALUE_2, "success weakCompareAndSetPlain $type$ value");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetPlain(array, i, VALUE_1, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetPlain $type$");
+                    $type$ x = ($type$) vh.get(array, i);
+                    assertEquals(x, VALUE_2, "failing weakCompareAndSetPlain $type$ value");
                 }
 
                 {
@@ -1637,9 +1644,16 @@ public class VarHandleTestByteArrayAs$Type$ extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetAcquire(array, i, VALUE_2, VALUE_1);
                     }
-                    assertEquals(success, true, "weakCompareAndSetAcquire $type$");
+                    assertEquals(success, true, "success weakCompareAndSetAcquire $type$");
                     $type$ x = ($type$) vh.get(array, i);
-                    assertEquals(x, VALUE_1, "weakCompareAndSetAcquire $type$");
+                    assertEquals(x, VALUE_1, "success weakCompareAndSetAcquire $type$");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetAcquire(array, i, VALUE_2, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetAcquire $type$");
+                    $type$ x = ($type$) vh.get(array, i);
+                    assertEquals(x, VALUE_1, "failing weakCompareAndSetAcquire $type$ value");
                 }
 
                 {
@@ -1647,9 +1661,16 @@ public class VarHandleTestByteArrayAs$Type$ extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetRelease(array, i, VALUE_1, VALUE_2);
                     }
-                    assertEquals(success, true, "weakCompareAndSetRelease $type$");
+                    assertEquals(success, true, "success weakCompareAndSetRelease $type$");
                     $type$ x = ($type$) vh.get(array, i);
-                    assertEquals(x, VALUE_2, "weakCompareAndSetRelease $type$");
+                    assertEquals(x, VALUE_2, "success weakCompareAndSetRelease $type$");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetRelease(array, i, VALUE_1, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetRelease $type$");
+                    $type$ x = ($type$) vh.get(array, i);
+                    assertEquals(x, VALUE_2, "failing weakCompareAndSetRelease $type$ value");
                 }
 
                 {
@@ -1657,9 +1678,16 @@ public class VarHandleTestByteArrayAs$Type$ extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSet(array, i, VALUE_2, VALUE_1);
                     }
-                    assertEquals(success, true, "weakCompareAndSet $type$");
+                    assertEquals(success, true, "success weakCompareAndSet $type$");
                     $type$ x = ($type$) vh.get(array, i);
-                    assertEquals(x, VALUE_1, "weakCompareAndSet $type$");
+                    assertEquals(x, VALUE_1, "success weakCompareAndSet $type$");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSet(array, i, VALUE_2, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSet $type$");
+                    $type$ x = ($type$) vh.get(array, i);
+                    assertEquals(x, VALUE_1, "failing weakCompareAndSet $type$ value");
                 }
 
                 // Compare set and get
@@ -1916,9 +1944,16 @@ public class VarHandleTestByteArrayAs$Type$ extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetPlain(array, i, VALUE_1, VALUE_2);
                     }
-                    assertEquals(success, true, "weakCompareAndSetPlain $type$");
+                    assertEquals(success, true, "success weakCompareAndSetPlain $type$");
                     $type$ x = ($type$) vh.get(array, i);
-                    assertEquals(x, VALUE_2, "weakCompareAndSetPlain $type$ value");
+                    assertEquals(x, VALUE_2, "success weakCompareAndSetPlain $type$ value");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetPlain(array, i, VALUE_1, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetPlain $type$");
+                    $type$ x = ($type$) vh.get(array, i);
+                    assertEquals(x, VALUE_2, "failing weakCompareAndSetPlain $type$ value");
                 }
 
                 {
@@ -1926,9 +1961,16 @@ public class VarHandleTestByteArrayAs$Type$ extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetAcquire(array, i, VALUE_2, VALUE_1);
                     }
-                    assertEquals(success, true, "weakCompareAndSetAcquire $type$");
+                    assertEquals(success, true, "success weakCompareAndSetAcquire $type$");
                     $type$ x = ($type$) vh.get(array, i);
-                    assertEquals(x, VALUE_1, "weakCompareAndSetAcquire $type$");
+                    assertEquals(x, VALUE_1, "success weakCompareAndSetAcquire $type$");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetAcquire(array, i, VALUE_2, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetAcquire $type$");
+                    $type$ x = ($type$) vh.get(array, i);
+                    assertEquals(x, VALUE_1, "failing weakCompareAndSetAcquire $type$ value");
                 }
 
                 {
@@ -1936,9 +1978,16 @@ public class VarHandleTestByteArrayAs$Type$ extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSetRelease(array, i, VALUE_1, VALUE_2);
                     }
-                    assertEquals(success, true, "weakCompareAndSetRelease $type$");
+                    assertEquals(success, true, "success weakCompareAndSetRelease $type$");
                     $type$ x = ($type$) vh.get(array, i);
-                    assertEquals(x, VALUE_2, "weakCompareAndSetRelease $type$");
+                    assertEquals(x, VALUE_2, "success weakCompareAndSetRelease $type$");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSetRelease(array, i, VALUE_1, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSetRelease $type$");
+                    $type$ x = ($type$) vh.get(array, i);
+                    assertEquals(x, VALUE_2, "failing weakCompareAndSetRelease $type$ value");
                 }
 
                 {
@@ -1946,9 +1995,16 @@ public class VarHandleTestByteArrayAs$Type$ extends VarHandleBaseByteArrayTest {
                     for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                         success = vh.weakCompareAndSet(array, i, VALUE_2, VALUE_1);
                     }
-                    assertEquals(success, true, "weakCompareAndSet $type$");
+                    assertEquals(success, true, "success weakCompareAndSet $type$");
                     $type$ x = ($type$) vh.get(array, i);
-                    assertEquals(x, VALUE_1, "weakCompareAndSet $type$");
+                    assertEquals(x, VALUE_1, "success weakCompareAndSet $type$");
+                }
+
+                {
+                    boolean success = vh.weakCompareAndSet(array, i, VALUE_2, VALUE_3);
+                    assertEquals(success, false, "failing weakCompareAndSet $type$");
+                    $type$ x = ($type$) vh.get(array, i);
+                    assertEquals(x, VALUE_1, "failing weakCompareAndSet $type$ value");
                 }
 
                 // Compare set and get

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodHandleAccess.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodHandleAccess.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -213,9 +213,16 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, $value1$, $value2$);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain $type$");
+            assertEquals(success, true, "success weakCompareAndSetPlain $type$");
             $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, $value2$, "weakCompareAndSetPlain $type$ value");
+            assertEquals(x, $value2$, "success weakCompareAndSetPlain $type$ value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, $value1$, $value3$);
+            assertEquals(success, false, "failing weakCompareAndSetPlain $type$");
+            $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, $value2$, "failing weakCompareAndSetPlain $type$ value");
         }
 
         {
@@ -223,9 +230,16 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, $value2$, $value1$);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire $type$");
+            assertEquals(success, true, "success weakCompareAndSetAcquire $type$");
             $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, $value1$, "weakCompareAndSetAcquire $type$");
+            assertEquals(x, $value1$, "success weakCompareAndSetAcquire $type$");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, $value2$, $value3$);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire $type$");
+            $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, $value1$, "failing weakCompareAndSetAcquire $type$ value");
         }
 
         {
@@ -233,9 +247,16 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, $value1$, $value2$);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease $type$");
+            assertEquals(success, true, "success weakCompareAndSetRelease $type$");
             $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, $value2$, "weakCompareAndSetRelease $type$");
+            assertEquals(x, $value2$, "success weakCompareAndSetRelease $type$");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, $value1$, $value3$);
+            assertEquals(success, false, "failing weakCompareAndSetRelease $type$");
+            $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, $value2$, "failing weakCompareAndSetRelease $type$ value");
         }
 
         {
@@ -243,9 +264,16 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, $value2$, $value1$);
             }
-            assertEquals(success, true, "weakCompareAndSet $type$");
+            assertEquals(success, true, "success weakCompareAndSet $type$");
             $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, $value1$, "weakCompareAndSet $type$");
+            assertEquals(x, $value1$, "success weakCompareAndSet $type$");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, $value2$, $value3$);
+            assertEquals(success, false, "failing weakCompareAndSet $type$");
+            $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, $value1$, "failing weakCompareAndSet $type$ value");
         }
 
         // Compare set and get
@@ -508,9 +536,16 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact($value1$, $value2$);
             }
-            assertEquals(success, true, "weakCompareAndSetPlain $type$");
+            assertEquals(success, true, "success weakCompareAndSetPlain $type$");
             $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, $value2$, "weakCompareAndSetPlain $type$ value");
+            assertEquals(x, $value2$, "success weakCompareAndSetPlain $type$ value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact($value1$, $value3$);
+            assertEquals(success, false, "failing weakCompareAndSetPlain $type$");
+            $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, $value2$, "failing weakCompareAndSetPlain $type$ value");
         }
 
         {
@@ -518,9 +553,16 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact($value2$, $value1$);
             }
-            assertEquals(success, true, "weakCompareAndSetAcquire $type$");
+            assertEquals(success, true, "success weakCompareAndSetAcquire $type$");
             $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, $value1$, "weakCompareAndSetAcquire $type$");
+            assertEquals(x, $value1$, "success weakCompareAndSetAcquire $type$");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact($value2$, $value3$);
+            assertEquals(success, false, "failing weakCompareAndSetAcquire $type$");
+            $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, $value1$, "failing weakCompareAndSetAcquire $type$ value");
         }
 
         {
@@ -528,9 +570,16 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact($value1$, $value2$);
             }
-            assertEquals(success, true, "weakCompareAndSetRelease $type$");
+            assertEquals(success, true, "success weakCompareAndSetRelease $type$");
             $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, $value2$, "weakCompareAndSetRelease $type$");
+            assertEquals(x, $value2$, "success weakCompareAndSetRelease $type$");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact($value1$, $value3$);
+            assertEquals(success, false, "failing weakCompareAndSetRelease $type$");
+            $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, $value2$, "failing weakCompareAndSetRelease $type$ value");
         }
 
         {
@@ -538,9 +587,16 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
             for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                 success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact($value2$, $value1$);
             }
-            assertEquals(success, true, "weakCompareAndSet $type$");
+            assertEquals(success, true, "success weakCompareAndSet $type$");
             $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(x, $value1$, "weakCompareAndSet $type$");
+            assertEquals(x, $value1$, "success weakCompareAndSet $type$");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact($value2$, $value3$);
+            assertEquals(success, false, "failing weakCompareAndSet $type$");
+            $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, $value1$, "failing weakCompareAndSetRe $type$ value");
         }
 
         // Compare set and get
@@ -828,9 +884,16 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, $value1$, $value2$);
                 }
-                assertEquals(success, true, "weakCompareAndSetPlain $type$");
+                assertEquals(success, true, "success weakCompareAndSetPlain $type$");
                 $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, $value2$, "weakCompareAndSetPlain $type$ value");
+                assertEquals(x, $value2$, "success weakCompareAndSetPlain $type$ value");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, $value1$, $value3$);
+                assertEquals(success, false, "failing weakCompareAndSetPlain $type$");
+                $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, $value2$, "failing weakCompareAndSetPlain $type$ value");
             }
 
             {
@@ -838,9 +901,16 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, $value2$, $value1$);
                 }
-                assertEquals(success, true, "weakCompareAndSetAcquire $type$");
+                assertEquals(success, true, "success weakCompareAndSetAcquire $type$");
                 $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, $value1$, "weakCompareAndSetAcquire $type$");
+                assertEquals(x, $value1$, "success weakCompareAndSetAcquire $type$");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, $value2$, $value3$);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire $type$");
+                $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, $value1$, "failing weakCompareAndSetAcquire $type$ value");
             }
 
             {
@@ -848,9 +918,16 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, $value1$, $value2$);
                 }
-                assertEquals(success, true, "weakCompareAndSetRelease $type$");
+                assertEquals(success, true, "success weakCompareAndSetRelease $type$");
                 $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, $value2$, "weakCompareAndSetRelease $type$");
+                assertEquals(x, $value2$, "success weakCompareAndSetRelease $type$");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, $value1$, $value3$);
+                assertEquals(success, false, "failing weakCompareAndSetAcquire $type$");
+                $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, $value2$, "failing weakCompareAndSetAcquire $type$ value");
             }
 
             {
@@ -858,9 +935,16 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
                 for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
                     success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, $value2$, $value1$);
                 }
-                assertEquals(success, true, "weakCompareAndSet $type$");
+                assertEquals(success, true, "success weakCompareAndSet $type$");
                 $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(x, $value1$, "weakCompareAndSet $type$");
+                assertEquals(x, $value1$, "success weakCompareAndSet $type$");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, $value2$, $value3$);
+                assertEquals(success, false, "failing weakCompareAndSet $type$");
+                $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, $value1$, "failing weakCompareAndSet $type$ value");
             }
 
             // Compare set and get


### PR DESCRIPTION
I noticed that current VarHandle/Unsafe test cases do not test the always-failing cases. Strong CASes do test both always-success and always-failing scenarios, while weak CASes only test spurious-failure tests. We should be also testing always-failing cases for these. Weak CAS can spuriously fail, but it cannot spuriously succeed.

The PR looks large, but the actual changes are in `*.template` files, and the rest is generated from them.

Additional testing:
 - [x] Linux x86_64 fastdebug `java/lang/invoke/VarHandles` and `compiler/unsafe` tests
 - [x]  Linux x86_32 fastdebug `java/lang/invoke/VarHandles` and `compiler/unsafe` tests
 - [x]  Linux AArch64 fastdebug `java/lang/invoke/VarHandles` and `compiler/unsafe` tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292443](https://bugs.openjdk.org/browse/JDK-8292443): Weak CAS VarHandle/Unsafe tests should test always-failing cases


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9892/head:pull/9892` \
`$ git checkout pull/9892`

Update a local copy of the PR: \
`$ git checkout pull/9892` \
`$ git pull https://git.openjdk.org/jdk pull/9892/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9892`

View PR using the GUI difftool: \
`$ git pr show -t 9892`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9892.diff">https://git.openjdk.org/jdk/pull/9892.diff</a>

</details>
