### PR TITLE
JDK-8292778: EncodingSupport_md.c convertUtf8ToPlatformString wrong placing of free

### DIFF
--- a/src/java.instrument/windows/native/libinstrument/EncodingSupport_md.c
+++ b/src/java.instrument/windows/native/libinstrument/EncodingSupport_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,8 +76,8 @@ convertUtf8ToPlatformString(char* utf8_str, int utf8_len, char* platform_str, in
                 if (plen >= 0) {
                     platform_str[plen] = '\0';
                 }
-                free(wstr);
             }
+            free(wstr);
         }
     }
     return plen;


### PR DESCRIPTION
There seems to be a case where EncodingSupport_md.c convertUtf8ToPlatformString might leak memory because of a wrong placing of free..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292778](https://bugs.openjdk.org/browse/JDK-8292778): EncodingSupport_md.c convertUtf8ToPlatformString wrong placing of free


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9981/head:pull/9981` \
`$ git checkout pull/9981`

Update a local copy of the PR: \
`$ git checkout pull/9981` \
`$ git pull https://git.openjdk.org/jdk pull/9981/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9981`

View PR using the GUI difftool: \
`$ git pr show -t 9981`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9981.diff">https://git.openjdk.org/jdk/pull/9981.diff</a>

</details>
