### PR TITLE
8292858: G1: Remove redundant check in G1FlushHumongousCandidateRemSets

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1322,8 +1322,7 @@ class G1MergeHeapRootsTask : public WorkerTask {
     virtual bool do_heap_region(HeapRegion* r) {
       G1CollectedHeap* g1h = G1CollectedHeap::heap();
 
-      if (!r->is_starts_humongous() ||
-          !g1h->region_attr(r->hrm_index()).is_humongous() ||
+      if (!g1h->region_attr(r->hrm_index()).is_humongous() ||
           r->rem_set()->is_empty()) {
         return false;
       }


### PR DESCRIPTION
Simple change of removing redundant code.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292858](https://bugs.openjdk.org/browse/JDK-8292858): G1: Remove redundant check in G1FlushHumongousCandidateRemSets


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9998/head:pull/9998` \
`$ git checkout pull/9998`

Update a local copy of the PR: \
`$ git checkout pull/9998` \
`$ git pull https://git.openjdk.org/jdk pull/9998/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9998`

View PR using the GUI difftool: \
`$ git pr show -t 9998`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9998.diff">https://git.openjdk.org/jdk/pull/9998.diff</a>

</details>
