### PR TITLE
JDK-8292866: Java_sun_awt_shell_Win32ShellFolder2_getLinkLocation check MultiByteToWideChar return value for failures

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -700,6 +700,7 @@ JNIEXPORT jlong JNICALL Java_sun_awt_shell_Win32ShellFolder2_getLinkLocation
     STRRET strret;
     OLECHAR olePath[MAX_PATH]; // wide-char version of path name
     LPWSTR wstr;
+    int ret;
 
     IShellFolder* pParent = (IShellFolder*)parentIShellFolder;
     if (pParent == NULL) {
@@ -719,12 +720,14 @@ JNIEXPORT jlong JNICALL Java_sun_awt_shell_Win32ShellFolder2_getLinkLocation
     switch (strret.uType) {
       case STRRET_CSTR :
         // IShellFolder::ParseDisplayName requires the path name in Unicode.
-        MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, strret.cStr, -1, olePath, MAX_PATH);
+        ret = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, strret.cStr, -1, olePath, MAX_PATH);
+        if (ret == 0) return 0;
         wstr = olePath;
         break;
 
       case STRRET_OFFSET :
-        MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, (CHAR *)pidl + strret.uOffset, -1, olePath, MAX_PATH);
+        ret = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, (CHAR *)pidl + strret.uOffset, -1, olePath, MAX_PATH);
+        if (ret == 0) return 0;
         wstr = olePath;
         break;
 

--- a/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp
@@ -721,13 +721,17 @@ JNIEXPORT jlong JNICALL Java_sun_awt_shell_Win32ShellFolder2_getLinkLocation
       case STRRET_CSTR :
         // IShellFolder::ParseDisplayName requires the path name in Unicode.
         ret = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, strret.cStr, -1, olePath, MAX_PATH);
-        if (ret == 0) return 0;
+        if (ret == 0) {
+            return NULL;
+        }
         wstr = olePath;
         break;
 
       case STRRET_OFFSET :
         ret = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, (CHAR *)pidl + strret.uOffset, -1, olePath, MAX_PATH);
-        if (ret == 0) return 0;
+        if (ret == 0) {
+            return NULL;
+        }
         wstr = olePath;
         break;
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar
states about MultiByteToWideChar : "The function returns 0 if it does not succeed" and lists a few failure cases.
However we miss checking the failure case in Java_sun_awt_shell_Win32ShellFolder2_getLinkLocation , seems we assume the function always works nicely (in most of the JDK coding the return value is checked ).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292866](https://bugs.openjdk.org/browse/JDK-8292866): Java_sun_awt_shell_Win32ShellFolder2_getLinkLocation check MultiByteToWideChar return value for failures


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10015/head:pull/10015` \
`$ git checkout pull/10015`

Update a local copy of the PR: \
`$ git checkout pull/10015` \
`$ git pull https://git.openjdk.org/jdk pull/10015/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10015`

View PR using the GUI difftool: \
`$ git pr show -t 10015`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10015.diff">https://git.openjdk.org/jdk/pull/10015.diff</a>

</details>
