### PR TITLE
8292877: java/util/concurrent/atomic/Serial.java uses {Double,Long}Accumulator incorrectly

### DIFF
--- a/test/jdk/java/util/concurrent/atomic/Serial.java
+++ b/test/jdk/java/util/concurrent/atomic/Serial.java
@@ -64,8 +64,8 @@ public class Serial {
     }
 
     static void testDoubleAccumulator() {
-        DoubleBinaryOperator plus = (DoubleBinaryOperator & Serializable) (x, y) -> x + y;
-        DoubleAccumulator a = new DoubleAccumulator(plus, 13.9d);
+        DoubleBinaryOperator op = (DoubleBinaryOperator & Serializable) (x, y) -> Math.max(x, y);
+        DoubleAccumulator a = new DoubleAccumulator(op, Double.NEGATIVE_INFINITY);
         a.accumulate(17.5d);
         DoubleAccumulator result = echo(a);
         if (result.get() != a.get())
@@ -89,8 +89,8 @@ public class Serial {
     }
 
     static void testLongAccumulator() {
-        LongBinaryOperator plus = (LongBinaryOperator & Serializable) (x, y) -> x + y;
-        LongAccumulator a = new LongAccumulator(plus, -2);
+        LongBinaryOperator op = (LongBinaryOperator & Serializable) (x, y) -> Math.max(x, y);
+        LongAccumulator a = new LongAccumulator(op, Long.MIN_VALUE);
         a.accumulate(34);
         LongAccumulator result = echo(a);
         if (result.get() != a.get())


### PR DESCRIPTION
[JDK-8026344](https://bugs.openjdk.org/browse/JDK-8026344) added tests that subtly contradict the contract for `{Double,Long}Accumulator`-s, which breaks the tests on some platforms even in the single-threaded case.

They use accumulators with binary plus as update function and using non-zero values as identity, which breaks once accumulators create many cells, reset their values to identity, and then apply the function over them, producing unexpected values.

See the investigation on RISC-V here:
  https://mail.openjdk.org/pipermail/riscv-port-dev/2022-August/000594.html

We can do what `DoubleAccumulator` javadocs do as the sample, namely: "For example, to maintain a running maximum value, you could supply Double::max along with Double.NEGATIVE_INFINITY as the identity."

Additional testing:
 - [x] Linux x86_64, `java/util/concurrent` tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292877](https://bugs.openjdk.org/browse/JDK-8292877): java/util/concurrent/atomic/Serial.java uses {Double,Long}Accumulator incorrectly


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Martin Buchholz](https://openjdk.org/census#martin) (@Martin-Buchholz - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10002/head:pull/10002` \
`$ git checkout pull/10002`

Update a local copy of the PR: \
`$ git checkout pull/10002` \
`$ git pull https://git.openjdk.org/jdk pull/10002/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10002`

View PR using the GUI difftool: \
`$ git pr show -t 10002`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10002.diff">https://git.openjdk.org/jdk/pull/10002.diff</a>

</details>
