### PR TITLE
JDK-8292903: enhance round_up_power_of_2 assertion output

### DIFF
--- a/src/hotspot/share/utilities/powerOfTwo.hpp
+++ b/src/hotspot/share/utilities/powerOfTwo.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,7 +103,8 @@ inline T round_down_power_of_2(T value) {
 template<typename T, ENABLE_IF(std::is_integral<T>::value)>
 inline T round_up_power_of_2(T value) {
   assert(value > 0, "Invalid value");
-  assert(value <= max_power_of_2<T>(), "Overflow");
+  assert(value <= max_power_of_2<T>(), "Overflowing maximum allowed power of two with " UINT64_FORMAT_X,
+         static_cast<uint64_t>(value));
   if (is_power_of_2(value)) {
     return value;
   }


### PR DESCRIPTION
There is an assertion in round_up_power_of_2 for value <= max_power_of_2 of the type; would be nice to show the value of the problematic argument in case of failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292903](https://bugs.openjdk.org/browse/JDK-8292903): enhance round_up_power_of_2 assertion output


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10016/head:pull/10016` \
`$ git checkout pull/10016`

Update a local copy of the PR: \
`$ git checkout pull/10016` \
`$ git pull https://git.openjdk.org/jdk pull/10016/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10016`

View PR using the GUI difftool: \
`$ git pr show -t 10016`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10016.diff">https://git.openjdk.org/jdk/pull/10016.diff</a>

</details>
