### PR TITLE
8292596: Make SymbolHashMap a ResourceHashtable

### DIFF
--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -2007,11 +2007,11 @@ jint ConstantPool::cpool_entry_size(jint idx) {
 } /* end cpool_entry_size */
 
 
-// SymbolHashMap is used to find a constant pool index from a string.
-// This function fills in SymbolHashMaps, one for utf8s and one for
+// SymbolHash is used to find a constant pool index from a string.
+// This function fills in SymbolHashs, one for utf8s and one for
 // class names, returns size of the cpool raw bytes.
-jint ConstantPool::hash_entries_to(SymbolHashMap *symmap,
-                                   SymbolHashMap *classmap) {
+jint ConstantPool::hash_entries_to(SymbolHash *symmap,
+                                   SymbolHash *classmap) {
   jint size = 0;
 
   for (u2 idx = 1; idx < length(); idx++) {
@@ -2050,7 +2050,7 @@ jint ConstantPool::hash_entries_to(SymbolHashMap *symmap,
 //   -1, in case of internal error
 //  > 0, count of the raw cpool bytes that have been copied
 int ConstantPool::copy_cpool_bytes(int cpool_size,
-                                   SymbolHashMap* tbl,
+                                   SymbolHash* tbl,
                                    unsigned char *bytes) {
   u2   idx1, idx2;
   jint size  = 0;

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -2021,7 +2021,7 @@ jint ConstantPool::hash_entries_to(SymbolHashMap *symmap,
     switch(tag) {
       case JVM_CONSTANT_Utf8: {
         Symbol* sym = symbol_at(idx);
-        symmap->add_entry(sym, idx);
+        symmap->add_if_absent(sym, idx);
         DBG(printf("adding symbol entry %s = %d\n", sym->as_utf8(), idx));
         break;
       }
@@ -2029,7 +2029,7 @@ jint ConstantPool::hash_entries_to(SymbolHashMap *symmap,
       case JVM_CONSTANT_UnresolvedClass:
       case JVM_CONSTANT_UnresolvedClassInError: {
         Symbol* sym = klass_name_at(idx);
-        classmap->add_entry(sym, idx);
+        classmap->add_if_absent(sym, idx);
         DBG(printf("adding class entry %s = %d\n", sym->as_utf8(), idx));
         break;
       }

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -2011,7 +2011,7 @@ jint ConstantPool::cpool_entry_size(jint idx) {
 // This function fills in SymbolHashMaps, one for utf8s and one for
 // class names, returns size of the cpool raw bytes.
 jint ConstantPool::hash_entries_to(SymbolHashMap *symmap,
-                                          SymbolHashMap *classmap) {
+                                   SymbolHashMap *classmap) {
   jint size = 0;
 
   for (u2 idx = 1; idx < length(); idx++) {
@@ -2050,8 +2050,8 @@ jint ConstantPool::hash_entries_to(SymbolHashMap *symmap,
 //   -1, in case of internal error
 //  > 0, count of the raw cpool bytes that have been copied
 int ConstantPool::copy_cpool_bytes(int cpool_size,
-                                          SymbolHashMap* tbl,
-                                          unsigned char *bytes) {
+                                   SymbolHashMap* tbl,
+                                   unsigned char *bytes) {
   u2   idx1, idx2;
   jint size  = 0;
   jint cnt   = length();
@@ -2426,61 +2426,5 @@ void ConstantPool::verify_on(outputStream* st) {
     // Note: pool_holder() can be NULL in temporary constant pools
     // used during constant pool merging
     guarantee(pool_holder()->is_klass(),    "should be klass");
-  }
-}
-
-
-SymbolHashMap::~SymbolHashMap() {
-  SymbolHashMapEntry* next;
-  for (int i = 0; i < _table_size; i++) {
-    for (SymbolHashMapEntry* cur = bucket(i); cur != NULL; cur = next) {
-      next = cur->next();
-      delete(cur);
-    }
-  }
-  FREE_C_HEAP_ARRAY(SymbolHashMapBucket, _buckets);
-}
-
-void SymbolHashMap::add_entry(Symbol* sym, u2 value) {
-  char *str = sym->as_utf8();
-  unsigned int hash = compute_hash(str, sym->utf8_length());
-  unsigned int index = hash % table_size();
-
-  // check if already in map
-  // we prefer the first entry since it is more likely to be what was used in
-  // the class file
-  for (SymbolHashMapEntry *en = bucket(index); en != NULL; en = en->next()) {
-    assert(en->symbol() != NULL, "SymbolHashMapEntry symbol is NULL");
-    if (en->hash() == hash && en->symbol() == sym) {
-        return;  // already there
-    }
-  }
-
-  SymbolHashMapEntry* entry = new SymbolHashMapEntry(hash, sym, value);
-  entry->set_next(bucket(index));
-  _buckets[index].set_entry(entry);
-  assert(entry->symbol() != NULL, "SymbolHashMapEntry symbol is NULL");
-}
-
-SymbolHashMapEntry* SymbolHashMap::find_entry(Symbol* sym) {
-  assert(sym != NULL, "SymbolHashMap::find_entry - symbol is NULL");
-  char *str = sym->as_utf8();
-  int   len = sym->utf8_length();
-  unsigned int hash = SymbolHashMap::compute_hash(str, len);
-  unsigned int index = hash % table_size();
-  for (SymbolHashMapEntry *en = bucket(index); en != NULL; en = en->next()) {
-    assert(en->symbol() != NULL, "SymbolHashMapEntry symbol is NULL");
-    if (en->hash() == hash && en->symbol() == sym) {
-      return en;
-    }
-  }
-  return NULL;
-}
-
-void SymbolHashMap::initialize_table(int table_size) {
-  _table_size = table_size;
-  _buckets = NEW_C_HEAP_ARRAY(SymbolHashMapBucket, table_size, mtSymbol);
-  for (int index = 0; index < table_size; index++) {
-    _buckets[index].clear();
   }
 }

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -915,9 +915,6 @@ class ConstantPool : public Metadata {
 };
 
 class SymbolHashMap: public CHeapObj<mtSymbol> {
-
- private:
-  // Default number of entries in the table
   ResourceHashtable<const Symbol*, u2, 256, ResourceObj::C_HEAP, mtSymbol, Symbol::compute_hash> _table;
 
  public:

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -918,7 +918,7 @@ class SymbolHashMap: public CHeapObj<mtSymbol> {
   ResourceHashtable<const Symbol*, u2, 256, ResourceObj::C_HEAP, mtSymbol, Symbol::compute_hash> _table;
 
  public:
-  void add_entry(const Symbol* sym, u2 value) {
+  void add_if_absent(const Symbol* sym, u2 value) {
     bool created;
     _table.put_if_absent(sym, value, &created);
   }

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
@@ -41,8 +41,8 @@ JvmtiConstantPoolReconstituter::JvmtiConstantPoolReconstituter(InstanceKlass* ik
   set_error(JVMTI_ERROR_NONE);
   _ik = ik;
   _cpool = constantPoolHandle(Thread::current(), ik->constants());
-  _symmap = new SymbolHashMap();
-  _classmap = new SymbolHashMap();
+  _symmap = new ConstantPool::SymbolHash();
+  _classmap = new ConstantPool::SymbolHash();
   _cpool_size = _cpool->hash_entries_to(_symmap, _classmap);
   if (_cpool_size == 0) {
     set_error(JVMTI_ERROR_OUT_OF_MEMORY);

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.hpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.hpp
@@ -26,13 +26,14 @@
 #define SHARE_PRIMS_JVMTICLASSFILERECONSTITUTER_HPP
 
 #include "jvmtifiles/jvmtiEnv.hpp"
+#include "oops/constantPool.hpp"
 
 
 class JvmtiConstantPoolReconstituter : public StackObj {
  private:
   int                  _cpool_size;
-  SymbolHashMap*       _symmap;
-  SymbolHashMap*       _classmap;
+  ConstantPool::SymbolHash*  _symmap;
+  ConstantPool::SymbolHash*  _classmap;
   constantPoolHandle   _cpool;
   InstanceKlass*       _ik;
   jvmtiError           _err;


### PR DESCRIPTION
Please review this straightforward change to use ResourceHashtable for SymbolHashMap, which is used by the Class File Reconstituter.  The table maps Symbol* to constant pool indices for loaded classes (Symbol refcounting unnecessary as the class is not unloaded because it's in use).
Tested with jvmti tests locally and tier 1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292596](https://bugs.openjdk.org/browse/JDK-8292596): Make SymbolHashMap a ResourceHashtable


### Reviewers
 * [Harold Seigel](https://openjdk.org/census#hseigel) (@hseigel - **Reviewer**) ⚠️ Review applies to [c0f966bb](https://git.openjdk.org/jdk/pull/9917/files/c0f966bbb5db6f1427e44f906cc89115a8b47524)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [c0f966bb](https://git.openjdk.org/jdk/pull/9917/files/c0f966bbb5db6f1427e44f906cc89115a8b47524)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9917/head:pull/9917` \
`$ git checkout pull/9917`

Update a local copy of the PR: \
`$ git checkout pull/9917` \
`$ git pull https://git.openjdk.org/jdk pull/9917/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9917`

View PR using the GUI difftool: \
`$ git pr show -t 9917`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9917.diff">https://git.openjdk.org/jdk/pull/9917.diff</a>

</details>
