### PR TITLE
8292562: (fc) Use copy_file_range in FileChannel::transferTo on Linux

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -573,7 +573,8 @@ public class FileChannelImpl
             do {
                 long comp = Blocker.begin();
                 try {
-                    n = transferTo0(fd, position, icount, targetFD);
+                    boolean append = fdAccess.getAppend(targetFD);
+                    n = transferTo0(fd, position, icount, targetFD, append);
                 } finally {
                     Blocker.end(comp);
                 }
@@ -801,7 +802,8 @@ public class FileChannelImpl
             do {
                 long comp = Blocker.begin();
                 try {
-                    n = transferFrom0(srcFD, fd, position, count);
+                    boolean append = fdAccess.getAppend(fd);
+                    n = transferFrom0(srcFD, fd, position, count, append);
                 } finally {
                     Blocker.end(comp);
                 }
@@ -1573,11 +1575,13 @@ public class FileChannelImpl
     // Transfers from src to dst, or returns IOStatus.UNSUPPORTED (-4) or
     // IOStatus.UNSUPPORTED_CASE (-6) if the kernel does not support it
     private static native long transferTo0(FileDescriptor src, long position,
-                                           long count, FileDescriptor dst);
+                                           long count, FileDescriptor dst,
+                                           boolean append);
 
     private static native long transferFrom0(FileDescriptor src,
                                              FileDescriptor dst,
-                                             long position, long count);
+                                             long position, long count,
+                                             boolean append);
 
     // Retrieves the maximum size of a transfer
     private static native int maxDirectTransferSize0();

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -570,10 +570,10 @@ public class FileChannelImpl
             ti = threads.add();
             if (!isOpen())
                 return -1;
