### PR TITLE
8292660: C2: blocks made unreachable by NeverBranch-to-Goto conversion are removed incorrectly

### DIFF
--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -151,6 +151,10 @@ bool Block::contains(const Node *n) const {
   return _nodes.contains(n);
 }
 
+bool Block::is_trivially_unreachable() const {
+  return num_preds() <= 1 && !head()->is_Root() && !head()->is_Start();
+}
+
 // Return empty status of a block.  Empty blocks contain only the head, other
 // ideal nodes, and an optional trailing goto.
 int Block::is_Empty() const {
@@ -170,7 +174,7 @@ int Block::is_Empty() const {
   }
 
   // Unreachable blocks are considered empty
-  if (num_preds() <= 1) {
+  if (is_trivially_unreachable()) {
     return success_result;
   }
 
@@ -568,12 +572,7 @@ static bool no_flip_branch(Block *b) {
   return false;
 }
 
-// Check for NeverBranch at block end.  This needs to become a GOTO to the
-// true target.  NeverBranch are treated as a conditional branch that always
-// goes the same direction for most of the optimizer and are used to give a
-// fake exit path to infinite loops.  At this late stage they need to turn
-// into Goto's so that when you enter the infinite loop you indeed hang.
-void PhaseCFG::convert_NeverBranch_to_Goto(Block *b) {
+Block* PhaseCFG::convert_NeverBranch_to_Goto(Block* b) {
   // Find true target
   int end_idx = b->end_idx();
   int idx = b->get_node(end_idx+1)->as_Proj()->_con;
@@ -608,19 +607,7 @@ void PhaseCFG::convert_NeverBranch_to_Goto(Block *b) {
   for (int k = 1; dead->get_node(k)->is_Phi(); k++) {
     dead->get_node(k)->del_req(j);
   }
-  // If the fake exit block becomes unreachable, remove it from the block list.
-  if (dead->num_preds() == 1) {
-    for (uint i = 0; i < number_of_blocks(); i++) {
-      Block* block = get_block(i);
-      if (block == dead) {
-        _blocks.remove(i);
-      } else if (block->_pre_order > dead->_pre_order) {
-        // Enforce contiguous pre-order indices (assumed by PhaseBlockLayout).
-        block->_pre_order--;
-      }
-    }
-    _number_of_blocks--;
-  }
+  return dead;
 }
 
 // Helper function to move block bx to the slot following b_index. Return
@@ -695,6 +682,7 @@ void PhaseCFG::remove_empty_blocks() {
   uint last = number_of_blocks();
   assert(get_block(0) == get_root_block(), "");
 
+  Block_List unreachable; // Worklist of unreachable blocks to be removed.
   for (uint i = 1; i < last; i++) {
     Block* block = get_block(i);
     if (block->is_connector()) {
@@ -708,7 +696,11 @@ void PhaseCFG::remove_empty_blocks() {
     // need to turn into Goto's so that when you enter the infinite loop you
     // indeed hang.
     if (block->get_node(block->end_idx())->Opcode() == Op_NeverBranch) {
-      convert_NeverBranch_to_Goto(block);
+      Block* dead = convert_NeverBranch_to_Goto(block);
+      // If the fake exit block becomes unreachable, save it for later removal.
+      if (dead->is_trivially_unreachable()) {
+        unreachable.push(dead);
+      }
     }
 
     // Look for uncommon blocks and move to end.
@@ -738,6 +730,41 @@ void PhaseCFG::remove_empty_blocks() {
       i--;
     }
   } // End of for all blocks
+
+  // Remove all blocks that are transitively unreachable after the
+  // NeverBranch-to-Goto conversion.
+  while (unreachable.size() > 0) {
+    Block* dead = unreachable.pop();
+    for (uint i = 0; i < number_of_blocks(); i++) {
+      Block* block = get_block(i);
+      if (block == dead) {
+        _blocks.remove(i);
+        _number_of_blocks--;
+        i--; // Ensure that we visit the block following the removed one.
+      }
+      if (block->_pre_order > dead->_pre_order) {
+        // Enforce contiguous pre-order indices (assumed by PhaseBlockLayout).
+        block->_pre_order--;
+      }
+      if (block->_rpo > dead->_rpo) {
+        // Enforce contiguous reverse post-order indices as well, for sanity.
+        block->_rpo--;
+      }
+    }
+    // Update the successors' predecessor list and push new unreachable blocks.
+    for (uint i = 0; i < dead->_num_succs; i++) {
+      Block* succ = dead->_succs[i];
+      Node* head = succ->head();
+      for (int j = head->req() - 1; j >= 1; j--) {
+        if (get_block_for_node(head->in(j)) == dead) {
+          head->del_req(j);
+        }
+      }
+      if (succ->is_trivially_unreachable()) {
+        unreachable.push(succ);
+      }
+    }
+  }
 }
 
 Block *PhaseCFG::fixup_trap_based_check(Node *branch, Block *block, int block_pos, Block *bnext) {

--- a/src/hotspot/share/opto/block.hpp
+++ b/src/hotspot/share/opto/block.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -321,6 +321,9 @@ public:
   // Check whether the node is in the block.
   bool contains (const Node *n) const;
 
+  // Whether the block is not "root"-like and does not have any predecessors.
+  bool is_trivially_unreachable() const;
+
   // Return the empty status of a block
   enum { not_empty, empty_with_goto, completely_empty };
   int is_Empty() const;
@@ -502,7 +505,8 @@ class PhaseCFG : public Phase {
   // goes the same direction for most of the optimizer and are used to give a
   // fake exit path to infinite loops.  At this late stage they need to turn
   // into Goto's so that when you enter the infinite loop you indeed hang.
-  void convert_NeverBranch_to_Goto(Block *b);
+  // Return the target block of the fake exit path.
+  Block* convert_NeverBranch_to_Goto(Block* b);
 
   CFGLoop* create_loop_tree();
   bool is_dominator(Node* dom_node, Node* node);

--- a/src/hotspot/share/opto/block.hpp
+++ b/src/hotspot/share/opto/block.hpp
@@ -505,8 +505,7 @@ class PhaseCFG : public Phase {
   // goes the same direction for most of the optimizer and are used to give a
   // fake exit path to infinite loops.  At this late stage they need to turn
   // into Goto's so that when you enter the infinite loop you indeed hang.
-  // Return the target block of the fake exit path.
-  Block* convert_NeverBranch_to_Goto(Block* b);
+  void convert_NeverBranch_to_Goto(Block *b);
 
   CFGLoop* create_loop_tree();
   bool is_dominator(Node* dom_node, Node* node);
@@ -614,6 +613,10 @@ class PhaseCFG : public Phase {
   void remove_empty_blocks();
   Block *fixup_trap_based_check(Node *branch, Block *block, int block_pos, Block *bnext);
   void fixup_flow();
+  // Remove all blocks that are transitively unreachable. Such blocks can be
+  // found e.g. after PhaseCFG::convert_NeverBranch_to_Goto(). This function
+  // assumes post-fixup_flow() block indices (Block::_pre_order, Block::_rpo).
+  void remove_unreachable_blocks();
 
   // Insert a node into a block at index and map the node to the block
   void insert(Block *b, uint idx, Node *n) {

--- a/src/hotspot/share/opto/block.hpp
+++ b/src/hotspot/share/opto/block.hpp
@@ -321,7 +321,7 @@ public:
   // Check whether the node is in the block.
   bool contains (const Node *n) const;
 
-  // Whether the block is not "root"-like and does not have any predecessors.
+  // Whether the block is not root-like and does not have any predecessors.
   bool is_trivially_unreachable() const;
 
   // Return the empty status of a block

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2970,6 +2970,7 @@ void Compile::Code_Gen() {
       cfg.set_loop_alignment();
     }
     cfg.fixup_flow();
+    cfg.remove_unreachable_blocks();
   }
 
   // Apply peephole optimizations

--- a/test/hotspot/jtreg/compiler/loopopts/TestMultipleInfiniteLoops.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestMultipleInfiniteLoops.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8292660
+ * @summary Test that blocks made unreachable after processing multiple infinite
+ *          loops in the block ordering phase are removed correctly.
+ *
+ * @run main/othervm -Xcomp -XX:CompileOnly=compiler.loopopts.TestMultipleInfiniteLoops::test
+ *                   compiler.loopopts.TestMultipleInfiniteLoops
+ */
+
+package compiler.loopopts;
+
+public class TestMultipleInfiniteLoops {
+
+    static int foo;
+
+    static void test() {
+        int i = 5, j;
+        while (i > 0) {
+            for (j = i; 1 > j; ) {
+                switch (i) {
+                case 4:
+                    foo = j;
+                }
+            }
+            i++;
+        }
+    }
+
+    public static void main(String[] args) {
+        test();
+    }
+}


### PR DESCRIPTION
This changeset addresses three issues in the current removal of unreachable blocks after NeverBranch-to-goto conversion (introduced recently by [JDK-8292285](https://bugs.openjdk.org/browse/JDK-8292285)):

1. The [unreachable block removal and pre-order index update loop](https://github.com/openjdk/jdk/blob/7b5f9edb59ef763acca80724ca37f3624d720d06/src/hotspot/share/opto/block.cpp#L613-L621) skips the block next to the removed one, and iterates beyond the end of the block list (`PhaseCFG::_blocks`). Skipping blocks can lead to duplicate pre-order indices (`Block::_pre_order`) and/or pre-order indices greater than the size of the block list, causing problems in later transformations.

2. The [outer block traversal loop](https://github.com/openjdk/jdk/blob/7b5f9edb59ef763acca80724ca37f3624d720d06/src/hotspot/share/opto/block.cpp#L698-L729) iterates beyond the end of the block list whenever one or more unreachable blocks are removed.

3. Transitively unreachable blocks (such as B10 in the following example), arising in methods with multiple infinite loops, are not removed:

![transitive](https://user-images.githubusercontent.com/8792647/186109043-416213b7-8735-41de-9910-acf0997db095.png)

This changeset addresses issues 2 and 3 by decoupling NeverBranch-to-goto conversion from removal of unreachable code. Instead of removing the blocks eagerly, the removal is postponed to a later phase that works in an iterative worklist fashion, making it possible to remove transitively unreachable blocks such as B10 in the above example. Postponing removal to a later phase (where `get_block(i)->_pre_order == i` holds) also simplifies addressing issue 1: in the changeset, it is sufficient to iterate over the blocks that follow the removed block in the block list to decrement their `_pre_order` index.

#### Testing

- tier1-3 (windows-x64, linux-x64, linux-aarch64, and macosx-x64; release and debug mode).
- tier4-7 (linux-x64; debug mode).
- fuzzing (~1 h. on each platform).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292660](https://bugs.openjdk.org/browse/JDK-8292660): C2: blocks made unreachable by NeverBranch-to-Goto conversion are removed incorrectly


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [7a95e6fc](https://git.openjdk.org/jdk/pull/9976/files/7a95e6fcd3979fb1ae5ea6e28de0bca283363679)
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9976/head:pull/9976` \
`$ git checkout pull/9976`

Update a local copy of the PR: \
`$ git checkout pull/9976` \
`$ git pull https://git.openjdk.org/jdk pull/9976/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9976`

View PR using the GUI difftool: \
`$ git pr show -t 9976`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9976.diff">https://git.openjdk.org/jdk/pull/9976.diff</a>

</details>
