### PR TITLE
8292914: Introduce a system property that enables stable names for lambda proxy classes

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -51,6 +51,9 @@ import static java.lang.invoke.MethodHandles.Lookup.ClassOption.STRONG;
 import static java.lang.invoke.MethodType.methodType;
 import static jdk.internal.org.objectweb.asm.Opcodes.*;
 
+import java.nio.charset.StandardCharsets;
+import java.util.zip.CRC32;
+
 /**
  * Lambda metafactory implementation which dynamically creates an
  * inner-class-like class per lambda callsite.
@@ -95,10 +98,9 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
     private static final boolean disableEagerInitialization;
 
     private static final boolean generateStableLambdaNames;
-    private static final char paddingCharacter = '#';
 
-    // Length of a single hash contained in the stable lambda name
-    private static final int stableLambdaNameHashLength;
+    private static final int mask1 = 0b10101010;
+    private static final int mask2 = 0b01010101;
 
     // condy to load implMethod from class data
     private static final ConstantDynamic implMethodCondy;
@@ -111,10 +113,8 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
         final String disableEagerInitializationKey = "jdk.internal.lambda.disableEagerInitialization";
         disableEagerInitialization = GetBooleanAction.privilegedGetProperty(disableEagerInitializationKey);
 
-        final String generateStableLambdaNameKey = "jdk.internal.lambda.generateStableLambdaNames";
-        generateStableLambdaNames = GetBooleanAction.privilegedGetProperty(generateStableLambdaNameKey);
-
-        stableLambdaNameHashLength = hashValueString(Long.MAX_VALUE).length();
+        final String generateStableLambdaNamesKey = "jdk.internal.lambda.generateStableLambdaNames";
+        generateStableLambdaNames = GetBooleanAction.privilegedGetProperty(generateStableLambdaNamesKey);
 
         // condy to load implMethod from class data
         MethodType classDataMType = methodType(Object.class, MethodHandles.Lookup.class, String.class, Class.class);
@@ -228,74 +228,71 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
         return name.replace('.', '/') + "$$Lambda$";
     }
 
-    private static String hashValueString(long hashValue) {
-        return Long.toString(hashValue, Character.MAX_RADIX);
-    }
     /**
-     * Calculate hash value of the given String in the same manner as the
-     * java.lang.StringUTF16#hashCode does, except that hash value
-     * is long instead of int.
+     * Create a stable name for the lambda class.
+     * When the CDS archiving is enabled, lambda classes
+     * are stored in the archive using some parameters from
+     * the InnerClassLambdaMetafactory. To distinguish between
+     * two lambdas, even when CDS archiving is disabled,
+     * use a superset of those parameters to create a stable name.
      *
-     * @param name String for which method calculates hash value for
+     * Concatenate all the parameters chosen for the stable name,
+     * and hash them into 64-bit hash value.
+     * Any additional changes to this method will result in unstable
+     * hash values across different versions. Thus, every change
+     * to this method should be regarded as a backward incompatible change.
      *
-     * @return a hash value for the given String
-     * */
-    private String fixedSizeStringHash(String name) {
-        long h = 0;
-        int length = name.length();
-        for (int i = 0; i < length; i++) {
-            h = 31 * h + name.charAt(i);
-        }
-
-        StringBuilder hash = new StringBuilder(hashValueString(Math.abs(h)));
-        int hashLength = hash.length();
-
-        // As all the hashes contained in the stable lambda names should
-        // be of the same length, we pad some of them with the special
-        // character '#' which is never part of the hash value.
-        while (hashLength != stableLambdaNameHashLength) {
-            hash.append(paddingCharacter);
-            hashLength++;
-        }
-
-        return hash.toString();
-    }
-
-    /**
-     * Creating stable name for lambda class.
-     * Parameters that are used to create stable name
-     * are a superset of the parameters that are used in
-     * {@link java.lang.invoke.LambdaProxyClassArchive#addToArchive}
-     * to store lambdas.
+     * No matter what hash function we use, there is a possibility of
+     * collisions in names. We expect a relatively low number of lambdas
+     * per class. Thus, we don't expect to have collisions using the described
+     * hash function. Every tool that uses this feature should handle potential
+     * collisions on its own. There is no guarantee that names will be unique,
+     * only that they will be stable (identical in every run).
      *
      * @return a stable name for the created lambda class.
      */
     private String stableLambdaClassName(Class<?> targetClass) {
         String name = createNameFromTargetClass(targetClass);
 
-        StringBuilder hashData = new StringBuilder().append(interfaceMethodName);
-        hashData.append(getQualifiedSignature(factoryType));
-        hashData.append(getQualifiedSignature(interfaceMethodType));
-        hashData.append(implementation.internalMemberName().toString());
-        hashData.append(getQualifiedSignature(dynamicMethodType));
-        hashData.append(isSerializable ? "true" : "false");
+        StringBuilder hashData1 = new StringBuilder(), hashData2 = new StringBuilder();
+        appendData(hashData1, hashData2, interfaceMethodName);
+        appendData(hashData1, hashData2, getQualifiedSignature(factoryType));
+        appendData(hashData1, hashData2, getQualifiedSignature(interfaceMethodType));
+        appendData(hashData1, hashData2, implementation.internalMemberName().toString());
+        appendData(hashData1, hashData2, getQualifiedSignature(dynamicMethodType));
 
         for (Class<?> clazz : altInterfaces) {
-            hashData.append(clazz.getName());
+            appendData(hashData1, hashData2, clazz.getName());
         }
 
         for (MethodType method : altMethods) {
-            hashData.append(getQualifiedSignature(method));
+            appendData(hashData1, hashData2, getQualifiedSignature(method));
         }
 
-        name += fixedSizeStringHash(hashData.toString());
+        return name + hashToHexString(hashData1.toString(), hashData2.toString());
+    }
 
