### PR TITLE
8292917: [JVMCI] Extend InstalledCode API to make an nmethod non entrant.

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -975,7 +975,7 @@ C2V_VMENTRY_0(jint, installCode0, (JNIEnv *env, jobject,
         assert(JVMCIENV->isa_HotSpotNmethod(installed_code_handle), "wrong type");
         // Clear the link to an old nmethod first
         JVMCIObject nmethod_mirror = installed_code_handle;
-        JVMCIENV->invalidate_nmethod_mirror(nmethod_mirror, JVMCI_CHECK_0);
+        JVMCIENV->invalidate_nmethod_mirror(nmethod_mirror, true, JVMCI_CHECK_0);
       } else {
         assert(JVMCIENV->isa_InstalledCode(installed_code_handle), "wrong type");
       }
@@ -1145,9 +1145,9 @@ C2V_VMENTRY(void, reprofile, (JNIEnv* env, jobject, ARGUMENT_PAIR(method)))
 C2V_END
 
 
-C2V_VMENTRY(void, invalidateHotSpotNmethod, (JNIEnv* env, jobject, jobject hs_nmethod))
+C2V_VMENTRY(void, invalidateHotSpotNmethod, (JNIEnv* env, jobject, jobject hs_nmethod, jboolean deoptimize))
   JVMCIObject nmethod_mirror = JVMCIENV->wrap(hs_nmethod);
-  JVMCIENV->invalidate_nmethod_mirror(nmethod_mirror, JVMCI_CHECK);
+  JVMCIENV->invalidate_nmethod_mirror(nmethod_mirror, deoptimize, JVMCI_CHECK);
 C2V_END
 
 C2V_VMENTRY_NULL(jlongArray, collectCounters, (JNIEnv* env, jobject))
@@ -2862,7 +2862,7 @@ JNINativeMethod CompilerToVM::methods[] = {
   {CC "getLocalVariableTableStart",                   CC "(" HS_METHOD2 ")J",                                                               FN_PTR(getLocalVariableTableStart)},
   {CC "getLocalVariableTableLength",                  CC "(" HS_METHOD2 ")I",                                                               FN_PTR(getLocalVariableTableLength)},
   {CC "reprofile",                                    CC "(" HS_METHOD2 ")V",                                                               FN_PTR(reprofile)},
-  {CC "invalidateHotSpotNmethod",                     CC "(" HS_NMETHOD ")V",                                                               FN_PTR(invalidateHotSpotNmethod)},
+  {CC "invalidateHotSpotNmethod",                     CC "(" HS_NMETHOD "Z)V",                                                              FN_PTR(invalidateHotSpotNmethod)},
   {CC "collectCounters",                              CC "()[J",                                                                            FN_PTR(collectCounters)},
   {CC "getCountersSize",                              CC "()I",                                                                             FN_PTR(getCountersSize)},
   {CC "setCountersSize",                              CC "(I)Z",                                                                            FN_PTR(setCountersSize)},

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -1532,7 +1532,7 @@ void JVMCIEnv::invalidate_nmethod_mirror(JVMCIObject mirror, bool deoptimize, JV
   if (!deoptimize) {
     // Prevent future executions of the nmethod but let current executions complete.
     nm->make_not_entrant();
-  } else if (nm->is_alive()) {
+} else {
     // We want the nmethod to be deoptimized immediately.
     Deoptimization::deoptimize_all_marked(nm);
   }

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -1510,7 +1510,7 @@ void JVMCIEnv::initialize_installed_code(JVMCIObject installed_code, CodeBlob* c
 }
 
 
-void JVMCIEnv::invalidate_nmethod_mirror(JVMCIObject mirror, JVMCI_TRAPS) {
+void JVMCIEnv::invalidate_nmethod_mirror(JVMCIObject mirror, bool deoptimize, JVMCI_TRAPS) {
   if (mirror.is_null()) {
     JVMCI_THROW(NullPointerException);
   }
@@ -1529,8 +1529,13 @@ void JVMCIEnv::invalidate_nmethod_mirror(JVMCIObject mirror, JVMCI_TRAPS) {
                     "Cannot invalidate HotSpotNmethod object in shared library VM heap from non-JavaThread");
   }
 
-  // Invalidating the HotSpotNmethod means we want the nmethod to be deoptimized.
-  Deoptimization::deoptimize_all_marked(nm);
+  if (!deoptimize) {
+    // Prevent future executions of the nmethod but let current executions complete.
+    nm->make_not_entrant();
+  } else if (nm->is_alive()) {
+    // We want the nmethod to be deoptimized immediately.
+    Deoptimization::deoptimize_all_marked(nm);
+  }
 
   // A HotSpotNmethod instance can only reference a single nmethod
   // during its lifetime so simply clear it here.

--- a/src/hotspot/share/jvmci/jvmciEnv.hpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.hpp
@@ -412,9 +412,11 @@ public:
   // Destroys a JNI global handle created by JVMCIEnv::make_global.
   void destroy_global(JVMCIObject object);
 
-  // Deoptimizes the nmethod (if any) in the HotSpotNmethod.address
-  // field of mirror. The field is subsequently zeroed.
-  void invalidate_nmethod_mirror(JVMCIObject mirror, JVMCI_TRAPS);
+  // Updates the nmethod (if any) in the HotSpotNmethod.address
+  // field of `mirror` to prevent it from being called.
+  // If `deoptimize` is true, the nmethod is immediately deoptimized.
+  // The HotSpotNmethod.address field is zero upon returning.
+  void invalidate_nmethod_mirror(JVMCIObject mirror, bool deoptimze, JVMCI_TRAPS);
 
   void initialize_installed_code(JVMCIObject installed_code, CodeBlob* cb, JVMCI_TRAPS);
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.code/src/jdk/vm/ci/code/InstalledCode.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.code/src/jdk/vm/ci/code/InstalledCode.java
@@ -29,12 +29,13 @@ package jdk.vm.ci.code;
 public class InstalledCode {
 
     /**
-     * Raw address address of entity representing this installed code.
+     * Address of the entity (e.g., HotSpot {@code nmethod} or {@code RuntimeStub}) representing
+     * this installed code.
      */
     protected long address;
 
     /**
-     * Raw address of entryPoint of this installed code.
+     * Address of the entryPoint of this installed code.
      */
     protected long entryPoint;
 
@@ -50,7 +51,8 @@ public class InstalledCode {
     }
 
     /**
-     * @return the address of entity representing this installed code.
+     * @return the address of entity (e.g., HotSpot {@code nmethod} or {@code RuntimeStub})
+     *         representing this installed code
      */
     public long getAddress() {
         return address;
@@ -94,8 +96,7 @@ public class InstalledCode {
     }
 
     /**
-     * @return true if the code represented by this object still exists and might have live
-     *         activations, false otherwise (may happen due to deopt, etc.)
+     * @return true if this object still points to installed code
      */
     public boolean isAlive() {
         return address != 0;
@@ -109,11 +110,27 @@ public class InstalledCode {
     }
 
     /**
-     * Invalidates this installed code such that any subsequent
-     * {@linkplain #executeVarargs(Object...) invocation} will throw an
-     * {@link InvalidInstalledCodeException} and all existing invocations will be deoptimized.
+     * Equivalent to calling {@link #invalidate(boolean)} with a {@code true} argument.
      */
     public void invalidate() {
+        invalidate(true);
+    }
+
+    /**
+     * Invalidates this installed code such that any subsequent
+     * {@linkplain #executeVarargs(Object...) invocation} will throw an
+     * {@link InvalidInstalledCodeException}.
+     *
+     * If this installed code is already {@linkplain #isValid() invalid}, this method has no effect.
+     * A subsequent call to {@link #isAlive()} or {@link #isValid()} on this object will return
+     * {@code false}.
+     *
+     * @param deoptimize if {@code true}, all existing invocations will be immediately deoptimized.
+     *            If {@code false}, any existing invocation will continue until it completes or
+     *            there is a subsequent call to this method with {@code deoptimize == true} before
+     *            the invocation completes.
+     */
+    public void invalidate(boolean deoptimize) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -715,12 +715,12 @@ final class CompilerToVM {
     private native void reprofile(HotSpotResolvedJavaMethodImpl method, long methodPointer);
 
     /**
-     * Invalidates {@code nmethodMirror} such that {@link InvalidInstalledCodeException} will be
-     * raised the next time {@code nmethodMirror} is {@linkplain #executeHotSpotNmethod executed}.
-     * The {@code nmethod} associated with {@code nmethodMirror} is also made non-entrant and any
-     * current activations of the {@code nmethod} are deoptimized.
+     * Updates {@code nmethodMirror} such that {@link InvalidInstalledCodeException} will be raised
+     * the next time {@code nmethodMirror} is {@linkplain #executeHotSpotNmethod executed}. The
+     * {@code nmethod} associated with {@code nmethodMirror} is also made non-entrant and if
+     * {@code deoptimize == true} any current activations of the {@code nmethod} are deoptimized.
      */
-    native void invalidateHotSpotNmethod(HotSpotNmethod nmethodMirror);
+    native void invalidateHotSpotNmethod(HotSpotNmethod nmethodMirror, boolean deoptimize);
 
     /**
      * Collects the current values of all JVMCI benchmark counters, summed up over all threads.

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotCodeCacheProvider.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotCodeCacheProvider.java
@@ -157,7 +157,8 @@ public class HotSpotCodeCacheProvider implements CodeCacheProvider {
     @Override
     public void invalidateInstalledCode(InstalledCode installedCode) {
         if (installedCode instanceof HotSpotNmethod) {
-            runtime.getCompilerToVM().invalidateHotSpotNmethod((HotSpotNmethod) installedCode);
+            HotSpotNmethod nmethod = (HotSpotNmethod) installedCode;
+            nmethod.invalidate(true);
         } else {
             throw new IllegalArgumentException("Cannot invalidate a " + Objects.requireNonNull(installedCode).getClass().getName());
         }

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotNmethod.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotNmethod.java
@@ -123,8 +123,8 @@ public class HotSpotNmethod extends HotSpotInstalledCode {
     }
 
     @Override
-    public void invalidate() {
-        compilerToVM().invalidateHotSpotNmethod(this);
+    public void invalidate(boolean deoptimize) {
+        compilerToVM().invalidateHotSpotNmethod(this, deoptimize);
     }
 
     @Override

--- a/test/hotspot/jtreg/compiler/jvmci/common/patches/jdk.internal.vm.ci/jdk/vm/ci/hotspot/CompilerToVMHelper.java
+++ b/test/hotspot/jtreg/compiler/jvmci/common/patches/jdk.internal.vm.ci/jdk/vm/ci/hotspot/CompilerToVMHelper.java
@@ -244,7 +244,7 @@ public class CompilerToVMHelper {
     }
 
     public static void invalidateHotSpotNmethod(HotSpotNmethod nmethodMirror) {
-        CTVM.invalidateHotSpotNmethod(nmethodMirror);
+        CTVM.invalidateHotSpotNmethod(nmethodMirror, true);
     }
 
     public static long[] collectCounters() {


### PR DESCRIPTION
The existing `InstalledCode.invalidate()` method not only makes the underlying nmethod non-entrant but also immediately deoptimizes all current activations of the nmethod.
In some scenarios, it's useful to be able to make the nmethod non-entrant but let existing activations complete. For example, which installing new code in Truffle tiered compilation.
This PR adds `InstalledCode.invalidate(boolean deoptimize)` for that purpose.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292917](https://bugs.openjdk.org/browse/JDK-8292917): [JVMCI] Extend InstalledCode API to make an nmethod non entrant.


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10039/head:pull/10039` \
`$ git checkout pull/10039`

Update a local copy of the PR: \
`$ git checkout pull/10039` \
`$ git pull https://git.openjdk.org/jdk pull/10039/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10039`

View PR using the GUI difftool: \
`$ git pr show -t 10039`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10039.diff">https://git.openjdk.org/jdk/pull/10039.diff</a>

</details>
