### PR TITLE
6852577: Only for Nimbus LAF UIManager.get("PasswordField.echoChar") is null

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
@@ -728,6 +728,8 @@ public class SynthLookAndFeel extends BasicLookAndFeel {
                              SwingUtilities2.getSystemMnemonicKeyMask())
                   });
 
+        table.put("PasswordField.echoChar", '*');
+
         // enabled antialiasing depending on desktop settings
         flushUnreferenced();
         SwingUtilities2.putAATextInfo(useLAFConditions(), table);

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthPasswordFieldUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthPasswordFieldUI.java
@@ -67,11 +67,15 @@ public class SynthPasswordFieldUI extends SynthTextFieldUI {
         return "PasswordField";
     }
 
+    /**
+     * Installs the necessary properties on the JPasswordField.
+     */
+    @Override
     protected void installDefaults() {
         super.installDefaults();
         String prefix = getPropertyPrefix();
         Character echoChar = (Character)UIManager.getDefaults().get(prefix + ".echoChar");
-        if(echoChar != null) {
+        if (echoChar != null) {
             LookAndFeel.installProperty(getComponent(), "echoChar", echoChar);
         }
     }

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthPasswordFieldUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthPasswordFieldUI.java
@@ -67,6 +67,15 @@ public class SynthPasswordFieldUI extends SynthTextFieldUI {
         return "PasswordField";
     }
 
+    protected void installDefaults() {
+        super.installDefaults();
+        String prefix = getPropertyPrefix();
+        Character echoChar = (Character)UIManager.getDefaults().get(prefix + ".echoChar");
+        if(echoChar != null) {
+            LookAndFeel.installProperty(getComponent(), "echoChar", echoChar);
+        }
+    }
+
     /**
      * Creates a view (PasswordView) for an element.
      *

--- a/test/jdk/javax/swing/plaf/nimbus/PasswordFieldTest.java
+++ b/test/jdk/javax/swing/plaf/nimbus/PasswordFieldTest.java
@@ -45,12 +45,12 @@ public class PasswordFieldTest {
 
     public static void main(String[] args) throws Exception {
         for (UIManager.LookAndFeelInfo laf :
-			UIManager.getInstalledLookAndFeels()) {
+                            UIManager.getInstalledLookAndFeels()) {
             System.out.println("Testing L&F: " + laf.getClassName());
             SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
 
             System.out.println("Echo char: " +
-			    UIManager.get("PasswordField.echoChar"));
+                            UIManager.get("PasswordField.echoChar"));
             if (UIManager.get("PasswordField.echoChar") == null) {
                 throw new RuntimeException(
                     "PasswordField.echoChar returns null for NimbusL&F");

--- a/test/jdk/javax/swing/plaf/nimbus/PasswordFieldTest.java
+++ b/test/jdk/javax/swing/plaf/nimbus/PasswordFieldTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 6852577
+ * @summary  Verifies PasswordField.echoChar is not null for Nimbus L&F
+ * @run main PasswordFieldTest
+ */
+
+import javax.swing.UIManager;
+import javax.swing.SwingUtilities;
+import javax.swing.UnsupportedLookAndFeelException;
+
+public class PasswordFieldTest {
+    private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
+        try {
+            UIManager.setLookAndFeel(laf.getClassName());
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Unsupported L&F: " + laf.getClassName());
+        } catch (ClassNotFoundException | InstantiationException
+                 | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        for (UIManager.LookAndFeelInfo laf : UIManager.getInstalledLookAndFeels()) {
+            System.out.println("Testing L&F: " + laf.getClassName());
+            SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
+
+            System.out.println("Echo char: " + UIManager.get("PasswordField.echoChar"));
+	    if (UIManager.get("PasswordField.echoChar") == null) {
+                throw new RuntimeException("PasswordField.echoChar returns null for NimbusL&F");
+            }		
+        }
+    }
+}

--- a/test/jdk/javax/swing/plaf/nimbus/PasswordFieldTest.java
+++ b/test/jdk/javax/swing/plaf/nimbus/PasswordFieldTest.java
@@ -44,17 +44,20 @@ public class PasswordFieldTest {
     }
 
     public static void main(String[] args) throws Exception {
-        for (UIManager.LookAndFeelInfo laf :
-                            UIManager.getInstalledLookAndFeels()) {
-            System.out.println("Testing L&F: " + laf.getClassName());
-            SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
+        SwingUtilities.invokeAndWait(() -> {
+            for (UIManager.LookAndFeelInfo laf :
+                                UIManager.getInstalledLookAndFeels()) {
+                System.out.println("Testing L&F: " + laf.getClassName());
+                setLookAndFeel(laf);
 
-            System.out.println("Echo char: " +
-                            UIManager.get("PasswordField.echoChar"));
-            if (UIManager.get("PasswordField.echoChar") == null) {
-                throw new RuntimeException(
-                    "PasswordField.echoChar returns null");
+                System.out.println("Echo char: " +
+                                UIManager.get("PasswordField.echoChar"));
+                if (UIManager.get("PasswordField.echoChar") == null) {
+                    throw new RuntimeException(
+                        "PasswordField.echoChar returns null for " +
+                            laf.getClassName());
+                }
             }
-        }
+        });
     }
 }

--- a/test/jdk/javax/swing/plaf/nimbus/PasswordFieldTest.java
+++ b/test/jdk/javax/swing/plaf/nimbus/PasswordFieldTest.java
@@ -44,14 +44,17 @@ public class PasswordFieldTest {
     }
 
     public static void main(String[] args) throws Exception {
-        for (UIManager.LookAndFeelInfo laf : UIManager.getInstalledLookAndFeels()) {
+        for (UIManager.LookAndFeelInfo laf :
+			UIManager.getInstalledLookAndFeels()) {
             System.out.println("Testing L&F: " + laf.getClassName());
             SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
 
-            System.out.println("Echo char: " + UIManager.get("PasswordField.echoChar"));
+            System.out.println("Echo char: " +
+			    UIManager.get("PasswordField.echoChar"));
             if (UIManager.get("PasswordField.echoChar") == null) {
-                throw new RuntimeException("PasswordField.echoChar returns null for NimbusL&F");
-            }		
+                throw new RuntimeException(
+                    "PasswordField.echoChar returns null for NimbusL&F");
+            }
         }
     }
 }

