### PR TITLE
JDK-8289510 : Improve test coverage for XPath Axes: namespace

### DIFF
--- a/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathExpNamespaceTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathExpNamespaceTest.java
@@ -88,9 +88,9 @@ public class XPathExpNamespaceTest extends XPathTestBase {
             + "        <Name>name3</Name>"
             + "        <Phone>3333333333</Phone>"
             + "        <Email id=\"z\">123@xyz.com</Email>"
-            + "        <Address>"
+            + "        <Address xmlns=\"default-namespace-uri\">"
             + "            <Street>3333 333rd ave</Street>"
-            + "            <City>The City</City>"
+            + "            <City xmlns=\"redeclared-namespace-uri\">The City</City>"
             + "            <State>The State</State>"
             + "        </Address>"
             + "    </VendCustomer>"
@@ -110,7 +110,9 @@ public class XPathExpNamespaceTest extends XPathTestBase {
                 {"//Customer/Name/namespace::xml", "xml", "xml", "xmlns:xml","http://www.w3.org/XML/1998/namespace"},
                 {"/Customers/Customer/Name/namespace::xml", "xml", "xml", "xmlns:xml","http://www.w3.org/XML/1998/namespace"},
                 {"//Customer/Name/namespace::dog", "dog", "xmlns", "xmlns:dog","www.pets.com"},
-                {"/Customers/Customer/Name/namespace::dog", "dog", "xmlns", "xmlns:dog","www.pets.com"}
+                {"/Customers/Customer/Name/namespace::dog", "dog", "xmlns", "xmlns:dog","www.pets.com"},
+                {"/Customers/VendCustomer/default-namespace-uri:Address/namespace::*[name()='']", "xmlns", null, "xmlns","default-namespace-uri"},
+                {"/Customers/VendCustomer/default-namespace-uri:Address/redeclared-namespace-uri:City/namespace::*[name()='']", "xmlns", null, "xmlns","redeclared-namespace-uri"}
         };
     }
 
@@ -141,11 +143,13 @@ public class XPathExpNamespaceTest extends XPathTestBase {
                 {"/Customers/namespace::*", 2},
                 {"/Customers/Customer/namespace::*", 3},
                 {"/Customers/Customer/Address/namespace::*", 2},
+                {"/Customers/www.foo.com:Customer/www.foo.com:Address/namespace::*", 2},
+                {"/Customers/*[name()='foo:Customer']/*[name() = 'foo:Address']/namespace::*", 2},
                 {"/Customers/Customer/Address/Street/namespace::*", 4},
                 {"/Customers/Customer/Address/City/namespace::*", 2},
                 {"/Customers/VendCustomer/namespace::*", 2},
-                {"/Customers/VendCustomer/Address/namespace::*", 2},
-                {"/Customers/VendCustomer/Address/City/namespace::*", 2},
+                {"/Customers/VendCustomer/default-namespace-uri:Address/namespace::*", 3},
+                {"/Customers/VendCustomer/default-namespace-uri:Address/redeclared-namespace-uri:City/namespace::*", 3},
                 {"/Customers/Customer[@id='x1']/namespace::*", 2}
         };
     }

