### PR TITLE
8292607: Remove unused dirty and dirty_card_range_after_reset in CardTable

### DIFF
--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -379,44 +379,6 @@ void CardTable::clear(MemRegion mr) {
   }
 }
 
-void CardTable::dirty(MemRegion mr) {
-  CardValue* first = byte_for(mr.start());
-  CardValue* last  = byte_after(mr.last());
-  memset(first, dirty_card, last-first);
-}
-
-MemRegion CardTable::dirty_card_range_after_reset(MemRegion mr,
-                                                  bool reset,
-                                                  int reset_val) {
-  for (int i = 0; i < _cur_covered_regions; i++) {
-    MemRegion mri = mr.intersection(_covered[i]);
-    if (!mri.is_empty()) {
-      CardValue* cur_entry, *next_entry, *limit;
-      for (cur_entry = byte_for(mri.start()), limit = byte_for(mri.last());
-           cur_entry <= limit;
-           cur_entry  = next_entry) {
-        next_entry = cur_entry + 1;
-        if (*cur_entry == dirty_card) {
-          size_t dirty_cards;
-          // Accumulate maximal dirty card range, starting at cur_entry
-          for (dirty_cards = 1;
-               next_entry <= limit && *next_entry == dirty_card;
-               dirty_cards++, next_entry++);
-          MemRegion cur_cards(addr_for(cur_entry),
-                              dirty_cards * _card_size_in_words);
-          if (reset) {
-            for (size_t i = 0; i < dirty_cards; i++) {
-              cur_entry[i] = reset_val;
-            }
-          }
-          return cur_cards;
-        }
-      }
-    }
-  }
-  return MemRegion(mr.end(), mr.end());
-}
-
 uintx CardTable::ct_max_alignment_constraint() {
   // Calculate maximum alignment using GCCardSizeInBytes as card_size hasn't been set yet
   return GCCardSizeInBytes * os::vm_page_size();

--- a/src/hotspot/share/gc/shared/cardTable.hpp
+++ b/src/hotspot/share/gc/shared/cardTable.hpp
@@ -173,7 +173,6 @@ public:
 
   virtual void invalidate(MemRegion mr);
   void clear(MemRegion mr);
-  void dirty(MemRegion mr);
 
   // Provide read-only access to the card table array.
   const CardValue* byte_for_const(const void* p) const {
@@ -219,13 +218,6 @@ public:
   // *** Card-table-RemSet-specific things.
 
   static uintx ct_max_alignment_constraint();
-
-  // Return the MemRegion corresponding to the first maximal run
-  // of dirty cards lying completely within MemRegion mr.
-  // If reset is "true", then sets those card table entries to the given
-  // value.
-  MemRegion dirty_card_range_after_reset(MemRegion mr, bool reset,
-                                         int reset_val);
 
   static uint card_shift() {
     return _card_shift;


### PR DESCRIPTION
Trivial change of removing dead code.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292607](https://bugs.openjdk.org/browse/JDK-8292607): Remove unused dirty and dirty_card_range_after_reset in CardTable


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9920/head:pull/9920` \
`$ git checkout pull/9920`

Update a local copy of the PR: \
`$ git checkout pull/9920` \
`$ git pull https://git.openjdk.org/jdk pull/9920/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9920`

View PR using the GUI difftool: \
`$ git pr show -t 9920`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9920.diff">https://git.openjdk.org/jdk/pull/9920.diff</a>

</details>
