### PR TITLE
8292850: Unused field 'expiredTimersKey' in javax.swing.TimerQueue

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/TimerQueue.java
+++ b/src/java.desktop/share/classes/javax/swing/TimerQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,15 +23,10 @@
  * questions.
  */
 
-
-
 package javax.swing;
-
-
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.*;
 import java.util.concurrent.atomic.AtomicLong;
@@ -49,8 +44,6 @@ class TimerQueue implements Runnable
 {
     private static final Object sharedInstanceKey =
         new StringBuffer("TimerQueue.sharedInstanceKey");
-    private static final Object expiredTimersKey =
-        new StringBuffer("TimerQueue.expiredTimersKey");
 
     private final DelayQueue<DelayedTimer> queue;
     private volatile boolean running;
@@ -268,7 +261,7 @@ class TimerQueue implements Runnable
 
 
         public final long getDelay(TimeUnit unit) {
-            return  unit.convert(time - now(), TimeUnit.NANOSECONDS);
+            return unit.convert(time - now(), TimeUnit.NANOSECONDS);
         }
 
         final void setTime(long nanos) {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292850](https://bugs.openjdk.org/browse/JDK-8292850): Unused field 'expiredTimersKey' in javax.swing.TimerQueue


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10001/head:pull/10001` \
`$ git checkout pull/10001`

Update a local copy of the PR: \
`$ git checkout pull/10001` \
`$ git pull https://git.openjdk.org/jdk pull/10001/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10001`

View PR using the GUI difftool: \
`$ git pr show -t 10001`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10001.diff">https://git.openjdk.org/jdk/pull/10001.diff</a>

</details>
