### PR TITLE
8292559: Add test for -XX:+CheckJNICalls showing changed signal handlers

### DIFF
--- a/make/test/JtregNativeHotspot.gmk
+++ b/make/test/JtregNativeHotspot.gmk
@@ -874,7 +874,7 @@ BUILD_HOTSPOT_JTREG_EXECUTABLES_LIBS_exesigtest := -ljvm
 
 ifeq ($(call isTargetOs, windows), true)
   BUILD_HOTSPOT_JTREG_EXECUTABLES_CFLAGS_exeFPRegs := -MT
-  BUILD_HOTSPOT_JTREG_EXCLUDE += exesigtest.c libterminatedThread.c libTestJNI.c libCompleteExit.c
+  BUILD_HOTSPOT_JTREG_EXCLUDE += exesigtest.c libterminatedThread.c libTestJNI.c libCompleteExit.c libTestPsig.c
   BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libatExit := jvm.lib
   BUILD_HOTSPOT_JTREG_EXECUTABLES_LIBS_exedaemonDestroy := jvm.lib
 else

--- a/test/hotspot/jtreg/runtime/posixSig/TestPosixSig.java
+++ b/test/hotspot/jtreg/runtime/posixSig/TestPosixSig.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test TestPosixSig.java
+ * @bug 8292559
+ * @summary test that -XX:+CheckJNICalss displays changed signal handlers.
+ * @requires os.family != "windows"
+ * @library /test/lib
+ * @run driver TestPosixSig
+ */
+
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class TestPosixSig {
+
+    private static native void changeSigActionFor(int val);
+
+    public static void main(String[] args) throws Throwable {
+        // Get the library path property.
+        String libpath = System.getProperty("java.library.path");
+
+        if (args.length == 0) {
+
+            // Create a new java process for the TestPsig Java/JNI test.
+            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+CheckJNICalls",
+                "-Djava.library.path=" + libpath + ":.",
+                "TestPosixSig", "dummy");
+
+            // Start the process and check the output.
+            OutputAnalyzer output = new OutputAnalyzer(pb.start());
+            String outputString = output.getOutput();
+            if (!outputString.contains("Warning: SIGILL handler modified!") ||
+                !outputString.contains("Warning: SIGFPE handler modified!")) {
+                System.out.println("output: " + outputString);
+                throw new RuntimeException("Test failed, missing signal Warning");
+            }
+            output.shouldHaveExitValue(0);
+
+        } else {
+            System.loadLibrary("TestPsig");
+            TestPosixSig.changeSigActionFor(8); // SIGFPE
+            TestPosixSig.changeSigActionFor(4); // SIGILL
+            Thread.sleep(600);
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/posixSig/libTestPsig.c
+++ b/test/hotspot/jtreg/runtime/posixSig/libTestPsig.c
@@ -28,12 +28,7 @@
 #include <errno.h>
 #include <string.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-void sig_handler(int sig, siginfo_t *info, ucontext_t *context) {
-
+static void sig_handler(int sig, siginfo_t *info, ucontext_t *context) {
     printf( " HANDLER (1) " );
 }
 
@@ -47,8 +42,3 @@ JNIEXPORT void JNICALL Java_TestPosixSig_changeSigActionFor(JNIEnv *env, jclass 
         printf("ERROR: failed to set %d signal handler error=%s\n", val, strerror(errno));
     }
 }
-
-#ifdef __cplusplus
-}
-#endif
-

--- a/test/hotspot/jtreg/runtime/posixSig/libTestPsig.c
+++ b/test/hotspot/jtreg/runtime/posixSig/libTestPsig.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdio.h>
+#include <jni.h>
+#include <signal.h>
+#include <sys/ucontext.h>
+#include <errno.h>
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void sig_handler(int sig, siginfo_t *info, ucontext_t *context) {
+
+    printf( " HANDLER (1) " );
+}
+
+JNIEXPORT void JNICALL Java_TestPosixSig_changeSigActionFor(JNIEnv *env, jclass klass, jint val) {
+    struct sigaction act;
+    act.sa_handler = (void (*)())sig_handler;
+    sigemptyset(&act.sa_mask);
+    act.sa_flags = 0;
+    int retval = sigaction(val, &act, 0);
+    if (retval != 0) {
+        printf("ERROR: failed to set %d signal handler error=%s\n", val, strerror(errno));
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+


### PR DESCRIPTION
Please review this small change to add a test that option -XX:+CheckJNICalls shows changed signal handlers.  This new test is a copy of the recently deleted TestPosixSig.java with small changes.  This version of the test only checks that handlers were changed for SIGFPE and SIGILL signals.

The test was tested using Mach5 to run it on Linux, Mac OS, and Windows.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292559](https://bugs.openjdk.org/browse/JDK-8292559): Add test for -XX:+CheckJNICalls showing changed signal handlers


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [0a2e92d5](https://git.openjdk.org/jdk/pull/9919/files/0a2e92d580083d8cbb842c1c049855e8dc9f0017)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [0a2e92d5](https://git.openjdk.org/jdk/pull/9919/files/0a2e92d580083d8cbb842c1c049855e8dc9f0017)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9919/head:pull/9919` \
`$ git checkout pull/9919`

Update a local copy of the PR: \
`$ git checkout pull/9919` \
`$ git pull https://git.openjdk.org/jdk pull/9919/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9919`

View PR using the GUI difftool: \
`$ git pr show -t 9919`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9919.diff">https://git.openjdk.org/jdk/pull/9919.diff</a>

</details>
