### PR TITLE
8292972: Initialize fields if CodeBlobIterator shortcuts without heaps

### DIFF
--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -380,6 +380,10 @@ template <class T, class Filter, bool is_relaxed> class CodeBlobIterator : publi
     : _only_not_unloading(filter == only_not_unloading)
   {
     if (Filter::heaps() == NULL) {
+      // The iterator is supposed to shortcut since we have
+      // _heap == _end, but make sure we do not have garbage
+      // in other fields as well.
+      _code_blob = nullptr;
       return;
     }
     _heap = Filter::heaps()->begin();


### PR DESCRIPTION
SonarCloud reports that `CodeBlobIterator::_code_blob` is not initialized on shortcut path:

```
  CodeBlobIterator(LivenessFilter filter, T* nm = NULL)
    : _only_not_unloading(filter == only_not_unloading)
  {
    if (Filter::heaps() == NULL) {
      return; <---- here
    }
```

It seems that we don't have an actual bug here, as iterator shortcuts on `_heap == _end`, but it would be cleaner to avoid garbage anyway.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292972](https://bugs.openjdk.org/browse/JDK-8292972): Initialize fields if CodeBlobIterator shortcuts without heaps


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10041/head:pull/10041` \
`$ git checkout pull/10041`

Update a local copy of the PR: \
`$ git checkout pull/10041` \
`$ git pull https://git.openjdk.org/jdk pull/10041/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10041`

View PR using the GUI difftool: \
`$ git pr show -t 10041`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10041.diff">https://git.openjdk.org/jdk/pull/10041.diff</a>

</details>
