### PR TITLE
8292848: AWT_Mixing and TrayIcon tests fail on el8 with hard-coded isOel7

### DIFF
--- a/test/jdk/java/awt/Mixing/AWT_Mixing/GlassPaneOverlappingTestBase.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/GlassPaneOverlappingTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -128,7 +128,7 @@ public abstract class GlassPaneOverlappingTestBase extends SimpleOverlappingTest
                tests fail starting after failing mixing tests but always pass alone.
              */
             Util.waitForIdle(robot);
-            ancestorLoc.translate(isOel7() ? 5 : f.getWidth() / 2 - 15, 2);
+            ancestorLoc.translate(isOel7orLater() ? 5 : f.getWidth() / 2 - 15, 2);
             robot.mouseMove(ancestorLoc.x, ancestorLoc.y);
             Util.waitForIdle(robot);
             robot.mousePress(InputEvent.BUTTON1_MASK);

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/SimpleOverlappingTestBase.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/SimpleOverlappingTestBase.java
@@ -171,7 +171,6 @@ public abstract class SimpleOverlappingTestBase extends OverlappingTestBase {
             }
         }
         return false;
-
     }
 
 }

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/SimpleOverlappingTestBase.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/SimpleOverlappingTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 import java.awt.*;
 import java.awt.event.*;
+import java.util.regex.*;
 import javax.swing.*;
 import test.java.awt.regtesthelpers.Util;
 
