### PR TITLE
7124710: interleaved RedefineClasses() and RetransformClasses() calls may have a problem

### DIFF
--- a/src/hotspot/share/classfile/klassFactory.cpp
+++ b/src/hotspot/share/classfile/klassFactory.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -132,8 +132,8 @@ static ClassFileStream* check_class_file_load_hook(ClassFileStream* stream,
 
     if (state != NULL) {
       Klass* k = state->get_class_being_redefined();
-
-      if (k != NULL) {
+      // use cached_class_file only for RetransformClasses
+      if (k != NULL && state->get_class_load_kind() == jvmti_class_load_kind_retransform) {
         InstanceKlass* class_being_redefined = InstanceKlass::cast(k);
         *cached_class_file = class_being_redefined->get_cached_class_file();
       }

--- a/src/hotspot/share/classfile/klassFactory.cpp
+++ b/src/hotspot/share/classfile/klassFactory.cpp
@@ -123,7 +123,10 @@ static ClassFileStream* check_class_file_load_hook(ClassFileStream* stream,
     Handle class_loader(THREAD, loader_data->class_loader());
 
     // Get the cached class file bytes (if any) from the class that
-    // is being redefined or retransformed. We use jvmti_thread_state()
+    // is being retransformed. If class file load hook provides
+    // modified class data during class loading or redefinition,
+    // new cached class file buffer should be allocated.
+    // We use jvmti_thread_state()
     // instead of JvmtiThreadState::state_for(jt) so we don't allocate
     // a JvmtiThreadState any earlier than necessary. This will help
     // avoid the bug described by 7126851.
@@ -132,7 +135,6 @@ static ClassFileStream* check_class_file_load_hook(ClassFileStream* stream,
 
     if (state != NULL) {
       Klass* k = state->get_class_being_redefined();
-      // use cached_class_file only for RetransformClasses
       if (k != NULL && state->get_class_load_kind() == jvmti_class_load_kind_retransform) {
         InstanceKlass* class_being_redefined = InstanceKlass::cast(k);
         *cached_class_file = class_being_redefined->get_cached_class_file();

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -4330,14 +4330,14 @@ void VM_RedefineClasses::redefine_single_class(Thread* current, jclass the_jclas
   transfer_old_native_function_registrations(the_class);
 
   if (scratch_class->get_cached_class_file() != the_class->get_cached_class_file()) {
-    // 1. the_class doesn't have a cache yet, scratch_class does have.
+    // 1. the_class doesn't have a cache yet, scratch_class does have a cache.
     // 2. The same class can be present twice in the scratch classes list or there
     // are multiple concurrent RetransformClasses calls on different threads.
     // the_class and scratch_class have the same cached bytes, but different buffers.
-    // In such cases we need to deallocate one of the buffer.
-    // 3. RedefineClasses and the_class has cached bytes from previous transformation.
+    // In such cases we need to deallocate one of the buffers.
+    // 3. RedefineClasses and the_class has cached bytes from a previous transformation.
     // In the case we need to use class bytes from scratch_class.
-    if (the_class->get_cached_class_file() != 0) {
+    if (the_class->get_cached_class_file() != nullptr) {
       os::free(the_class->get_cached_class_file());
     }
     the_class->set_cached_class_file(scratch_class->get_cached_class_file());

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -4329,20 +4329,18 @@ void VM_RedefineClasses::redefine_single_class(Thread* current, jclass the_jclas
   int emcp_method_count = check_methods_and_mark_as_obsolete();
   transfer_old_native_function_registrations(the_class);
 
-  // The class file bytes from before any retransformable agents mucked
-  // with them was cached on the scratch class, move to the_class.
-  // Note: we still want to do this if nothing needed caching since it
-  // should get cleared in the_class too.
-  if (the_class->get_cached_class_file() == 0) {
-    // the_class doesn't have a cache yet so copy it
-    the_class->set_cached_class_file(scratch_class->get_cached_class_file());
-  }
-  else if (scratch_class->get_cached_class_file() !=
-           the_class->get_cached_class_file()) {
-    // The same class can be present twice in the scratch classes list or there
+  if (scratch_class->get_cached_class_file() != the_class->get_cached_class_file()) {
+    // 1. the_class doesn't have a cache yet, scratch_class does have.
+    // 2. The same class can be present twice in the scratch classes list or there
     // are multiple concurrent RetransformClasses calls on different threads.
-    // In such cases we have to deallocate scratch_class cached_class_file.
-    os::free(scratch_class->get_cached_class_file());
+    // the_class and scratch_class have the same cached bytes, but different buffers.
+    // In such cases we need to deallocate one of the buffer.
+    // 3. RedefineClasses and the_class has cached bytes from previous transformation.
+    // In the case we need to use class bytes from scratch_class.
+    if (the_class->get_cached_class_file() != 0) {
+      os::free(the_class->get_cached_class_file());
+    }
+    the_class->set_cached_class_file(scratch_class->get_cached_class_file());
   }
 
   // NULL out in scratch class to not delete twice.  The class to be redefined

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/RedefineRetransform.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/RedefineRetransform.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ *
+ * @bug 7124710
+ *
+ * @requires vm.jvmti
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ * @library /test/lib
+ *
+ * @comment main/othervm/native -Xlog:redefine*=trace -agentlib:RedefineRetransform RedefineRetransform
+ * @run main/othervm/native -agentlib:RedefineRetransform RedefineRetransform 1
+ * @run main/othervm/native -agentlib:RedefineRetransform RedefineRetransform 2
+ * @run main/othervm/native -agentlib:RedefineRetransform RedefineRetransform 3
+ * @run main/othervm/native -agentlib:RedefineRetransform RedefineRetransform 4
+ * @run main/othervm/native -agentlib:RedefineRetransform RedefineRetransform 5
+ * @run main/othervm/native -agentlib:RedefineRetransform RedefineRetransform 6
+ */
+
+import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import jdk.internal.org.objectweb.asm.AnnotationVisitor;
+import jdk.internal.org.objectweb.asm.ClassReader;
+import jdk.internal.org.objectweb.asm.ClassVisitor;
+import jdk.internal.org.objectweb.asm.ClassWriter;
+import jdk.internal.org.objectweb.asm.Opcodes;
+import jdk.internal.org.objectweb.asm.Type;
+
+public class RedefineRetransform {
+    static {
+        System.loadLibrary("RedefineRetransform");
+    }
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface ClassVersion {
+		int value();
+	}
+
+	// Use runtime-visible annotation to specify class version
+	@ClassVersion(0)
+	static class TestClass {
+		public TestClass() { }
+	}
+
+	// redefines testClass with classBytes, instrument with classLoadHookBytes (is != null)
+	private static native byte[] nRedefine(Class testClass, byte[] classBytes, byte[] classLoadHookBytes);
+    // retransforms testClass with classBytes (if != null)
+	private static native byte[] nRetransform(Class testClass, byte[] classBytes);
+
+	private static byte[] initialClassBytes;
+
+	private static class VersionScanner extends ClassVisitor {
+		private Integer detectedVersion;
+		private Integer versionToSet;
+		// to get version
+		public VersionScanner() {
+			super(Opcodes.ASM7);
+		}
+		// to set version
+		public VersionScanner(int verToSet, ClassVisitor classVisitor) {
+			super(Opcodes.ASM7, classVisitor);
+			versionToSet = verToSet;
+		}
+
+		public int detectedVersion() {
+			if (detectedVersion == null) {
+				throw new RuntimeException("Version not detected");
+			}
+			return detectedVersion;
+		}
+
+		@Override
+		public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+			//log("visitAnnotation: descr = '" + descriptor + "', visible = " + visible);
+			if (Type.getDescriptor(ClassVersion.class).equals(descriptor)) {
+				return new AnnotationVisitor(Opcodes.ASM7, super.visitAnnotation(descriptor, visible)) {
+					@Override
+					public void visit(String name, Object value) {
+						//log("visit: name = '" + name + "', value = " + value
+						//		+ " (" + (value == null ? "N/A" : value.getClass()) + ")");
+						if ("value".equals(name) && value instanceof Integer intValue) {
+							detectedVersion = intValue;
+							if (versionToSet != null) {
+								//log("replace with " + versionToSet);
+								value = versionToSet;
+							}
+						}
+						super.visit(name, value);
+					}
+				};
+			}
+			return super.visitAnnotation(descriptor, visible);
+		}
+	}
+
+	private static byte[] getClassBytes(int ver) {
+		if (ver < 0) {
+			return null;
+		}
+		ClassWriter cw = new ClassWriter(0);
+		ClassReader cr = new ClassReader(initialClassBytes);
+		cr.accept(new VersionScanner(ver, cw), 0);
+		return cw.toByteArray();
+	}
+
+	private static int getClassBytesVersion(byte[] classBytes) {
+		ClassReader cr = new ClassReader(classBytes);
+		VersionScanner scanner = new VersionScanner();
+		cr.accept(scanner, 0);
+		return scanner.detectedVersion();
+	}
+
+	static void init() {
+		try {
+			initialClassBytes = TestClass.class.getClassLoader()
+					.getResourceAsStream("RedefineRetransform$TestClass.class")
+					.readAllBytes();
+			log("Read TestClass bytes: " + initialClassBytes.length);
+		} catch (IOException ex) {
+			throw new RuntimeException("Failed to read class bytes", ex);
+		}
+	}
+
+	static void redefine(int ver) {
+		redefine(ver, -1);
+	}
+
+	static void redefine(int ver, int classLoadHookVer) {
+		byte[] classBytes = getClassBytes(ver);
+		byte[] classLoadHookBytes = getClassBytes(classLoadHookVer);
+
+		byte[] hookClassBytes = nRedefine(TestClass.class, classBytes, classLoadHookBytes);
+		if (hookClassBytes == null) {
+			throw new RuntimeException("Redefine error (ver = " + ver + ")");
+		}
+		// verity ClassFileLoadHook get expected class bytes
+		int hookVer = getClassBytesVersion(hookClassBytes);
+		if (hookVer != ver) {
+			throw new RuntimeException("CLFH got unexpected version: "  + hookVer
+					+ " (expected " + ver + ")");
+		}
+	}
+
+	static void retransform(int ver, int expectedVer) {
+		byte[] classBytes = getClassBytes(ver);
+		byte[] hookClassBytes = nRetransform(TestClass.class, classBytes);
+		int hookVer = getClassBytesVersion(hookClassBytes);
+		if (hookVer != expectedVer) {
+			throw new RuntimeException("CLFH got unexpected version: "  + hookVer
+					+ " (expected " + expectedVer + ")");
+		}
+	}
+
+    public static void main(String[] args) throws Exception {
+		int testCase;
+		try {
+			testCase= Integer.valueOf(args[0]);
+		} catch (Exception ex) {
+			throw new RuntimeException("Single numeric argument expected", ex);
+		}
+		init();
+		switch (testCase) {
+		case 1:
+			test("Redefine-Retransform-Retransform", () -> {
+				redefine(1);
+				retransform(2, 1);
+				retransform(3, 1);
+			});
+			break;
+
+		case 2:
+			test("Redefine-Retransform-Redefine-Redefine", () -> {
+				redefine(1);
+				retransform(2, 1);
+				redefine(3);
+				redefine(4);
+			});
+			break;
+
+		case 3:
+			test("Redefine-Retransform-Redefine-Retransform", () -> {
+				redefine(1);
+				retransform(2, 1);    // sets cached class bytes
+				redefine(3);					// resets cached class bytes
+				retransform(4, 3);
+			});
+			break;
+
+		case 4:
+			test("Retransform-Redefine-Retransform-Retransform", () -> {
+				retransform(1, 0);	// sets cached class bytes
+				redefine(2);					// reset cached class bytes
+				retransform(3, 2);	// sets cached class bytes
+				retransform(4, 2);
+			});
+			break;
+
+		case 5:
+			test("Redefine-Retransform-Redefine-Retransform with CFLH", () -> {
+				redefine(1, 5);	// sets cached class bytes
+				retransform(2, 1);
+				redefine(3, 6);	// updates cached class bytes
+				retransform(4, 3);
+			});
+			break;
+
+		case 6:
+			test("Retransform-Redefine-Retransform-Retransform with CFLH", () -> {
+				retransform(1, 0);	// sets cached class bytes
+				redefine(2, 5);	// updates cached class bytes
+				retransform(3, 2);
+				retransform(4, 2);
+			});
+			break;
+		}
+    }
+
+    private static void log(Object msg) {
+        System.out.println(msg);
+    }
+
+    private interface Test {
+        void test();
+    }
+
+    private static void test(String name, Test theTest) {
+        log(">>Test: " + name);
+        theTest.test();
+		log("<<Test: " + name + " - OK");
+		log("");
+    }
+}

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/RedefineRetransform.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/RedefineRetransform.java
@@ -56,187 +56,187 @@ public class RedefineRetransform {
     }
 
 	@Retention(RetentionPolicy.RUNTIME)
-	@interface ClassVersion {
-		int value();
-	}
+    @interface ClassVersion {
+        int value();
+    }
 
-	// Use runtime-visible annotation to specify class version
-	@ClassVersion(0)
-	static class TestClass {
-		public TestClass() { }
-	}
+    // Use runtime-visible annotation to specify class version
+    @ClassVersion(0)
+    static class TestClass {
+        public TestClass() { }
+    }
 
-	// redefines testClass with classBytes, instrument with classLoadHookBytes (is != null)
-	private static native byte[] nRedefine(Class testClass, byte[] classBytes, byte[] classLoadHookBytes);
+    // redefines testClass with classBytes, instrument with classLoadHookBytes (is != null)
+    private static native byte[] nRedefine(Class testClass, byte[] classBytes, byte[] classLoadHookBytes);
     // retransforms testClass with classBytes (if != null)
-	private static native byte[] nRetransform(Class testClass, byte[] classBytes);
+    private static native byte[] nRetransform(Class testClass, byte[] classBytes);
 
-	private static byte[] initialClassBytes;
+    private static byte[] initialClassBytes;
 
-	private static class VersionScanner extends ClassVisitor {
-		private Integer detectedVersion;
-		private Integer versionToSet;
-		// to get version
-		public VersionScanner() {
-			super(Opcodes.ASM7);
-		}
-		// to set version
-		public VersionScanner(int verToSet, ClassVisitor classVisitor) {
-			super(Opcodes.ASM7, classVisitor);
-			versionToSet = verToSet;
-		}
+    private static class VersionScanner extends ClassVisitor {
+        private Integer detectedVersion;
+        private Integer versionToSet;
+        // to get version
+        public VersionScanner() {
+            super(Opcodes.ASM7);
+        }
+        // to set version
+        public VersionScanner(int verToSet, ClassVisitor classVisitor) {
+            super(Opcodes.ASM7, classVisitor);
+            versionToSet = verToSet;
+        }
 
-		public int detectedVersion() {
-			if (detectedVersion == null) {
-				throw new RuntimeException("Version not detected");
-			}
-			return detectedVersion;
-		}
+        public int detectedVersion() {
+            if (detectedVersion == null) {
+                throw new RuntimeException("Version not detected");
+            }
+            return detectedVersion;
+        }
 
-		@Override
-		public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
-			//log("visitAnnotation: descr = '" + descriptor + "', visible = " + visible);
-			if (Type.getDescriptor(ClassVersion.class).equals(descriptor)) {
-				return new AnnotationVisitor(Opcodes.ASM7, super.visitAnnotation(descriptor, visible)) {
-					@Override
-					public void visit(String name, Object value) {
-						//log("visit: name = '" + name + "', value = " + value
-						//		+ " (" + (value == null ? "N/A" : value.getClass()) + ")");
-						if ("value".equals(name) && value instanceof Integer intValue) {
-							detectedVersion = intValue;
-							if (versionToSet != null) {
-								//log("replace with " + versionToSet);
-								value = versionToSet;
-							}
-						}
-						super.visit(name, value);
-					}
-				};
-			}
-			return super.visitAnnotation(descriptor, visible);
-		}
-	}
+        @Override
+        public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+            //log("visitAnnotation: descr = '" + descriptor + "', visible = " + visible);
+            if (Type.getDescriptor(ClassVersion.class).equals(descriptor)) {
+                return new AnnotationVisitor(Opcodes.ASM7, super.visitAnnotation(descriptor, visible)) {
+                    @Override
+                    public void visit(String name, Object value) {
+                        //log("visit: name = '" + name + "', value = " + value
+                        //        + " (" + (value == null ? "N/A" : value.getClass()) + ")");
+                        if ("value".equals(name) && value instanceof Integer intValue) {
+                            detectedVersion = intValue;
+                            if (versionToSet != null) {
+                                //log("replace with " + versionToSet);
+                                value = versionToSet;
+                            }
+                        }
+                        super.visit(name, value);
+                    }
+                };
+            }
+            return super.visitAnnotation(descriptor, visible);
+        }
+    }
 
-	private static byte[] getClassBytes(int ver) {
-		if (ver < 0) {
-			return null;
-		}
-		ClassWriter cw = new ClassWriter(0);
-		ClassReader cr = new ClassReader(initialClassBytes);
-		cr.accept(new VersionScanner(ver, cw), 0);
-		return cw.toByteArray();
-	}
+    private static byte[] getClassBytes(int ver) {
+        if (ver < 0) {
+            return null;
+        }
+        ClassWriter cw = new ClassWriter(0);
+        ClassReader cr = new ClassReader(initialClassBytes);
+        cr.accept(new VersionScanner(ver, cw), 0);
+        return cw.toByteArray();
+    }
 
-	private static int getClassBytesVersion(byte[] classBytes) {
-		ClassReader cr = new ClassReader(classBytes);
-		VersionScanner scanner = new VersionScanner();
-		cr.accept(scanner, 0);
-		return scanner.detectedVersion();
-	}
+    private static int getClassBytesVersion(byte[] classBytes) {
+        ClassReader cr = new ClassReader(classBytes);
+        VersionScanner scanner = new VersionScanner();
+        cr.accept(scanner, 0);
+        return scanner.detectedVersion();
+    }
 
-	static void init() {
-		try {
-			initialClassBytes = TestClass.class.getClassLoader()
-					.getResourceAsStream("RedefineRetransform$TestClass.class")
-					.readAllBytes();
-			log("Read TestClass bytes: " + initialClassBytes.length);
-		} catch (IOException ex) {
-			throw new RuntimeException("Failed to read class bytes", ex);
-		}
-	}
+    static void init() {
+        try {
+            initialClassBytes = TestClass.class.getClassLoader()
+                    .getResourceAsStream("RedefineRetransform$TestClass.class")
+                    .readAllBytes();
+            log("Read TestClass bytes: " + initialClassBytes.length);
+        } catch (IOException ex) {
+            throw new RuntimeException("Failed to read class bytes", ex);
+        }
+    }
 
-	static void redefine(int ver) {
-		redefine(ver, -1);
-	}
+    static void redefine(int ver) {
+        redefine(ver, -1);
+    }
 
-	static void redefine(int ver, int classLoadHookVer) {
-		byte[] classBytes = getClassBytes(ver);
-		byte[] classLoadHookBytes = getClassBytes(classLoadHookVer);
+    static void redefine(int ver, int classLoadHookVer) {
+        byte[] classBytes = getClassBytes(ver);
+        byte[] classLoadHookBytes = getClassBytes(classLoadHookVer);
 
-		byte[] hookClassBytes = nRedefine(TestClass.class, classBytes, classLoadHookBytes);
-		if (hookClassBytes == null) {
-			throw new RuntimeException("Redefine error (ver = " + ver + ")");
-		}
-		// verity ClassFileLoadHook get expected class bytes
-		int hookVer = getClassBytesVersion(hookClassBytes);
-		if (hookVer != ver) {
-			throw new RuntimeException("CLFH got unexpected version: "  + hookVer
-					+ " (expected " + ver + ")");
-		}
-	}
+        byte[] hookClassBytes = nRedefine(TestClass.class, classBytes, classLoadHookBytes);
+        if (hookClassBytes == null) {
+            throw new RuntimeException("Redefine error (ver = " + ver + ")");
+        }
+        // verity ClassFileLoadHook get expected class bytes
+        int hookVer = getClassBytesVersion(hookClassBytes);
+        if (hookVer != ver) {
+            throw new RuntimeException("CLFH got unexpected version: "  + hookVer
+                    + " (expected " + ver + ")");
+        }
+    }
 
-	static void retransform(int ver, int expectedVer) {
-		byte[] classBytes = getClassBytes(ver);
-		byte[] hookClassBytes = nRetransform(TestClass.class, classBytes);
-		int hookVer = getClassBytesVersion(hookClassBytes);
-		if (hookVer != expectedVer) {
-			throw new RuntimeException("CLFH got unexpected version: "  + hookVer
-					+ " (expected " + expectedVer + ")");
-		}
-	}
+    static void retransform(int ver, int expectedVer) {
+        byte[] classBytes = getClassBytes(ver);
+        byte[] hookClassBytes = nRetransform(TestClass.class, classBytes);
+        int hookVer = getClassBytesVersion(hookClassBytes);
+        if (hookVer != expectedVer) {
+            throw new RuntimeException("CLFH got unexpected version: "  + hookVer
+                    + " (expected " + expectedVer + ")");
+        }
+    }
 
     public static void main(String[] args) throws Exception {
-		int testCase;
-		try {
-			testCase= Integer.valueOf(args[0]);
-		} catch (Exception ex) {
-			throw new RuntimeException("Single numeric argument expected", ex);
-		}
-		init();
-		switch (testCase) {
-		case 1:
-			test("Redefine-Retransform-Retransform", () -> {
-				redefine(1);
-				retransform(2, 1);
-				retransform(3, 1);
-			});
-			break;
+        int testCase;
+        try {
+            testCase= Integer.valueOf(args[0]);
+        } catch (Exception ex) {
+            throw new RuntimeException("Single numeric argument expected", ex);
+        }
+        init();
+        switch (testCase) {
+        case 1:
+            test("Redefine-Retransform-Retransform", () -> {
+                redefine(1);
+                retransform(2, 1);
+                retransform(3, 1);
+            });
+            break;
 
-		case 2:
-			test("Redefine-Retransform-Redefine-Redefine", () -> {
-				redefine(1);
-				retransform(2, 1);
-				redefine(3);
-				redefine(4);
-			});
-			break;
+        case 2:
+            test("Redefine-Retransform-Redefine-Redefine", () -> {
+                redefine(1);
+                retransform(2, 1);
+                redefine(3);
+                redefine(4);
+            });
+            break;
 
-		case 3:
-			test("Redefine-Retransform-Redefine-Retransform", () -> {
-				redefine(1);
-				retransform(2, 1);    // sets cached class bytes
-				redefine(3);					// resets cached class bytes
-				retransform(4, 3);
-			});
-			break;
+        case 3:
+            test("Redefine-Retransform-Redefine-Retransform", () -> {
+                redefine(1);
+                retransform(2, 1);    // sets cached class bytes
+                redefine(3);                    // resets cached class bytes
+                retransform(4, 3);
+            });
+            break;
 
-		case 4:
-			test("Retransform-Redefine-Retransform-Retransform", () -> {
-				retransform(1, 0);	// sets cached class bytes
-				redefine(2);					// reset cached class bytes
-				retransform(3, 2);	// sets cached class bytes
-				retransform(4, 2);
-			});
-			break;
+        case 4:
+            test("Retransform-Redefine-Retransform-Retransform", () -> {
+                retransform(1, 0);    // sets cached class bytes
+                redefine(2);                    // reset cached class bytes
+                retransform(3, 2);    // sets cached class bytes
+                retransform(4, 2);
+            });
+            break;
 
-		case 5:
-			test("Redefine-Retransform-Redefine-Retransform with CFLH", () -> {
-				redefine(1, 5);	// sets cached class bytes
-				retransform(2, 1);
-				redefine(3, 6);	// updates cached class bytes
-				retransform(4, 3);
-			});
-			break;
+        case 5:
+            test("Redefine-Retransform-Redefine-Retransform with CFLH", () -> {
+                redefine(1, 5);    // sets cached class bytes
+                retransform(2, 1);
+                redefine(3, 6);    // updates cached class bytes
+                retransform(4, 3);
+            });
+            break;
 
-		case 6:
-			test("Retransform-Redefine-Retransform-Retransform with CFLH", () -> {
-				retransform(1, 0);	// sets cached class bytes
-				redefine(2, 5);	// updates cached class bytes
-				retransform(3, 2);
-				retransform(4, 2);
-			});
-			break;
-		}
+        case 6:
+            test("Retransform-Redefine-Retransform-Retransform with CFLH", () -> {
+                retransform(1, 0);    // sets cached class bytes
+                redefine(2, 5);    // updates cached class bytes
+                retransform(3, 2);
+                retransform(4, 2);
+            });
+            break;
+        }
     }
 
     private static void log(Object msg) {
@@ -250,7 +250,7 @@ public class RedefineRetransform {
     private static void test(String name, Test theTest) {
         log(">>Test: " + name);
         theTest.test();
-		log("<<Test: " + name + " - OK");
-		log("");
+        log("<<Test: " + name + " - OK");
+        log("");
     }
 }

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/RedefineRetransform.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/RedefineRetransform.java
@@ -55,7 +55,7 @@ public class RedefineRetransform {
         System.loadLibrary("RedefineRetransform");
     }
 
-	@Retention(RetentionPolicy.RUNTIME)
+    @Retention(RetentionPolicy.RUNTIME)
     @interface ClassVersion {
         int value();
     }

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/RedefineRetransform.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/RedefineRetransform.java
@@ -171,7 +171,7 @@ public class RedefineRetransform {
         if (hookClassBytes == null) {
             throw new RuntimeException("Redefine error (ver = " + ver + ")");
         }
-        // verity ClassFileLoadHook get expected class bytes
+        // verity ClassFileLoadHook gets the expected class bytes
         int hookVer = getClassBytesVersion(hookClassBytes);
         if (hookVer != ver) {
             throw new RuntimeException("CLFH got unexpected version: "  + hookVer
@@ -194,7 +194,7 @@ public class RedefineRetransform {
     public static void main(String[] args) throws Exception {
         int testCase;
         try {
-            testCase= Integer.valueOf(args[0]);
+            testCase = Integer.valueOf(args[0]);
         } catch (Exception ex) {
             throw new RuntimeException("Single numeric argument expected", ex);
         }
@@ -212,7 +212,7 @@ public class RedefineRetransform {
             test("Redefine-Retransform-Redefine-Redefine", () -> {
                 redefine(1);        // cached class bytes are not set
                 retransform(2, 1);  // sets cached class bytes to ver 1
-                redefine(3);        // resets cached class bytes
+                redefine(3);        // resets cached class bytes to nullptr
                 redefine(4);        // cached class bytes are not set
             });
             break;
@@ -221,7 +221,7 @@ public class RedefineRetransform {
             test("Redefine-Retransform-Redefine-Retransform", () -> {
                 redefine(1);        // cached class bytes are not set
                 retransform(2, 1);  // sets cached class bytes to ver 1
-                redefine(3);        // resets cached class bytes
+                redefine(3);        // resets cached class bytes to nullptr
                 retransform(4, 3);  // sets cached class bytes to ver 3
             });
             break;
@@ -229,7 +229,7 @@ public class RedefineRetransform {
         case 4:
             test("Retransform-Redefine-Retransform-Retransform", () -> {
                 retransform(1, 0);  // sets cached class bytes to ver 0 (initially loaded)
-                redefine(2);        // resets cached class bytes
+                redefine(2);        // resets cached class bytes to nullptr
                 retransform(3, 2);  // sets cached class bytes to ver 2
                 retransform(4, 2);  // uses existing cache
             });
@@ -239,7 +239,7 @@ public class RedefineRetransform {
             test("Redefine-Retransform-Redefine-Retransform with CFLH", () -> {
                 redefine(1, 5);     // CFLH sets cached class bytes to ver 1
                 retransform(2, 1);  // uses existing cache
-                redefine(3, 6);     // resets cached class bytes,
+                redefine(3, 6);     // resets cached class bytes to nullptr,
                                     // CFLH sets cached class bytes to ver 3
                 retransform(4, 3);  // uses existing cache
             });
@@ -248,7 +248,7 @@ public class RedefineRetransform {
         case 6:
             test("Retransform-Redefine-Retransform-Retransform with CFLH", () -> {
                 retransform(1, 0);  // sets cached class bytes to ver 0 (initially loaded)
-                redefine(2, 5);     // resets cached class bytes,
+                redefine(2, 5);     // resets cached class bytes to nullptr,
                                     // CFLH sets cached class bytes to ver 2
                 retransform(3, 2);  // uses existing cache
                 retransform(4, 2);  // uses existing cache

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/RedefineRetransform.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/RedefineRetransform.java
@@ -171,7 +171,7 @@ public class RedefineRetransform {
         if (hookClassBytes == null) {
             throw new RuntimeException("Redefine error (ver = " + ver + ")");
         }
-        // verity ClassFileLoadHook gets the expected class bytes
+        // verify ClassFileLoadHook gets the expected class bytes
         int hookVer = getClassBytesVersion(hookClassBytes);
         if (hookVer != ver) {
             throw new RuntimeException("CLFH got unexpected version: "  + hookVer

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/libRedefineRetransform.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/libRedefineRetransform.cpp
@@ -31,8 +31,6 @@ static jvmtiEnv* jvmti = nullptr;
 
 static const char testClassName[] = "RedefineRetransform$TestClass";
 
-extern "C" {
-
 static void _log(const char* format, ...) {
     va_list args;
     va_start(args, format);
@@ -177,6 +175,8 @@ public:
 
 ClassFileLoadHookHelper* ClassFileLoadHookHelper::instance = nullptr;
 
+
+extern "C" {
 
 JNIEXPORT void JNICALL
 callbackClassFileLoadHook(jvmtiEnv *jvmti_env,

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/libRedefineRetransform.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/libRedefineRetransform.cpp
@@ -45,8 +45,8 @@ static bool isTestClass(const char* name) {
 
 /*
  * Helper class for data exchange between RedefineClasses/RetransformClasses and
- * ClassFileLoadHook callback (saves class bytes passed to CFLH,
- * allows to set new class bytes to return from CFLH).
+ * ClassFileLoadHook callback (saves class bytes to be passed to CFLH,
+ * allows setting new class bytes to return from CFLH).
  * Callers create an instance on the stack, ClassFileLoadHook handler uses getInstance().
  */
 class ClassFileLoadHookHelper {

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/libRedefineRetransform.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/libRedefineRetransform.cpp
@@ -218,18 +218,18 @@ JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM* jvm, char* options, void* reserved) 
 
     caps.can_redefine_classes = 1;
     caps.can_retransform_classes = 1;
-    res = jvmti->AddCapabilities(&caps);
-    if (res != JVMTI_ERROR_NONE) {
-        _log("Failed to add capabilities: %ld\n", res);
+    jvmtiError err = jvmti->AddCapabilities(&caps);
+    if (err != JVMTI_ERROR_NONE) {
+        _log("Failed to add capabilities: %d\n", err);
         return JNI_ERR;
     }
 
     jvmtiEventCallbacks eventCallbacks;
     memset(&eventCallbacks, 0, sizeof(eventCallbacks));
     eventCallbacks.ClassFileLoadHook = callbackClassFileLoadHook;
-    res = jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks));
-    if (res != JVMTI_ERROR_NONE) {
-        _log("Error setting event callbacks: %ld\n", res);
+    err = jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks));
+    if (err != JVMTI_ERROR_NONE) {
+        _log("Error setting event callbacks: %d\n", err);
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/libRedefineRetransform.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/libRedefineRetransform.cpp
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+#include <stdio.h>
+#include <jvmti.h>
+#include <jni.h>
+#include <string.h>
+
+
+// set by Agent_OnLoad
+static jvmtiEnv* jvmti = NULL;
+
+static const char testClassName[] = "RedefineRetransform$TestClass";
+
+// to redefine from ClassFileLoadHock callback
+// set by caller:
+static jbyteArray classLoadHookNewClassBytes = nullptr;
+// set by ClassFileLoadHock callback:
+static unsigned char* classLoadHookSavedClassBytes = nullptr;
+static jint classLoadHookSavedClassBytesLen = 0;
+
+extern "C" {
+
+static void _log(const char* format, ...) {
+    va_list args;
+    va_start(args, format);
+    vprintf(format, args);
+    va_end(args);
+    fflush(0);
+}
+
+static bool isTestClass(const char* name) {
+    return name != nullptr && strcmp(name, testClassName) == 0;
+}
+
+JNIEXPORT void JNICALL
+callbackClassFileLoadHook(jvmtiEnv *jvmti_env,
+        JNIEnv* jni_env,
+        jclass class_being_redefined,
+        jobject loader,
+        const char* name,
+        jobject protection_domain,
+        jint class_data_len,
+        const unsigned char* class_data,
+        jint* new_class_data_len,
+        unsigned char** new_class_data) {
+    if (isTestClass(name)) {
+        _log(">>ClassFileLoadHook: %s, %ld bytes, ptr = %p\n", name, class_data_len, class_data);
+
+        // save class bytes
+        jvmtiError err = jvmti->Allocate(class_data_len, &classLoadHookSavedClassBytes);
+        if (err != JVMTI_ERROR_NONE) {
+            _log("ClassFileLoadHook: failed to allocate %ld bytes for saved class bytes: %d", class_data_len, err);
+            return;
+        }
+        memcpy(classLoadHookSavedClassBytes, class_data, class_data_len);
+        classLoadHookSavedClassBytesLen = class_data_len;
+
+        // set new class bytes
+        if (classLoadHookNewClassBytes != nullptr) {
+            jsize len = jni_env->GetArrayLength(classLoadHookNewClassBytes);
+            unsigned char* buf = nullptr;
+            err = jvmti->Allocate(len, &buf);
+            if (err != JVMTI_ERROR_NONE) {
+                _log("ClassFileLoadHook: failed to allocate %ld bytes for new class bytes: %d", len, err);
+                return;
+            }
+
+            jbyte* arrayPtr = jni_env->GetByteArrayElements(classLoadHookNewClassBytes, nullptr);
+            if (arrayPtr == nullptr) {
+                _log("ClassFileLoadHook: failed to get array elements\n");
+                jvmti->Deallocate(buf);
+                return;
+            }
+
+            memcpy(buf, arrayPtr, len);
+
+            jni_env->ReleaseByteArrayElements(classLoadHookNewClassBytes, arrayPtr, JNI_ABORT);
+
+            *new_class_data = buf;
+            *new_class_data_len = len;
+
+            _log("  ClassFileLoadHook: set new class bytes\n");
+        }
+        _log("<<ClassFileLoadHook\n");
+    }
+}
+
+JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM* jvm, char* options, void* reserved) {
+    jint res = jvm->GetEnv((void **)&jvmti, JVMTI_VERSION_1_1);
+    if (res != JNI_OK) {
+        _log("Failed to get JVMTI interface: %ld\n", res);
+        return JNI_ERR;
+    }
+
+    jvmtiCapabilities caps;
+    memset(&caps, 0, sizeof(caps));
+
+    caps.can_redefine_classes = 1;
+    caps.can_retransform_classes = 1;
+    jvmti->AddCapabilities(&caps);
+
+    jvmtiEventCallbacks eventCallbacks;
+    memset(&eventCallbacks, 0, sizeof(eventCallbacks));
+    eventCallbacks.ClassFileLoadHook = callbackClassFileLoadHook;
+    res = jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks));
+    if (res != JVMTI_ERROR_NONE) {
+        _log("Error setting event callbacks: %ld\n", res);
+        return JNI_ERR;
+    }
+
+    return JNI_OK;
+}
+
+JNIEXPORT void JNICALL
+Agent_OnUnload(JavaVM* jvm) {
+    return;
+}
+
+
+JNIEXPORT jbyteArray JNICALL
+Java_RedefineRetransform_nRedefine(JNIEnv* env, jclass klass,
+                                   jclass testClass, jbyteArray classBytes, jbyteArray classLoadHookBytes) {
+
+    _log(">>nRedefine\n");
+    jsize len = env->GetArrayLength(classBytes);
+    jbyte* arrayPtr = env->GetByteArrayElements(classBytes, nullptr);
+    if (arrayPtr == nullptr) {
+        _log("nRedefine: Failed to get array elements\n");
+        return nullptr;
+    }
+    if (classLoadHookBytes != nullptr) {
+        classLoadHookNewClassBytes = (jbyteArray)env->NewGlobalRef(classLoadHookBytes);
+    }
+
+
+    jvmtiError err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, nullptr);
+    if (err != JVMTI_ERROR_NONE) {
+        env->ReleaseByteArrayElements(classBytes, arrayPtr, JNI_ABORT);
+        _log("nRedefine: SetEventNotificationMode(JVMTI_ENABLE) error %d\n", err);
+        return nullptr;
+    }
+
+    jvmtiClassDefinition classDef;
+    memset(&classDef, 0, sizeof(classDef));
+    classDef.klass = testClass;
+    classDef.class_byte_count = len;
+    classDef.class_bytes = (unsigned char *)arrayPtr;
+
+    jvmtiError err2 = jvmti->RedefineClasses(1, &classDef);
+
+    if (err2 != JVMTI_ERROR_NONE) {
+        _log("nRedefine: RedefineClasses error %d", err2);
+        // don't exit here, need to cleanup
+    }
+
+    err = jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, nullptr);
+    if (err != JVMTI_ERROR_NONE) {
+        _log("nRedefine: SetEventNotificationMode(JVMTI_DISABLE) error %d\n", err);
+    }
+
+    env->ReleaseByteArrayElements(classBytes, arrayPtr, JNI_ABORT);
+
+    if (classLoadHookBytes != nullptr) {
+        env->DeleteGlobalRef(classLoadHookNewClassBytes);
+        classLoadHookNewClassBytes = nullptr;
+    }
+
+    if (err != JVMTI_ERROR_NONE || err2 != JVMTI_ERROR_NONE) {
+        return nullptr;
+    }
+
+    if (classLoadHookSavedClassBytes == nullptr) {
+        _log("nRedefine: classLoadHookSavedClassBytes is NULL\n");
+        return nullptr;
+    }
+
+    jbyteArray result = env->NewByteArray(classLoadHookSavedClassBytesLen);
+    if (result == nullptr) {
+        _log("nRedefine: NewByteArray(%ld) failed\n", classLoadHookSavedClassBytesLen);
+    } else {
+        jbyte* arrayPtr = env->GetByteArrayElements(result, nullptr);
+        if (arrayPtr == nullptr) {
+            _log("nRedefine: Failed to get array elements\n");
+            result = nullptr;
+        } else {
+            memcpy(arrayPtr, classLoadHookSavedClassBytes, classLoadHookSavedClassBytesLen);
+            env->ReleaseByteArrayElements(result, arrayPtr, JNI_COMMIT);
+        }
+    }
+
+    jvmti->Deallocate(classLoadHookSavedClassBytes);
+    classLoadHookSavedClassBytes = nullptr;
+
+    return result;
+}
+
+JNIEXPORT jbyteArray JNICALL
+Java_RedefineRetransform_nRetransform(JNIEnv* env, jclass klass, jclass testClass, jbyteArray classBytes) {
+
+    _log(">>nRetransform\n");
+    if (classBytes != nullptr) {
+        classLoadHookNewClassBytes = (jbyteArray)env->NewGlobalRef(classBytes);
+    }
+
+    jvmtiError err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, nullptr);
+    if (err != JVMTI_ERROR_NONE) {
+        _log("nRetransform: SetEventNotificationMode(JVMTI_ENABLE) error %d\n", err);
+        return nullptr;
+    }
+
+    jvmtiError err2 = jvmti->RetransformClasses(1, &testClass);
+    if (err2 != JVMTI_ERROR_NONE) {
+        _log("nRetransform: RetransformClasses error %d\n", err2);
+        // don't exit here, disable CFLH event
+    }
+
+    err = jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, nullptr);
+    if (err != JVMTI_ERROR_NONE) {
+        _log("nRetransform: SetEventNotificationMode(JVMTI_DISABLE) error %d\n", err);
+    }
+
+    if (classBytes != nullptr) {
+        env->DeleteGlobalRef(classLoadHookNewClassBytes);
+        classLoadHookNewClassBytes = nullptr;
+    }
+
+    if (err != JVMTI_ERROR_NONE || err2 != JVMTI_ERROR_NONE) {
+        return nullptr;
+    }
+
+    if (classLoadHookSavedClassBytes == nullptr) {
+        _log("nRetransform: classLoadHookSavedClassBytes is NULL\n");
+        return nullptr;
+    }
+
+    jbyteArray result = env->NewByteArray(classLoadHookSavedClassBytesLen);
+    if (result == nullptr) {
+        _log("nRetransform: NewByteArray(%ld) failed\n", classLoadHookSavedClassBytesLen);
+    } else {
+        jbyte* arrayPtr = env->GetByteArrayElements(result, nullptr);
+        if (arrayPtr == nullptr) {
+            _log("nRetransform: Failed to get array elements\n");
+            result = nullptr;
+        }
+        else {
+            memcpy(arrayPtr, classLoadHookSavedClassBytes, classLoadHookSavedClassBytesLen);
+            env->ReleaseByteArrayElements(result, arrayPtr, JNI_COMMIT);
+        }
+    }
+
+    jvmti->Deallocate(classLoadHookSavedClassBytes);
+    classLoadHookSavedClassBytes = nullptr;
+
+    return result;
+}
+
+}


### PR DESCRIPTION
The problem is RedefineClasses does not update cached_class_bytes, so subsequent RetransformClasses gets obsolete class bytes (this are testcases 3-6 from the new test)

cached_class_bytes are set when an agent instruments the class from ClassFileLoadHook.
After successful RedefineClasses it should be reset.
The fix updates ClassFileLoadHook caller to not use old cached_class_bytes with RedefineClasses (if some agent instruments the class, new cached_class_bytes are allocated for scratch_class) and updates cached_class_bytes after successful RedefineClasses or RetransformClasses.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7124710](https://bugs.openjdk.org/browse/JDK-7124710): interleaved RedefineClasses() and RetransformClasses() calls may have a problem


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [d853f23f](https://git.openjdk.org/jdk/pull/10032/files/d853f23f7fbe76b794e5ffbc54f57553a8eb34d5)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to [36c4ba60](https://git.openjdk.org/jdk/pull/10032/files/36c4ba6046953703655f192fc6b4d9edaef1be37)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10032/head:pull/10032` \
`$ git checkout pull/10032`

Update a local copy of the PR: \
`$ git checkout pull/10032` \
`$ git pull https://git.openjdk.org/jdk pull/10032/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10032`

View PR using the GUI difftool: \
`$ git pr show -t 10032`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10032.diff">https://git.openjdk.org/jdk/pull/10032.diff</a>

</details>
