### PR TITLE
8292916: Streamline LoaderConstraint purging

### DIFF
--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -103,13 +103,7 @@ class ConstraintSet {                               // copied into hashtable as 
     _constraints->push(new_constraint);
   }
 
-  void remove_constraint(Symbol* name, LoaderConstraint* constraint) {
-    LogTarget(Info, class, loader, constraints) lt;
-    if (lt.is_enabled()) {
-      ResourceMark rm;
-      lt.print("purging complete constraint for name %s",
-               name->as_C_string());
-    }
+  void remove_constraint(LoaderConstraint* constraint) {
     _constraints->remove(constraint);
     delete constraint;
   }
@@ -206,7 +200,13 @@ class PurgeUnloadedConstraints : public StackObj {
                           probe->loader_data(i)->loader_name_and_id());
           }
         }
-        set.remove_constraint(name, probe);
+        LogTarget(Info, class, loader, constraints) lt;
+        if (lt.is_enabled()) {
+          ResourceMark rm;
+          lt.print("purging complete constraint for name %s",
+                   name->as_C_string());
+        }
+        set.remove_constraint(probe);
       } else {
         // The class is alive or null but some of of the loaders may not be.
         // Remove entries no longer alive from loader array
@@ -233,7 +233,13 @@ class PurgeUnloadedConstraints : public StackObj {
         // Check whether the set should be purged
         // Only one loader doesn't enforce a constraint.
         if (probe->num_loaders() < 2) {
-          set.remove_constraint(name, probe);
+          LogTarget(Info, class, loader, constraints) lt;
+          if (lt.is_enabled()) {
+            ResourceMark rm;
+            lt.print("purging complete constraint for name %s",
+                     name->as_C_string());
+          }
+          set.remove_constraint(probe);
         }
       }
     }
@@ -448,7 +454,7 @@ void LoaderConstraintTable::merge_loader_constraints(Symbol* class_name,
 
   // Remove src from set
   ConstraintSet* set = _loader_constraint_table.get(class_name);
-  set->remove_constraint(class_name, src);
+  set->remove_constraint(src);
 }
 
 void LoaderConstraintTable::verify() {


### PR DESCRIPTION
The code to purge loader constraints walks through the class loader list of an unloaded class, and then asserts that the there are no leftovers. It can just directly remove the list of loaders without that walk.

Also I left the variable name 'probe' to help with diffs for [JDK-8291969](https://bugs.openjdk.org/browse/JDK-8291969) a little, but it's a bad variable name.

Tested with tier1-3 which contains jck tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292916](https://bugs.openjdk.org/browse/JDK-8292916): Streamline LoaderConstraint purging


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10023/head:pull/10023` \
`$ git checkout pull/10023`

Update a local copy of the PR: \
`$ git checkout pull/10023` \
`$ git pull https://git.openjdk.org/jdk pull/10023/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10023`

View PR using the GUI difftool: \
`$ git pr show -t 10023`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10023.diff">https://git.openjdk.org/jdk/pull/10023.diff</a>

</details>
