### PR TITLE
8292682: Code change of JDK-8282730 not updated to reflect CSR update

### DIFF
--- a/src/java.base/share/classes/javax/security/auth/spi/LoginModule.java
+++ b/src/java.base/share/classes/javax/security/auth/spi/LoginModule.java
@@ -225,7 +225,7 @@ public interface LoginModule {
      * @return {@code true} if this method succeeded, or {@code false}
      *                  if this {@code LoginModule} should be ignored.
      *
-     * @implSpec Implementations should check if a variable is {@code null}
+     * @implNote Implementations should check if a variable is {@code null}
      *      before removing it from the Principals or Credentials set
      *      of a {@code Subject}, otherwise a {@code NullPointerException}
      *      will be thrown as these sets {@linkplain Subject#Subject()


### PR DESCRIPTION
The final version of the CSR at https://bugs.openjdk.org/browse/JDK-8290119 uses `@implNote` for the new text, but the code change was not updated before the integration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292682](https://bugs.openjdk.org/browse/JDK-8292682): Code change of JDK-8282730 not updated to reflect CSR update


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9949/head:pull/9949` \
`$ git checkout pull/9949`

Update a local copy of the PR: \
`$ git checkout pull/9949` \
`$ git pull https://git.openjdk.org/jdk pull/9949/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9949`

View PR using the GUI difftool: \
`$ git pr show -t 9949`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9949.diff">https://git.openjdk.org/jdk/pull/9949.diff</a>

</details>
