### PR TITLE
8290711: assert(false) failed: infinite loop in PhaseIterGVN::optimize

### DIFF
--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1961,9 +1961,11 @@ Node *PhaseCCP::transform( Node *n ) {
   trstack.push(new_node);           // Process children of cloned node
 
   // This CCP pass may prove that no exit test for a loop ever succeeds (i.e. the loop is infinite). In that case,
-  // the logic below doesn't follow any path from Root to the loop body (they are proven never taken). If CCP only works
+  // the logic below doesn't follow any path from Root to the loop body: there's at least one such path but it's proven
+  // never taken (its type is TOP). As a consequence the node on the exit path that's input to Root (let's call it n) is
+  // replaced by the top node and the inputs of that node n are not enqueued for further processing. If CCP only works
   // through the graph from Root, this causes the loop body to never be processed here even when it's not dead (that
-  // it's reachable from Root following its uses). To prevent that issue, transform() starts walking the graph from Root
+  // is reachable from Root following its uses). To prevent that issue, transform() starts walking the graph from Root
   // and all safepoints.
   for (uint i = 0; i < _safepoints.size(); ++i) {
     Node* nn = _safepoints.at(i);

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1970,7 +1970,7 @@ Node *PhaseCCP::transform( Node *n ) {
     Node* new_node = _nodes[nn->_idx];
     assert(new_node == NULL, "");
     new_node = transform_once(nn);
-    _nodes.map( nn->_idx, new_node );
+    _nodes.map(nn->_idx, new_node);
     trstack.push(new_node);
   }
 

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1966,8 +1966,8 @@ Node *PhaseCCP::transform( Node *n ) {
   // it's reachable from Root following its uses). To prevent that issue, transform() starts walking the graph from Root
   // and all safepoints.
   for (uint i = 0; i < _safepoints.size(); ++i) {
-    Node *nn = _safepoints.at(i);
-    Node *new_node = _nodes[nn->_idx];
+    Node* nn = _safepoints.at(i);
+    Node* new_node = _nodes[nn->_idx];
     assert(new_node == NULL, "");
     new_node = transform_once(nn);
     _nodes.map( nn->_idx, new_node );

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1773,6 +1773,7 @@ void PhaseCCP::analyze() {
   while (worklist.size() != 0) {
     Node* n = fetch_next_node(worklist);
     if (n->is_SafePoint()) {
+      // Keep track of SafePoint nodes for PhaseCCP::transform()
       _safepoints.push(n);
     }
     const Type* new_type = n->Value(this);
@@ -1959,6 +1960,11 @@ Node *PhaseCCP::transform( Node *n ) {
 
   trstack.push(new_node);           // Process children of cloned node
 
+  // This CCP pass may prove that no exit test for a loop ever succeeds (i.e. the loop is infinite). In that case,
+  // the logic below doesn't follow any path from Root to the loop body (they are proven never taken). If CCP only works
+  // through the graph from Root, this causes the loop body to never be processed here even when it's not dead (that
+  // it's reachable from Root following its uses). To prevent that issue, transform() starts walking the graph from Root
+  // and all safepoints.
   for (uint i = 0; i < _safepoints.size(); ++i) {
     Node *nn = _safepoints.at(i);
     Node *new_node = _nodes[nn->_idx];

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -566,6 +566,7 @@ protected:
 // Phase for performing global Conditional Constant Propagation.
 // Should be replaced with combined CCP & GVN someday.
 class PhaseCCP : public PhaseIterGVN {
+  Unique_Node_List _safepoints;
   // Non-recursive.  Use analysis to transform single Node.
   virtual Node* transform_once(Node* n);
 
@@ -582,7 +583,6 @@ class PhaseCCP : public PhaseIterGVN {
   void push_loadp(Unique_Node_List& worklist, const Node* use) const;
   static void push_load_barrier(Unique_Node_List& worklist, const BarrierSetC2* barrier_set, const Node* use);
   void push_and(Unique_Node_List& worklist, const Node* parent, const Node* use) const;
-  Unique_Node_List _safepoints;
 
  public:
   PhaseCCP( PhaseIterGVN *igvn ); // Compute conditional constants

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -582,6 +582,7 @@ class PhaseCCP : public PhaseIterGVN {
   void push_loadp(Unique_Node_List& worklist, const Node* use) const;
   static void push_load_barrier(Unique_Node_List& worklist, const BarrierSetC2* barrier_set, const Node* use);
   void push_and(Unique_Node_List& worklist, const Node* parent, const Node* use) const;
+  Unique_Node_List _safepoints;
 
  public:
   PhaseCCP( PhaseIterGVN *igvn ); // Compute conditional constants

--- a/test/hotspot/jtreg/compiler/ccp/TestInfiniteIGVNAfterCCP.java
+++ b/test/hotspot/jtreg/compiler/ccp/TestInfiniteIGVNAfterCCP.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8290711
+ * @summary assert(false) failed: infinite loop in PhaseIterGVN::optimize
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:-TieredCompilation TestInfiniteIGVNAfterCCP
+ */
+
+
+import java.util.function.BooleanSupplier;
+
+public class TestInfiniteIGVNAfterCCP {
+    private static int inc;
+    private static volatile boolean barrier;
+
+    static class A {
+        int field1;
+        int field2;
+    }
+
+    public static void main(String[] args) {
+        A a = new A();
+        for (int i = 0; i < 20_000; i++) {
+            test(false, a, false);
+            inc = 0;
+            testHelper(true, () -> inc < 10, a, 4, true);
+            inc = 0;
+            testHelper(true, () -> inc < 10, a, 4, false);
+            testHelper(false, () -> inc < 10, a, 42, false);
+        }
+    }
+
+    private static void test(boolean flag2, A a, boolean flag1) {
+        int i = 2;
+        for (; i < 4; i *= 2);
+        testHelper(flag2, () -> true, a, i, flag1);
+    }
+
+    private static void testHelper(boolean flag2, BooleanSupplier f, A a, int i, boolean flag1) {
+        if (i == 4) {
+            if (a == null) {
+
+            }
+        } else {
+            a = null;
+        }
+        if (flag2) {
+            while (true) {
+                synchronized (new Object()) {
+
+                }
+                if (!f.getAsBoolean()) {
+                    break;
+                }
+                if (flag1) {
+                    if (a == null) {
+
+                    }
+                }
+                barrier = true;
+                inc++;
+                if (inc % 2 == 0) {
+                    a.field1++;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
In the test case: the loop is an infinite loop but loop optimizations
don't add a NeverBranch node because the loop is reachable from Root
(following Root's inputs) through a null check in the loop body. When
CCP runs, it finds the null check never fails. PhaseCCP::transform()
works through the graph starting from Root and following its inputs.
But because the null check never fails, it doesn't follow the path to
the loop body and it doesn't update the type of nodes in the loop body
(as done in PhaseCCP::transform_once()). That's wrong as the loop body
is not dead. As a consequence, for one CastPP node, its bottom type
and the type recorded in PhaseCCP's type table differ. When igvn runs
next, for some nodes, MemNode::Ideal_common() sees a difference
between the address type recorded by igvn and the one reported by
bottom_type(). That causes memory nodes to be indefinitely
re-enqueued for igvn.

The fix I propose is similar to one Tobias implemented in the valhalla
repo (JDK-8265973). With this fix, all loops are always considered
reachable by PhaseCCP::transform() (which I think, worst case, is only
a waste of compilation time but has no correctness issue). To achieve
that safepoints are collected by CCP before PhaseCCP::transform()
transform() follows inputs from Root and safepoints.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290711](https://bugs.openjdk.org/browse/JDK-8290711): assert(false) failed: infinite loop in PhaseIterGVN::optimize


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9961/head:pull/9961` \
`$ git checkout pull/9961`

Update a local copy of the PR: \
`$ git checkout pull/9961` \
`$ git pull https://git.openjdk.org/jdk pull/9961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9961`

View PR using the GUI difftool: \
`$ git pr show -t 9961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9961.diff">https://git.openjdk.org/jdk/pull/9961.diff</a>

</details>
