### PR TITLE
8292713: Unsafe.allocateInstance should be intrinsified without UseUnalignedAccesses

### DIFF
--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -419,6 +419,7 @@ bool vmIntrinsics::disabled_by_jvm_flags(vmIntrinsics::ID id) {
   case vmIntrinsics::_compareAndExchangeReference:
   case vmIntrinsics::_compareAndExchangeReferenceAcquire:
   case vmIntrinsics::_compareAndExchangeReferenceRelease:
+  case vmIntrinsics::_allocateInstance:
     if (!InlineUnsafeOps) return true;
     break;
   case vmIntrinsics::_getShortUnaligned:
@@ -429,7 +430,6 @@ bool vmIntrinsics::disabled_by_jvm_flags(vmIntrinsics::ID id) {
   case vmIntrinsics::_putCharUnaligned:
   case vmIntrinsics::_putIntUnaligned:
   case vmIntrinsics::_putLongUnaligned:
-  case vmIntrinsics::_allocateInstance:
     if (!InlineUnsafeOps || !UseUnalignedAccesses) return true;
     break;
   case vmIntrinsics::_hashCode:


### PR DESCRIPTION
See the rationale and references in the bug. I spotted that RISC-V tests are remarkably slow, and profiler shows that `Unsafe.allocateInstance` is very hot and native. RISC-V and ARM32 systems are `UseUnalignedAccess = false`, and I believe the `_allocateInstance` intrinsic is disabled on these paths by mistake. This PR improves the selected tests very considerably, and I think it actually fixes the real performance bug in `java.lang.invoke`-rich code paths.

Raspberry Pi 4, ARM32 fastdebug build:

```
$ time make test TEST=java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java

# Baseline

real	4m37.970s
user	6m5.490s
sys	0m21.731s

real	4m52.363s
user	6m24.100s
sys	0m21.363s

# Patched

real	2m32.678s ; <--- 1.8x faster
user	4m33.749s
sys	0m22.127s

real	2m38.451s ; <--- 1.8x faster, reproducible
user	4m44.788s
sys	0m22.160s
```

HiFive Unmatched, RISC-V fastdebug build:

```
$ time make test TEST=java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java

# Baseline

real	19m3.479s
user	27m2.932s
sys	0m27.766s

real	18m52.351s
user	27m23.917s
sys	0m27.682s

# Patched

real	10m5.971s  ; <--- 1.9x faster
user	18m11.538s
sys	0m28.204s

real	10m18.973s ; <--- 1.9x faster, reproducible
user	18m31.067s
sys	0m28.053s
```

Additional testing:
 - [x] Linux RISC-V build, timing tests
 - [x] Linux ARM32 build, timing tests
 - [x] Linux ARM32 fastdebug `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292713](https://bugs.openjdk.org/browse/JDK-8292713): Unsafe.allocateInstance should be intrinsified without UseUnalignedAccesses


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9970/head:pull/9970` \
`$ git checkout pull/9970`

Update a local copy of the PR: \
`$ git checkout pull/9970` \
`$ git pull https://git.openjdk.org/jdk pull/9970/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9970`

View PR using the GUI difftool: \
`$ git pr show -t 9970`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9970.diff">https://git.openjdk.org/jdk/pull/9970.diff</a>

</details>
