### PR TITLE
8292556: Clean up unused Hashtable instantiations

### DIFF
--- a/src/hotspot/share/utilities/hashtable.cpp
+++ b/src/hotspot/share/utilities/hashtable.cpp
@@ -77,10 +77,6 @@ template <MEMFLAGS F> void BasicHashtable<F>::free_buckets() {
 // Default overload, for types that are uninteresting.
 template<typename T> static size_t literal_size(T) { return 0; }
 
-static size_t literal_size(Symbol *symbol) {
-  return symbol->size() * HeapWordSize;
-}
-
 static size_t literal_size(oop obj) {
   if (obj == NULL) {
     return 0;
@@ -258,26 +254,14 @@ template <class T> void BasicHashtable<F>::verify_table(const char* table_name) 
 #endif // PRODUCT
 
 // Explicitly instantiate these types
-template class Hashtable<nmethod*, mtGC>;
-template class HashtableEntry<nmethod*, mtGC>;
 template class BasicHashtable<mtGC>;
-template class Hashtable<ConstantPool*, mtClass>;
-template class Hashtable<Klass*, mtClass>;
+template class BasicHashtable<mtClass>;
+template class BasicHashtable<mtServiceability>;
+
+template class Hashtable<nmethod*, mtGC>;
 template class Hashtable<InstanceKlass*, mtClass>;
 template class Hashtable<WeakHandle, mtClass>;
 template class Hashtable<WeakHandle, mtServiceability>;
-template class Hashtable<Symbol*, mtModule>;
-template class Hashtable<Symbol*, mtClass>;
-template class HashtableEntry<Symbol*, mtClass>;
-template class HashtableBucket<mtClass>;
-template class BasicHashtableEntry<mtSymbol>;
-template class BasicHashtable<mtClass>;
-template class BasicHashtable<mtClassShared>;
-template class BasicHashtable<mtInternal>;
-template class BasicHashtable<mtModule>;
-template class BasicHashtable<mtCompiler>;
-template class BasicHashtable<mtServiceability>;
-template class BasicHashtable<mtLogging>;
 
 template void BasicHashtable<mtClass>::verify_table<DictionaryEntry>(char const*);
 template void BasicHashtable<mtClass>::verify_table<ProtectionDomainCacheEntry>(char const*);


### PR DESCRIPTION
These instantiations in hashtable.cpp are now unused.  Tested with tier1 on Oracle supported platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292556](https://bugs.openjdk.org/browse/JDK-8292556): Clean up unused Hashtable instantiations


### Reviewers
 * [Harold Seigel](https://openjdk.org/census#hseigel) (@hseigel - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9907/head:pull/9907` \
`$ git checkout pull/9907`

Update a local copy of the PR: \
`$ git checkout pull/9907` \
`$ git pull https://git.openjdk.org/jdk pull/9907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9907`

View PR using the GUI difftool: \
`$ git pr show -t 9907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9907.diff">https://git.openjdk.org/jdk/pull/9907.diff</a>

</details>