--- a/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathExpNamespaceTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathExpNamespaceTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package xpath;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/*
+ * @test
+ * @bug 8289510
+ * @library /javax/xml/jaxp/unittest
+ * @run testng/othervm xpath.XPathExpNamespaceTest
+ * @summary Tests for XPath namespace axis specifier.
+ */
+public class XPathExpNamespaceTest extends XPathTestBase {
+    static final String RAW_XML
+            = "<Customers xmlns:foo=\"www.foo.com\">"
+            + "    <Customer id=\"x1\">"
+            + "        <Name>name1</Name>"
+            + "        <Phone>1111111111</Phone>"
+            + "        <Email id=\"x\">123@xyz.com</Email>"
+            + "        <Address>"
+            + "            <Street xmlns:street=\"www.street.com\" xmlns:bstreet=\"www.bstreet.com\">1111 111st ave</Street>"
+            + "            <City>The City</City>"
+            + "            <State>The State</State>"
+            + "        </Address>"
+            + "    </Customer>"
+            + "    <Customer id=\"x2\" xmlns:dog=\"www.pets.com\">"
+            + "        <Name>name2</Name>"
+            + "        <Phone>2222222222</Phone>"
+            + "        <Email id=\"y\">123@xyz.com</Email>"
+            + "        <dog:Address>"
+            + "            <Street>2222 222nd ave</Street>"
+            + "            <City>The City</City>"
+            + "            <State>The State</State>"
+            + "        </dog:Address>"
+            + "    </Customer>"
+            + "    <Customer id=\"x3\">"
+            + "        <Name>name3</Name>"
+            + "        <Phone>3333333333</Phone>"
+            + "        <Email id=\"z\">123@xyz.com</Email>"
+            + "        <Address>"
+            + "            <Street>3333 333rd ave</Street>"
+            + "            <City>The City</City>"
+            + "            <State>The State</State>"
+            + "        </Address>"
+            + "    </Customer>"
+            + "    <foo:Customer foo:id=\"x1\">"
+            + "        <foo:Name>name1</foo:Name>"
+            + "        <foo:Phone>1111111111</foo:Phone>"
+            + "        <foo:Email foo:id=\"x\">123@xyz.com</foo:Email>"
+            + "        <foo:Address>"
+            + "            <foo:Street>1111 111st ave</foo:Street>"
+            + "            <foo:City>The City</foo:City>"
+            + "            <foo:State>The State</foo:State>"
+            + "        </foo:Address>"
+            + "    </foo:Customer>"
+            + "    <VendCustomer id=\"vx1\">"
+            + "        <Name>name3</Name>"
+            + "        <Phone>3333333333</Phone>"
+            + "        <Email id=\"z\">123@xyz.com</Email>"
+            + "        <Address>"
+            + "            <Street>3333 333rd ave</Street>"
+            + "            <City>The City</City>"
+            + "            <State>The State</State>"
+            + "        </Address>"
+            + "    </VendCustomer>"
+            + "</Customers>";
+
+    @DataProvider(name = "namespaceXpath")
+    public Object[][] getNamespaceXpathExpression() {
+        return new Object[][] {
+                {"/Customers/namespace::foo", "foo", "xmlns", "xmlns:foo","www.foo.com"},
+                {"/Customers/namespace::xml", "xml", "xml", "xmlns:xml", "http://www.w3.org/XML/1998/namespace"},
+                {"/Customers/Customer/Name/namespace::foo", "foo", "xmlns", "xmlns:foo","www.foo.com"},
+                {"/Customers/Customer/Name/namespace::xml", "xml", "xml", "xmlns:xml","http://www.w3.org/XML/1998/namespace"},
+                {"/Customers/Customer/Name/namespace::dog", "dog", "xmlns", "xmlns:dog","www.pets.com"}
+        };
+    }
+
+    @DataProvider(name = "namespaceXpathEmpty")
+    public Object[][] getNamespaceXpathExpressionEmpty() {
+        return new Object[][] {
+                {"/Customers/VendCustomer/Name/namespace::dog"},
+                {"/Customers/Customer/Name/namespace::cat"},
+                {"/Customers/Customer/Address/namespace::street"},
+                {"/Customers/VendCustomer/Address/namespace::street"}
+        };
+
+    }
+
+    @DataProvider(name = "namespaceXpathNodeCount")
+    public Object[][] getNamespaceXpathExpressionNodeCount() {
+        return new Object[][] {
+                {"/Customers/namespace::*", 2},
+                {"/Customers/Customer/namespace::*", 3},
+                {"/Customers/Customer/Address/namespace::*", 2},
+                {"/Customers/Customer/Address/namespace::*", 2},
+                {"/Customers/Customer/Address/Street/namespace::*", 4},
+                {"/Customers/Customer/Address/City/namespace::*", 2},
+                {"/Customers/VendCustomer/namespace::*", 2},
+                {"/Customers/VendCustomer/Address/namespace::*", 2},
+                {"/Customers/VendCustomer/Address/City/namespace::*", 2},
+                {"/Customers/Customer[@id='x1']/namespace::*", 2}
+        };
+    }
+
+    @Test(dataProvider = "namespaceXpath")
+    public void namespaceExpTests(String exp, String localName, String nsPrefix, String nsNodeName, String nsUri) throws XPathExpressionException {
+        Document doc = documentOf(DECLARATION + RAW_XML);
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        Node node = xPath.evaluateExpression(exp, doc, Node.class);
+        Assert.assertEquals(node.getLocalName(), localName);
+        Assert.assertEquals(node.getPrefix(), nsPrefix);
+        Assert.assertEquals(node.getNodeName(), nsNodeName);
+        Assert.assertEquals(node.getNodeValue(),nsUri);
+    }
+
+    @Test(dataProvider = "namespaceXpathEmpty")
+    public void NamespaceScopeTests(String exp) throws XPathExpressionException {
+        Document doc = documentOf(DECLARATION + RAW_XML);
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        Node node = xPath.evaluateExpression(exp, doc, Node.class);
+        Assert.assertNull(node);
+    }
+
+    @Test(dataProvider = "namespaceXpathNodeCount")
+    public void NamespaceNodesCountTests(String exp, int nodeCount) throws XPathExpressionException {
+        Document doc = documentOf(DECLARATION + RAW_XML);
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        NodeList nodeList = (NodeList) xPath.evaluate(exp, doc, XPathConstants.NODESET);
+        Assert.assertEquals(nodeList.getLength(), nodeCount);
+    }
+}

