### PR TITLE
JDK-8292586: simplify cleanups in NTLMAuthSequence getCredentialsHandle

### DIFF
--- a/src/java.base/windows/native/libnet/NTLMAuthSequence.c
+++ b/src/java.base/windows/native/libnet/NTLMAuthSequence.c
@@ -141,7 +141,7 @@ cleanup:
     if (pDomain != NULL)
         JNU_ReleaseStringPlatformChars(env, domain, pDomain);
 
-    if (ss == 0) {
+    if (ss == SEC_E_OK) {
         return (jlong) pCred;
     } else {
         return 0;

--- a/src/java.base/windows/native/libnet/NTLMAuthSequence.c
+++ b/src/java.base/windows/native/libnet/NTLMAuthSequence.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,7 +76,7 @@ JNIEXPORT jlong JNICALL Java_sun_net_www_protocol_http_ntlm_NTLMAuthSequence_get
     CredHandle      *pCred;
     TimeStamp            ltime;
     jboolean         isCopy;
-    SECURITY_STATUS      ss;
+    SECURITY_STATUS      ss = SEC_E_INTERNAL_ERROR;
 
     if (user != 0) {
         pUser = JNU_GetStringPlatformChars(env, user, &isCopy);
@@ -86,31 +86,19 @@ JNIEXPORT jlong JNICALL Java_sun_net_www_protocol_http_ntlm_NTLMAuthSequence_get
     if (domain != 0) {
         pDomain = JNU_GetStringPlatformChars(env, domain, &isCopy);
         if (pDomain == NULL) {
-            if (pUser != NULL)
-                JNU_ReleaseStringPlatformChars(env, user, pUser);
-            return 0;  // pending Exception
+            goto cleanup;
         }
     }
     if (password != 0) {
         pPassword = JNU_GetStringPlatformChars(env, password, &isCopy);
         if (pPassword == NULL) {
-            if(pUser != NULL)
-                JNU_ReleaseStringPlatformChars(env, user, pUser);
-            if(pDomain != NULL)
-                JNU_ReleaseStringPlatformChars(env, domain, pDomain);
-            return 0;  // pending Exception
+            goto cleanup;
         }
     }
     pCred = (CredHandle *)malloc(sizeof (CredHandle));
     if (pCred == NULL) {
         JNU_ThrowOutOfMemoryError(env, "native memory allocation failed");
-        if (pUser != NULL)
-            JNU_ReleaseStringPlatformChars(env, user, pUser);
-        if (pPassword != NULL)
-            JNU_ReleaseStringPlatformChars(env, password, pPassword);
-        if (pDomain != NULL)
-            JNU_ReleaseStringPlatformChars(env, domain, pDomain);
-        return NULL;
+        goto cleanup;
     }
 
     if ( ((pUser != NULL) || (pPassword != NULL)) || (pDomain != NULL)) {
@@ -145,6 +133,7 @@ JNIEXPORT jlong JNICALL Java_sun_net_www_protocol_http_ntlm_NTLMAuthSequence_get
         );
 
     /* Release resources held by JNU_GetStringPlatformChars */
+cleanup:
     if (pUser != NULL)
         JNU_ReleaseStringPlatformChars(env, user, pUser);
     if (pPassword != NULL)


### PR DESCRIPTION
NTLMAuthSequence getCredentialsHandle has a number of cleanup paths doing various JNU_ReleaseStringPlatformChars calls; those could be placed at one place in the function.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292586](https://bugs.openjdk.org/browse/JDK-8292586): simplify cleanups in NTLMAuthSequence getCredentialsHandle


### Reviewers
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9914/head:pull/9914` \
`$ git checkout pull/9914`

Update a local copy of the PR: \
`$ git checkout pull/9914` \
`$ git pull https://git.openjdk.org/jdk pull/9914/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9914`

View PR using the GUI difftool: \
`$ git pr show -t 9914`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9914.diff">https://git.openjdk.org/jdk/pull/9914.diff</a>

</details>
