### PR TITLE
8282684: Obsolete UseContainerCpuShares and PreferContainerQuotaForCPUCount flags

### DIFF
--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -59,15 +59,6 @@
   product(bool, UseContainerSupport, true,                              \
           "Enable detection and runtime container configuration support") \
                                                                         \
-  product(bool, UseContainerCpuShares, false,                           \
-          "(Deprecated) Include CPU shares in the CPU availability"     \
-          " calculation.")                                              \
-                                                                        \
-  product(bool, PreferContainerQuotaForCPUCount, true,                  \
-          "(Deprecated) Calculate the container CPU availability based" \
-          " on the value of quotas (if set), when true. Otherwise, use" \
-          " the CPU shares value, provided it is less than quota.")     \
-                                                                        \
   product(bool, AdjustStackSizeForTLS, false,                           \
           "Increase the thread stack size to include space for glibc "  \
           "static thread-local storage (TLS) if true")                  \

--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -88,16 +88,8 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
                 long numPeriods = containerMetrics.getCpuNumPeriods();
                 long quotaNanos = TimeUnit.MICROSECONDS.toNanos(quota * numPeriods);
                 return getUsageDividesTotal(cpuUsageSupplier().getAsLong(), quotaNanos);
-            } else if (share > 0) {
-                long hostTicks = getHostTotalCpuTicks0();
-                int totalCPUs = getHostOnlineCpuCount0();
-                int containerCPUs = getAvailableProcessors();
-                // scale the total host load to the actual container cpus
-                double scaleFactor = ((double) containerCPUs) / totalCPUs;
-                hostTicks = (long) (hostTicks * scaleFactor);
-                return getUsageDividesTotal(cpuUsageSupplier().getAsLong(), hostTicks);
             } else {
-                // If CPU quotas and shares are not active then find the average load for
+                // If CPU quotas are not active then find the average load for
                 // all online CPUs that are allowed to run this container.
 
                 // If the cpuset is the same as the host's one there is no need to iterate over each CPU

--- a/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
@@ -58,11 +58,6 @@ public class TestCPUAwareness {
             // cpuset, period, shares, expected Active Processor Count
             testComboWithCpuSets();
 
-            // cpu shares - it should be safe to use CPU shares exceeding available CPUs
-            testCpuShares(256, 1);
-            testCpuShares(2048, 2);
-            testCpuShares(4096, 4);
-
             // leave one CPU for system and tools, otherwise this test may be unstable
             int maxNrOfAvailableCpus =  availableCPUs - 1;
             for (int i=1; i < maxNrOfAvailableCpus; i = i * 2) {
@@ -100,11 +95,6 @@ public class TestCPUAwareness {
         String cpuSetStr = CPUSetsReader.readFromProcStatus("Cpus_allowed_list");
         System.out.println("cpuSetStr = " + cpuSetStr);
 
-        // OLD = use the deprecated -XX:+UseContainerCpuShares flag, which
-        // will be removed in the next JDK release. See JDK-8281181.
-        boolean OLD = true;
-        boolean NEW = false;
-
         if (cpuSetStr == null) {
             System.out.printf("The cpuset test cases are skipped");
         } else {
@@ -113,32 +103,21 @@ public class TestCPUAwareness {
             // Test subset of cpuset with one element
             if (cpuSet.size() >= 1) {
                 String testCpuSet = CPUSetsReader.listToString(cpuSet, 1);
-                testAPCCombo(OLD, testCpuSet, 200*1000, 100*1000,   4*1024, true, 1);
-                testAPCCombo(NEW, testCpuSet, 200*1000, 100*1000,   4*1024, true, 1);
+                testAPCCombo(testCpuSet, 200*1000, 100*1000,   4*1024, 1);
             }
 
             // Test subset of cpuset with two elements
             if (cpuSet.size() >= 2) {
                 String testCpuSet = CPUSetsReader.listToString(cpuSet, 2);
-                testAPCCombo(OLD, testCpuSet, 200*1000, 100*1000, 4*1024, true, 2);
-                testAPCCombo(OLD, testCpuSet, 200*1000, 100*1000, 1023,   true, 2);
-                testAPCCombo(OLD, testCpuSet, 200*1000, 100*1000, 1023,   false,1);
-
-                testAPCCombo(NEW, testCpuSet, 200*1000, 100*1000, 4*1024, true, 2);
-                testAPCCombo(NEW, testCpuSet, 200*1000, 100*1000, 1023,   true, 2);
-                testAPCCombo(NEW, testCpuSet, 200*1000, 100*1000, 1023,   false,2);
+                testAPCCombo(testCpuSet, 200*1000, 100*1000, 4*1024, 2);
+                testAPCCombo(testCpuSet, 200*1000, 100*1000, 1023,   2);
             }
 
             // Test subset of cpuset with three elements
             if (cpuSet.size() >= 3) {
                 String testCpuSet = CPUSetsReader.listToString(cpuSet, 3);
-                testAPCCombo(OLD, testCpuSet, 100*1000, 100*1000, 2*1024, true, 1);
-                testAPCCombo(OLD, testCpuSet, 200*1000, 100*1000, 1023,   true, 2);
-                testAPCCombo(OLD, testCpuSet, 200*1000, 100*1000, 1023,   false,1);
-
-                testAPCCombo(NEW, testCpuSet, 100*1000, 100*1000, 2*1024, true, 1);
-                testAPCCombo(NEW, testCpuSet, 200*1000, 100*1000, 1023,   true, 2);
-                testAPCCombo(NEW, testCpuSet, 200*1000, 100*1000, 1023,   false,2);
+                testAPCCombo(testCpuSet, 100*1000, 100*1000, 2*1024, 1);
+                testAPCCombo(testCpuSet, 200*1000, 100*1000, 1023,   2);
             }
         }
     }
@@ -195,20 +174,13 @@ public class TestCPUAwareness {
     }
 
 
-    // Test correctess of automatically selected active processor count
-    // Note: when -XX:+UseContainerCpuShares is removed,
-    // useContainerCpuShares, shares, and usePreferContainerQuotaForCPUCount
-    // should also be removed.
-    private static void testAPCCombo(boolean useContainerCpuShares, String cpuset, int quota, int period, int shares,
-                                     boolean usePreferContainerQuotaForCPUCount,
+    private static void testAPCCombo(String cpuset, int quota, int period, int shares,
                                      int expectedAPC) throws Exception {
         Common.logNewTestCase("test APC Combo");
         System.out.println("cpuset = " + cpuset);
         System.out.println("quota = " + quota);
         System.out.println("period = " + period);
         System.out.println("shares = " + shares);
-        System.out.println("useContainerCpuShares = " + useContainerCpuShares);
-        System.out.println("usePreferContainerQuotaForCPUCount = " + usePreferContainerQuotaForCPUCount);
         System.out.println("expectedAPC = " + expectedAPC);
 
         expectedAPC = adjustExpectedAPCForAvailableCPUs(expectedAPC);
@@ -219,40 +191,10 @@ public class TestCPUAwareness {
             .addDockerOpts("--cpu-quota=" + quota)
             .addDockerOpts("--cpu-shares=" + shares);
 
-        if (useContainerCpuShares) opts.addJavaOpts("-XX:+UseContainerCpuShares");  // deprecated
-        if (!usePreferContainerQuotaForCPUCount) opts.addJavaOpts("-XX:-PreferContainerQuotaForCPUCount");  // deprecated
-
         Common.run(opts)
             .shouldMatch("active_processor_count.*" + expectedAPC);
     }
 
-
-    // Note: when -XX:+UseContainerCpuShares is removed, this test should also be removed.
-    private static void testCpuShares(int shares, int expectedAPC) throws Exception {
-        Common.logNewTestCase("test cpu shares, shares = " + shares);
-        System.out.println("expectedAPC = " + expectedAPC);
-
-        expectedAPC = adjustExpectedAPCForAvailableCPUs(expectedAPC);
-
-        DockerRunOptions opts = Common.newOpts(imageName)
-            .addDockerOpts("--cpu-shares=" + shares);
-        opts.addJavaOpts("-XX:+UseContainerCpuShares"); // deprecated
-        OutputAnalyzer out = Common.run(opts);
-        // Cgroups v2 needs to do some scaling of raw shares values. Hence,
-        // 256 CPU shares come back as 264. Raw value written to cpu.weight
-        // is 10. The reason this works for >= 1024 shares value is because
-        // post-scaling the closest multiple of 1024 is found and returned.
-        //
-        // For values < 1024, this doesn't happen so loosen the match to a
-        // 3-digit number and ensure the active_processor_count is as
-        // expected.
-        if (shares < 1024) {
-            out.shouldMatch("CPU Shares is.*\\d{3}");
-        } else {
-            out.shouldMatch("CPU Shares is.*" + shares);
-        }
-        out.shouldMatch("active_processor_count.*" + expectedAPC);
-    }
 
     private static void testOperatingSystemMXBeanAwareness(String cpuAllocation, String expectedCpus) throws Exception {
         Common.logNewTestCase("Check OperatingSystemMXBean");


### PR DESCRIPTION
Please review this fix to obsolete two container JVM flags related to using CPU shares to compute active processor count within containers.  This fix obsoletes the flags and removes the use of CPU shares from the calculations.  The fix was tested by running the container tests on Linux x64 and Linux aarch64 using Mach5

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282684](https://bugs.openjdk.org/browse/JDK-8282684): Obsolete UseContainerCpuShares and PreferContainerQuotaForCPUCount flags


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9948/head:pull/9948` \
`$ git checkout pull/9948`

Update a local copy of the PR: \
`$ git checkout pull/9948` \
`$ git pull https://git.openjdk.org/jdk pull/9948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9948`

View PR using the GUI difftool: \
`$ git pr show -t 9948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9948.diff">https://git.openjdk.org/jdk/pull/9948.diff</a>

</details>
