### PR TITLE
8292691: Move CompilerConfig::is_xxx() inline functions out of compilerDefinitions.hpp

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -35,6 +35,7 @@
 #include "ci/ciArray.hpp"
 #include "ci/ciObjArrayKlass.hpp"
 #include "ci/ciTypeArrayKlass.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
 #include "utilities/powerOfTwo.hpp"

--- a/src/hotspot/cpu/aarch64/gc/shenandoah/c1/shenandoahBarrierSetC1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/c1/shenandoahBarrierSetC1_aarch64.cpp
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 #include "c1/c1_LIRAssembler.hpp"
 #include "c1/c1_MacroAssembler.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "gc/shared/gc_globals.hpp"
 #include "gc/shenandoah/shenandoahBarrierSet.hpp"
 #include "gc/shenandoah/shenandoahBarrierSetAssembler.hpp"

--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -25,6 +25,7 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.inline.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/tlab_globals.hpp"

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 #include "c1/c1_MacroAssembler.hpp"
 #include "c1/c1_Runtime1.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
 #include "gc/shared/collectedHeap.hpp"

--- a/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
@@ -29,6 +29,7 @@
 #include "c1/c1_MacroAssembler.hpp"
 #include "c1/c1_Runtime1.hpp"
 #include "ci/ciUtilities.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "compiler/oopMap.hpp"
 #include "gc/shared/cardTable.hpp"
 #include "gc/shared/cardTableBarrierSet.hpp"

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -27,6 +27,7 @@
 #include "asm/macroAssembler.hpp"
 #include "asm/macroAssembler.inline.hpp"
 #include "code/codeBlob.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "logging/log.hpp"
 #include "logging/logStream.hpp"
 #include "memory/resourceArea.hpp"

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -27,7 +27,6 @@
 
 #include "code/oopRecorder.hpp"
 #include "code/relocInfo.hpp"
-#include "compiler/compiler_globals.hpp"
 #include "utilities/align.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/growableArray.hpp"

--- a/src/hotspot/share/c1/c1_Compilation.hpp
+++ b/src/hotspot/share/c1/c1_Compilation.hpp
@@ -29,6 +29,7 @@
 #include "ci/ciMethodData.hpp"
 #include "code/exceptionHandlerTable.hpp"
 #include "compiler/compiler_globals.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "compiler/compilerDirectives.hpp"
 #include "memory/resourceArea.hpp"
 #include "runtime/deoptimization.hpp"

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -31,6 +31,7 @@
 #include "c1/c1_MacroAssembler.hpp"
 #include "c1/c1_ValueStack.hpp"
 #include "ci/ciInstance.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "compiler/oopMap.hpp"
 #include "runtime/os.hpp"
 #include "runtime/vm_version.hpp"

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -34,6 +34,7 @@
 #include "ci/ciInstance.hpp"
 #include "ci/ciObjArray.hpp"
 #include "ci/ciUtilities.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/c1/barrierSetC1.hpp"
 #include "oops/klass.inline.hpp"

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -32,6 +32,7 @@
 #include "code/debugInfoRec.hpp"
 #include "code/dependencies.hpp"
 #include "code/exceptionHandlerTable.hpp"
+#include "compiler/compiler_globals.hpp"
 #include "compiler/compilerThread.hpp"
 #include "oops/methodData.hpp"
 #include "runtime/javaThread.hpp"

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@
 #include "ci/ciSymbols.hpp"
 #include "ci/ciUtilities.inline.hpp"
 #include "compiler/abstractCompiler.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "compiler/methodLiveness.hpp"
 #include "interpreter/interpreter.hpp"
 #include "interpreter/linkResolver.hpp"

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -34,6 +34,7 @@
 #include "classfile/systemDictionary.hpp"
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "interpreter/linkResolver.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/oopFactory.hpp"

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -35,6 +35,7 @@
 #include "code/pcDesc.hpp"
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "compiler/oopMap.hpp"
 #include "gc/shared/barrierSetNMethod.hpp"
 #include "gc/shared/collectedHeap.hpp"

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -26,6 +26,7 @@
 #include "code/scopeDesc.hpp"
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "compiler/compilerOracle.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/methodData.hpp"

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -24,10 +24,8 @@
 
 #include "precompiled.hpp"
 #include "code/codeCache.hpp"