-        return name;
+    private void appendData(StringBuilder hashData1, StringBuilder hashData2, String data) {
+        for (int i = 0; i < data.length(); i++) {
+            hashData1.append((char)(data.charAt(i) & mask1));
+            hashData2.append((char)(data.charAt(i) & mask2));
+        }
+    }
+
+    private long hashStringToLong(String hashData) {
+        CRC32 crc32 = new CRC32();
+        crc32.update(hashData.getBytes(StandardCharsets.UTF_8));
+        return crc32.getValue();
+    }
+
+    private String hashToHexString(String hashData1, String hashData2) {
+        long hashValueData1 = hashStringToLong(hashData1);
+        long hashValueData2 = hashStringToLong(hashData2);
+        return Long.toHexString(hashValueData1 | (hashValueData2 << 32));
     }
 
     private String getQualifiedSignature(MethodType type) {
-        StringJoiner sj = new StringJoiner(",", "(",
-                ")" + type.returnType().getName());
+        StringJoiner sj = new StringJoiner(",", "(", ")" + type.returnType().getName());
         Class<?>[] ptypes = type.ptypes();
         for (int i = 0; i < ptypes.length; i++) {
             sj.add(ptypes[i].getName());

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -278,6 +278,7 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
         hashData.append(getQualifiedSignature(interfaceMethodType));
         hashData.append(implementation.internalMemberName().toString());
         hashData.append(getQualifiedSignature(dynamicMethodType));
+        hashData.append(isSerializable ? "true" : "false");
 
         for (Class<?> clazz : altInterfaces) {
             hashData.append(clazz.getName());

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -95,7 +95,7 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
     private static final boolean disableEagerInitialization;
 
     private static final boolean generateStableLambdaNames;
-    private static final char paddingCharacter = 'a';
+    private static final char paddingCharacter = '#';
 
     // Length of a single hash contained in the stable lambda name
     private static final int stableLambdaNameHashLength;
@@ -261,22 +261,6 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
         return hash.toString();
     }
 
-    private String stableLambdaNameHash(String name) {
-        StringBuilder[] hashFragments = new StringBuilder[]{new StringBuilder(), new StringBuilder()};
-        int n = name.length();
-
-        for (int i = 0; i < n; i++) {
-            hashFragments[i % hashFragments.length].append(name.charAt(i));
-        }
-
-        StringBuilder stableNameHash = new StringBuilder();
-        for (StringBuilder sb : hashFragments) {
-            stableNameHash.append(fixedSizeStringHash(sb.toString()));
-        }
-
-        return stableNameHash.toString();
-    }
-
     /**
      * Creating stable name for lambda class.
      * Parameters that are used to create stable name
@@ -303,7 +287,7 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
             hashData.append(getQualifiedSignature(method));
         }
 
-        name += stableLambdaNameHash(hashData.toString());
+        name += fixedSizeStringHash(hashData.toString());
 
         return name;
     }

--- a/test/jdk/java/lang/invoke/lambda/TestStableLambdaName.java
+++ b/test/jdk/java/lang/invoke/lambda/TestStableLambdaName.java
@@ -103,8 +103,9 @@ public class TestStableLambdaName {
 
     private static String removeHashFromLambdaName(String name) {
         String architecture = System.getProperty("sun.arch.data.model");
-        System.err.println("Architecture: " + architecture);
-        return name.substring(0, name.indexOf("/0x"));
+        String architecture2 = System.getProperty("os.arch");
+        System.err.println("Architecture: " + architecture + " " + architecture2);
+        return name.substring(0, name.indexOf("/0x0"));
     }
 
     private static void createPlainLambdas(Set<String> lambdaNames, int flags, MethodHandle[] methodHandles) throws Throwable {

--- a/test/jdk/java/lang/invoke/lambda/TestStableLambdaName.java
+++ b/test/jdk/java/lang/invoke/lambda/TestStableLambdaName.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Test if the names of the lambda classes are stable when {@code -Djdk.internal.lambda.stableLambdaName}
+ *          flag is set to true. This test directly calls java.lang.invoke.LambdaMetafactory#altMetafactory
+ *          method to create multilple lambda instances and then checks their names stability. We created a
+ *          multidimensional space of possible values for each parameter that
+ *          {@link java.lang.invoke.LambdaMetafactory#altMetafactory} takes and then search that space by combining
+ *          different values of those parameters. There is a rule we have to follow:
+ *          Alternative methods of the specific method must have the same signature with difference in parameter types
+ *          as long as the parameter of the alternative method is the superclass type of the type of corresponding parameter in
+ *          original method
+ * @run main/othervm -Djdk.internal.lambda.generateStableLambdaNames=true TestStableLambdaName
+ */
+
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.rmi.Remote;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+public class TestStableLambdaName {
+    private static final MethodHandles.Lookup lookup = MethodHandles.lookup();
+
+    /* Different types of lambda classes based on value of flags parameter in the
+     * java.lang.invoke.LambdaMetafactory#altMetafactory.
+     * java.lang.invoke.LambdaMetafactory#altMetafactory uses bitwise and with this
+     * parameter and predefined values to determine if lambda is serializable, has
+     * altMethods and altInterfaces etc.
+     */
+    private enum lambdaType {
+        NOT_SERIALIZABLE_NO_ALT_METHODS_NO_ALT_INTERFACES (0),
+        SERIALIZABLE_ONLY (1),
+        NOT_SERIALIZABLE_HAS_ALT_INTERFACES(2),
+        SERIALIZABLE_HAS_ALT_INTERFACES(3),
+        NOT_SERIALIZABLE_HAS_ALT_METHODS(4),
+        SERIALIZABLE_HAS_ALT_METHODS(5),
+        NOT_SERIALIZABLE_HAS_ALT_METHODS_HAS_ALT_INTERFACES(6),
+        SERIALIZABLE_HAS_ALT_METHODS_HAS_ALT_INTERFACES(7);
+
+        private final int index;
+        lambdaType(int i) {
+            index = i;
+        }
+    }
+
+    private static final String[] interfaceMethods = new String[]{"accept", "consume", "apply", "supply", "get", "test", "getAsBoolean"};
+    private static final Class<?>[] interfaces = new Class<?>[]{Consumer.class, Function.class, Predicate.class, Supplier.class, BooleanSupplier.class};
+    // List of method types for defined methods
+    private static final MethodType[] methodTypes = new MethodType[]{MethodType.methodType(String.class, Integer.class), MethodType.methodType(Throwable.class, AssertionError.class)};
+    private static final Class<?>[] altInterfaces = new Class<?>[]{Cloneable.class, Remote.class};
+    // Alternative methods that corresponds to method1
+    private static final MethodType[] altMethodsMethod1 = new MethodType[]{MethodType.methodType(String.class, Number.class)};
+    // Alternative methods that corresponds to method2
+    private static final MethodType[] altMethodsMethod2 = new MethodType[]{MethodType.methodType(Throwable.class, Error.class), MethodType.methodType(Throwable.class, Throwable.class)};
+
+    private static String method1(Number number) {
+        return String.valueOf(number);
+    }
+
+    private static String method1(Integer number) { return String.valueOf(number); }
+
+    private static Throwable method2(AssertionError error) {
+        return error;
+    }
+
+    private static Throwable method2(Error error) {
+        return error;
+    }
+
+    private static Throwable method2(Throwable throwable) {
+        return throwable;
+    }
+
+    private static String removeHashFromLambdaName(String name) {
+        return name.substring(0, name.indexOf("/0x0"));
+    }
+
+    private static void createPlainLambdas(Set<String> lambdaNames, int flags, MethodHandle[] methodHandles) throws Throwable {
+        for (String interfaceMethod : interfaceMethods) {
+            for (Class<?> interfaceClass : interfaces) {
+                for (int i = 0; i < methodTypes.length; i++) {
+                    Object lambda = LambdaMetafactory.altMetafactory(lookup, interfaceMethod, MethodType.methodType(interfaceClass),
+                            methodTypes[i], methodHandles[i], methodTypes[i], flags).getTarget().invoke();
+                    lambdaNames.add(removeHashFromLambdaName(lambda.getClass().getName()));
+                }
+            }
+        }
+    }
+
+    private static Object lambdaWithOneAltInterface(String interfaceMethod, Class<?> interfaceClass, MethodType methodType, MethodHandle methodHandle, int flags, Class<?> altInterface) throws Throwable {
+        int numOfAltInterfaces = 1;
+        return LambdaMetafactory.altMetafactory(lookup, interfaceMethod, MethodType.methodType(interfaceClass),
+                methodType, methodHandle, methodType, flags, numOfAltInterfaces, altInterface).getTarget().invoke();
+    }
+
+    private static Object lambdaWithMultipleAltInterfaces(String interfaceMethod, Class<?> interfaceClass,  MethodType methodType, MethodHandle methodHandle, int flags) throws Throwable {
+        int numOfAltInterfaces = 2;
+        int altInterfacesIndex = 0;
+        return LambdaMetafactory.altMetafactory(lookup, interfaceMethod, MethodType.methodType(interfaceClass),
+                methodType, methodHandle, methodType, flags, numOfAltInterfaces, altInterfaces[altInterfacesIndex++], altInterfaces[altInterfacesIndex]).getTarget().invoke();
+    }
+
+    private static void createLambdasWithAltInterfaces(Set<String> lambdaNames, int flags, MethodHandle[] methodHandles) throws Throwable {
+        Object lambda;
+        for (String interfaceMethod : interfaceMethods) {
+            for (Class<?> interfaceClass : interfaces) {
+                for (int i = 0; i < methodTypes.length; i++) {
+                    for (Class<?> altInterface : altInterfaces) {
+                        lambda = lambdaWithOneAltInterface(interfaceMethod, interfaceClass, methodTypes[i], methodHandles[i], flags, altInterface);
+                        lambdaNames.add(removeHashFromLambdaName(lambda.getClass().getName()));
+                    }
+
+                    lambda = lambdaWithMultipleAltInterfaces(interfaceMethod, interfaceClass, methodTypes[i], methodHandles[i], flags);
+                    lambdaNames.add(removeHashFromLambdaName(lambda.getClass().getName()));
+                }
+            }
+        }
+    }
+
+    private static Object lambdaWithOneAltMethod(String interfaceMethod, Class<?> interfaceClass,  MethodType methodType, MethodHandle methodHandle,
+                                                 int flags, MethodType altMethod, MethodHandle[] methodHandles) throws Throwable {
+        int numOfAltMethods = 1;
+        return LambdaMetafactory.altMetafactory(lookup, interfaceMethod, MethodType.methodType(interfaceClass),
+                methodType, methodHandle, methodType, flags, numOfAltMethods, altMethod).getTarget().invoke();
+    }
+
+    private static Object lambdaWithMultipleAltMethods(String interfaceMethod, Class<?> interfaceClass, int flags, MethodHandle[] methodHandles) throws Throwable {
+        int numOfAltMethods = 2;
+        int indexOfAltMethod = 0;
+        MethodType methodTypeMethod2 = methodTypes[1];
+        MethodHandle methodHandleMethod2 = methodHandles[1];
+        return LambdaMetafactory.altMetafactory(lookup, interfaceMethod, MethodType.methodType(interfaceClass),
+                methodTypeMethod2, methodHandleMethod2, methodTypeMethod2, flags, numOfAltMethods, altMethodsMethod2[indexOfAltMethod++],
+                altMethodsMethod2[indexOfAltMethod]).getTarget().invoke();
+    }
+
+    private static void createLambdasWithAltMethods(Set<String> lambdaNames, int flags, MethodHandle[] methodHandles) throws Throwable {
+        int indexOfMethodWithOneAltMethod = 0;
+        int indexOfMethodWithTwoAltMethods = 1;
+        int altMethodIndex = 0;
+        Object lambda;
+        for (String interfaceMethod : interfaceMethods) {
+            for (Class<?> interfaceClass : interfaces) {
+                lambda = lambdaWithOneAltMethod(interfaceMethod, interfaceClass, methodTypes[indexOfMethodWithOneAltMethod], methodHandles[indexOfMethodWithOneAltMethod],
+                        flags, altMethodsMethod1[altMethodIndex], methodHandles);
+                lambdaNames.add(removeHashFromLambdaName(lambda.getClass().getName()));
+
+                for (MethodType altMethod : altMethodsMethod2) {
+                    lambda = lambdaWithOneAltMethod(interfaceMethod, interfaceClass, methodTypes[indexOfMethodWithTwoAltMethods], methodHandles[indexOfMethodWithTwoAltMethods],
+                            flags, altMethod, methodHandles);
+                    lambdaNames.add(removeHashFromLambdaName(lambda.getClass().getName()));
+                }
+
+                lambda = lambdaWithMultipleAltMethods(interfaceMethod, interfaceClass, flags, methodHandles);
+            }
+        }
+    }
+
+    private static Object lambdaWithOneAltInterfaceAndOneAltMethod(String interfaceMethod, Class<?> interfaceClass, MethodType methodType, MethodHandle methodHandle, int flags,
+                                                                   Class<?> altInterface, MethodType altMethod) throws Throwable {
+        int numOfAltInterfaces = 1;
+        int numOfAltMethods = 1;
+        return LambdaMetafactory.altMetafactory(lookup, interfaceMethod, MethodType.methodType(interfaceClass),
+                methodType, methodHandle, methodType, flags, numOfAltInterfaces, altInterface, numOfAltMethods, altMethod).getTarget().invoke();
+    }
+
+    private static Object lambdaWithOneAltInterfaceAndMultipleAltMethods(String interfaceMethod, Class<?> interfaceClass, int flags, Class<?> altInterface,
+                                                                         MethodHandle[] methodHandles) throws Throwable {
+        int numOfAltInterfaces = 1;
+        int numOfAltMethods = 2;
+        int indexOfAltMethod = 0;
+        MethodType methodTypeMethod2 = methodTypes[1];
+        MethodHandle methodHandleMethod2 = methodHandles[1];
+
+        return LambdaMetafactory.altMetafactory(lookup, interfaceMethod, MethodType.methodType(interfaceClass),
+                methodTypeMethod2, methodHandleMethod2, methodTypeMethod2, flags, numOfAltInterfaces, altInterface, numOfAltMethods, altMethodsMethod2[indexOfAltMethod++],
+                altMethodsMethod2[indexOfAltMethod]).getTarget().invoke();
+    }
+
+    private static Object lambdaWithMultipleAltInterfaceAndMultipleAltMethods(String interfaceMethod, Class<?> interfaceClass, int flags, MethodHandle[] methodHandles) throws Throwable {
+        int numOfAltInterfaces = 2;
+        int numOfAltMethods = 2;
+        int indexOfAltInterface = 0;
+        int indexOfAltMethod = 0;
+        MethodType methodTypeMethod2 = methodTypes[1];
+        MethodHandle methodHandleMethod2 = methodHandles[1];
+
+        return LambdaMetafactory.altMetafactory(lookup, interfaceMethod, MethodType.methodType(interfaceClass), methodTypeMethod2, methodHandleMethod2, methodTypeMethod2,
+                flags, numOfAltInterfaces, altInterfaces[indexOfAltInterface++], altInterfaces[indexOfAltInterface], numOfAltMethods, altMethodsMethod2[indexOfAltMethod++],
+                altMethodsMethod2[indexOfAltMethod]).getTarget().invoke();
+    }
+    private static void createLambdasWithAltInterfacesAndAltMethods(Set<String> lambdaNames, int flags, MethodHandle[] methodHandles) throws Throwable {
+        int indexOfMethodWithOneAltMethod = 0;
+        int indexOfMethodWithTwoAltMethods = 1;
+        int altMethodIndex = 0;
+        Object lambda;
+
+        for (String interfaceMethod : interfaceMethods) {
+            for (Class<?> interfaceClass : interfaces) {
+                for (Class<?> altInterface : altInterfaces) {
+                    lambda = lambdaWithOneAltInterfaceAndOneAltMethod(interfaceMethod, interfaceClass, methodTypes[indexOfMethodWithOneAltMethod], methodHandles[indexOfMethodWithOneAltMethod], flags,
+                            altInterface, altMethodsMethod1[altMethodIndex]);
+                    lambdaNames.add(removeHashFromLambdaName(lambda.getClass().getName()));
+                    lambda = lambdaWithOneAltInterfaceAndMultipleAltMethods(interfaceMethod, interfaceClass, flags, altInterface, methodHandles);
+                    lambdaNames.add(removeHashFromLambdaName(lambda.getClass().getName()));
+
+                    for (MethodType altMethod : altMethodsMethod2) {
+                        lambda = lambdaWithOneAltInterfaceAndOneAltMethod(interfaceMethod, interfaceClass, methodTypes[indexOfMethodWithTwoAltMethods], methodHandles[indexOfMethodWithTwoAltMethods], flags,
+                                altInterface, altMethod);
+                        lambdaNames.add(removeHashFromLambdaName(lambda.getClass().getName()));
+                    }
+                }
+                lambda = lambdaWithMultipleAltInterfaceAndMultipleAltMethods(interfaceMethod, interfaceClass, flags, methodHandles);
+                lambdaNames.add(removeHashFromLambdaName(lambda.getClass().getName()));
+            }
+        }
+    }
+
+    private static void createLambdasWithDifferentParameters(Set<String> lambdaNames, MethodHandle[] methodHandles) throws Throwable {
+        // All lambdas with flags 0
+        createPlainLambdas(lambdaNames, lambdaType.NOT_SERIALIZABLE_NO_ALT_METHODS_NO_ALT_INTERFACES.index, methodHandles);
+
+        // All lambdas with flags 1
+        createPlainLambdas(lambdaNames, lambdaType.SERIALIZABLE_ONLY.index, methodHandles);
+
+        // All lambdas with flags 2
+        createLambdasWithAltInterfaces(lambdaNames, lambdaType.NOT_SERIALIZABLE_HAS_ALT_INTERFACES.index, methodHandles);
+
+        // All lambdas with flags 3
+        createLambdasWithAltInterfaces(lambdaNames, lambdaType.SERIALIZABLE_HAS_ALT_INTERFACES.index, methodHandles);
+
+        // All lambdas with flags 4
+        createLambdasWithAltMethods(lambdaNames, lambdaType.NOT_SERIALIZABLE_HAS_ALT_METHODS.index, methodHandles);
+
+        // All lambdas with flags 5
+        createLambdasWithAltMethods(lambdaNames, lambdaType.SERIALIZABLE_HAS_ALT_METHODS.index, methodHandles);
+
+        // All lambdas with flags 6
+        createLambdasWithAltInterfacesAndAltMethods(lambdaNames, lambdaType.NOT_SERIALIZABLE_HAS_ALT_METHODS_HAS_ALT_INTERFACES.index, methodHandles);
+
+        // All lambdas with flags 7
+        createLambdasWithAltInterfacesAndAltMethods(lambdaNames, lambdaType.SERIALIZABLE_HAS_ALT_METHODS_HAS_ALT_INTERFACES.index, methodHandles);
+    }
+
+    public static void main(String[] args) throws Throwable {
+        MethodType methodTypeForMethod1 = methodTypes[0];
+        MethodType methodTypeForMethod2 = methodTypes[1];
+        MethodHandle[] methodHandles = new MethodHandle[]{lookup.findStatic(TestStableLambdaName.class, "method1", methodTypeForMethod1),
+                lookup.findStatic(TestStableLambdaName.class, "method2", methodTypeForMethod2)};
+
+        Set<String> lambdaClassStableNames = new HashSet<>();
+        createLambdasWithDifferentParameters(lambdaClassStableNames, methodHandles);
+
+        Set<String> lambdaClassStableNamesTest = new HashSet<>();
+        createLambdasWithDifferentParameters(lambdaClassStableNamesTest, methodHandles);
+
+        if (lambdaClassStableNames.size() != lambdaClassStableNamesTest.size()) {
+            throw new RuntimeException(lambdaClassStableNames.size() + " names was created during name creation run, but " + lambdaClassStableNamesTest.size() + " names were created during test run. " +
+                    "Number of created names must be the same.");
+        }
+
+        if (!lambdaClassStableNamesTest.containsAll(lambdaClassStableNames)) {
+            throw new RuntimeException("Different names for lambda classes were created during name creation run and test run. All the created names in both runs must be the same.");
+        }
+    }
+}

--- a/test/jdk/java/lang/invoke/lambda/TestStableLambdaName.java
+++ b/test/jdk/java/lang/invoke/lambda/TestStableLambdaName.java
@@ -103,8 +103,7 @@ public class TestStableLambdaName {
 
     private static String removeHashFromLambdaName(String name) {
         String architecture = System.getProperty("sun.arch.data.model");
-        String architecture2 = System.getProperty("os.arch");
-        System.err.println("Architecture: " + architecture + " " + architecture2);
+        System.err.println("Architecture: " + architecture);
         return name.substring(0, name.indexOf("/0x0"));
     }
 

--- a/test/jdk/java/lang/invoke/lambda/TestStableLambdaName.java
+++ b/test/jdk/java/lang/invoke/lambda/TestStableLambdaName.java
@@ -246,6 +246,15 @@ public class TestStableLambdaName {
         }
     }
 
+    private static void createMethodReferencesLambdas(Set<String> lambdaNames) {
+        Runnable lambda = TestStableLambdaName::foo;
+        lambdaNames.add(removeHashFromLambdaName(lambda.getClass().getName()));
+    }
+
+    private static void foo() {
+        System.out.println("Hello world!");
+    }
+
     private static void createLambdasWithDifferentParameters(Set<String> lambdaNames, MethodHandle[] methodHandles) throws Throwable {
         // All lambdas with flags 0
         createPlainLambdas(lambdaNames, lambdaType.NOT_SERIALIZABLE_NO_ALT_METHODS_NO_ALT_INTERFACES.index, methodHandles);
@@ -270,6 +279,9 @@ public class TestStableLambdaName {
 
         // All lambdas with flags 7
         createLambdasWithAltInterfacesAndAltMethods(lambdaNames, lambdaType.SERIALIZABLE_HAS_ALT_METHODS_HAS_ALT_INTERFACES.index, methodHandles);
+
+        // Method reference lambdas
+        createMethodReferencesLambdas(lambdaNames);
     }
 
     public static void main(String[] args) throws Throwable {

--- a/test/jdk/java/lang/invoke/lambda/TestStableLambdaName.java
+++ b/test/jdk/java/lang/invoke/lambda/TestStableLambdaName.java
@@ -102,6 +102,7 @@ public class TestStableLambdaName {
     }
 
     private static String removeHashFromLambdaName(String name) {
+        System.err.println("Lambda name debug purposes: " + name);
         return name.substring(0, name.indexOf("/0x0"));
     }
 

--- a/test/jdk/java/lang/invoke/lambda/TestStableLambdaName.java
+++ b/test/jdk/java/lang/invoke/lambda/TestStableLambdaName.java
@@ -102,9 +102,7 @@ public class TestStableLambdaName {
     }
 
     private static String removeHashFromLambdaName(String name) {
-        String architecture = System.getProperty("sun.arch.data.model");
-        System.err.println("Architecture: " + architecture);
-        return name.substring(0, name.indexOf("/0x0"));
+        return name.substring(0, name.indexOf("/0x"));
     }
 
     private static void createPlainLambdas(Set<String> lambdaNames, int flags, MethodHandle[] methodHandles) throws Throwable {

--- a/test/jdk/java/lang/invoke/lambda/TestStableLambdaName.java
+++ b/test/jdk/java/lang/invoke/lambda/TestStableLambdaName.java
@@ -102,8 +102,9 @@ public class TestStableLambdaName {
     }
 
     private static String removeHashFromLambdaName(String name) {
-        System.err.println("Lambda name debug purposes: " + name);
-        return name.substring(0, name.indexOf("/0x0"));
+        String architecture = System.getProperty("sun.arch.data.model");
+        System.err.println("Architecture: " + architecture);
+        return name.substring(0, name.indexOf("/0x"));
     }
 
     private static void createPlainLambdas(Set<String> lambdaNames, int flags, MethodHandle[] methodHandles) throws Throwable {

--- a/test/jdk/java/lang/invoke/lambda/TestStableLambdaNames.java
+++ b/test/jdk/java/lang/invoke/lambda/TestStableLambdaNames.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @summary Test if the names of the lambda classes are stable when {@code -Djdk.internal.lambda.stableLambdaName}
+ * @summary Test if the names of the lambda classes are stable when {@code -Djdk.internal.lambda.generateStableLambdaNames}
  *          flag is set to true. This test directly calls java.lang.invoke.LambdaMetafactory#altMetafactory
  *          method to create multilple lambda instances and then checks their names stability. We created a
  *          multidimensional space of possible values for each parameter that
@@ -32,7 +32,7 @@
  *          Alternative methods of the specific method must have the same signature with difference in parameter types
  *          as long as the parameter of the alternative method is the superclass type of the type of corresponding parameter in
  *          original method
- * @run main/othervm -Djdk.internal.lambda.generateStableLambdaNames=true TestStableLambdaName
+ * @run main/othervm -Djdk.internal.lambda.generateStableLambdaNames=true TestStableLambdaNames
  */
 
 import java.lang.invoke.LambdaMetafactory;
@@ -48,12 +48,13 @@ import java.util.function.Predicate;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
-public class TestStableLambdaName {
+public class TestStableLambdaNames {
     private static final MethodHandles.Lookup lookup = MethodHandles.lookup();
 
-    /* Different types of lambda classes based on value of flags parameter in the
-     * java.lang.invoke.LambdaMetafactory#altMetafactory.
-     * java.lang.invoke.LambdaMetafactory#altMetafactory uses bitwise and with this
+    /**
+     * Different types of lambda classes based on value of flags parameter in the
+     * {@link java.lang.invoke.LambdaMetafactory#altMetafactory}.
+     * {@link java.lang.invoke.LambdaMetafactory#altMetafactory} uses bitwise and with this
      * parameter and predefined values to determine if lambda is serializable, has
      * altMethods and altInterfaces etc.
      */
@@ -73,15 +74,15 @@ public class TestStableLambdaName {
         }
     }
 
-    private static final String[] interfaceMethods = new String[]{"accept", "consume", "apply", "supply", "get", "test", "getAsBoolean"};
-    private static final Class<?>[] interfaces = new Class<?>[]{Consumer.class, Function.class, Predicate.class, Supplier.class, BooleanSupplier.class};
-    // List of method types for defined methods
-    private static final MethodType[] methodTypes = new MethodType[]{MethodType.methodType(String.class, Integer.class), MethodType.methodType(Throwable.class, AssertionError.class)};
-    private static final Class<?>[] altInterfaces = new Class<?>[]{Cloneable.class, Remote.class};
-    // Alternative methods that corresponds to method1
-    private static final MethodType[] altMethodsMethod1 = new MethodType[]{MethodType.methodType(String.class, Number.class)};
-    // Alternative methods that corresponds to method2
-    private static final MethodType[] altMethodsMethod2 = new MethodType[]{MethodType.methodType(Throwable.class, Error.class), MethodType.methodType(Throwable.class, Throwable.class)};
+    private static final String[] interfaceMethods = {"accept", "consume", "apply", "supply", "get", "test", "getAsBoolean"};
+    private static final Class<?>[] interfaces = {Consumer.class, Function.class, Predicate.class, Supplier.class, BooleanSupplier.class};
+    /** List of method types for defined methods */
+    private static final MethodType[] methodTypes = {MethodType.methodType(String.class, Integer.class), MethodType.methodType(Throwable.class, AssertionError.class)};
+    private static final Class<?>[] altInterfaces = {Cloneable.class, Remote.class};
+    /** Alternative methods that corresponds to method1 */
+    private static final MethodType[] altMethodsMethod1 = {MethodType.methodType(String.class, Number.class)};
+    /** Alternative methods that corresponds to method2 */
+    private static final MethodType[] altMethodsMethod2 = {MethodType.methodType(Throwable.class, Error.class), MethodType.methodType(Throwable.class, Throwable.class)};
 
     private static String method1(Number number) {
         return String.valueOf(number);
@@ -102,7 +103,7 @@ public class TestStableLambdaName {
     }
 
     private static String removeHashFromLambdaName(String name) {
-        return name.substring(0, name.indexOf("/0x"));
+        return name.substring(0, name.indexOf("/0x0"));
     }
 
     private static void createPlainLambdas(Set<String> lambdaNames, int flags, MethodHandle[] methodHandles) throws Throwable {
@@ -246,15 +247,6 @@ public class TestStableLambdaName {
         }
     }
 
-    private static void createMethodReferencesLambdas(Set<String> lambdaNames) {
-        Runnable lambda = TestStableLambdaName::foo;
-        lambdaNames.add(removeHashFromLambdaName(lambda.getClass().getName()));
-    }
-
-    private static void foo() {
-        System.out.println("Hello world!");
-    }
-
     private static void createLambdasWithDifferentParameters(Set<String> lambdaNames, MethodHandle[] methodHandles) throws Throwable {
         // All lambdas with flags 0
         createPlainLambdas(lambdaNames, lambdaType.NOT_SERIALIZABLE_NO_ALT_METHODS_NO_ALT_INTERFACES.index, methodHandles);
@@ -279,19 +271,17 @@ public class TestStableLambdaName {
 
         // All lambdas with flags 7
         createLambdasWithAltInterfacesAndAltMethods(lambdaNames, lambdaType.SERIALIZABLE_HAS_ALT_METHODS_HAS_ALT_INTERFACES.index, methodHandles);
-
-        // Method reference lambdas
-        createMethodReferencesLambdas(lambdaNames);
     }
 
     public static void main(String[] args) throws Throwable {
         MethodType methodTypeForMethod1 = methodTypes[0];
         MethodType methodTypeForMethod2 = methodTypes[1];
-        MethodHandle[] methodHandles = new MethodHandle[]{lookup.findStatic(TestStableLambdaName.class, "method1", methodTypeForMethod1),
-                lookup.findStatic(TestStableLambdaName.class, "method2", methodTypeForMethod2)};
+        MethodHandle[] methodHandles = {lookup.findStatic(TestStableLambdaNames.class, "method1", methodTypeForMethod1),
+                lookup.findStatic(TestStableLambdaNames.class, "method2", methodTypeForMethod2)};
 
         Set<String> lambdaClassStableNames = new HashSet<>();
         createLambdasWithDifferentParameters(lambdaClassStableNames, methodHandles);
+        System.err.println(lambdaClassStableNames.size());
 
         Set<String> lambdaClassStableNamesTest = new HashSet<>();
         createLambdasWithDifferentParameters(lambdaClassStableNamesTest, methodHandles);

--- a/test/jdk/java/lang/invoke/lambda/TestStableLambdaNames.java
+++ b/test/jdk/java/lang/invoke/lambda/TestStableLambdaNames.java
@@ -103,7 +103,7 @@ public class TestStableLambdaNames {
     }
 
     private static String removeHashFromLambdaName(String name) {
-        return name.substring(0, name.indexOf("/0x0"));
+        return name.substring(0, name.indexOf("/0x"));
     }
 
     private static void createPlainLambdas(Set<String> lambdaNames, int flags, MethodHandle[] methodHandles) throws Throwable {


### PR DESCRIPTION
This PR introduces an option to output stable names for the lambda classes in the JDK. A stable name consists of two parts: The first part is the predefined value `$$Lambda$` appended to the lambda capturing class, and the second is a 64-bit hash part of the name. Thus, it looks like `lambdaCapturingClass$$Lambda$hashValue`.
Parameters used to create a stable hash are a superset of the parameters used for lambda class archiving when the CDS dumping option is enabled. During this process, all the mutual parameters are in the same form as they are in the low-level implementation (`SystemDictionaryShared::add_lambda_proxy_class`) of the archiving process.
We decided to use a well-specified `CRC32` algorithm from the standard Java library. We created two 32-bit hashes from the parameters used to create stable names. Then, we combined those two 32-bit hashes into one 64-bit hash value.
We chose `CRC32` because it is a well-specified hash function, and we don't need to write additional code in the JDK. `SHA-256, MD5`, and all other hash functions that rely on `MessageDigest` use lambdas in the implementation, so they are unsuitable for our purpose. We also considered a few different hash functions with a low collision rate. All these functions would require at least 100 lines of additional code in the JDK. The best alternative we found is 64-bit` MurmurHash2`: https://commons.apache.org/proper/commons-codec/jacoco/org.apache.commons.codec.digest/MurmurHash2.java.html.  In case adding a new hash implementation (e.g., Murmur2) to the JDK is preferred, this PR can be easily modified.
We found the post (https://softwareengineering.stackexchange.com/questions/49550/which-hashing-algorithm-is-best-for-uniqueness-and-speed/145633#145633) that compares different hash functions.
We also tested the `CRC32` hash function against half a billion generated strings, and there were no collisions. Note that the capturing-class name is also part of the lambda class name, so the potential collisions can only appear in a single class. Thus, we do not expect to have name collisions due to a relatively low number of lambdas per class. Every tool that uses this feature should handle potential collisions on its own.  
We found an overall approximation of the collision rate too. You can find it here: https://preshing.com/20110504/hash-collision-probabilities/.

JDK currently adds an atomic integer after `$$Lambda$`, and the names of the lambdas depend on the creation order. In the `TestStableLambdaNames`, we generate all the lambdas two times. In the first run, the method createPlainLambdas generate the following lambdas:

- TestStableLambdaNames$$Lambda$1/0x0000000800c00400
- TestStableLambdaNames$$Lambda$2/0x0000000800c01800
- TestStableLambdaNames$$Lambda$3/0x0000000800c01a38
The same method in the second run generates lambdas with different names:
- TestStableLambdaNames$$Lambda$1471/0x0000000800d10000
- TestStableLambdaNames$$Lambda$1472/0x0000000800d10238
- TestStableLambdaNames$$Lambda$1473/0x0000000800d10470

If we use the introduced flag, generated lambdas are:
- TestStableLambdaNames$$Lambda$65ba26bbc6c7500d/0x0000000800c00400
- TestStableLambdaNames$$Lambda$1569c8c4abe3ab18/0x0000000800c01800
- TestStableLambdaNames$$Lambda$493c0ecaaf682428/0x0000000800c01a38
In the second run of the method, generated lambdas are:
- TestStableLambdaNames$$Lambda$65ba26bbc6c7500d/0x0000000800d10000
- TestStableLambdaNames$$Lambda$1569c8c4abe3ab18/0x0000000800d10238
- TestStableLambdaNames$$Lambda$493c0ecaaf682428/0x0000000800d10470

We can see that the introduced hash value does not change between two calls of the method `createPlainLambdas`. That was not the case in the JDK run without this change. Those lambdas are extracted directly from the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blockers
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8292914](https://bugs.openjdk.org/browse/JDK-8292914)
&nbsp;⚠️ Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed with the updated jcheck configuration)
&nbsp;⚠️ Whitespace errors (failed with the updated jcheck configuration)

### Issue
 * [JDK-8292914](https://bugs.openjdk.org/browse/JDK-8292914): Lambda proxies have unstable names (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/10024/head:pull/10024` \
`$ git checkout pull/10024`

Update a local copy of the PR: \
`$ git checkout pull/10024` \
`$ git pull https://git.openjdk.org/jdk.git pull/10024/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10024`

View PR using the GUI difftool: \
`$ git pr show -t 10024`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10024.diff">https://git.openjdk.org/jdk/pull/10024.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/10024#issuecomment-1237254604)