### PR TITLE
8291969: Convert LoaderConstraintsTable to ResourceHashtable

### DIFF
--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -33,6 +33,7 @@
 #include "oops/klass.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/handles.inline.hpp"
+#include "runtime/mutexLocker.hpp"
 #include "runtime/safepoint.hpp"
 #include "utilities/resourceHash.hpp"
 

--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -52,6 +52,8 @@ class LoaderConstraint : public CHeapObj<mtClass> {
     add_loader(class_loader1);
     add_loader(class_loader2);
   }
+  LoaderConstraint(const LoaderConstraint& src) = delete;
+  LoaderConstraint& operator=(const LoaderConstraint&) = delete;
 
   ~LoaderConstraint() { delete _loaders; }
 
@@ -410,8 +412,8 @@ void LoaderConstraintTable::merge_loader_constraints(Symbol* class_name,
                                                      LoaderConstraint* p2,
                                                      InstanceKlass* klass) {
 
-  // Copy into the shorter of the constraints.
-  LoaderConstraint* dest = p1->num_loaders() <= p2->num_loaders() ? p1 : p2;
+  // Copy into the longer of the constraints.
+  LoaderConstraint* dest = p1->num_loaders() <= p2->num_loaders() ? p2 : p1;
   LoaderConstraint* src = dest == p1 ? p2 : p1;
 
   for (int i = 0; i < src->num_loaders(); i++) {

--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -27,80 +27,157 @@
 #include "classfile/classLoaderDataGraph.hpp"
 #include "classfile/dictionary.hpp"
 #include "classfile/loaderConstraints.hpp"
+#include "classfile/placeholders.hpp"
 #include "logging/log.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/klass.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/safepoint.hpp"
-#include "utilities/hashtable.inline.hpp"
+#include "utilities/resourceHash.hpp"
 
-void LoaderConstraintEntry::set_loader(int i, oop p) {
-  set_loader_data(i, ClassLoaderData::class_loader_data(p));
-}
+// Implementation Classes for Loader Constraints
 
-LoaderConstraintTable::LoaderConstraintTable(int table_size)
-  : Hashtable<InstanceKlass*, mtClass>(table_size, sizeof(LoaderConstraintEntry)) {};
+class LoaderConstraint : public CHeapObj<mtClass> {
+  InstanceKlass*         _klass;
+  // Loader constraints enforce correct linking behavior.
+  // Thus, it really operates on ClassLoaderData which represents linking domain,
+  // not class loaders.
+  GrowableArray<ClassLoaderData*>*  _loaders;                // initiating loaders
+ public:
+  LoaderConstraint(InstanceKlass* klass, oop class_loader1, oop class_loader2) :
+     _klass(klass) {
+    _loaders = new (ResourceObj::C_HEAP, mtClass) GrowableArray<ClassLoaderData*>(10, mtClass);
+    set_loader(class_loader1);
+    set_loader(class_loader2);
+  }
+
+  LoaderConstraint() { delete _loaders; }
+
+  InstanceKlass* klass() const     { return _klass; }
+  void set_klass(InstanceKlass* k) { _klass = k; }
+
+  void extend_loader_constraint(Symbol* class_name, Handle loader, InstanceKlass* klass);
+
+  int num_loaders() const { return _loaders->length(); }
+  ClassLoaderData* loader_data(int i) { return _loaders->at(i); }
+  void set_loader_data(ClassLoaderData* p) { _loaders->push(p); }
+
+  void remove_loader_at(int n) {
+    assert(_loaders->at(n)->is_unloading(), "should be unloading");
+    _loaders->remove_at(n);
+  }
+
+  // convenience
+  void set_loader(oop p) {
+    _loaders->push(ClassLoaderData::class_loader_data(p));
+  }
+};
+
+class LoaderConstraintEntry : public StackObj {      // copied into hashtable as value
+ private:
+  GrowableArray<LoaderConstraint*>*  _constraints;   // loader constraints for this class name.
+ public:
+
+  LoaderConstraintEntry(LoaderConstraint* constraint) {
+    _constraints = new (ResourceObj::C_HEAP, mtClass) GrowableArray<LoaderConstraint*>(5, mtClass);
+    _constraints->push(constraint);
+  }
+
+  void clean_up() {  // No dtor, dtors are dangerous
+    delete _constraints;
+  }
+
+  int num_constraints() const { return _constraints->length(); }
+  LoaderConstraint* constraint_at(int i) const { return _constraints->at(i); }
+
+  void add_constraint(LoaderConstraint* new_constraint) {
+    _constraints->push(new_constraint);
+  }
+
+  void remove_constraint(LoaderConstraint* constraint) {
+    _constraints->remove(constraint);
+    delete constraint;
+  }
+};
 
 
-LoaderConstraintEntry* LoaderConstraintTable::new_entry(
-                                 unsigned int hash, Symbol* name,
-                                 InstanceKlass* klass, int num_loaders,
-                                 int max_loaders) {
-  LoaderConstraintEntry* entry;
-  entry = (LoaderConstraintEntry*)Hashtable<InstanceKlass*, mtClass>::new_entry(hash, klass);
-  entry->set_name(name);
-  entry->set_num_loaders(num_loaders);
-  entry->set_max_loaders(max_loaders);
-  return entry;
-}
+ResourceHashtable<Symbol*, LoaderConstraintEntry, 107, ResourceObj::C_HEAP, mtClass> _loader_constraint_table;
 
-void LoaderConstraintTable::free_entry(LoaderConstraintEntry *entry) {
-  // decrement name refcount before freeing
-  entry->name()->decrement_refcount();
-  BasicHashtable<mtClass>::free_entry(entry);
+void LoaderConstraint::extend_loader_constraint(Symbol* class_name,
+                                                Handle loader,
+                                                InstanceKlass* klass) {
+  set_loader(loader());
+  LogTarget(Info, class, loader, constraints) lt;
+  if (lt.is_enabled()) {
+    ResourceMark rm;
+    lt.print("extending constraint for name %s by adding loader: %s %s",
+               class_name->as_C_string(),
+               ClassLoaderData::class_loader_data(loader())->loader_name_and_id(),
+               _klass == NULL ? " and setting class object" : "");
+  }
+  if (_klass == NULL) {
+    set_klass(klass);
+  } else {
+    assert(klass == NULL || _klass == klass, "constraints corrupted");
+  }
 }
 
 // The loaderConstraintTable must always be accessed with the
 // SystemDictionary lock held. This is true even for readers as
 // entries in the table could be being dynamically resized.
 
-LoaderConstraintEntry** LoaderConstraintTable::find_loader_constraint(
+LoaderConstraint* LoaderConstraintTable::find_loader_constraint(
                                     Symbol* name, Handle loader) {
+
   assert_lock_strong(SystemDictionary_lock);
-  unsigned int hash = compute_hash(name);
-  int index = hash_to_index(hash);
-  LoaderConstraintEntry** pp = bucket_addr(index);
+  LoaderConstraintEntry* entry = _loader_constraint_table.get(name);
+  if (entry == nullptr) {
+    return nullptr;
+  }
+
   ClassLoaderData* loader_data = ClassLoaderData::class_loader_data(loader());
 
-  while (*pp) {
-    LoaderConstraintEntry* p = *pp;
-    if (p->hash() == hash) {
-      if (p->name() == name) {
-        for (int i = p->num_loaders() - 1; i >= 0; i--) {
-          if (p->loader_data(i) == loader_data &&
-              // skip unloaded klasses
-              (p->klass() == NULL ||
-               p->klass()->is_loader_alive())) {
-            return pp;
-          }
+  for (int i = 0; i < entry->num_constraints(); i++) {
+    LoaderConstraint* p = entry->constraint_at(i);
+    for (int i = p->num_loaders() - 1; i >= 0; i--) {
+        if (p->loader_data(i) == loader_data &&
+            // skip unloaded klasses
+            (p->klass() == nullptr ||
+             p->klass()->is_loader_alive())) {
+          return p;
         }
-      }
     }
-    pp = p->next_addr();
   }
-  return pp;
+  return nullptr;
 }
 
+// Either add it to an existing entry in the table or make a new one.
+void LoaderConstraintTable::add_loader_constraint(Symbol* name, InstanceKlass* klass, oop class_loader1, oop class_loader2) {
+  assert_lock_strong(SystemDictionary_lock);
+  LoaderConstraint* constraint = new LoaderConstraint(klass, class_loader1, class_loader2);
 
-void LoaderConstraintTable::purge_loader_constraints() {
-  assert_locked_or_safepoint(SystemDictionary_lock);
-  LogTarget(Info, class, loader, constraints) lt;
-  // Remove unloaded entries from constraint table
-  for (int index = 0; index < table_size(); index++) {
-    LoaderConstraintEntry** p = bucket_addr(index);
-    while(*p) {
-      LoaderConstraintEntry* probe = *p;
+  // The klass may be null if it hasn't been loaded yet, for instance while checking
+  // an parameter name to a method call.  We impose this constraint that the
+  // class that is eventually loaded much match between these two loaders.
+  LoaderConstraintEntry* entry = _loader_constraint_table.get(name);
+  if (entry == nullptr) {
+    LoaderConstraintEntry entry(constraint);
+    // Increment the key refcount when putting in the table.
+    name->increment_refcount();
+    _loader_constraint_table.put(name, entry);
+  } else {
+    entry->add_constraint(constraint);
+  }
+}
+
+class PurgeUnloadedConstraints : public StackObj {
+ public:
+  bool do_entry(Symbol*& name, LoaderConstraintEntry& entry) {
+    LogTarget(Info, class, loader, constraints) lt;
+    int len = entry.num_constraints();
+    for (int i = len - 1; i >= 0; i--) {
+      LoaderConstraint* probe = entry.constraint_at(i);
       InstanceKlass* klass = probe->klass();
       // Remove klass that is no longer alive
       if (klass != NULL &&
@@ -110,30 +187,24 @@ void LoaderConstraintTable::purge_loader_constraints() {
           ResourceMark rm;
           lt.print("purging class object from constraint for name %s,"
                      " loader list:",
-                     probe->name()->as_C_string());
+                     name->as_C_string());
           for (int i = 0; i < probe->num_loaders(); i++) {
             lt.print("    [%d]: %s", i,
                           probe->loader_data(i)->loader_name_and_id());
           }
         }
       }
+
       // Remove entries no longer alive from loader array
-      int n = 0;
-      while (n < probe->num_loaders()) {
+      for (int n = probe->num_loaders() - 1; n >= 0; n--) {
         if (probe->loader_data(n)->is_unloading()) {
           if (lt.is_enabled()) {
             ResourceMark rm;
             lt.print("purging loader %s from constraint for name %s",
                      probe->loader_data(n)->loader_name_and_id(),
-                     probe->name()->as_C_string()
-                     );
+                     name->as_C_string());
           }
-
-          // Compact array
-          int num = probe->num_loaders() - 1;
-          probe->set_num_loaders(num);
-          probe->set_loader_data(n, probe->loader_data(num));
-          probe->set_loader_data(num, NULL);
+          probe->remove_loader_at(n);
 
           if (lt.is_enabled()) {
             ResourceMark rm;
@@ -143,35 +214,41 @@ void LoaderConstraintTable::purge_loader_constraints() {
                             probe->loader_data(i)->loader_name_and_id());
             }
           }
-
-          continue;  // current element replaced, so restart without
-                     // incrementing n
-          }
-        n++;
+        }
       }
       // Check whether entry should be purged
       if (probe->num_loaders() < 2) {
-            if (lt.is_enabled()) {
-              ResourceMark rm;
-              lt.print("purging complete constraint for name %s",
-                         probe->name()->as_C_string());
-            }
+        if (lt.is_enabled()) {
+          ResourceMark rm;
+          lt.print("purging complete constraint for name %s",
+                   name->as_C_string());
+        }
 
-        // Purge entry
-        *p = probe->next();
-        FREE_C_HEAP_ARRAY(oop, probe->loaders());
-        free_entry(probe);
+        entry.remove_constraint(probe);
       } else {
 #ifdef ASSERT
         if (probe->klass() != NULL) {
           assert(probe->klass()->is_loader_alive(), "klass should be live");
         }
 #endif
-        // Go to next entry
-        p = probe->next_addr();
       }
     }
+    if (entry.num_constraints() == 0) {
+      // decrement name refcount before freeing
+      name->decrement_refcount();
+      entry.clean_up();
+      return true;
+    }
+    // Don't unlink this entry
+    return false;
   }
+};
+
+void LoaderConstraintTable::purge_loader_constraints() {
+  assert_locked_or_safepoint(SystemDictionary_lock);
+  // Remove unloaded entries from constraint table
+  PurgeUnloadedConstraints purge;
+  _loader_constraint_table.unlink(&purge);
 }
 
 void log_ldr_constraint_msg(Symbol* class_name, const char* reason,
@@ -207,10 +284,10 @@ bool LoaderConstraintTable::add_entry(Symbol* class_name,
   }
 
   InstanceKlass* klass = klass1 != NULL ? klass1 : klass2;
-  LoaderConstraintEntry** pp1 = find_loader_constraint(class_name, class_loader1);
-  if (*pp1 != NULL && (*pp1)->klass() != NULL) {
+  LoaderConstraint* pp1 = find_loader_constraint(class_name, class_loader1);
+  if (pp1 != NULL && pp1->klass() != NULL) {
     if (klass != NULL) {
-      if (klass != (*pp1)->klass()) {
+      if (klass != pp1->klass()) {
         log_ldr_constraint_msg(class_name,
                                "The class object presented by loader[0] does not match "
                                "the stored class object in the constraint",
@@ -218,14 +295,14 @@ bool LoaderConstraintTable::add_entry(Symbol* class_name,
         return false;
       }
     } else {
-      klass = (*pp1)->klass();
+      klass = pp1->klass();
     }
   }
 
-  LoaderConstraintEntry** pp2 = find_loader_constraint(class_name, class_loader2);
-  if (*pp2 != NULL && (*pp2)->klass() != NULL) {
+  LoaderConstraint* pp2 = find_loader_constraint(class_name, class_loader2);
+  if (pp2 != NULL && pp2->klass() != NULL) {
     if (klass != NULL) {
-      if (klass != (*pp2)->klass()) {
+      if (klass != pp2->klass()) {
         log_ldr_constraint_msg(class_name,
                                "The class object presented by loader[1] does not match "
                                "the stored class object in the constraint",
@@ -233,20 +310,13 @@ bool LoaderConstraintTable::add_entry(Symbol* class_name,
         return false;
       }
     } else {
-      klass = (*pp2)->klass();
+      klass = pp2->klass();
     }
   }
 
-  if (*pp1 == NULL && *pp2 == NULL) {
-    unsigned int hash = compute_hash(class_name);
-    int index = hash_to_index(hash);
-    LoaderConstraintEntry* p;
-    p = new_entry(hash, class_name, klass, 2, 2);
-    p->set_loaders(NEW_C_HEAP_ARRAY(ClassLoaderData*, 2, mtClass));
-    p->set_loader(0, class_loader1());
-    p->set_loader(1, class_loader2());
-    Hashtable<InstanceKlass*, mtClass>::add_entry(index, p);
+  if (pp1 == NULL && pp2 == NULL) {
 
+    add_loader_constraint(class_name, klass, class_loader1(), class_loader2());
     if (lt.is_enabled()) {
       ResourceMark rm;
       lt.print("adding new constraint for name: %s, loader[0]: %s,"
@@ -256,10 +326,10 @@ bool LoaderConstraintTable::add_entry(Symbol* class_name,
                     ClassLoaderData::class_loader_data(class_loader2())->loader_name_and_id()
                     );
     }
-  } else if (*pp1 == *pp2) {
+  } else if (pp1 == pp2) {
     /* constraint already imposed */
-    if ((*pp1)->klass() == NULL) {
-      (*pp1)->set_klass(klass);
+    if (pp1->klass() == NULL) {
+      pp1->set_klass(klass);
       if (lt.is_enabled()) {
         ResourceMark rm;
         lt.print("setting class object in existing constraint for"
@@ -269,19 +339,18 @@ bool LoaderConstraintTable::add_entry(Symbol* class_name,
                       );
       }
     } else {
-      assert((*pp1)->klass() == klass, "loader constraints corrupted");
+      assert(pp1->klass() == klass, "loader constraints corrupted");
     }
-  } else if (*pp1 == NULL) {
-    extend_loader_constraint(*pp2, class_loader1, klass);
-  } else if (*pp2 == NULL) {
-    extend_loader_constraint(*pp1, class_loader2, klass);
+  } else if (pp1 == NULL) {
+    pp2->extend_loader_constraint(class_name, class_loader1, klass);
+  } else if (pp2 == NULL) {
+    pp1->extend_loader_constraint(class_name, class_loader2, klass);
   } else {
-    merge_loader_constraints(pp1, pp2, klass);
+    merge_loader_constraints(class_name, pp1, pp2, klass);
   }
 
   return true;
 }
-
 
 // return true if the constraint was updated, false if the constraint is
 // violated
@@ -289,7 +358,7 @@ bool LoaderConstraintTable::check_or_update(InstanceKlass* k,
                                             Handle loader,
                                             Symbol* name) {
   LogTarget(Info, class, loader, constraints) lt;
-  LoaderConstraintEntry* p = *(find_loader_constraint(name, loader));
+  LoaderConstraint* p = find_loader_constraint(name, loader);
   if (p && p->klass() != NULL && p->klass() != k) {
     if (lt.is_enabled()) {
       ResourceMark rm;
@@ -316,7 +385,7 @@ bool LoaderConstraintTable::check_or_update(InstanceKlass* k,
 
 InstanceKlass* LoaderConstraintTable::find_constrained_klass(Symbol* name,
                                                        Handle loader) {
-  LoaderConstraintEntry *p = *(find_loader_constraint(name, loader));
+  LoaderConstraint *p = find_loader_constraint(name, loader);
   if (p != NULL && p->klass() != NULL) {
     assert(p->klass()->is_instance_klass(), "sanity");
     if (!p->klass()->is_loaded()) {
@@ -331,113 +400,61 @@ InstanceKlass* LoaderConstraintTable::find_constrained_klass(Symbol* name,
   return NULL;
 }
 
-void LoaderConstraintTable::ensure_loader_constraint_capacity(
-                                                     LoaderConstraintEntry *p,
-                                                    int nfree) {
-    if (p->max_loaders() - p->num_loaders() < nfree) {
-        int n = nfree + p->num_loaders();
-        ClassLoaderData** new_loaders = NEW_C_HEAP_ARRAY(ClassLoaderData*, n, mtClass);
-        memcpy(new_loaders, p->loaders(), sizeof(ClassLoaderData*) * p->num_loaders());
-        p->set_max_loaders(n);
-        FREE_C_HEAP_ARRAY(ClassLoaderData*, p->loaders());
-        p->set_loaders(new_loaders);
-    }
-}
-
-
-void LoaderConstraintTable::extend_loader_constraint(LoaderConstraintEntry* p,
-                                                     Handle loader,
+void LoaderConstraintTable::merge_loader_constraints(Symbol* class_name,
+                                                     LoaderConstraint* p1,
+                                                     LoaderConstraint* p2,
                                                      InstanceKlass* klass) {
-  ensure_loader_constraint_capacity(p, 1);
-  int num = p->num_loaders();
-  p->set_loader(num, loader());
-  p->set_num_loaders(num + 1);
-  LogTarget(Info, class, loader, constraints) lt;
-  if (lt.is_enabled()) {
-    ResourceMark rm;
-    lt.print("extending constraint for name %s by adding loader[%d]: %s %s",
-               p->name()->as_C_string(),
-               num,
-               ClassLoaderData::class_loader_data(loader())->loader_name_and_id(),
-               (p->klass() == NULL ? " and setting class object" : "")
-               );
-  }
-  if (p->klass() == NULL) {
-    p->set_klass(klass);
-  } else {
-    assert(klass == NULL || p->klass() == klass, "constraints corrupted");
-  }
-}
 
+  // Copy into the shorter of the constraints.
+  LoaderConstraint* dest = p1->num_loaders() <= p2->num_loaders() ? p1 : p2;
+  LoaderConstraint* src = dest == p1 ? p2 : p1;
 
-void LoaderConstraintTable::merge_loader_constraints(
-                                                   LoaderConstraintEntry** pp1,
-                                                   LoaderConstraintEntry** pp2,
-                                                   InstanceKlass* klass) {
-  // make sure *pp1 has higher capacity
-  if ((*pp1)->max_loaders() < (*pp2)->max_loaders()) {
-    LoaderConstraintEntry** tmp = pp2;
-    pp2 = pp1;
-    pp1 = tmp;
-  }
-
-  LoaderConstraintEntry* p1 = *pp1;
-  LoaderConstraintEntry* p2 = *pp2;
-
-  ensure_loader_constraint_capacity(p1, p2->num_loaders());
-
-  for (int i = 0; i < p2->num_loaders(); i++) {
-    int num = p1->num_loaders();
-    p1->set_loader_data(num, p2->loader_data(i));
-    p1->set_num_loaders(num + 1);
+  for (int i = 0; i < src->num_loaders(); i++) {
+    // do we care about duplicates???
+    dest->set_loader_data(src->loader_data(i));
   }
 
   LogTarget(Info, class, loader, constraints) lt;
   if (lt.is_enabled()) {
     ResourceMark rm;
-    lt.print("merged constraints for name %s, new loader list:",
-                  p1->name()->as_C_string()
-                  );
+    lt.print("merged constraints for name %s, new loader list:", class_name->as_C_string());
 
-    for (int i = 0; i < p1->num_loaders(); i++) {
-      lt.print("    [%d]: %s", i,
-                    p1->loader_data(i)->loader_name_and_id());
+    for (int i = 0; i < dest->num_loaders(); i++) {
+      lt.print("    [%d]: %s", i, dest->loader_data(i)->loader_name_and_id());
     }
-    if (p1->klass() == NULL) {
+    if (dest->klass() == NULL) {
       lt.print("... and setting class object");
     }
   }
 
-  // p1->klass() will hold NULL if klass, p2->klass(), and old
-  // p1->klass() are all NULL.  In addition, all three must have
+  // dest->klass() will hold NULL if klass, src->klass(), and old
+  // dest->klass() are all NULL.  In addition, all three must have
   // matching non-NULL values, otherwise either the constraints would
   // have been violated, or the constraints had been corrupted (and an
   // assertion would fail).
-  if (p2->klass() != NULL) {
-    assert(p2->klass() == klass, "constraints corrupted");
+  if (src->klass() != NULL) {
+    assert(src->klass() == klass, "constraints corrupted");
   }
-  if (p1->klass() == NULL) {
-    p1->set_klass(klass);
+  if (dest->klass() == NULL) {
+    dest->set_klass(klass);
   } else {
-    assert(p1->klass() == klass, "constraints corrupted");
+    assert(dest->klass() == klass, "constraints corrupted");
   }
 
-  *pp2 = p2->next();
-  FREE_C_HEAP_ARRAY(oop, p2->loaders());
-  free_entry(p2);
-  return;
+  // Remove src from entry
+  LoaderConstraintEntry* entry = _loader_constraint_table.get(class_name);
+  entry->remove_constraint(src);
 }
 
-
 void LoaderConstraintTable::verify() {
-  Thread *thread = Thread::current();
-  for (int cindex = 0; cindex < table_size(); cindex++) {
-    for (LoaderConstraintEntry* probe = bucket(cindex);
-                                probe != NULL;
-                                probe = probe->next()) {
+  auto check = [&] (Symbol*& key, LoaderConstraintEntry& entry) {
+    // foreach constraint in entry, check the klass is in the dictionary or placeholder table.
+    int len = entry.num_constraints();
+    for (int i = 0; i < len; i++) {
+      LoaderConstraint* probe = entry.constraint_at(i);
       if (probe->klass() != NULL) {
         InstanceKlass* ik = probe->klass();
-        guarantee(ik->name() == probe->name(), "name should match");
+        guarantee(ik->name() == key, "name should match");
         Symbol* name = ik->name();
         ClassLoaderData* loader_data = ik->class_loader_data();
         Dictionary* dictionary = loader_data->dictionary();
@@ -462,21 +479,33 @@ void LoaderConstraintTable::verify() {
         assert(ClassLoaderDataGraph::contains_loader_data(probe->loader_data(n)), "The loader is missing");
       }
     }
-  }
+  };
+  assert_locked_or_safepoint(SystemDictionary_lock);
+  _loader_constraint_table.iterate_all(check);
+}
+
+void LoaderConstraintTable::print_table_statistics(outputStream* st) {
+  auto size = [&] (Symbol*& key, LoaderConstraintEntry& entry) {
+    // sizeof entry is included in the size of the hashtable node
+    int sum = 0;
+    int len = entry.num_constraints();
+    for (int i = 0; i < len; i++) {
+      LoaderConstraint* probe = entry.constraint_at(i);
+      sum += sizeof(*probe) + (probe->num_loaders() * sizeof(ClassLoaderData*));
+    }
+    return sum;
+  };
+  TableStatistics ts = _loader_constraint_table.statistics_calculate(size);
+  ts.print(st, "LoaderConstraintTable");
 }
 
 // Called with the system dictionary lock held
-void LoaderConstraintTable::print_on(outputStream* st) const {
-  ResourceMark rm;
-  assert_locked_or_safepoint(SystemDictionary_lock);
-  st->print_cr("Java loader constraints (table_size=%d, constraints=%d)",
-               table_size(), number_of_entries());
-  for (int cindex = 0; cindex < table_size(); cindex++) {
-    for (LoaderConstraintEntry* probe = bucket(cindex);
-                                probe != NULL;
-                                probe = probe->next()) {
-      st->print("%4d: ", cindex);
-      st->print("Symbol: %s loaders:", probe->name()->as_C_string());
+void LoaderConstraintTable::print_on(outputStream* st) {
+  auto printer = [&] (Symbol*& key, LoaderConstraintEntry& entry) {
+    int len = entry.num_constraints();
+    for (int i = 0; i < len; i++) {
+      LoaderConstraint* probe = entry.constraint_at(i);
+      st->print("Symbol: %s loaders:", key->as_C_string());
       for (int n = 0; n < probe->num_loaders(); n++) {
         st->cr();
         st->print("    ");
@@ -484,7 +513,12 @@ void LoaderConstraintTable::print_on(outputStream* st) const {
       }
       st->cr();
     }
-  }
+  };
+  assert_locked_or_safepoint(SystemDictionary_lock);
+  ResourceMark rm;
+  st->print_cr("Java loader constraints (table_size=%d, constraints=%d)",
+               _loader_constraint_table.table_size(), _loader_constraint_table.number_of_entries());
+  _loader_constraint_table.iterate_all(printer);
 }
 
-void LoaderConstraintTable::print() const { print_on(tty); }
+void LoaderConstraintTable::print() { print_on(tty); }

--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -75,22 +75,22 @@ class LoaderConstraint : public CHeapObj<mtClass> {
   }
 };
 
-// For this class name, these are the LoaderConstraints for classes loaded with this name.
-class ClassNameEntry {                               // copied into hashtable as value
+// For this class name, these are the set of LoaderConstraints for classes loaded with this name.
+class ConstraintSet {                               // copied into hashtable as value
  private:
   GrowableArray<LoaderConstraint*>*  _constraints;   // loader constraints for this class name.
 
  public:
-  ClassNameEntry() : _constraints(nullptr) {}
-  ClassNameEntry(const ClassNameEntry&) = delete;
-  ClassNameEntry& operator=(const ClassNameEntry&) = delete;
+  ConstraintSet() : _constraints(nullptr) {}
+  ConstraintSet(const ConstraintSet&) = delete;
+  ConstraintSet& operator=(const ConstraintSet&) = delete;
 
   void initialize(LoaderConstraint* constraint) {
     _constraints = new (ResourceObj::C_HEAP, mtClass) GrowableArray<LoaderConstraint*>(5, mtClass);
     _constraints->push(constraint);
   }
 
-  ~ClassNameEntry() {
+  ~ConstraintSet() {
     delete _constraints;
   }
 
@@ -108,7 +108,7 @@ class ClassNameEntry {                               // copied into hashtable as
 };
 
 
-ResourceHashtable<Symbol*, ClassNameEntry, 107, ResourceObj::C_HEAP, mtClass> _loader_constraint_table;
+ResourceHashtable<Symbol*, ConstraintSet, 107, ResourceObj::C_HEAP, mtClass> _loader_constraint_table;
 
 void LoaderConstraint::extend_loader_constraint(Symbol* class_name,
                                                 Handle loader,
@@ -137,7 +137,7 @@ LoaderConstraint* LoaderConstraintTable::find_loader_constraint(
                                     Symbol* name, Handle loader) {
 
   assert_lock_strong(SystemDictionary_lock);
-  ClassNameEntry* entry = _loader_constraint_table.get(name);
+  ConstraintSet* entry = _loader_constraint_table.get(name);
   if (entry == nullptr) {
     return nullptr;
   }
@@ -167,7 +167,7 @@ void LoaderConstraintTable::add_loader_constraint(Symbol* name, InstanceKlass* k
   // a parameter name to a method call.  We impose this constraint that the
   // class that is eventually loaded must match between these two loaders.
   bool created;
-  ClassNameEntry* entry = _loader_constraint_table.put_if_absent(name, &created);
+  ConstraintSet* entry = _loader_constraint_table.put_if_absent(name, &created);
   if (created) {
     // Increment the key refcount when putting in the table.
     name->increment_refcount();
@@ -179,7 +179,7 @@ void LoaderConstraintTable::add_loader_constraint(Symbol* name, InstanceKlass* k
 
 class PurgeUnloadedConstraints : public StackObj {
  public:
-  bool do_entry(Symbol*& name, ClassNameEntry& entry) {
+  bool do_entry(Symbol*& name, ConstraintSet& entry) {
     LogTarget(Info, class, loader, constraints) lt;
     int len = entry.num_constraints();
     for (int i = len - 1; i >= 0; i--) {
@@ -447,12 +447,12 @@ void LoaderConstraintTable::merge_loader_constraints(Symbol* class_name,
   }
 
   // Remove src from entry
-  ClassNameEntry* entry = _loader_constraint_table.get(class_name);
+  ConstraintSet* entry = _loader_constraint_table.get(class_name);
   entry->remove_constraint(src);
 }
 
 void LoaderConstraintTable::verify() {
-  auto check = [&] (Symbol*& key, ClassNameEntry& entry) {
+  auto check = [&] (Symbol*& key, ConstraintSet& entry) {
     // foreach constraint in entry, check the klass is in the dictionary or placeholder table.
     int len = entry.num_constraints();
     for (int i = 0; i < len; i++) {
@@ -490,7 +490,7 @@ void LoaderConstraintTable::verify() {
 }
 
 void LoaderConstraintTable::print_table_statistics(outputStream* st) {
-  auto size = [&] (Symbol*& key, ClassNameEntry& entry) {
+  auto size = [&] (Symbol*& key, ConstraintSet& entry) {
     // sizeof entry is included in the size of the hashtable node
     int sum = 0;
     int len = entry.num_constraints();
@@ -506,7 +506,7 @@ void LoaderConstraintTable::print_table_statistics(outputStream* st) {
 
 // Called with the system dictionary lock held
 void LoaderConstraintTable::print_on(outputStream* st) {
-  auto printer = [&] (Symbol*& key, ClassNameEntry& entry) {
+  auto printer = [&] (Symbol*& key, ConstraintSet& entry) {
     int len = entry.num_constraints();
     for (int i = 0; i < len; i++) {
       LoaderConstraint* probe = entry.constraint_at(i);

--- a/src/hotspot/share/classfile/loaderConstraints.hpp
+++ b/src/hotspot/share/classfile/loaderConstraints.hpp
@@ -30,8 +30,6 @@
 
 class ClassLoaderData;
 class LoaderConstraint;
-class LoaderConstraintEntry;
-class PlaceholderTable;
 class Symbol;
 
 class LoaderConstraintTable : public AllStatic {

--- a/src/hotspot/share/classfile/loaderConstraints.hpp
+++ b/src/hotspot/share/classfile/loaderConstraints.hpp
@@ -25,39 +25,29 @@
 #ifndef SHARE_CLASSFILE_LOADERCONSTRAINTS_HPP
 #define SHARE_CLASSFILE_LOADERCONSTRAINTS_HPP
 
-#include "classfile/placeholders.hpp"
-#include "utilities/hashtable.hpp"
+#include "oops/oopsHierarchy.hpp"
+#include "runtime/handles.hpp"
 
 class ClassLoaderData;
+class LoaderConstraint;
 class LoaderConstraintEntry;
+class PlaceholderTable;
 class Symbol;
 
-class LoaderConstraintTable : public Hashtable<InstanceKlass*, mtClass> {
+class LoaderConstraintTable : public AllStatic {
 
 private:
-  LoaderConstraintEntry** find_loader_constraint(Symbol* name,
-                                                 Handle loader);
+  static LoaderConstraint* find_loader_constraint(Symbol* name, Handle loader);
 
+  static void add_loader_constraint(Symbol* name, InstanceKlass* klass, oop class_loader1, oop class_loader2);
+
+  static void merge_loader_constraints(Symbol* class_name, LoaderConstraint* pp1,
+                                       LoaderConstraint* pp2, InstanceKlass* klass);
 public:
 
-  LoaderConstraintTable(int table_size);
-
-  LoaderConstraintEntry* new_entry(unsigned int hash, Symbol* name,
-                                   InstanceKlass* klass, int num_loaders,
-                                   int max_loaders);
-  void free_entry(LoaderConstraintEntry *entry);
-
-  LoaderConstraintEntry* bucket(int i) const {
-    return (LoaderConstraintEntry*)Hashtable<InstanceKlass*, mtClass>::bucket(i);
-  }
-
-  LoaderConstraintEntry** bucket_addr(int i) {
-    return (LoaderConstraintEntry**)Hashtable<InstanceKlass*, mtClass>::bucket_addr(i);
-  }
-
   // Check class loader constraints
-  bool add_entry(Symbol* name, InstanceKlass* klass1, Handle loader1,
-                                    InstanceKlass* klass2, Handle loader2);
+  static bool add_entry(Symbol* name, InstanceKlass* klass1, Handle loader1,
+                        InstanceKlass* klass2, Handle loader2);
 
   // Note:  The main entry point for this module is via SystemDictionary.
   // SystemDictionary::check_signature_loaders(Symbol* signature,
@@ -65,71 +55,17 @@ public:
   //                                           Handle loader1, Handle loader2,
   //                                           bool is_method)
 
-  InstanceKlass* find_constrained_klass(Symbol* name, Handle loader);
+  static InstanceKlass* find_constrained_klass(Symbol* name, Handle loader);
 
   // Class loader constraints
+  static bool check_or_update(InstanceKlass* k, Handle loader, Symbol* name);
 
-  void ensure_loader_constraint_capacity(LoaderConstraintEntry *p, int nfree);
-  void extend_loader_constraint(LoaderConstraintEntry* p, Handle loader,
-                                InstanceKlass* klass);
-  void merge_loader_constraints(LoaderConstraintEntry** pp1,
-                                LoaderConstraintEntry** pp2, InstanceKlass* klass);
+  static void purge_loader_constraints();
 
-  bool check_or_update(InstanceKlass* k, Handle loader, Symbol* name);
-
-  void purge_loader_constraints();
-
-  void verify();
-  void print() const;
-  void print_on(outputStream* st) const;
-};
-
-class LoaderConstraintEntry : public HashtableEntry<InstanceKlass*, mtClass> {
-private:
-  Symbol*                _name;                   // class name
-  int                    _num_loaders;
-  int                    _max_loaders;
-  // Loader constraints enforce correct linking behavior.
-  // Thus, it really operates on ClassLoaderData which represents linking domain,
-  // not class loaders.
-  ClassLoaderData**              _loaders;                // initiating loaders
-
-public:
-
-  InstanceKlass* klass() { return literal(); }
-  InstanceKlass** klass_addr() { return literal_addr(); }
-  void set_klass(InstanceKlass* k) { set_literal(k); }
-
-  LoaderConstraintEntry* next() {
-    return (LoaderConstraintEntry*)HashtableEntry<InstanceKlass*, mtClass>::next();
-  }
-
-  LoaderConstraintEntry** next_addr() {
-    return (LoaderConstraintEntry**)HashtableEntry<InstanceKlass*, mtClass>::next_addr();
-  }
-  void set_next(LoaderConstraintEntry* next) {
-    HashtableEntry<InstanceKlass*, mtClass>::set_next(next);
-  }
-
-  Symbol* name() { return _name; }
-  void set_name(Symbol* name) {
-    _name = name;
-    if (name != NULL) name->increment_refcount();
-  }
-
-  int num_loaders() { return _num_loaders; }
-  void set_num_loaders(int i) { _num_loaders = i; }
-
-  int max_loaders() { return _max_loaders; }
-  void set_max_loaders(int i) { _max_loaders = i; }
-
-  ClassLoaderData** loaders() { return _loaders; }
-  void set_loaders(ClassLoaderData** loaders) { _loaders = loaders; }
-
-  ClassLoaderData* loader_data(int i) { return _loaders[i]; }
-  void set_loader_data(int i, ClassLoaderData* p) { _loaders[i] = p; }
-  // convenience
-  void set_loader(int i, oop p);
+  static void print_table_statistics(outputStream* st);
+  static void verify();
+  static void print();
+  static void print_on(outputStream* st);
 };
 
 #endif // SHARE_CLASSFILE_LOADERCONSTRAINTS_HPP

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -126,11 +126,6 @@ const int defaultProtectionDomainCacheSize = 1009;
 const int _resolution_error_size  = 107;                     // number of entries in resolution error table
 const int _invoke_method_size     = 139;                     // number of entries in invoke method table
 
-// Constraints on class loaders
-const int _loader_constraint_size = 107;                     // number of entries in constraint table
-static LoaderConstraintTable*  _loader_constraints;
-static LoaderConstraintTable* constraints() { return _loader_constraints; }
-
 // ----------------------------------------------------------------------------
 // Java-level SystemLoader and PlatformLoader
 oop SystemDictionary::java_system_loader() {
@@ -1662,7 +1657,7 @@ bool SystemDictionary::do_unloading(GCTimer* gc_timer) {
       MANAGEMENT_ONLY(FinalizerService::purge_unloaded();)
       MutexLocker ml1(is_concurrent ? SystemDictionary_lock : NULL);
       ClassLoaderDataGraph::clean_module_and_package_info();
-      constraints()->purge_loader_constraints();
+      LoaderConstraintTable::purge_loader_constraints();
       ResolutionErrorTable::purge_resolution_errors();
     }
   }
@@ -1714,7 +1709,6 @@ void SystemDictionary::methods_do(void f(Method*)) {
 
 void SystemDictionary::initialize(TRAPS) {
   // Allocate arrays
-  _loader_constraints  = new LoaderConstraintTable(_loader_constraint_size);
   _pd_cache_table = new ProtectionDomainCacheTable(defaultProtectionDomainCacheSize);
 
 #if INCLUDE_CDS
@@ -1769,12 +1763,12 @@ void SystemDictionary::check_constraints(unsigned int name_hash,
     }
 
     if (throwException == false) {
-      if (constraints()->check_or_update(k, class_loader, name) == false) {
+      if (LoaderConstraintTable::check_or_update(k, class_loader, name) == false) {
         throwException = true;
         ss.print("loader constraint violation: loader %s", loader_data->loader_name_and_id());
         ss.print(" wants to load %s %s.",
                  k->external_kind(), k->external_name());
-        Klass *existing_klass = constraints()->find_constrained_klass(name, class_loader);
+        Klass *existing_klass = LoaderConstraintTable::find_constrained_klass(name, class_loader);
         if (existing_klass != NULL && existing_klass->class_loader() != class_loader()) {
           ss.print(" A different %s with the same name was previously loaded by %s. (%s)",
                    existing_klass->external_kind(),
@@ -1845,7 +1839,7 @@ Klass* SystemDictionary::find_constrained_instance_or_array_klass(
       klass = Universe::typeArrayKlassObj(t);
     } else {
       MutexLocker mu(current, SystemDictionary_lock);
-      klass = constraints()->find_constrained_klass(ss.as_symbol(), class_loader);
+      klass = LoaderConstraintTable::find_constrained_klass(ss.as_symbol(), class_loader);
     }
     // If element class already loaded, allocate array klass
     if (klass != NULL) {
@@ -1854,7 +1848,7 @@ Klass* SystemDictionary::find_constrained_instance_or_array_klass(
   } else {
     MutexLocker mu(current, SystemDictionary_lock);
     // Non-array classes are easy: simply check the constraint table.
-    klass = constraints()->find_constrained_klass(class_name, class_loader);
+    klass = LoaderConstraintTable::find_constrained_klass(class_name, class_loader);
   }
 
   return klass;
@@ -1896,7 +1890,7 @@ bool SystemDictionary::add_loader_constraint(Symbol* class_name,
     MutexLocker mu_s(SystemDictionary_lock);
     InstanceKlass* klass1 = dictionary1->find_class(name_hash1, constraint_name);
     InstanceKlass* klass2 = dictionary2->find_class(name_hash2, constraint_name);
-    bool result = constraints()->add_entry(constraint_name, klass1, class_loader1,
+    bool result = LoaderConstraintTable::add_entry(constraint_name, klass1, class_loader1,
                                            klass2, class_loader2);
 #if INCLUDE_CDS
     if (Arguments::is_dumping_archive() && klass_being_linked != NULL &&
@@ -2482,7 +2476,7 @@ void SystemDictionary::print_on(outputStream *st) {
   st->cr();
 
   // loader constraints - print under SD_lock
-  constraints()->print_on(st);
+  LoaderConstraintTable::print_on(st);
   st->cr();
 
   _pd_cache_table->print_on(st);
@@ -2492,8 +2486,6 @@ void SystemDictionary::print_on(outputStream *st) {
 void SystemDictionary::print() { print_on(tty); }
 
 void SystemDictionary::verify() {
-  guarantee(constraints() != NULL,
-            "Verify of loader constraints failed");
 
   GCMutexLocker mu(SystemDictionary_lock);
 
@@ -2501,8 +2493,7 @@ void SystemDictionary::verify() {
   ClassLoaderDataGraph::verify_dictionary();
 
   // Verify constraint table
-  guarantee(constraints() != NULL, "Verify of loader constraints failed");
-  constraints()->verify();
+  LoaderConstraintTable::verify();
 
   _pd_cache_table->verify();
 }
@@ -2514,7 +2505,7 @@ void SystemDictionary::dump(outputStream *st, bool verbose) {
   } else {
     CDS_ONLY(SystemDictionaryShared::print_table_statistics(st));
     ClassLoaderDataGraph::print_table_statistics(st);
-    constraints()->print_table_statistics(st, "LoaderConstraints Table");
+    LoaderConstraintTable::print_table_statistics(st);
     pd_cache_table()->print_table_statistics(st, "ProtectionDomainCache Table");
   }
 }

--- a/test/hotspot/jtreg/runtime/logging/loadLibraryTest/LoadLibraryTest.java
+++ b/test/hotspot/jtreg/runtime/logging/loadLibraryTest/LoadLibraryTest.java
@@ -123,6 +123,7 @@ public class LoadLibraryTest {
             "-XX:+WhiteBoxAPI", "-Xmn8m", "-Xlog:library=info",
             "-Djava.library.path=" + System.getProperty("java.library.path"),
             "-XX:+UnlockDiagnosticVMOptions", "-XX:+WhiteBoxAPI",
+            "-Xlog:class+loader+constraints",
             "LoadLibraryTest$LoadLibrary", System.getProperty("test.classes"));
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());


### PR DESCRIPTION
This converts the LoaderConstraintTable to ResourceHashtable.  It's a bit different than the other conversions in that the LoaderConstraintEntry has to be restructured to hold all the loader constraints for that class name, since the search key is the class name.  Also, I replaced the raw arrays with GrowableArray, because it's less code.
Tested with tier1-3, and tier 4-7 previously with other changes.  I also verified code paths with some temporary asserts with existing tests, including jck tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291969](https://bugs.openjdk.org/browse/JDK-8291969): Convert LoaderConstraintsTable to ResourceHashtable


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to [684ba580](https://git.openjdk.org/jdk/pull/9904/files/684ba58028ad5082cacd4cfdb5f3fa4585731e0d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9904/head:pull/9904` \
`$ git checkout pull/9904`

Update a local copy of the PR: \
`$ git checkout pull/9904` \
`$ git pull https://git.openjdk.org/jdk pull/9904/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9904`

View PR using the GUI difftool: \
`$ git pr show -t 9904`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9904.diff">https://git.openjdk.org/jdk/pull/9904.diff</a>

</details>
