### PR TITLE
JDK-8292561: Make "ReplayCompiles" a diagnostic product switch

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -647,12 +647,10 @@ ciKlass* ciEnv::get_klass_by_index_impl(const constantPoolHandle& cpool,
   // It is known to be accessible, since it was found in the constant pool.
   ciKlass* ciKlass = get_klass(klass);
   is_accessible = true;
-#ifndef PRODUCT
   if (ReplayCompiles && ciKlass == _unloaded_ciinstance_klass) {
     // Klass was unresolved at replay dump time and therefore not accessible.
     is_accessible = false;
   }
-#endif
   return ciKlass;
 }
 
@@ -943,11 +941,9 @@ ciMethod* ciEnv::get_method_by_index_impl(const constantPoolHandle& cpool,
            : !m->method_holder()->is_loaded())) {
         m = NULL;
       }
-#ifdef ASSERT
       if (m != NULL && ReplayCompiles && !ciReplay::is_loaded(m)) {
         m = NULL;
       }
-#endif
       if (m != NULL) {
         // We found the method.
         return get_method(m);

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -27,7 +27,6 @@
 
 #include "ci/ciClassList.hpp"
 #include "ci/ciObjectFactory.hpp"
-#include "ci/ciReplay.hpp"
 #include "classfile/vmClassMacros.hpp"
 #include "code/debugInfoRec.hpp"
 #include "code/dependencies.hpp"
@@ -191,13 +190,6 @@ private:
     if (o == NULL) {
       return NULL;
     } else {
-      if (ReplayCompiles && o->is_klass()) {
-        Klass* k = (Klass*)o;
-        if (k->is_instance_klass() && ciReplay::is_klass_unresolved((InstanceKlass*)k)) {
-          // Klass was unresolved at replay dump time. Simulate this case.
-          return ciEnv::_unloaded_ciinstance_klass;
-        }
-      }
       return _factory->get_metadata(o);
     }
   }

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -191,7 +191,6 @@ private:
     if (o == NULL) {
       return NULL;
     } else {
-#ifndef PRODUCT
       if (ReplayCompiles && o->is_klass()) {
         Klass* k = (Klass*)o;
         if (k->is_instance_klass() && ciReplay::is_klass_unresolved((InstanceKlass*)k)) {
@@ -199,7 +198,6 @@ private:
           return ciEnv::_unloaded_ciinstance_klass;
         }
       }
-#endif
       return _factory->get_metadata(o);
     }
   }

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -155,11 +155,9 @@ ciMethod::ciMethod(const methodHandle& h_m, ciInstanceKlass* holder) :
   if (_interpreter_invocation_count == 0)
     _interpreter_invocation_count = 1;
   _instructions_size = -1;
-#ifdef ASSERT
   if (ReplayCompiles) {
     ciReplay::initialize(this);
   }
-#endif
 }
 
 

--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -261,14 +261,12 @@ bool ciMethodData::load_data() {
   _arg_local = mdo->arg_local();
   _arg_stack = mdo->arg_stack();
   _arg_returned  = mdo->arg_returned();
-#ifndef PRODUCT
   if (ReplayCompiles) {
     ciReplay::initialize(this);
     if (is_empty()) {
       return false;
     }
   }
-#endif
   return true;
 }
 

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -36,6 +36,7 @@
 #include "ci/ciObjArrayKlass.hpp"
 #include "ci/ciObject.hpp"
 #include "ci/ciObjectFactory.hpp"
+#include "ci/ciReplay.hpp"
 #include "ci/ciSymbol.hpp"
 #include "ci/ciSymbols.hpp"
 #include "ci/ciTypeArray.hpp"
