### PR TITLE
8292679: Simplify thread creation in gtest and port 2 tests to new way

### DIFF
--- a/test/hotspot/gtest/classfile/test_symbolTable.cpp
+++ b/test/hotspot/gtest/classfile/test_symbolTable.cpp
@@ -114,8 +114,8 @@ TEST_VM(SymbolTable, test_symbol_refcount_parallel) {
       EXPECT_TRUE(sym->refcount() != 0) << "Symbol refcount unexpectedly zeroed";
     }
   };
-  TestThreadGroup<decltype(symbolThread), int, symTestThreadCount>
-    ttg(symbolThread, []() { return 0; });
+  TestThreadGroup<decltype(symbolThread), int>
+    ttg(symbolThread, []() { return 0; }, symTestThreadCount);
   ttg.doit();
   ttg.join();
 }

--- a/test/hotspot/gtest/classfile/test_symbolTable.cpp
+++ b/test/hotspot/gtest/classfile/test_symbolTable.cpp
@@ -93,55 +93,29 @@ TEST_VM(SymbolTable, temp_new_symbol) {
 // TODO: Make two threads one decrementing the refcount and the other trying to increment.
 // try_increment_refcount should return false
 
-#define SYM_NAME_LENGTH 30
-static char symbol_name[SYM_NAME_LENGTH];
+TEST_VM(SymbolTable, test_symbol_refcount_parallel) {
+  constexpr int symbol_name_length = 30;
+  char symbol_name[30];
+  // Find a symbol where there will probably be only one instance.
+  for (int i = 0; i < 100; i++) {
+    os::snprintf(symbol_name, symbol_name_length, "some_symbol%d", i);
+    TempNewSymbol ts = SymbolTable::new_symbol(symbol_name);
+    if (ts->refcount() == 1) {
+      EXPECT_TRUE(ts->refcount() == 1) << "Symbol is just created";
+      break;  // found a unique symbol
+    }
+  }
 
-class SymbolThread : public JavaTestThread {
-  public:
-  SymbolThread(Semaphore* post) : JavaTestThread(post) {}
-  virtual ~SymbolThread() {}
-  void main_run() {
+  constexpr int symTestThreadCount = 5;
+  auto symbolThread= [&](Thread* _current, int _ig) {
     for (int i = 0; i < 1000; i++) {
       TempNewSymbol sym = SymbolTable::new_symbol(symbol_name);
       // Create and destroy new symbol
       EXPECT_TRUE(sym->refcount() != 0) << "Symbol refcount unexpectedly zeroed";
     }
-  }
-};
-
-#define SYM_TEST_THREAD_COUNT 5
-
-class DriverSymbolThread : public JavaTestThread {
-public:
-  Semaphore _done;
-  DriverSymbolThread(Semaphore* post) : JavaTestThread(post) { };
-  virtual ~DriverSymbolThread(){}
-
-  void main_run() {
-    Semaphore done(0);
-
-    // Find a symbol where there will probably be only one instance.
-    for (int i = 0; i < 100; i++) {
-       os::snprintf(symbol_name, SYM_NAME_LENGTH, "some_symbol%d", i);
-       TempNewSymbol ts = SymbolTable::new_symbol(symbol_name);
-       if (ts->refcount() == 1) {
-         EXPECT_TRUE(ts->refcount() == 1) << "Symbol is just created";
-         break;  // found a unique symbol
-       }
-    }
-
-    SymbolThread* st[SYM_TEST_THREAD_COUNT];
-    for (int i = 0; i < SYM_TEST_THREAD_COUNT; i++) {
-      st[i] = new SymbolThread(&done);
-      st[i]->doit();
-    }
-
-    for (int i = 0; i < SYM_TEST_THREAD_COUNT; i++) {
-      done.wait();
-    }
-  }
-};
-
-TEST_VM(SymbolTable, test_symbol_refcount_parallel) {
-  mt_test_doer<DriverSymbolThread>();
+  };
+  TestThreadGroup<decltype(symbolThread), int, symTestThreadCount>
+    ttg(symbolThread, []() { return 0; });
+  ttg.doit();
+  ttg.join();
 }

--- a/test/hotspot/gtest/classfile/test_symbolTable.cpp
+++ b/test/hotspot/gtest/classfile/test_symbolTable.cpp
@@ -95,7 +95,7 @@ TEST_VM(SymbolTable, temp_new_symbol) {
 
 TEST_VM(SymbolTable, test_symbol_refcount_parallel) {
   constexpr int symbol_name_length = 30;
-  char symbol_name[30];
+  char symbol_name[symbol_name_length];
   // Find a symbol where there will probably be only one instance.
   for (int i = 0; i < 100; i++) {
     os::snprintf(symbol_name, symbol_name_length, "some_symbol%d", i);

--- a/test/hotspot/gtest/classfile/test_symbolTable.cpp
+++ b/test/hotspot/gtest/classfile/test_symbolTable.cpp
@@ -107,15 +107,14 @@ TEST_VM(SymbolTable, test_symbol_refcount_parallel) {
   }
 
   constexpr int symTestThreadCount = 5;
-  auto symbolThread= [&](Thread* _current, int _ig) {
+  auto symbolThread= [&](Thread* _current, int _id) {
     for (int i = 0; i < 1000; i++) {
       TempNewSymbol sym = SymbolTable::new_symbol(symbol_name);
       // Create and destroy new symbol
       EXPECT_TRUE(sym->refcount() != 0) << "Symbol refcount unexpectedly zeroed";
     }
   };
-  TestThreadGroup<decltype(symbolThread), int>
-    ttg(symbolThread, []() { return 0; }, symTestThreadCount);
+  TestThreadGroup<decltype(symbolThread)> ttg(symbolThread, symTestThreadCount);
   ttg.doit();
   ttg.join();
 }

--- a/test/hotspot/gtest/threadHelper.inline.hpp
+++ b/test/hotspot/gtest/threadHelper.inline.hpp
@@ -168,7 +168,9 @@ public:
       _threads[i] = new BasicTestThread<F>(fun, i, &_sem);
     }
   }
-  ~TestThreadGroup() {}
+  ~TestThreadGroup() {
+    FREE_C_HEAP_ARRAY(BasicTestThread<F>*, _threads);
+  }
 
   void doit() {
     _blocker = VMThreadBlocker::start();

--- a/test/hotspot/gtest/threadHelper.inline.hpp
+++ b/test/hotspot/gtest/threadHelper.inline.hpp
@@ -147,29 +147,27 @@ public:
 };
 
 // A TestThreadGroup tracks multiple threads running the same function.
-template<typename F, typename S>
+template<typename F>
 class TestThreadGroup {
 private:
   VMThreadBlocker* _blocker;
-  BasicTestThread<F, S>** _threads;
+  BasicTestThread<F, int>** _threads;
   const int _length;
   Semaphore _sem;
 
   // We have this  local typedef because NEW_C_HEAP_ARRAY will
   // fail to expand because of the comma in <F, S>
-  using ThreadPointer = BasicTestThread<F, S>*;
+  using ThreadPointer = BasicTestThread<F, int>*;
 public:
   NONCOPYABLE(TestThreadGroup);
 
-  // Use state_fun to generate varying state of type S for each function F.
-  template<typename StateGenerator>
-  TestThreadGroup(F fun, StateGenerator state_fun, const int number_of_threads)
+  TestThreadGroup(F fun, const int number_of_threads)
     :
     _threads(NEW_C_HEAP_ARRAY(ThreadPointer, number_of_threads, mtTest)),
     _length(number_of_threads),
     _sem() {
     for (int i = 0; i < _length; i++) {
-      _threads[i] = new BasicTestThread<F, S>(fun, state_fun(), &_sem);
+      _threads[i] = new BasicTestThread<F, int>(fun, i, &_sem);
     }
   }
   ~TestThreadGroup() {}

--- a/test/hotspot/gtest/threadHelper.inline.hpp
+++ b/test/hotspot/gtest/threadHelper.inline.hpp
@@ -124,8 +124,8 @@ public:
   }
 };
 
-// Calls a single-argument function of type F with the current thread (this) and a self-assigned thread id as its input
-// in a new thread when doit() is run.
+// Calls a single-argument function of type F with the current thread (this)
+// and a self-assigned thread id as its input in a new thread when doit() is run.
 template<typename F>
 class BasicTestThread : public JavaTestThread {
 private:
@@ -145,7 +145,9 @@ public:
   }
 };
 
-// A TestThreadGroup tracks multiple threads running the same function.
+// A TestThreadGroup starts and tracks N threads running the same callable F.
+// The callable F should have the signature void(Thread*,int) where Thread*
+// is the current thread and int is an id in the range [0,N).
 template<typename F>
 class TestThreadGroup {
 private:

--- a/test/hotspot/gtest/utilities/test_globalCounter.cpp
+++ b/test/hotspot/gtest/utilities/test_globalCounter.cpp
@@ -58,10 +58,12 @@ TEST_VM(GlobalCounter, critical_section) {
     }
   };
 
-  TestThreadGroup<decltype(rcu_reader), volatile TestData**, number_of_readers> ttg(rcu_reader,
-                                                                                    [&]() {
-                                                                                      return &test;
-                                                                                    });
+  TestThreadGroup<decltype(rcu_reader), volatile TestData**>
+    ttg(rcu_reader,
+        [&]() {
+          return &test;
+        },
+        number_of_readers);
 
   TestData* tmp = new TestData();
   tmp->test_value = good_value;

--- a/test/hotspot/gtest/utilities/test_globalCounter.cpp
+++ b/test/hotspot/gtest/utilities/test_globalCounter.cpp
@@ -41,7 +41,8 @@ TEST_VM(GlobalCounter, critical_section) {
   Semaphore wrt_start;
   volatile TestData* test = nullptr;
 
-  auto rcu_reader = [&](Thread* current, volatile TestData** _test) {
+  auto rcu_reader = [&](Thread* current, int _id) {
+    volatile TestData** _test = &test;
     wrt_start.signal();
     while (!rt_exit) {
       GlobalCounter::CSContext cs_context = GlobalCounter::critical_section_begin(current);
@@ -58,12 +59,7 @@ TEST_VM(GlobalCounter, critical_section) {
     }
   };
 
-  TestThreadGroup<decltype(rcu_reader), volatile TestData**>
-    ttg(rcu_reader,
-        [&]() {
-          return &test;
-        },
-        number_of_readers);
+  TestThreadGroup<decltype(rcu_reader)> ttg(rcu_reader, number_of_readers);
 
   TestData* tmp = new TestData();
   tmp->test_value = good_value;

--- a/test/hotspot/gtest/utilities/test_globalCounter.cpp
+++ b/test/hotspot/gtest/utilities/test_globalCounter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,93 +24,65 @@
 #include "precompiled.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/os.hpp"
+#include "threadHelper.inline.hpp"
 #include "utilities/globalCounter.hpp"
 #include "utilities/globalCounter.inline.hpp"
-#include "threadHelper.inline.hpp"
 
-#define GOOD_VALUE 1337
-#define BAD_VALUE  4711
+constexpr const int good_value = 1337;
+constexpr const int bad_value =  4711;
 
 struct TestData {
   long test_value;
 };
 
-class RCUReaderThread : public JavaTestThread {
-public:
-  static volatile bool _exit;
-  volatile TestData** _test;
-  Semaphore* _wrt_start;
-  RCUReaderThread(Semaphore* post, volatile TestData** test, Semaphore* wrt_start)
-    : JavaTestThread(post), _test(test), _wrt_start(wrt_start) {};
-  virtual ~RCUReaderThread(){}
-  void main_run() {
-    _wrt_start->signal();
-    while (!_exit) {
-      GlobalCounter::CSContext cs_context = GlobalCounter::critical_section_begin(this);
-      volatile TestData* test = Atomic::load_acquire(_test);
-      long value = Atomic::load_acquire(&test->test_value);
-      ASSERT_EQ(value, GOOD_VALUE);
-      GlobalCounter::critical_section_end(this, cs_context);
+TEST_VM(GlobalCounter, critical_section) {
+  constexpr int number_of_readers = 4;
+  volatile bool rt_exit = false;
+  Semaphore wrt_start;
+  volatile TestData* test = nullptr;
+
+  auto rcu_reader = [&](Thread* current, volatile TestData** _test) {
+    wrt_start.signal();
+    while (!rt_exit) {
+      GlobalCounter::CSContext cs_context = GlobalCounter::critical_section_begin(current);
+      volatile TestData* read_test = Atomic::load_acquire(_test);
+      long value = Atomic::load_acquire(&read_test->test_value);
+      ASSERT_EQ(value, good_value);
+      GlobalCounter::critical_section_end(current, cs_context);
       {
-        GlobalCounter::CriticalSection cs(this);
+        GlobalCounter::CriticalSection cs(current);
         volatile TestData* test = Atomic::load_acquire(_test);
         long value = Atomic::load_acquire(&test->test_value);
-        ASSERT_EQ(value, GOOD_VALUE);
+        ASSERT_EQ(value, good_value);
       }
     }
-  }
-};
-
-volatile bool RCUReaderThread::_exit = false;
-
-class RCUWriterThread : public JavaTestThread {
-public:
-  RCUWriterThread(Semaphore* post) : JavaTestThread(post) {
   };
-  virtual ~RCUWriterThread(){}
-  void main_run() {
-    static const int NUMBER_OF_READERS = 4;
-    Semaphore post;
-    Semaphore wrt_start;
-    volatile TestData* test = NULL;
 
-    RCUReaderThread* reader1 = new RCUReaderThread(&post, &test, &wrt_start);
-    RCUReaderThread* reader2 = new RCUReaderThread(&post, &test, &wrt_start);
-    RCUReaderThread* reader3 = new RCUReaderThread(&post, &test, &wrt_start);
-    RCUReaderThread* reader4 = new RCUReaderThread(&post, &test, &wrt_start);
+  TestThreadGroup<decltype(rcu_reader), volatile TestData**, number_of_readers> ttg(rcu_reader,
+                                                                                    [&]() {
+                                                                                      return &test;
+                                                                                    });
 
-    TestData* tmp = new TestData();
-    tmp->test_value = GOOD_VALUE;
-    Atomic::release_store_fence(&test, tmp);
-
-    reader1->doit();
-    reader2->doit();
-    reader3->doit();
-    reader4->doit();
-
-    int nw = NUMBER_OF_READERS;
-    while (nw > 0) {
-      wrt_start.wait();
-      --nw;
-    }
-    jlong stop_ms = os::javaTimeMillis() + 1000; // 1 seconds max test time
-    for (int i = 0; i < 100000 && stop_ms > os::javaTimeMillis(); i++) {
-      volatile TestData* free_tmp = test;
-      tmp = new TestData();
-      tmp->test_value = GOOD_VALUE;
-      Atomic::release_store(&test, tmp);
-      GlobalCounter::write_synchronize();
-      free_tmp->test_value = BAD_VALUE;
-      delete free_tmp;
-    }
-    RCUReaderThread::_exit = true;
-    for (int i = 0; i < NUMBER_OF_READERS; i++) {
-      post.wait();
-    }
+  TestData* tmp = new TestData();
+  tmp->test_value = good_value;
+  Atomic::release_store(&test, tmp);
+  rt_exit = false;
+  ttg.doit();
+  int nw = number_of_readers;
+  while (nw > 0) {
+    wrt_start.wait();
+    --nw;
   }
-};
-
-TEST_VM(GlobalCounter, critical_section) {
-  RCUReaderThread::_exit = false;
-  mt_test_doer<RCUWriterThread>();
+  jlong stop_ms = os::javaTimeMillis() + 1000; // 1 seconds max test time
+  for (int i = 0; i < 100000 && stop_ms > os::javaTimeMillis(); i++) {
+    volatile TestData* free_tmp = test;
+    tmp = new TestData();
+    tmp->test_value = good_value;
+    Atomic::release_store(&test, tmp);
+    GlobalCounter::write_synchronize();
+    free_tmp->test_value = bad_value;
+    delete free_tmp;
+  }
+  rt_exit = true;
+  ttg.join();
 }


### PR DESCRIPTION
This PR removes a lot of boilerplate that was required when creating multi-threaded tests and ports 2 tests to show that the number of lines of code is significantly reduced and that porting is fairly trivial. The ported tests also serve as an introduction to others who're looking into writing their own multi-threaded tests.

Testing: Ran the ported tests on my machine, also running the tests on x64 {Windows, Linux, Mac OS X],  aarch64 { Linux, Mac OS X} and tier1 for "completeness".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292679](https://bugs.openjdk.org/browse/JDK-8292679): Simplify thread creation in gtest and port 2 tests to new way


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [bf1b5524](https://git.openjdk.org/jdk/pull/9962/files/bf1b552493531de697d1b26999d703914105800e)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9962/head:pull/9962` \
`$ git checkout pull/9962`

Update a local copy of the PR: \
`$ git checkout pull/9962` \
`$ git pull https://git.openjdk.org/jdk pull/9962/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9962`

View PR using the GUI difftool: \
`$ git pr show -t 9962`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9962.diff">https://git.openjdk.org/jdk/pull/9962.diff</a>

</details>
