### PR TITLE
8288129: Shenandoah: Skynet test crashed with iu + aggressive

### DIFF
--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahIUMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahIUMode.cpp
@@ -51,9 +51,6 @@ void ShenandoahIUMode::initialize_flags() const {
     FLAG_SET_DEFAULT(ShenandoahSATBBarrier, false);
   }
 
-  // Disable Loom
-  SHENANDOAH_ERGO_DISABLE_FLAG(VMContinuations);
-
   SHENANDOAH_ERGO_ENABLE_FLAG(ExplicitGCInvokesConcurrent);
   SHENANDOAH_ERGO_ENABLE_FLAG(ShenandoahImplicitGCInvokesConcurrent);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2310,6 +2310,8 @@ void ShenandoahHeap::flush_liveness_cache(uint worker_id) {
 }
 
 bool ShenandoahHeap::requires_barriers(stackChunkOop obj) const {
+  if (ShenandoahIUBarrier) return true;
+
   if (is_idle()) return false;
 
   // Objects allocated after marking start are implicitly alive, don't need any barriers during

--- a/src/hotspot/share/oops/stackChunkOop.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.hpp
@@ -190,6 +190,9 @@ public:
               int* out_frames = NULL, int* out_interpreted_frames = NULL) NOT_DEBUG({ return true; });
 
 private:
+  template<typename T, BarrierType barrier>
+  void do_barriers_for_header();
+
   template <BarrierType barrier, ChunkFrames frames = ChunkFrames::Mixed, typename RegisterMapT>
   void do_barriers0(const StackChunkFrameStream<frames>& f, const RegisterMapT* map);
 


### PR DESCRIPTION
Please review this patch to fix the crash when running Loom with Shenandoah in iu+aggressive mode.

When running with `-XX:+ShenandoahVerify`, the issue manifests as assertion at:

```
   1 #
   2 # A fatal error has been detected by the Java Runtime Environment:
   3 #
   4 #  Internal Error (/home/asmehra/data/ashu-mehra/loom/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp:92), pid=920144, tid=920156
   5 #  Error: Before Evacuation, Reachable; Must be marked in complete bitmap, except j.l.r.Reference referents
   6 
   7 Referenced from:
   8   interior location: 0x00007f0a40000090
   9   0x00007f0a40000060 - klass 0x00007f0a0d89a290 jdk.internal.vm.StackChunk
  10         allocated after mark start
  11     not after update watermark
  12         marked strong
  13         marked weak
  14     not in collection set
  15   mark: mark(is_neutral no_hash age=0)
  16   region: |    0|R  |BTE 7f0a40000000, 7f0a401ff9b0, 7f0a40200000|TAMS 7f0a40000000|UWM 7f0a401ff9b0|U  2046K|T  2046K|G     0B|S     0B|L  2046K|CP   0
  17 
  18 Object:
  19   0x00007f0c2f848a40 - klass 0x00007f0a0d89a290 jdk.internal.vm.StackChunk
  20     not allocated after mark start
  21     not after update watermark
  22     not marked strong
  23     not marked weak
  24         in collection set
  25   mark: mark(is_neutral no_hash age=0)
  26   region: | 3964|CS |BTE 7f0c2f800000, 7f0c2fa00000, 7f0c2fa00000|TAMS 7f0c2fa00000|UWM 7f0c2fa00000|U  2048K|T     0B|G  2048K|S     0B|L  1612K|CP   0
  27 
  28 Forwardee:
  29   (the object itself)
```

The StackChunk object `0x00007f0c2f848a40` is not marked which happens to be referenced from the parent field of the newly allocated StackChunk object `0x00007f0a40000060`.
The sequence for setting `StackChunk::parent` is as follows. At some point during the process of freezing the continuation, the jvm does:

```
	continuationWrapper::_tail = stackChunk1
	stackChunk2 = allocate new StackChunk
	stackChunk2::parent = continuationWrapper::_tail
	continuationWrapper::_tail = stackChunk2
```

At the end of the sequence stackChunk1 is only reachable from stackChunk2. If stackChunk2 happens to be allocated after concurrent mark has started and if the shenandoahgc is using IU mode, then the stackChunk2 would would not be scanned. This results in gc missing the marking of stackChunk1 which triggers the the assertion during heap verification.

This is similar to the sequence described by @fisk [here](https://github.com/openjdk/jdk19/pull/140#issuecomment-1185491224)

There is code in `FreezeBase::finish_freeze()` to call `stackChunkOopDesc::do_barriers()` which triggers the gc barriers for the newly allocated StackChunk object. But it has two problems:
1. The call to `stackChunkOopDesc::do_barriers()` is guarded by a flag [1] which is false for StackChunk objects allocated after marking has started [2]
2. `stackChunkOopDesc::do_barriers()` currently triggers the gc barriers for the oops in the stack represented by the newly allocated StackChunk, but it ignores the oops in the StackChunk header

To fix these two issues, we need the following changes:
1. Always enable barrier for Shenandoah IU mode (this change is same as 8288129: Shenandoah: Skynet test crashed with iu + aggressive #9494).
2. Add the code in `stackChunkOopDesc::do_barriers` to run the barriers on the oops present in the stack chunk header.

[1] https://github.com/openjdk/jdk/blob/9a0d1e7ce86368cdcade713a9e220604f7d77ecf/src/hotspot/share/runtime/continuationFreezeThaw.cpp#L1201
[2] https://github.com/openjdk/jdk/blob/9a0d1e7ce86368cdcade713a9e220604f7d77ecf/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp#L2308

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288129](https://bugs.openjdk.org/browse/JDK-8288129): Shenandoah: Skynet test crashed with iu + aggressive


### Contributors
 * Zhengyu Gu `<zgu@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9982/head:pull/9982` \
`$ git checkout pull/9982`

Update a local copy of the PR: \
`$ git checkout pull/9982` \
`$ git pull https://git.openjdk.org/jdk pull/9982/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9982`

View PR using the GUI difftool: \
`$ git pr show -t 9982`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9982.diff">https://git.openjdk.org/jdk/pull/9982.diff</a>

</details>
