### PR TITLE
8292694: x86_64 c2i/i2c adapters may use more stack space than necessary

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -9453,3 +9453,19 @@ void MacroAssembler::get_thread(Register thread) {
 
 
 #endif // !WIN32 || _LP64
+
+void MacroAssembler::check_stack_alignment(Register sp, const char* msg, unsigned bias, Register tmp) {
+  Label L_stack_ok;
+  if (bias == 0) {
+    testptr(sp, 2 * wordSize - 1);
+  } else {
+    // lea(tmp, Address(rsp, bias);
+    mov(tmp, sp);
+    addptr(tmp, bias);
+    testptr(tmp, 2 * wordSize - 1);
+  }
+  jcc(Assembler::equal, L_stack_ok);
+  block_comment(msg);
+  stop(msg);
+  bind(L_stack_ok);
+}

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -2094,6 +2094,9 @@ public:
 #endif // _LP64
 
   void vallones(XMMRegister dst, int vector_len);
+
+  void check_stack_alignment(Register sp, const char* msg, unsigned bias = 0, Register tmp = noreg);
+
 };
 
 /**

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -661,13 +661,6 @@ address TemplateInterpreterGenerator::generate_Continuation_doYield_entry(void) 
   address entry = __ pc();
   assert(StubRoutines::cont_doYield() != NULL, "stub not yet generated");
 
-#ifdef _LP64
-  const Register sender_sp = r13;
-  // This frame needs to be walkable as a compiled frame, so
-  // undo any c2i adapter adjustment by reseting sp to
-  // sender sp.  Luckily there are no arguments to worry about.
-  __ lea(rsp, Address(sender_sp, -wordSize)); // sender_sp with return address pushed
-#endif
   __ push_cont_fastpath();
 
   __ jump(RuntimeAddress(CAST_FROM_FN_PTR(address, StubRoutines::cont_doYield())));

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -661,6 +661,13 @@ address TemplateInterpreterGenerator::generate_Continuation_doYield_entry(void) 
   address entry = __ pc();
   assert(StubRoutines::cont_doYield() != NULL, "stub not yet generated");
 
+#ifdef _LP64
+  const Register sender_sp = r13;
+  // This frame needs to be walkable as a compiled frame, so
+  // undo any c2i adapter adjustment by reseting sp to
+  // sender sp.  Luckily there are no arguments to worry about.
+  __ lea(rsp, Address(sender_sp, -wordSize)); // sender_sp with return address pushed
+#endif
   __ push_cont_fastpath();
 
   __ jump(RuntimeAddress(CAST_FROM_FN_PTR(address, StubRoutines::cont_doYield())));


### PR DESCRIPTION
The c2i adapter includes the return address in the alignment calculation, making %rsp always mis-aligned according to the ABI.

The i2c adapter aligns "extrawords" even though %rsp is aligned later, and the incoming stack is not guaranteed to be aligned.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292694](https://bugs.openjdk.org/browse/JDK-8292694): x86_64 c2i/i2c adapters may use more stack space than necessary


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10034/head:pull/10034` \
`$ git checkout pull/10034`

Update a local copy of the PR: \
`$ git checkout pull/10034` \
`$ git pull https://git.openjdk.org/jdk pull/10034/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10034`

View PR using the GUI difftool: \
`$ git pr show -t 10034`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10034.diff">https://git.openjdk.org/jdk/pull/10034.diff</a>

</details>
