### PR TITLE
7175397: The divider color is not changed to green when dragging for Nimbus LaF.

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
@@ -21330,7 +21330,7 @@
                <uiProperty name="centerOneTouchButtons" type="BOOLEAN" value="true"/>
                <uiProperty name="oneTouchButtonOffset" type="INT" value="30"/>
                <uiProperty name="oneTouchExpandable" type="BOOLEAN" value="false"/>
-               <uiProperty name="continuousLayout" type="BOOLEAN" value="true"/>
+               <uiProperty name="continuousLayout" type="BOOLEAN" value="false"/>
             </uiproperties>
          </style>
          <backgroundStates>

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthSplitPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthSplitPaneUI.java
@@ -65,6 +65,8 @@ public class SynthSplitPaneUI extends BasicSplitPaneUI
      */
     private SynthStyle dividerStyle;
 
+    private Color dividerDraggingColor;
+
     /**
      *
      * Constructs a {@code SynthSplitPaneUI}.
@@ -88,6 +90,8 @@ public class SynthSplitPaneUI extends BasicSplitPaneUI
     @SuppressWarnings("deprecation")
     protected void installDefaults() {
         updateStyle(splitPane);
+
+        dividerDraggingColor = UIManager.getColor("SplitPaneDivider.draggingColor");
 
         setOrientation(splitPane.getOrientation());
         setContinuousLayout(splitPane.isContinuousLayout());
@@ -265,6 +269,16 @@ public class SynthSplitPaneUI extends BasicSplitPaneUI
         return new Canvas() {
             public void paint(Graphics g) {
                 paintDragDivider(g, 0, 0, getWidth(), getHeight());
+                if(!isContinuousLayout() && getLastDragLocation() != -1) {
+                    Dimension      size = splitPane.getSize();
+
+                    g.setColor(dividerDraggingColor);
+                    if(getOrientation() == JSplitPane.HORIZONTAL_SPLIT) {
+                        g.fillRect(0, 0, dividerSize - 1, size.height - 1);
+                    } else {
+                        g.fillRect(0, 0, size.width - 1, dividerSize - 1);
+                    }
+                }
             }
         };
     }
@@ -335,6 +349,8 @@ public class SynthSplitPaneUI extends BasicSplitPaneUI
                                    MOUSE_OVER) | PRESSED);
         Shape oldClip = g.getClip();
         g.clipRect(x, y, w, h);
+
+
         context.getPainter().paintSplitPaneDragDivider(context, g, x, y, w, h,
                                            splitPane.getOrientation());
         g.setClip(oldClip);
@@ -347,12 +363,21 @@ public class SynthSplitPaneUI extends BasicSplitPaneUI
     public void finishedPaintingChildren(JSplitPane jc, Graphics g) {
         if(jc == splitPane && getLastDragLocation() != -1 &&
                               !isContinuousLayout() && !draggingHW) {
+            Dimension      size = splitPane.getSize();
+
+            g.setColor(dividerDraggingColor);
             if(jc.getOrientation() == JSplitPane.HORIZONTAL_SPLIT) {
+
                 paintDragDivider(g, getLastDragLocation(), 0, dividerSize - 1,
                                  splitPane.getHeight() - 1);
+                g.fillRect(getLastDragLocation(), 0, dividerSize - 1,
+                        size.height - 1);
             } else {
+
                 paintDragDivider(g, 0, getLastDragLocation(),
                                  splitPane.getWidth() - 1, dividerSize - 1);
+                g.fillRect(0, getLastDragLocation(), size.width - 1,
+                        dividerSize - 1);
             }
         }
     }


### PR DESCRIPTION
SplitPaneDivider.draggingColor UIProperty was not honoured in Nimbus L&F. 
Added support for setting SplitPane dragging color for Nimbus L&F by drawing a fillRect of the set color as done in BasicLookAndFeel.
The fix relies on `continuousLayout` property being false by default which is enabled for Nimbus, which is set to default false now, same as in other L&F. I think it was set true just to have documented default value in JDK-6937415

All jtreg swing tests are ok along with SwingSet2 JSplitPane demo in Nimbus L&F.