### PR TITLE
8065554: MatchResult should provide values of named-capturing groups

### DIFF
--- a/src/java.base/share/classes/java/util/regex/MatchResult.java
+++ b/src/java.base/share/classes/java/util/regex/MatchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,9 @@
 
 package java.util.regex;
 
+import java.util.Map;
+import java.util.Objects;
+
 /**
  * The result of a match operation.
  *
@@ -48,7 +51,7 @@ public interface MatchResult {
      *          If no match has yet been attempted,
      *          or if the previous match operation failed
      */
-    public int start();
+    int start();
 
     /**
      * Returns the start index of the subsequence captured by the given group
@@ -74,7 +77,39 @@ public interface MatchResult {
      *          If there is no capturing group in the pattern
      *          with the given index
      */
-    public int start(int group);
+    int start(int group);
+
+    /**
+     * Returns the start index of the subsequence captured by the given
+     * <a href="Pattern.html#groupname">named-capturing group</a> during the
+     * previous match operation.
+     *
+     * @param  name
+     *         The name of a named-capturing group in this matcher's pattern
+     *
+     * @return  The index of the first character captured by the group,
+     *          or {@code -1} if the match was successful but the group
+     *          itself did not match anything
+     *
+     * @throws  IllegalStateException
+     *          If no match has yet been attempted,
+     *          or if the previous match operation failed
+     *
+     * @throws  IllegalArgumentException
+     *          If there is no capturing group in the pattern
+     *          with the given name
+     *
+     * @implNote The default implementation of this method makes use of the
+     *          map returned by {@link #namedGroups()}.
+     *          It is thus sufficient to override {@link #namedGroups()} for
+     *          this method to work. However, overriding this method directly
+     *          might be preferable for other reasons.
+     *
+     * @since 20
+     */
+    default int start(String name) {
+        return start(groupIndex(name));
+    }
 
     /**
      * Returns the offset after the last character matched.
@@ -85,7 +120,7 @@ public interface MatchResult {
      *          If no match has yet been attempted,
      *          or if the previous match operation failed
      */
-    public int end();
+    int end();
 
     /**
      * Returns the offset after the last character of the subsequence
@@ -111,7 +146,39 @@ public interface MatchResult {
      *          If there is no capturing group in the pattern
      *          with the given index
      */
-    public int end(int group);
+    int end(int group);
+
+    /**
+     * Returns the offset after the last character of the subsequence
+     * captured by the given <a href="Pattern.html#groupname">named-capturing
+     * group</a> during the previous match operation.
+     *
+     * @param  name
+     *         The name of a named-capturing group in this matcher's pattern
+     *
+     * @return  The offset after the last character captured by the group,
+     *          or {@code -1} if the match was successful
+     *          but the group itself did not match anything
+     *
+     * @throws  IllegalStateException
+     *          If no match has yet been attempted,
+     *          or if the previous match operation failed
+     *
+     * @throws  IllegalArgumentException
+     *          If there is no capturing group in the pattern
+     *          with the given name
+     *
+     * @implNote The default implementation of this method makes use of the
+     *          map returned by {@link #namedGroups()}.
+     *          It is thus sufficient to override {@link #namedGroups()} for
+     *          this method to work. However, overriding this method directly
+     *          might be preferable for other reasons.
+     *
+     * @since 20
+     */
+    default int end(String name) {
+        return end(groupIndex(name));
+    }
 
     /**
      * Returns the input subsequence matched by the previous match.
@@ -132,7 +199,7 @@ public interface MatchResult {
      *          If no match has yet been attempted,
      *          or if the previous match operation failed
      */
-    public String group();
+    String group();
 
     /**
      * Returns the input subsequence captured by the given group during the
@@ -170,7 +237,45 @@ public interface MatchResult {
      *          If there is no capturing group in the pattern
      *          with the given index
      */
-    public String group(int group);
+    String group(int group);
+
+    /**
+     * Returns the input subsequence captured by the given
+     * <a href="Pattern.html#groupname">named-capturing group</a> during the
+     * previous match operation.
+     *
+     * <p> If the match was successful but the group specified failed to match
+     * any part of the input sequence, then {@code null} is returned. Note
+     * that some groups, for example {@code (a*)}, match the empty string.
+     * This method will return the empty string when such a group successfully
+     * matches the empty string in the input.  </p>
+     *
+     * @param  name
+     *         The name of a named-capturing group in this matcher's pattern
+     *
+     * @return  The (possibly empty) subsequence captured by the named group
+     *          during the previous match, or {@code null} if the group
+     *          failed to match part of the input
+     *
+     * @throws  IllegalStateException
+     *          If no match has yet been attempted,
+     *          or if the previous match operation failed
+     *
+     * @throws  IllegalArgumentException
+     *          If there is no capturing group in the pattern
+     *          with the given name
+     *
+     * @implNote The default implementation of this method makes use of the
+     *          map returned by {@link #namedGroups()}.
+     *          It is thus sufficient to override {@link #namedGroups()} for
+     *          this method to work. However, overriding this method directly
+     *          might be preferable for other reasons.
+     *
+     * @since 20
+     */
+    default String group(String name) {
+        return group(groupIndex(name));
+    }
 
     /**
      * Returns the number of capturing groups in this match result's pattern.
@@ -184,6 +289,53 @@ public interface MatchResult {
      *
      * @return The number of capturing groups in this matcher's pattern
      */
