### PR TITLE
8292509: ProblemList java/lang/invoke/lambda/LogGeneratedClassesTest.java on windows

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -102,6 +102,8 @@ applications/jcstress/copy.java 8229852 linux-all
 
 containers/docker/TestJcmd.java 8278102 linux-all
 
+runtime/cds/appcds/cacheObject/ArchivedEnumTest.java 8292499 generic-all
+
 #############################################################################
 
 # :hotspot_serviceability

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -497,6 +497,7 @@ java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-x6
 java/lang/invoke/RicochetTest.java                              8251969 generic-all
 java/lang/ProcessBuilder/PipelineLeaksFD.java                   8291760 linux-all
 jdk/internal/misc/TerminatingThreadLocal/TestTerminatingThreadLocal.java 8292051 generic-all
+java/lang/invoke/lambda/LogGeneratedClassesTest.java            8292498 windows-x64
 
 ############################################################################
 


### PR DESCRIPTION
Trivial fixes to ProblemList two different tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8292509](https://bugs.openjdk.org/browse/JDK-8292509): ProblemList java/lang/invoke/lambda/LogGeneratedClassesTest.java on windows
 * [JDK-8292510](https://bugs.openjdk.org/browse/JDK-8292510): ProblemList runtime/cds/appcds/cacheObject/ArchivedEnumTest.java


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9894/head:pull/9894` \
`$ git checkout pull/9894`

Update a local copy of the PR: \
`$ git checkout pull/9894` \
`$ git pull https://git.openjdk.org/jdk pull/9894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9894`

View PR using the GUI difftool: \
`$ git pr show -t 9894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9894.diff">https://git.openjdk.org/jdk/pull/9894.diff</a>

</details>
