### PR TITLE
8292937: Improve performance of some read operations of RandomAccessFile

### DIFF
--- a/src/java.base/share/classes/java/io/Bits.java
+++ b/src/java.base/share/classes/java/io/Bits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,10 @@ class Bits {
     static short getShort(byte[] b, int off) {
         return (short) ((b[off + 1] & 0xFF) +
                         (b[off] << 8));
+    }
+
+    static int getUnsignedShort(byte[] b, int off) {
+        return ((b[off] & 0xFF) << 8) + (b[off + 1] & 0xFF);
     }
 
     static int getInt(byte[] b, int off) {

--- a/test/micro/org/openjdk/bench/java/io/RandomAccessFileReadBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/io/RandomAccessFileReadBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/io/RandomAccessFileReadBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/io/RandomAccessFileReadBenchmark.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package micro.org.openjdk.bench.java.io;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+@Fork(2)
+@State(Scope.Thread)
+@Warmup(iterations=5, time = 1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Measurement(iterations = 5, time = 2)
+public class RandomAccessFileReadBenchmark {
+
+    @Param({"1", "5"})
+    private int kiloBytes;
+
+    private File file;
+
+    @Setup(Level.Iteration)
+    public void beforeRun() throws IOException {
+        var bytes = new byte[kiloBytes * 1024];
+        ThreadLocalRandom.current().nextBytes(bytes);
+        file = File.createTempFile(getClass().getName(), ".txt");
+        Files.write(file.toPath(), bytes);
+    }
+
+    @TearDown(Level.Iteration)
+    public void afterRun() {
+        file.delete();
+    }
+
+    @Benchmark
+    public void readShort(Blackhole bh) throws IOException {
+        RandomAccessFile raf = new RandomAccessFile(file, "r");
+        int size = kiloBytes * 1024;
+        for (int i = 0; i < size / 2; i++) {
+            bh.consume(raf.readShort());
+        }
+        raf.close();
+    }
+
+    @Benchmark
+    public void readInt(Blackhole bh) throws IOException {
+        RandomAccessFile raf = new RandomAccessFile(file, "r");
+        int size = kiloBytes * 1024;
+        for (int i = 0; i < size / 4; i++) {
+            bh.consume(raf.readInt());
+        }
+        raf.close();
+    }
+
+    @Benchmark
+    public void readLong(Blackhole bh) throws IOException {
+        RandomAccessFile raf = new RandomAccessFile(file, "r");
+        int size = kiloBytes * 1024;
+        for (int i = 0; i < size / 8; i++) {
+            bh.consume(raf.readLong());
+        }
+        raf.close();
+    }
+
+}


### PR DESCRIPTION
Currently some operations of RandomAccessFile are implemented with multiple read() invocations:
```java
public final int readInt() throws IOException {
    int ch1 = this.read();
    int ch2 = this.read();
    int ch3 = this.read();
    int ch4 = this.read();
    if ((ch1 | ch2 | ch3 | ch4) < 0)
      throw new EOFException();
    return ((ch1 << 24) + (ch2 << 16) + (ch3 << 8) + (ch4 << 0));
}
```
This can be improved by using bulk reads:
```java
public final int readInt() throws IOException {
  readFully(readBuffer, 0, 4);
  return Bits.getInt(readBuffer, 0);
}
```
Benchmarking:
```
baselile
Benchmark                                (kiloBytes)  Mode  Cnt     Score      Error  Units
RandomAccessFileReadBenchmark.readInt              1  avgt   10  1060,526 ±   62,036  us/op
RandomAccessFileReadBenchmark.readInt              5  avgt   10  5745,671 ± 1374,277  us/op
RandomAccessFileReadBenchmark.readLong             1  avgt   10  1399,494 ±  378,072  us/op
RandomAccessFileReadBenchmark.readLong             5  avgt   10  4864,425 ±  329,282  us/op
RandomAccessFileReadBenchmark.readShort            1  avgt   10  1111,163 ±   70,883  us/op
RandomAccessFileReadBenchmark.readShort            5  avgt   10  4933,058 ±  339,273  us/op

patch
Benchmark                                (kiloBytes)  Mode  Cnt     Score    Error  Units
RandomAccessFileReadBenchmark.readInt              1  avgt   10   311,404 ± 17,337  us/op
RandomAccessFileReadBenchmark.readInt              5  avgt   10  1210,381 ± 22,742  us/op
RandomAccessFileReadBenchmark.readLong             1  avgt   10   201,726 ±  8,885  us/op
RandomAccessFileReadBenchmark.readLong             5  avgt   10   667,117 ±  6,779  us/op
RandomAccessFileReadBenchmark.readShort            1  avgt   10   560,259 ± 16,783  us/op
RandomAccessFileReadBenchmark.readShort            5  avgt   10  2251,975 ± 54,533  us/op
```