### PR TITLE
8292657: Calling GetLocalXXX from virtual thread with thread parameter set to NULL returns carrier locals

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -2246,7 +2246,7 @@ JvmtiEnv::GetLocalObject(jthread thread, jint depth, jint slot, jobject* value_p
   JvmtiVTMSTransitionDisabler disabler;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      current_thread, depth, slot);
@@ -2286,7 +2286,7 @@ JvmtiEnv::GetLocalInstance(jthread thread, jint depth, jobject* value_ptr){
   JvmtiVTMSTransitionDisabler disabler;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetReceiver op(this, Handle(current_thread, thread_obj),
                                    current_thread, depth);
@@ -2327,7 +2327,7 @@ JvmtiEnv::GetLocalInt(jthread thread, jint depth, jint slot, jint* value_ptr) {
   JvmtiVTMSTransitionDisabler disabler;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_INT);
@@ -2368,7 +2368,7 @@ JvmtiEnv::GetLocalLong(jthread thread, jint depth, jint slot, jlong* value_ptr) 
   JvmtiVTMSTransitionDisabler disabler;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_LONG);
@@ -2409,7 +2409,7 @@ JvmtiEnv::GetLocalFloat(jthread thread, jint depth, jint slot, jfloat* value_ptr
   JvmtiVTMSTransitionDisabler disabler;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_FLOAT);
@@ -2450,7 +2450,7 @@ JvmtiEnv::GetLocalDouble(jthread thread, jint depth, jint slot, jdouble* value_p
   JvmtiVTMSTransitionDisabler disabler;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_DOUBLE);
@@ -2492,7 +2492,7 @@ JvmtiEnv::SetLocalObject(jthread thread, jint depth, jint slot, jobject value) {
   val.l = value;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_OBJECT, val);
@@ -2528,7 +2528,7 @@ JvmtiEnv::SetLocalInt(jthread thread, jint depth, jint slot, jint value) {
   val.i = value;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_INT, val);
@@ -2564,7 +2564,7 @@ JvmtiEnv::SetLocalLong(jthread thread, jint depth, jint slot, jlong value) {
   val.j = value;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_LONG, val);
@@ -2600,7 +2600,7 @@ JvmtiEnv::SetLocalFloat(jthread thread, jint depth, jint slot, jfloat value) {
   val.f = value;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_FLOAT, val);
@@ -2636,7 +2636,7 @@ JvmtiEnv::SetLocalDouble(jthread thread, jint depth, jint slot, jdouble value) {
   val.d = value;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_DOUBLE, val);

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1310,6 +1310,17 @@ JvmtiEnvBase::is_cthread_with_continuation(JavaThread* jt) {
   return cont_entry != NULL && is_cthread_with_mounted_vthread(jt);
 }
 
