### PR TITLE
8292494: Ensure SystemDictionary::set_platform_loader and set_system_loader are called only once

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -203,15 +203,14 @@ ClassLoaderData* SystemDictionary::register_loader(Handle class_loader, bool cre
 }
 
 void SystemDictionary::set_system_loader(ClassLoaderData *cld) {
-  if (_java_system_loader.is_empty()) {
-    _java_system_loader = cld->class_loader_handle();
-  }
+  assert(_java_system_loader.is_empty(), "already set!");
+  _java_system_loader = cld->class_loader_handle();
+
 }
 
 void SystemDictionary::set_platform_loader(ClassLoaderData *cld) {
-  if (_java_platform_loader.is_empty()) {
-    _java_platform_loader = cld->class_loader_handle();
-  }
+  assert(_java_platform_loader.is_empty(), "already set!");
+  _java_platform_loader = cld->class_loader_handle();
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
The `SystemDictionary::set_platform_loader` and the `SystemDictionary::set_system_loader` functions should only be called once during VM startup, this simple fix ensures that.

Passed mach5 tiers 1,2,3 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292494](https://bugs.openjdk.org/browse/JDK-8292494): Ensure SystemDictionary::set_platform_loader and set_system_loader are called only once


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9988/head:pull/9988` \
`$ git checkout pull/9988`

Update a local copy of the PR: \
`$ git checkout pull/9988` \
`$ git pull https://git.openjdk.org/jdk pull/9988/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9988`

View PR using the GUI difftool: \
`$ git pr show -t 9988`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9988.diff">https://git.openjdk.org/jdk/pull/9988.diff</a>

</details>
