### PR TITLE
8292847: Zero: Allow ergonomics to select the GC

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3151,9 +3151,8 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
   // Zero always runs in interpreted mode
   set_mode_flags(_int);
 
-  // Zero runs without compilers. Do not let compiler
-  // selection code to force it into Serial GC, let the
-  // GC ergonomics decide.
+  // Zero runs without compilers. Do not let compiler selection code
+  // to force it into Serial GC, let the GC ergonomics decide.
   if (FLAG_IS_DEFAULT(NeverActAsServerClassMachine)) {
     FLAG_SET_ERGO(NeverActAsServerClassMachine, false);
   }

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3150,6 +3150,13 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
 #ifdef ZERO
   // Zero always runs in interpreted mode
   set_mode_flags(_int);
+
+  // Zero runs without compilers. Do not let compiler
+  // selection code to force it into Serial GC, let the
+  // GC ergonomics decide.
+  if (FLAG_IS_DEFAULT(NeverActAsServerClassMachine)) {
+    FLAG_SET_ERGO(NeverActAsServerClassMachine, false);
+  }
 #endif
 
   // eventually fix up InitialTenuringThreshold if only MaxTenuringThreshold is set


### PR DESCRIPTION
Zero is currently defaulting to Serial GC on all machines, due to the fact that `NeverActAsServerClassMachine` is `true`. It is set in `compiler_globals.pd` under `#if !defined(COMPILER1) && !defined(COMPILER2) && !INCLUDE_JVMCI`. `NeverActAsServerClassMachine` mostly affects compiler ergonomics, which Zero does not need, but it also affects the selection of default GC.

After [JDK-8256497](https://bugs.openjdk.org/browse/JDK-8256497), we can let Zero default to G1. After [JDK-8292329](https://bugs.openjdk.org/browse/JDK-8292329), it would help Zero to use the CDS shared heap.

Additional testing:
 - [x] Linux x86_64 Zero fastdebug, `make bootcycle-images`
 - [x]  Linux x86_64 Zero fastdebug, `tier1` tests (many known failures)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292847](https://bugs.openjdk.org/browse/JDK-8292847): Zero: Allow ergonomics to select the GC


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9994/head:pull/9994` \
`$ git checkout pull/9994`

Update a local copy of the PR: \
`$ git checkout pull/9994` \
`$ git pull https://git.openjdk.org/jdk pull/9994/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9994`

View PR using the GUI difftool: \
`$ git pr show -t 9994`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9994.diff">https://git.openjdk.org/jdk/pull/9994.diff</a>

</details>
