### PR TITLE
8292921: Rewrite object field printer

### DIFF
--- a/src/hotspot/share/runtime/fieldDescriptor.cpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.cpp
@@ -156,18 +156,15 @@ void fieldDescriptor::print() const { print_on(tty); }
 
 void fieldDescriptor::print_on_for(outputStream* st, oop obj) {
   print_on(st);
+
   BasicType ft = field_type();
-  jint as_int = 0;
   switch (ft) {
     case T_BYTE:
-      as_int = (jint)obj->byte_field(offset());
       st->print(" %d", obj->byte_field(offset()));
       break;
     case T_CHAR:
-      as_int = (jint)obj->char_field(offset());
       {
         jchar c = obj->char_field(offset());
-        as_int = c;
         st->print(" %c %d", isprint(c) ? c : ' ', c);
       }
       break;
@@ -175,11 +172,9 @@ void fieldDescriptor::print_on_for(outputStream* st, oop obj) {
       st->print(" %lf", obj->double_field(offset()));
       break;
     case T_FLOAT:
-      as_int = obj->int_field(offset());
       st->print(" %f", obj->float_field(offset()));
       break;
     case T_INT:
-      as_int = obj->int_field(offset());
       st->print(" %d", obj->int_field(offset()));
       break;
     case T_LONG:
@@ -187,16 +182,13 @@ void fieldDescriptor::print_on_for(outputStream* st, oop obj) {
       st->print_jlong(obj->long_field(offset()));
       break;
     case T_SHORT:
-      as_int = obj->short_field(offset());
       st->print(" %d", obj->short_field(offset()));
       break;
     case T_BOOLEAN:
-      as_int = obj->bool_field(offset());
       st->print(" %s", obj->bool_field(offset()) ? "true" : "false");
       break;
     case T_ARRAY:
       st->print(" ");
-      NOT_LP64(as_int = obj->int_field(offset()));
       if (obj->obj_field(offset()) != NULL) {
         obj->obj_field(offset())->print_value_on(st);
       } else {
@@ -205,7 +197,6 @@ void fieldDescriptor::print_on_for(outputStream* st, oop obj) {
       break;
     case T_OBJECT:
       st->print(" ");
-      NOT_LP64(as_int = obj->int_field(offset()));
       if (obj->obj_field(offset()) != NULL) {
         obj->obj_field(offset())->print_value_on(st);
       } else {
@@ -216,18 +207,35 @@ void fieldDescriptor::print_on_for(outputStream* st, oop obj) {
       ShouldNotReachHere();
       break;
   }
-  // Print a hint as to the underlying integer representation. This can be wrong for
-  // pointers on an LP64 machine
+
+  // Print  a hint as to the underlying integer representation.
+  if (is_reference_type(ft)) {
 #ifdef _LP64
-  if (is_reference_type(ft) && UseCompressedOops) {
-    st->print(" (%x)", obj->int_field(offset()));
-  }
-  else // <- intended
+    if (UseCompressedOops) {
+      st->print(" (" PTR32_FORMAT ")", obj->int_field(offset()));
+    } else {
+      st->print(" (" PTR_FORMAT ")", obj->long_field(offset()));
+    }
+#else
+    st->print(" (" PTR_FORMAT ")", obj->int_field(offset()));
 #endif
-  if (ft == T_LONG || ft == T_DOUBLE LP64_ONLY(|| !is_java_primitive(ft)) ) {
-    st->print(" (%x %x)", obj->int_field(offset()), obj->int_field(offset()+sizeof(jint)));
-  } else if (as_int < 0 || as_int > 9) {
-    st->print(" (%x)", as_int);
+  } else { // Primitives
+    if (ft == T_LONG || ft == T_DOUBLE) {
+      st->print(" (" PTR64_FORMAT ")", obj->long_field(offset()));
+    } else {
+      jint as_int = 0;
+      switch (ft) {
+        case T_BYTE:    as_int = (jint)obj->byte_field(offset()); break;
+        case T_CHAR:    as_int = (jint)obj->char_field(offset()); break;
+        case T_FLOAT:   as_int = obj->int_field(offset());        break;
+        case T_INT:     as_int = obj->int_field(offset());        break;
+        case T_SHORT:   as_int = obj->short_field(offset());      break;
+        case T_BOOLEAN: as_int = obj->bool_field(offset());       break;
+      default:
+        ShouldNotReachHere();
+        break;
+      }
+      st->print(" (" PTR32_FORMAT ")", as_int);
+    }
   }
 }
-


### PR DESCRIPTION
See this as a RFC rather than a fully ready PR:

fieldDescriptor::print_on_for is a bit inconsistent in how it deals with printing the "underlying representation" of the field values. I'd like to change to make it easier to both read output that gets generated in our hs_err files, but also make it easier to understand the code.

This started out as a small patch in Generational ZGC to change how the underlying representation was written. Before this patch, the fields in the hs_err files were written with this format:
```
 - final 'interruptLock' 'Ljava/lang/Object;' @112  a 'java/lang/Object'{0x000004000f635e80} (5e808a30, 4000f63)
```
and with the suggested change we get:
```
 - final 'interruptLock' 'Ljava/lang/Object;' @112  a 'java/lang/Object'{0x000004000f635e80} (0x04000f635e808a30)
```
which makes it much easier to read the colored pointer (0x04000f635e808a30) of the object address (0x000004000f635e80).

I think this is good even for the upstream repository, so I'd like to propose that we print the underlying representation as a full hex value without trying to split the value into 4-bytes chunks.

There used to be a filter that said that we shouldn't print the underlying bits if the value was a positive, single digit, 4-bytes primitive. I've removed that code, but that will add more logging (esp. of 0 values). So, I'd like to get some feedback on that.

A full example of the generated output:
```
java.lang.Class 
{0x00007ffc36801080} - klass: 'java/lang/Class'
 - ---- fields (total size 26 words):
 - private volatile transient 'classRedefinedCount' 'I' @12  0 (0x00000000)
 - abstract internal 'klass' 'J' @16  2147753408 (0x0000000080041dc0)
 - abstract internal 'array_klass' 'J' @24  0 (0x0000000000000000)
 - abstract internal 'oop_size' 'I' @32  26 (0x0000001a)
 - abstract internal 'static_oop_field_count' 'I' @36  2 (0x00000002)
 - private volatile transient 'cachedConstructor' 'Ljava/lang/reflect/Constructor;' @40  NULL (0x0000000000000000)
 - private transient 'name' 'Ljava/lang/String;' @48  NULL (0x0000000000000000)
 - private transient 'module' 'Ljava/lang/Module;' @56  NULL (0x0000000000000000)
 - private final 'classLoader' 'Ljava/lang/ClassLoader;' @64  NULL (0x0000000000000000)
 - private transient 'classData' 'Ljava/lang/Object;' @72  NULL (0x0000000000000000)
 - private transient 'packageName' 'Ljava/lang/String;' @80  NULL (0x0000000000000000)
 - private final 'componentType' 'Ljava/lang/Class;' @88  NULL (0x0000000000000000)
 - private volatile transient 'reflectionData' 'Ljava/lang/ref/SoftReference;' @96  NULL (0x0000000000000000)
 - private volatile transient 'genericInfo' 'Lsun/reflect/generics/repository/ClassRepository;' @104  NULL (0x0000000000000000)
 - private volatile transient 'enumConstants' '[Ljava/lang/Object;' @112  NULL (0x0000000000000000)
 - private volatile transient 'enumConstantDirectory' 'Ljava/util/Map;' @120  NULL (0x0000000000000000)
 - private volatile transient 'annotationData' 'Ljava/lang/Class$AnnotationData;' @128  NULL (0x0000000000000000)
 - private volatile transient 'annotationType' 'Lsun/reflect/annotation/AnnotationType;' @136  NULL (0x0000000000000000)
 - transient 'classValueMap' 'Ljava/lang/ClassValue$ClassValueMap;' @144  NULL (0x0000000000000000)
 - abstract internal 'protection_domain' 'Ljava/lang/Object;' @152  NULL (0x0000000000000000)
 - abstract internal 'signers_name' 'Ljava/lang/Object;' @160  NULL (0x0000000000000000)
 - abstract internal 'source_file' 'Ljava/lang/Object;' @168  NULL (0x0000000000000000)
 - signature: Ljava/lang/String;
 - ---- static fields (2):
 - private static final 'serialVersionUID' 'J' @192  -6849794470754667710 (0xa0f0a4387a3bb342)
 - static final 'COMPACT_STRINGS' 'Z' @202  false (0x00000000)
 - private static final 'serialPersistentFields' '[Ljava/io/ObjectStreamField;' @176  NULL (0x0000000000000000)
 - private static final 'REPL' 'C' @200    65533 (0x0000fffd)
 - public static final 'CASE_INSENSITIVE_ORDER' 'Ljava/util/Comparator;' @184  NULL (0x0000000000000000)
 - static final 'LATIN1' 'B' @203  0 (0x00000000)
 - static final 'UTF16' 'B' @204  1 (0x00000001)
```