### PR TITLE
8292446: Make TableRateStatistics optional in CHT

### DIFF
--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -223,7 +223,7 @@ void StringTable::create_table() {
   _current_size = ((size_t)1) << start_size_log_2;
   log_trace(stringtable)("Start size: " SIZE_FORMAT " (" SIZE_FORMAT ")",
                          _current_size, start_size_log_2);
-  _local_table = new StringTableHash(start_size_log_2, END_SIZE, REHASH_LEN);
+  _local_table = new StringTableHash(start_size_log_2, END_SIZE, REHASH_LEN, true);
   _oop_storage = OopStorageSet::create_weak("StringTable Weak", mtSymbol);
   _oop_storage->register_num_dead_callback(&gc_notification);
 }

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -783,7 +783,7 @@ bool SymbolTable::do_rehash() {
 
   // We use current size
   size_t new_size = _local_table->get_size_log2(Thread::current());
-  SymbolTableHash* new_table = new SymbolTableHash(new_size, END_SIZE, REHASH_LEN);
+  SymbolTableHash* new_table = new SymbolTableHash(new_size, END_SIZE, REHASH_LEN, true);
   // Use alt hash from now on
   _alt_hash = true;
   if (!_local_table->try_move_nodes_to(Thread::current(), new_table)) {

--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -34,6 +34,7 @@
 #include "runtime/globals_extension.hpp"
 #include "runtime/java.hpp"
 #include "utilities/bitMap.inline.hpp"
+#include "utilities/concurrentHashTable.hpp"
 #include "utilities/concurrentHashTable.inline.hpp"
 #include "utilities/globalDefinitions.hpp"
 
@@ -280,7 +281,7 @@ public:
                      size_t initial_log_table_size = InitialLogTableSize) :
     _inserted_card(false),
     _mm(mm),
-    _table(mm, initial_log_table_size) {
+    _table(mm, initial_log_table_size, false) {
   }
 
   ~G1CardSetHashTable() {

--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -34,7 +34,6 @@
 #include "runtime/globals_extension.hpp"
 #include "runtime/java.hpp"
 #include "utilities/bitMap.inline.hpp"
-#include "utilities/concurrentHashTable.hpp"
 #include "utilities/concurrentHashTable.inline.hpp"
 #include "utilities/globalDefinitions.hpp"
 

--- a/src/hotspot/share/prims/resolvedMethodTable.cpp
+++ b/src/hotspot/share/prims/resolvedMethodTable.cpp
@@ -101,7 +101,7 @@ OopStorage*              ResolvedMethodTable::_oop_storage;
 volatile size_t          _items_count           = 0;
 
 void ResolvedMethodTable::create_table() {
-  _local_table  = new ResolvedMethodTableHash(ResolvedMethodTableSizeLog, END_SIZE, GROW_HINT, false);
+  _local_table  = new ResolvedMethodTableHash(ResolvedMethodTableSizeLog, END_SIZE, GROW_HINT);
   log_trace(membername, table)("Start size: " SIZE_FORMAT " (" SIZE_FORMAT ")",
                                _current_size, ResolvedMethodTableSizeLog);
   _oop_storage = OopStorageSet::create_weak("ResolvedMethodTable Weak", mtClass);

--- a/src/hotspot/share/prims/resolvedMethodTable.cpp
+++ b/src/hotspot/share/prims/resolvedMethodTable.cpp
@@ -101,7 +101,7 @@ OopStorage*              ResolvedMethodTable::_oop_storage;
 volatile size_t          _items_count           = 0;
 
 void ResolvedMethodTable::create_table() {
-  _local_table  = new ResolvedMethodTableHash(ResolvedMethodTableSizeLog, END_SIZE, GROW_HINT);
+  _local_table  = new ResolvedMethodTableHash(ResolvedMethodTableSizeLog, END_SIZE, GROW_HINT, nullptr, false);
   log_trace(membername, table)("Start size: " SIZE_FORMAT " (" SIZE_FORMAT ")",
                                _current_size, ResolvedMethodTableSizeLog);
   _oop_storage = OopStorageSet::create_weak("ResolvedMethodTable Weak", mtClass);

--- a/src/hotspot/share/prims/resolvedMethodTable.cpp
+++ b/src/hotspot/share/prims/resolvedMethodTable.cpp
@@ -101,7 +101,7 @@ OopStorage*              ResolvedMethodTable::_oop_storage;
 volatile size_t          _items_count           = 0;
 
 void ResolvedMethodTable::create_table() {
-  _local_table  = new ResolvedMethodTableHash(ResolvedMethodTableSizeLog, END_SIZE, GROW_HINT, nullptr, false);
+  _local_table  = new ResolvedMethodTableHash(ResolvedMethodTableSizeLog, END_SIZE, GROW_HINT, false);
   log_trace(membername, table)("Start size: " SIZE_FORMAT " (" SIZE_FORMAT ")",
                                _current_size, ResolvedMethodTableSizeLog);
   _oop_storage = OopStorageSet::create_weak("ResolvedMethodTable Weak", mtClass);

--- a/src/hotspot/share/services/finalizerService.cpp
+++ b/src/hotspot/share/services/finalizerService.cpp
@@ -271,7 +271,7 @@ void FinalizerService::init() {
   assert(_table == nullptr, "invariant");
   const size_t start_size_log_2 = ceil_log2(DEFAULT_TABLE_SIZE);
   _table = new FinalizerHashtable(start_size_log_2, MAX_SIZE, FinalizerHashtable::DEFAULT_GROW_HINT,
-                                  nullptr, false);
+                                  false);
 }
 
 static FinalizerEntry* lookup_entry(const InstanceKlass* ik, Thread* thread) {

--- a/src/hotspot/share/services/finalizerService.cpp
+++ b/src/hotspot/share/services/finalizerService.cpp
@@ -270,8 +270,7 @@ void FinalizerService::do_concurrent_work(JavaThread* service_thread) {
 void FinalizerService::init() {
   assert(_table == nullptr, "invariant");
   const size_t start_size_log_2 = ceil_log2(DEFAULT_TABLE_SIZE);
-  _table = new FinalizerHashtable(start_size_log_2, MAX_SIZE, FinalizerHashtable::DEFAULT_GROW_HINT,
-                                  false);
+  _table = new FinalizerHashtable(start_size_log_2, MAX_SIZE, FinalizerHashtable::DEFAULT_GROW_HINT);
 }
 
 static FinalizerEntry* lookup_entry(const InstanceKlass* ik, Thread* thread) {

--- a/src/hotspot/share/services/finalizerService.cpp
+++ b/src/hotspot/share/services/finalizerService.cpp
@@ -270,7 +270,8 @@ void FinalizerService::do_concurrent_work(JavaThread* service_thread) {
 void FinalizerService::init() {
   assert(_table == nullptr, "invariant");
   const size_t start_size_log_2 = ceil_log2(DEFAULT_TABLE_SIZE);
-  _table = new FinalizerHashtable(start_size_log_2, MAX_SIZE);
+  _table = new FinalizerHashtable(start_size_log_2, MAX_SIZE, FinalizerHashtable::DEFAULT_GROW_HINT,
+                                  nullptr, false);
 }
 
 static FinalizerEntry* lookup_entry(const InstanceKlass* ik, Thread* thread) {

--- a/src/hotspot/share/services/threadIdTable.cpp
+++ b/src/hotspot/share/services/threadIdTable.cpp
@@ -123,7 +123,7 @@ void ThreadIdTable::create_table(size_t size) {
       size_log > DEFAULT_TABLE_SIZE_LOG ? size_log : DEFAULT_TABLE_SIZE_LOG;
   _current_size = (size_t)1 << start_size_log;
   _local_table = new ThreadIdTableHash(start_size_log, END_SIZE,
-                                       ThreadIdTableHash::DEFAULT_GROW_HINT, nullptr, false);
+                                       ThreadIdTableHash::DEFAULT_GROW_HINT, false);
 }
 
 void ThreadIdTable::item_added() {

--- a/src/hotspot/share/services/threadIdTable.cpp
+++ b/src/hotspot/share/services/threadIdTable.cpp
@@ -122,8 +122,8 @@ void ThreadIdTable::create_table(size_t size) {
   size_t start_size_log =
       size_log > DEFAULT_TABLE_SIZE_LOG ? size_log : DEFAULT_TABLE_SIZE_LOG;
   _current_size = (size_t)1 << start_size_log;
-  _local_table = new ThreadIdTableHash(start_size_log, END_SIZE,
-                                       ThreadIdTableHash::DEFAULT_GROW_HINT, false);
+  _local_table =
+      new ThreadIdTableHash(start_size_log, END_SIZE, ThreadIdTableHash::DEFAULT_GROW_HINT);
 }
 
 void ThreadIdTable::item_added() {

--- a/src/hotspot/share/services/threadIdTable.cpp
+++ b/src/hotspot/share/services/threadIdTable.cpp
@@ -122,7 +122,8 @@ void ThreadIdTable::create_table(size_t size) {
   size_t start_size_log =
       size_log > DEFAULT_TABLE_SIZE_LOG ? size_log : DEFAULT_TABLE_SIZE_LOG;
   _current_size = (size_t)1 << start_size_log;
-  _local_table = new ThreadIdTableHash(start_size_log, END_SIZE);
+  _local_table = new ThreadIdTableHash(start_size_log, END_SIZE,
+                                       ThreadIdTableHash::DEFAULT_GROW_HINT, nullptr, false);
 }
 
 void ThreadIdTable::item_added() {

--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -42,6 +42,22 @@ template <typename CONFIG, MEMFLAGS F>
 class ConcurrentHashTable : public CHeapObj<F> {
   typedef typename CONFIG::Value VALUE;
  private:
+  // _stats_rate is null if statistics are not enabled.
+  TableRateStatistics* _stats_rate;
+  void safe_stats_add() {
+    if(_stats_rate != nullptr) {
+      _stats_rate->add();
+    }
+  }
+  void safe_stats_remove() {
+    if(_stats_rate != nullptr) {
+      _stats_rate->remove();
+    }
+  }
+  // Calculate statistics. Item sizes are calculated with VALUE_SIZE_FUNC.
+  template <typename VALUE_SIZE_FUNC>
+  TableStatistics statistics_calculate(Thread* thread, VALUE_SIZE_FUNC& vs_f);
+
   // This is the internal node structure.
   // Only constructed with placement new from memory allocated with MEMFLAGS of
   // the InternalTable or user-defined memory.
@@ -379,14 +395,13 @@ class ConcurrentHashTable : public CHeapObj<F> {
   ConcurrentHashTable(size_t log2size = DEFAULT_START_SIZE_LOG2,
                       size_t log2size_limit = DEFAULT_MAX_SIZE_LOG2,
                       size_t grow_hint = DEFAULT_GROW_HINT,
-                      void* context = NULL);
+                      void* context = NULL,
+                      bool enable_statistics = true);
 
   explicit ConcurrentHashTable(void* context, size_t log2size = DEFAULT_START_SIZE_LOG2) :
     ConcurrentHashTable(log2size, DEFAULT_MAX_SIZE_LOG2, DEFAULT_GROW_HINT, context) {}
 
   ~ConcurrentHashTable();
-
-  TableRateStatistics _stats_rate;
 
   size_t get_mem_size(Thread* thread);
 
@@ -481,10 +496,6 @@ class ConcurrentHashTable : public CHeapObj<F> {
   // DELETE_FUNC is called, when the resize lock is successfully obtained.
   template <typename EVALUATE_FUNC, typename DELETE_FUNC>
   void bulk_delete(Thread* thread, EVALUATE_FUNC& eval_f, DELETE_FUNC& del_f);
-
-  // Calculate statistics. Item sizes are calculated with VALUE_SIZE_FUNC.
-  template <typename VALUE_SIZE_FUNC>
-  TableStatistics statistics_calculate(Thread* thread, VALUE_SIZE_FUNC& vs_f);
 
   // Gets statistics if available, if not return old one. Item sizes are calculated with
   // VALUE_SIZE_FUNC.

--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -44,12 +44,12 @@ class ConcurrentHashTable : public CHeapObj<F> {
  private:
   // _stats_rate is null if statistics are not enabled.
   TableRateStatistics* _stats_rate;
-  void safe_stats_add() {
+  inline void safe_stats_add() {
     if (_stats_rate != nullptr) {
       _stats_rate->add();
     }
   }
-  void safe_stats_remove() {
+  inline void safe_stats_remove() {
     if (_stats_rate != nullptr) {
       _stats_rate->remove();
     }

--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -43,7 +43,7 @@ class ConcurrentHashTable : public CHeapObj<F> {
   typedef typename CONFIG::Value VALUE;
  private:
   // _stats_rate is null if statistics are not enabled.
-  TableRateStatistics* _stats_rate;
+  TableRateStatistics* _stats_rate  = nullptr;
   void safe_stats_add() {
     if (_stats_rate != nullptr) {
       _stats_rate->add();
@@ -396,7 +396,7 @@ class ConcurrentHashTable : public CHeapObj<F> {
                       size_t log2size_limit = DEFAULT_MAX_SIZE_LOG2,
                       size_t grow_hint = DEFAULT_GROW_HINT,
                       void* context = nullptr,
-                      /*bool enable_statistics = DEFAULT_ENABLE_STATISTICS*/);
+                      bool enable_statistics = DEFAULT_ENABLE_STATISTICS);
 
   explicit ConcurrentHashTable(void* context, size_t log2size = DEFAULT_START_SIZE_LOG2, bool enable_statistics = DEFAULT_ENABLE_STATISTICS) :
     ConcurrentHashTable(log2size, DEFAULT_MAX_SIZE_LOG2, DEFAULT_GROW_HINT, context, enable_statistics) {}

--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -391,7 +391,7 @@ class ConcurrentHashTable : public CHeapObj<F> {
   static const size_t DEFAULT_MAX_SIZE_LOG2 = 21;
   static const size_t DEFAULT_START_SIZE_LOG2 = 13;
   static const size_t DEFAULT_GROW_HINT = 4; // Chain length
-  static const bool DEFAULT_ENABLE_STATISTICS = true;
+  static const bool DEFAULT_ENABLE_STATISTICS = false;
   ConcurrentHashTable(size_t log2size = DEFAULT_START_SIZE_LOG2,
                       size_t log2size_limit = DEFAULT_MAX_SIZE_LOG2,
                       size_t grow_hint = DEFAULT_GROW_HINT,

--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -45,12 +45,12 @@ class ConcurrentHashTable : public CHeapObj<F> {
   // _stats_rate is null if statistics are not enabled.
   TableRateStatistics* _stats_rate;
   void safe_stats_add() {
-    if(_stats_rate != nullptr) {
+    if (_stats_rate != nullptr) {
       _stats_rate->add();
     }
   }
   void safe_stats_remove() {
-    if(_stats_rate != nullptr) {
+    if (_stats_rate != nullptr) {
       _stats_rate->remove();
     }
   }
@@ -396,7 +396,7 @@ class ConcurrentHashTable : public CHeapObj<F> {
                       size_t log2size_limit = DEFAULT_MAX_SIZE_LOG2,
                       size_t grow_hint = DEFAULT_GROW_HINT,
                       void* context = nullptr,
-                      bool enable_statistics = DEFAULT_ENABLE_STATISTICS);
+                      /*bool enable_statistics = DEFAULT_ENABLE_STATISTICS*/);
 
   explicit ConcurrentHashTable(void* context, size_t log2size = DEFAULT_START_SIZE_LOG2, bool enable_statistics = DEFAULT_ENABLE_STATISTICS) :
     ConcurrentHashTable(log2size, DEFAULT_MAX_SIZE_LOG2, DEFAULT_GROW_HINT, context, enable_statistics) {}

--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -225,11 +225,6 @@ class ConcurrentHashTable : public CHeapObj<F> {
   InternalTable* _table;      // Active table.
   InternalTable* _new_table;  // Table we are resizing to.
 
-  // Default sizes
-  static const size_t DEFAULT_MAX_SIZE_LOG2 = 21;
-  static const size_t DEFAULT_START_SIZE_LOG2 = 13;
-  static const size_t DEFAULT_GROW_HINT = 4; // Chain length
-
   const size_t _log2_size_limit;  // The biggest size.
   const size_t _log2_start_size;  // Start size.
   const size_t _grow_hint;        // Number of linked items
@@ -392,14 +387,19 @@ class ConcurrentHashTable : public CHeapObj<F> {
   void delete_in_bucket(Thread* thread, Bucket* bucket, LOOKUP_FUNC& lookup_f);
 
  public:
+  // Default sizes
+  static const size_t DEFAULT_MAX_SIZE_LOG2 = 21;
+  static const size_t DEFAULT_START_SIZE_LOG2 = 13;
+  static const size_t DEFAULT_GROW_HINT = 4; // Chain length
+  static const bool DEFAULT_ENABLE_STATISTICS = true;
   ConcurrentHashTable(size_t log2size = DEFAULT_START_SIZE_LOG2,
                       size_t log2size_limit = DEFAULT_MAX_SIZE_LOG2,
                       size_t grow_hint = DEFAULT_GROW_HINT,
-                      void* context = NULL,
-                      bool enable_statistics = true);
+                      void* context = nullptr,
+                      bool enable_statistics = DEFAULT_ENABLE_STATISTICS);
 
-  explicit ConcurrentHashTable(void* context, size_t log2size = DEFAULT_START_SIZE_LOG2) :
-    ConcurrentHashTable(log2size, DEFAULT_MAX_SIZE_LOG2, DEFAULT_GROW_HINT, context) {}
+  explicit ConcurrentHashTable(void* context, size_t log2size = DEFAULT_START_SIZE_LOG2, bool enable_statistics = DEFAULT_ENABLE_STATISTICS) :
+    ConcurrentHashTable(log2size, DEFAULT_MAX_SIZE_LOG2, DEFAULT_GROW_HINT, context, enable_statistics) {}
 
   ~ConcurrentHashTable();
 

--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -43,7 +43,7 @@ class ConcurrentHashTable : public CHeapObj<F> {
   typedef typename CONFIG::Value VALUE;
  private:
   // _stats_rate is null if statistics are not enabled.
-  TableRateStatistics* _stats_rate  = nullptr;
+  TableRateStatistics* _stats_rate;
   void safe_stats_add() {
     if (_stats_rate != nullptr) {
       _stats_rate->add();
@@ -395,11 +395,11 @@ class ConcurrentHashTable : public CHeapObj<F> {
   ConcurrentHashTable(size_t log2size = DEFAULT_START_SIZE_LOG2,
                       size_t log2size_limit = DEFAULT_MAX_SIZE_LOG2,
                       size_t grow_hint = DEFAULT_GROW_HINT,
-                      void* context = nullptr,
-                      bool enable_statistics = DEFAULT_ENABLE_STATISTICS);
+                      bool enable_statistics = DEFAULT_ENABLE_STATISTICS,
+                      void* context = nullptr);
 
   explicit ConcurrentHashTable(void* context, size_t log2size = DEFAULT_START_SIZE_LOG2, bool enable_statistics = DEFAULT_ENABLE_STATISTICS) :
-    ConcurrentHashTable(log2size, DEFAULT_MAX_SIZE_LOG2, DEFAULT_GROW_HINT, context, enable_statistics) {}
+    ConcurrentHashTable(log2size, DEFAULT_MAX_SIZE_LOG2, DEFAULT_GROW_HINT, enable_statistics, context) {}
 
   ~ConcurrentHashTable();
 

--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -1007,7 +1007,7 @@ inline size_t ConcurrentHashTable<CONFIG, F>::
 // Constructor
 template <typename CONFIG, MEMFLAGS F>
 inline ConcurrentHashTable<CONFIG, F>::
-ConcurrentHashTable(size_t log2size, size_t log2size_limit, size_t grow_hint, void* context, bool enable_statistics)
+ConcurrentHashTable(size_t log2size, size_t log2size_limit, size_t grow_hint, bool enable_statistics, void* context)
     : _context(context), _new_table(NULL), _log2_size_limit(log2size_limit),
       _log2_start_size(log2size), _grow_hint(grow_hint),
       _size_limit_reached(false), _resize_lock_owner(NULL),
@@ -1015,6 +1015,8 @@ ConcurrentHashTable(size_t log2size, size_t log2size_limit, size_t grow_hint, vo
 {
   if (enable_statistics) {
     _stats_rate = new TableRateStatistics();
+  } else {
+    _stats_rate = nullptr;
   }
   _resize_lock =
     new Mutex(Mutex::nosafepoint-2, "ConcurrentHashTableResize_lock");

--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -472,7 +472,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   GlobalCounter::write_synchronize();
   delete_f(rem_n->value());
   Node::destroy_node(_context, rem_n);
-  JFR_ONLY(_stats_rate.remove();)
+  JFR_ONLY(safe_stats_remove();)
   return true;
 }
 
@@ -521,7 +521,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
     for (size_t node_it = 0; node_it < nd; node_it++) {
       del_f(ndel[node_it]->value());
       Node::destroy_node(_context, ndel[node_it]);
-      JFR_ONLY(_stats_rate.remove();)
+      JFR_ONLY(safe_stats_remove();)
       DEBUG_ONLY(ndel[node_it] = (Node*)POISON_PTR;)
     }
     cs_context = GlobalCounter::critical_section_begin(thread);
@@ -560,7 +560,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
     GlobalCounter::write_synchronize();
     for (size_t node_it = 0; node_it < dels; node_it++) {
       Node::destroy_node(_context, ndel[node_it]);
-      JFR_ONLY(_stats_rate.remove();)
+      JFR_ONLY(safe_stats_remove();)
       DEBUG_ONLY(ndel[node_it] = (Node*)POISON_PTR;)
     }
   }
@@ -902,7 +902,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
         new_node->set_next(first_at_start);
         if (bucket->cas_first(new_node, first_at_start)) {
           foundf(new_node->value());
-          JFR_ONLY(_stats_rate.add();)
+          JFR_ONLY(safe_stats_add();)
           new_node = NULL;
           ret = true;
           break; /* leave critical section */
@@ -1007,13 +1007,15 @@ inline size_t ConcurrentHashTable<CONFIG, F>::
 // Constructor
 template <typename CONFIG, MEMFLAGS F>
 inline ConcurrentHashTable<CONFIG, F>::
-  ConcurrentHashTable(size_t log2size, size_t log2size_limit, size_t grow_hint, void* context)
+ConcurrentHashTable(size_t log2size, size_t log2size_limit, size_t grow_hint, void* context, bool enable_statistics)
     : _context(context), _new_table(NULL), _log2_size_limit(log2size_limit),
       _log2_start_size(log2size), _grow_hint(grow_hint),
       _size_limit_reached(false), _resize_lock_owner(NULL),
       _invisible_epoch(0)
 {
-  _stats_rate = TableRateStatistics();
+  if (enable_statistics) {
+    _stats_rate = new TableRateStatistics();
+  }
   _resize_lock =
     new Mutex(Mutex::nosafepoint-2, "ConcurrentHashTableResize_lock");
   _table = new InternalTable(log2size);
@@ -1102,7 +1104,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   if (!bucket->cas_first(new_node, bucket->first())) {
     assert(false, "bad");
   }
-  JFR_ONLY(_stats_rate.add();)
+  JFR_ONLY(safe_stats_add();)
   return true;
 }
 
@@ -1224,7 +1226,7 @@ inline TableStatistics ConcurrentHashTable<CONFIG, F>::
     summary.add((double)count);
   }
 
-  return TableStatistics(_stats_rate, summary, literal_bytes, sizeof(Bucket), sizeof(Node));
+  return TableStatistics(*_stats_rate, summary, literal_bytes, sizeof(Bucket), sizeof(Node));
 }
 
 template <typename CONFIG, MEMFLAGS F>

--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -1030,6 +1030,7 @@ inline ConcurrentHashTable<CONFIG, F>::
   delete _resize_lock;
   free_nodes();
   delete _table;
+  delete _stats_rate;
 }
 
 template <typename CONFIG, MEMFLAGS F>

--- a/src/hotspot/share/utilities/tableStatistics.hpp
+++ b/src/hotspot/share/utilities/tableStatistics.hpp
@@ -30,7 +30,7 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/numberSeq.hpp"
 
-class TableRateStatistics : CHeapObj<mtStatistics> {
+class TableRateStatistics : public CHeapObj<mtStatistics> {
 
   friend class TableStatistics;
 


### PR DESCRIPTION
Right now the footprint of disabling statistics for tables where they're not used is minimal as they're single instance and static. We're working on using CHT in more contexts, where it will be dynamically allocated, and then these changes will add up to something more substantial.

Passes tier1+tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292446](https://bugs.openjdk.org/browse/JDK-8292446): Make TableRateStatistics optional in CHT


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9899/head:pull/9899` \
`$ git checkout pull/9899`

Update a local copy of the PR: \
`$ git checkout pull/9899` \
`$ git pull https://git.openjdk.org/jdk pull/9899/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9899`

View PR using the GUI difftool: \
`$ git pr show -t 9899`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9899.diff">https://git.openjdk.org/jdk/pull/9899.diff</a>

</details>
