### PR TITLE
8293004: (fs) FileChannel.transferXXX use of copy_file_range needs fallback handling for ENOSYS

### DIFF
--- a/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
+++ b/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
@@ -190,6 +190,7 @@ Java_sun_nio_ch_FileChannelImpl_transferTo0(JNIEnv *env, jobject this,
                 case EINTR:
                     return IOS_INTERRUPTED;
                 case EINVAL:
+                case ENOSYS:
                 case EXDEV:
                     // ignore and try sendfile()
                     break;
@@ -307,6 +308,8 @@ Java_sun_nio_ch_FileChannelImpl_transferFrom0(JNIEnv *env, jobject this,
     if (n < 0) {
         if (errno == EAGAIN)
             return IOS_UNAVAILABLE;
+        if (errno == ENOSYS)
+            return IOS_UNSUPPORTED_CASE;
         if ((errno == EBADF || errno == EINVAL || errno == EXDEV) &&
             ((ssize_t)count >= 0))
             return IOS_UNSUPPORTED_CASE;


### PR DESCRIPTION
Now that the userspace emulation is not leveraged anymore, it would be possible to issue the system call directly for all glibc versions, but it's probably best not to start using `copy_file_range` where it hasn't been used before (the el7 kernel has a strange backport, if I recall correctly).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293004](https://bugs.openjdk.org/browse/JDK-8293004): (fs) FileChannel.transferXXX use of copy_file_range needs fallback handling for ENOSYS


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10055/head:pull/10055` \
`$ git checkout pull/10055`

Update a local copy of the PR: \
`$ git checkout pull/10055` \
`$ git pull https://git.openjdk.org/jdk pull/10055/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10055`

View PR using the GUI difftool: \
`$ git pr show -t 10055`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10055.diff">https://git.openjdk.org/jdk/pull/10055.diff</a>

</details>
