### PR TITLE
8292919: Build failure due to UseJVMCICompiler was not declared when C2 is disabled after JDK-8292691

### DIFF
--- a/src/hotspot/share/compiler/oopMap.inline.hpp
+++ b/src/hotspot/share/compiler/oopMap.inline.hpp
@@ -31,6 +31,9 @@
 #include "runtime/frame.inline.hpp"
 #include "runtime/globals.hpp"
 #include "utilities/ostream.hpp"
+#if INCLUDE_JVMCI
+#include "jvmci/jvmci_globals.hpp"
+#endif
 
 inline const ImmutableOopMap* ImmutableOopMapSet::find_map_at_slot(int slot, int pc_offset) const {
   assert(slot >= 0 && slot < _count, "bounds count: %d slot: %d", _count, slot);


### PR DESCRIPTION
Hi all,

Please review this trivial fix which fixes the build failure when C2 is disabled due to the definition of `UseJVMCICompiler` is missing.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292919](https://bugs.openjdk.org/browse/JDK-8292919): Build failure due to UseJVMCICompiler was not declared when C2 is disabled after JDK-8292691


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10027/head:pull/10027` \
`$ git checkout pull/10027`

Update a local copy of the PR: \
`$ git checkout pull/10027` \
`$ git pull https://git.openjdk.org/jdk pull/10027/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10027`

View PR using the GUI difftool: \
`$ git pr show -t 10027`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10027.diff">https://git.openjdk.org/jdk/pull/10027.diff</a>

</details>
