### PR TITLE
8292375: Make ProtectionDomainCache not a Hashtable

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -142,6 +142,7 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   ModuleEntryTable*  volatile _modules;  // The modules defined by the class loader.
   ModuleEntry* _unnamed_module;          // This class loader's unnamed module.
   Dictionary*  _dictionary;              // The loaded InstanceKlasses, including initiated by this class loader
+  GrowableArray<WeakHandle>* _protection_domains;  // Protection domains shared by classes in this loader
 
   // These method IDs are created for the class loader and set to NULL when the
   // class loader is unloaded.  They are rarely freed, only for redefine classes
@@ -310,6 +311,9 @@ class ClassLoaderData : public CHeapObj<mtClass> {
 
   static ClassLoaderData* class_loader_data(oop loader);
   static ClassLoaderData* class_loader_data_or_null(oop loader);
+
+  WeakHandle add_protection_domain(Handle protection_domain);
+  int remove_weak_protection_domains();
 
   // Returns Klass* of associated class loader, or NULL if associated loader is 'bootstrap'.
   // Also works if unloading.

--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -191,9 +191,9 @@ bool DictionaryEntry::contains_protection_domain(oop protection_domain) const {
 void DictionaryEntry::add_protection_domain(ClassLoaderData* loader_data, Handle protection_domain) {
   assert_lock_strong(SystemDictionary_lock);
   if (!contains_protection_domain(protection_domain())) {
-    ProtectionDomainCacheEntry* entry = SystemDictionary::pd_cache_table()->get(protection_domain);
+    WeakHandle pd = loader_data->add_protection_domain(protection_domain);
     // Additions and deletions hold the SystemDictionary_lock, readers are lock-free
-    ProtectionDomainEntry* new_head = new ProtectionDomainEntry(entry, _pd_set);
+    ProtectionDomainEntry* new_head = new ProtectionDomainEntry(pd, _pd_set);
     release_set_pd_set(new_head);
   }
   LogTarget(Trace, protectiondomain) lt;

--- a/src/hotspot/share/classfile/protectionDomainCache.cpp
+++ b/src/hotspot/share/classfile/protectionDomainCache.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,27 +31,13 @@
 #include "logging/logStream.hpp"
 #include "memory/iterator.hpp"
 #include "memory/resourceArea.hpp"
-#include "memory/universe.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/weakHandle.inline.hpp"
-#include "runtime/atomic.hpp"
+#include "runtime/mutexLocker.hpp"
 #include "utilities/growableArray.hpp"
-#include "utilities/hashtable.inline.hpp"
 
-unsigned int ProtectionDomainCacheTable::compute_hash(Handle protection_domain) {
-  // Identity hash can safepoint, so keep protection domain in a Handle.
-  return (unsigned int)(protection_domain->identity_hash());
-}
-
-int ProtectionDomainCacheTable::index_for(Handle protection_domain) {
-  return hash_to_index(compute_hash(protection_domain));
-}
-
-ProtectionDomainCacheTable::ProtectionDomainCacheTable(int table_size)
-  : Hashtable<WeakHandle, mtClass>(table_size, sizeof(ProtectionDomainCacheEntry))
-{   _dead_entries = false;
-    _total_oops_removed = 0;
-}
+int ProtectionDomainCacheTable::_total_oops_removed = 0;
+bool ProtectionDomainCacheTable::_dead_entries = false;
 
 void ProtectionDomainCacheTable::trigger_cleanup() {
   MutexLocker ml(Service_lock, Mutex::_no_safepoint_check_flag);
@@ -59,6 +45,7 @@ void ProtectionDomainCacheTable::trigger_cleanup() {
   Service_lock->notify_all();
 }
 
+// Unlinks weak protection domains off each dictionary entry pd_set.
 class CleanProtectionDomainEntries : public CLDClosure {
   GrowableArray<ProtectionDomainEntry*>* _delete_list;
  public:
@@ -73,6 +60,16 @@ class CleanProtectionDomainEntries : public CLDClosure {
   }
 };
 
+// Unlinks weak protection domains off class loader data list.
+class RemoveWeakProtectionDomains : public CLDClosure {
+  public:
+    int _oops_removed;
+    RemoveWeakProtectionDomains() : _oops_removed(0) {}
+    void do_cld(ClassLoaderData* data) {
+      _oops_removed += data->remove_weak_protection_domains();
+    }
+};
+
 static GrowableArray<ProtectionDomainEntry*>* _delete_list = NULL;
 
 class HandshakeForPD : public HandshakeClosure {
@@ -85,7 +82,7 @@ class HandshakeForPD : public HandshakeClosure {
   }
 };
 
-static void purge_deleted_entries() {
+static bool purge_deleted_entries() {
   // If there are any deleted entries, Handshake-all then they'll be
   // safe to remove since traversing the pd_set list does not stop for
   // safepoints and only JavaThreads will read the pd_set.
@@ -102,7 +99,9 @@ static void purge_deleted_entries() {
       delete entry;
     }
     assert(_delete_list->length() == 0, "should be cleared");
+    return true; // some were deleted
   }
+  return false;  // never mind
 }
 
 void ProtectionDomainCacheTable::unlink() {
@@ -127,109 +126,22 @@ void ProtectionDomainCacheTable::unlink() {
   }
 
   // Purge any deleted entries outside of the SystemDictionary_lock.
-  purge_deleted_entries();
+  bool any_deleted = purge_deleted_entries();
 
-  MutexLocker ml(SystemDictionary_lock);
-  int oops_removed = 0;
-  for (int i = 0; i < table_size(); ++i) {
-    ProtectionDomainCacheEntry** p = bucket_addr(i);
-    ProtectionDomainCacheEntry* entry = bucket(i);
-    while (entry != NULL) {
-      oop pd = entry->object_no_keepalive();
-      if (pd != NULL) {
-        p = entry->next_addr();
-      } else {
-        oops_removed++;
-        LogTarget(Debug, protectiondomain, table) lt;
-        if (lt.is_enabled()) {
-          LogStream ls(lt);
-          ls.print_cr("protection domain unlinked at %d", i);
-        }
-        entry->literal().release(Universe::vm_weak());
-        *p = entry->next();
-        free_entry(entry);
-      }
-      entry = *p;
-    }
+  if (any_deleted) {
+    MutexLocker mlcld(ClassLoaderDataGraph_lock);
+    RemoveWeakProtectionDomains remove;
+    ClassLoaderDataGraph::loaded_cld_do(&remove);
+    _total_oops_removed = remove._oops_removed;
   }
-  _total_oops_removed += oops_removed;
+
   _dead_entries = false;
 }
 
-void ProtectionDomainCacheTable::print_on(outputStream* st) const {
-  assert_locked_or_safepoint(SystemDictionary_lock);
-  st->print_cr("Protection domain cache table (table_size=%d, classes=%d)",
-               table_size(), number_of_entries());
-  for (int index = 0; index < table_size(); index++) {
-    for (ProtectionDomainCacheEntry* probe = bucket(index);
-                                     probe != NULL;
-                                     probe = probe->next()) {
-      st->print_cr("%4d: protection_domain: " PTR_FORMAT, index, p2i(probe->object_no_keepalive()));
-    }
-  }
-}
-
-void ProtectionDomainCacheTable::verify() {
-  verify_table<ProtectionDomainCacheEntry>("Protection Domain Table");
-}
-
-oop ProtectionDomainCacheEntry::object() {
-  return literal().resolve();
-}
 
 // The object_no_keepalive() call peeks at the phantomly reachable oop without
 // keeping it alive. This is okay to do in the VM thread state if it is not
 // leaked out to become strongly reachable.
-oop ProtectionDomainCacheEntry::object_no_keepalive() {
-  return literal().peek();
-}
-
 oop ProtectionDomainEntry::object_no_keepalive() {
-  return _pd_cache->object_no_keepalive();
-}
-
-void ProtectionDomainCacheEntry::verify() {
-  guarantee(object_no_keepalive() == NULL || oopDesc::is_oop(object_no_keepalive()), "must be an oop");
-}
-
-ProtectionDomainCacheEntry* ProtectionDomainCacheTable::get(Handle protection_domain) {
-  unsigned int hash = compute_hash(protection_domain);
-  int index = hash_to_index(hash);
-
-  ProtectionDomainCacheEntry* entry = find_entry(index, protection_domain);
-  if (entry == NULL) {
-    entry = add_entry(index, hash, protection_domain);
-  }
-  // keep entry alive
-  (void)entry->object();
-  return entry;
-}
-
-ProtectionDomainCacheEntry* ProtectionDomainCacheTable::find_entry(int index, Handle protection_domain) {
-  assert_locked_or_safepoint(SystemDictionary_lock);
-  for (ProtectionDomainCacheEntry* e = bucket(index); e != NULL; e = e->next()) {
-    if (e->object_no_keepalive() == protection_domain()) {
-      return e;
-    }
-  }
-
-  return NULL;
-}
-
-ProtectionDomainCacheEntry* ProtectionDomainCacheTable::add_entry(int index, unsigned int hash, Handle protection_domain) {
-  assert_locked_or_safepoint(SystemDictionary_lock);
-  assert(index == index_for(protection_domain), "incorrect index?");
-  assert(find_entry(index, protection_domain) == NULL, "no double entry");
-
-  LogTarget(Debug, protectiondomain, table) lt;
-  if (lt.is_enabled()) {
-    LogStream ls(lt);
-    ls.print("protection domain added ");
-    protection_domain->print_value_on(&ls);
-    ls.cr();
-  }
-  WeakHandle w(Universe::vm_weak(), protection_domain);
-  ProtectionDomainCacheEntry* p = new_entry(hash, w);
-  Hashtable<WeakHandle, mtClass>::add_entry(index, p);
-  return p;
+  return _object.peek();
 }

--- a/src/hotspot/share/classfile/protectionDomainCache.hpp
+++ b/src/hotspot/share/classfile/protectionDomainCache.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,88 +28,31 @@
 #include "oops/oop.hpp"
 #include "oops/weakHandle.hpp"
 #include "runtime/atomic.hpp"
-#include "utilities/hashtable.hpp"
 
-// This class caches the approved protection domains that can access loaded classes.
-// Dictionary entry pd_set point to entries in this hashtable.   Please refer
-// to dictionary.hpp pd_set for more information about how protection domain entries
-// are used.
-// This table is walked during GC, rather than the class loader data graph dictionaries.
-class ProtectionDomainCacheEntry : public HashtableEntry<WeakHandle, mtClass> {
-  friend class VMStructs;
- public:
-  oop object();
-  oop object_no_keepalive();
-
-  ProtectionDomainCacheEntry* next() {
-    return (ProtectionDomainCacheEntry*)HashtableEntry<WeakHandle, mtClass>::next();
-  }
-
-  ProtectionDomainCacheEntry** next_addr() {
-    return (ProtectionDomainCacheEntry**)HashtableEntry<WeakHandle, mtClass>::next_addr();
-  }
-
-  void verify();
-};
-
-// The ProtectionDomainCacheTable contains all protection domain oops. The
-// dictionary entries reference its entries instead of having references to oops
-// directly.
-// This is used to speed up system dictionary iteration: the oops in the
-// protection domain are the only ones referring the Java heap. So when there is
-// need to update these, instead of going over every entry of the system dictionary,
-// we only need to iterate over this set.
 // The amount of different protection domains used is typically magnitudes smaller
 // than the number of system dictionary entries (loaded classes).
-class ProtectionDomainCacheTable : public Hashtable<WeakHandle, mtClass> {
-  ProtectionDomainCacheEntry* bucket(int i) const {
-    return (ProtectionDomainCacheEntry*) Hashtable<WeakHandle, mtClass>::bucket(i);
-  }
-
-  // The following method is not MT-safe and must be done under lock.
-  ProtectionDomainCacheEntry** bucket_addr(int i) {
-    return (ProtectionDomainCacheEntry**) Hashtable<WeakHandle, mtClass>::bucket_addr(i);
-  }
-
-  ProtectionDomainCacheEntry* new_entry(unsigned int hash, WeakHandle protection_domain) {
-    ProtectionDomainCacheEntry* entry = (ProtectionDomainCacheEntry*)
-      Hashtable<WeakHandle, mtClass>::new_entry(hash, protection_domain);
-    return entry;
-  }
-
-  static unsigned int compute_hash(Handle protection_domain);
-
-  int index_for(Handle protection_domain);
-  ProtectionDomainCacheEntry* add_entry(int index, unsigned int hash, Handle protection_domain);
-  ProtectionDomainCacheEntry* find_entry(int index, Handle protection_domain);
-
-  bool _dead_entries;
-  int _total_oops_removed;
+class ProtectionDomainCacheTable : public AllStatic {
+  static int _total_oops_removed;
+  static bool _dead_entries;
 
 public:
-  ProtectionDomainCacheTable(int table_size);
-  ProtectionDomainCacheEntry* get(Handle protection_domain);
+  static void unlink();
+  static void trigger_cleanup();
+  static bool has_work() { return _dead_entries; }
 
-  void unlink();
-
-  void print_on(outputStream* st) const;
-  void verify();
-
-  bool has_work() { return _dead_entries; }
-  void trigger_cleanup();
-
-  int removed_entries_count() { return _total_oops_removed; };
+  static int removed_entries_count() { return _total_oops_removed; };
+  static void inc_removed_entries_count() { _total_oops_removed++; }
 };
 
-
 // This describes the linked list protection domain for each DictionaryEntry in pd_set.
+// The WeakHandle is stored in a list in each ClassLoaderData.
 class ProtectionDomainEntry :public CHeapObj<mtClass> {
-  ProtectionDomainCacheEntry* _pd_cache;
+  WeakHandle _object;
   ProtectionDomainEntry* volatile _next;
  public:
 
-  ProtectionDomainEntry(ProtectionDomainCacheEntry* pd_cache,
-                        ProtectionDomainEntry* head) : _pd_cache(pd_cache), _next(head) {}
+  ProtectionDomainEntry(WeakHandle obj,
+                        ProtectionDomainEntry* head) : _object(obj), _next(head) {}
 
   ProtectionDomainEntry* next_acquire() { return Atomic::load_acquire(&_next); }
   void release_set_next(ProtectionDomainEntry* entry) { Atomic::release_store(&_next, entry); }

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -189,9 +189,6 @@ class SystemDictionary : AllStatic {
   // loaders.  Returns "true" iff something was unloaded.
   static bool do_unloading(GCTimer* gc_timer);
 
-  // Protection Domain Table
-  static ProtectionDomainCacheTable* pd_cache_table() { return _pd_cache_table; }
-
   // Printing
   static void print();
   static void print_on(outputStream* st);
@@ -299,9 +296,6 @@ public:
 
   // Invoke methods (JSR 292)
   static SymbolPropertyTable*    _invoke_method_table;
-
-  // ProtectionDomain cache
-  static ProtectionDomainCacheTable*   _pd_cache_table;
 
 protected:
   static InstanceKlass* _well_known_klasses[];

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -2393,7 +2393,7 @@ WB_ENTRY(jlong, WB_ResolvedMethodItemsCount(JNIEnv* env, jobject o))
 WB_END
 
 WB_ENTRY(jint, WB_ProtectionDomainRemovedCount(JNIEnv* env, jobject o))
-  return (jint) SystemDictionary::pd_cache_table()->removed_entries_count();
+  return (jint) ProtectionDomainCacheTable::removed_entries_count();
 WB_END
 
 WB_ENTRY(jint, WB_GetKlassMetadataSize(JNIEnv* env, jobject wb, jclass mirror))

--- a/src/hotspot/share/runtime/serviceThread.cpp
+++ b/src/hotspot/share/runtime/serviceThread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@
 #include "classfile/protectionDomainCache.hpp"
 #include "classfile/stringTable.hpp"
 #include "classfile/symbolTable.hpp"
-#include "classfile/systemDictionary.hpp"
 #include "classfile/vmClasses.hpp"
 #include "gc/shared/oopStorage.hpp"
 #include "gc/shared/oopStorageSet.hpp"
@@ -150,7 +149,7 @@ void ServiceThread::service_thread_entry(JavaThread* jt, TRAPS) {
               (finalizerservice_work = FinalizerService::has_work()) |
               (resolved_method_table_work = ResolvedMethodTable::has_work()) |
               (thread_id_table_work = ThreadIdTable::has_work()) |
-              (protection_domain_table_work = SystemDictionary::pd_cache_table()->has_work()) |
+              (protection_domain_table_work = ProtectionDomainCacheTable::has_work()) |
               (oopstorage_work = OopStorage::has_cleanup_work_and_reset()) |
               (oop_handles_to_release = (_oop_handle_list != NULL)) |
               (cldg_cleanup_work = ClassLoaderDataGraph::should_clean_metaspaces_and_reset()) |
@@ -207,7 +206,7 @@ void ServiceThread::service_thread_entry(JavaThread* jt, TRAPS) {
     }
 
     if (protection_domain_table_work) {
-      SystemDictionary::pd_cache_table()->unlink();
+      ProtectionDomainCacheTable::unlink();
     }
 
     if (oopstorage_work) {

--- a/src/hotspot/share/utilities/hashtable.cpp
+++ b/src/hotspot/share/utilities/hashtable.cpp
@@ -28,7 +28,6 @@
 #include "classfile/moduleEntry.hpp"
 #include "classfile/packageEntry.hpp"
 #include "classfile/placeholders.hpp"
-#include "classfile/protectionDomainCache.hpp"
 #include "classfile/vmClasses.hpp"
 #include "code/nmethod.hpp"
 #include "logging/log.hpp"
@@ -260,8 +259,6 @@ template class BasicHashtable<mtServiceability>;
 
 template class Hashtable<nmethod*, mtGC>;
 template class Hashtable<InstanceKlass*, mtClass>;
-template class Hashtable<WeakHandle, mtClass>;
 template class Hashtable<WeakHandle, mtServiceability>;
 
 template void BasicHashtable<mtClass>::verify_table<DictionaryEntry>(char const*);
-template void BasicHashtable<mtClass>::verify_table<ProtectionDomainCacheEntry>(char const*);

--- a/test/hotspot/jtreg/runtime/Dictionary/ProtectionDomainBenchTest.java
+++ b/test/hotspot/jtreg/runtime/Dictionary/ProtectionDomainBenchTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Adds lots of ProtectionDomains to the ClassLoaderData
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @run driver ProtectionDomainBenchTest
+ */
+
+import java.security.ProtectionDomain;
+import jdk.test.lib.compiler.InMemoryJavaCompiler;
+import jdk.internal.misc.Unsafe;
+import static jdk.test.lib.Asserts.*;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class ProtectionDomainBenchTest {
+
+  // This tests adding a lot of classes with protection domains to a class loader
+  static int numberOfClasses = 20;
+
+  public static void main(String args[]) throws Exception {
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                                  "-Xlog:protectiondomain+table=debug",
+                                  "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+                                  "-XX:+UnlockDiagnosticVMOptions",
+                                  "-Djava.security.manager=allow",
+                                  Test.class.getName());
+    OutputAnalyzer output = new OutputAnalyzer(pb.start());
+    output.shouldContain("protection domain added at " + numberOfClasses);
+    output.shouldContain("class loader: a 'ProtectionDomainBenchTest$Test$TestClassLoader'");
+    output.shouldHaveExitValue(0);
+  }
+
+  static class Test {
+    static String B(int count) {
+        return new String("public class B" + count + " {"
+                + "   static int intField;"
+                + "   public static void compiledMethod() { "
+                + "       intField++;"
+                + "   }"
+                + "}");
+    }
+
+    static byte[][] compiledClasses;
+    static Class[] loadedClasses;
+    static int index = 0;
+
+    static void setupClasses() throws Exception {
+        compiledClasses = new byte[numberOfClasses][];
+        loadedClasses = new Class[numberOfClasses];
+        for (int i = 0; i < numberOfClasses; i++) {
+            compiledClasses[i] = InMemoryJavaCompiler.compile("B" + i, B(i));
+        }
+    }
+
+    public static void test() throws Exception {
+      TestClassLoader loader1 = new TestClassLoader();
+      for (index = 0; index < compiledClasses.length; index++) {
+        String name = new String("B" + index);
+        Class c = loader1.findClass(name);
+        loadedClasses[index] = c;
+      }
+    }
+
+    public static void main(String[] args) throws Exception {
+      setupClasses();
+      test();
+    }
+
+    private static class TestClassLoader extends ClassLoader {
+      public TestClassLoader() {
+        super();
+      }
+
+      protected Class<?> findClass(String name) throws ClassNotFoundException {
+        if (name.equals("B" + index)) {
+          assert compiledClasses[index]  != null;
+          ProtectionDomain pd = new ProtectionDomain(null, null); // create fresh pd for each
+          return defineClass(name, compiledClasses[index] , 0, (compiledClasses[index]).length, pd);
+        } else {
+          return super.findClass(name);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292375](https://bugs.openjdk.org/browse/JDK-8292375): Make ProtectionDomainCache not a Hashtable


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9924/head:pull/9924` \
`$ git checkout pull/9924`

Update a local copy of the PR: \
`$ git checkout pull/9924` \
`$ git pull https://git.openjdk.org/jdk pull/9924/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9924`

View PR using the GUI difftool: \
`$ git pr show -t 9924`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9924.diff">https://git.openjdk.org/jdk/pull/9924.diff</a>

</details>