@@ -142,7 +143,7 @@ public abstract class SimpleOverlappingTestBase extends OverlappingTestBase {
         JFrame ancestor = (JFrame)(testedComponent.getTopLevelAncestor());
         if( ancestor != null ) {
             Point ancestorLoc = ancestor.getLocationOnScreen();
-            ancestorLoc.translate(isOel7() ? 5 :
+            ancestorLoc.translate(isOel7orLater() ? 5 :
                                              ancestor.getWidth() / 2 - 15, 2);
             robot.mouseMove(ancestorLoc.x, ancestorLoc.y);
             Util.waitForIdle(robot);
@@ -158,10 +159,19 @@ public abstract class SimpleOverlappingTestBase extends OverlappingTestBase {
         return wasLWClicked;
     }
 
-    public boolean isOel7() {
-        return System.getProperty("os.name").toLowerCase()
-                .contains("linux") && System.getProperty("os.version")
-                .toLowerCase().contains("el7");
+    public boolean isOel7orLater() {
+        if (System.getProperty("os.name").toLowerCase().contains("linux") &&
+            System.getProperty("os.version").toLowerCase().contains("el")) {
+            Pattern p = Pattern.compile("el(\\d+)");
+            Matcher m = p.matcher(System.getProperty("os.version"));
+            if (m.find()) {
+                try {
+                    return Integer.parseInt(m.group(1)) >= 7;
+                } catch (NumberFormatException nfe) {}
+            }
+        }
+        return false;
+
     }
 
 }

--- a/test/jdk/java/awt/TrayIcon/ActionCommand/ActionCommand.java
+++ b/test/jdk/java/awt/TrayIcon/ActionCommand/ActionCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class ActionCommand {
                         "and rerun test.");
             } else  if (System.getProperty("os.name").toLowerCase().startsWith("mac")){
                 isMacOS = true;
-            } else if (SystemTrayIconHelper.isOel7()) {
+            } else if (SystemTrayIconHelper.isOel7orLater()) {
                 System.out.println("OEL 7 doesn't support double click in " +
                         "systray. Skipped");
                 return;

--- a/test/jdk/java/awt/TrayIcon/ActionEventMask/ActionEventMask.java
+++ b/test/jdk/java/awt/TrayIcon/ActionEventMask/ActionEventMask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,7 +70,7 @@ public class ActionEventMask {
         } else {
             if (System.getProperty("os.name").toLowerCase().startsWith("mac")) {
                 isMacOS = true;
-            } else if (SystemTrayIconHelper.isOel7()) {
+            } else if (SystemTrayIconHelper.isOel7orLater()) {
                 System.out.println("OEL 7 doesn't support double click in " +
                         "systray. Skipped");
                 return;

--- a/test/jdk/java/awt/TrayIcon/ModalityTest/ModalityTest.java
+++ b/test/jdk/java/awt/TrayIcon/ModalityTest/ModalityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import java.awt.image.BufferedImage;
  */
 public class ModalityTest {
 
-    private static boolean isOEL7;
+    private static boolean isOel7orLater;
     TrayIcon icon;
     ExtendedRobot robot;
     Dialog d;
@@ -85,7 +85,7 @@ public class ModalityTest {
                         "\"Always show all icons and notifications on the taskbar\" true " +
                         "to avoid this problem. Or change behavior only for Java SE tray " +
                         "icon and rerun test.");
-            isOEL7 = SystemTrayIconHelper.isOel7();
+            isOel7orLater = SystemTrayIconHelper.isOel7orLater();
             new ModalityTest().doTest();
         }
     }
@@ -230,7 +230,7 @@ public class ModalityTest {
         Point iconPosition = SystemTrayIconHelper.getTrayIconLocation(icon);
         if (iconPosition == null)
             throw new RuntimeException("Unable to find the icon location!");
-        if (isOEL7) {
+        if (isOel7orLater) {
             // close tray
             robot.mouseMove(100,100);
             robot.click(InputEvent.BUTTON1_MASK);
@@ -243,7 +243,7 @@ public class ModalityTest {
         robot.mouseMove(iconPosition.x, iconPosition.y);
         robot.waitForIdle(2000);
 
-        if(!isOEL7) {
+        if(!isOel7orLater) {
             SystemTrayIconHelper.doubleClick(robot);
 
             if (!actionPerformed) {
@@ -260,7 +260,7 @@ public class ModalityTest {
 
         for (int i = 0; i < buttonTypes.length; i++) {
             mousePressed = false;
-            if(isOEL7) {
+            if(isOel7orLater) {
                 SystemTrayIconHelper.openTrayIfNeeded(robot);
                 robot.mouseMove(iconPosition.x, iconPosition.y);
                 robot.click(buttonTypes[i]);
@@ -283,7 +283,7 @@ public class ModalityTest {
 
             mouseReleased = false;
             mouseClicked = false;
-            if(isOEL7) {
+            if(isOel7orLater) {
                 SystemTrayIconHelper.openTrayIfNeeded(robot);
                 robot.mouseMove(iconPosition.x, iconPosition.y);
                 robot.click(buttonTypes[i]);
@@ -315,7 +315,7 @@ public class ModalityTest {
                 throw new RuntimeException("FAIL: mouseClicked not triggered when " +
                         buttonNames[i] + " pressed & released");
         }
-        if (!isOEL7) {
+        if (!isOel7orLater) {
             mouseMoved = false;
             robot.mouseMove(iconPosition.x, iconPosition.y);
             robot.glide(iconPosition.x + 100, iconPosition.y);

--- a/test/jdk/java/awt/TrayIcon/MouseEventMask/MouseEventMaskTest.java
+++ b/test/jdk/java/awt/TrayIcon/MouseEventMask/MouseEventMaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,7 @@ public class MouseEventMaskTest {
                         "\"Always show all icons and notifications on the taskbar\" true " +
                         "to avoid this problem. Or change behavior only for Java SE tray " +
                         "icon and rerun test.");
-            } else if (SystemTrayIconHelper.isOel7()) {
+            } else if (SystemTrayIconHelper.isOel7orLater()) {
                 return;
             }
             new MouseEventMaskTest().doTest();

--- a/test/jdk/java/awt/TrayIcon/MouseMovedTest/MouseMovedTest.java
+++ b/test/jdk/java/awt/TrayIcon/MouseMovedTest/MouseMovedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ public class MouseMovedTest {
             return;
         }
 
-        if (SystemTrayIconHelper.isOel7()) {
+        if (SystemTrayIconHelper.isOel7orLater()) {
             return;
         }
 

--- a/test/jdk/java/awt/TrayIcon/SecurityCheck/FunctionalityCheck/FunctionalityCheck.java
+++ b/test/jdk/java/awt/TrayIcon/SecurityCheck/FunctionalityCheck/FunctionalityCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ public class FunctionalityCheck {
     boolean mouseReleased = false;
     boolean mouseClicked = false;
     boolean mouseMoved = false;
-    static boolean isOEL7;
+    static boolean isOel7orLater;
 
     static final int[] buttonTypes = {
         InputEvent.BUTTON1_MASK,
@@ -74,7 +74,7 @@ public class FunctionalityCheck {
             System.out.println("SystemTray not supported on the platform under test. " +
                                "Marking the test passed");
         } else {
-            isOEL7 = SystemTrayIconHelper.isOel7();
+            isOel7orLater = SystemTrayIconHelper.isOel7orLater();
             new FunctionalityCheck().doTest();
         }
     }
@@ -194,7 +194,7 @@ public class FunctionalityCheck {
         Point iconPosition = SystemTrayIconHelper.getTrayIconLocation(icon);
         if (iconPosition == null)
             throw new RuntimeException("Unable to find the icon location!");
-        if (isOEL7) {
+        if (isOel7orLater) {
             // close tray
             robot.mouseMove(100,100);
             robot.click(InputEvent.BUTTON1_MASK);
@@ -203,7 +203,7 @@ public class FunctionalityCheck {
 
         robot.mouseMove(iconPosition.x, iconPosition.y);
         robot.waitForIdle();
-        if(!isOEL7) {
+        if(!isOel7orLater) {
             SystemTrayIconHelper.doubleClick(robot);
 
             if (!actionPerformed) {
@@ -220,7 +220,7 @@ public class FunctionalityCheck {
 
         for (int i = 0; i < buttonTypes.length; i++) {
             mousePressed = false;
-            if(isOEL7) {
+            if(isOel7orLater) {
                 SystemTrayIconHelper.openTrayIfNeeded(robot);
                 robot.mouseMove(iconPosition.x, iconPosition.y);
                 robot.click(buttonTypes[i]);
@@ -243,7 +243,7 @@ public class FunctionalityCheck {
 
             mouseReleased = false;
             mouseClicked = false;
-            if(isOEL7) {
+            if(isOel7orLater) {
                 SystemTrayIconHelper.openTrayIfNeeded(robot);
                 robot.mouseMove(iconPosition.x, iconPosition.y);
                 robot.click(buttonTypes[i]);
@@ -275,7 +275,7 @@ public class FunctionalityCheck {
                 throw new RuntimeException("FAIL: mouseClicked not triggered when " +
                         buttonNames[i] + " pressed & released");
         }
-        if(!isOEL7) {
+        if(!isOel7orLater) {
             mouseMoved = false;
             robot.mouseMove(iconPosition.x + 100, iconPosition.y);
             robot.glide(iconPosition.x, iconPosition.y);

--- a/test/jdk/java/awt/TrayIcon/SystemTrayIconHelper.java
+++ b/test/jdk/java/awt/TrayIcon/SystemTrayIconHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,9 @@ import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 
 /*
  * @summary This is a helper class to find the location of a system tray icon,
@@ -210,7 +213,7 @@ public class SystemTrayIconHelper {
         String sysv = System.getProperty("os.version");
         System.out.println("System version is " + sysv);
         //Additional step to raise the system try in Gnome 3 in OEL 7
-        if(isOel7()) {
+        if(isOel7orLater()) {
             System.out.println("OEL 7 detected");
             GraphicsConfiguration gc = GraphicsEnvironment.
                     getLocalGraphicsEnvironment().getDefaultScreenDevice().
@@ -234,9 +237,17 @@ public class SystemTrayIconHelper {
         return false;
     }
 
-    public static boolean isOel7() {
-        return System.getProperty("os.name").toLowerCase()
-                .contains("linux") && System.getProperty("os.version")
-                .toLowerCase().contains("el7");
+    public static boolean isOel7orLater() {
+        if (System.getProperty("os.name").toLowerCase().contains("linux") &&
+            System.getProperty("os.version").toLowerCase().contains("el")) {
+            Pattern p = Pattern.compile("el(\\d+)");
+            Matcher m = p.matcher(System.getProperty("os.version"));
+            if (m.find()) {
+                try {
+                    return Integer.parseInt(m.group(1)) >= 7;
+                } catch (NumberFormatException nfe) {}
+            }
+        }
+        return false;
     }
 }

--- a/test/jdk/java/awt/TrayIcon/SystemTrayIconHelper.java
+++ b/test/jdk/java/awt/TrayIcon/SystemTrayIconHelper.java
@@ -33,7 +33,6 @@ import java.security.PrivilegedExceptionAction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-
 /*
  * @summary This is a helper class to find the location of a system tray icon,
  *          and skip some OS specific cases in tests.

--- a/test/jdk/java/awt/TrayIcon/TrayIconEventModifiers/TrayIconEventModifiersTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconEventModifiers/TrayIconEventModifiersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,7 +110,7 @@ public class TrayIconEventModifiersTest {
 
             System.out.println(System.getProperty("os.arch"));
 
-            if (SystemTrayIconHelper.isOel7()) {
+            if (SystemTrayIconHelper.isOel7orLater()) {
                 System.out.println("OEL 7 doesn't support click modifiers in " +
                         "systray. Skipped");
                 return;

--- a/test/jdk/java/awt/TrayIcon/TrayIconEvents/TrayIconEventsTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconEvents/TrayIconEventsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ import java.awt.image.BufferedImage;
 
 public class TrayIconEventsTest {
 
-    private static boolean isOEL7;
+    private static boolean isOel7orLater;
     TrayIcon icon;
     ExtendedRobot robot;
 
@@ -82,7 +82,7 @@ public class TrayIconEventsTest {
                         "\"Always show all icons and notifications on the taskbar\" true " +
                         "to avoid this problem. Or change behavior only for Java SE " +
                         "tray icon.");
-            isOEL7 = SystemTrayIconHelper.isOel7();
+            isOel7orLater = SystemTrayIconHelper.isOel7orLater();
             new TrayIconEventsTest().doTest();
         }
     }
@@ -201,7 +201,7 @@ public class TrayIconEventsTest {
         Point iconPosition = SystemTrayIconHelper.getTrayIconLocation(icon);
         if (iconPosition == null)
             throw new RuntimeException("Unable to find the icon location!");
-        if (isOEL7) {
+        if (isOel7orLater) {
             // close tray
             robot.mouseMove(100,100);
             robot.click(InputEvent.BUTTON1_MASK);
@@ -210,7 +210,7 @@ public class TrayIconEventsTest {
 
         robot.mouseMove(iconPosition.x, iconPosition.y);
         robot.waitForIdle();
-        if(!isOEL7) {
+        if(!isOel7orLater) {
             SystemTrayIconHelper.doubleClick(robot);
 
             if (!actionPerformed) {
@@ -227,7 +227,7 @@ public class TrayIconEventsTest {
 
         for (int i = 0; i < buttonTypes.length; i++) {
             mousePressed = false;
-            if(isOEL7) {
+            if(isOel7orLater) {
                 SystemTrayIconHelper.openTrayIfNeeded(robot);
                 robot.mouseMove(iconPosition.x, iconPosition.y);
                 robot.click(buttonTypes[i]);
@@ -250,7 +250,7 @@ public class TrayIconEventsTest {
 
             mouseReleased = false;
             mouseClicked = false;
-            if(isOEL7) {
+            if(isOel7orLater) {
                 SystemTrayIconHelper.openTrayIfNeeded(robot);
                 robot.mouseMove(iconPosition.x, iconPosition.y);
                 robot.click(buttonTypes[i]);
@@ -283,7 +283,7 @@ public class TrayIconEventsTest {
                         buttonNames[i] + " pressed & released");
         }
 
-        if (!isOEL7) {
+        if (!isOel7orLater) {
             mouseMoved = false;
             robot.mouseMove(iconPosition.x + 100, iconPosition.y);
             robot.glide(iconPosition.x, iconPosition.y);

--- a/test/jdk/java/awt/TrayIcon/TrayIconMouseTest/TrayIconMouseTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconMouseTest/TrayIconMouseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,7 +76,7 @@ public class TrayIconMouseTest {
             } else if (osName.startsWith("win")) {
                 isWinOS = true;
             } else {
-                isOelOS = SystemTrayIconHelper.isOel7();
+                isOelOS = SystemTrayIconHelper.isOel7orLater();
             }
             new TrayIconMouseTest().doTest();
         }


### PR DESCRIPTION
Could you please review the JDK-8292848 bug fixes?
The purpose of the isOel7 method is to detect differences in GNOME version changes, and the isOel7 
result should be true after version 8.
I modified the isOel7 method to use regular expressions instead of hard-coded versions to be able to 
detect the new os version.
I also changed the method name to match the new conditions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292848](https://bugs.openjdk.org/browse/JDK-8292848): AWT_Mixing and TrayIcon tests fail on el8 with hard-coded isOel7


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9995/head:pull/9995` \
`$ git checkout pull/9995`

Update a local copy of the PR: \
`$ git checkout pull/9995` \
`$ git pull https://git.openjdk.org/jdk pull/9995/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9995`

View PR using the GUI difftool: \
`$ git pr show -t 9995`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9995.diff">https://git.openjdk.org/jdk/pull/9995.diff</a>

</details>