+// If (thread == NULL) then return current thread object.
+// Otherwise return JNIHandles::resolve_external_guard(thread).
+oop
+JvmtiEnvBase::current_thread_obj_or_resolve_external_guard(jthread thread) {
+  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  if (thread == NULL) {
+    thread_obj = get_vthread_or_thread_oop(JavaThread::current());
+  }
+  return thread_obj;
+}
+
 jvmtiError
 JvmtiEnvBase::get_threadOop_and_JavaThread(ThreadsList* t_list, jthread thread,
                                            JavaThread** jt_pp, oop* thread_oop_p) {

--- a/src/hotspot/share/prims/jvmtiEnvBase.hpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.hpp
@@ -167,6 +167,10 @@ class JvmtiEnvBase : public CHeapObj<mtInternal> {
     return byte_offset_of(JvmtiEnvBase, _jvmti_external);
   };
 
+  // If (thread == NULL) then return current thread object.
+  // Otherwise return JNIHandles::resolve_external_guard(thread).
+  static oop current_thread_obj_or_resolve_external_guard(jthread thread);
+
   static jvmtiError get_JavaThread(ThreadsList* tlist, jthread thread, JavaThread** jt_pp) {
     jvmtiError err = JVMTI_ERROR_NONE;
     if (thread == NULL) {

--- a/src/hotspot/share/prims/jvmtiExtensions.cpp
+++ b/src/hotspot/share/prims/jvmtiExtensions.cpp
@@ -136,6 +136,10 @@ static jvmtiError JNICALL GetCarrierThread(const jvmtiEnv* env, ...) {
   ThreadsListHandle tlh(current_thread);
   JavaThread* java_thread;
   oop vthread_oop = NULL;
+
+  if (vthread == NULL) {
+    vthread = (jthread)JNIHandles::make_local(current_thread, JvmtiEnvBase::get_vthread_or_thread_oop(current_thread));
+  }
   jvmtiError err = JvmtiExport::cv_external_thread_to_JavaThread(tlh.list(), vthread, &java_thread, &vthread_oop);
   if (err != JVMTI_ERROR_NONE) {
     // We got an error code so we don't have a JavaThread *, but

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/GetSetLocalTest/libGetSetLocalTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/GetSetLocalTest/libGetSetLocalTest.cpp
@@ -312,8 +312,6 @@ static void
 test_GetSetLocal(jvmtiEnv *jvmti, JNIEnv* jni, jthread vthread, int depth, int frame_count, bool at_event) {
   Values values0 = { NULL, NULL, 1, 2L, (jfloat)3.2F, (jdouble)4.500000047683716 };
   Values values1 = { NULL, NULL, 2, 3L, (jfloat)4.2F, (jdouble)5.500000047683716 };
-  // jthread cthread = at_event ? get_carrier_thread(jvmti, jni, get_current_thread(jvmti, jni))
-  //                            : get_carrier_thread(jvmti, jni, vthread);
   jthread cthread = get_carrier_thread(jvmti, jni, vthread);
 
   values0.tt = vthread;

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/libVThreadTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/libVThreadTest.cpp
@@ -156,9 +156,7 @@ test_GetCarrierThread(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread, jthread vthr
 
   // #1: Test JVMTI GetCarrierThread extension function with NULL vthread
   err = GetCarrierThread(jvmti, jni, NULL, &vthread_thread);
-  if (err != JVMTI_ERROR_INVALID_THREAD) {
-    fatal(jni, "event handler: JVMTI GetCarrierThread with NULL vthread failed to return JVMTI_ERROR_INVALID_THREAD");
-  }
+  check_jvmti_status(jni, err, "event handler: error in JVMTI GetCarrierThread");
 
   // #2: Test JVMTI GetCarrierThread extension function with a bad vthread
   err = GetCarrierThread(jvmti, jni, thread, &vthread_thread);


### PR DESCRIPTION
If JVM TI GetLocalXXX/SetLocalXXX is called from a virtual thread with the thread parameter set to NULL (meaning current thread) then it should get/set the value of the locals in the virtual thread frames. Instead, it reads the carrier thread locals and/or crashes.

The fix is that the relevant checking of the jthread parameter for NULL and adjusting it to current thread is added.
It is done in new utility `function current_thread_obj_or_resolve_external_guard(jthread thread)`. For more convenient testing the same adjustment is done in the JVM TI extension function `GetCarrierThread()`.

The test serviceability/jvmti/vthread/GetSetLocalTest is updated to add previously missed test coverage.

The test serviceability/jvmti/vthread/VThreadTest has been updated to adopt to update behavior of the `GetCarrierThread`.

The fix was verified with the test/hotspot/jtreg/serviceability/jvmti/vthread/ tests.

The fix was also tested with the existing JVM TI and JDI tests to make sure no regressions are introduced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292657](https://bugs.openjdk.org/browse/JDK-8292657): Calling GetLocalXXX from virtual thread with thread parameter set to NULL returns carrier locals


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10051/head:pull/10051` \
`$ git checkout pull/10051`

Update a local copy of the PR: \
`$ git checkout pull/10051` \
`$ git pull https://git.openjdk.org/jdk pull/10051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10051`

View PR using the GUI difftool: \
`$ git pr show -t 10051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10051.diff">https://git.openjdk.org/jdk/pull/10051.diff</a>

</details>
