### PR TITLE
8292632: compiler/sharedstubs/SharedTrampolineTest.java fails with "Error: VM option 'PrintRelocations' is develop and is available only in debug version of VM."

### DIFF
--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedTrampolineTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedTrampolineTest.java
@@ -28,7 +28,7 @@
  * @bug 8280152
  * @library /test/lib
  *
- * @requires os.arch=="aarch64"
+ * @requires vm.debug & os.arch=="aarch64"
  *
  * @run driver compiler.sharedstubs.SharedTrampolineTest
  */


### PR DESCRIPTION
A trivial fix so that compiler/sharedstubs/SharedTrampolineTest.java requires
debug bits to use the '-XX:PrintRelocations' option.

This failure was reproduced on my M1 MacMini with 'release' bits and I verified
that the test no longer runs with 'release' bits after the fix. I also verified that
the test runs and passes with 'fastdebug' bits.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292632](https://bugs.openjdk.org/browse/JDK-8292632): compiler/sharedstubs/SharedTrampolineTest.java fails with "Error: VM option 'PrintRelocations' is develop and is available only in debug version of VM."


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9930/head:pull/9930` \
`$ git checkout pull/9930`

Update a local copy of the PR: \
`$ git checkout pull/9930` \
`$ git pull https://git.openjdk.org/jdk pull/9930/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9930`

View PR using the GUI difftool: \
`$ git pr show -t 9930`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9930.diff">https://git.openjdk.org/jdk/pull/9930.diff</a>

</details>
