### PR TITLE
8292587: AArch64: Support SVE fabd instruction

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_vector.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_vector.ad
@@ -1655,14 +1655,45 @@ instruct vabsD_masked(vReg dst_src, pRegGov pg) %{
 
 // vector fabs diff
 
-instruct vfabd(vReg dst, vReg src1, vReg src2) %{
-  predicate(Matcher::vector_length_in_bytes(n) <= 16);
+instruct vfabd_neon(vReg dst, vReg src1, vReg src2) %{
+  predicate(VM_Version::use_neon_for_vector(Matcher::vector_length_in_bytes(n)) &&
+            !n->as_Vector()->is_predicated_vector());
   match(Set dst (AbsVF (SubVF src1 src2)));
   match(Set dst (AbsVD (SubVD src1 src2)));
-  format %{ "vfabd $dst, $src1, $src2\t# vector <= 128 bits" %}
+  format %{ "vfabd_neon $dst, $src1, $src2" %}
   ins_encode %{
     __ fabd($dst$$FloatRegister, get_arrangement(this),
             $src1$$FloatRegister, $src2$$FloatRegister);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vfabd_sve(vReg dst_src1, vReg src2) %{
+  predicate(!VM_Version::use_neon_for_vector(Matcher::vector_length_in_bytes(n)) &&
+            !n->as_Vector()->is_predicated_vector());
+  match(Set dst_src1 (AbsVF (SubVF dst_src1 src2)));
+  match(Set dst_src1 (AbsVD (SubVD dst_src1 src2)));
+  format %{ "vfabd_sve $dst_src1, $dst_src1, $src2" %}
+  ins_encode %{
+    assert(UseSVE > 0, "must be sve");
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ sve_fabd($dst_src1$$FloatRegister, __ elemType_to_regVariant(bt),
+                ptrue, $src2$$FloatRegister);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// vector fabs diff - predicated
+
+instruct vfabd_masked(vReg dst_src1, vReg src2, pRegGov pg) %{
+  predicate(UseSVE > 0);
+  match(Set dst_src1 (AbsVF (SubVF (Binary dst_src1 src2) pg) pg));
+  match(Set dst_src1 (AbsVD (SubVD (Binary dst_src1 src2) pg) pg));
+  format %{ "vfabd_masked $dst_src1, $pg, $dst_src1, $src2" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ sve_fabd($dst_src1$$FloatRegister, __ elemType_to_regVariant(bt),
+                $pg$$PRegister, $src2$$FloatRegister);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -3155,6 +3155,7 @@ public:
     sve_predicate_reg_insn(op1, op2, Zd_or_Zdn_or_Vd, T, Pg, Zn_or_Zm);                               \
   }
 
+  INSN(sve_fabd,   0b01100101, 0b001000100); // floating-point absolute difference
   INSN(sve_fabs,   0b00000100, 0b011100101);
   INSN(sve_fadd,   0b01100101, 0b000000100);
   INSN(sve_fadda,  0b01100101, 0b011000001); // add strictly-ordered reduction to scalar Vd

--- a/test/hotspot/gtest/aarch64/aarch64-asmtest.py
+++ b/test/hotspot/gtest/aarch64/aarch64-asmtest.py
@@ -1918,6 +1918,7 @@ generate(SVEVectorOp, [["add", "ZZZ"],
                        ["bic", "ZZZ"],
                        ["uzp1", "ZZZ"],
                        ["uzp2", "ZZZ"],
+                       ["fabd", "ZPZ", "m", "dn"],
                        # SVE2 instructions
                        ["bext", "ZZZ"],
                        ["bdep", "ZZZ"],

--- a/test/hotspot/gtest/aarch64/asmtest.out.h
+++ b/test/hotspot/gtest/aarch64/asmtest.out.h
@@ -1207,19 +1207,20 @@
     __ sve_bic(z1, z10, z19);                          //       bic     z1.d, z10.d, z19.d
     __ sve_uzp1(z19, __ H, z23, z23);                  //       uzp1    z19.h, z23.h, z23.h
     __ sve_uzp2(z30, __ S, z17, z19);                  //       uzp2    z30.s, z17.s, z19.s
-    __ sve_bext(z20, __ H, z4, z20);                   //       bext    z20.h, z4.h, z20.h
-    __ sve_bdep(z30, __ D, z22, z30);                  //       bdep    z30.d, z22.d, z30.d
+    __ sve_fabd(z20, __ S, p1, z20);                   //       fabd    z20.s, p1/m, z20.s, z20.s
+    __ sve_bext(z30, __ D, z22, z30);                  //       bext    z30.d, z22.d, z30.d
+    __ sve_bdep(z25, __ H, z17, z17);                  //       bdep    z25.h, z17.h, z17.h
 
 // SVEReductionOp
-    __ sve_andv(v25, __ H, p4, z17);                   //       andv h25, p4, z17.h
-    __ sve_orv(v11, __ S, p3, z28);                    //       orv s11, p3, z28.s
-    __ sve_eorv(v5, __ H, p0, z13);                    //       eorv h5, p0, z13.h
-    __ sve_smaxv(v2, __ H, p1, z10);                   //       smaxv h2, p1, z10.h
-    __ sve_sminv(v19, __ H, p1, z25);                  //       sminv h19, p1, z25.h
-    __ sve_fminv(v2, __ S, p0, z29);                   //       fminv s2, p0, z29.s
-    __ sve_fmaxv(v20, __ D, p1, z20);                  //       fmaxv d20, p1, z20.d
-    __ sve_fadda(v28, __ S, p3, z13);                  //       fadda s28, p3, s28, z13.s
-    __ sve_uaddv(v13, __ H, p7, z1);                   //       uaddv d13, p7, z1.h
+    __ sve_andv(v11, __ S, p3, z28);                   //       andv s11, p3, z28.s
+    __ sve_orv(v5, __ H, p0, z13);                     //       orv h5, p0, z13.h
+    __ sve_eorv(v2, __ H, p1, z10);                    //       eorv h2, p1, z10.h
+    __ sve_smaxv(v19, __ H, p1, z25);                  //       smaxv h19, p1, z25.h
+    __ sve_sminv(v2, __ B, p0, z29);                   //       sminv b2, p0, z29.b
+    __ sve_fminv(v20, __ D, p1, z20);                  //       fminv d20, p1, z20.d
+    __ sve_fmaxv(v28, __ S, p3, z13);                  //       fmaxv s28, p3, z13.s
+    __ sve_fadda(v13, __ S, p7, z1);                   //       fadda s13, p7, s13, z1.s
+    __ sve_uaddv(v27, __ D, p0, z3);                   //       uaddv d27, p0, z3.d
 
     __ bind(forth);
 
@@ -1238,30 +1239,30 @@
     0x9101a1a0,     0xb10a5cc8,     0xd10810aa,     0xf10fd061,
     0x120cb166,     0x321764bc,     0x52174681,     0x720c0227,
     0x9241018e,     0xb25a2969,     0xd278b411,     0xf26aad01,
-    0x14000000,     0x17ffffd7,     0x140003fe,     0x94000000,
-    0x97ffffd4,     0x940003fb,     0x3400000a,     0x34fffa2a,
-    0x34007f0a,     0x35000008,     0x35fff9c8,     0x35007ea8,
-    0xb400000b,     0xb4fff96b,     0xb4007e4b,     0xb500001d,
-    0xb5fff91d,     0xb5007dfd,     0x10000013,     0x10fff8b3,
-    0x10007d93,     0x90000013,     0x36300016,     0x3637f836,
-    0x36307d16,     0x3758000c,     0x375ff7cc,     0x37587cac,
+    0x14000000,     0x17ffffd7,     0x140003ff,     0x94000000,
+    0x97ffffd4,     0x940003fc,     0x3400000a,     0x34fffa2a,
+    0x34007f2a,     0x35000008,     0x35fff9c8,     0x35007ec8,
+    0xb400000b,     0xb4fff96b,     0xb4007e6b,     0xb500001d,
+    0xb5fff91d,     0xb5007e1d,     0x10000013,     0x10fff8b3,
+    0x10007db3,     0x90000013,     0x36300016,     0x3637f836,
+    0x36307d36,     0x3758000c,     0x375ff7cc,     0x37587ccc,
     0x128313a0,     0x528a32c7,     0x7289173b,     0x92ab3acc,
     0xd2a0bf94,     0xf2c285e8,     0x9358722f,     0x330e652f,
     0x53067f3b,     0x93577c53,     0xb34a1aac,     0xd35a4016,
     0x13946c63,     0x93c3dbc8,     0x54000000,     0x54fff5a0,
-    0x54007a80,     0x54000001,     0x54fff541,     0x54007a21,
-    0x54000002,     0x54fff4e2,     0x540079c2,     0x54000002,
-    0x54fff482,     0x54007962,     0x54000003,     0x54fff423,
-    0x54007903,     0x54000003,     0x54fff3c3,     0x540078a3,
-    0x54000004,     0x54fff364,     0x54007844,     0x54000005,
-    0x54fff305,     0x540077e5,     0x54000006,     0x54fff2a6,
-    0x54007786,     0x54000007,     0x54fff247,     0x54007727,
-    0x54000008,     0x54fff1e8,     0x540076c8,     0x54000009,
-    0x54fff189,     0x54007669,     0x5400000a,     0x54fff12a,
-    0x5400760a,     0x5400000b,     0x54fff0cb,     0x540075ab,
-    0x5400000c,     0x54fff06c,     0x5400754c,     0x5400000d,
-    0x54fff00d,     0x540074ed,     0x5400000e,     0x54ffefae,
-    0x5400748e,     0x5400000f,     0x54ffef4f,     0x5400742f,
+    0x54007aa0,     0x54000001,     0x54fff541,     0x54007a41,
+    0x54000002,     0x54fff4e2,     0x540079e2,     0x54000002,
+    0x54fff482,     0x54007982,     0x54000003,     0x54fff423,
+    0x54007923,     0x54000003,     0x54fff3c3,     0x540078c3,
+    0x54000004,     0x54fff364,     0x54007864,     0x54000005,
+    0x54fff305,     0x54007805,     0x54000006,     0x54fff2a6,
+    0x540077a6,     0x54000007,     0x54fff247,     0x54007747,
+    0x54000008,     0x54fff1e8,     0x540076e8,     0x54000009,
+    0x54fff189,     0x54007689,     0x5400000a,     0x54fff12a,
+    0x5400762a,     0x5400000b,     0x54fff0cb,     0x540075cb,
+    0x5400000c,     0x54fff06c,     0x5400756c,     0x5400000d,
+    0x54fff00d,     0x5400750d,     0x5400000e,     0x54ffefae,
+    0x540074ae,     0x5400000f,     0x54ffef4f,     0x5400744f,
     0xd40658e1,     0xd4014d22,     0xd4046543,     0xd4273f60,
     0xd44cad80,     0xd503201f,     0xd503203f,     0xd503205f,
     0xd503209f,     0xd50320bf,     0xd503219f,     0xd50323bf,
@@ -1491,9 +1492,9 @@
     0x65aabf65,     0x65b4daae,     0x65e5f723,     0x65a1523d,
     0x65e07dae,     0x04965e82,     0x04026d1d,     0x043632ee,
     0x04ba3333,     0x047532ac,     0x04f33141,     0x05776af3,
-    0x05b36e3e,     0x4554b094,     0x45deb6de,     0x045a3239,
-    0x04982f8b,     0x045921a5,     0x04482542,     0x044a2733,
-    0x658723a2,     0x65c62694,     0x65982dbc,     0x04413c2d,
-
+    0x05b36e3e,     0x65888694,     0x45deb2de,     0x4551b639,
+    0x049a2f8b,     0x045821a5,     0x04592542,     0x04482733,
+    0x040a23a2,     0x65c72694,     0x65862dbc,     0x65983c2d,
+    0x04c1207b,
   };
 // END  Generated code -- do not edit

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorAbsDiffTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorAbsDiffTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import compiler.lib.ir_framework.*;
+
+import java.util.Random;
+
+import jdk.incubator.vector.DoubleVector;
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+
+/**
+ * @test
+ * @bug 8292587
+ * @key randomness
+ * @library /test/lib /
+ * @requires os.arch=="aarch64"
+ * @summary AArch64: Support SVE fabd instruction
+ * @modules jdk.incubator.vector
+ *
+ * @run driver compiler.vectorapi.VectorAbsDiffTest
+ */
+
+public class VectorAbsDiffTest {
+    private static final VectorSpecies<Double> D_SPECIES = DoubleVector.SPECIES_MAX;
+    private static final VectorSpecies<Float> F_SPECIES = FloatVector.SPECIES_MAX;
+
+    private static int LENGTH = 1024;
+    private static final Random RD = Utils.getRandomInstance();
+
+    private static float[] fa;
+    private static float[] fb;
+    private static float[] fr;
+    private static double[] da;
+    private static double[] db;
+    private static double[] dr;
+    private static boolean[] m;
+
+    static {
+        fa = new float[LENGTH];
+        fb = new float[LENGTH];
+        fr = new float[LENGTH];
+        da = new double[LENGTH];
+        db = new double[LENGTH];
+        dr = new double[LENGTH];
+        m = new boolean[LENGTH];
+
+        for (int i = 0; i < LENGTH; i++) {
+            fa[i] = RD.nextFloat((float) 25.0);
+            fb[i] = RD.nextFloat((float) 25.0);
+            da[i] = RD.nextDouble(25.0);
+            db[i] = RD.nextDouble(25.0);
+            m[i] = RD.nextBoolean();
+        }
+    }
+
+    @Test
+    @IR(counts = {"vfabd", "> 0"})
+    public static void testFloatAbsDiff() {
+        for (int i = 0; i < LENGTH; i += F_SPECIES.length()) {
+            FloatVector av = FloatVector.fromArray(F_SPECIES, fa, i);
+            FloatVector bv = FloatVector.fromArray(F_SPECIES, fb, i);
+            av.sub(bv).lanewise(VectorOperators.ABS).intoArray(fr, i);
+        }
+    }
+
+    @Run(test = "testFloatAbsDiff")
+    public static void testFloatAbsDiff_runner() {
+        testFloatAbsDiff();
+        for (int i = 0; i < F_SPECIES.length(); i++) {
+            Asserts.assertEquals(Math.abs(fa[i] - fb[i]), fr[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = {"vfabd_masked", "> 0"}, applyIf = {"UseSVE", "> 0"})
+    public static void testFloatAbsDiffMasked() {
+        VectorMask<Float> mask = VectorMask.fromArray(F_SPECIES, m, 0);
+        for (int i = 0; i < LENGTH; i += F_SPECIES.length()) {
+            FloatVector av = FloatVector.fromArray(F_SPECIES, fa, i);
+            FloatVector bv = FloatVector.fromArray(F_SPECIES, fb, i);
+            av.lanewise(VectorOperators.SUB, bv, mask).lanewise(VectorOperators.ABS, mask).intoArray(fr, i);
+        }
+    }
+
+    @Run(test = "testFloatAbsDiffMasked")
+    public static void testFloatAbsDiffMasked_runner() {
+        testFloatAbsDiffMasked();
+        for (int i = 0; i < F_SPECIES.length(); i++) {
+            if (m[i]) {
+                Asserts.assertEquals(Math.abs(fa[i] - fb[i]), fr[i]);
+            } else {
+                Asserts.assertEquals(fa[i], fr[i]);
+            }
+        }
+    }
+
+    @Test
+    @IR(counts = {"vfabd", "> 0"})
+    public static void testDoubleAbsDiff() {
+        for (int i = 0; i < LENGTH; i += D_SPECIES.length()) {
+            DoubleVector av = DoubleVector.fromArray(D_SPECIES, da, i);
+            DoubleVector bv = DoubleVector.fromArray(D_SPECIES, db, i);
+            av.sub(bv).lanewise(VectorOperators.ABS).intoArray(dr, i);
+        }
+    }
+
+    @Run(test = "testDoubleAbsDiff")
+    public static void testDoubleAbsDiff_runner() {
+        testDoubleAbsDiff();
+        for (int i = 0; i < D_SPECIES.length(); i++) {
+            Asserts.assertEquals(Math.abs(da[i] - db[i]), dr[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = {"vfabd_masked", "> 0"}, applyIf = {"UseSVE", "> 0"})
+    public static void testDoubleAbsDiffMasked() {
+        VectorMask<Double> mask = VectorMask.fromArray(D_SPECIES, m, 0);
+        for (int i = 0; i < LENGTH; i += D_SPECIES.length()) {
+            DoubleVector av = DoubleVector.fromArray(D_SPECIES, da, i);
+            DoubleVector bv = DoubleVector.fromArray(D_SPECIES, db, i);
+            av.lanewise(VectorOperators.SUB, bv, mask).lanewise(VectorOperators.ABS, mask).intoArray(dr, i);
+        }
+    }
+
+    @Run(test = "testDoubleAbsDiffMasked")
+    public static void testDoubleAbsDiffMasked_runner() {
+        testDoubleAbsDiffMasked();
+        for (int i = 0; i < D_SPECIES.length(); i++) {
+            if (m[i]) {
+                Asserts.assertEquals(Math.abs(da[i] - db[i]), dr[i]);
+            } else {
+                Asserts.assertEquals(da[i], dr[i]);
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("--add-modules=jdk.incubator.vector");
+    }
+}

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorAbsDiffTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorAbsDiffTest.java
@@ -94,7 +94,7 @@ public class VectorAbsDiffTest {
     @Run(test = "testFloatAbsDiff")
     public static void testFloatAbsDiff_runner() {
         testFloatAbsDiff();
-        for (int i = 0; i < F_SPECIES.length(); i++) {
+        for (int i = 0; i < LENGTH; i++) {
             Asserts.assertEquals(Math.abs(fa[i] - fb[i]), fr[i]);
         }
     }
@@ -102,10 +102,10 @@ public class VectorAbsDiffTest {
     @Test
     @IR(counts = {"vfabd_masked", "> 0"}, applyIf = {"UseSVE", "> 0"})
     public static void testFloatAbsDiffMasked() {
-        VectorMask<Float> mask = VectorMask.fromArray(F_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += F_SPECIES.length()) {
             FloatVector av = FloatVector.fromArray(F_SPECIES, fa, i);
             FloatVector bv = FloatVector.fromArray(F_SPECIES, fb, i);
+            VectorMask<Float> mask = VectorMask.fromArray(F_SPECIES, m, i);
             av.lanewise(VectorOperators.SUB, bv, mask).lanewise(VectorOperators.ABS, mask).intoArray(fr, i);
         }
     }
@@ -113,7 +113,7 @@ public class VectorAbsDiffTest {
     @Run(test = "testFloatAbsDiffMasked")
     public static void testFloatAbsDiffMasked_runner() {
         testFloatAbsDiffMasked();
-        for (int i = 0; i < F_SPECIES.length(); i++) {
+        for (int i = 0; i < LENGTH; i++) {
             if (m[i]) {
                 Asserts.assertEquals(Math.abs(fa[i] - fb[i]), fr[i]);
             } else {
@@ -135,7 +135,7 @@ public class VectorAbsDiffTest {
     @Run(test = "testDoubleAbsDiff")
     public static void testDoubleAbsDiff_runner() {
         testDoubleAbsDiff();
-        for (int i = 0; i < D_SPECIES.length(); i++) {
+        for (int i = 0; i < LENGTH; i++) {
             Asserts.assertEquals(Math.abs(da[i] - db[i]), dr[i]);
         }
     }
@@ -143,10 +143,10 @@ public class VectorAbsDiffTest {
     @Test
     @IR(counts = {"vfabd_masked", "> 0"}, applyIf = {"UseSVE", "> 0"})
     public static void testDoubleAbsDiffMasked() {
-        VectorMask<Double> mask = VectorMask.fromArray(D_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += D_SPECIES.length()) {
             DoubleVector av = DoubleVector.fromArray(D_SPECIES, da, i);
             DoubleVector bv = DoubleVector.fromArray(D_SPECIES, db, i);
+            VectorMask<Double> mask = VectorMask.fromArray(D_SPECIES, m, i);
             av.lanewise(VectorOperators.SUB, bv, mask).lanewise(VectorOperators.ABS, mask).intoArray(dr, i);
         }
     }
@@ -154,7 +154,7 @@ public class VectorAbsDiffTest {
     @Run(test = "testDoubleAbsDiffMasked")
     public static void testDoubleAbsDiffMasked_runner() {
         testDoubleAbsDiffMasked();
-        for (int i = 0; i < D_SPECIES.length(); i++) {
+        for (int i = 0; i < LENGTH; i++) {
             if (m[i]) {
                 Asserts.assertEquals(Math.abs(da[i] - db[i]), dr[i]);
             } else {

--- a/test/micro/org/openjdk/bench/vm/compiler/FloatingScalarVectorAbsDiff.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/FloatingScalarVectorAbsDiff.java
@@ -68,14 +68,14 @@ public class FloatingScalarVectorAbsDiff {
     @Benchmark
     public void testVectorAbsDiffFloat() {
         for (int i = 0; i < count; i++) {
-            floatsD[i] = Math.abs(floatsA[i] - floatsB[i]);
+            floatsD[i] = Math.abs(Math.abs(floatsA[i] - floatsB[i]) - 3.14f);
         }
     }
 
     @Benchmark
     public void testVectorAbsDiffDouble() {
         for (int i = 0; i < count; i++) {
-            doublesD[i] = Math.abs(doublesA[i] - doublesB[i]);
+            doublesD[i] = Math.abs(Math.abs(doublesA[i] - doublesB[i]) - 3.14d);
         }
     }
 


### PR DESCRIPTION
Scalar and NEON fabd instructions were initially supported in
JDK-8256318. In this patch, we support SVE fabd instruction [1] and add
one Jtreg test case as well.

With this patch, two instructions `fsub + fabs` would be combined into
one single `fabd` instruction.

```
  fsub    z16.s, z16.s, z17.s
  fabs    z16.s, p7/m, z16.s

  -->

  fabd    z16.s, p7/m, z16.s, z17.s
```

In the initial evaluation of JMH case, i.e.
FloatingScalarVectorAbsDiff.java, we found the performance uplift done
by this optimization was easily hidden by the heavy memory load/store
instructions. To avoid that, we updated the JMH case a bit, adding one
more group of subtraction and Math.abs operations in the loop body.

Here shows the data with the new JMH case on one 256-bit SVE machine. We
can observe about 39% and 35% improvements for the two functions
respectively.

```
Benchmark                                             Before    After  Units
FloatingScalarVectorAbsDiff.testVectorAbsDiffDouble  260.468  160.965  ns/op
FloatingScalarVectorAbsDiff.testVectorAbsDiffFloat   133.963   87.292  ns/op
```

Jtreg testing: tier1~3 passed on one NEON-only machine and one 256-bit SVE machine.

[1] https://developer.arm.com/documentation/ddi0596/2021-12/SVE-Instructions/FABD--Floating-point-absolute-difference--predicated--

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292587](https://bugs.openjdk.org/browse/JDK-8292587): AArch64: Support SVE fabd instruction


### Reviewers
 * [Ningsheng Jian](https://openjdk.org/census#njian) (@nsjian - Committer) ⚠️ Review applies to [c6157252](https://git.openjdk.org/jdk/pull/10011/files/c6157252148f4e17863b713c1d7c9e05a4c5af6c)
 * [Fei Gao](https://openjdk.org/census#fgao) (@fg1417 - Author)
 * [Nick Gasson](https://openjdk.org/census#ngasson) (@nick-arm - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10011/head:pull/10011` \
`$ git checkout pull/10011`

Update a local copy of the PR: \
`$ git checkout pull/10011` \
`$ git pull https://git.openjdk.org/jdk pull/10011/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10011`

View PR using the GUI difftool: \
`$ git pr show -t 10011`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10011.diff">https://git.openjdk.org/jdk/pull/10011.diff</a>

</details>
