### PR TITLE
8292671: Hotspot Style Guide should allow covariant returns

### DIFF
--- a/doc/hotspot-style.html
+++ b/doc/hotspot-style.html
@@ -429,7 +429,6 @@ while ( test_foo(args...) ) { // No, excess spaces around control</code></pre></
 <li><p><code>override</code> virtual specifiers for virtual functions (<a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2009/n2928.htm">n2928</a>), (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2010/n3206.htm">n3206</a>), (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2011/n3272.htm">n3272</a>)</p></li>
 <li><p>Range-based <code>for</code> loops (<a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2009/n2930.html">n2930</a>) (<a href="https://en.cppreference.com/w/cpp/language/range-for">range-for</a>)</p></li>
 <li><p>Unrestricted Unions (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2544.pdf">n2544</a>)</p></li>
-<li><p>Covariant return types</p></li>
 </ul>
 <h3 id="excluded-features">Excluded Features</h3>
 <ul>
@@ -448,7 +447,7 @@ while ( test_foo(args...) ) { // No, excess spaces around control</code></pre></
 <li><p>Avoid non-local variables with non-constexpr initialization. In particular, avoid variables with types requiring non-trivial initialization or destruction. Initialization order problems can be difficult to deal with and lead to surprises, as can destruction ordering. HotSpot doesn't generally try to cleanup on exit, and running destructors at exit can also lead to problems.</p></li>
 <li><p><code>[[deprecated]]</code> attribute (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3760.html">n3760</a>) — Not relevant in HotSpot code.</p></li>
 <li><p>Avoid most operator overloading, preferring named functions. When operator overloading is used, ensure the semantics conform to the normal expected behavior of the operation.</p></li>
-<li><p>Avoid most implicit conversion constructors and (implicit or explicit) conversion operators. (Note that conversion to <code>bool</code> isn't needed in HotSpot code because of the "no implicit boolean" guideline.)</p></li>
+<li><p>Avoid most implicit conversion constructors and (implicit or explicit) conversion operators. (Note that conversion to <code>bool</code> isn't needed in HotSpot code because of the &quot;no implicit boolean&quot; guideline.)</p></li>
 <li><p>Avoid <code>goto</code> statements.</p></li>
 </ul>
 <h3 id="undecided-features">Undecided Features</h3>

--- a/doc/hotspot-style.html
+++ b/doc/hotspot-style.html
@@ -429,6 +429,7 @@ while ( test_foo(args...) ) { // No, excess spaces around control</code></pre></
 <li><p><code>override</code> virtual specifiers for virtual functions (<a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2009/n2928.htm">n2928</a>), (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2010/n3206.htm">n3206</a>), (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2011/n3272.htm">n3272</a>)</p></li>
 <li><p>Range-based <code>for</code> loops (<a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2009/n2930.html">n2930</a>) (<a href="https://en.cppreference.com/w/cpp/language/range-for">range-for</a>)</p></li>
 <li><p>Unrestricted Unions (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2544.pdf">n2544</a>)</p></li>
+<li><p>Covariant return types</p></li>
 </ul>
 <h3 id="excluded-features">Excluded Features</h3>
 <ul>
@@ -447,8 +448,7 @@ while ( test_foo(args...) ) { // No, excess spaces around control</code></pre></
 <li><p>Avoid non-local variables with non-constexpr initialization. In particular, avoid variables with types requiring non-trivial initialization or destruction. Initialization order problems can be difficult to deal with and lead to surprises, as can destruction ordering. HotSpot doesn't generally try to cleanup on exit, and running destructors at exit can also lead to problems.</p></li>
 <li><p><code>[[deprecated]]</code> attribute (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3760.html">n3760</a>) — Not relevant in HotSpot code.</p></li>
 <li><p>Avoid most operator overloading, preferring named functions. When operator overloading is used, ensure the semantics conform to the normal expected behavior of the operation.</p></li>
-<li><p>Avoid most implicit conversion constructors and (implicit or explicit) conversion operators. (Note that conversion to <code>bool</code> isn't needed in HotSpot code because of the &quot;no implicit boolean&quot; guideline.)</p></li>
-<li><p>Avoid covariant return types.</p></li>
+<li><p>Avoid most implicit conversion constructors and (implicit or explicit) conversion operators. (Note that conversion to <code>bool</code> isn't needed in HotSpot code because of the "no implicit boolean" guideline.)</p></li>
 <li><p>Avoid <code>goto</code> statements.</p></li>
 </ul>
 <h3 id="undecided-features">Undecided Features</h3>

--- a/doc/hotspot-style.md
+++ b/doc/hotspot-style.md
@@ -1070,6 +1070,8 @@ and other supported compilers may not have anything similar.
 * Unrestricted Unions
 ([n2544](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2544.pdf))
 
+* Covariant return types
+
 ### Excluded Features
 
 * New string and character literals
@@ -1119,8 +1121,6 @@ normal expected behavior of the operation.
 * Avoid most implicit conversion constructors and (implicit or explicit)
 conversion operators.  (Note that conversion to `bool` isn't needed
 in HotSpot code because of the "no implicit boolean" guideline.)
-
-* Avoid covariant return types.
 
 * Avoid `goto` statements.
 

--- a/doc/hotspot-style.md
+++ b/doc/hotspot-style.md
@@ -1070,8 +1070,6 @@ and other supported compilers may not have anything similar.
 * Unrestricted Unions
 ([n2544](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2544.pdf))
 
-* Covariant return types
-
 ### Excluded Features
 
 * New string and character literals


### PR DESCRIPTION
The style guide explicitly lists covariant returns as a disallowed
feature of c++. I propose we allow that feature.

This came up on the c2 side where, with JDK-8275201, I introduced some
uses of covariant returns at a number of locations in the c2 code
because I felt the code was cleaner that way. I wasn't aware it was
mentioned on the style guide. This was noticed by another openjdk
contributor and I prepared a change to revert the use of covariant
returns I had introduced:

https://github.com/openjdk/jdk/pull/9237

But it feels that change actually makes the code less clear and
comments on the PR indicates some other contributors feel the same
way.

It's unclear to me why covariant returns are disallowed in the first
place and the (few) contributors I asked don't seem to know either. So
I propose simply allowing covariant returns.

/cc hotspot

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292671](https://bugs.openjdk.org/browse/JDK-8292671): Hotspot Style Guide should allow covariant returns


### Reviewers
 * [John R Rose](https://openjdk.org/census#jrose) (@rose00 - **Reviewer**) ⚠️ Review applies to [fea33592](https://git.openjdk.org/jdk/pull/9941/files/fea33592a5d220a548325cad46487b6b4f8bb967)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to [fea33592](https://git.openjdk.org/jdk/pull/9941/files/fea33592a5d220a548325cad46487b6b4f8bb967)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [fea33592](https://git.openjdk.org/jdk/pull/9941/files/fea33592a5d220a548325cad46487b6b4f8bb967)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [fea33592](https://git.openjdk.org/jdk/pull/9941/files/fea33592a5d220a548325cad46487b6b4f8bb967)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [fea33592](https://git.openjdk.org/jdk/pull/9941/files/fea33592a5d220a548325cad46487b6b4f8bb967)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9941/head:pull/9941` \
`$ git checkout pull/9941`

Update a local copy of the PR: \
`$ git checkout pull/9941` \
`$ git pull https://git.openjdk.org/jdk pull/9941/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9941`

View PR using the GUI difftool: \
`$ git pr show -t 9941`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9941.diff">https://git.openjdk.org/jdk/pull/9941.diff</a>

</details>
