### PR TITLE
8292606: G1 and Epsilon header cleanup for JDK-8282729

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonHeap.hpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2022, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,12 @@
 #ifndef SHARE_GC_EPSILON_EPSILONHEAP_HPP
 #define SHARE_GC_EPSILON_EPSILONHEAP_HPP
 
+#include "gc/epsilon/epsilonBarrierSet.hpp"
+#include "gc/epsilon/epsilonMonitoringSupport.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/softRefPolicy.hpp"
 #include "gc/shared/space.hpp"
-#include "gc/epsilon/epsilonMonitoringSupport.hpp"
-#include "gc/epsilon/epsilonBarrierSet.hpp"
+#include "memory/virtualspace.hpp"
 #include "services/memoryManager.hpp"
 
 class EpsilonHeap : public CollectedHeap {

--- a/src/hotspot/share/gc/g1/g1CollectionSetChooser.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetChooser.hpp
@@ -26,6 +26,7 @@
 #define SHARE_GC_G1_G1COLLECTIONSETCHOOSER_HPP
 
 #include "gc/g1/heapRegion.hpp"
+#include "gc/shared/gc_globals.hpp"
 #include "memory/allStatic.hpp"
 #include "runtime/globals.hpp"
 

--- a/src/hotspot/share/gc/g1/g1FullGCScope.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "gc/g1/g1FullGCScope.hpp"
+#include "gc/shared/gc_globals.hpp"
 
 G1FullGCJFRTracerMark::G1FullGCJFRTracerMark(STWGCTimer* timer, GCTracer* tracer)
   : G1JFRTracerMark(timer, tracer) {

--- a/src/hotspot/share/gc/g1/g1HeapRegionEventSender.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionEventSender.cpp
@@ -24,8 +24,9 @@
 
 #include "precompiled.hpp"
 #include "gc/g1/g1CollectedHeap.hpp"
+#include "gc/g1/g1HeapRegionEventSender.hpp"
 #include "gc/g1/heapRegion.hpp"
-#include "g1HeapRegionEventSender.hpp"
+#include "gc/shared/gc_globals.hpp"
 #include "jfr/jfrEvents.hpp"
 #include "runtime/vmThread.hpp"
 

--- a/src/hotspot/share/gc/g1/g1HeapSizingPolicy.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapSizingPolicy.cpp
@@ -23,9 +23,10 @@
  */
 
 #include "precompiled.hpp"
+#include "gc/g1/g1Analytics.hpp"
 #include "gc/g1/g1CollectedHeap.hpp"
 #include "gc/g1/g1HeapSizingPolicy.hpp"
-#include "gc/g1/g1Analytics.hpp"
+#include "gc/shared/gc_globals.hpp"
 #include "logging/log.hpp"
 #include "runtime/globals.hpp"
 #include "utilities/debug.hpp"

--- a/src/hotspot/share/gc/g1/g1MemoryPool.cpp
+++ b/src/hotspot/share/gc/g1/g1MemoryPool.cpp
@@ -26,6 +26,7 @@
 #include "gc/g1/g1CollectedHeap.hpp"
 #include "gc/g1/g1MemoryPool.hpp"
 #include "gc/g1/heapRegion.hpp"
+#include "gc/shared/gc_globals.hpp"
 
 G1MemoryPoolSuper::G1MemoryPoolSuper(G1CollectedHeap* g1h,
                                      const char* name,

--- a/src/hotspot/share/gc/g1/g1NUMA.cpp
+++ b/src/hotspot/share/gc/g1/g1NUMA.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "gc/g1/g1NUMA.hpp"
+#include "gc/shared/gc_globals.hpp"
 #include "logging/logStream.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/os.hpp"

--- a/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
+++ b/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 #include "gc/g1/g1BiasedArray.hpp"
 #include "gc/g1/g1NUMA.hpp"
 #include "gc/g1/g1RegionToSpaceMapper.hpp"
+#include "gc/shared/gc_globals.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/virtualspace.hpp"
 #include "runtime/mutexLocker.hpp"

--- a/src/hotspot/share/gc/g1/g1SegmentedArrayFreeMemoryTask.cpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArrayFreeMemoryTask.cpp
@@ -29,6 +29,7 @@
 #include "gc/g1/g1SegmentedArrayFreeMemoryTask.hpp"
 #include "gc/g1/g1_globals.hpp"
 #include "gc/g1/heapRegionRemSet.hpp"
+#include "gc/shared/gc_globals.hpp"
 #include "gc/shared/gcTraceTime.inline.hpp"
 #include "gc/shared/suspendibleThreadSet.hpp"
 #include "runtime/os.hpp"


### PR DESCRIPTION
In [JDK-8282729](https://bugs.openjdk.org/browse/JDK-8282729) a few headers where found which were indirectly included via `#include "gc/shared/blockOffsetTable.hpp", [JDK-8282729](https://bugs.openjdk.org/browse/JDK-8282729) moves the Serial part of `blockOffsetTable` into `gc/serial` so those headers needs to be fixed for G1 and Epsilon. These header fixes were moved out of the issue to make the review processes easier. Here is a list of the files in question.
* `src/hotspot/share/gc/epsilon/epsilonHeap.hpp`
    * Uses `VirtualSpace`
* `src/hotspot/share/gc/g1/g1CollectionSetChooser.hpp`
    * Uses `G1MixedGCLiveThresholdPercent`
* `src/hotspot/share/gc/g1/g1FullGCScope.cpp`
    * Uses `MarkSweepDeadRatio`
* `src/hotspot/share/gc/g1/g1HeapRegionEventSender.cpp`
    * Uses `UseG1GC`
* `src/hotspot/share/gc/g1/g1HeapSizingPolicy.cpp`
    * Uses `GCTimeRatio`, `G1ExpandByPercentOfAvailable`, `MaxHeapSize`, `MinHeapSize`, `MaxHeapFreeRatio`, `MinHeapFreeRatio`
* `src/hotspot/share/gc/g1/g1MemoryPool.cpp`
    * Uses `UseG1GC`
* `src/hotspot/share/gc/g1/g1NUMA.cpp`
    * Uses `AlwaysPreTouch`
* `src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp`
    * Uses `AlwaysPreTouch`
* `src/hotspot/share/gc/g1/g1SegmentedArrayFreeMemoryTask.cpp`
    * Uses `G1RemSetFreeMemoryStepDurationMillis`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292606](https://bugs.openjdk.org/browse/JDK-8292606): G1 and Epsilon header cleanup for JDK-8282729


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9921/head:pull/9921` \
`$ git checkout pull/9921`

Update a local copy of the PR: \
`$ git checkout pull/9921` \
`$ git pull https://git.openjdk.org/jdk pull/9921/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9921`

View PR using the GUI difftool: \
`$ git pr show -t 9921`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9921.diff">https://git.openjdk.org/jdk/pull/9921.diff</a>

</details>