-    public int groupCount();
+    int groupCount();
+
+    /**
+     * Returns an unmodifiable map from capturing group names to group numbers.
+     * If there are no named groups, returns an empty map.
+     *
+     * @return an unmodifiable map from capturing group names to group numbers
+     *
+     * @implSpec
+     * The default implementation of this method throws
+     * {@link UnsupportedOperationException}.
+     *
+     * @apiNote
+     * This method must be overridden by an implementation that supports named groups.
+     *
+     * @since 20
+     */
+    default Map<String,Integer> namedGroups() {
+        throw new UnsupportedOperationException("namedGroups()");
+    }
+
+    private int groupIndex(String name) {
+        Objects.requireNonNull(name, "Group name");
+        Integer index = namedGroups().get(name);
+        if (index != null) {
+            return index;
+        }
+        throw new IllegalArgumentException("No group with name <" + name + ">");
+    }
+
+    /**
+     * Returns whether {@code this} contains a valid match from
+     * a previous match or find operation.
+     *
+     * @return whether {@code this} contains a valid match
+     *
+     * @implSpec
+     * The default implementation of this method throws
+     * {@link UnsupportedOperationException}.
+     *
+     * @apiNote
+     * This method must be overridden by an implementation.
+     *
+     * @since 20
+     */
+    default boolean hasMatch() {
+        throw new UnsupportedOperationException("hasMatch()");
+    }
 
 }