@@ -284,6 +285,14 @@ ciMetadata* ciObjectFactory::cached_metadata(Metadata* key) {
 // is created.
 ciMetadata* ciObjectFactory::get_metadata(Metadata* key) {
   ASSERT_IN_VM;
+
+  if (ReplayCompiles && key->is_klass()) {
+    Klass* k = (Klass*)key;
+    if (k->is_instance_klass() && ciReplay::is_klass_unresolved((InstanceKlass*)k)) {
+      // Klass was unresolved at replay dump time. Simulate this case.
+      return ciEnv::_unloaded_ciinstance_klass;
+    }
+  }
 
 #ifdef ASSERT
   if (CIObjectFactoryVerify) {

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -56,8 +56,6 @@
 #include "utilities/macros.hpp"
 #include "utilities/utf8.hpp"
 
-#ifndef PRODUCT
-
 // ciReplay
 
 typedef struct _ciMethodDataRecord {
@@ -1584,7 +1582,6 @@ bool ciReplay::is_klass_unresolved(const InstanceKlass* klass) {
   ciInstanceKlassRecord* rec = replay_state->find_ciInstanceKlass(klass);
   return rec == NULL;
 }
-#endif // PRODUCT
 
 oop ciReplay::obj_field(oop obj, Symbol* name) {
   InstanceKlass* ik = InstanceKlass::cast(obj->klass());

--- a/src/hotspot/share/ci/ciReplay.hpp
+++ b/src/hotspot/share/ci/ciReplay.hpp
@@ -99,7 +99,6 @@
 class ciReplay {
   CI_PACKAGE_ACCESS
 
-#ifndef PRODUCT
  private:
   static int replay_impl(TRAPS);
 
@@ -123,7 +122,6 @@ class ciReplay {
   static bool should_not_inline(ciMethod* method);
   static bool should_inline(void* data, ciMethod* method, int bci, int inline_depth, bool& should_delay);
   static bool should_not_inline(void* data, ciMethod* method, int bci, int inline_depth);
-#endif
 
  public:
   static oop obj_field(oop obj, Symbol* name);

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -305,7 +305,7 @@
   product(ccstrlist, CompileCommand, "",                                    \
           "Prepend to .hotspot_compiler; e.g. log,java/lang/String.<init>") \
                                                                             \
-  develop(bool, ReplayCompiles, false,                                      \
+  product(bool, ReplayCompiles, false, DIAGNOSTIC,                          \
           "Enable replay of compilations from ReplayDataFile")              \
                                                                             \
   product(ccstr, ReplayDataFile, NULL,                                      \
@@ -316,7 +316,7 @@
           "File containing inlining replay information"                     \
           "[default: ./inline_pid%p.log] (%p replaced with pid)")           \
                                                                             \
-  develop(intx, ReplaySuppressInitializers, 2,                              \
+  product(intx, ReplaySuppressInitializers, 2, DIAGNOSTIC,                  \
           "Control handling of class initialization during replay: "        \
           "0 - don't do anything special; "                                 \
           "1 - treat all class initializers as empty; "                     \
@@ -325,7 +325,7 @@
           "    pretend they are empty after starting replay")               \
           range(0, 3)                                                       \
                                                                             \
-  develop(bool, ReplayIgnoreInitErrors, false,                              \
+  product(bool, ReplayIgnoreInitErrors, false, DIAGNOSTIC,                  \
           "Ignore exceptions thrown during initialization for replay")      \
                                                                             \
   product(bool, DumpReplayDataOnError, true,                                \

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -3656,9 +3656,7 @@ static jint JNI_CreateJavaVM_inner(JavaVM **vm, void **penv, void *args) {
 
     post_thread_start_event(thread);
 
-#ifndef PRODUCT
     if (ReplayCompiles) ciReplay::replay(thread);
-#endif
 
 #ifdef ASSERT
     // Some platforms (like Win*) need a wrapper around these test

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3871,7 +3871,7 @@ bool Arguments::handle_deprecated_print_gc_flags() {
 }
 
 static void apply_debugger_ergo() {
-#ifdef ASSERT
+#ifndef PRODUCT
   // UseDebuggerErgo is notproduct
   if (ReplayCompiles) {
     FLAG_SET_ERGO_IF_DEFAULT(UseDebuggerErgo, true);

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3871,9 +3871,12 @@ bool Arguments::handle_deprecated_print_gc_flags() {
 }
 
 static void apply_debugger_ergo() {
+#ifdef ASSERT
+  // UseDebuggerErgo is notproduct
   if (ReplayCompiles) {
     FLAG_SET_ERGO_IF_DEFAULT(UseDebuggerErgo, true);
   }
+#endif
 
   if (UseDebuggerErgo) {
     // Turn on sub-flags

--- a/test/hotspot/jtreg/compiler/ciReplay/TestInvalidReplayFile.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/TestInvalidReplayFile.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+ * @test
+ * @summary Test that VM rejects and invalid replay file.
+ * @library /test/lib
+ * @requires vm.compMode != "Xint"
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver TestInvalidReplayFile
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import java.io.File;
+import java.io.FileWriter;
+
+public class TestInvalidReplayFile {
+
+
+    public static void main(String[] args) throws Exception {
+
+        // This test also serves as a very basic sanity test for release VMs (accepting the replay options and
+        // attempting to read the replay file). Most of the tests in ciReplay use -XX:CICrashAt to induce artificial
+        // crashes into the compiler, and that option is not available for release VMs. Therefore we cannot generate
+        // replay files as a test in release builds.
+
+        File f = new File("bogus-replay-file.txt");
+        FileWriter w = new FileWriter(f);
+        w.write("Bogus 123");
+        w.flush();
+        w.close();
+
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-Xmx100M",
+                "-XX:+ReplayCompiles", "-XX:ReplayDataFile=./bogus-replay-file.txt");
+
+        OutputAnalyzer output_detail = new OutputAnalyzer(pb.start());
+        output_detail.shouldNotHaveExitValue(0);
+        output_detail.shouldContain("Error while parsing");
+
+    }
+}
+
+


### PR DESCRIPTION
See discussion: https://mail.openjdk.org/pipermail/hotspot-compiler-dev/2022-August/057988.html

Making ReplayCompiles a (diagnostic) runtime switch can help when facing problems with shipped release VMs:
- Investigate the effects of compiler errors in shipped VMs to estimate the bug impact
- Investigate if a given build is affected by a compiler bug

Making the option product increases libjvm.so text size by 54kb (Linux x64). No measurable runtime overhead.

Tests: Almost all tests in compiler/ciReplay generate replay files by inducing a crash with `-XX:CICrashAt`. That won't work in release builds. I added a simple test that checks that invalid replay files are correctly refused, and that test can also be done on a release VM. So we at least have a test for release that checks argument parsing.

(Note: I have https://github.com/openjdk/jdk/pull/9891 open, which could in the future serve as an alternative to CICrashAt by limiting the compiler arena).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292561](https://bugs.openjdk.org/browse/JDK-8292561): Make "ReplayCompiles" a diagnostic product switch


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Xin Liu](https://openjdk.org/census#xliu) (@navyxliu - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9935/head:pull/9935` \
`$ git checkout pull/9935`

Update a local copy of the PR: \
`$ git checkout pull/9935` \
`$ git pull https://git.openjdk.org/jdk pull/9935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9935`

View PR using the GUI difftool: \
`$ git pr show -t 9935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9935.diff">https://git.openjdk.org/jdk/pull/9935.diff</a>

</details>
