### PR TITLE
8291736: find_method_handle_intrinsic leaks Method*

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -2079,6 +2079,8 @@ Method* SystemDictionary::find_method_handle_intrinsic(vmIntrinsicID iid,
     }
 
     bool throw_error = false;
+    // This function could get an OOM but it is safe to call inside of a lock because
+    // throwing OutOfMemoryError doesn't call Java code.
     methodHandle m = Method::make_method_handle_intrinsic(iid, signature, CHECK_NULL);
     if (!Arguments::is_interpreter_only() || iid == vmIntrinsics::_linkToNative) {
         // Generate a compiled form of the MH intrinsic

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -2074,7 +2074,7 @@ Method* SystemDictionary::find_method_handle_intrinsic(vmIntrinsicID iid,
   InvokeMethodKey key(signature, iid_as_int);
   Method** met = _invoke_method_intrinsic_table.get(key);
   if (met != nullptr) {
-   return *met;
+    return *met;
   }
 
   methodHandle m = Method::make_method_handle_intrinsic(iid, signature, CHECK_NULL);


### PR DESCRIPTION
As part of the SymbolPropertyTable conversion, we noticed that threads could race to add the Method entry to the table, and the loser wasn't deleted.  This change locks the InvokeMethodTable_lock through the Method creation so that it's not leaked.  See bug for details, but this was performance tested with our general suite of performance tests to show no significant differences.
Also tested with tier1-3, and previously 4-7 with SymbolPropertyTable conversion patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291736](https://bugs.openjdk.org/browse/JDK-8291736): find_method_handle_intrinsic leaks Method*


### Reviewers
 * [Harold Seigel](https://openjdk.org/census#hseigel) (@hseigel - **Reviewer**) ⚠️ Review applies to [73f02463](https://git.openjdk.org/jdk/pull/9983/files/73f02463d9513c5a74022420e9407787a6b25f8c)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to [73f02463](https://git.openjdk.org/jdk/pull/9983/files/73f02463d9513c5a74022420e9407787a6b25f8c)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9983/head:pull/9983` \
`$ git checkout pull/9983`

Update a local copy of the PR: \
`$ git checkout pull/9983` \
`$ git pull https://git.openjdk.org/jdk pull/9983/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9983`

View PR using the GUI difftool: \
`$ git pr show -t 9983`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9983.diff">https://git.openjdk.org/jdk/pull/9983.diff</a>

</details>
