### PR TITLE
8292043: Incorrect decoding near EOF for stateful decoders like UTF-16

### DIFF
--- a/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
@@ -378,7 +378,6 @@ public class StreamDecoder extends Reader {
                     eof = true;
                     if ((cb.position() == 0) && (!bb.hasRemaining()))
                         break;
-                    decoder.reset();
                 }
                 continue;
             }

--- a/test/jdk/java/io/InputStreamReader/StatefulDecoderNearEOF.java
+++ b/test/jdk/java/io/InputStreamReader/StatefulDecoderNearEOF.java
@@ -29,29 +29,51 @@
  */
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.MalformedInputException;
 import java.nio.charset.StandardCharsets;
+import java.util.stream.IntStream;
 
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 @Test
 public class StatefulDecoderNearEOF {
-    private static final byte[] INPUT = {
-            (byte) 0xff, (byte) 0xfe, // BOM (in UTF-16LE)
-            0, (byte) 0xd8, // High surrogate (in UTF-16LE)
-    };
 
-    public void testStatefulDecoderNearEOF() {
-        assertThrows(MalformedInputException.class, () -> {
-            try (var r = new InputStreamReader(
-                    new ByteArrayInputStream(INPUT),
-                    StandardCharsets.UTF_16.newDecoder().onMalformedInput(CodingErrorAction.REPORT))) {
-                System.out.printf("%04x%n", r.read()); // \u00d8 (wrong, uses UTF-16BE)
-                System.out.printf("%04x%n", r.read()); // EOF
-            }
-        });
+    @DataProvider
+    public Object[][] inputs() {
+        return new Object[][] {
+            // BOM, followed by High surrogate (in UTF-16LE).
+            // First read() should throw an exception.
+            {new byte[] {(byte)0xff, (byte)0xfe, 0, (byte)0xd8}, 0},
+
+            // BOM, followed by 'A', 'B', 'C', then by High surrogate (in UTF-16LE).
+            // Fourth read() should throw an exception.
+            {new byte[] {(byte)0xff, (byte)0xfe, (byte)0x41, 0, (byte)0x42, 0, (byte)0x43, 0, 0, (byte)0xd8}, 3},
+        };
+    }
+
+    @Test (dataProvider = "inputs")
+    public void testStatefulDecoderNearEOF(byte[] ba, int numSucessReads) throws IOException {
+        try (var r = new InputStreamReader(
+                new ByteArrayInputStream(ba),
+                StandardCharsets.UTF_16.newDecoder().onMalformedInput(CodingErrorAction.REPORT))) {
+            // Issue read() as many as numSucessReads which should not fail
+            IntStream.rangeClosed(1, numSucessReads).forEach(i -> {
+                try {
+                    assertEquals(r.read(), (int)ba[i * 2]);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+
+            // Final dangling high surrogate should throw an exception
+            assertThrows(MalformedInputException.class, () -> r.read());
+        }
     }
 }

--- a/test/jdk/java/io/InputStreamReader/StatefulDecoderNearEOF.java
+++ b/test/jdk/java/io/InputStreamReader/StatefulDecoderNearEOF.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8292043
+ * @run testng StatefulDecoderNearEOF
+ * @summary Check MalformedInputException is thrown with stateful decoders
+ *      with malformed input before EOF
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.MalformedInputException;
+import java.nio.charset.StandardCharsets;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertThrows;
+
+@Test
+public class StatefulDecoderNearEOF {
+    private static final byte[] INPUT = {
+            (byte) 0xff, (byte) 0xfe, // BOM (in UTF-16LE)
+            0, (byte) 0xd8, // High surrogate (in UTF-16LE)
+    };
+
+    public void testStatefulDecoderNearEOF() {
+        assertThrows(MalformedInputException.class, () -> {
+            try (var r = new InputStreamReader(
+                    new ByteArrayInputStream(INPUT),
+                    StandardCharsets.UTF_16.newDecoder().onMalformedInput(CodingErrorAction.REPORT))) {
+                System.out.printf("%04x%n", r.read()); // \u00d8 (wrong, uses UTF-16BE)
+                System.out.printf("%04x%n", r.read()); // EOF
+            }
+        });
+    }
+}


### PR DESCRIPTION
Fixing incorrect state handling with EOF in `StreamDecoder`. There's a `reset()` call to the decoder seeing the EOF before the last `decode()` operation to handle the state correctly. Removing the call should not affect other cases because `reset()` is issued down the execution.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292043](https://bugs.openjdk.org/browse/JDK-8292043): Incorrect decoding near EOF for stateful decoders like UTF-16


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to [24977db2](https://git.openjdk.org/jdk/pull/9945/files/24977db257f7334810decfe94bd5dd537c93d39d)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9945/head:pull/9945` \
`$ git checkout pull/9945`

Update a local copy of the PR: \
`$ git checkout pull/9945` \
`$ git pull https://git.openjdk.org/jdk pull/9945/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9945`

View PR using the GUI difftool: \
`$ git pr show -t 9945`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9945.diff">https://git.openjdk.org/jdk/pull/9945.diff</a>

</details>
