### PR TITLE
8271615: vmTestbase/vm/jit/LongTransitions/ test fail due to locale mismatch

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/LTTest.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/LTTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/LTTest.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/LTTest.java
@@ -6218,6 +6218,15 @@ public class LTTest
             fisJava.read(javaData);
             for ( int cnt=0;cnt<byteCount;++cnt)
             {
+                // Special handling for a decimal point.
+                // Decimal point differs based on locale, could be '.' or ','.
+                // Due to settings on a test host environment locale may differ between
+                // the native side vs Java side thus causing mismatch and test failure.
+                if ( cData[cnt] == '.' || cData[cnt] == ',' ) {
+                    if (javaData[cnt] == '.' || javaData[cnt] == ',') {
+                        continue;
+                    }
+                }
                 if ( cData[cnt]!=javaData[cnt] )
                 {
                     System.out.println("FAIL:Test failed! "+cnt+" byte are wrong! C file - " + cData[cnt] + " Java file - "+javaData[cnt] );

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/LTTest.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/LTTest.java
@@ -6222,10 +6222,9 @@ public class LTTest
                 // Decimal point differs based on locale, could be '.' or ','.
                 // Due to settings on a test host environment locale may differ between
                 // the native side vs Java side thus causing mismatch and test failure.
-                if ( cData[cnt] == '.' || cData[cnt] == ',' ) {
-                    if (javaData[cnt] == '.' || javaData[cnt] == ',') {
-                        continue;
-                    }
+                if ((cData[cnt] == '.' || cData[cnt] == ',') &&
+                    (javaData[cnt] == '.' || javaData[cnt] == ',')) {
+                    continue;
                 }
                 if ( cData[cnt]!=javaData[cnt] )
                 {


### PR DESCRIPTION
Decimal point differs based on locale, could be '.' or ','.                                                                                                                          
Due to settings on a test host environment locale may differ between                                                                                                                 
the native side vs Java side thus causing mismatch and test failure.

Solution: added special handling in comparison loop for decimal points.

Testing: PASS (see bug comments for details)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271615](https://bugs.openjdk.org/browse/JDK-8271615): vmTestbase/vm/jit/LongTransitions/ test fail due to locale mismatch


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10033/head:pull/10033` \
`$ git checkout pull/10033`

Update a local copy of the PR: \
`$ git checkout pull/10033` \
`$ git pull https://git.openjdk.org/jdk pull/10033/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10033`

View PR using the GUI difftool: \
`$ git pr show -t 10033`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10033.diff">https://git.openjdk.org/jdk/pull/10033.diff</a>

</details>
