### PR TITLE
8292880: Improve debuggee logging for com/sun/jdi/ClassUnloadEventTest.java

### DIFF
--- a/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
+++ b/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
@@ -205,7 +205,7 @@ public class ClassUnloadEventTest {
         LaunchingConnector launchingConnector = Bootstrap.virtualMachineManager().defaultConnector();
         Map<String, Connector.Argument> arguments = launchingConnector.defaultArguments();
         arguments.get("main").setValue(ClassUnloadEventTest.class.getName());
-        arguments.get("options").setValue("--add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:class+unload=info");
+        arguments.get("options").setValue("--add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:class+unload=info -Xlog:gc");
         return launchingConnector.launch(arguments);
     }
 }

--- a/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
+++ b/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
@@ -54,7 +54,12 @@ public class ClassUnloadEventTest {
 
     public static void main(String[] args) throws Exception {
         if (args.length == 0) {
-            runDebuggee();
+            try {
+                runDebuggee();
+            } catch (Exception e) {
+                e.printStackTrace();
+                throw e;
+            }
         } else {
             runDebugger();
         }
@@ -96,7 +101,7 @@ public class ClassUnloadEventTest {
                     Class.forName(CLASS_NAME_PREFIX + index, true, loader);
                 }
             } catch (Exception e) {
-                throw new RuntimeException("Failed to create Sample class");
+                throw new RuntimeException("Failed to create Sample class", e);
             }
         }
         loader = null;
@@ -109,6 +114,8 @@ public class ClassUnloadEventTest {
             Thread.sleep(5000);
         } catch (InterruptedException e) {
         }
+
+        System.out.println("Exiting debuggee");
     }
 
     private static void runDebugger() throws Exception {
@@ -169,6 +176,21 @@ public class ClassUnloadEventTest {
             eventSet.resume();
         }
 
+        /* Dump debuggee output. */
+        Process p = vm.process();
+        BufferedReader in = new BufferedReader(new InputStreamReader(p.getInputStream()));
+        BufferedReader err = new BufferedReader(new InputStreamReader(p.getErrorStream()));
+        String line = in.readLine();
+        while (line != null) {
+            System.out.println("stdout: " + line);
+            line = in.readLine();
+        }
+        line = err.readLine();
+        while (line != null) {
+            System.out.println("stderr: " + line);
+            line = err.readLine();
+        }
+
         if (unloadedSampleClasses.size() != NUM_CLASSES) {
             throw new RuntimeException("Wrong number of class unload events: expected " + NUM_CLASSES + " got " + unloadedSampleClasses.size());
         }
@@ -183,7 +205,7 @@ public class ClassUnloadEventTest {
         LaunchingConnector launchingConnector = Bootstrap.virtualMachineManager().defaultConnector();
         Map<String, Connector.Argument> arguments = launchingConnector.defaultArguments();
         arguments.get("main").setValue(ClassUnloadEventTest.class.getName());
-        arguments.get("options").setValue("--add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI");
+        arguments.get("options").setValue("--add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:class+unload=info");
         return launchingConnector.launch(arguments);
     }
 }


### PR DESCRIPTION
In order to help debug [JDK-8292879](https://bugs.openjdk.org/browse/JDK-8292879) failures, turn on class unload tracing in the debuggee and also have the debugger dump all the debuggee output. See the CR for example output.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292880](https://bugs.openjdk.org/browse/JDK-8292880): Improve debuggee logging for com/sun/jdi/ClassUnloadEventTest.java


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**) ⚠️ Review applies to [0812d708](https://git.openjdk.org/jdk/pull/10004/files/0812d7087ae4cb6bd70b2daad59b9da9b2fc1790)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10004/head:pull/10004` \
`$ git checkout pull/10004`

Update a local copy of the PR: \
`$ git checkout pull/10004` \
`$ git pull https://git.openjdk.org/jdk pull/10004/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10004`

View PR using the GUI difftool: \
`$ git pr show -t 10004`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10004.diff">https://git.openjdk.org/jdk/pull/10004.diff</a>

</details>
