### PR TITLE
7175396: The text on label is not painted red for Nimbus LaF.

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLabelUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLabelUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLabelUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLabelUI.java
@@ -47,8 +47,6 @@ import java.beans.PropertyChangeEvent;
  */
 public class SynthLabelUI extends BasicLabelUI implements SynthUI {
     private SynthStyle style;
-    private Color fgColor;
-
     /**
      *
      * Constructs a {@code SynthLabelUI}.
@@ -71,12 +69,16 @@ public class SynthLabelUI extends BasicLabelUI implements SynthUI {
     @Override
     protected void installDefaults(JLabel c) {
         updateStyle(c);
-        fgColor =  UIManager.getColor("Label.foreground");
+        Color fg = c.getForeground();
+        if (fg == null || fg instanceof UIResource) {
+            c.setForeground(UIManager.getColor("Label.foreground"));
+        }
     }
 
     void updateStyle(JLabel c) {
         SynthContext context = getContext(c, ENABLED);
         style = SynthLookAndFeel.updateStyle(context, this);
+
     }
 
     /**
@@ -88,6 +90,10 @@ public class SynthLabelUI extends BasicLabelUI implements SynthUI {
 
         style.uninstallDefaults(context);
         style = null;
+        Color fg = c.getForeground();
+        if (fg instanceof UIResource) {
+            c.setForeground(null);
+        }
     }
 
     /**
@@ -217,9 +223,6 @@ public class SynthLabelUI extends BasicLabelUI implements SynthUI {
         } else {
             g.setColor(context.getStyle().getColor(context,
                     ColorType.TEXT_FOREGROUND));
-            if (fgColor != null) {
-                label.setForeground(fgColor);
-            }
         }
 
         g.setFont(style.getFont(context));

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLabelUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLabelUI.java
@@ -35,6 +35,7 @@ import java.awt.Rectangle;
 import java.awt.Insets;
 import java.awt.Graphics;
 import java.awt.FontMetrics;
+import java.awt.Color;
 import java.beans.PropertyChangeEvent;
 
 /**
@@ -214,6 +215,10 @@ public class SynthLabelUI extends BasicLabelUI implements SynthUI {
         } else {
             g.setColor(context.getStyle().getColor(context,
                     ColorType.TEXT_FOREGROUND));
+            Color col = UIManager.getColor("Label.foreground");
+            if (col != null) {
+                label.setForeground(col);
+            }
         }
 
         g.setFont(style.getFont(context));

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLabelUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLabelUI.java
@@ -30,12 +30,12 @@ import javax.swing.plaf.*;
 import javax.swing.plaf.basic.*;
 import javax.swing.text.View;
 import javax.swing.tree.DefaultTreeCellRenderer;
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Rectangle;
 import java.awt.Insets;
 import java.awt.Graphics;
 import java.awt.FontMetrics;
-import java.awt.Color;
 import java.beans.PropertyChangeEvent;
 
 /**
@@ -47,6 +47,7 @@ import java.beans.PropertyChangeEvent;
  */
 public class SynthLabelUI extends BasicLabelUI implements SynthUI {
     private SynthStyle style;
+    private Color fgColor;
 
     /**
      *
@@ -70,6 +71,7 @@ public class SynthLabelUI extends BasicLabelUI implements SynthUI {
     @Override
     protected void installDefaults(JLabel c) {
         updateStyle(c);
+        fgColor =  UIManager.getColor("Label.foreground");
     }
 
     void updateStyle(JLabel c) {
@@ -215,9 +217,8 @@ public class SynthLabelUI extends BasicLabelUI implements SynthUI {
         } else {
             g.setColor(context.getStyle().getColor(context,
                     ColorType.TEXT_FOREGROUND));
-            Color col = UIManager.getColor("Label.foreground");
-            if (col != null) {
-                label.setForeground(col);
+            if (fgColor != null) {
+                label.setForeground(fgColor);
             }
         }
 

--- a/test/jdk/javax/swing/plaf/nimbus/TestNimbusLabel.java
+++ b/test/jdk/javax/swing/plaf/nimbus/TestNimbusLabel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,10 +71,10 @@ public class TestNimbusLabel
 
             SwingUtilities.invokeAndWait(() -> {
                 frame = new JFrame();
-                UIManager.getDefaults().put("Label.foreground", 
-				             java.awt.Color.red);
-                label = 
-		    new JLabel("<html><body>Can You Read This?</body></html>");
+                UIManager.getDefaults().put("Label.foreground",
+                                            java.awt.Color.red);
+                label =
+                    new JLabel("<html><body>Can You Read This?</body></html>");
 
                 frame.getContentPane().add(label);
                 frame.setUndecorated(true);
@@ -87,13 +87,13 @@ public class TestNimbusLabel
 
             Point p = frame.getLocationOnScreen();
             Dimension d = frame.getSize();
-            System.out.println("width " + d.getWidth() + 
-			        " height " + d.getHeight());
+            System.out.println("width " + d.getWidth() +
+                                " height " + d.getHeight());
             int y = p.y + d.height/2;
 
             for (int x = p.x; x < p.x + d.width; x++) {
                     System.out.println("color(" + x + "," + y + ")=" +
-				    robot.getPixelColor(x, y));
+                                        robot.getPixelColor(x, y));
                     Color color = robot.getPixelColor(x, y);
                     if (checkPixel(color)) {
                         passed = true;
@@ -108,12 +108,12 @@ public class TestNimbusLabel
                 ImageIO.write(img, "png", new File("label.png"));
                 throw new RuntimeException("Label.foreground color not honoured");
             }
-	} finally {
+        } finally {
             SwingUtilities.invokeAndWait(() -> {
                 if (frame != null) {
                     frame.dispose();
                 }
-            });		
-	}
+            });
+        }
     }
 }

--- a/test/jdk/javax/swing/plaf/nimbus/TestNimbusLabel.java
+++ b/test/jdk/javax/swing/plaf/nimbus/TestNimbusLabel.java
@@ -74,7 +74,7 @@ public class TestNimbusLabel
                 UIManager.getDefaults().put("Label.foreground",
                                             java.awt.Color.red);
                 label =
-                    new JLabel("<html><body>Can You Read This?</body></html>");
+                    new JLabel("<html><body>This text should be in red</body></html>");
 
                 frame.getContentPane().add(label);
                 frame.setUndecorated(true);

--- a/test/jdk/javax/swing/plaf/nimbus/TestNimbusLabel.java
+++ b/test/jdk/javax/swing/plaf/nimbus/TestNimbusLabel.java
@@ -44,7 +44,7 @@ import javax.swing.UIManager;
 public class TestNimbusLabel
 {
     private static JFrame frame;
-    private static int colorTolerance = 5;
+    private static final int colorTolerance = 5;
 
     private static boolean checkPixel(Color color) {
         int red1 = color.getRed();
@@ -53,12 +53,9 @@ public class TestNimbusLabel
         int red2 = Color.red.getRed();
         int blue2 = Color.red.getBlue();
         int green2 = Color.red.getGreen();
-        if ((Math.abs(red1 - red2) < colorTolerance) &&
+        return ((Math.abs(red1 - red2) < colorTolerance) &&
                 (Math.abs(green1 - green2) < colorTolerance) &&
-                (Math.abs(blue1 - blue2) < colorTolerance)) {
-            return true;
-        }
-        return false;
+                (Math.abs(blue1 - blue2) < colorTolerance));
     }
 
     public static void main(String[] args) throws Exception {
@@ -100,10 +97,7 @@ public class TestNimbusLabel
                 }
             }
             if (!passed) {
-                BufferedImage img =
-                    robot.createScreenCapture(new Rectangle(p.x, p.y,
-                            d.width,
-                            d.height));
+                BufferedImage img = robot.createScreenCapture(new Rectangle(p, d));
                 ImageIO.write(img, "png", new File("label.png"));
                 throw new RuntimeException("Label.foreground color not honoured");
             }

--- a/test/jdk/javax/swing/plaf/nimbus/TestNimbusLabel.java
+++ b/test/jdk/javax/swing/plaf/nimbus/TestNimbusLabel.java
@@ -43,9 +43,7 @@ import javax.swing.UIManager;
 
 public class TestNimbusLabel
 {
-    private static JLabel label;
     private static JFrame frame;
-    private static boolean passed = false;
     private static int colorTolerance = 5;
 
     private static boolean checkPixel(Color color) {
@@ -64,6 +62,7 @@ public class TestNimbusLabel
     }
 
     public static void main(String[] args) throws Exception {
+        boolean passed = false;
 
         try {
             UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
@@ -72,8 +71,8 @@ public class TestNimbusLabel
             SwingUtilities.invokeAndWait(() -> {
                 frame = new JFrame();
                 UIManager.getDefaults().put("Label.foreground",
-                                            java.awt.Color.red);
-                label =
+                                            Color.RED);
+                JLabel label =
                     new JLabel("<html><body>This text should be in red</body></html>");
 
                 frame.getContentPane().add(label);
@@ -92,13 +91,13 @@ public class TestNimbusLabel
             int y = p.y + d.height/2;
 
             for (int x = p.x; x < p.x + d.width; x++) {
-                    System.out.println("color(" + x + "," + y + ")=" +
-                                        robot.getPixelColor(x, y));
-                    Color color = robot.getPixelColor(x, y);
-                    if (checkPixel(color)) {
-                        passed = true;
-                        break;
-                    }
+                Color color = robot.getPixelColor(x, y);
+                System.out.println("color(" + x + "," + y + ")=" +
+                                    color);
+                if (checkPixel(color)) {
+                    passed = true;
+                    break;
+                }
             }
             if (!passed) {
                 BufferedImage img =

--- a/test/jdk/javax/swing/plaf/nimbus/TestNimbusLabel.java
+++ b/test/jdk/javax/swing/plaf/nimbus/TestNimbusLabel.java
@@ -25,7 +25,7 @@
  * @bug 7175396
  * @key headful
  * @summary  Verifies the text on label is painted red for Nimbus LaF.
- * @run main TestNimbusLabel
+ * @run main/othervm -Dsun.java2d.uiScale=1.0 TestNimbusLabel
  */
 
 import java.io.File;
@@ -117,3 +117,4 @@ public class TestNimbusLabel
         }
     }
 }
