### PR TITLE
8290910: Wrong memory state is picked in SuperWord::co_locate_pack()

### DIFF
--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -549,6 +549,8 @@ class SuperWord : public ResourceObj {
   Node* pick_mem_state(Node_List* pk);
   Node* find_first_mem_state(Node_List* pk);
   Node* find_last_mem_state(Node_List* pk, Node* first_mem);
+  // Determine if the load pack is dependent on the last_mem.
+  bool dependent_on_last_mem(Node* last_mem, Node_List* pk);
 
   // Convert packs into vector node operations
   bool output();

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestPickLastMemoryState.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestPickLastMemoryState.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/**
+ * @test
+ * @requires vm.compiler2.enabled
+ * @bug 8290910
+ * @summary Test which needs to select the memory state of the last load in a load pack in SuperWord::co_locate_pack.
+ *
+ * @run main/othervm -Xcomp -Xbatch -XX:CompileCommand=compileonly,compiler.loopopts.superword.TestPickLastMemoryState::*
+ *                   compiler.loopopts.superword.TestPickLastMemoryState
+ */
+
+package compiler.loopopts.superword;
+
+public class TestPickLastMemoryState {
+    static final int N = 400;
+    static long lArrFld[] = new long[N];
+    static long iMeth_check_sum;
+    static long[] golden_sum = {22154, 44050, 66167, 88359, 110684, 132686, 154755, 176703, 198872, 220874};
+
+    static void iMeth() {
+        int i1 , i2 = -222, iArr[] = new int[N];
+        init(iArr, 212);
+        // For the following loop, statement 1 can be vectorized but statement 2 can't. When
+        // finding the memory state for the LoadI pack, we cannot pick the memory state from
+        // the first load as the LoadI vector operation must load the memory after iArr writes
+        // 'iArr[i1 + 1] - (i2++)' to 'iArr[i1 + 1]'. We must take the memory state of the last
+        // load where we have assigned new values ('iArr[i1 + 1] - (i2++)') to the iArr array.
+        for (i1 = 6; i1 < 227; i1++) {
+            iArr[i1] += lArrFld[i1]++; // statement 1
+            iArr[i1 + 1] -= (i2++); // statement 2
+        }
+        iMeth_check_sum += checkSum(iArr);
+    }
+
+    static void init(int[] a, int seed) {
+        for (int j = 0; j < a.length; j++) {
+            a[j] = (j % 2 == 0) ? seed + j : seed - j;
+        }
+    }
+
+    static long checkSum(int[] a) {
+        long sum = 0;
+        for (int j = 0; j < a.length; j++) {
+            sum += (a[j] / (j + 1) + a[j] % (j + 1));
+        }
+        return sum;
+    }
+
+    static void reset() {
+        for (int i = 0; i < N; i++) {
+            lArrFld[i] = 0;
+        }
+        iMeth_check_sum = 0;
+    }
+
+    static void test() {
+        for (int i = 0; i < 10; i++) {
+            iMeth();
+            if (iMeth_check_sum != golden_sum[i]) {
+                throw new RuntimeException("iMeth wrong result at " + i + ": " + iMeth_check_sum);
+            }
+        }
+    }
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 5_000; i++) {
+            reset();
+            test();
+        }
+    }
+}
+


### PR DESCRIPTION
After JDK-8283091, the loop below can be vectorized partially.
Statement 1 can be vectorized but statement 2 can't.
```
// int[] iArr; long[] lArrFld; int i1,i2;
for (i1 = 6; i1 < 227; i1++) {
  iArr[i1] += lArrFld[i1]++; // statement 1
  iArr[i1 + 1] -= (i2++); // statement 2
}
```

But we got incorrect results because the vector packs of iArr are
scheduled incorrectly like:
```
...
load_vector XMM1,[R8 + #16 + R11 << #2]
movl    RDI, [R8 + #20 + R11 << #2] # int
load_vector XMM2,[R9 + #8 + R11 << #3]
subl    RDI, R11    # int
vpaddq  XMM3,XMM2,XMM0  ! add packedL
store_vector [R9 + #8 + R11 << #3],XMM3
vector_cast_l2x  XMM2,XMM2  !
vpaddd  XMM1,XMM2,XMM1  ! add packedI
addl    RDI, #228   # int
movl    [R8 + #20 + R11 << #2], RDI # int
movl    RBX, [R8 + #24 + R11 << #2] # int
subl    RBX, R11    # int
addl    RBX, #227   # int
movl    [R8 + #24 + R11 << #2], RBX # int
...
movl    RBX, [R8 + #40 + R11 << #2] # int
subl    RBX, R11    # int
addl    RBX, #223   # int
movl    [R8 + #40 + R11 << #2], RBX # int
movl    RDI, [R8 + #44 + R11 << #2] # int
subl    RDI, R11    # int
addl    RDI, #222   # int
movl    [R8 + #44 + R11 << #2], RDI # int
store_vector [R8 + #16 + R11 << #2],XMM1
...
```
simplified as:
```
load_vector iArr in statement 1
unvectorized loads/stores in statement 2
store_vector iArr in statement 1
```
We cannot pick the memory state from the first load for LoadI pack
here, as the LoadI vector operation must load the new values in memory
after iArr writes `iArr[i1 + 1] - (i2++)` to `iArr[i1 + 1]`(statement 2).
We must take the memory state of the last load where we have assigned
new values `iArr[i1 + 1] - (i2++)` to the iArr array.

In JDK-8240281, we picked the memory state of the first load[1]. Different
from the scenario in JDK-8240281, the store, which is dependent on an
earlier load here, is in a pack to be scheduled and the LoadI pack
depends on the last_mem. As designed[2], to schedule the StoreI pack,
all memory operations in another single pack should be moved in the same
direction. We know that the store in the pack depends on one of loads in
the LoadI pack, so the LoadI pack should be scheduled before the StoreI
pack. And the LoadI pack depends on the last_mem, so the last_mem must
be scheduled before the LoadI pack and also before the store pack.
Therefore, we need to take the memory state of the last load for the
LoadI pack here.

To fix it, the pack adds additional checks while picking the memory state
of the first load. When the store locates in a pack and the load pack
relies on the last_mem, we shouldn't choose the memory state of the
first load but choose the memory state of the last load.

[1]https://github.com/openjdk/jdk/blob/0ae834105740f7cf73fe96be22e0f564ad29b18d/src/hotspot/share/opto/superword.cpp#L2380
[2]https://github.com/openjdk/jdk/blob/0ae834105740f7cf73fe96be22e0f564ad29b18d/src/hotspot/share/opto/superword.cpp#L2232
