### PR TITLE
8292608: [AIX] Broken build after 8291945

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -2302,7 +2302,7 @@ void os::init(void) {
 
   // For now UseLargePages is just ignored.
   FLAG_SET_ERGO(UseLargePages, false);
-  _page_sizes.add(os::vm_page_size);
+  _page_sizes.add(os::vm_page_size());
 
   // debug trace
   trcVerbose("os::vm_page_size %s", describe_pagesize(os::vm_page_size()));


### PR DESCRIPTION
Improvements to the os class for AIX contained a minor bug.

```
- _page_sizes.add(AIX::_page_size);
+ _page_sizes.add(os::vm_page_size);
```

`AIX::_page_size` is an `int`, but `os::vm_page_size` is a `() -> int`. Adding the parens (changing vm_page_size to a function call) does the trick.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292608](https://bugs.openjdk.org/browse/JDK-8292608): [AIX] Broken build after 8291945


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9922/head:pull/9922` \
`$ git checkout pull/9922`

Update a local copy of the PR: \
`$ git checkout pull/9922` \
`$ git pull https://git.openjdk.org/jdk pull/9922/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9922`

View PR using the GUI difftool: \
`$ git pr show -t 9922`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9922.diff">https://git.openjdk.org/jdk/pull/9922.diff</a>

</details>
