### PR TITLE
8207166: jdk/jshell/JdiHangingLaunchExecutionControlTest.java - launch timeout

### DIFF
--- a/test/langtools/jdk/jshell/HangingRemoteAgent.java
+++ b/test/langtools/jdk/jshell/HangingRemoteAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,12 +30,15 @@ import jdk.jshell.execution.RemoteExecutionControl;
 import jdk.jshell.spi.ExecutionControlProvider;
 
 /**
- * Hang for three minutes (long enough to cause a timeout).
+ * HangingRemoteAgent main() runs in its loop for 2X the timeout
+ * we give the launcher to fail to attach.
  */
 class HangingRemoteAgent extends RemoteExecutionControl {
 
-    private static final long DELAY = 4000L;
-    private static final int TIMEOUT = 2000;
+    private static float timeoutFactor = Float.parseFloat(System.getProperty("test.timeout.factor", "1.0"));
+
+    private static final int TIMEOUT = (int)(2000 * timeoutFactor);
+    private static final long DELAY = TIMEOUT * 2L;
     private static final boolean INFRA_VERIFY = false;
 
     public static void main(String[] args) throws Exception {

--- a/test/langtools/jdk/jshell/JdiHangingLaunchExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/JdiHangingLaunchExecutionControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8169519
+ * @bug 8169519 8207166
  * @summary Tests for JDI connector timeout failure
  * @modules jdk.jshell/jdk.jshell jdk.jshell/jdk.jshell.spi jdk.jshell/jdk.jshell.execution
  * @build HangingRemoteAgent


### PR DESCRIPTION
A trivial fix to scale time values for HangingRemoteAgent.java by JTREG timeoutFactor.
Also cleaned up an incorrect comment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8207166](https://bugs.openjdk.org/browse/JDK-8207166): jdk/jshell/JdiHangingLaunchExecutionControlTest.java - launch timeout


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10049/head:pull/10049` \
`$ git checkout pull/10049`

Update a local copy of the PR: \
`$ git checkout pull/10049` \
`$ git pull https://git.openjdk.org/jdk pull/10049/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10049`

View PR using the GUI difftool: \
`$ git pr show -t 10049`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10049.diff">https://git.openjdk.org/jdk/pull/10049.diff</a>

</details>
