### PR TITLE
8292511: AArch64: Align CPU feature name for NEON with hwcap

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -104,7 +104,7 @@ public:
 
 #define CPU_FEATURE_FLAGS(decl)               \
     decl(FP,            fp,            0)     \
-    decl(ASIMD,         simd,          1)     \
+    decl(ASIMD,         asimd,         1)     \
     decl(EVTSTRM,       evtstrm,       2)     \
     decl(AES,           aes,           3)     \
     decl(PMULL,         pmull,         4)     \

--- a/test/hotspot/jtreg/compiler/vectorapi/AllBitsSetVectorMatchRuleTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/AllBitsSetVectorMatchRuleTest.java
@@ -42,7 +42,7 @@ import jdk.test.lib.Utils;
  * @key randomness
  * @library /test/lib /
  * @requires vm.compiler2.enabled
- * @requires vm.cpu.features ~= ".*simd.*"
+ * @requires vm.cpu.features ~= ".*asimd.*"
  * @summary AArch64: [vector] Make all bits set vector sharable for match rules
  * @modules jdk.incubator.vector
  *

--- a/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransforms.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransforms.java
@@ -77,7 +77,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
     public void test_reversebytes_long_transform1(long[] lout, long[] linp) {
         VectorMask<Long> mask = VectorMask.fromLong(LSPECIES, 3);
         for (int i = 0; i < LSPECIES.loopBound(linp.length); i+=LSPECIES.length()) {
@@ -96,7 +96,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
     public void test_reversebytes_long_transform2(long[] lout, long[] linp) {
         VectorMask<Long> mask1 = VectorMask.fromLong(LSPECIES, 3);
         VectorMask<Long> mask2 = VectorMask.fromLong(LSPECIES, 3);
@@ -116,7 +116,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"simd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
     public void test_reversebytes_long_transform3(long[] lout, long[] linp) {
         for (int i = 0; i < LSPECIES.loopBound(linp.length); i+=LSPECIES.length()) {
             LongVector.fromArray(LSPECIES, linp, i)
@@ -134,7 +134,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
     public void test_reversebytes_int_transform1(int[] iout, int[] iinp) {
         VectorMask<Integer> mask = VectorMask.fromLong(ISPECIES, 3);
         for (int i = 0; i < ISPECIES.loopBound(iinp.length); i+=ISPECIES.length()) {
@@ -153,7 +153,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
     public void test_reversebytes_int_transform2(int[] iout, int[] iinp) {
         VectorMask<Integer> mask1 = VectorMask.fromLong(ISPECIES, 3);
         VectorMask<Integer> mask2 = VectorMask.fromLong(ISPECIES, 3);
@@ -173,7 +173,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"simd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
     public void test_reversebytes_int_transform3(int[] iout, int[] iinp) {
         for (int i = 0; i < ISPECIES.loopBound(iinp.length); i+=ISPECIES.length()) {
             IntVector.fromArray(ISPECIES, iinp, i)
@@ -191,7 +191,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
     public void test_reversebytes_short_transform1(short[] sout, short[] sinp) {
         VectorMask<Short> mask = VectorMask.fromLong(SSPECIES, 3);
         for (int i = 0; i < SSPECIES.loopBound(sinp.length); i+=SSPECIES.length()) {
@@ -210,7 +210,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"simd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
     public void test_reversebytes_short_transform2(short[] sout, short[] sinp) {
         VectorMask<Short> mask1 = VectorMask.fromLong(SSPECIES, 3);
         VectorMask<Short> mask2 = VectorMask.fromLong(SSPECIES, 3);
@@ -230,7 +230,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"simd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
     public void test_reversebytes_short_transform3(short[] sout, short[] sinp) {
         for (int i = 0; i < SSPECIES.loopBound(sinp.length); i+=SSPECIES.length()) {
             ShortVector.fromArray(SSPECIES, sinp, i)

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorLogicalOpIdentityTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorLogicalOpIdentityTest.java
@@ -157,7 +157,7 @@ public class VectorLogicalOpIdentityTest {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.LOAD_VECTOR, ">=1"})
-    @IR(failOn = IRNode.AND_V, applyIfCPUFeatureAnd = {"simd", "true", "sve", "false"})
+    @IR(failOn = IRNode.AND_V, applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     public static void testMaskedAndMinusOne2() {
         VectorMask<Byte> mask = VectorMask.fromArray(B_SPECIES, m, 0);
         ByteVector av = ByteVector.fromArray(B_SPECIES, ba, 0);
@@ -178,7 +178,7 @@ public class VectorLogicalOpIdentityTest {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.STORE_VECTOR, ">=1"})
-    @IR(failOn = IRNode.AND_V, applyIfCPUFeatureAnd = {"simd", "true", "sve", "false"})
+    @IR(failOn = IRNode.AND_V, applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     public static void testMaskedAndZero1() {
         VectorMask<Short> mask = VectorMask.fromArray(S_SPECIES, m, 0);
         ShortVector av = ShortVector.fromArray(S_SPECIES, sa, 0);
@@ -279,7 +279,7 @@ public class VectorLogicalOpIdentityTest {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.STORE_VECTOR, ">=1"})
-    @IR(failOn = IRNode.OR_V, applyIfCPUFeatureAnd = {"simd", "true", "sve", "false"})
+    @IR(failOn = IRNode.OR_V, applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     public static void testMaskedOrMinusOne1() {
         VectorMask<Byte> mask = VectorMask.fromArray(B_SPECIES, m, 0);
         ByteVector av = ByteVector.fromArray(B_SPECIES, ba, 0);
@@ -338,7 +338,7 @@ public class VectorLogicalOpIdentityTest {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.LOAD_VECTOR, ">=1"})
-    @IR(failOn = IRNode.OR_V, applyIfCPUFeatureAnd = {"simd", "true", "sve", "false"})
+    @IR(failOn = IRNode.OR_V, applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     public static void testMaskedOrZero2() {
         VectorMask<Byte> mask = VectorMask.fromArray(B_SPECIES, m, 0);
         ByteVector av = ByteVector.fromArray(B_SPECIES, ba, 0);
@@ -394,7 +394,7 @@ public class VectorLogicalOpIdentityTest {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.STORE_VECTOR, ">=1"})
-    @IR(failOn = IRNode.XOR_V, applyIfCPUFeatureAnd = {"simd", "true", "sve", "false"})
+    @IR(failOn = IRNode.XOR_V, applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     public static void testMaskedXorSame() {
         VectorMask<Short> mask = VectorMask.fromArray(S_SPECIES, m, 0);
         ShortVector av = ShortVector.fromArray(S_SPECIES, sa, 0);

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastNeon.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastNeon.java
@@ -35,7 +35,7 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.misc
  * @summary Test that vector cast intrinsics work as intended on neon.
- * @requires vm.cpu.features ~= ".*simd.*"
+ * @requires vm.cpu.features ~= ".*asimd.*"
  * @library /test/lib /
  * @run main compiler.vectorapi.reshape.TestVectorCastNeon
  */


### PR DESCRIPTION
AArch64 hwcap uses `asimd` to represent the CPU feature of NEON. But in
vm_version_aarch64.hpp, this name is redefined as `simd`. This renaming
looks trivial but can easily lead to bugs in test cases as more and more
people start writing jtreg IR tests today.

For example, if someone just finds CPU feature name from some documents
or `/proc/cpuinfo`, and writes below annotations in his test case, the
test case won't run on AArch64.
- `@requires vm.cpu.features ~= ".*asimd.*"`
- `@IR(applyIfCPUFeature = {"asimd", "true"}, counts = {...})`

So in this patch we propose to align the CPU feature names. Some related
jtreg cases are also updated. There's another misalignment of the names
for CPU feature `sha2`. We don't change it as we have some discussions
in https://bugs.openjdk.org/browse/JDK-8285266.

Tested tier1 and hotspot:compiler/vectorapi on x86 and AArch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292511](https://bugs.openjdk.org/browse/JDK-8292511): AArch64: Align CPU feature name for NEON with hwcap


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Ningsheng Jian](https://openjdk.org/census#njian) (@nsjian - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9913/head:pull/9913` \
`$ git checkout pull/9913`

Update a local copy of the PR: \
`$ git checkout pull/9913` \
`$ git pull https://git.openjdk.org/jdk pull/9913/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9913`

View PR using the GUI difftool: \
`$ git pr show -t 9913`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9913.diff">https://git.openjdk.org/jdk/pull/9913.diff</a>

</details>
