### PR TITLE
8292448: Convert BitMapFragmentTable to ResourceHashtable

### DIFF
--- a/src/hotspot/share/utilities/hashtable.cpp
+++ b/src/hotspot/share/utilities/hashtable.cpp
@@ -278,7 +278,6 @@ template class BasicHashtable<mtCode>;
 template class BasicHashtable<mtInternal>;
 template class BasicHashtable<mtModule>;
 template class BasicHashtable<mtCompiler>;
-template class BasicHashtable<mtTracing>;
 template class BasicHashtable<mtServiceability>;
 template class BasicHashtable<mtLogging>;
 

--- a/src/hotspot/share/utilities/objectBitSet.inline.hpp
+++ b/src/hotspot/share/utilities/objectBitSet.inline.hpp
@@ -52,15 +52,8 @@ ObjectBitSet<F>::~ObjectBitSet() {
     delete current;
     current = next;
   }
-  class Deleter {
-    public:
-    bool do_entry(uintptr_t& key, CHeapBitMap*& fragment) {
-      // fragment is already deleted above, but now delete the table nodes.
-      return true;
-    }
-  };
-  Deleter deleter;
-  _bitmap_fragments.unlink(&deleter);
+  // destructors for ResourceHashtable base deletes nodes, and
+  // ResizeableResourceHashtableStorage deletes the table.
 }
 
 template<MEMFLAGS F>

--- a/src/hotspot/share/utilities/objectBitSet.inline.hpp
+++ b/src/hotspot/share/utilities/objectBitSet.inline.hpp
@@ -29,7 +29,6 @@
 
 #include "memory/memRegion.hpp"
 #include "utilities/bitMap.inline.hpp"
-#include "utilities/hashtable.inline.hpp"
 
 template<MEMFLAGS F>
 ObjectBitSet<F>::BitMapFragment::BitMapFragment(uintptr_t granule, BitMapFragment* next) :
@@ -39,7 +38,7 @@ ObjectBitSet<F>::BitMapFragment::BitMapFragment(uintptr_t granule, BitMapFragmen
 
 template<MEMFLAGS F>
 ObjectBitSet<F>::ObjectBitSet() :
-        _bitmap_fragments(32),
+        _bitmap_fragments(32, 8*K),
         _fragment_list(NULL),
         _last_fragment_bits(NULL),
         _last_fragment_granule(UINTPTR_MAX) {
@@ -53,52 +52,15 @@ ObjectBitSet<F>::~ObjectBitSet() {
     delete current;
     current = next;
   }
-}
-
-template<MEMFLAGS F>
-ObjectBitSet<F>::BitMapFragmentTable::~BitMapFragmentTable() {
-  for (int index = 0; index < BasicHashtable<F>::table_size(); index ++) {
-    Entry* e = bucket(index);
-    while (e != nullptr) {
-      Entry* tmp = e;
-      e = e->next();
-      BasicHashtable<F>::free_entry(tmp);
+  class Deleter {
+    public:
+    bool do_entry(uintptr_t& key, CHeapBitMap*& fragment) {
+      // fragment is already deleted above, but now delete the table nodes.
+      return true;
     }
-  }
-}
-
-template<MEMFLAGS F>
-inline typename ObjectBitSet<F>::BitMapFragmentTable::Entry* ObjectBitSet<F>::BitMapFragmentTable::bucket(int i) const {
-  return (Entry*)BasicHashtable<F>::bucket(i);
-}
-
-template<MEMFLAGS F>
-inline typename ObjectBitSet<F>::BitMapFragmentTable::Entry*
-  ObjectBitSet<F>::BitMapFragmentTable::new_entry(unsigned int hash, uintptr_t key, CHeapBitMap* value) {
-
-  Entry* entry = (Entry*)BasicHashtable<F>::new_entry(hash);
-  entry->_key = key;
-  entry->_value = value;
-  return entry;
-}
-
-template<MEMFLAGS F>
-inline void ObjectBitSet<F>::BitMapFragmentTable::add(uintptr_t key, CHeapBitMap* value) {
-  unsigned hash = hash_segment(key);
-  Entry* entry = new_entry(hash, key, value);
-  BasicHashtable<F>::add_entry(hash_to_index(hash), entry);
-}
-
-template<MEMFLAGS F>
-inline CHeapBitMap** ObjectBitSet<F>::BitMapFragmentTable::lookup(uintptr_t key) {
-  unsigned hash = hash_segment(key);
-  int index = hash_to_index(hash);
-  for (Entry* e = bucket(index); e != NULL; e = e->next()) {
-    if (e->hash() == hash && e->_key == key) {
-      return &(e->_value);
-    }
-  }
-  return NULL;
+  };
+  Deleter deleter;
+  _bitmap_fragments.unlink(&deleter);
 }
 
 template<MEMFLAGS F>
@@ -114,17 +76,15 @@ inline CHeapBitMap* ObjectBitSet<F>::get_fragment_bits(uintptr_t addr) {
   }
   CHeapBitMap* bits = NULL;
 
-  CHeapBitMap** found = _bitmap_fragments.lookup(granule);
+  CHeapBitMap** found = _bitmap_fragments.get(granule);
   if (found != NULL) {
     bits = *found;
   } else {
     BitMapFragment* fragment = new BitMapFragment(granule, _fragment_list);
     bits = fragment->bits();
     _fragment_list = fragment;
-    if (_bitmap_fragments.number_of_entries() * 100 / _bitmap_fragments.table_size() > 25) {
-      _bitmap_fragments.resize(_bitmap_fragments.table_size() * 2);
-    }
-    _bitmap_fragments.add(granule, bits);
+    _bitmap_fragments.put(granule, bits);
+    _bitmap_fragments.maybe_grow();
   }
 
   _last_fragment_bits = bits;


### PR DESCRIPTION
This is an uncomplicated conversion of the bitmap fragment table into a ResizeableResourceHashtable.  Ran tiers 1-3 and 4-7 with other changes, and verified that the memory for ResourceHashtableStorage is freed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292448](https://bugs.openjdk.org/browse/JDK-8292448): Convert BitMapFragmentTable to ResourceHashtable


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9893/head:pull/9893` \
`$ git checkout pull/9893`

Update a local copy of the PR: \
`$ git checkout pull/9893` \
`$ git pull https://git.openjdk.org/jdk pull/9893/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9893`

View PR using the GUI difftool: \
`$ git pr show -t 9893`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9893.diff">https://git.openjdk.org/jdk/pull/9893.diff</a>

</details>
