### PR TITLE
8292994: ProblemList vmTestbase/gc/lock/jni/jnilock001/TestDescription.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -149,6 +149,7 @@ vmTestbase/nsk/jvmti/SetJNIFunctionTable/setjniftab001/TestDescription.java 8219
 vmTestbase/nsk/jvmti/AttachOnDemand/attach002a/TestDescription.java 8277812 generic-all
 vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 8073470 linux-all
 
+vmTestbase/gc/lock/jni/jnilock001/TestDescription.java 8292946 generic-all
 vmTestbase/gc/lock/jni/jnilock002/TestDescription.java 8192647 generic-all
 
 vmTestbase/jit/escape/LockCoarsening/LockCoarsening001.java 8148743 generic-all


### PR DESCRIPTION
A trivial fix to ProblemList vmTestbase/gc/lock/jni/jnilock001/TestDescription.java.

So far this failure has only been seen with SerialGC, but there isn't a ProblemList
specific for GC-type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292994](https://bugs.openjdk.org/browse/JDK-8292994): ProblemList vmTestbase/gc/lock/jni/jnilock001/TestDescription.java


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10050/head:pull/10050` \
`$ git checkout pull/10050`

Update a local copy of the PR: \
`$ git checkout pull/10050` \
`$ git pull https://git.openjdk.org/jdk pull/10050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10050`

View PR using the GUI difftool: \
`$ git pr show -t 10050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10050.diff">https://git.openjdk.org/jdk/pull/10050.diff</a>

</details>
