### PR TITLE
8291651: CleanerTest.java fails with "Cleanable was cleaned"

### DIFF
--- a/test/jdk/java/lang/ref/CleanerTest.java
+++ b/test/jdk/java/lang/ref/CleanerTest.java
@@ -56,9 +56,10 @@ import org.testng.annotations.Test;
  * @modules java.base/jdk.internal.misc
  *          java.base/jdk.internal.ref
  *          java.management
- * @compile --enable-preview -source ${jdk.version} CleanerTest.java
+ * @enablePreview
+ * @compile -source ${jdk.version} CleanerTest.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run testng/othervm --enable-preview
+ * @run testng/othervm
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *      -verbose:gc CleanerTest
  */
@@ -102,7 +103,7 @@ public class CleanerTest {
 
         CleanableCase s = setupPhantom(COMMON, cleaner);
         cleaner = null;
-        checkCleaned(s.getSemaphore(), true, "Cleaner was cleaned:");
+        checkCleaned(s.getSemaphore(), true, "Cleaner was cleaned");
     }
 
     /**
@@ -137,7 +138,7 @@ public class CleanerTest {
 
         CleanableCase s = setupPhantom(COMMON, cleaner);
         cleaner = null;
-        checkCleaned(s.getSemaphore(), true, "Cleaner was cleaned:");
+        checkCleaned(s.getSemaphore(), true, "Cleaner was cleaned");
     }
 
     /**
@@ -219,9 +220,9 @@ public class CleanerTest {
 
         checkCleaned(test.getSemaphore(),
                 r == CleanableCase.EV_CLEAN,
-                "Cleanable was cleaned:");
+                "Cleanable was cleaned");
         checkCleaned(cc.getSemaphore(), true,
-                "The reference to the Cleanable was freed:");
+                "The reference to the Cleanable was freed");
     }
 
     /**
@@ -280,8 +281,8 @@ public class CleanerTest {
      * Use a larger number of cycles to wait for an expected cleaning to occur.
      *
      * @param semaphore a Semaphore
-     * @param expectCleaned true if cleaning should occur
-     * @param msg a message to explain the error
+     * @param expectCleaned true if cleaning the function should have been run, otherwise not run
+     * @param msg a message describing the cleaning function expected to be run or not run
      */
     static void checkCleaned(Semaphore semaphore, boolean expectCleaned, String msg) {
         long max_cycles = expectCleaned ? 10 : 3;
@@ -551,7 +552,7 @@ public class CleanerTest {
         }
 
         obj = null;
-        checkCleaned(s1, true, "reference was cleaned:");
+        checkCleaned(s1, true, "reference was cleaned");
         cleaner = null;
     }
 
@@ -566,6 +567,6 @@ public class CleanerTest {
         CleanableCase s = setupPhantom(cleaner, obj);
         obj = null;
         checkCleaned(s.getSemaphore(), true,
-                "Object was cleaned using CleanerFactory.cleaner():");
+                "Object cleaned using internal CleanerFactory.cleaner()");
     }
 }


### PR DESCRIPTION
CleanerTest is failing intermittently on Aarch64, with -Xcomp, and using a VirtualThread for the Cleaner in the test.
The extensively relies on references processing and invokes GC on a very short cycle.
The existing 10ms delay between GC requests is too short for the changes to reference states to be reliably visible.

The delay between gc requests is extended to 200ms and the tests pass reliably.
There are small improvements in diagnostic messages and cleanup of unused imports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291651](https://bugs.openjdk.org/browse/JDK-8291651): CleanerTest.java fails with "Cleanable was cleaned"


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10048/head:pull/10048` \
`$ git checkout pull/10048`

Update a local copy of the PR: \
`$ git checkout pull/10048` \
`$ git pull https://git.openjdk.org/jdk pull/10048/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10048`

View PR using the GUI difftool: \
`$ git pr show -t 10048`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10048.diff">https://git.openjdk.org/jdk/pull/10048.diff</a>

</details>
