### PR TITLE
8292656: G1: Remove G1HotCardCache::_use_cache

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1048,7 +1048,7 @@ void G1CollectedHeap::prepare_heap_for_mutators() {
 }
 
 void G1CollectedHeap::abort_refinement() {
-  if (G1HotCardCache::default_use_cache()) {
+  if (G1HotCardCache::use_cache()) {
     _hot_card_cache->reset_hot_cache();
   }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1048,7 +1048,7 @@ void G1CollectedHeap::prepare_heap_for_mutators() {
 }
 
 void G1CollectedHeap::abort_refinement() {
-  if (_hot_card_cache->use_cache()) {
+  if (G1HotCardCache::default_use_cache()) {
     _hot_card_cache->reset_hot_cache();
   }
 
@@ -3377,7 +3377,6 @@ void G1CollectedHeap::update_used_after_gc(bool evacuation_failed) {
 
 void G1CollectedHeap::reset_hot_card_cache() {
   _hot_card_cache->reset_hot_cache();
-  _hot_card_cache->set_use_cache(true);
 }
 
 void G1CollectedHeap::purge_code_root_memory() {

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -121,7 +121,7 @@ void G1FullGCPrepareTask::G1ResetMetadataClosure::reset_region_metadata(HeapRegi
   hr->clear_cardtable();
 
   G1HotCardCache* hcc = _g1h->hot_card_cache();
-  if (hcc->use_cache()) {
+  if (G1HotCardCache::default_use_cache()) {
     hcc->reset_card_counts(hr);
   }
 }

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -121,7 +121,7 @@ void G1FullGCPrepareTask::G1ResetMetadataClosure::reset_region_metadata(HeapRegi
   hr->clear_cardtable();
 
   G1HotCardCache* hcc = _g1h->hot_card_cache();
-  if (G1HotCardCache::default_use_cache()) {
+  if (G1HotCardCache::use_cache()) {
     hcc->reset_card_counts(hr);
   }
 }

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
@@ -83,7 +83,7 @@ G1GCPhaseTimes::G1GCPhaseTimes(STWGCTimer* gc_timer, uint max_gc_threads) :
   }
 
   _gc_par_phases[MergeLB] = new WorkerDataArray<double>("MergeLB", "Log Buffers (ms):", max_gc_threads);
-  if (G1HotCardCache::default_use_cache()) {
+  if (G1HotCardCache::use_cache()) {
     _gc_par_phases[MergeHCC] = new WorkerDataArray<double>("MergeHCC", "Hot Card Cache (ms):", max_gc_threads);
     _gc_par_phases[MergeHCC]->create_thread_work_items("Dirty Cards:", MergeHCCDirtyCards);
     _gc_par_phases[MergeHCC]->create_thread_work_items("Skipped Cards:", MergeHCCSkippedCards);
@@ -434,7 +434,7 @@ double G1GCPhaseTimes::print_evacuate_initial_collection_set() const {
   debug_time("Prepare Merge Heap Roots", _cur_prepare_merge_heap_roots_time_ms);
   debug_phase(_gc_par_phases[MergeER]);
   debug_phase(_gc_par_phases[MergeRS]);
-  if (G1HotCardCache::default_use_cache()) {
+  if (G1HotCardCache::use_cache()) {
     debug_phase(_gc_par_phases[MergeHCC]);
   }
   debug_phase(_gc_par_phases[MergeLB]);

--- a/src/hotspot/share/gc/g1/g1HotCardCache.cpp
+++ b/src/hotspot/share/gc/g1/g1HotCardCache.cpp
@@ -30,15 +30,13 @@
 #include "runtime/atomic.hpp"
 
 G1HotCardCache::G1HotCardCache(G1CollectedHeap *g1h):
-  _g1h(g1h), _use_cache(false), _card_counts(g1h),
+  _g1h(g1h), _card_counts(g1h),
   _hot_cache(NULL), _hot_cache_size(0), _hot_cache_par_chunk_size(0),
   _hot_cache_idx(0), _hot_cache_par_claimed_idx(0), _cache_wrapped_around(false)
 {}
 
 void G1HotCardCache::initialize(G1RegionToSpaceMapper* card_counts_storage) {
   if (default_use_cache()) {
-    _use_cache = true;
-
     _hot_cache_size = (size_t)1 << G1ConcRSLogCacheSize;
     _hot_cache = ArrayAllocator<CardValue*>::allocate(_hot_cache_size, mtGC);
 
@@ -95,7 +93,6 @@ void G1HotCardCache::drain(G1CardTableEntryClosure* cl, uint worker_id) {
   assert(default_use_cache(), "Drain only necessary if we use the hot card cache.");
 
   assert(_hot_cache != NULL, "Logic");
-  assert(!use_cache(), "cache should be disabled");
 
   while (_hot_cache_par_claimed_idx < _hot_cache_size) {
     size_t end_idx = Atomic::add(&_hot_cache_par_claimed_idx,

--- a/src/hotspot/share/gc/g1/g1HotCardCache.cpp
+++ b/src/hotspot/share/gc/g1/g1HotCardCache.cpp
@@ -36,7 +36,7 @@ G1HotCardCache::G1HotCardCache(G1CollectedHeap *g1h):
 {}
 
 void G1HotCardCache::initialize(G1RegionToSpaceMapper* card_counts_storage) {
-  if (default_use_cache()) {
+  if (use_cache()) {
     _hot_cache_size = (size_t)1 << G1ConcRSLogCacheSize;
     _hot_cache = ArrayAllocator<CardValue*>::allocate(_hot_cache_size, mtGC);
 
@@ -53,7 +53,7 @@ void G1HotCardCache::initialize(G1RegionToSpaceMapper* card_counts_storage) {
 }
 
 G1HotCardCache::~G1HotCardCache() {
-  if (default_use_cache()) {
+  if (use_cache()) {
     assert(_hot_cache != NULL, "Logic");
     ArrayAllocator<CardValue*>::free(_hot_cache, _hot_cache_size);
     _hot_cache = NULL;
@@ -90,7 +90,7 @@ CardTable::CardValue* G1HotCardCache::insert(CardValue* card_ptr) {
 }
 
 void G1HotCardCache::drain(G1CardTableEntryClosure* cl, uint worker_id) {
-  assert(default_use_cache(), "Drain only necessary if we use the hot card cache.");
+  assert(use_cache(), "Drain only necessary if we use the hot card cache.");
 
   assert(_hot_cache != NULL, "Logic");
 

--- a/src/hotspot/share/gc/g1/g1HotCardCache.hpp
+++ b/src/hotspot/share/gc/g1/g1HotCardCache.hpp
@@ -58,8 +58,6 @@ public:
 private:
   G1CollectedHeap*  _g1h;
 
-  bool              _use_cache;
-
   G1CardCounts      _card_counts;
 
 
@@ -98,12 +96,6 @@ private:
   ~G1HotCardCache();
 
   void initialize(G1RegionToSpaceMapper* card_counts_storage);
-
-  bool use_cache() { return _use_cache; }
-
-  void set_use_cache(bool b) {
-    _use_cache = (b ? default_use_cache() : false);
-  }
 
   // Returns the card to be refined or NULL.
   //

--- a/src/hotspot/share/gc/g1/g1HotCardCache.hpp
+++ b/src/hotspot/share/gc/g1/g1HotCardCache.hpp
@@ -88,7 +88,7 @@ private:
   static const int ClaimChunkSize = 32;
 
  public:
-  static bool default_use_cache() {
+  static bool use_cache() {
     return (G1ConcRSLogCacheSize > 0);
   }
 
@@ -120,7 +120,7 @@ private:
   // Resets the hot card cache and discards the entries.
   void reset_hot_cache() {
     assert(SafepointSynchronize::is_at_safepoint(), "Should be at a safepoint");
-    if (default_use_cache()) {
+    if (use_cache()) {
       reset_hot_cache_internal();
     }
   }

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1657,7 +1657,7 @@ bool G1RemSet::clean_card_before_refine(CardValue** const card_ptr_addr) {
   //   * a pointer to a "hot" card that was evicted from the "hot" cache.
   //
 
-  if (_hot_card_cache->use_cache()) {
+  if (G1HotCardCache::default_use_cache()) {
     assert(!SafepointSynchronize::is_at_safepoint(), "sanity");
 
     const CardValue* orig_card_ptr = card_ptr;

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1491,7 +1491,7 @@ public:
     }
 
     // Apply closure to log entries in the HCC.
-    if (_initial_evacuation && G1HotCardCache::default_use_cache()) {
+    if (_initial_evacuation && G1HotCardCache::use_cache()) {
       assert(merge_remset_phase == G1GCPhaseTimes::MergeRS, "Wrong merge phase");
       G1GCParPhaseTimesTracker x(p, G1GCPhaseTimes::MergeHCC, worker_id);
       G1MergeLogBufferCardsClosure cl(g1h, _scan_state);
@@ -1657,7 +1657,7 @@ bool G1RemSet::clean_card_before_refine(CardValue** const card_ptr_addr) {
   //   * a pointer to a "hot" card that was evicted from the "hot" cache.
   //
 
-  if (G1HotCardCache::default_use_cache()) {
+  if (G1HotCardCache::use_cache()) {
     assert(!SafepointSynchronize::is_at_safepoint(), "sanity");
 
     const CardValue* orig_card_ptr = card_ptr;

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -492,9 +492,7 @@ void G1YoungCollector::pre_evacuate_collection_set(G1EvacInfo* evacuation_info, 
     phase_times()->record_concatenate_dirty_card_logs_time_ms(dt.seconds() * MILLIUNITS);
   }
 
-  // Disable the hot card cache.
   hot_card_cache()->reset_hot_cache_claimed_index();
-  hot_card_cache()->set_use_cache(false);
 
   // Initialize the GC alloc regions.
   allocator()->init_gc_alloc_regions(evacuation_info);


### PR DESCRIPTION
Simple change  of removing an unneeded field. This PR contains two commits:

1. Removing the field and its accessors.
2. Renaming a method.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292656](https://bugs.openjdk.org/browse/JDK-8292656): G1: Remove G1HotCardCache::_use_cache


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9939/head:pull/9939` \
`$ git checkout pull/9939`

Update a local copy of the PR: \
`$ git checkout pull/9939` \
`$ git pull https://git.openjdk.org/jdk pull/9939/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9939`

View PR using the GUI difftool: \
`$ git pr show -t 9939`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9939.diff">https://git.openjdk.org/jdk/pull/9939.diff</a>

</details>