-#include "compiler/compiler_globals.hpp"
-#include "compiler/compilerDefinitions.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "include/jvm_io.h"
-#include "jvmci/jvmci_globals.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/continuation.hpp"
 #include "runtime/flags/jvmFlag.hpp"
@@ -113,105 +111,6 @@ void CompilationModeFlag::print_error() {
     comma = true;
   }
   jio_fprintf(defaultStream::error_stream(), "\n");
-}
-
-
-bool CompilerConfig::is_jvmci_compiler()    { return JVMCI_ONLY(has_jvmci() && UseJVMCICompiler) NOT_JVMCI(false); }
-bool CompilerConfig::is_jvmci()             { return JVMCI_ONLY(has_jvmci() && EnableJVMCI) NOT_JVMCI(false);      }
-
-// is_*_only() functions describe situations in which the JVM is in one way or another
-// forced to use a particular compiler or their combination. The constraint functions
-// deliberately ignore the fact that there may also be methods installed
-// through JVMCI (where the JVMCI compiler was invoked not through the broker). Be sure
-// to check for those (using is_jvmci()) in situations where it matters.
-//
-
-// Is the JVM in a configuration that permits only c1-compiled methods (level 1,2,3)?
-bool CompilerConfig::is_c1_only() {
-  if (!is_interpreter_only() && has_c1()) {
-    const bool c1_only = !has_c2() && !is_jvmci_compiler();
-    const bool tiered_degraded_to_c1_only = TieredCompilation && TieredStopAtLevel >= CompLevel_simple && TieredStopAtLevel < CompLevel_full_optimization;
-    const bool c1_only_compilation_mode = CompilationModeFlag::quick_only();
-    return c1_only || tiered_degraded_to_c1_only || c1_only_compilation_mode;
-  }
-  return false;
-}
-
-bool CompilerConfig::is_c1_or_interpreter_only_no_jvmci() {
-  assert(is_jvmci_compiler() && is_jvmci() || !is_jvmci_compiler(), "JVMCI compiler implies enabled JVMCI");
-  return !is_jvmci() && (is_interpreter_only() || is_c1_only());
-}
-
-bool CompilerConfig::is_c1_only_no_jvmci() {
-  return is_c1_only() && !is_jvmci();
-}
-
-// Is the JVM in a configuration that permits only c1-compiled methods at level 1?
-bool CompilerConfig::is_c1_simple_only() {
-  if (is_c1_only()) {
-    const bool tiered_degraded_to_level_1 = TieredCompilation && TieredStopAtLevel == CompLevel_simple;
-    const bool c1_only_compilation_mode = CompilationModeFlag::quick_only();
-    const bool tiered_off = !TieredCompilation;
-    return tiered_degraded_to_level_1 || c1_only_compilation_mode || tiered_off;
-  }
-  return false;
-}
-
-bool CompilerConfig::is_c2_enabled() {
-  return has_c2() && !is_interpreter_only() && !is_c1_only() && !is_jvmci_compiler();
-}
-
-bool CompilerConfig::is_jvmci_compiler_enabled() {
-  return is_jvmci_compiler() && !is_interpreter_only() && !is_c1_only();
-}
-// Is the JVM in a configuration that permits only c2-compiled methods?
-bool CompilerConfig::is_c2_only() {
-  if (is_c2_enabled()) {
-    const bool c2_only = !has_c1();
-    // There is no JVMCI compiler to replace C2 in the broker, and the user (or ergonomics)
-    // is forcing C1 off.
-    const bool c2_only_compilation_mode = CompilationModeFlag::high_only();
-    const bool tiered_off = !TieredCompilation;
-    return c2_only || c2_only_compilation_mode || tiered_off;
-  }
-  return false;
-}
-
-// Is the JVM in a configuration that permits only jvmci-compiled methods?
-bool CompilerConfig::is_jvmci_compiler_only() {
-  if (is_jvmci_compiler_enabled()) {
-    const bool jvmci_compiler_only = !has_c1();
-    // JVMCI compiler replaced C2 and the user (or ergonomics) is forcing C1 off.
-    const bool jvmci_only_compilation_mode = CompilationModeFlag::high_only();
-    const bool tiered_off = !TieredCompilation;
-    return jvmci_compiler_only || jvmci_only_compilation_mode || tiered_off;
-  }
-  return false;
-}
-
-bool CompilerConfig::is_c2_or_jvmci_compiler_only() {
-  return is_c2_only() || is_jvmci_compiler_only();
-}
-
-// Tiered is basically C1 & (C2 | JVMCI) minus all the odd cases with restrictions.
-bool CompilerConfig::is_tiered() {
-  assert(is_c1_simple_only() && is_c1_only() || !is_c1_simple_only(), "c1 simple mode must imply c1-only mode");
-  return has_tiered() && !is_interpreter_only() && !is_c1_only() && !is_c2_or_jvmci_compiler_only();
-}
-
-bool CompilerConfig::is_c1_enabled() {
-  return has_c1() && !is_interpreter_only() && !is_c2_or_jvmci_compiler_only();
-}
-
-bool CompilerConfig::is_c1_profiling() {
-  const bool c1_only_profiling = is_c1_only() && !is_c1_simple_only();
-  const bool tiered = is_tiered();
-  return c1_only_profiling || tiered;
-}
-
-
-bool CompilerConfig::is_c2_or_jvmci_compiler_enabled() {
-  return is_c2_enabled() || is_jvmci_compiler_enabled();
 }
 
 // Returns threshold scaled with CompileThresholdScaling
