### PR TITLE
JDK-8292595: jdwp utf_util getWideString might leak memory

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/utf_util.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/utf_util.c
@@ -343,6 +343,7 @@ static WCHAR* getWideString(UINT codePage, char* str, int len, int *pwlen) {
     }
     if (MultiByteToWideChar(codePage, 0, str, len, wstr, wlen) == 0) {
         UTF_ERROR(("Can't get WIDE string"));
+        free(wstr);
         return NULL;
     }
     return wstr;

--- a/src/jdk.jdwp.agent/share/native/libjdwp/utf_util.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/utf_util.c
@@ -31,15 +31,18 @@
 #include "utf_util.h"
 
 
-/* Error and assert macros */
-#define UTF_ERROR(m) utfError(__FILE__, __LINE__,  m)
+/* Error, warning and assert macros */
+#define UTF_ERROR(m) utfError(__FILE__, __LINE__, m, 1)
+#define UTF_WARNING(m) utfError(__FILE__, __LINE__, m, 0)
 #define UTF_ASSERT(x) ( (x)==0 ? UTF_ERROR("ASSERT ERROR " #x) : (void)0 )
 
 // Platform independent part
 
-static void utfError(char *file, int line, char *message) {
+static void utfError(char *file, int line, char *message, int abrt) {
     (void)fprintf(stderr, "UTF ERROR [\"%s\":%d]: %s\n", file, line, message);
-    abort();
+    if (abrt) {
+        abort();
+    }
 }
 
 /* Determine length of this Standard UTF-8 in Modified UTF-8.
@@ -333,7 +336,7 @@ static WCHAR* getWideString(UINT codePage, char* str, int len, int *pwlen) {
     wlen = MultiByteToWideChar(codePage, 0, str, len, NULL, 0);
     *pwlen = wlen;
     if (wlen <= 0) {
-        UTF_ERROR(("Can't get WIDE string length"));
+        UTF_WARNING(("Can't get WIDE string length"));
         return NULL;
     }
     wstr = (WCHAR*)malloc(wlen * sizeof(WCHAR));
@@ -342,7 +345,7 @@ static WCHAR* getWideString(UINT codePage, char* str, int len, int *pwlen) {
         return NULL;
     }
     if (MultiByteToWideChar(codePage, 0, str, len, wstr, wlen) == 0) {
-        UTF_ERROR(("Can't get WIDE string"));
+        UTF_WARNING(("Can't get WIDE string"));
         free(wstr);
         return NULL;
     }


### PR DESCRIPTION
There seems to be a case where utf_util.c getWideString might leak memory in an early return.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292595](https://bugs.openjdk.org/browse/JDK-8292595): jdwp utf_util getWideString might leak memory


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9918/head:pull/9918` \
`$ git checkout pull/9918`

Update a local copy of the PR: \
`$ git checkout pull/9918` \
`$ git pull https://git.openjdk.org/jdk pull/9918/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9918`

View PR using the GUI difftool: \
`$ git pr show -t 9918`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9918.diff">https://git.openjdk.org/jdk/pull/9918.diff</a>

</details>
