### PR TITLE
8292983: ModuleReferenceImpl.computeHash should record algorithm for cache checks

### DIFF
--- a/src/java.base/share/classes/jdk/internal/module/ModuleReferenceImpl.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleReferenceImpl.java
@@ -64,8 +64,7 @@ public class ModuleReferenceImpl extends ModuleReference {
 
     // Single-slot cache of this module's hash to avoid needing to compute
     // it many times. For correctness under concurrent updates, we need to
-    // wrap the fields updated at the same time with a record, which carries
-    // the implicit final-field semantics for its members.
+    // wrap the fields updated at the same time with a record.
     private record CachedHash(byte[] hash, String algorithm) {}
     private CachedHash cachedHash;
 


### PR DESCRIPTION
Look at implementation and figure out what happens if you do:

```
 computeHash("SHA-1") = someHash;
 computeHash("SHA-256") = ...?
```

The caching method should actually check the algorithms match.

Not a bug at this point, since only use SHA-256 today, but this is a landmine ready to fire. 

Additional testing:
 - [x] Linux x86_64 release, `java/lang/module` tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292983](https://bugs.openjdk.org/browse/JDK-8292983): ModuleReferenceImpl.computeHash should record algorithm for cache checks


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10044/head:pull/10044` \
`$ git checkout pull/10044`

Update a local copy of the PR: \
`$ git checkout pull/10044` \
`$ git pull https://git.openjdk.org/jdk pull/10044/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10044`

View PR using the GUI difftool: \
`$ git pr show -t 10044`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10044.diff">https://git.openjdk.org/jdk/pull/10044.diff</a>

</details>
