### PR TITLE
8292633: runtime/cds/appcds/dynamicArchive/CDSStreamTestDriver.java fails to compile

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/CDSStreamTestDriver.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/CDSStreamTestDriver.java
@@ -37,6 +37,7 @@
 
 import org.testng.annotations.Test;
 import java.io.File;
+import java.nio.file.Path;
 import jtreg.SkippedException;
 import jdk.test.whitebox.gc.GC;
 


### PR DESCRIPTION
This change adds the missing import statement of https://github.com/openjdk/jdk/commit/62a7fc60d3b3a27525fc01930834dab6f89bd451 introduced by https://bugs.openjdk.org/browse/JDK-8292315

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292633](https://bugs.openjdk.org/browse/JDK-8292633): runtime/cds/appcds/dynamicArchive/CDSStreamTestDriver.java fails to compile


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9928/head:pull/9928` \
`$ git checkout pull/9928`

Update a local copy of the PR: \
`$ git checkout pull/9928` \
`$ git pull https://git.openjdk.org/jdk pull/9928/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9928`

View PR using the GUI difftool: \
`$ git pr show -t 9928`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9928.diff">https://git.openjdk.org/jdk/pull/9928.diff</a>

</details>
