### PR TITLE
8292864: Remove resourceHash.hpp from header files

### DIFF
--- a/src/hotspot/share/cds/dynamicArchive.hpp
+++ b/src/hotspot/share/cds/dynamicArchive.hpp
@@ -33,7 +33,6 @@
 #include "oops/oop.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/macros.hpp"
-#include "utilities/resourceHash.hpp"
 
 #if INCLUDE_CDS
 

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -30,7 +30,6 @@
 #include "memory/virtualspace.hpp"
 #include "oops/oop.hpp"
 #include "utilities/macros.hpp"
-#include "utilities/resourceHash.hpp"
 
 class FileMapInfo;
 class outputStream;

--- a/src/hotspot/share/cds/runTimeClassInfo.hpp
+++ b/src/hotspot/share/cds/runTimeClassInfo.hpp
@@ -34,7 +34,6 @@
 #include "oops/instanceKlass.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "utilities/growableArray.hpp"
-#include "utilities/resourceHash.hpp"
 
 class DumpTimeClassInfo;
 class Method;

--- a/src/hotspot/share/classfile/defaultMethods.cpp
+++ b/src/hotspot/share/classfile/defaultMethods.cpp
@@ -46,8 +46,6 @@
 #include "utilities/accessFlags.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/ostream.hpp"
-#include "utilities/pair.hpp"
-#include "utilities/resourceHash.hpp"
 
 typedef enum { QUALIFIED, DISQUALIFIED } QualifiedState;
 

--- a/src/hotspot/share/classfile/systemDictionaryShared.hpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.hpp
@@ -34,7 +34,6 @@
 #include "classfile/systemDictionary.hpp"
 #include "oops/klass.hpp"
 #include "oops/oopHandle.hpp"
-#include "utilities/resourceHash.hpp"
 
 
 /*===============================================================================


### PR DESCRIPTION
Please review this other trivial change to remove unneeded header files.  Tested with cross compile other platforms and tier1 on Oracle platforms (x86, aarch64).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292864](https://bugs.openjdk.org/browse/JDK-8292864): Remove resourceHash.hpp from header files


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/9999/head:pull/9999` \
`$ git checkout pull/9999`

Update a local copy of the PR: \
`$ git checkout pull/9999` \
`$ git pull https://git.openjdk.org/jdk pull/9999/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9999`

View PR using the GUI difftool: \
`$ git pr show -t 9999`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/9999.diff">https://git.openjdk.org/jdk/pull/9999.diff</a>

</details>
