### PR TITLE
8293009: Remove unused field 'millisPerHour' in DateFormatSymbols

### DIFF
--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -696,11 +696,6 @@ public class DateFormatSymbols implements Serializable, Cloneable {
     }
 
     // =======================privates===============================
-
-    /**
-     * Useful constant for defining time zone offsets.
-     */
-    static final int millisPerHour = 60*60*1000;
 
     /**
      * Cache to hold DateFormatSymbols instances per Locale.


### PR DESCRIPTION
Field `java.text.DateFormatSymbols#millisPerHour` is unused. It was unused in initial OpenJDK sources.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293009](https://bugs.openjdk.org/browse/JDK-8293009): Remove unused field 'millisPerHour' in DateFormatSymbols


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10005/head:pull/10005` \
`$ git checkout pull/10005`

Update a local copy of the PR: \
`$ git checkout pull/10005` \
`$ git pull https://git.openjdk.org/jdk pull/10005/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10005`

View PR using the GUI difftool: \
`$ git pr show -t 10005`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10005.diff">https://git.openjdk.org/jdk/pull/10005.diff</a>

</details>