@@ -322,10 +221,6 @@ bool CompilerConfig::is_compilation_mode_selected() {
          !FLAG_IS_DEFAULT(CompilationMode)
          JVMCI_ONLY(|| !FLAG_IS_DEFAULT(EnableJVMCI)
                     || !FLAG_IS_DEFAULT(UseJVMCICompiler));
-}
-
-bool CompilerConfig::is_interpreter_only() {
-  return Arguments::is_interpreter_only() || TieredStopAtLevel == CompLevel_none;
 }
 
 static bool check_legacy_flags() {

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -24,6 +24,10 @@
 
 #include "precompiled.hpp"
 #include "code/codeCache.hpp"
+#include "compiler/compiler_globals.hpp"
+#include "compiler/compilerDefinitions.hpp"
+#include "include/jvm_io.h"
+#include "jvmci/jvmci_globals.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/continuation.hpp"
 #include "runtime/flags/jvmFlag.hpp"
@@ -32,8 +36,6 @@
 #include "runtime/flags/jvmFlagLimit.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/globals_extension.hpp"
-#include "compiler/compilerDefinitions.hpp"
-#include "gc/shared/gcConfig.hpp"
 #include "utilities/defaultStream.hpp"
 
 const char* compilertype2name_tab[compiler_number_of_types] = {
@@ -111,6 +113,105 @@ void CompilationModeFlag::print_error() {
     comma = true;
   }
   jio_fprintf(defaultStream::error_stream(), "\n");
+}
+
+
+bool CompilerConfig::is_jvmci_compiler()    { return JVMCI_ONLY(has_jvmci() && UseJVMCICompiler) NOT_JVMCI(false); }
+bool CompilerConfig::is_jvmci()             { return JVMCI_ONLY(has_jvmci() && EnableJVMCI) NOT_JVMCI(false);      }
+
+// is_*_only() functions describe situations in which the JVM is in one way or another
+// forced to use a particular compiler or their combination. The constraint functions
+// deliberately ignore the fact that there may also be methods installed
+// through JVMCI (where the JVMCI compiler was invoked not through the broker). Be sure
+// to check for those (using is_jvmci()) in situations where it matters.
+//
+
+// Is the JVM in a configuration that permits only c1-compiled methods (level 1,2,3)?
+bool CompilerConfig::is_c1_only() {
+  if (!is_interpreter_only() && has_c1()) {
+    const bool c1_only = !has_c2() && !is_jvmci_compiler();
+    const bool tiered_degraded_to_c1_only = TieredCompilation && TieredStopAtLevel >= CompLevel_simple && TieredStopAtLevel < CompLevel_full_optimization;
+    const bool c1_only_compilation_mode = CompilationModeFlag::quick_only();
+    return c1_only || tiered_degraded_to_c1_only || c1_only_compilation_mode;
+  }
+  return false;
+}
+
+bool CompilerConfig::is_c1_or_interpreter_only_no_jvmci() {
+  assert(is_jvmci_compiler() && is_jvmci() || !is_jvmci_compiler(), "JVMCI compiler implies enabled JVMCI");
+  return !is_jvmci() && (is_interpreter_only() || is_c1_only());
+}
+
+bool CompilerConfig::is_c1_only_no_jvmci() {
+  return is_c1_only() && !is_jvmci();
+}
+
+// Is the JVM in a configuration that permits only c1-compiled methods at level 1?
+bool CompilerConfig::is_c1_simple_only() {
+  if (is_c1_only()) {
+    const bool tiered_degraded_to_level_1 = TieredCompilation && TieredStopAtLevel == CompLevel_simple;
+    const bool c1_only_compilation_mode = CompilationModeFlag::quick_only();
+    const bool tiered_off = !TieredCompilation;
+    return tiered_degraded_to_level_1 || c1_only_compilation_mode || tiered_off;
+  }
+  return false;
+}
+
+bool CompilerConfig::is_c2_enabled() {
+  return has_c2() && !is_interpreter_only() && !is_c1_only() && !is_jvmci_compiler();
+}
+
+bool CompilerConfig::is_jvmci_compiler_enabled() {
+  return is_jvmci_compiler() && !is_interpreter_only() && !is_c1_only();
+}
+// Is the JVM in a configuration that permits only c2-compiled methods?
+bool CompilerConfig::is_c2_only() {
+  if (is_c2_enabled()) {
+    const bool c2_only = !has_c1();
+    // There is no JVMCI compiler to replace C2 in the broker, and the user (or ergonomics)
+    // is forcing C1 off.
+    const bool c2_only_compilation_mode = CompilationModeFlag::high_only();
+    const bool tiered_off = !TieredCompilation;
+    return c2_only || c2_only_compilation_mode || tiered_off;
+  }
+  return false;
+}
+
+// Is the JVM in a configuration that permits only jvmci-compiled methods?
+bool CompilerConfig::is_jvmci_compiler_only() {
+  if (is_jvmci_compiler_enabled()) {
+    const bool jvmci_compiler_only = !has_c1();
+    // JVMCI compiler replaced C2 and the user (or ergonomics) is forcing C1 off.
+    const bool jvmci_only_compilation_mode = CompilationModeFlag::high_only();
+    const bool tiered_off = !TieredCompilation;
+    return jvmci_compiler_only || jvmci_only_compilation_mode || tiered_off;
+  }
+  return false;
+}
+
+bool CompilerConfig::is_c2_or_jvmci_compiler_only() {
+  return is_c2_only() || is_jvmci_compiler_only();
+}
+
+// Tiered is basically C1 & (C2 | JVMCI) minus all the odd cases with restrictions.
+bool CompilerConfig::is_tiered() {
+  assert(is_c1_simple_only() && is_c1_only() || !is_c1_simple_only(), "c1 simple mode must imply c1-only mode");
+  return has_tiered() && !is_interpreter_only() && !is_c1_only() && !is_c2_or_jvmci_compiler_only();
+}
+
+bool CompilerConfig::is_c1_enabled() {
+  return has_c1() && !is_interpreter_only() && !is_c2_or_jvmci_compiler_only();
+}
+
+bool CompilerConfig::is_c1_profiling() {
+  const bool c1_only_profiling = is_c1_only() && !is_c1_simple_only();
+  const bool tiered = is_tiered();
+  return c1_only_profiling || tiered;
+}
+
+
+bool CompilerConfig::is_c2_or_jvmci_compiler_enabled() {
+  return is_c2_enabled() || is_jvmci_compiler_enabled();
 }
 
 // Returns threshold scaled with CompileThresholdScaling

--- a/src/hotspot/share/compiler/compilerDefinitions.hpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.hpp
@@ -136,9 +136,9 @@ public:
   constexpr static bool has_jvmci()  { return JVMCI_ONLY(true) NOT_JVMCI(false);            }
   constexpr static bool has_tiered() { return has_c1() && (has_c2() || has_jvmci());        }
 
-  static bool is_jvmci_compiler();
-  static bool is_jvmci();
-  static bool is_interpreter_only();
+  inline static bool is_jvmci_compiler();
+  inline static bool is_jvmci();
+  inline static bool is_interpreter_only();
 
   // is_*_only() functions describe situations in which the JVM is in one way or another
   // forced to use a particular compiler or their combination. The constraint functions
@@ -146,22 +146,22 @@ public:
   // through JVMCI (where the JVMCI compiler was invoked not through the broker). Be sure
   // to check for those (using is_jvmci()) in situations where it matters.
 
-  static bool is_tiered();
+  inline static bool is_tiered();
 
-  static bool is_c1_enabled();
-  static bool is_c1_only();
-  static bool is_c1_simple_only();
-  static bool is_c1_or_interpreter_only_no_jvmci();
-  static bool is_c1_only_no_jvmci();
-  static bool is_c1_profiling();
+  inline static bool is_c1_enabled();
+  inline static bool is_c1_only();
+  inline static bool is_c1_simple_only();
+  inline static bool is_c1_or_interpreter_only_no_jvmci();
+  inline static bool is_c1_only_no_jvmci();
+  inline static bool is_c1_profiling();
 
-  static bool is_jvmci_compiler_enabled();
-  static bool is_jvmci_compiler_only();
+  inline static bool is_jvmci_compiler_enabled();
+  inline static bool is_jvmci_compiler_only();
 
-  static bool is_c2_only();
-  static bool is_c2_enabled();
-  static bool is_c2_or_jvmci_compiler_only();
-  static bool is_c2_or_jvmci_compiler_enabled();
+  inline static bool is_c2_only();
+  inline static bool is_c2_enabled();
+  inline static bool is_c2_or_jvmci_compiler_only();
+  inline static bool is_c2_or_jvmci_compiler_enabled();
 
 private:
   static bool is_compilation_mode_selected();

--- a/src/hotspot/share/compiler/compilerDefinitions.hpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.hpp
@@ -25,10 +25,8 @@
 #ifndef SHARE_COMPILER_COMPILERDEFINITIONS_HPP
 #define SHARE_COMPILER_COMPILERDEFINITIONS_HPP
 
-#include "compiler/compiler_globals.hpp"
-#include "jvmci/jvmci_globals.hpp"
 #include "memory/allStatic.hpp"
-#include "runtime/globals.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 // The (closed set) of concrete compiler classes.
 enum CompilerType : u1 {
@@ -138,8 +136,8 @@ public:
   constexpr static bool has_jvmci()  { return JVMCI_ONLY(true) NOT_JVMCI(false);            }
   constexpr static bool has_tiered() { return has_c1() && (has_c2() || has_jvmci());        }
 
-  static bool is_jvmci_compiler()    { return JVMCI_ONLY(has_jvmci() && UseJVMCICompiler) NOT_JVMCI(false); }
-  static bool is_jvmci()             { return JVMCI_ONLY(has_jvmci() && EnableJVMCI) NOT_JVMCI(false);      }
+  static bool is_jvmci_compiler();
+  static bool is_jvmci();
   static bool is_interpreter_only();
 
   // is_*_only() functions describe situations in which the JVM is in one way or another
@@ -147,96 +145,23 @@ public:
   // deliberately ignore the fact that there may also be methods installed
   // through JVMCI (where the JVMCI compiler was invoked not through the broker). Be sure
   // to check for those (using is_jvmci()) in situations where it matters.
-  //
 
-  // Is the JVM in a configuration that permits only c1-compiled methods (level 1,2,3)?
-  static bool is_c1_only() {
-    if (!is_interpreter_only() && has_c1()) {
-      const bool c1_only = !has_c2() && !is_jvmci_compiler();
-      const bool tiered_degraded_to_c1_only = TieredCompilation && TieredStopAtLevel >= CompLevel_simple && TieredStopAtLevel < CompLevel_full_optimization;
-      const bool c1_only_compilation_mode = CompilationModeFlag::quick_only();
-      return c1_only || tiered_degraded_to_c1_only || c1_only_compilation_mode;
-    }
-    return false;
-  }
+  static bool is_tiered();
 
-  static bool is_c1_or_interpreter_only_no_jvmci() {
-    assert(is_jvmci_compiler() && is_jvmci() || !is_jvmci_compiler(), "JVMCI compiler implies enabled JVMCI");
-    return !is_jvmci() && (is_interpreter_only() || is_c1_only());
-  }
+  static bool is_c1_enabled();
+  static bool is_c1_only();
+  static bool is_c1_simple_only();
+  static bool is_c1_or_interpreter_only_no_jvmci();
+  static bool is_c1_only_no_jvmci();
+  static bool is_c1_profiling();
 
-  static bool is_c1_only_no_jvmci() {
-    return is_c1_only() && !is_jvmci();
-  }
+  static bool is_jvmci_compiler_enabled();
+  static bool is_jvmci_compiler_only();
 
-  // Is the JVM in a configuration that permits only c1-compiled methods at level 1?
-  static bool is_c1_simple_only() {
-    if (is_c1_only()) {
-      const bool tiered_degraded_to_level_1 = TieredCompilation && TieredStopAtLevel == CompLevel_simple;
-      const bool c1_only_compilation_mode = CompilationModeFlag::quick_only();
-      const bool tiered_off = !TieredCompilation;
-      return tiered_degraded_to_level_1 || c1_only_compilation_mode || tiered_off;
-    }
-    return false;
-  }
-
-  static bool is_c2_enabled() {
-    return has_c2() && !is_interpreter_only() && !is_c1_only() && !is_jvmci_compiler();
-  }
-
-  static bool is_jvmci_compiler_enabled() {
-    return is_jvmci_compiler() && !is_interpreter_only() && !is_c1_only();
-  }
-  // Is the JVM in a configuration that permits only c2-compiled methods?
-  static bool is_c2_only() {
-    if (is_c2_enabled()) {
-      const bool c2_only = !has_c1();
-      // There is no JVMCI compiler to replace C2 in the broker, and the user (or ergonomics)
-      // is forcing C1 off.
-      const bool c2_only_compilation_mode = CompilationModeFlag::high_only();
-      const bool tiered_off = !TieredCompilation;
-      return c2_only || c2_only_compilation_mode || tiered_off;
-    }
-    return false;
-  }
-
-  // Is the JVM in a configuration that permits only jvmci-compiled methods?
-  static bool is_jvmci_compiler_only() {
-    if (is_jvmci_compiler_enabled()) {
-      const bool jvmci_compiler_only = !has_c1();
-      // JVMCI compiler replaced C2 and the user (or ergonomics) is forcing C1 off.
-      const bool jvmci_only_compilation_mode = CompilationModeFlag::high_only();
-      const bool tiered_off = !TieredCompilation;
-      return jvmci_compiler_only || jvmci_only_compilation_mode || tiered_off;
-    }
-    return false;
-  }
-
-  static bool is_c2_or_jvmci_compiler_only() {
-    return is_c2_only() || is_jvmci_compiler_only();
-  }
-
-  // Tiered is basically C1 & (C2 | JVMCI) minus all the odd cases with restrictions.
-  static bool is_tiered() {
-    assert(is_c1_simple_only() && is_c1_only() || !is_c1_simple_only(), "c1 simple mode must imply c1-only mode");
-    return has_tiered() && !is_interpreter_only() && !is_c1_only() && !is_c2_or_jvmci_compiler_only();
-  }
-
-  static bool is_c1_enabled() {
-    return has_c1() && !is_interpreter_only() && !is_c2_or_jvmci_compiler_only();
-  }
-
-  static bool is_c1_profiling() {
-    const bool c1_only_profiling = is_c1_only() && !is_c1_simple_only();
-    const bool tiered = is_tiered();
-    return c1_only_profiling || tiered;
-  }
-
-
-  static bool is_c2_or_jvmci_compiler_enabled() {
-    return is_c2_enabled() || is_jvmci_compiler_enabled();
-  }
-
+  static bool is_c2_only();
+  static bool is_c2_enabled();
+  static bool is_c2_or_jvmci_compiler_only();
+  static bool is_c2_or_jvmci_compiler_enabled();
 
 private:
   static bool is_compilation_mode_selected();

--- a/src/hotspot/share/compiler/compilerDefinitions.inline.hpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.inline.hpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_COMPILER_COMPILERDEFINITIONS_INLINE_HPP
+#define SHARE_COMPILER_COMPILERDEFINITIONS_INLINE_HPP
+
+#include "compiler/compilerDefinitions.hpp"
+
+#include "compiler/compiler_globals.hpp"
+#include "compiler/compilerDefinitions.hpp"
+#include "runtime/arguments.hpp"
+
+inline bool CompilerConfig::is_interpreter_only() {
+  return Arguments::is_interpreter_only() || TieredStopAtLevel == CompLevel_none;
+}
+
+inline bool CompilerConfig::is_jvmci_compiler()    { return JVMCI_ONLY(has_jvmci() && UseJVMCICompiler) NOT_JVMCI(false); }
+inline bool CompilerConfig::is_jvmci()             { return JVMCI_ONLY(has_jvmci() && EnableJVMCI     ) NOT_JVMCI(false); }
+
+// is_*_only() functions describe situations in which the JVM is in one way or another
+// forced to use a particular compiler or their combination. The constraint functions
+// deliberately ignore the fact that there may also be methods installed
+// through JVMCI (where the JVMCI compiler was invoked not through the broker). Be sure
+// to check for those (using is_jvmci()) in situations where it matters.
+//
+
+// Is the JVM in a configuration that permits only c1-compiled methods (level 1,2,3)?
+inline bool CompilerConfig::is_c1_only() {
+  if (!is_interpreter_only() && has_c1()) {
+    const bool c1_only = !has_c2() && !is_jvmci_compiler();
+    const bool tiered_degraded_to_c1_only = TieredCompilation && TieredStopAtLevel >= CompLevel_simple && TieredStopAtLevel < CompLevel_full_optimization;
+    const bool c1_only_compilation_mode = CompilationModeFlag::quick_only();
+    return c1_only || tiered_degraded_to_c1_only || c1_only_compilation_mode;
+  }
+  return false;
+}
+
+inline bool CompilerConfig::is_c1_or_interpreter_only_no_jvmci() {
+  assert(is_jvmci_compiler() && is_jvmci() || !is_jvmci_compiler(), "JVMCI compiler implies enabled JVMCI");
+  return !is_jvmci() && (is_interpreter_only() || is_c1_only());
+}
+
+inline bool CompilerConfig::is_c1_only_no_jvmci() {
+  return is_c1_only() && !is_jvmci();
+}
+
+// Is the JVM in a configuration that permits only c1-compiled methods at level 1?
+inline bool CompilerConfig::is_c1_simple_only() {
+  if (is_c1_only()) {
+    const bool tiered_degraded_to_level_1 = TieredCompilation && TieredStopAtLevel == CompLevel_simple;
+    const bool c1_only_compilation_mode = CompilationModeFlag::quick_only();
+    const bool tiered_off = !TieredCompilation;
+    return tiered_degraded_to_level_1 || c1_only_compilation_mode || tiered_off;
+  }
+  return false;
+}
+
+inline bool CompilerConfig::is_c2_enabled() {
+  return has_c2() && !is_interpreter_only() && !is_c1_only() && !is_jvmci_compiler();
+}
+
+inline bool CompilerConfig::is_jvmci_compiler_enabled() {
+  return is_jvmci_compiler() && !is_interpreter_only() && !is_c1_only();
+}
+// Is the JVM in a configuration that permits only c2-compiled methods?
+inline bool CompilerConfig::is_c2_only() {
+  if (is_c2_enabled()) {
+    const bool c2_only = !has_c1();
+    // There is no JVMCI compiler to replace C2 in the broker, and the user (or ergonomics)
+    // is forcing C1 off.
+    const bool c2_only_compilation_mode = CompilationModeFlag::high_only();
+    const bool tiered_off = !TieredCompilation;
+    return c2_only || c2_only_compilation_mode || tiered_off;
+  }
+  return false;
+}
+
+// Is the JVM in a configuration that permits only jvmci-compiled methods?
+inline bool CompilerConfig::is_jvmci_compiler_only() {
+  if (is_jvmci_compiler_enabled()) {
+    const bool jvmci_compiler_only = !has_c1();
+    // JVMCI compiler replaced C2 and the user (or ergonomics) is forcing C1 off.
+    const bool jvmci_only_compilation_mode = CompilationModeFlag::high_only();
+    const bool tiered_off = !TieredCompilation;
+    return jvmci_compiler_only || jvmci_only_compilation_mode || tiered_off;
+  }
+  return false;
+}
+
+inline bool CompilerConfig::is_c2_or_jvmci_compiler_only() {
+  return is_c2_only() || is_jvmci_compiler_only();
+}
+
+// Tiered is basically C1 & (C2 | JVMCI) minus all the odd cases with restrictions.
+inline bool CompilerConfig::is_tiered() {
+  assert(is_c1_simple_only() && is_c1_only() || !is_c1_simple_only(), "c1 simple mode must imply c1-only mode");
+  return has_tiered() && !is_interpreter_only() && !is_c1_only() && !is_c2_or_jvmci_compiler_only();
+}
+
+inline bool CompilerConfig::is_c1_enabled() {
+  return has_c1() && !is_interpreter_only() && !is_c2_or_jvmci_compiler_only();
+}
+
+inline bool CompilerConfig::is_c1_profiling() {
+  const bool c1_only_profiling = is_c1_only() && !is_c1_simple_only();
+  const bool tiered = is_tiered();
+  return c1_only_profiling || tiered;
+}
+
+inline bool CompilerConfig::is_c2_or_jvmci_compiler_enabled() {
+  return is_c2_enabled() || is_jvmci_compiler_enabled();
+}
+
+#endif // SHARE_COMPILER_COMPILERDEFINITIONS_INLINE_HPP

--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -26,6 +26,7 @@
 #include "ci/ciMethod.hpp"
 #include "ci/ciUtilities.inline.hpp"
 #include "compiler/abstractCompiler.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "compiler/compilerDirectives.hpp"
 #include "compiler/compilerOracle.hpp"
 #include "memory/allocation.inline.hpp"

--- a/src/hotspot/share/gc/shared/cardTableBarrierSet.cpp
+++ b/src/hotspot/share/gc/shared/cardTableBarrierSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "gc/shared/cardTable.hpp"
 #include "gc/shared/cardTableBarrierSetAssembler.hpp"
 #include "gc/shared/cardTableBarrierSet.inline.hpp"

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "classfile/javaClasses.inline.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
 #include "gc/shared/gc_globals.hpp"

--- a/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp
+++ b/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
  */
 
 #include "precompiled.hpp"
-#include "compiler/compilerDefinitions.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/threadLocalAllocBuffer.inline.hpp"
 #include "gc/shared/tlab_globals.hpp"

--- a/src/hotspot/share/jvmci/jvmciCompiler.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompiler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 #include "precompiled.hpp"
 #include "classfile/vmClasses.hpp"
 #include "compiler/compileBroker.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "classfile/moduleEntry.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "jvmci/jvmciEnv.hpp"

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -26,6 +26,7 @@
 #include "ci/ciMethodData.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "compiler/compilationPolicy.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "compiler/compilerOracle.hpp"
 #include "interpreter/bytecode.hpp"
 #include "interpreter/bytecodeStream.hpp"

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "classfile/vmClasses.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #include "jfr/support/jfrIntrinsics.hpp"
 #include "opto/c2compiler.hpp"

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -34,6 +34,7 @@
 #include "code/pcDesc.hpp"
 #include "code/scopeDesc.hpp"
 #include "compiler/compilationPolicy.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "interpreter/bytecode.hpp"
 #include "interpreter/interpreter.hpp"

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -24,7 +24,7 @@
 
 #include "precompiled.hpp"
 #include "code/relocInfo.hpp"
-#include "compiler/compilerDefinitions.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "compiler/compilerDirectives.hpp"
 #include "oops/metadata.hpp"
 #include "runtime/os.hpp"


### PR DESCRIPTION
Many of the `CompilerConfig::is_xxx()` inline functions in compilerDefinitions.hpp depend on the following headers

- compiler_globals.hpp
- c1_globals.hpp
- c2_globals.hpp
- jvmci_globals.hpp

However, only a few files actually use these functions. To improve C++ compilation time, we should move these inline functions to compilerDefinitions.inline.hpp

This reduces the inclusion of the above headers from 762 to 321.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292691](https://bugs.openjdk.org/browse/JDK-8292691): Move CompilerConfig::is_xxx() inline functions out of compilerDefinitions.hpp


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [adda27ae](https://git.openjdk.org/jdk/pull/9953/files/adda27ae445eb61eaf81f18b61c403d29ceb167b)
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9953/head:pull/9953` \
`$ git checkout pull/9953`

Update a local copy of the PR: \
`$ git checkout pull/9953` \
`$ git pull https://git.openjdk.org/jdk pull/9953/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9953`

View PR using the GUI difftool: \
`$ git pr show -t 9953`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9953.diff">https://git.openjdk.org/jdk/pull/9953.diff</a>

</details>