--- a/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathExpNamespaceTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathExpNamespaceTest.java
@@ -111,13 +111,19 @@ public class XPathExpNamespaceTest extends XPathTestBase {
                 {"/Customers/Customer/Name/namespace::xml", "xml", "xml", "xmlns:xml","http://www.w3.org/XML/1998/namespace"},
                 {"//Customer/Name/namespace::dog", "dog", "xmlns", "xmlns:dog","www.pets.com"},
                 {"/Customers/Customer/Name/namespace::dog", "dog", "xmlns", "xmlns:dog","www.pets.com"},
+                {"//www.foo.com:Customer/namespace::foo", "foo", "xmlns", "xmlns:foo", "www.foo.com"},
+                {"/Customers/*[name() = 'foo:Customer']/namespace::foo", "foo", "xmlns", "xmlns:foo", "www.foo.com"},
+                {"/Customers/*[namespace-uri() = 'www.foo.com']/namespace::foo", "foo", "xmlns", "xmlns:foo", "www.foo.com"},
+                {"/Customers/*[contains(name(.), 'foo:')]/namespace::foo", "foo", "xmlns", "xmlns:foo", "www.foo.com"},
+                {"/Customers/*[starts-with(name(.), 'foo:')]/namespace::foo", "foo", "xmlns", "xmlns:foo", "www.foo.com"},
+                {"//*[local-name()='Customer' and namespace-uri() = 'www.foo.com']/namespace::foo", "foo", "xmlns", "xmlns:foo", "www.foo.com"},
                 {"/Customers/VendCustomer/default-namespace-uri:Address/namespace::*[name()='']", "xmlns", null, "xmlns","default-namespace-uri"},
                 {"/Customers/VendCustomer/default-namespace-uri:Address/redeclared-namespace-uri:City/namespace::*[name()='']", "xmlns", null, "xmlns","redeclared-namespace-uri"}
         };
     }
 
     /*
-     * DataProvider: provides XPath namespace expressions which should provide no namespace nodes.
+     * DataProvider: provides XPath namespace expressions which should return no namespace nodes.
      */
     @DataProvider(name = "namespaceXpathEmpty")
     public Object[][] getNamespaceXpathExpressionEmpty() {
@@ -129,7 +135,10 @@ public class XPathExpNamespaceTest extends XPathTestBase {
                 {"//Customer/Address/namespace::street"},
                 {"/Customers/Customer/Address/namespace::street"},
                 {"//VendCustomer/Address/namespace::street"},
-                {"/Customers/VendCustomer/Address/namespace::street"}
+                {"/Customers/VendCustomer/Address/namespace::street"},
+                {"//@id/namespace::*"},
+                {"//@*[name() = 'foo:id']/namespace::*"},
+                {"//@*[local-name() = 'id' and namespace-uri() = 'www.foo.com']/namespace::*"}
         };
 
     }
@@ -164,7 +173,9 @@ public class XPathExpNamespaceTest extends XPathTestBase {
                 {"namespace-uri(//www.pets.com:Address)","www.pets.com" },
                 {"namespace-uri(/Customers/www.foo.com:Customer)","www.foo.com" },
                 {"namespace-uri(/Customers/Customer/www.pets.com:Address)","www.pets.com" },
-                {"namespace-uri(/Customers/VendCustomer/Email)","" }
+                {"namespace-uri(/Customers/VendCustomer/Email)","" },
+                {"namespace-uri(//@*[name() = 'id'])", ""},
+                {"namespace-uri(//@*[name() = 'foo:id'])", "www.foo.com"}
         };
     }
 


### PR DESCRIPTION
Added tests for namespace Axis. Tests incluse namspace expressions, namespace node counts and namespace node scope.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289510](https://bugs.openjdk.org/browse/JDK-8289510): Improve test coverage for XPath Axes: namespace


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)
 * @bwhuang-us (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9906/head:pull/9906` \
`$ git checkout pull/9906`

Update a local copy of the PR: \
`$ git checkout pull/9906` \
`$ git pull https://git.openjdk.org/jdk pull/9906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9906`

View PR using the GUI difftool: \
`$ git pr show -t 9906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9906.diff">https://git.openjdk.org/jdk/pull/9906.diff</a>

</details>
