### PR TITLE
8292738 : JInternalFrame backgroundShadowBorder & foregroundShadowBorder line is longer in Mac Look and Feel

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaInternalFrameUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaInternalFrameUI.java
@@ -752,7 +752,7 @@ public class AquaInternalFrameUI extends BasicInternalFrameUI implements SwingCo
                 @Override
                 public void paint(final Graphics g, int x, int y, int w, int h) {
                     g.setColor(new Color(0, 0, 0, 64));
-                    g.drawLine(x + 2, y - 8, x + w - 2, y - 8);
+                    g.drawLine(x + 5, y - 8, x + w - 5, y - 8);
                 }
             },
             0, 7, 1.1f, 1.0f, 24, 51, 51, 25, 25, 25, 25);
@@ -771,7 +771,7 @@ public class AquaInternalFrameUI extends BasicInternalFrameUI implements SwingCo
                 @Override
                 public void paint(final Graphics g, int x, int y, int w, int h) {
                     g.setColor(new Color(0, 0, 0, 32));
-                    g.drawLine(x, y - 11, x + w - 1, y - 11);
+                    g.drawLine(x + 10, y - 11, x + w - 10, y - 11);
                 }
             },
             0, 0, 3.0f, 1.0f, 10, 51, 51, 25, 25, 25, 25);


### PR DESCRIPTION
Border line is seen outside  round Rectangle both for JInternalFrame backgroundShadowBorder & foregroundShadowBorder line in mac L&F.
![Screen Shot 2022-08-22 at 4 17 49 PM](https://user-images.githubusercontent.com/87324768/186021010-d21aed21-9e05-4b28-846b-2628e367f183.png)

I have circled the extra part of the line. To make it more visible I changed the color of the backgroundShadowBorder to red
![Screen Shot 2022-08-22 at 4 17 37 PM](https://user-images.githubusercontent.com/87324768/186021095-cbfffdba-d43a-47e7-a50b-551c59cb767b.png)

Fixed the extra length of the line 
![Fixed](https://user-images.githubusercontent.com/87324768/186021195-688c3613-fc50-41c3-8cad-94173385dfeb.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292738](https://bugs.openjdk.org/browse/JDK-8292738): JInternalFrame backgroundShadowBorder & foregroundShadowBorder line is longer in Mac Look and Feel


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9971/head:pull/9971` \
`$ git checkout pull/9971`

Update a local copy of the PR: \
`$ git checkout pull/9971` \
`$ git pull https://git.openjdk.org/jdk pull/9971/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9971`

View PR using the GUI difftool: \
`$ git pr show -t 9971`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9971.diff">https://git.openjdk.org/jdk/pull/9971.diff</a>

</details>
