### PR TITLE
8292315: Tests should not rely on specific JAR file names (hotspot)

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/CDSStreamTestDriver.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/CDSStreamTestDriver.java
@@ -49,7 +49,6 @@ public class CDSStreamTestDriver extends DynamicArchiveTestBase {
 
     private static final String classDir = System.getProperty("test.classes");
     private static final String mainClass = "TestStreamApp";
-    private static final String javaClassPath = System.getProperty("java.class.path");
     private static final String ps = System.getProperty("path.separator");
     private static final String skippedException = "jtreg.SkippedException: Unable to map shared archive: test did not complete";
 
@@ -57,14 +56,7 @@ public class CDSStreamTestDriver extends DynamicArchiveTestBase {
         String topArchiveName = getNewArchiveName();
         String appJar = JarBuilder.build("streamapp", new File(classDir), null);
 
-        String[] classPaths = javaClassPath.split(File.pathSeparator);
-        String testngJar = null;
-        for (String path : classPaths) {
-            if (path.endsWith("testng.jar")) {
-                testngJar = path;
-                break;
-            }
-        }
+        String testngJar = Path.of(Test.class.getProtectionDomain().getCodeSource().getLocation().toURI()).toString();
 
         String[] testClassNames = { "CustomFJPoolTest" };
 


### PR DESCRIPTION
These changes improve test stability by removing a hard-coded dependency on a JAR file name.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292315](https://bugs.openjdk.org/browse/JDK-8292315): Tests should not rely on specific JAR file names (hotspot)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9916/head:pull/9916` \
`$ git checkout pull/9916`

Update a local copy of the PR: \
`$ git checkout pull/9916` \
`$ git pull https://git.openjdk.org/jdk pull/9916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9916`

View PR using the GUI difftool: \
`$ git pr show -t 9916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9916.diff">https://git.openjdk.org/jdk/pull/9916.diff</a>

</details>
