### PR TITLE
8278165: Clarify that ZipInputStream does not access the CEN fields for a ZipEntry

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,14 @@ import static java.util.zip.ZipUtils.*;
  * This class implements an input stream filter for reading files in the
  * ZIP file format. Includes support for both compressed and uncompressed
  * entries.
+ *<p>
+ *     {@code ZipInputStream}  will stream the Zip file entries within
+ *     the Zip file by sequentially reading the Local file (LOC) header for each
+ *     entry. {@code ZipInputStream} does not access the Central directory
+ *     (CEN) header for each entry and therefore will not have access to
+ *     CEN header fields such as the external file attributes. {@linkplain ZipFile}
+ *     may be used when the information stored within the CEN header is required.
+ *</p>
  *
  * @author      David Connelly
  * @since 1.1


### PR DESCRIPTION
Please review this update to the ZipInputStream class description to clarify that ZipInputStream does not access the CEN header for the Zip file entries therefore does not have access to information that is specifically stored within the CEN Header such as Posix Permissions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278165](https://bugs.openjdk.org/browse/JDK-8278165): Clarify that ZipInputStream does not access the CEN fields for a ZipEntry


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10046/head:pull/10046` \
`$ git checkout pull/10046`

Update a local copy of the PR: \
`$ git checkout pull/10046` \
`$ git pull https://git.openjdk.org/jdk pull/10046/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10046`

View PR using the GUI difftool: \
`$ git pr show -t 10046`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10046.diff">https://git.openjdk.org/jdk/pull/10046.diff</a>

</details>
