### PR TITLE
8292708: Rename G1ParScanThreadState::flush to flush_stats

### DIFF
--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -111,7 +111,7 @@ G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
   initialize_numa_stats();
 }
 
-size_t G1ParScanThreadState::flush(size_t* surviving_young_words, uint num_workers) {
+size_t G1ParScanThreadState::flush_stats(size_t* surviving_young_words, uint num_workers) {
   _rdc_local_qset.flush();
   flush_numa_stats();
   // Update allocation statistics.
@@ -579,7 +579,7 @@ const size_t* G1ParScanThreadStateSet::surviving_young_words() const {
   return _surviving_young_words_total;
 }
 
-void G1ParScanThreadStateSet::flush() {
+void G1ParScanThreadStateSet::flush_stats() {
   assert(!_flushed, "thread local state from the per thread states should be flushed once");
 
   for (uint worker_id = 0; worker_id < _n_workers; ++worker_id) {
@@ -592,7 +592,7 @@ void G1ParScanThreadStateSet::flush() {
     // because it resets the PLAB allocator where we get this info from.
     size_t lab_waste_bytes = pss->lab_waste_words() * HeapWordSize;
     size_t lab_undo_waste_bytes = pss->lab_undo_waste_words() * HeapWordSize;
-    size_t copied_bytes = pss->flush(_surviving_young_words_total, _n_workers) * HeapWordSize;
+    size_t copied_bytes = pss->flush_stats(_surviving_young_words_total, _n_workers) * HeapWordSize;
 
     p->record_or_add_thread_work_item(G1GCPhaseTimes::MergePSS, worker_id, copied_bytes, G1GCPhaseTimes::MergePSSCopiedBytes);
     p->record_or_add_thread_work_item(G1GCPhaseTimes::MergePSS, worker_id, lab_waste_bytes, G1GCPhaseTimes::MergePSSLABWasteBytes);

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
@@ -152,7 +152,7 @@ public:
 
   // Pass locally gathered statistics to global state. Returns the total number of
   // HeapWords copied.
-  size_t flush(size_t* surviving_young_words, uint num_workers);
+  size_t flush_stats(size_t* surviving_young_words, uint num_workers);
 
 private:
   void do_partial_array(PartialArrayScanTask task);
@@ -252,7 +252,7 @@ class G1ParScanThreadStateSet : public StackObj {
   G1RedirtyCardsQueueSet* rdcqs() { return _rdcqs; }
   PreservedMarksSet* preserved_marks_set() { return _preserved_marks_set; }
 
-  void flush();
+  void flush_stats();
   void record_unused_optional_region(HeapRegion* hr);
 
   G1ParScanThreadState* state_for_worker(uint worker_id);

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -49,7 +49,7 @@ public:
 
   double worker_cost() const override { return 1.0; }
 
-  void do_work(uint worker_id) override { _per_thread_states->flush(); }
+  void do_work(uint worker_id) override { _per_thread_states->flush_stats(); }
 };
 
 class G1PostEvacuateCollectionSetCleanupTask1::RecalculateUsedTask : public G1AbstractSubTask {


### PR DESCRIPTION
Hi,

  can I have quick reviews for this trivial(?) rename of two methods as suggested in the review for [JDK-8288966](https://bugs.openjdk.org/browse/JDK-8288966)?

Testing: local compilation, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292708](https://bugs.openjdk.org/browse/JDK-8292708): Rename G1ParScanThreadState::flush to flush_stats


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9960/head:pull/9960` \
`$ git checkout pull/9960`

Update a local copy of the PR: \
`$ git checkout pull/9960` \
`$ git pull https://git.openjdk.org/jdk pull/9960/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9960`

View PR using the GUI difftool: \
`$ git pr show -t 9960`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9960.diff">https://git.openjdk.org/jdk/pull/9960.diff</a>

</details>
