### PR TITLE
6447816: Provider filtering (getProviders) is not working with OR'd conditions

### DIFF
--- a/src/java.base/share/classes/java/security/Security.java
+++ b/src/java.base/share/classes/java/security/Security.java
@@ -826,7 +826,6 @@ public final class Security {
 
         Criteria(String key, String value) throws InvalidParameterException {
             int snEndIndex = key.indexOf('.');
-            System.out.println("applying " + key + ", " + value);
 
             if (snEndIndex <= 0) {
                 // There must be a dot in the filter, and the dot

--- a/test/jdk/java/security/Security/ProviderFiltering.java
+++ b/test/jdk/java/security/Security/ProviderFiltering.java
@@ -91,6 +91,10 @@ public class ProviderFiltering {
         testIPE("Cipher.RC2 SupportedKeyClasses:a|b");
 
         String p = "SUN";
+
+        // test alias
+        doit("Signature.NONEwithDSA", p);
+
         String sigService = "Signature.SHA256withDSA";
         // javadoc allows extra spaces in between
         String key = sigService + "   SupportedKeyClasses";

--- a/test/jdk/java/security/Security/ProviderFiltering.java
+++ b/test/jdk/java/security/Security/ProviderFiltering.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6447816
+ * @summary Check that provider service matching/filtering is done correctly.
+ * @run main/othervm ProviderFiltering
+ */
+
+import java.util.*;
+import java.security.*;
+
+public class ProviderFiltering {
+
+    private static void doit(Object filter, String... expectedPNs) {
+        System.out.println("Filter: " + filter);
+        System.out.println("Expected Provider(s): " +
+                (expectedPNs.length > 0 ? Arrays.toString(expectedPNs) :
+                "<NONE>"));
+        Provider ps[];
+        if (filter instanceof String filterStr) {
+            ps = Security.getProviders(filterStr);
+        } else if (filter instanceof Map filterMap) {
+            ps = Security.getProviders(filterMap);
+        } else {
+            throw new RuntimeException("Error: unknown input type: " + filter);
+        }
+
+        if (ps == null) {
+            if (expectedPNs.length != 0) {
+                throw new RuntimeException("Fail: expected provider(s) " +
+                        "not found");
+            }
+        } else {
+            if (ps.length == expectedPNs.length) {
+                // check the provider names
+                for (int i = 0; i < ps.length; i++) {
+                    if (!ps[i].getName().equals(expectedPNs[i])) {
+                        throw new RuntimeException("Fail: provider name " +
+                                "mismatch at index " + i + ", got " +
+                                ps[i].getName());
+                    }
+                }
+            } else {
+                throw new RuntimeException("Fail: # of providers mismatch");
+            }
+        }
+        System.out.println("=> Passed");
+    }
+
+
+    public static void main(String[] args)
+                throws NoSuchAlgorithmException {
+        String p = "SUN";
+        String key = "Signature.SHA1withDSA SupportedKeyClasses";
+        String valComp1 = "java.security.interfaces.DSAPublicKey";
+        String valComp2 = "java.security.interfaces.DSAPrivateKey";
+        String valComp2CN = valComp2.substring(valComp2.lastIndexOf('.') + 1);
+
+        // test using String filter
+        // 1. exact match
+        doit(key + ":" + valComp1 + "|" + valComp2, p);
+        // 2. value w/ space prefix
+        doit(key + ": " + valComp1, p);
+        // 3. value w/ space suffix
+        doit(key + ":" + valComp2 + " ", p);
+        // 4. partial value, e.g. class name only
+        doit(key + ":" + valComp2CN, p);
+        // 5. different values ordering
+        doit(key + ":" + valComp2 + "|" + valComp1, p);
+
+        // repeat above tests using filter Map
+        Map<String,String> filters = new HashMap<>();
+        filters.put(key, valComp1 + "|" + valComp2);
+        doit(filters, p);
+        filters.put(key, " " + valComp1);
+        doit(filters, p);
+        filters.put(key, valComp2 + " ");
+        doit(filters, p);
+        filters.put(key, valComp2CN);
+        doit(filters, p);
+        filters.put(key, valComp2 + " | " + valComp1);
+        doit(filters, p);
+
+        // add more filters to the map
+        filters.put("Signature.SHA256withDSA", "");
+        doit(filters, p);
+        filters.put("Cipher.Nonexisting", "");
+        doit(filters);
+
+        // test against a custom provider and attribute
+        filters.clear();
+        String service = "Signature.SHA1withRSA";
+        String customKey = "customAttr";
+        String customValue = "customValue";
+        String pName = "TestProv";
+        Provider testProv = new TestProvider(pName, service, customKey,
+                customValue);
+        Security.insertProviderAt(testProv, 1);
+        // should find both TestProv and SunRsaSign and in this order
+        doit(service, pName, "SunRsaSign");
+        filters.put(service, "");
+        doit(filters, pName, "SunRsaSign");
+
+        String specAttr = service + " " + customKey + ":" + customValue;
+        // should find only TestProv
+        doit(specAttr, pName);
+        filters.put(service + " " + customKey, " " + customValue + " ");
+        doit(filters, pName);
+
+        // should find no proviser now that TestProv is removed
+        Security.removeProvider(pName);
+        doit(specAttr);
+        doit(filters);
+    }
+
+    private static class TestProvider extends Provider {
+        TestProvider(String name, String service, String attrKey,
+                String attrValue) {
+            super(name, "0.0", "Not for use in production systems!");
+            put(service, "a.b.c");
+            put(service + " " + attrKey, attrValue);
+        }
+    }
+}

--- a/test/jdk/java/security/Security/ProviderFiltering.java
+++ b/test/jdk/java/security/Security/ProviderFiltering.java
@@ -73,7 +73,7 @@ public class ProviderFiltering {
     public static void main(String[] args)
                 throws NoSuchAlgorithmException {
         String p = "SUN";
-        String key = "Signature.SHA1withDSA SupportedKeyClasses";
+        String key = "Signature.SHA256withDSA SupportedKeyClasses";
         String valComp1 = "java.security.interfaces.DSAPublicKey";
         String valComp2 = "java.security.interfaces.DSAPrivateKey";
         String valComp2CN = valComp2.substring(valComp2.lastIndexOf('.') + 1);
@@ -111,17 +111,17 @@ public class ProviderFiltering {
 
         // test against a custom provider and attribute
         filters.clear();
-        String service = "Signature.SHA1withRSA";
+        String service = "Signature.SHA256withDSA";
         String customKey = "customAttr";
         String customValue = "customValue";
         String pName = "TestProv";
         Provider testProv = new TestProvider(pName, service, customKey,
                 customValue);
         Security.insertProviderAt(testProv, 1);
-        // should find both TestProv and SunRsaSign and in this order
-        doit(service, pName, "SunRsaSign");
+        // should find both TestProv and SUN and in this order
+        doit(service, pName, "SUN");
         filters.put(service, "");
-        doit(filters, pName, "SunRsaSign");
+        doit(filters, pName, "SUN");
 
         String specAttr = service + " " + customKey + ":" + customValue;
         // should find only TestProv


### PR DESCRIPTION
Existing provider filtering code only handles two standard attribute "KeySize" and "ImplementedIn", the rest are compared by exact match. Over time, more standard attributes are added which contain multiple values separated by "|". We should enhance the provider filtering code to better compare these.

Documentation update for this is tracked separately under https://bugs.openjdk.org/browse/JDK-6447817.

Thanks in advance for review~

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6447816](https://bugs.openjdk.org/browse/JDK-6447816): Provider filtering (getProviders) is not working with OR'd conditions


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10008/head:pull/10008` \
`$ git checkout pull/10008`

Update a local copy of the PR: \
`$ git checkout pull/10008` \
`$ git pull https://git.openjdk.org/jdk pull/10008/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10008`

View PR using the GUI difftool: \
`$ git pr show -t 10008`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10008.diff">https://git.openjdk.org/jdk/pull/10008.diff</a>

</details>