--- a/src/java.base/share/classes/java/util/regex/MatchResult.java
+++ b/src/java.base/share/classes/java/util/regex/MatchResult.java
@@ -112,6 +112,11 @@ public interface MatchResult {
      *          If the default implementation of {@link #namedGroups()}
      *          is not overridden.
      *
+     * @implSpec
+     * The default implementation of this method invokes {@link #namedGroups()}
+     * to obtain the group number from the {@code name} argument, and uses this
+     * number as argument to an invocation of {@link #start(int)}.
+     *
      * @since 20
      */
     default int start(String name) {
@@ -178,6 +183,11 @@ public interface MatchResult {
      * @throws UnsupportedOperationException
      *          If the default implementation of {@link #namedGroups()}
      *          is not overridden.
+     *
+     * @implSpec
+     * The default implementation of this method invokes {@link #namedGroups()}
+     * to obtain the group number from the {@code name} argument, and uses this
+     * number as argument to an invocation of {@link #end(int)}.
      *
      * @since 20
      */
@@ -273,6 +283,11 @@ public interface MatchResult {
      * @throws UnsupportedOperationException
      *          If the default implementation of {@link #namedGroups()}
      *          is not overridden.
+     *
+     * @implSpec
+     * The default implementation of this method invokes {@link #namedGroups()}
+     * to obtain the group number from the {@code name} argument, and uses this
+     * number as argument to an invocation of {@link #group(int)}.
      *
      * @since 20
      */

--- a/src/java.base/share/classes/java/util/regex/MatchResult.java
+++ b/src/java.base/share/classes/java/util/regex/MatchResult.java
@@ -36,6 +36,15 @@ import java.util.Objects;
  * groups and group boundaries can be seen but not modified through
  * a {@code MatchResult}.
  *
+ * @implNote
+ * Support for named groups is implemented by the default methods
+ * {@link #start(String)}, {@link #end(String)} and {@link #group(String)}.
+ * They all make use of the map returned by {@link #namedGroups()}, whose
+ * default implementation simply throws {@link UnsupportedOperationException}.
+ * It is thus sufficient to override {@link #namedGroups()} for these methods
+ * to work. However, overriding them directly might be preferable for
+ * performance or other reasons.
+ *
  * @author  Michael McCloskey
  * @see Matcher
  * @since 1.5
@@ -99,21 +108,14 @@ public interface MatchResult {
      *          If there is no capturing group in the pattern
      *          with the given name
      *
-     * @implNote
-     * The default implementation of this method makes use of the map returned
-     * by {@link #namedGroups()}. It is thus sufficient to override
-     * {@link #namedGroups()} for this method to work. However, overriding this
-     * method directly might be preferable for performance or for other reasons.
-     *
-     * @implSpec
-     * The default implementation of this method throws
-     * {@link UnsupportedOperationException} if {@link #namedGroups()} is not
-     * overridden.
+     * @throws UnsupportedOperationException
+     *          If the default implementation of {@link #namedGroups()}
+     *          is not overridden.
      *
      * @since 20
      */
     default int start(String name) {
-        return start(groupIndex(name));
+        return start(groupNumber(name));
     }
 
     /**
@@ -173,21 +175,14 @@ public interface MatchResult {
      *          If there is no capturing group in the pattern
      *          with the given name
      *
-     * @implNote
-     * The default implementation of this method makes use of the map returned
-     * by {@link #namedGroups()}. It is thus sufficient to override
-     * {@link #namedGroups()} for this method to work. However, overriding this
-     * method directly might be preferable for performance or for other reasons.
-     *
-     * @implSpec
-     * The default implementation of this method throws
-     * {@link UnsupportedOperationException} if {@link #namedGroups()} is not
-     * overridden.
+     * @throws UnsupportedOperationException
+     *          If the default implementation of {@link #namedGroups()}
+     *          is not overridden.
      *
      * @since 20
      */
     default int end(String name) {
-        return end(groupIndex(name));
+        return end(groupNumber(name));
     }
 
     /**
@@ -275,21 +270,14 @@ public interface MatchResult {
      *          If there is no capturing group in the pattern
      *          with the given name
      *
-     * @implNote
-     * The default implementation of this method makes use of the map returned
-     * by {@link #namedGroups()}. It is thus sufficient to override
-     * {@link #namedGroups()} for this method to work. However, overriding this
-     * method directly might be preferable for performance or for other reasons.
-     *
-     * @implSpec
-     * The default implementation of this method throws
-     * {@link UnsupportedOperationException} if {@link #namedGroups()} is not
-     * overridden.
+     * @throws UnsupportedOperationException
+     *          If the default implementation of {@link #namedGroups()}
+     *          is not overridden.
      *
      * @since 20
      */
     default String group(String name) {
-        return group(groupIndex(name));
+        return group(groupNumber(name));
     }
 
     /**
@@ -312,12 +300,12 @@ public interface MatchResult {
      *
      * @return an unmodifiable map from capturing group names to group numbers
      *
-     * @implSpec
-     * The default implementation of this method throws
-     * {@link UnsupportedOperationException}.
+     * @throws UnsupportedOperationException
+     *          The default implementation of this method always throws
      *
      * @apiNote
-     * This method must be overridden by an implementation that supports named groups.
+     * This method must be overridden by an implementation that supports
+     * named groups.
      *
      * @since 20
      */
@@ -325,11 +313,11 @@ public interface MatchResult {
         throw new UnsupportedOperationException("namedGroups()");
     }
 
-    private int groupIndex(String name) {
+    private int groupNumber(String name) {
         Objects.requireNonNull(name, "Group name");
-        Integer index = namedGroups().get(name);
-        if (index != null) {
-            return index;
+        Integer number = namedGroups().get(name);
+        if (number != null) {
+            return number;
         }
         throw new IllegalArgumentException("No group with name <" + name + ">");
     }
@@ -340,12 +328,8 @@ public interface MatchResult {
      *
      * @return whether {@code this} contains a valid match
      *
-     * @implSpec
-     * The default implementation of this method throws
-     * {@link UnsupportedOperationException}.
-     *
-     * @apiNote
-     * This method must be overridden by an implementation.
+     * @throws UnsupportedOperationException
+     *          The default implementation of this method always throws
      *
      * @since 20
      */

--- a/src/java.base/share/classes/java/util/regex/MatchResult.java
+++ b/src/java.base/share/classes/java/util/regex/MatchResult.java
@@ -108,14 +108,10 @@ public interface MatchResult {
      *          If there is no capturing group in the pattern
      *          with the given name
      *
-     * @throws UnsupportedOperationException
-     *          If the default implementation of {@link #namedGroups()}
-     *          is not overridden.
-     *
      * @implSpec
      * The default implementation of this method invokes {@link #namedGroups()}
-     * to obtain the group number from the {@code name} argument, and uses this
-     * number as argument to an invocation of {@link #start(int)}.
+     * to obtain the group number from the {@code name} argument, and uses it
+     * as argument to an invocation of {@link #start(int)}.
      *
      * @since 20
      */
@@ -180,14 +176,10 @@ public interface MatchResult {
      *          If there is no capturing group in the pattern
      *          with the given name
      *
-     * @throws UnsupportedOperationException
-     *          If the default implementation of {@link #namedGroups()}
-     *          is not overridden.
-     *
      * @implSpec
      * The default implementation of this method invokes {@link #namedGroups()}
-     * to obtain the group number from the {@code name} argument, and uses this
-     * number as argument to an invocation of {@link #end(int)}.
+     * to obtain the group number from the {@code name} argument, and uses it
+     * as argument to an invocation of {@link #end(int)}.
      *
      * @since 20
      */
@@ -280,14 +272,10 @@ public interface MatchResult {
      *          If there is no capturing group in the pattern
      *          with the given name
      *
-     * @throws UnsupportedOperationException
-     *          If the default implementation of {@link #namedGroups()}
-     *          is not overridden.
-     *
      * @implSpec
      * The default implementation of this method invokes {@link #namedGroups()}
-     * to obtain the group number from the {@code name} argument, and uses this
-     * number as argument to an invocation of {@link #group(int)}.
+     * to obtain the group number from the {@code name} argument, and uses it
+     * as argument to an invocation of {@link #group(int)}.
      *
      * @since 20
      */

--- a/src/java.base/share/classes/java/util/regex/MatchResult.java
+++ b/src/java.base/share/classes/java/util/regex/MatchResult.java
@@ -315,8 +315,11 @@ public interface MatchResult {
      *
      * @return an unmodifiable map from capturing group names to group numbers
      *
-     * @throws UnsupportedOperationException
-     *          The default implementation of this method always throws
+     * @throws UnsupportedOperationException if the implementation does not
+     *          support named groups.
+     *
+     * @implSpec The default implementation of this method always throws
+     *          {@link UnsupportedOperationException}
      *
      * @apiNote
      * This method must be overridden by an implementation that supports
@@ -343,8 +346,11 @@ public interface MatchResult {
      *
      * @return whether {@code this} contains a valid match
      *
-     * @throws UnsupportedOperationException
-     *          The default implementation of this method always throws
+     * @throws UnsupportedOperationException if the implementation cannot report
+     *          whether it has a match
+     *
+     * @implSpec The default implementation of this method always throws
+     *          {@link UnsupportedOperationException}
      *
      * @since 20
      */

--- a/src/java.base/share/classes/java/util/regex/MatchResult.java
+++ b/src/java.base/share/classes/java/util/regex/MatchResult.java
@@ -99,11 +99,16 @@ public interface MatchResult {
      *          If there is no capturing group in the pattern
      *          with the given name
      *
-     * @implNote The default implementation of this method makes use of the
-     *          map returned by {@link #namedGroups()}.
-     *          It is thus sufficient to override {@link #namedGroups()} for
-     *          this method to work. However, overriding this method directly
-     *          might be preferable for other reasons.
+     * @implNote
+     * The default implementation of this method makes use of the map returned
+     * by {@link #namedGroups()}. It is thus sufficient to override
+     * {@link #namedGroups()} for this method to work. However, overriding this
+     * method directly might be preferable for performance or for other reasons.
+     *
+     * @implSpec
+     * The default implementation of this method throws
+     * {@link UnsupportedOperationException} if {@link #namedGroups()} is not
+     * overridden.
      *
      * @since 20
      */
@@ -168,11 +173,16 @@ public interface MatchResult {
      *          If there is no capturing group in the pattern
      *          with the given name
      *
-     * @implNote The default implementation of this method makes use of the
-     *          map returned by {@link #namedGroups()}.
-     *          It is thus sufficient to override {@link #namedGroups()} for
-     *          this method to work. However, overriding this method directly
-     *          might be preferable for other reasons.
+     * @implNote
+     * The default implementation of this method makes use of the map returned
+     * by {@link #namedGroups()}. It is thus sufficient to override
+     * {@link #namedGroups()} for this method to work. However, overriding this
+     * method directly might be preferable for performance or for other reasons.
+     *
+     * @implSpec
+     * The default implementation of this method throws
+     * {@link UnsupportedOperationException} if {@link #namedGroups()} is not
+     * overridden.
      *
      * @since 20
      */
@@ -265,11 +275,16 @@ public interface MatchResult {
      *          If there is no capturing group in the pattern
      *          with the given name
      *
-     * @implNote The default implementation of this method makes use of the
-     *          map returned by {@link #namedGroups()}.
-     *          It is thus sufficient to override {@link #namedGroups()} for
-     *          this method to work. However, overriding this method directly
-     *          might be preferable for other reasons.
+     * @implNote
+     * The default implementation of this method makes use of the map returned
+     * by {@link #namedGroups()}. It is thus sufficient to override
+     * {@link #namedGroups()} for this method to work. However, overriding this
+     * method directly might be preferable for performance or for other reasons.
+     *
+     * @implSpec
+     * The default implementation of this method throws
+     * {@link UnsupportedOperationException} if {@link #namedGroups()} is not
+     * overridden.
      *
      * @since 20
      */

--- a/src/java.base/share/classes/java/util/regex/Matcher.java
+++ b/src/java.base/share/classes/java/util/regex/Matcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package java.util.regex;
 
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Spliterator;
@@ -229,6 +230,8 @@ public final class Matcher implements MatchResult {
      */
     int modCount;
 
+    private Map<String, Integer> namedGroups;
+
     /**
      * No default constructor.
      */
@@ -278,7 +281,8 @@ public final class Matcher implements MatchResult {
                                         this.last,
                                         groupCount(),
                                         this.groups.clone(),
-                                        text);
+                                        text,
+                                        namedGroups());
     }
 
     private static class ImmutableMatchResult implements MatchResult {
@@ -287,15 +291,18 @@ public final class Matcher implements MatchResult {
         private final int[] groups;
         private final int groupCount;
         private final String text;
+        private final Map<String, Integer> namedGroups;
 
         ImmutableMatchResult(int first, int last, int groupCount,
-                             int[] groups, String text)
+                             int[] groups, String text,
+                             Map<String, Integer> namedGroups)
         {
             this.first = first;
             this.last = last;
             this.groupCount = groupCount;
             this.groups = groups;
             this.text = text;
+            this.namedGroups = namedGroups;
         }
 
         @Override
@@ -307,8 +314,7 @@ public final class Matcher implements MatchResult {
         @Override
         public int start(int group) {
             checkMatch();
-            if (group < 0 || group > groupCount)
-                throw new IndexOutOfBoundsException("No group " + group);
+            checkGroup(group);
             return groups[group * 2];
         }
 
@@ -321,8 +327,7 @@ public final class Matcher implements MatchResult {
         @Override
         public int end(int group) {
             checkMatch();
-            if (group < 0 || group > groupCount)
-                throw new IndexOutOfBoundsException("No group " + group);
+            checkGroup(group);
             return groups[group * 2 + 1];
         }
 
@@ -340,18 +345,33 @@ public final class Matcher implements MatchResult {
         @Override
         public String group(int group) {
             checkMatch();
-            if (group < 0 || group > groupCount)
-                throw new IndexOutOfBoundsException("No group " + group);
-            if ((groups[group*2] == -1) || (groups[group*2+1] == -1))
+            checkGroup(group);
+            if ((groups[group * 2] == -1) || (groups[group * 2 + 1] == -1))
                 return null;
             return text.subSequence(groups[group * 2], groups[group * 2 + 1]).toString();
         }
 
+        @Override
+        public Map<String, Integer> namedGroups() {
+            return namedGroups;
+        }
+
+        @Override
+        public boolean hasMatch() {
+            return first >= 0;
+        }
+
+        private void checkGroup(int group) {
+            if (group < 0 || group > groupCount)
+                throw new IndexOutOfBoundsException("No group " + group);
+        }
+
         private void checkMatch() {
-            if (first < 0)
+            if (!hasMatch())
                 throw new IllegalStateException("No match found");
 
         }
+
     }
 
     /**
@@ -446,8 +466,7 @@ public final class Matcher implements MatchResult {
      *          or if the previous match operation failed
      */
     public int start() {
-        if (first < 0)
-            throw new IllegalStateException("No match available");
+        checkMatch();
         return first;
     }
 
@@ -476,10 +495,8 @@ public final class Matcher implements MatchResult {
      *          with the given index
      */
     public int start(int group) {
-        if (first < 0)
-            throw new IllegalStateException("No match available");
-        if (group < 0 || group > groupCount())
-            throw new IndexOutOfBoundsException("No group " + group);
+        checkMatch();
+        checkGroup(group);
         return groups[group * 2];
     }
 
@@ -518,8 +535,7 @@ public final class Matcher implements MatchResult {
      *          or if the previous match operation failed
      */
     public int end() {
-        if (first < 0)
-            throw new IllegalStateException("No match available");
+        checkMatch();
         return last;
     }
 
@@ -548,10 +564,8 @@ public final class Matcher implements MatchResult {
      *          with the given index
      */
     public int end(int group) {
-        if (first < 0)
-            throw new IllegalStateException("No match available");
-        if (group < 0 || group > groupCount())
-            throw new IndexOutOfBoundsException("No group " + group);
+        checkMatch();
+        checkGroup(group);
         return groups[group * 2 + 1];
     }
 
@@ -640,10 +654,8 @@ public final class Matcher implements MatchResult {
      *          with the given index
      */
     public String group(int group) {
-        if (first < 0)
-            throw new IllegalStateException("No match found");
-        if (group < 0 || group > groupCount())
-            throw new IndexOutOfBoundsException("No group " + group);
+        checkMatch();
+        checkGroup(group);
         if ((groups[group*2] == -1) || (groups[group*2+1] == -1))
             return null;
         return getSubSequence(groups[group * 2], groups[group * 2 + 1]).toString();
@@ -900,9 +912,7 @@ public final class Matcher implements MatchResult {
      *          that does not exist in the pattern
      */
     public Matcher appendReplacement(StringBuffer sb, String replacement) {
-        // If no match, return error
-        if (first < 0)
-            throw new IllegalStateException("No match available");
+        checkMatch();
         StringBuilder result = new StringBuilder();
         appendExpandedReplacement(replacement, result);
         // Append the intervening text
@@ -991,8 +1001,7 @@ public final class Matcher implements MatchResult {
      */
     public Matcher appendReplacement(StringBuilder sb, String replacement) {
         // If no match, return error
-        if (first < 0)
-            throw new IllegalStateException("No match available");
+        checkMatch();
         StringBuilder result = new StringBuilder();
         appendExpandedReplacement(replacement, result);
         // Append the intervening text
@@ -1055,10 +1064,10 @@ public final class Matcher implements MatchResult {
                         throw new IllegalArgumentException(
                             "capturing group name {" + gname +
                             "} starts with digit character");
-                    if (!parentPattern.namedGroups().containsKey(gname))
+                    if (!namedGroups().containsKey(gname))
                         throw new IllegalArgumentException(
                             "No group with name {" + gname + "}");
-                    refNum = parentPattern.namedGroups().get(gname);
+                    refNum = namedGroups().get(gname);
                     cursor++;
                 } else {
                     // The first number is always a group
@@ -1796,10 +1805,47 @@ public final class Matcher implements MatchResult {
      */
     int getMatchedGroupIndex(String name) {
         Objects.requireNonNull(name, "Group name");
-        if (first < 0)
-            throw new IllegalStateException("No match found");
-        if (!parentPattern.namedGroups().containsKey(name))
+        checkMatch();
+        if (!namedGroups().containsKey(name))
             throw new IllegalArgumentException("No group with name <" + name + ">");
-        return parentPattern.namedGroups().get(name);
+        return namedGroups().get(name);
     }
+
+    private void checkGroup(int group) {
+        if (group < 0 || group > groupCount())
+            throw new IndexOutOfBoundsException("No group " + group);
+    }
+
+    private void checkMatch() {
+        if (!hasMatch())
+            throw new IllegalStateException("No match found");
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@inheritDoc}
+     *
+     * @since {@inheritDoc}
+     */
+    @Override
+    public Map<String, Integer> namedGroups() {
+        if (namedGroups == null) {
+            return namedGroups = parentPattern.namedGroups();
+        }
+        return namedGroups;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@inheritDoc}
+     *
+     * @since {@inheritDoc}
+     */
+    @Override
+    public boolean hasMatch() {
+        return first >= 0;
+    }
+
 }

--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -1842,12 +1842,24 @@ loop:   for(int x=0, offset=0; x<nCodePoints; x++, offset+=len) {
         topClosureNodes = null;
     }
 
-    Map<String, Integer> namedGroups() {
+    private Map<String, Integer> namedGroupsMap() {
         Map<String, Integer> groups = namedGroups;
         if (groups == null) {
             namedGroups = groups = new HashMap<>(2);
         }
         return groups;
+    }
+
+    /**
+     * Returns an unmodifiable map from capturing group names to group numbers.
+     * If there are no named groups, returns an empty map.
+     *
+     * @return an unmodifiable map from capturing group names to group numbers
+     *
+     * @since 20
+     */
+    public Map<String, Integer> namedGroups() {
+        return Map.copyOf(namedGroupsMap());
     }
 
     /**
@@ -2553,14 +2565,14 @@ loop:   for(int x=0, offset=0; x<nCodePoints; x++, offset+=len) {
             if (read() != '<')
                 throw error("\\k is not followed by '<' for named capturing group");
             String name = groupname(read());
-            if (!namedGroups().containsKey(name))
+            if (!namedGroupsMap().containsKey(name))
                 throw error("named capturing group <" + name + "> does not exist");
             if (create) {
                 hasGroupRef = true;
                 if (has(CASE_INSENSITIVE))
-                    root = new CIBackRef(namedGroups().get(name), has(UNICODE_CASE));
+                    root = new CIBackRef(namedGroupsMap().get(name), has(UNICODE_CASE));
                 else
-                    root = new BackRef(namedGroups().get(name));
+                    root = new BackRef(namedGroupsMap().get(name));
             }
             return -1;
         case 'l':
@@ -3007,13 +3019,13 @@ loop:   for(int x=0, offset=0; x<nCodePoints; x++, offset+=len) {
                     if (ch != '=' && ch != '!') {
                         // named captured group
                         String name = groupname(ch);
-                        if (namedGroups().containsKey(name))
+                        if (namedGroupsMap().containsKey(name))
                             throw error("Named capturing group <" + name
                                         + "> is already defined");
                         capturingGroup = true;
                         head = createGroup(false);
                         tail = root;
-                        namedGroups().put(name, capturingGroupCount - 1);
+                        namedGroupsMap().put(name, capturingGroupCount - 1);
                         head.next = expr(tail);
                         break;
                     }

--- a/test/jdk/java/util/regex/NamedGroupsTests.java
+++ b/test/jdk/java/util/regex/NamedGroupsTests.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8065554
+ * @run main NamedGroupsTests
+ */
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class NamedGroupsTests {
+
+    public static void main(String[] args) {
+        testPatternNamedGroups();
+        testMatcherNamedGroups();
+        testMatchResultNamedGroups();
+
+        testMatcherHasMatch();
+        testMatchResultHasMatch();
+
+        testMatchResultStartEndGroup();
+    }
+
+    private static void testMatchResultStartEndGroup() {
+        testMatchResultStartEndGroup1();
+        testMatchResultStartEndGroup2();
+        testMatchResultStartEndGroup3();
+        testMatchResultStartEndGroup4();
+    }
+
+    private static void testMatchResultStartEndGroup1() {
+        List<MatchResult> list = Pattern.compile("(?<some>.+?)(?<rest>.*)").matcher("")
+                .results().toList();
+        for (var result : list) {
+            if (result.start("some") >= 0) {
+                throw new RuntimeException("start(\"some\")");
+            }
+            if (result.start("rest") >= 0) {
+                throw new RuntimeException("start(\"rest\")");
+            }
+            if (result.end("some") >= 0) {
+                throw new RuntimeException("end(\"some\")");
+            }
+            if (result.end("rest") >= 0) {
+                throw new RuntimeException("end(\"rest\")");
+            }
+            if (result.group("some") != null) {
+                throw new RuntimeException("group(\"some\")");
+            }
+            if (result.group("rest") != null) {
+                throw new RuntimeException("group(\"rest\")");
+            }
+        }
+    }
+
+    private static void testMatchResultStartEndGroup2() {
+        List<MatchResult> list = Pattern.compile("(?<some>.+?)(?<rest>.*)").matcher("abc")
+                .results().toList();
+        for (var result : list) {
+            if (result.start("some") < 0) {
+                throw new RuntimeException("start(\"some\")");
+            }
+            if (result.start("rest") < 0) {
+                throw new RuntimeException("start(\"rest\")");
+            }
+            if (result.end("some") < 0) {
+                throw new RuntimeException("end(\"some\")");
+            }
+            if (result.end("rest") < 0) {
+                throw new RuntimeException("end(\"rest\")");
+            }
+            if (result.group("some") == null) {
+                throw new RuntimeException("group(\"some\")");
+            }
+            if (result.group("rest") == null) {
+                throw new RuntimeException("group(\"rest\")");
+            }
+        }
+    }
+
+    private static void testMatchResultStartEndGroup3() {
+        Pattern.compile("(?<some>.+?)(?<rest>.*)").matcher("")
+                .results()
+                .forEach(r -> {
+                        try {
+                            r.start("noSuchGroup");
+                            r.end("noSuchGroup");
+                            r.group("noSuchGroup");
+                        } catch (IllegalArgumentException e) {  // swallowing intended
+                        }
+                    });
+    }
+
+    private static void testMatchResultStartEndGroup4() {
+        List<MatchResult> list = Pattern.compile("(?<some>.+?)(?<rest>.*)").matcher("abc")
+                .results().toList();
+        for (var result : list) {
+            try {
+                result.start("noSuchGroup");
+                result.end("noSuchGroup");
+                result.group("noSuchGroup");
+            } catch (IllegalArgumentException e) {  // swallowing intended
+            }
+        }
+    }
+
+    private static void testMatchResultHasMatch() {
+        testMatchResultHasMatch1();
+        testMatchResultHasMatch2();
+    }
+
+    private static void testMatchResultHasMatch1() {
+        Matcher m = Pattern.compile(".+").matcher("");
+        m.find();
+        if (m.toMatchResult().hasMatch()) {
+            throw new RuntimeException();
+        };
+    }
+
+    private static void testMatchResultHasMatch2() {
+        Matcher m = Pattern.compile(".+").matcher("abc");
+        m.find();
+        if (!m.toMatchResult().hasMatch()) {
+            throw new RuntimeException();
+        };
+    }
+
+    private static void testMatcherHasMatch() {
+        testMatcherHasMatch1();
+        testMatcherHasMatch2();
+    }
+
+    private static void testMatcherHasMatch1() {
+        Matcher m = Pattern.compile(".+").matcher("");
+        m.find();
+        if (m.hasMatch()) {
+            throw new RuntimeException();
+        };
+    }
+
+    private static void testMatcherHasMatch2() {
+        Matcher m = Pattern.compile(".+").matcher("abc");
+        m.find();
+        if (!m.hasMatch()) {
+            throw new RuntimeException();
+        };
+    }
+
+    private static void testMatchResultNamedGroups() {
+        testMatchResultNamedGroups1();
+        testMatchResultNamedGroups2();
+        testMatchResultNamedGroups3();
+        testMatchResultNamedGroups4();
+    }
+
+    private static void testMatchResultNamedGroups1() {
+        if (!Pattern.compile(".*").matcher("")
+                .toMatchResult().namedGroups().isEmpty()) {
+            throw new RuntimeException();
+        };
+    }
+
+    private static void testMatchResultNamedGroups2() {
+        if (!Pattern.compile("(.*)").matcher("")
+                .toMatchResult().namedGroups().isEmpty()) {
+            throw new RuntimeException();
+        };
+    }
+
+    private static void testMatchResultNamedGroups3() {
+        if (!Pattern.compile("(?<all>.*)").matcher("")
+                .toMatchResult().namedGroups()
+                .equals(Map.of("all", 1))) {
+            throw new RuntimeException();
+        };
+    }
+
+    private static void testMatchResultNamedGroups4() {
+        if (!Pattern.compile("(?<some>.+?)(?<rest>.*)").matcher("")
+                .toMatchResult().namedGroups()
+                .equals(Map.of("some", 1, "rest", 2))) {
+            throw new RuntimeException();
+        };
+    }
+
+    private static void testMatcherNamedGroups() {
+        testmatcherNamedGroups1();
+        testMatcherNamedGroups2();
+        testMatcherNamedGroups3();
+        testMatcherNamedGroups4();
+    }
+
+    private static void testmatcherNamedGroups1() {
+        if (!Pattern.compile(".*").matcher("").namedGroups().isEmpty()) {
+            throw new RuntimeException();
+        };
+    }
+
+    private static void testMatcherNamedGroups2() {
+        if (!Pattern.compile("(.*)").matcher("").namedGroups().isEmpty()) {
+            throw new RuntimeException();
+        };
+    }
+
+    private static void testMatcherNamedGroups3() {
+        if (!Pattern.compile("(?<all>.*)").matcher("").namedGroups()
+                .equals(Map.of("all", 1))) {
+            throw new RuntimeException();
+        };
+    }
+
+    private static void testMatcherNamedGroups4() {
+        if (!Pattern.compile("(?<some>.+?)(?<rest>.*)").matcher("").namedGroups()
+                .equals(Map.of("some", 1, "rest", 2))) {
+            throw new RuntimeException();
+        };
+    }
+
+    private static void testPatternNamedGroups() {
+        testPatternNamedGroups1();
+        testPatternNamedGroups2();
+        testPatternNamedGroups3();
+        testPatternNamedGroups4();
+    }
+
+    private static void testPatternNamedGroups1() {
+        if (!Pattern.compile(".*").namedGroups().isEmpty()) {
+            throw new RuntimeException();
+        };
+    }
+
+    private static void testPatternNamedGroups2() {
+        if (!Pattern.compile("(.*)").namedGroups().isEmpty()) {
+            throw new RuntimeException();
+        };
+    }
+
+    private static void testPatternNamedGroups3() {
+        if (!Pattern.compile("(?<all>.*)").namedGroups()
+                .equals(Map.of("all", 1))) {
+            throw new RuntimeException();
+        };
+    }
+
+    private static void testPatternNamedGroups4() {
+        if (!Pattern.compile("(?<some>.+?)(?<rest>.*)").namedGroups()
+                .equals(Map.of("some", 1, "rest", 2))) {
+            throw new RuntimeException();
+        };
+    }
+
+}

--- a/test/jdk/java/util/regex/NamedGroupsTests.java
+++ b/test/jdk/java/util/regex/NamedGroupsTests.java
@@ -27,9 +27,7 @@
  * @run main NamedGroupsTests
  */
 
-import java.util.List;
 import java.util.Map;
-import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -50,83 +48,75 @@ public class NamedGroupsTests {
         testMatchResultStartEndGroup1();
         testMatchResultStartEndGroup2();
         testMatchResultStartEndGroup3();
-        testMatchResultStartEndGroup4();
     }
 
     private static void testMatchResultStartEndGroup1() {
-        List<MatchResult> list = Pattern.compile("(?<some>.+?)(?<rest>.*)").matcher("")
-                .results().toList();
-        for (var result : list) {
-            if (result.start("some") >= 0) {
-                throw new RuntimeException("start(\"some\")");
-            }
-            if (result.start("rest") >= 0) {
-                throw new RuntimeException("start(\"rest\")");
-            }
-            if (result.end("some") >= 0) {
-                throw new RuntimeException("end(\"some\")");
-            }
-            if (result.end("rest") >= 0) {
-                throw new RuntimeException("end(\"rest\")");
-            }
-            if (result.group("some") != null) {
-                throw new RuntimeException("group(\"some\")");
-            }
-            if (result.group("rest") != null) {
-                throw new RuntimeException("group(\"rest\")");
-            }
-        }
-    }
-
-    private static void testMatchResultStartEndGroup2() {
-        List<MatchResult> list = Pattern.compile("(?<some>.+?)(?<rest>.*)").matcher("abc")
-                .results().toList();
-        for (var result : list) {
-            if (result.start("some") < 0) {
-                throw new RuntimeException("start(\"some\")");
-            }
-            if (result.start("rest") < 0) {
-                throw new RuntimeException("start(\"rest\")");
-            }
-            if (result.end("some") < 0) {
-                throw new RuntimeException("end(\"some\")");
-            }
-            if (result.end("rest") < 0) {
-                throw new RuntimeException("end(\"rest\")");
-            }
-            if (result.group("some") == null) {
-                throw new RuntimeException("group(\"some\")");
-            }
-            if (result.group("rest") == null) {
-                throw new RuntimeException("group(\"rest\")");
-            }
-        }
-    }
-
-    private static void testMatchResultStartEndGroup3() {
         Pattern.compile("(?<some>.+?)(?<rest>.*)").matcher("")
                 .results()
                 .forEach(r -> {
-                        try {
-                            r.start("noSuchGroup");
-                            r.end("noSuchGroup");
-                            r.group("noSuchGroup");
-                        } catch (IllegalArgumentException e) {  // swallowing intended
-                        }
-                    });
+                    if (r.start("some") >= 0) {
+                        throw new RuntimeException("start(\"some\")");
+                    }
+                    if (r.start("rest") >= 0) {
+                        throw new RuntimeException("start(\"rest\")");
+                    }
+                    if (r.end("some") >= 0) {
+                        throw new RuntimeException("end(\"some\")");
+                    }
+                    if (r.end("rest") >= 0) {
+                        throw new RuntimeException("end(\"rest\")");
+                    }
+                    if (r.group("some") != null) {
+                        throw new RuntimeException("group(\"some\")");
+                    }
+                    if (r.group("rest") != null) {
+                        throw new RuntimeException("group(\"rest\")");
+                    }
+                });
     }
 
-    private static void testMatchResultStartEndGroup4() {
-        List<MatchResult> list = Pattern.compile("(?<some>.+?)(?<rest>.*)").matcher("abc")
-                .results().toList();
-        for (var result : list) {
-            try {
-                result.start("noSuchGroup");
-                result.end("noSuchGroup");
-                result.group("noSuchGroup");
-            } catch (IllegalArgumentException e) {  // swallowing intended
-            }
-        }
+    private static void testMatchResultStartEndGroup2() {
+        Pattern.compile("(?<some>.+?)(?<rest>.*)").matcher("abc")
+                .results()
+                .forEach(r -> {
+                    if (r.start("some") < 0) {
+                        throw new RuntimeException("start(\"some\")");
+                    }
+                    if (r.start("rest") < 0) {
+                        throw new RuntimeException("start(\"rest\")");
+                    }
+                    if (r.end("some") < 0) {
+                        throw new RuntimeException("end(\"some\")");
+                    }
+                    if (r.end("rest") < 0) {
+                        throw new RuntimeException("end(\"rest\")");
+                    }
+                    if (r.group("some") == null) {
+                        throw new RuntimeException("group(\"some\")");
+                    }
+                    if (r.group("rest") == null) {
+                        throw new RuntimeException("group(\"rest\")");
+                    }
+                });
+    }
+
+    private static void testMatchResultStartEndGroup3() {
+        Pattern.compile("(?<some>.+?)(?<rest>.*)").matcher("abc")
+                .results()
+                .forEach(r -> {
+                    try {
+                        r.start("noSuchGroup");
+                    } catch (IllegalArgumentException e) {  // swallowing intended
+                    }
+                    try {
+                        r.end("noSuchGroup");
+                    } catch (IllegalArgumentException e) {  // swallowing intended
+                    }
+                    try {
+                        r.group("noSuchGroup");
+                    } catch (IllegalArgumentException e) {  // swallowing intended
+                    }
+                });
     }
 
     private static void testMatchResultHasMatch() {
@@ -139,7 +129,7 @@ public class NamedGroupsTests {
         m.find();
         if (m.toMatchResult().hasMatch()) {
             throw new RuntimeException();
-        };
+        }
     }
 
     private static void testMatchResultHasMatch2() {
@@ -147,7 +137,7 @@ public class NamedGroupsTests {
         m.find();
         if (!m.toMatchResult().hasMatch()) {
             throw new RuntimeException();
-        };
+        }
     }
 
     private static void testMatcherHasMatch() {
@@ -160,7 +150,7 @@ public class NamedGroupsTests {
         m.find();
         if (m.hasMatch()) {
             throw new RuntimeException();
-        };
+        }
     }
 
     private static void testMatcherHasMatch2() {
@@ -168,7 +158,7 @@ public class NamedGroupsTests {
         m.find();
         if (!m.hasMatch()) {
             throw new RuntimeException();
-        };
+        }
     }
 
     private static void testMatchResultNamedGroups() {
@@ -182,14 +172,14 @@ public class NamedGroupsTests {
         if (!Pattern.compile(".*").matcher("")
                 .toMatchResult().namedGroups().isEmpty()) {
             throw new RuntimeException();
-        };
+        }
     }
 
     private static void testMatchResultNamedGroups2() {
         if (!Pattern.compile("(.*)").matcher("")
                 .toMatchResult().namedGroups().isEmpty()) {
             throw new RuntimeException();
-        };
+        }
     }
 
     private static void testMatchResultNamedGroups3() {
@@ -197,7 +187,7 @@ public class NamedGroupsTests {
                 .toMatchResult().namedGroups()
                 .equals(Map.of("all", 1))) {
             throw new RuntimeException();
-        };
+        }
     }
 
     private static void testMatchResultNamedGroups4() {
@@ -205,40 +195,40 @@ public class NamedGroupsTests {
                 .toMatchResult().namedGroups()
                 .equals(Map.of("some", 1, "rest", 2))) {
             throw new RuntimeException();
-        };
+        }
     }
 
     private static void testMatcherNamedGroups() {
-        testmatcherNamedGroups1();
+        testMatcherNamedGroups1();
         testMatcherNamedGroups2();
         testMatcherNamedGroups3();
         testMatcherNamedGroups4();
     }
 
-    private static void testmatcherNamedGroups1() {
+    private static void testMatcherNamedGroups1() {
         if (!Pattern.compile(".*").matcher("").namedGroups().isEmpty()) {
             throw new RuntimeException();
-        };
+        }
     }
 
     private static void testMatcherNamedGroups2() {
         if (!Pattern.compile("(.*)").matcher("").namedGroups().isEmpty()) {
             throw new RuntimeException();
-        };
+        }
     }
 
     private static void testMatcherNamedGroups3() {
         if (!Pattern.compile("(?<all>.*)").matcher("").namedGroups()
                 .equals(Map.of("all", 1))) {
             throw new RuntimeException();
-        };
+        }
     }
 
     private static void testMatcherNamedGroups4() {
         if (!Pattern.compile("(?<some>.+?)(?<rest>.*)").matcher("").namedGroups()
                 .equals(Map.of("some", 1, "rest", 2))) {
             throw new RuntimeException();
-        };
+        }
     }
 
     private static void testPatternNamedGroups() {
@@ -251,27 +241,27 @@ public class NamedGroupsTests {
     private static void testPatternNamedGroups1() {
         if (!Pattern.compile(".*").namedGroups().isEmpty()) {
             throw new RuntimeException();
-        };
+        }
     }
 
     private static void testPatternNamedGroups2() {
         if (!Pattern.compile("(.*)").namedGroups().isEmpty()) {
             throw new RuntimeException();
-        };
+        }
     }
 
     private static void testPatternNamedGroups3() {
         if (!Pattern.compile("(?<all>.*)").namedGroups()
                 .equals(Map.of("all", 1))) {
             throw new RuntimeException();
-        };
+        }
     }
 
     private static void testPatternNamedGroups4() {
         if (!Pattern.compile("(?<some>.+?)(?<rest>.*)").namedGroups()
                 .equals(Map.of("some", 1, "rest", 2))) {
             throw new RuntimeException();
-        };
+        }
     }
 
 }


### PR DESCRIPTION
Add support for named groups to java.util.regex.MatchResult
<!-- csr: 'update' -->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8065554](https://bugs.openjdk.org/browse/JDK-8065554): MatchResult should provide values of named-capturing groups
 * [JDK-8292872](https://bugs.openjdk.org/browse/JDK-8292872): MatchResult should provide values of named-capturing groups (**CSR**)


### Reviewers
 * [Stuart Marks](https://openjdk.org/census#smarks) (@stuart-marks - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10000/head:pull/10000` \
`$ git checkout pull/10000`

Update a local copy of the PR: \
`$ git checkout pull/10000` \
`$ git pull https://git.openjdk.org/jdk pull/10000/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10000`

View PR using the GUI difftool: \
`$ git pr show -t 10000`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10000.diff">https://git.openjdk.org/jdk/pull/10000.diff</a>

</details>