+            boolean append = fdAccess.getAppend(targetFD);
             do {
                 long comp = Blocker.begin();
                 try {
-                    boolean append = fdAccess.getAppend(targetFD);
                     n = transferTo0(fd, position, icount, targetFD, append);
                 } finally {
                     Blocker.end(comp);

--- a/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
+++ b/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
@@ -169,25 +169,20 @@ JNIEXPORT jlong JNICALL
 Java_sun_nio_ch_FileChannelImpl_transferTo0(JNIEnv *env, jobject this,
                                             jobject srcFDO,
                                             jlong position, jlong count,
-                                            jobject dstFDO)
+                                            jobject dstFDO, jboolean append)
 {
     jint srcFD = fdval(env, srcFDO);
     jint dstFD = fdval(env, dstFDO);
 
 #if defined(__linux__)
-    // Check whether the destination is in append mode: copy_file_range fails
-    // with EBADF in this case and sendfile fails with EINVAL.
-    int dstFlags = fcntl(dstFD, F_GETFL);
-    if (dstFlags < 0) {
-        JNU_ThrowIOExceptionWithLastError(env, "Destination flags");
-        return IOS_THROWN;
-    }
-    if ((dstFlags & O_APPEND) != 0)
+    // copy_file_range fails with EBADF when appending, and sendfile
+    // fails with EINVAL
+    if (append == JNI_TRUE)
         return IOS_UNSUPPORTED_CASE;
 
     off64_t offset = (off64_t)position;
     jlong n;
-    if (my_copy_file_range_func) {
+    if (my_copy_file_range_func != NULL) {
         size_t len = (size_t)count;
         n = my_copy_file_range_func(srcFD, &offset, dstFD, NULL, len, 0);
         if (n < 0) {
@@ -293,11 +288,15 @@ Java_sun_nio_ch_FileChannelImpl_transferTo0(JNIEnv *env, jobject this,
 JNIEXPORT jlong JNICALL
 Java_sun_nio_ch_FileChannelImpl_transferFrom0(JNIEnv *env, jobject this,
                                               jobject srcFDO, jobject dstFDO,
-                                              jlong position, jlong count)
+                                              jlong position, jlong count,
+                                              jboolean append)
 {
 #if defined(__linux__)
     if (my_copy_file_range_func == NULL)
         return IOS_UNSUPPORTED;
+    // copy_file_range fails with EBADF when appending
+    if (append == JNI_TRUE)
+        return IOS_UNSUPPORTED_CASE;
 
     jint srcFD = fdval(env, srcFDO);
     jint dstFD = fdval(env, dstFDO);

--- a/src/java.base/windows/native/libnio/ch/FileChannelImpl.c
+++ b/src/java.base/windows/native/libnio/ch/FileChannelImpl.c
@@ -147,7 +147,7 @@ JNIEXPORT jlong JNICALL
 Java_sun_nio_ch_FileChannelImpl_transferTo0(JNIEnv *env, jobject this,
                                             jobject srcFD,
                                             jlong position, jlong count,
-                                            jobject dstFD)
+                                            jobject dstFD, jboolean append)
 {
     const int PACKET_SIZE = 524288;
 
@@ -191,7 +191,8 @@ Java_sun_nio_ch_FileChannelImpl_transferTo0(JNIEnv *env, jobject this,
 JNIEXPORT jlong JNICALL
 Java_sun_nio_ch_FileChannelImpl_transferFrom0(JNIEnv *env, jobject this,
                                               jobject srcFDO, jobject dstFDO,
-                                              jlong position, jlong count)
+                                              jlong position, jlong count,
+                                              jboolean append)
 {
     return IOS_UNSUPPORTED;
 }

--- a/test/jdk/java/nio/channels/FileChannel/TransferToAppending.java
+++ b/test/jdk/java/nio/channels/FileChannel/TransferToAppending.java
@@ -25,7 +25,6 @@
  * @bug 8292562
  * @summary Test transferTo and transferFrom when target is appending
  * @library /test/lib
- * @build jdk.test.lib.Platform
  * @build jdk.test.lib.RandomFactory
  * @run main TransferToAppending
  * @key randomness
@@ -37,7 +36,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.channels.FileChannel;
 import java.util.Random;
-import jdk.test.lib.Platform;
 import jdk.test.lib.RandomFactory;
 
 import static java.nio.file.StandardOpenOption.*;

--- a/test/jdk/java/nio/channels/FileChannel/TransferToAppending.java
+++ b/test/jdk/java/nio/channels/FileChannel/TransferToAppending.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8292562
+ * @summary Test transferTo when target is appending
+ * @library /test/lib
+ * @build jdk.test.lib.RandomFactory
+ * @run main TransferToAppending
+ * @key randomness
+ */
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.channels.FileChannel;
+import java.util.Random;
+import jdk.test.lib.RandomFactory;
+
+import static java.nio.file.StandardOpenOption.*;
+
+public class TransferToAppending {
+    private static final int MIN_SIZE =   128;
+    private static final int MAX_SIZE = 32768;
+    private static final Random RND = RandomFactory.getRandom();
+
+    public static void main(String... args) throws IOException {
+        // Create files of size in [MIN_SIZE,MAX_SIZE) filled with random bytes
+        Path source = createFile("src");
+        Path target = createFile("tgt");
+
+        try (FileChannel src = FileChannel.open(source, READ, WRITE);
+             FileChannel tgt = FileChannel.open(target, WRITE, APPEND);) {
+            // Set source range to a subset of the source
+            long srcSize = Files.size(source);
+            long position = RND.nextInt((int)srcSize);
+            long count = RND.nextInt((int)(srcSize - position));
+            long tgtSize = Files.size(target);
+
+            // Transfer subrange to target
+            src.transferTo(position, count, tgt);
+
+            // Target size should be increased by 'count'.
+            if (Files.size(target) != tgtSize + count) {
+                String msg = String.format("Bad size: expected %d, actual %d%n",
+                                           tgtSize + count, Files.size(target));
+                throw new RuntimeException(msg);
+            }
+
+            tgt.close();
+
+            // Load subrange of source
+            ByteBuffer bufSrc = ByteBuffer.allocate((int)count);
+            src.position(position);
+            src.read(bufSrc);
+
+            try (FileChannel result = FileChannel.open(target, READ, WRITE)) {
+                // Load appended range of target
+                ByteBuffer bufTgt = ByteBuffer.allocate((int)count);
+                result.position(tgtSize);
+                result.read(bufTgt);
+
+                // Subranges of values should be equal
+                if (bufSrc.mismatch(bufTgt) != -1) {
+                    throw new RuntimeException("Range of values unequal");
+                }
+            }
+        } finally {
+            Files.delete(source);
+            Files.delete(target);
+        }
+    }
+
+    private static Path createFile(String name) throws IOException {
+        Path path = Files.createTempFile(name, ".dat");
+        try (FileChannel fc = FileChannel.open(path, CREATE, READ, WRITE)) {
+            int size = Math.max(RND.nextInt(MAX_SIZE), 128);
+            byte[] b = new byte[size];
+            RND.nextBytes(b);
+            fc.write(ByteBuffer.wrap(b));
+        }
+        return path;
+    }
+}


### PR DESCRIPTION
Add `copy_file_range(2)` to the native Linux implementation of `FileChannel::transferTo`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292562](https://bugs.openjdk.org/browse/JDK-8292562): (fc) Use copy_file_range in FileChannel::transferTo on Linux


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9925/head:pull/9925` \
`$ git checkout pull/9925`

Update a local copy of the PR: \
`$ git checkout pull/9925` \
`$ git pull https://git.openjdk.org/jdk pull/9925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9925`

View PR using the GUI difftool: \
`$ git pr show -t 9925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9925.diff">https://git.openjdk.org/jdk/pull/9925.diff</a>

</details>
