### PR TITLE
8292698: Improve performance of DataInputStream

### DIFF
--- a/src/java.base/share/classes/java/io/DataInputStream.java
+++ b/src/java.base/share/classes/java/io/DataInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,8 +57,8 @@ public class DataInputStream extends FilterInputStream implements DataInput {
     /**
      * working arrays initialized on demand by readUTF
      */
-    private byte bytearr[] = new byte[80];
-    private char chararr[] = new char[80];
+    private byte[] bytearr = new byte[80];
+    private char[] chararr = new char[80];
 
     /**
      * Reads some number of bytes from the contained input stream and
@@ -197,6 +197,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
     public final void readFully(byte[] b, int off, int len) throws IOException {
         Objects.checkFromIndexSize(off, len, b.length);
         int n = 0;
+        InputStream in = this.in;
         while (n < len) {
             int count = in.read(b, off + n, len - n);
             if (count < 0)
@@ -223,6 +224,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
         int total = 0;
         int cur = 0;
 
+        InputStream in = this.in;
         while ((total<n) && ((cur = (int) in.skip(n-total)) > 0)) {
             total += cur;
         }
@@ -315,6 +317,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
      * @see        java.io.FilterInputStream#in
      */
     public final short readShort() throws IOException {
+        InputStream in = this.in;
         int ch1 = in.read();
         int ch2 = in.read();
         if ((ch1 | ch2) < 0)
@@ -340,6 +343,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
      * @see        java.io.FilterInputStream#in
      */
     public final int readUnsignedShort() throws IOException {
+        InputStream in = this.in;
         int ch1 = in.read();
         int ch2 = in.read();
         if ((ch1 | ch2) < 0)
@@ -365,6 +369,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
      * @see        java.io.FilterInputStream#in
      */
     public final char readChar() throws IOException {
+        InputStream in = this.in;
         int ch1 = in.read();
         int ch2 = in.read();
         if ((ch1 | ch2) < 0)
@@ -390,6 +395,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
      * @see        java.io.FilterInputStream#in
      */
     public final int readInt() throws IOException {
+        InputStream in = this.in;
         int ch1 = in.read();
         int ch2 = in.read();
         int ch3 = in.read();
@@ -399,7 +405,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
         return ((ch1 << 24) + (ch2 << 16) + (ch3 << 8) + (ch4 << 0));
     }
 
-    private byte readBuffer[] = new byte[8];
+    private final byte[] readBuffer = new byte[8];
 
     /**
      * See the general contract of the {@code readLong}
@@ -474,7 +480,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
         return Double.longBitsToDouble(readLong());
     }
 
-    private char lineBuffer[];
+    private char[] lineBuffer;
 
     /**
      * See the general contract of the {@code readLine}
@@ -505,7 +511,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
      */
     @Deprecated
     public final String readLine() throws IOException {
-        char buf[] = lineBuffer;
+        char[] buf = lineBuffer;
 
         if (buf == null) {
             buf = lineBuffer = new char[128];
@@ -514,6 +520,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
         int room = buf.length;
         int offset = 0;
         int c;
+        InputStream in = this.in;
 
 loop:   while (true) {
             switch (c = in.read()) {
@@ -634,7 +641,7 @@ loop:   while (true) {
                     if (count > utflen)
                         throw new UTFDataFormatException(
                             "malformed input: partial character at end");
-                    char2 = (int) bytearr[count-1];
+                    char2 = bytearr[count-1];
                     if ((char2 & 0xC0) != 0x80)
                         throw new UTFDataFormatException(
                             "malformed input around byte " + count);
@@ -647,8 +654,8 @@ loop:   while (true) {
                     if (count > utflen)
                         throw new UTFDataFormatException(
                             "malformed input: partial character at end");
-                    char2 = (int) bytearr[count-2];
-                    char3 = (int) bytearr[count-1];
+                    char2 = bytearr[count-2];
+                    char3 = bytearr[count-1];
                     if (((char2 & 0xC0) != 0x80) || ((char3 & 0xC0) != 0x80))
                         throw new UTFDataFormatException(
                             "malformed input around byte " + (count-1));

--- a/test/micro/org/openjdk/bench/java/io/DataInputStreamTest.java
+++ b/test/micro/org/openjdk/bench/java/io/DataInputStreamTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020, 2021, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package micro.org.openjdk.bench.java.io;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(value = 4, warmups = 0)
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 2, time = 2)
+@State(Scope.Benchmark)
+public class DataInputStreamTest {
+    private final int size = 1024;
+
+    private ByteArrayInputStream bais;
+
+    @Setup(Level.Iteration)
+    public void setup() {
+        byte[] bytes = new byte[size];
+        ThreadLocalRandom.current().nextBytes(bytes);
+        bais = new ByteArrayInputStream(bytes);
+    }
+
+    @Benchmark
+    public void readChar(Blackhole bh) throws Exception {
+        bais.reset();
+        DataInputStream dis = new DataInputStream(bais);
+        for (int i = 0; i < size / 2; i++) {
+            bh.consume(dis.readChar());
+        }
+    }
+
+    @Benchmark
+    public void readInt(Blackhole bh) throws Exception {
+        bais.reset();
+        DataInputStream dis = new DataInputStream(bais);
+        for (int i = 0; i < size / 4; i++) {
+            bh.consume(dis.readInt());
+        }
+    }
+}


### PR DESCRIPTION
I found out that reading from `DataInputStream` wrapping `ByteArrayInputStream` (as well as `BufferedInputStream` or any `InputStream` relying on `byte[]`) can be significantly improved by accessing volatile `in` field only once per operation.

Current implementation does it for each call of `in.read()`, i.e. in `readInt()` method we do it 4 times:
```
public final int readInt() throws IOException {
    InputStream in = this.in;
    int ch1 = in.read();
    int ch2 = in.read();
    int ch3 = in.read();
    int ch4 = in.read();
    if ((ch1 | ch2 | ch3 | ch4) < 0)
        throw new EOFException();
    return ((ch1 << 24) + (ch2 << 16) + (ch3 << 8) + (ch4 << 0));
}
```
Apparently accessing volatile reference with underlying `byte[]` prevents runtime from doing some optimizations, so dereferencing local variable should be more efficient.

Benchmarking:

baseline:
```
Benchmark                     Mode  Cnt   Score   Error  Units
DataInputStreamTest.readChar  avgt   20  22,889 ± 0,648  us/op
DataInputStreamTest.readInt   avgt   20  21,804 ± 0,197  us/op
```
patch:
```
Benchmark                     Mode  Cnt   Score   Error  Units
DataInputStreamTest.readChar  avgt   20  11,018 ± 0,089  us/op
DataInputStreamTest.readInt   avgt   20   5,608 ± 0,087  us/op
```