### PR TITLE
8292488: JFR: Incorrect comment in ActiveRecordingEvent

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/events/ActiveRecordingEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/ActiveRecordingEvent.java
@@ -41,7 +41,7 @@ import jdk.jfr.internal.Type;
 public final class ActiveRecordingEvent extends AbstractJDKEvent {
 
     // The order of these fields must be the same as the parameters in
-    // commit(... , long, String, String, String, long, long, long, long, long)
+    // commit(... , long, String, String, long, long, long, long, long)
 
     @Label("Id")
     public long id;


### PR DESCRIPTION
please review this change.
I checked the build succecfully just in case. No error occured.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292488](https://bugs.openjdk.org/browse/JDK-8292488): JFR: Incorrect comment in ActiveRecordingEvent


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9897/head:pull/9897` \
`$ git checkout pull/9897`

Update a local copy of the PR: \
`$ git checkout pull/9897` \
`$ git pull https://git.openjdk.org/jdk pull/9897/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9897`

View PR using the GUI difftool: \
`$ git pr show -t 9897`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9897.diff">https://git.openjdk.org/jdk/pull/9897.diff</a>

</details>
