### PR TITLE
8292623: Reduce runtime of java.io microbenchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/java/io/DataOutputStreamTest.java
+++ b/test/micro/org/openjdk/bench/java/io/DataOutputStreamTest.java
@@ -30,9 +30,9 @@ import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Fork(value = 1, warmups = 0)
+@Fork(2)
 @Measurement(iterations = 6, time = 1)
-@Warmup(iterations=2, time = 2)
+@Warmup(iterations=4, time = 2)
 @State(Scope.Benchmark)
 public class DataOutputStreamTest {
 

--- a/test/micro/org/openjdk/bench/java/io/FileChannelRead.java
+++ b/test/micro/org/openjdk/bench/java/io/FileChannelRead.java
@@ -38,6 +38,9 @@ import org.openjdk.jmh.annotations.*;
  */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(2)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class FileChannelRead {
 

--- a/test/micro/org/openjdk/bench/java/io/FileChannelWrite.java
+++ b/test/micro/org/openjdk/bench/java/io/FileChannelWrite.java
@@ -37,6 +37,9 @@ import org.openjdk.jmh.annotations.*;
  */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(2)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class FileChannelWrite {
 

--- a/test/micro/org/openjdk/bench/java/io/FileRead.java
+++ b/test/micro/org/openjdk/bench/java/io/FileRead.java
@@ -37,6 +37,9 @@ import org.openjdk.jmh.annotations.*;
  */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(2)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class FileRead {
 

--- a/test/micro/org/openjdk/bench/java/io/FileWrite.java
+++ b/test/micro/org/openjdk/bench/java/io/FileWrite.java
@@ -36,6 +36,9 @@ import org.openjdk.jmh.annotations.*;
  */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(2)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class FileWrite {
 

--- a/test/micro/org/openjdk/bench/java/io/ObjectStreamClasses.java
+++ b/test/micro/org/openjdk/bench/java/io/ObjectStreamClasses.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.io;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.io.ObjectStreamClass;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class ObjectStreamClasses {
 

--- a/test/micro/org/openjdk/bench/java/io/RandomAccessRead.java
+++ b/test/micro/org/openjdk/bench/java/io/RandomAccessRead.java
@@ -30,13 +30,16 @@ import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.annotations.TearDown;
 
 /**
@@ -45,6 +48,9 @@ import org.openjdk.jmh.annotations.TearDown;
  */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(2)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class RandomAccessRead {
 

--- a/test/micro/org/openjdk/bench/java/io/RandomAccessWrite.java
+++ b/test/micro/org/openjdk/bench/java/io/RandomAccessWrite.java
@@ -30,13 +30,16 @@ import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.annotations.TearDown;
 
 /**
@@ -45,6 +48,9 @@ import org.openjdk.jmh.annotations.TearDown;
  */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(2)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class RandomAccessWrite {
 

--- a/test/micro/org/openjdk/bench/java/io/SerializationWriteReplace.java
+++ b/test/micro/org/openjdk/bench/java/io/SerializationWriteReplace.java
@@ -25,12 +25,15 @@ package org.openjdk.bench.java.io;
 import org.openjdk.bench.java.io.BlackholedOutputStream;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.io.IOException;
@@ -41,6 +44,9 @@ import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class SerializationWriteReplace {
 

--- a/test/micro/org/openjdk/bench/java/io/UTF8.java
+++ b/test/micro/org/openjdk/bench/java/io/UTF8.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.io;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.io.DataOutputStream;
@@ -40,6 +43,9 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class UTF8 {
 


### PR DESCRIPTION
These changes reduce the run time from about 3h15m to about 2h5m.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292623](https://bugs.openjdk.org/browse/JDK-8292623): Reduce runtime of java.io microbenchmarks


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9942/head:pull/9942` \
`$ git checkout pull/9942`

Update a local copy of the PR: \
`$ git checkout pull/9942` \
`$ git pull https://git.openjdk.org/jdk pull/9942/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9942`

View PR using the GUI difftool: \
`$ git pr show -t 9942`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9942.diff">https://git.openjdk.org/jdk/pull/9942.diff</a>

</details>
