### PR TITLE
8292592: JFR test TestNative is not reliable due to low rate of sampling.

### DIFF
--- a/test/jdk/jdk/jfr/event/profiling/TestNative.java
+++ b/test/jdk/jdk/jfr/event/profiling/TestNative.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.event.profiling;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedFrame;
+import jdk.jfr.consumer.RecordingStream;
+import jdk.jfr.internal.JVM;
+import jdk.test.lib.jfr.EventNames;
+
+/*
+ * @test
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @modules jdk.jfr/jdk.jfr.internal
+ * @run main jdk.jfr.event.profiling.TestNative
+ */
+public class TestNative {
+
+    final static String NATIVE_EVENT = EventNames.NativeMethodSample;
+
+    static volatile boolean alive = true;
+
+    public static void main(String[] args) throws Exception {
+        try (RecordingStream rs = new RecordingStream()) {
+            rs.enable(NATIVE_EVENT).withPeriod(Duration.ofMillis(1));
+            rs.onEvent(NATIVE_EVENT, e -> {
+                alive = false;
+                rs.close();
+            });
+            Thread t = new Thread(TestNative::nativeMethod);
+            t.setDaemon(true);
+            t.start();
+            rs.start();
+        }
+
+    }
+
+    public static void nativeMethod() {
+        while (alive) {
+            JVM.getJVM().getPid();
+        }
+    }
+}

--- a/test/jdk/jdk/jfr/event/profiling/TestNative.java
+++ b/test/jdk/jdk/jfr/event/profiling/TestNative.java
@@ -24,12 +24,8 @@
 package jdk.jfr.event.profiling;
 
 import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import jdk.jfr.Recording;
-import jdk.jfr.consumer.RecordedFrame;
 import jdk.jfr.consumer.RecordingStream;
 import jdk.jfr.internal.JVM;
 import jdk.test.lib.jfr.EventNames;

--- a/test/jdk/jdk/jfr/event/profiling/TestSamplingLongPeriod.java
+++ b/test/jdk/jdk/jfr/event/profiling/TestSamplingLongPeriod.java
@@ -24,14 +24,8 @@
 package jdk.jfr.event.profiling;
 
 import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.atomic.AtomicInteger;
 
-import jdk.jfr.Recording;
-import jdk.jfr.consumer.RecordedFrame;
 import jdk.jfr.consumer.RecordingStream;
-import jdk.jfr.internal.JVM;
 import jdk.test.lib.jfr.EventNames;
 import jdk.test.lib.jfr.RecurseThread;
 


### PR DESCRIPTION
Split TestNative into two different test, so native sampling can have a high frequency.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292592](https://bugs.openjdk.org/browse/JDK-8292592): JFR test TestNative is not reliable due to low rate of sampling.


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**) ⚠️ Review applies to [4b19fef9](https://git.openjdk.org/jdk/pull/9915/files/4b19fef9ad4190a454fa3d1a25a64e8ab3ff1601)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [4b19fef9](https://git.openjdk.org/jdk/pull/9915/files/4b19fef9ad4190a454fa3d1a25a64e8ab3ff1601)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9915/head:pull/9915` \
`$ git checkout pull/9915`

Update a local copy of the PR: \
`$ git checkout pull/9915` \
`$ git pull https://git.openjdk.org/jdk pull/9915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9915`

View PR using the GUI difftool: \
`$ git pr show -t 9915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9915.diff">https://git.openjdk.org/jdk/pull/9915.diff</a>

</details>
