### PR TITLE
8292544: G1: Remove virtual specifier for methods in G1EdenRegions and G1SurvivorRegions

### DIFF
--- a/src/hotspot/share/gc/g1/g1EdenRegions.hpp
+++ b/src/hotspot/share/gc/g1/g1EdenRegions.hpp
@@ -41,7 +41,7 @@ private:
 public:
   G1EdenRegions() : _length(0), _used_bytes(0), _regions_on_node() { }
 
-  virtual uint add(HeapRegion* hr) {
+  uint add(HeapRegion* hr) {
     assert(!hr->is_eden(), "should not already be set");
     _length++;
     return _regions_on_node.add(hr);

--- a/src/hotspot/share/gc/g1/g1SurvivorRegions.hpp
+++ b/src/hotspot/share/gc/g1/g1SurvivorRegions.hpp
@@ -41,7 +41,7 @@ private:
 public:
   G1SurvivorRegions();
 
-  virtual uint add(HeapRegion* hr);
+  uint add(HeapRegion* hr);
 
   void convert_to_eden();
 


### PR DESCRIPTION
Simple change of removing unneeded specifier.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292544](https://bugs.openjdk.org/browse/JDK-8292544): G1: Remove virtual specifier for methods in G1EdenRegions and G1SurvivorRegions


### Reviewers
 * [Leo Korinth](https://openjdk.org/census#lkorinth) (@lkorinth - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9903/head:pull/9903` \
`$ git checkout pull/9903`

Update a local copy of the PR: \
`$ git checkout pull/9903` \
`$ git pull https://git.openjdk.org/jdk pull/9903/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9903`

View PR using the GUI difftool: \
`$ git pr show -t 9903`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9903.diff">https://git.openjdk.org/jdk/pull/9903.diff</a>

</details>
