### PR TITLE
8292968: java.net.ContentHandler's javadoc has a broken reference

### DIFF
--- a/src/java.base/share/classes/java/net/ContentHandler.java
+++ b/src/java.base/share/classes/java/net/ContentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ import java.io.IOException;
  * If no content handler could be {@linkplain URLConnection#getContent() found},
  * URLConnection will look for a content handler in a user-definable set of places.
  * Users can define a vertical-bar delimited set of class prefixes
- * to search through by defining the <i>{@value java.net.URLConnection#contentPathProp}</i>
+ * to search through by defining the {@systemProperty java.content.handler.pkgs} system
  * property. The class name must be of the form:
  * <blockquote>
  *     <i>{package-prefix}.{major}.{minor}</i>


### PR DESCRIPTION
Can I please get a review of this javadoc only change which addresses https://bugs.openjdk.org/browse/JDK-8292968?

The updated javadoc now uses the `@systemProperty`, since this is the place where the semantics of this system property has been described. As per the expectations of `@systemProperty` (https://mail.openjdk.org/pipermail/core-libs-dev/2018-November/056653.html) this would then be a relevant place to use that javadoc tag. 

After this change, I've run `make docs` and verified that the generated javadoc renders properly and `java.content.handler.pkgs` shows up in the system properties listing page.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292968](https://bugs.openjdk.org/browse/JDK-8292968): java.net.ContentHandler's javadoc has a broken reference


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10040/head:pull/10040` \
`$ git checkout pull/10040`

Update a local copy of the PR: \
`$ git checkout pull/10040` \
`$ git pull https://git.openjdk.org/jdk pull/10040/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10040`

View PR using the GUI difftool: \
`$ git pr show -t 10040`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10040.diff">https://git.openjdk.org/jdk/pull/10040.diff</a>

</details>
