### PR TITLE
8292948: JEditorPane ignores font-size styles in external linked css-file

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
@@ -2821,17 +2821,18 @@ public class StyleSheet extends StyleContext {
         }
 
         Object doGetAttribute(Object key) {
-            if (key == CSS.Attribute.FONT_SIZE && !isDefined(key)) {
+            Object retValue = super.getAttribute(key);
+            if (retValue != null) {
+                return retValue;
+            }
+
+            if (key == CSS.Attribute.FONT_SIZE) {
                 // CSS.FontSize represents a specified value and we need
                 // to inherit a computed value so don't resolve percentage
                 // value from parent.
                 return fontSizeInherit();
             }
 
-            Object retValue = super.getAttribute(key);
-            if (retValue != null) {
-                return retValue;
-            }
             // didn't find it... try parent if it's a css attribute
             // that is inherited.
             if (key instanceof CSS.Attribute) {

--- a/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.css
+++ b/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.css
@@ -1,6 +1,6 @@
 .base {
-  font: 14px sans-serif;
-  font-size: 14;
+  font: 16px sans-serif;
+  font-size: 16;
 }
 
 .bigger {
@@ -10,5 +10,5 @@
 
 .smaller {
   font-style: italic;
-  font-size: 85%;
+  font-size: 75%;
 }

--- a/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.css
+++ b/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.css
@@ -1,0 +1,14 @@
+.base {
+  font: 14px sans-serif;
+  font-size: 14;
+}
+
+.bigger {
+  font-weight: bold;
+  font-size: 150%;
+}
+
+.smaller {
+  font-style: italic;
+  font-size: 85%;
+}

--- a/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.html
+++ b/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.html
@@ -9,9 +9,9 @@
 
 <div class="base">
 
-  <p class="bigger">Bigger text (21)</p>
+  <p class="bigger">Bigger text (24)</p>
 
-  <p>Normal size text (14)</p>
+  <p>Normal size text (16)</p>
 
   <p class="smaller">Smaller text (12)</p>
 

--- a/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.html
+++ b/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>JDK-8292948: JEditorPane ignores font-size styles in external linked css-file</title>
+  <link rel="stylesheet" href="TestExternalCSSFontSize.css" type="text/css">
+</head>
+<body>
+
+<div class="base">
+
+  <p class="bigger">Bigger text (21)</p>
+
+  <p>Normal size text (14)</p>
+
+  <p class="smaller">Smaller text (12)</p>
+
+</div>
+
+</body>
+</html>

--- a/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.java
+++ b/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.java
@@ -46,7 +46,7 @@ import javax.swing.text.View;
  */
 public class TestExternalCSSFontSize {
 
-    private static final int[] expectedFontSizes = { 21, 14, 12 };
+    private static final int[] expectedFontSizes = { 24, 16, 12 };
 
     private volatile JEditorPane editor;
 

--- a/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.java
+++ b/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.java
@@ -66,7 +66,7 @@ public class TestExternalCSSFontSize {
         editor = new JEditorPane();
         editor.setContentType("text/html");
         editor.addPropertyChangeListener("page", evt -> {
-            System.out.append("loaded: ").println(evt.getNewValue());
+            System.out.append("Loaded: ").println(evt.getNewValue());
             try {
                 run();
             } catch (Throwable e) {
@@ -105,13 +105,13 @@ public class TestExternalCSSFontSize {
     private void assertFontSize(GlyphView child, int index) {
         printSource(child);
         if (index >= expectedFontSizes.length) {
-            throw new AssertionError("unexpected text run #"
+            throw new AssertionError("Unexpected text run #"
                     + index + " (>= " + expectedFontSizes.length + ")");
         }
 
         int actualFontSize = child.getFont().getSize();
         if (actualFontSize != expectedFontSizes[index]) {
-            throw new AssertionError("font size expected ["
+            throw new AssertionError("Font size expected ["
                     + expectedFontSizes[index] + "] but found [" + actualFontSize +"]");
         }
     }
@@ -139,7 +139,7 @@ public class TestExternalCSSFontSize {
         if (finishLatch.get() != null
                 && !finishLatch.get().await(5, TimeUnit.SECONDS)
                 && failure == null) {
-            throw new IllegalStateException("page loading timed out");
+            throw new IllegalStateException("Page loading timed out");
         }
 
         if (failure != null) {

--- a/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.java
+++ b/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.java
@@ -41,7 +41,7 @@ import javax.swing.text.View;
 /*
  * @test
  * @bug 8292948
- * @summary  Tests font-size declarations from external style sheet.
+ * @summary Tests font-size declarations from an external style sheet.
  * @run main TestExternalCSSFontSize
  */
 public class TestExternalCSSFontSize {

--- a/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.java
+++ b/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
+import javax.swing.JEditorPane;
+import javax.swing.SwingUtilities;
+import javax.swing.text.GlyphView;
+import javax.swing.text.View;
+
+/*
+ * @test
+ * @bug 8292948
+ * @summary  Tests font-size declarations from external style sheet.
+ * @run main TestExternalCSSFontSize
+ */
+public class TestExternalCSSFontSize {
+
+    private static final int[] expectedFontSizes = { 21, 14, 12 };
+
+    private JEditorPane editor;
+
+    private volatile Throwable failure;
+
+    TestExternalCSSFontSize() {}
+
+    CountDownLatch setUp() throws Exception {
+        File htmlFile = new File("TestExternalCSSFontSize.html");
+        if (!htmlFile.exists()) {
+            throw new FileNotFoundException(htmlFile.getAbsolutePath());
+        }
+
+        CountDownLatch finishLatch = new CountDownLatch(1);
+        editor = new JEditorPane();
+        editor.setContentType("text/html");
+        editor.addPropertyChangeListener("page", evt -> {
+            System.out.append("loaded: ").println(evt.getNewValue());
+            try {
+                run();
+            } catch (Throwable e) {
+                failure = e;
+            } finally {
+                finishLatch.countDown();
+            }
+        });
+        editor.setPage(htmlFile.toURI().toURL());
+        return finishLatch;
+    }
+
+    void run() {
+        editor.setSize(editor.getPreferredSize()); // Do lay out text
+
+        scanFontSizes(editor.getUI().getRootView(editor), 0);
+    }
+
+    private int scanFontSizes(View view, int branchIndex) {
+        int currentIndex = branchIndex;
+        for (int i = 0; i < view.getViewCount(); i++) {
+            View child = view.getView(i);
+            if (child instanceof GlyphView) {
+                if (child.getElement()
+                        .getAttributes().getAttribute("CR") == Boolean.TRUE) {
+                    continue;
+                }
+                assertFontSize((GlyphView) child, currentIndex++);
+            } else {
+                currentIndex = scanFontSizes(child, currentIndex);
+            }
+        }
+        return currentIndex;
+    }
+
+    private void assertFontSize(GlyphView child, int index) {
+        printSource(child);
+        if (index >= expectedFontSizes.length) {
+            throw new AssertionError("unexpected text run #"
+                    + index + " (>= " + expectedFontSizes.length + ")");
+        }
+
+        int actualFontSize = child.getFont().getSize();
+        if (actualFontSize != expectedFontSizes[index]) {
+            throw new AssertionError("font size expected ["
+                    + expectedFontSizes[index] + "] but found [" + actualFontSize +"]");
+        }
+    }
+
+    private void printSource(View textRun) {
+        try {
+            editor.getEditorKit().write(System.out,
+                    editor.getDocument(), textRun.getStartOffset(),
+                    textRun.getEndOffset() - textRun.getStartOffset());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    void start() throws Throwable {
+        AtomicReference<CountDownLatch> finishLatch = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            try {
+                finishLatch.set(setUp());
+            } catch (Throwable e) {
+                failure = e;
+            }
+        });
+
+        if (finishLatch.get() != null
+                && !finishLatch.get().await(5, TimeUnit.SECONDS)
+                && failure == null) {
+            throw new IllegalStateException("page loading timed out");
+        }
+
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    public static void main(String[] args) throws Throwable {
+        TestExternalCSSFontSize test = new TestExternalCSSFontSize();
+        boolean success = false;
+        try {
+            test.start();
+            success = true;
+        } finally {
+            if (!success && test.editor != null) {
+                SwingUtilities.invokeAndWait(() -> captureImage(test.editor, "-failure"));
+            } else if (hasOpt(args, "-capture")) {
+                SwingUtilities.invokeAndWait(() -> captureImage(test.editor, "-success"));
+            }
+        }
+    }
+
+    private static boolean hasOpt(String[] args, String opt) {
+        return Arrays.asList(args).contains(opt);
+    }
+
+    static void captureImage(Component comp, String suffix) {
+        try {
+            BufferedImage capture = new BufferedImage(comp.getWidth(),
+                                comp.getHeight(), BufferedImage.TYPE_INT_ARGB);
+            Graphics g = capture.getGraphics();
+            comp.paint(g);
+            g.dispose();
+
+            ImageIO.write(capture, "png",
+                    new File(TestExternalCSSFontSize.class
+                                .getSimpleName() + suffix + ".png"));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.java
+++ b/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.java
@@ -154,10 +154,13 @@ public class TestExternalCSSFontSize {
             test.start();
             success = true;
         } finally {
-            if (!success && test.editor != null) {
-                SwingUtilities.invokeAndWait(() -> captureImage(test.editor, "-failure"));
-            } else if (hasOpt(args, "-capture")) {
-                SwingUtilities.invokeAndWait(() -> captureImage(test.editor, "-success"));
+            if (!success || hasOpt(args, "-capture")) {
+                if (test.editor == null) {
+                    System.err.println("Can't save image (test.editor is null)");
+                } else {
+                    String suffix = success ? "-success" : "-failure";
+                    SwingUtilities.invokeAndWait(() -> captureImage(test.editor, suffix));
+                }
             }
         }
     }
@@ -168,8 +171,9 @@ public class TestExternalCSSFontSize {
 
     static void captureImage(Component comp, String suffix) {
         try {
-            BufferedImage capture = new BufferedImage(comp.getWidth(),
-                                comp.getHeight(), BufferedImage.TYPE_INT_ARGB);
+            BufferedImage capture =
+                    new BufferedImage(comp.getWidth(), comp.getHeight(),
+                                      BufferedImage.TYPE_INT_ARGB);
             Graphics g = capture.getGraphics();
             comp.paint(g);
             g.dispose();

--- a/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.java
+++ b/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.java
@@ -29,7 +29,6 @@ import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import java.awt.Component;
 import java.awt.Graphics;
 import java.awt.image.BufferedImage;
 import javax.imageio.ImageIO;
@@ -143,7 +142,7 @@ public class TestExternalCSSFontSize {
                     System.err.println("Can't save image (test.editor is null)");
                 } else {
                     String suffix = success ? "-success" : "-failure";
-                    SwingUtilities.invokeAndWait(() -> captureImage(test.editor, suffix));
+                    SwingUtilities.invokeAndWait(() -> test.captureImage(suffix));
                 }
             }
         }
@@ -153,18 +152,17 @@ public class TestExternalCSSFontSize {
         return Arrays.asList(args).contains(opt);
     }
 
-    static void captureImage(Component comp, String suffix) {
+    private void captureImage(String suffix) {
         try {
             BufferedImage capture =
-                    new BufferedImage(comp.getWidth(), comp.getHeight(),
+                    new BufferedImage(editor.getWidth(), editor.getHeight(),
                                       BufferedImage.TYPE_INT_ARGB);
             Graphics g = capture.getGraphics();
-            comp.paint(g);
+            editor.paint(g);
             g.dispose();
 
             ImageIO.write(capture, "png",
-                    new File(TestExternalCSSFontSize.class
-                                .getSimpleName() + suffix + ".png"));
+                    new File(getClass().getSimpleName() + suffix + ".png"));
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.java
+++ b/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.java
@@ -24,6 +24,7 @@
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -55,9 +56,10 @@ public class TestExternalCSSFontSize {
     TestExternalCSSFontSize() {}
 
     CountDownLatch setUp() throws Exception {
-        File htmlFile = new File("TestExternalCSSFontSize.html");
-        if (!htmlFile.exists()) {
-            throw new FileNotFoundException(htmlFile.getAbsolutePath());
+        String fileName = getClass().getName().replace('.', '/') + ".html";
+        URL htmlFile = getClass().getClassLoader().getResource(fileName);
+        if (htmlFile == null) {
+            throw new FileNotFoundException("Resource not found: " + fileName);
         }
 
         CountDownLatch finishLatch = new CountDownLatch(1);
@@ -73,7 +75,7 @@ public class TestExternalCSSFontSize {
                 finishLatch.countDown();
             }
         });
-        editor.setPage(htmlFile.toURI().toURL());
+        editor.setPage(htmlFile);
         return finishLatch;
     }
 


### PR DESCRIPTION
[JDK-8292948] reveals a regression by the fix for [JDK-8257664] (#1759) causing `font-size` declarations from external style sheets to be ignored.

As far as I've traced, the problem is with the `isDefined(CSS.Attribute.FONT_SIZE)` test:

https://github.com/openjdk/jdk/blob/70b5b3119b2ed032b021a080f34a4fa28d092fb5/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java#L2825-L2830

It misses declarations from linked styles via a `resolver` ([`AttributeSet.ResolveAttribute`](https://github.com/openjdk/jdk/blob/b0e0b87891eb81c2b33c1cfa598701b7bd2e5bdf/src/java.desktop/share/classes/javax/swing/text/AttributeSet.java#L187-L191)) attribute that happens to hold the external style sheet rules.  The fix for this would be to move the implied `CSS.Attribute.FONT_SIZE` handling after:

https://github.com/openjdk/jdk/blob/70b5b3119b2ed032b021a080f34a4fa28d092fb5/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java#L2833-L2835

and drop the `isDefined()` test.

\[I'll prepare a jtreg test further.\]

[JDK-8292948]: https://bugs.openjdk.org/browse/JDK-8292948 "JEditorPane ignores font-size styles in external linked css-file"
[JDK-8257664]: https://bugs.openjdk.org/browse/JDK-8257664 "HTMLEditorKit: Wrong CSS relative font sizes"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292948](https://bugs.openjdk.org/browse/JDK-8292948): JEditorPane ignores font-size styles in external linked css-file


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10054/head:pull/10054` \
`$ git checkout pull/10054`

Update a local copy of the PR: \
`$ git checkout pull/10054` \
`$ git pull https://git.openjdk.org/jdk pull/10054/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10054`

View PR using the GUI difftool: \
`$ git pr show -t 10054`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10054.diff">https://git.openjdk.org/jdk/pull/10054.diff</a>

</details>
