### PR TITLE
8292676: Remove two kerberos tests from problem list

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -618,8 +618,6 @@ com/sun/security/auth/callback/TextCallbackHandler/Password.java 8039280 generic
 com/sun/security/sasl/gsskerb/AuthOnly.java                     8039280 generic-all
 com/sun/security/sasl/gsskerb/ConfSecurityLayer.java            8039280 generic-all
 com/sun/security/sasl/gsskerb/NoSecurityLayer.java              8039280 generic-all
-javax/security/auth/kerberos/KerberosHashEqualsTest.java        8039280 generic-all
-javax/security/auth/kerberos/KerberosTixDateTest.java           8039280 generic-all
 sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
 sun/security/provider/PolicyParser/ExtDirsChange.java           8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all


### PR DESCRIPTION
The two tests are no longer manual and should be removed from the problem list.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292676](https://bugs.openjdk.org/browse/JDK-8292676): Remove two kerberos tests from problem list


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9943/head:pull/9943` \
`$ git checkout pull/9943`

Update a local copy of the PR: \
`$ git checkout pull/9943` \
`$ git pull https://git.openjdk.org/jdk pull/9943/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9943`

View PR using the GUI difftool: \
`$ git pr show -t 9943`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9943.diff">https://git.openjdk.org/jdk/pull/9943.diff</a>

</details>
