### PR TITLE
8293008: Replace uses of StringBuffer with StringBuilder in MergeCollation

### DIFF
--- a/src/java.base/share/classes/java/text/MergeCollation.java
+++ b/src/java.base/share/classes/java/text/MergeCollation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,7 +86,7 @@ final class MergeCollation {
      * before & and <
      */
     public String getPattern(boolean withWhiteSpace) {
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         PatternEntry tmp = null;
         ArrayList<PatternEntry> extList = null;
         int i;
@@ -146,7 +146,7 @@ final class MergeCollation {
      * builder.
      */
     public String emitPattern(boolean withWhiteSpace) {
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         for (int i = 0; i < patterns.size(); ++i)
         {
             PatternEntry entry = patterns.get(i);

--- a/src/java.base/share/classes/java/text/PatternEntry.java
+++ b/src/java.base/share/classes/java/text/PatternEntry.java
@@ -52,14 +52,14 @@ class PatternEntry {
     /**
      * Gets the current extension, quoted
      */
-    public void appendQuotedExtension(StringBuilder toAddTo) {
+    private void appendQuotedExtension(StringBuilder toAddTo) {
         appendQuoted(extension,toAddTo);
     }
 
     /**
      * Gets the current chars, quoted
      */
-    public void appendQuotedChars(StringBuilder toAddTo) {
+    private void appendQuotedChars(StringBuilder toAddTo) {
         appendQuoted(chars,toAddTo);
     }
 
@@ -151,7 +151,7 @@ class PatternEntry {
         }
     }
 
-    static void appendQuoted(String chars, StringBuilder toAddTo) {
+    private static void appendQuoted(String chars, StringBuilder toAddTo) {
         boolean inQuote = false;
         char ch = chars.charAt(0);
         if (Character.isSpaceChar(ch)) {

--- a/src/java.base/share/classes/java/text/PatternEntry.java
+++ b/src/java.base/share/classes/java/text/PatternEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,14 +52,14 @@ class PatternEntry {
     /**
      * Gets the current extension, quoted
      */
-    public void appendQuotedExtension(StringBuffer toAddTo) {
+    public void appendQuotedExtension(StringBuilder toAddTo) {
         appendQuoted(extension,toAddTo);
     }
 
     /**
      * Gets the current chars, quoted
      */
-    public void appendQuotedChars(StringBuffer toAddTo) {
+    public void appendQuotedChars(StringBuilder toAddTo) {
         appendQuoted(chars,toAddTo);
     }
 
@@ -83,7 +83,7 @@ class PatternEntry {
      * For debugging.
      */
     public String toString() {
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         addToBuffer(result, true, false, null);
         return result.toString();
     }
@@ -111,7 +111,7 @@ class PatternEntry {
 
     // ===== privates =====
 
-    void addToBuffer(StringBuffer toAddTo,
+    void addToBuffer(StringBuilder toAddTo,
                      boolean showExtension,
                      boolean showWhiteSpace,
                      PatternEntry lastEntry)
@@ -151,7 +151,7 @@ class PatternEntry {
         }
     }
 
-    static void appendQuoted(String chars, StringBuffer toAddTo) {
+    static void appendQuoted(String chars, StringBuilder toAddTo) {
         boolean inQuote = false;
         char ch = chars.charAt(0);
         if (Character.isSpaceChar(ch)) {
@@ -173,9 +173,6 @@ class PatternEntry {
                     toAddTo.append('\'');
                     break;
                 default:
-                    if (inQuote) {
-                        inQuote = false; toAddTo.append('\'');
-                    }
                     break;
                 }
            }

--- a/src/java.base/share/classes/java/text/PatternEntry.java
+++ b/src/java.base/share/classes/java/text/PatternEntry.java
@@ -173,6 +173,9 @@ class PatternEntry {
                     toAddTo.append('\'');
                     break;
                 default:
+                    if (inQuote) {
+                        inQuote = false; toAddTo.append('\'');
+                    }
                     break;
                 }
            }


### PR DESCRIPTION
Couple of package-private classes in `java.text` package still use `StringBuffer`: `MergeCollation` and `PatternEntry`.
StringBuffer is a legacy synchronized class. StringBuilder is a direct replacement to StringBuffer which generally have better performance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293008](https://bugs.openjdk.org/browse/JDK-8293008): Replace uses of StringBuffer with StringBuilder in MergeCollation


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [a53bcac0](https://git.openjdk.org/jdk/pull/10007/files/a53bcac04c3b268fb72d086e6c9b948409548072)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to [a53bcac0](https://git.openjdk.org/jdk/pull/10007/files/a53bcac04c3b268fb72d086e6c9b948409548072)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10007/head:pull/10007` \
`$ git checkout pull/10007`

Update a local copy of the PR: \
`$ git checkout pull/10007` \
`$ git pull https://git.openjdk.org/jdk pull/10007/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10007`

View PR using the GUI difftool: \
`$ git pr show -t 10007`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10007.diff">https://git.openjdk.org/jdk/pull/10007.diff</a>

</details>
