### PR TITLE
8292329: Enable CDS shared heap for zero builds

### DIFF
--- a/make/Images.gmk
+++ b/make/Images.gmk
@@ -128,8 +128,7 @@ define CreateCDSArchive
   $1_$2_DUMP_EXTRA_ARG := $(if $(filter _nocoops, $2),-XX:-UseCompressedOops,)
   $1_$2_DUMP_TYPE      := $(if $(filter _nocoops, $2),-NOCOOPS,)
 
-  # Only G1 supports dumping the shared heap, so explicitly use G1
-  # it if the JVM supports it. (Note: the default GC with zero is SerialGC)
+  # Only G1 supports dumping the shared heap, so explicitly use G1 if the JVM supports it.
   $1_$2_CDS_DUMP_FLAGS := $(CDS_DUMP_FLAGS) $(if $(filter g1gc, $(JVM_FEATURES_$1)),-XX:+UseG1GC)
 
   ifeq ($(OPENJDK_TARGET_OS), windows)

--- a/make/Images.gmk
+++ b/make/Images.gmk
@@ -114,6 +114,12 @@ $(eval $(call SetupExecute, jlink_jre, \
 
 JLINK_JRE_TARGETS := $(jlink_jre)
 
+# Optimize CDS shared heap for small heap sizes, which are typically used
+# for small cloud-based apps that have the most critical start-up requirement.
+# The trade-off is that when larger heap sizes are used, the shared heap
+# may need to be relocated at runtime.
+CDS_DUMP_FLAGS = -Xmx128M -Xms128M
+
 # Helper function for creating the CDS archives for the JDK and JRE
 #
 # Param1 - VM variant (e.g., server, client, zero, ...)
@@ -122,6 +128,10 @@ define CreateCDSArchive
   $1_$2_DUMP_EXTRA_ARG := $(if $(filter _nocoops, $2),-XX:-UseCompressedOops,)
   $1_$2_DUMP_TYPE      := $(if $(filter _nocoops, $2),-NOCOOPS,)
 
+  # Only G1 supports dumping the shared heap, so explicitly use G1
+  # it if the JVM supports it. (Note: the default GC with zero is SerialGC)
+  $1_$2_CDS_DUMP_FLAGS := $(CDS_DUMP_FLAGS) $(if $(filter g1gc, $(JVM_FEATURES_$1)),-XX:+UseG1GC)
+
   ifeq ($(OPENJDK_TARGET_OS), windows)
     $1_$2_CDS_ARCHIVE := bin/$1/classes$2.jsa
   else
@@ -129,25 +139,25 @@ define CreateCDSArchive
   endif
 
   $$(eval $$(call SetupExecute, $1_$2_gen_cds_archive_jdk, \
-      WARN := Creating CDS$$($1_$2_DUMP_TYPE) archive for jdk image for $1, \
+      WARN := Creating CDS$$($1_$2_DUMP_TYPE) archive for jdk image for $1: $$($1_$2_CDS_DUMP_FLAGS), \
       DEPS := $$(jlink_jdk), \
       OUTPUT_FILE := $$(JDK_IMAGE_DIR)/$$($1_$2_CDS_ARCHIVE), \
       SUPPORT_DIR := $$(SUPPORT_OUTPUTDIR)/images/jdk, \
       COMMAND := $$(FIXPATH) $$(JDK_IMAGE_DIR)/bin/java -Xshare:dump \
           -XX:SharedArchiveFile=$$(JDK_IMAGE_DIR)/$$($1_$2_CDS_ARCHIVE) \
-          -$1 $$($1_$2_DUMP_EXTRA_ARG) -Xmx128M -Xms128M $$(LOG_INFO), \
+          -$1 $$($1_$2_DUMP_EXTRA_ARG) $$($1_$2_CDS_DUMP_FLAGS) $$(LOG_INFO), \
   ))
 
   JDK_TARGETS += $$($1_$2_gen_cds_archive_jdk)
 
   $$(eval $$(call SetupExecute, $1_$2_gen_cds_archive_jre, \
-      WARN := Creating CDS$$($1_$2_DUMP_TYPE) archive for jre image for $1, \
+      WARN := Creating CDS$$($1_$2_DUMP_TYPE) archive for jre image for $1: $$($1_$2_CDS_DUMP_FLAGS), \
       DEPS := $$(jlink_jre), \
       OUTPUT_FILE := $$(JRE_IMAGE_DIR)/$$($1_$2_CDS_ARCHIVE), \
       SUPPORT_DIR := $$(SUPPORT_OUTPUTDIR)/images/jre, \
       COMMAND := $$(FIXPATH) $$(JRE_IMAGE_DIR)/bin/java -Xshare:dump \
           -XX:SharedArchiveFile=$$(JRE_IMAGE_DIR)/$$($1_$2_CDS_ARCHIVE) \
-          -$1 $$($1_$2_DUMP_EXTRA_ARG) -Xmx128M -Xms128M $$(LOG_INFO), \
+          -$1 $$($1_$2_DUMP_EXTRA_ARG) $$($1_$2_CDS_DUMP_FLAGS) $$(LOG_INFO), \
   ))
 
   JRE_TARGETS += $$($1_$2_gen_cds_archive_jre)

--- a/make/Images.gmk
+++ b/make/Images.gmk
@@ -138,7 +138,8 @@ define CreateCDSArchive
   endif
 
   $$(eval $$(call SetupExecute, $1_$2_gen_cds_archive_jdk, \
-      WARN := Creating CDS$$($1_$2_DUMP_TYPE) archive for jdk image for $1: $$($1_$2_CDS_DUMP_FLAGS), \
+      WARN := Creating CDS$$($1_$2_DUMP_TYPE) archive for jdk image for $1, \
+      INFO := Using CDS flags for $1: $$($1_$2_CDS_DUMP_FLAGS), \
       DEPS := $$(jlink_jdk), \
       OUTPUT_FILE := $$(JDK_IMAGE_DIR)/$$($1_$2_CDS_ARCHIVE), \
       SUPPORT_DIR := $$(SUPPORT_OUTPUTDIR)/images/jdk, \
@@ -150,7 +151,8 @@ define CreateCDSArchive
   JDK_TARGETS += $$($1_$2_gen_cds_archive_jdk)
 
   $$(eval $$(call SetupExecute, $1_$2_gen_cds_archive_jre, \
-      WARN := Creating CDS$$($1_$2_DUMP_TYPE) archive for jre image for $1: $$($1_$2_CDS_DUMP_FLAGS), \
+      WARN := Creating CDS$$($1_$2_DUMP_TYPE) archive for jre image for $1, \
+      INFO := Using CDS flags for $1: $$($1_$2_CDS_DUMP_FLAGS), \
       DEPS := $$(jlink_jre), \
       OUTPUT_FILE := $$(JRE_IMAGE_DIR)/$$($1_$2_CDS_ARCHIVE), \
       SUPPORT_DIR := $$(SUPPORT_OUTPUTDIR)/images/jre, \


### PR DESCRIPTION
ZERO uses UseSerialGC by default. When we dump the default CDS archive during the build process, it fails to dump the shared heap (which requires G1GC).

The fix is to force -XX:+UseG1GC when dumping the default CDS archive during the build process.

Speed up:

(Before)
$ perf stat -r 40 ./images/jdk/bin/java -version
0.018080 +- 0.000388 seconds time elapsed ( +- 2.15% )

(After)
$ perf stat -r 40 ./images/jdk/bin/java -version
0.011986 +- 0.000205 seconds time elapsed ( +- 1.71% )

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292329](https://bugs.openjdk.org/browse/JDK-8292329): Enable CDS shared heap for zero builds


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [f57ba86b](https://git.openjdk.org/jdk/pull/9984/files/f57ba86bd3ed9dd8844aa0a0b7e42f78918683b3)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [f57ba86b](https://git.openjdk.org/jdk/pull/9984/files/f57ba86bd3ed9dd8844aa0a0b7e42f78918683b3)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9984/head:pull/9984` \
`$ git checkout pull/9984`

Update a local copy of the PR: \
`$ git checkout pull/9984` \
`$ git pull https://git.openjdk.org/jdk pull/9984/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9984`

View PR using the GUI difftool: \
`$ git pr show -t 9984`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9984.diff">https://git.openjdk.org/jdk/pull/9984.diff</a>

</details>
