### PR TITLE
7113208: Incorrect javadoc on java.net.DatagramPacket.setLength()

### DIFF
--- a/src/java.base/share/classes/java/net/DatagramPacket.java
+++ b/src/java.base/share/classes/java/net/DatagramPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -394,8 +394,9 @@ class DatagramPacket {
      * Set the length for this packet. The length of the packet is
      * the number of bytes from the packet's data buffer that will be
      * sent, or the number of bytes of the packet's data buffer that
-     * will be used for receiving data. The length must be lesser or
-     * equal to the offset plus the length of the packet's buffer.
+     * will be used for receiving data. The {@code length} plus the
+     * {@link #getOffset() offset} must be lesser or equal to the
+     * length of the packet's data buffer.
      *
      * @param   length      the length to set for this packet.
      *

--- a/src/java.base/share/classes/java/net/DatagramPacket.java
+++ b/src/java.base/share/classes/java/net/DatagramPacket.java
@@ -25,6 +25,8 @@
 
 package java.net;
 
+import java.util.Objects;
+
 import jdk.internal.util.Preconditions;
 
 /**
@@ -287,12 +289,9 @@ class DatagramPacket {
      * @since   1.2
      */
     public synchronized void setData(byte[] buf, int offset, int length) {
-        /* this will check to see if buf is null */
-        if (length < 0 || offset < 0 ||
-            (length + offset) < 0 ||
-            ((length + offset) > buf.length)) {
-            throw new IllegalArgumentException("illegal length or offset");
-        }
+        Objects.requireNonNull(buf);
+        Preconditions.checkFromIndexSize(offset, length, buf.length,
+                Preconditions.outOfBoundsExceptionFormatter(IllegalArgumentException::new));
         this.buf = buf;
         this.length = length;
         this.bufLength = length;

--- a/src/java.base/share/classes/java/net/DatagramPacket.java
+++ b/src/java.base/share/classes/java/net/DatagramPacket.java
@@ -25,6 +25,8 @@
 
 package java.net;
 
+import jdk.internal.util.Preconditions;
+
 /**
  * This class represents a datagram packet.
  * <p>
@@ -410,10 +412,8 @@ class DatagramPacket {
      * @since   1.1
      */
     public synchronized void setLength(int length) {
-        if ((length + offset) > buf.length || length < 0 ||
-            (length + offset) < 0) {
-            throw new IllegalArgumentException("illegal length");
-        }
+        Preconditions.checkFromIndexSize(offset, length, buf.length,
+                Preconditions.outOfBoundsExceptionFormatter(IllegalArgumentException::new));
         this.length = length;
         this.bufLength = this.length;
     }


### PR DESCRIPTION
Can I please get a review of this javadoc only change for `DatagramPacket#setLength()` method? This addresses https://bugs.openjdk.org/browse/JDK-7113208.

I haven't create a CSR because the javadoc was already stating the correct behaviour in the `@throws` documentation as follows:

> @throws  IllegalArgumentException    if the length is negative,
     *          or if the length plus the offset is greater than the
     *          length of the packet's data buffer.

This commit merely fixes the main part of the javadoc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7113208](https://bugs.openjdk.org/browse/JDK-7113208): Incorrect javadoc on java.net.DatagramPacket.setLength()


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10037/head:pull/10037` \
`$ git checkout pull/10037`

Update a local copy of the PR: \
`$ git checkout pull/10037` \
`$ git pull https://git.openjdk.org/jdk pull/10037/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10037`

View PR using the GUI difftool: \
`$ git pr show -t 10037`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10037.diff">https://git.openjdk.org/jdk/pull/10037.diff</a>

</details>
