### PR TITLE
8292816: GPL Classpath exception missing from assemblyprefix.h

### DIFF
--- a/make/data/autoheaders/assemblyprefix.h
+++ b/make/data/autoheaders/assemblyprefix.h
@@ -4,7 +4,9 @@
 #
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
-# published by the Free Software Foundation.
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
 #
 # This code is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or


### PR DESCRIPTION
Adds Classpath exception to assemblyprefix.h. Affects copyright header only.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292816](https://bugs.openjdk.org/browse/JDK-8292816): GPL Classpath exception missing from assemblyprefix.h


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9990/head:pull/9990` \
`$ git checkout pull/9990`

Update a local copy of the PR: \
`$ git checkout pull/9990` \
`$ git pull https://git.openjdk.org/jdk pull/9990/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9990`

View PR using the GUI difftool: \
`$ git pr show -t 9990`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9990.diff">https://git.openjdk.org/jdk/pull/9990.diff</a>

</details>
