### PR TITLE
8292763: JDK-8292716 breaks configure without jtreg

### DIFF
--- a/make/autoconf/lib-tests.m4
+++ b/make/autoconf/lib-tests.m4
@@ -218,19 +218,20 @@ AC_DEFUN_ONCE([LIB_TESTS_SETUP_JTREG],
   AC_SUBST(JT_HOME)
 
   # Verify jtreg version
+  if test "x$JT_HOME" != x; then
+    AC_MSG_CHECKING([jtreg version number])
+    # jtreg -version looks like this: "jtreg 6.1+1-19"
+    # Extract actual version part ("6.1" in this case)
+    jtreg_version_full=`$JAVA -jar $JT_HOME/lib/jtreg.jar -version | $HEAD -n 1 | $CUT -d ' ' -f 2`
+    jtreg_version=${jtreg_version_full/%+*}
+    AC_MSG_RESULT([$jtreg_version])
 
-  AC_MSG_CHECKING([jtreg version number])
-  # jtreg -version looks like this: "jtreg 6.1+1-19"
-  # Extract actual version part ("6.1" in this case)
-  jtreg_version_full=`$JAVA -jar $JT_HOME/lib/jtreg.jar -version | $HEAD -n 1 | $CUT -d ' ' -f 2`
-  jtreg_version=${jtreg_version_full/%+*}
-  AC_MSG_RESULT([$jtreg_version])
-
-  # This is a simplified version of TOOLCHAIN_CHECK_COMPILER_VERSION
-  comparable_actual_version=`$AWK -F. '{ printf("%05d%05d%05d%05d\n", [$]1, [$]2, [$]3, [$]4) }' <<< "$jtreg_version"`
-  comparable_minimum_version=`$AWK -F. '{ printf("%05d%05d%05d%05d\n", [$]1, [$]2, [$]3, [$]4) }' <<< "$JTREG_MINIMUM_VERSION"`
-  if test $comparable_actual_version -lt $comparable_minimum_version ; then
-    AC_MSG_ERROR([jtreg version is too old, at least version $JTREG_MINIMUM_VERSION is required])
+    # This is a simplified version of TOOLCHAIN_CHECK_COMPILER_VERSION
+    comparable_actual_version=`$AWK -F. '{ printf("%05d%05d%05d%05d\n", [$]1, [$]2, [$]3, [$]4) }' <<< "$jtreg_version"`
+    comparable_minimum_version=`$AWK -F. '{ printf("%05d%05d%05d%05d\n", [$]1, [$]2, [$]3, [$]4) }' <<< "$JTREG_MINIMUM_VERSION"`
+    if test $comparable_actual_version -lt $comparable_minimum_version ; then
+      AC_MSG_ERROR([jtreg version is too old, at least version $JTREG_MINIMUM_VERSION is required])
+    fi
   fi
 ])
 


### PR DESCRIPTION
The fix for JDK-8292716 was supposed to verify version number requirements for jtreg. Unfortunately, it breaks configure if no jtreg is supplied.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292763](https://bugs.openjdk.org/browse/JDK-8292763): JDK-8292716 breaks configure without jtreg


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9975/head:pull/9975` \
`$ git checkout pull/9975`

Update a local copy of the PR: \
`$ git checkout pull/9975` \
`$ git pull https://git.openjdk.org/jdk pull/9975/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9975`

View PR using the GUI difftool: \
`$ git pr show -t 9975`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9975.diff">https://git.openjdk.org/jdk/pull/9975.diff</a>

</details>
