### PR TITLE
8290781: Segfault at PhaseIdealLoop::clone_loop_handle_data_uses

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -2167,7 +2167,7 @@ static void clone_outer_loop_helper(Node* n, const IdealLoopTree *loop, const Id
       // the outer loop too
         Node* u_c = u->in(0);
         if (u_c != NULL) {
-          IdealLoopTree *u_c_loop = phase->get_loop(u_c);
+          IdealLoopTree* u_c_loop = phase->get_loop(u_c);
           if (outer_loop->is_member(u_c_loop) && !loop->is_member(u_c_loop)) {
             wq.push(u);
           }

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -2160,11 +2160,18 @@ static void clone_outer_loop_helper(Node* n, const IdealLoopTree *loop, const Id
       Node* c = phase->get_ctrl(u);
       IdealLoopTree* u_loop = phase->get_loop(c);
       assert(!loop->is_member(u_loop), "can be in outer loop or out of both loops only");
-      if (outer_loop->is_member(u_loop) ||
-          // nodes pinned with control in the outer loop but not referenced from the safepoint must be moved out of
-          // the outer loop too
-          (u->in(0) != NULL && outer_loop->is_member(phase->get_loop(u->in(0))))) {
+      if (outer_loop->is_member(u_loop)) {
         wq.push(u);
+      } else {
+      // nodes pinned with control in the outer loop but not referenced from the safepoint must be moved out of
+      // the outer loop too
+        Node *u_c = u->in(0);
+        if (u_c != NULL) {
+          IdealLoopTree *u_c_loop = phase->get_loop(u_c);
+          if (outer_loop->is_member(u_c_loop) && !loop->is_member(u_c_loop)) {
+            wq.push(u);
+          }
+        }
       }
     }
   }

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -2165,7 +2165,7 @@ static void clone_outer_loop_helper(Node* n, const IdealLoopTree *loop, const Id
       } else {
       // nodes pinned with control in the outer loop but not referenced from the safepoint must be moved out of
       // the outer loop too
-        Node *u_c = u->in(0);
+        Node* u_c = u->in(0);
         if (u_c != NULL) {
           IdealLoopTree *u_c_loop = phase->get_loop(u_c);
           if (outer_loop->is_member(u_c_loop) && !loop->is_member(u_c_loop)) {

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -2163,8 +2163,8 @@ static void clone_outer_loop_helper(Node* n, const IdealLoopTree *loop, const Id
       if (outer_loop->is_member(u_loop)) {
         wq.push(u);
       } else {
-      // nodes pinned with control in the outer loop but not referenced from the safepoint must be moved out of
-      // the outer loop too
+        // nodes pinned with control in the outer loop but not referenced from the safepoint must be moved out of
+        // the outer loop too
         Node* u_c = u->in(0);
         if (u_c != NULL) {
           IdealLoopTree* u_c_loop = phase->get_loop(u_c);

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestLSMBadControlOverride.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestLSMBadControlOverride.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8290781
+ * @summary Segfault at PhaseIdealLoop::clone_loop_handle_data_uses
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:-TieredCompilation TestLSMBadControlOverride
+ */
+
+public class TestLSMBadControlOverride {
+    private static volatile int barrier;
+
+    public static void main(String[] args) {
+        int[] array = new int[100];
+        int[] small = new int[10];
+        for (int i = 0; i < 20_000; i++) {
+            test(array, array, true, true);
+            test(array, array, true, false);
+            test(array, array, false, false);
+            try {
+                test(small, array,true, true);
+            } catch (ArrayIndexOutOfBoundsException aieoobe) {
+
+            }
+        }
+    }
+
+    private static int test(int[] array, int[] array2, boolean flag1, boolean flag2) {
+        int i;
+        int v = 0;
+        int v1 = 0;
+        for (i = 0; i < 100; i++) {
+            v1 = array[i];
+        }
+        v += v1;
+        if (flag1) {
+            if (flag2) {
+                barrier = 42;
+            }
+        }
+        for (int j = 0; j < 100; j++) {
+            array[j] = j;
+            v += array[i-1];
+        }
+        return v;
+    }
+}


### PR DESCRIPTION
In the test case, both:

            v1 = array[i];
(in the first loop), and

            v += array[i-1];

(in the second one) access the same element. The bound check for the
second access is optimized out and the load of that access becomes
control dependent on the range check of the first one.

In the context of loop strip mining, data nodes that are in the outer
loop are expected to be reachable from the safepoint node. There are
rare case when it's not the case so I added logic to fix those cases
before loop cloning. That logic covers both nodes that have control in
the outer loop and control input in the outer loop. That logic is
incorrect (in the case of a node with a control input in the outer
loop): when cloning the first loop body, that logic finds the load
referenced from the range check in the loop body. That load has a
control input that's in the inner loop. But the logic only check
whether it's in the outer loop: anything in the inner loop is also in
the outer loop with that logic. The control of the load is then
wrongly updated to be outside the outer loop. That then causes a crash
because the load is recorded as being in the body of the second loop
but its control is not.

The fix I propose stengthen the logic that checks for nodes in the
outer loop: it checks that the control input is in the outer loop but
not in the inner loop.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290781](https://bugs.openjdk.org/browse/JDK-8290781): Segfault at PhaseIdealLoop::clone_loop_handle_data_uses


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [43dfe289](https://git.openjdk.org/jdk/pull/9997/files/43dfe289fa53208636df3fdab8781f0ded6cb02f)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [90938577](https://git.openjdk.org/jdk/pull/9997/files/90938577880b8648fb95012c9ee2ca51e7e93919)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9997/head:pull/9997` \
`$ git checkout pull/9997`

Update a local copy of the PR: \
`$ git checkout pull/9997` \
`$ git pull https://git.openjdk.org/jdk pull/9997/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9997`

View PR using the GUI difftool: \
`$ git pr show -t 9997`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9997.diff">https://git.openjdk.org/jdk/pull/9997.diff</a>

</details>
