### PR TITLE
8292739: Invalid legacy entries may be returned by Provider.getServices() call

### DIFF
--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -1321,7 +1321,13 @@ public abstract class Provider extends Properties {
                 set.addAll(serviceMap.values());
             }
             if (!legacyMap.isEmpty()) {
-                set.addAll(legacyMap.values());
+                legacyMap.entrySet().forEach(entry -> {
+                    if (!entry.getValue().isValid()) {
+                        legacyMap.remove(entry.getKey(), entry.getValue());
+                    } else {
+                        set.add(entry.getValue());
+                    }
+                });
             }
             serviceSet = Collections.unmodifiableSet(set);
             servicesChanged = false;

--- a/test/jdk/java/security/Provider/CaseSensitiveServices.java
+++ b/test/jdk/java/security/Provider/CaseSensitiveServices.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 5097015 8130181 8279222
+ * @bug 5097015 8130181 8279222 8292739
  * @summary make sure we correctly treat Provider string entries as case insensitive
  * @author Andreas Sterbenz
  */
@@ -42,15 +42,23 @@ public class CaseSensitiveServices extends Provider {
         put("MESSAGEDIGEST.BAZ", "com.Baz");
         // reassign the DEF alias to algorithm Bar
         put("ALg.aliaS.MESSAGEdigest.DEF", "Bar");
+        // invalid entry since it misses the corresponding impl class info
+        // e.g. put("MessageDigest.Invalid", "implClass");
+        put("MessageDigest.Invalid xYz", "aBc");
     }
 
     public static void main(String[] args) throws Exception {
         Provider p = new CaseSensitiveServices();
-        System.out.println(p.getServices());
+
+        System.out.println("Services: " + p.getServices());
+
         if (p.getServices().size() != 3) {
             throw new Exception("services.size() should be 3");
         }
 
+        if (p.getService("MessageDigest", "Invalid") != null) {
+            throw new Exception("Invalid service returned");
+        }
         Service s = testService(p, "MessageDigest", "fOO");
         String val = s.getAttribute("Xyz");
         if ("aBc".equals(val) == false) {
@@ -70,7 +78,8 @@ public class CaseSensitiveServices extends Provider {
         System.out.println("OK");
     }
 
-    private static Service testService(Provider p, String type, String alg) throws Exception {
+    private static Service testService(Provider p, String type, String alg)
+            throws Exception {
         System.out.println("Getting " + type + "." + alg + "...");
         Service s = p.getService(type, alg);
         System.out.println(s);


### PR DESCRIPTION
Invalid legacy services are screened and removed in Provider.getService(...) call. This fix is to also screen and remove the invalid legacy services when Provider.getServices() is called.

Leveraged existing test case to test this particular scenario by adding one invalid legacy registration.

Thanks!
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292739](https://bugs.openjdk.org/browse/JDK-8292739): Invalid legacy entries may be returned by Provider.getServices() call


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9992/head:pull/9992` \
`$ git checkout pull/9992`

Update a local copy of the PR: \
`$ git checkout pull/9992` \
`$ git pull https://git.openjdk.org/jdk pull/9992/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9992`

View PR using the GUI difftool: \
`$ git pr show -t 9992`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9992.diff">https://git.openjdk.org/jdk/pull/9992.diff</a>

</details>
