### PR TITLE
8292686: runtime/cds/appcds/TestWithProfiler.java SIGSEGV in TableStatistics ctr

### DIFF
--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -503,7 +503,7 @@ bool StringTable::do_rehash() {
 
   // We use current size, not max size.
   size_t new_size = _local_table->get_size_log2(Thread::current());
-  StringTableHash* new_table = new StringTableHash(new_size, END_SIZE, REHASH_LEN);
+  StringTableHash* new_table = new StringTableHash(new_size, END_SIZE, REHASH_LEN, true);
   // Use alt hash from now on
   _alt_hash = true;
   if (!_local_table->try_move_nodes_to(Thread::current(), new_table)) {

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -172,7 +172,7 @@ void SymbolTable::create_table ()  {
   _current_size = ((size_t)1) << start_size_log_2;
   log_trace(symboltable)("Start size: " SIZE_FORMAT " (" SIZE_FORMAT ")",
                          _current_size, start_size_log_2);
-  _local_table = new SymbolTableHash(start_size_log_2, END_SIZE, REHASH_LEN);
+  _local_table = new SymbolTableHash(start_size_log_2, END_SIZE, REHASH_LEN, true);
 
   // Initialize the arena for global symbols, size passed in depends on CDS.
   if (symbol_alloc_arena_size == 0) {


### PR DESCRIPTION
There were two ConcurrentHashTable constructors that needed the non-default value of true in order to allocate TableRateStatistics in SymbolTable and StringTable, so I added them.  Default parameters are dangerous.  This is a trivial fix.
Tested tier 1-3 in progress.   Tested with failed test and JFR tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292686](https://bugs.openjdk.org/browse/JDK-8292686): runtime/cds/appcds/TestWithProfiler.java SIGSEGV in TableStatistics ctr


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9952/head:pull/9952` \
`$ git checkout pull/9952`

Update a local copy of the PR: \
`$ git checkout pull/9952` \
`$ git pull https://git.openjdk.org/jdk pull/9952/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9952`

View PR using the GUI difftool: \
`$ git pr show -t 9952`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9952.diff">https://git.openjdk.org/jdk/pull/9952.diff</a>

</details>