+

--- a/test/jdk/javax/swing/plaf/nimbus/TestNimbusLabel.java
+++ b/test/jdk/javax/swing/plaf/nimbus/TestNimbusLabel.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 7175396
+ * @key headful
+ * @summary  Verifies the text on label is painted red for Nimbus LaF.
+ * @run main TestNimbusLabel
+ */
+
+import java.io.File;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class TestNimbusLabel
+{
+    private static JLabel label;
+    private static JFrame frame;
+    private static boolean passed = false;
+    private static int colorTolerance = 5;
+
+    private static boolean checkPixel(Color color) {
+        int red1 = color.getRed();
+        int blue1 = color.getBlue();
+        int green1 = color.getGreen();
+        int red2 = Color.red.getRed();
+        int blue2 = Color.red.getBlue();
+        int green2 = Color.red.getGreen();
+        if ((Math.abs(red1 - red2) < colorTolerance) &&
+                (Math.abs(green1 - green2) < colorTolerance) &&
+                (Math.abs(blue1 - blue2) < colorTolerance)) {
+            return true;
+        }
+        return false;
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        try {
+            UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
+            Robot robot = new Robot();
+
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame();
+                UIManager.getDefaults().put("Label.foreground", 
+				             java.awt.Color.red);
+                label = 
+		    new JLabel("<html><body>Can You Read This?</body></html>");
+
+                frame.getContentPane().add(label);
+                frame.setUndecorated(true);
+                frame.setLocationRelativeTo(null);
+                frame.pack();
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            Point p = frame.getLocationOnScreen();
+            Dimension d = frame.getSize();
+            System.out.println("width " + d.getWidth() + 
+			        " height " + d.getHeight());
+            int y = p.y + d.height/2;
+
+            for (int x = p.x; x < p.x + d.width; x++) {
+                    System.out.println("color(" + x + "," + y + ")=" +
+				    robot.getPixelColor(x, y));
+                    Color color = robot.getPixelColor(x, y);
+                    if (checkPixel(color)) {
+                        passed = true;
+                        break;
+                    }
+            }
+            if (!passed) {
+                BufferedImage img =
+                    robot.createScreenCapture(new Rectangle(p.x, p.y,
+                            d.width,
+                            d.height));
+                ImageIO.write(img, "png", new File("label.png"));
+                throw new RuntimeException("Label.foreground color not honoured");
+            }
+	} finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });		
+	}
+    }
+}


### PR DESCRIPTION
Label.foreground UIProperty is not honored by Nimbus L&F.
Added support for setting JLabel foreground color for Nimbus L&F

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7175396](https://bugs.openjdk.org/browse/JDK-7175396): The text on label is not painted red for Nimbus LaF.


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer) ⚠️ Review applies to [b6d0a8bd](https://git.openjdk.org/jdk/pull/9900/files/b6d0a8bd76555032a5870ba667b661c155d64b7a)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer) ⚠️ Review applies to [e6de6d08](https://git.openjdk.org/jdk/pull/9900/files/e6de6d08a03e099a1b01365da41cdcdcebe031fe)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9900/head:pull/9900` \
`$ git checkout pull/9900`

Update a local copy of the PR: \
`$ git checkout pull/9900` \
`$ git pull https://git.openjdk.org/jdk pull/9900/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9900`

View PR using the GUI difftool: \
`$ git pr show -t 9900`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9900.diff">https://git.openjdk.org/jdk/pull/9900.diff</a>

</details>
