### PR TITLE
8292368: [ppc64] internal error g1BarrierSet.inline.hpp assert(oopDesc::is_oop(pre_val, true)) failed: Error

### DIFF
--- a/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
@@ -72,7 +72,9 @@ bool BarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
       // conversion that performs the load barriers. This is too subtle, so we instead
       // perform an explicit keep alive call.
       oop obj = NativeAccess<ON_PHANTOM_OOP_REF | AS_NO_KEEPALIVE>::oop_load(p);
-      Universe::heap()->keep_alive(obj);
+      if (obj != nullptr) {
+        Universe::heap()->keep_alive(obj);
+      }
     }
 
     virtual void do_oop(narrowOop* p) { ShouldNotReachHere(); }


### PR DESCRIPTION
C1 patching stubs contain null Oops on PPC64. Null check is missing in [JDK-8292077](https://bugs.openjdk.org/browse/JDK-8292077).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292368](https://bugs.openjdk.org/browse/JDK-8292368): [ppc64] internal error g1BarrierSet.inline.hpp assert(oopDesc::is_oop(pre_val, true)) failed: Error


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9968/head:pull/9968` \
`$ git checkout pull/9968`

Update a local copy of the PR: \
`$ git checkout pull/9968` \
`$ git pull https://git.openjdk.org/jdk pull/9968/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9968`

View PR using the GUI difftool: \
`$ git pr show -t 9968`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9968.diff">https://git.openjdk.org/jdk/pull/9968.diff</a>

</details>