--- a/test/jdk/javax/swing/plaf/nimbus/PasswordFieldTest.java
+++ b/test/jdk/javax/swing/plaf/nimbus/PasswordFieldTest.java
@@ -49,7 +49,7 @@ public class PasswordFieldTest {
             SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
 
             System.out.println("Echo char: " + UIManager.get("PasswordField.echoChar"));
-	    if (UIManager.get("PasswordField.echoChar") == null) {
+            if (UIManager.get("PasswordField.echoChar") == null) {
                 throw new RuntimeException("PasswordField.echoChar returns null for NimbusL&F");
             }		
         }

--- a/test/jdk/javax/swing/plaf/nimbus/PasswordFieldTest.java
+++ b/test/jdk/javax/swing/plaf/nimbus/PasswordFieldTest.java
@@ -53,7 +53,7 @@ public class PasswordFieldTest {
                             UIManager.get("PasswordField.echoChar"));
             if (UIManager.get("PasswordField.echoChar") == null) {
                 throw new RuntimeException(
-                    "PasswordField.echoChar returns null for NimbusL&F");
+                    "PasswordField.echoChar returns null");
             }
         }
     }


### PR DESCRIPTION
Default echo character obtained through `PasswordField.echoChar` UIProperty returns null for Nimbus L&F,
which is fixed by adding the default character * in the UIDefault table.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6852577](https://bugs.openjdk.org/browse/JDK-6852577): Only for Nimbus LAF UIManager.get("PasswordField.echoChar") is null


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Author) ⚠️ Review applies to [51919462](https://git.openjdk.org/jdk/pull/10035/files/51919462f67eca4fc1e0fa742999b3a3469f5c9e)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10035/head:pull/10035` \
`$ git checkout pull/10035`

Update a local copy of the PR: \
`$ git checkout pull/10035` \
`$ git pull https://git.openjdk.org/jdk pull/10035/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10035`

View PR using the GUI difftool: \
`$ git pr show -t 10035`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10035.diff">https://git.openjdk.org/jdk/pull/10035.diff</a>

</details>
