### PR TITLE
8292654: G1 remembered set memory footprint regression after JDK-8286115

### DIFF
--- a/src/hotspot/share/gc/g1/g1Arguments.cpp
+++ b/src/hotspot/share/gc/g1/g1Arguments.cpp
@@ -137,7 +137,7 @@ void G1Arguments::initialize_card_set_configuration() {
   if (FLAG_IS_DEFAULT(G1RemSetArrayOfCardsEntries)) {
     uint max_cards_in_inline_ptr = G1CardSetConfiguration::max_cards_in_inline_ptr(HeapRegion::LogOfHRGrainBytes - CardTable::card_shift());
     FLAG_SET_ERGO(G1RemSetArrayOfCardsEntries, MAX2(max_cards_in_inline_ptr * 2,
-                                                    G1RemSetArrayOfCardsEntriesBase << region_size_log_mb));
+                                                    G1RemSetArrayOfCardsEntriesBase << (region_size_log_mb + 1)));
   }
 
   // Round to next 8 byte boundary for array to maximize space usage.

--- a/src/hotspot/share/gc/g1/g1Arguments.cpp
+++ b/src/hotspot/share/gc/g1/g1Arguments.cpp
@@ -137,7 +137,7 @@ void G1Arguments::initialize_card_set_configuration() {
   if (FLAG_IS_DEFAULT(G1RemSetArrayOfCardsEntries)) {
     uint max_cards_in_inline_ptr = G1CardSetConfiguration::max_cards_in_inline_ptr(HeapRegion::LogOfHRGrainBytes - CardTable::card_shift());
     FLAG_SET_ERGO(G1RemSetArrayOfCardsEntries, MAX2(max_cards_in_inline_ptr * 2,
-                                                    G1RemSetArrayOfCardsEntriesBase << (region_size_log_mb + 1)));
+                                                    G1RemSetArrayOfCardsEntriesBase << region_size_log_mb));
   }
 
   // Round to next 8 byte boundary for array to maximize space usage.

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -216,7 +216,7 @@
           "The threshold that defines (>=) a hot card.")                    \
           range(0, max_jubyte)                                              \
                                                                             \
-  develop(uint, G1RemSetArrayOfCardsEntriesBase, 4,                         \
+  develop(uint, G1RemSetArrayOfCardsEntriesBase, 8,                         \
           "Maximum number of entries per region in the Array of Cards "     \
           "card set container per MB of a heap region.")                    \
           range(1, 65536)                                                   \


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that reverts [JDK-8286115](https://bugs.openjdk.org/browse/JDK-8286115) to get back remset memory footprint to previous levels?

Testing: local remset size testing

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292654](https://bugs.openjdk.org/browse/JDK-8292654): G1 remembered set memory footprint regression after JDK-8286115


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9966/head:pull/9966` \
`$ git checkout pull/9966`

Update a local copy of the PR: \
`$ git checkout pull/9966` \
`$ git pull https://git.openjdk.org/jdk pull/9966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9966`

View PR using the GUI difftool: \
`$ git pr show -t 9966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9966.diff">https://git.openjdk.org/jdk/pull/9966.diff</a>

</details>
