### PR TITLE
8292376: A few Swing methods use inheritDoc on exceptions which are not inherited

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JSpinner.java
+++ b/src/java.desktop/share/classes/javax/swing/JSpinner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/JSpinner.java
+++ b/src/java.desktop/share/classes/javax/swing/JSpinner.java
@@ -935,7 +935,6 @@ public class JSpinner extends JComponent implements Accessible
          * Returns an enum indicating how the baseline of the component
          * changes as the size changes.
          *
-         * @throws NullPointerException {@inheritDoc}
          * @see javax.swing.JComponent#getBaseline(int, int)
          * @since 1.6
          */

--- a/src/java.desktop/share/classes/javax/swing/border/AbstractBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/AbstractBorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/border/AbstractBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/AbstractBorder.java
@@ -181,7 +181,7 @@ public abstract class AbstractBorder implements Border, Serializable
      * @param c <code>Component</code> to return baseline resize behavior for
      * @return an enum indicating how the baseline changes as the border is
      *         resized
-     * @throws NullPointerException if passed in {@code Component} is {@code null}
+     * @throws NullPointerException if {@code Component} is {@code null}
      * @see java.awt.Component#getBaseline(int,int)
      * @see java.awt.Component#getBaselineResizeBehavior()
      * @since 1.6

--- a/src/java.desktop/share/classes/javax/swing/border/AbstractBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/AbstractBorder.java
@@ -181,6 +181,7 @@ public abstract class AbstractBorder implements Border, Serializable
      * @param c <code>Component</code> to return baseline resize behavior for
      * @return an enum indicating how the baseline changes as the border is
      *         resized
+     * @throws NullPointerException if passed in {@code Component} is {@code null}
      * @see java.awt.Component#getBaseline(int,int)
      * @see java.awt.Component#getBaselineResizeBehavior()
      * @since 1.6

--- a/src/java.desktop/share/classes/javax/swing/border/TitledBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/TitledBorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/border/TitledBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/TitledBorder.java
@@ -587,7 +587,7 @@ public class TitledBorder extends AbstractBorder
     /**
      * Returns the baseline.
      *
-     * @throws NullPointerException {@inheritDoc}
+     * @throws NullPointerException if passed in {@code Component} is {@code null}
      * @throws IllegalArgumentException {@inheritDoc}
      * @see javax.swing.JComponent#getBaseline(int, int)
      * @since 1.6

--- a/src/java.desktop/share/classes/javax/swing/border/TitledBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/TitledBorder.java
@@ -587,7 +587,7 @@ public class TitledBorder extends AbstractBorder
     /**
      * Returns the baseline.
      *
-     * @throws NullPointerException if passed in {@code Component} is {@code null}
+     * @throws NullPointerException if {@code Component} is {@code null}
      * @throws IllegalArgumentException {@inheritDoc}
      * @see javax.swing.JComponent#getBaseline(int, int)
      * @since 1.6


### PR DESCRIPTION
Document update for getBaselineResizeBehavior() and getBaseline() method description in JSpinner, AbstractBorder and TitledBorder .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8292376](https://bugs.openjdk.org/browse/JDK-8292376): A few Swing methods use inheritDoc on exceptions which are not inherited
 * [JDK-8293470](https://bugs.openjdk.org/browse/JDK-8293470): A few Swing methods use inheritDoc on exceptions which are not inherited (**CSR**)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9902/head:pull/9902` \
`$ git checkout pull/9902`

Update a local copy of the PR: \
`$ git checkout pull/9902` \
`$ git pull https://git.openjdk.org/jdk pull/9902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9902`

View PR using the GUI difftool: \
`$ git pr show -t 9902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9902.diff">https://git.openjdk.org/jdk/pull/9902.diff</a>

</details>
