### PR TITLE
8293011: riscv: Duplicated stubs to interpreter for static calls

### DIFF
--- a/src/hotspot/cpu/riscv/codeBuffer_riscv.cpp
+++ b/src/hotspot/cpu/riscv/codeBuffer_riscv.cpp
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,15 +22,10 @@
  *
  */
 
-#ifndef CPU_RISCV_CODEBUFFER_RISCV_HPP
-#define CPU_RISCV_CODEBUFFER_RISCV_HPP
+#include "precompiled.hpp"
+#include "asm/codeBuffer.inline.hpp"
+#include "asm/macroAssembler.hpp"
 
-private:
-  void pd_initialize() {}
-  bool pd_finalize_stubs();
-
-public:
-  void flush_bundle(bool start_new_bundle) {}
-  static constexpr bool supports_shared_stubs() { return true; }
-
-#endif // CPU_RISCV_CODEBUFFER_RISCV_HPP
+bool CodeBuffer::pd_finalize_stubs() {
+  return emit_shared_stubs_to_interp<MacroAssembler>(this, _shared_stub_to_interp_requests);
+}

--- a/src/hotspot/cpu/riscv/codeBuffer_riscv.cpp
+++ b/src/hotspot/cpu/riscv/codeBuffer_riscv.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * Copyright (c) 2022, Institute of Software, Chinese Academy of Sciences. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2284,11 +2284,17 @@ encode %{
         return;
       }
 
-      // Emit stub for static call
-      address stub = CompiledStaticCall::emit_to_interp_stub(cbuf);
-      if (stub == NULL) {
-        ciEnv::current()->record_failure("CodeCache is full");
-        return;
+      if (CodeBuffer::supports_shared_stubs() && _method->can_be_statically_bound()) {
+        // Calls of the same statically bound method can share
+        // a stub to the interpreter.
+        cbuf.shared_stub_to_interp_for(_method, cbuf.insts()->mark_off());
+      } else {
+        // Emit stub for static call
+        address stub = CompiledStaticCall::emit_to_interp_stub(cbuf);
+        if (stub == NULL) {
+          ciEnv::current()->record_failure("CodeCache is full");
+          return;
+        }
       }
     }
   %}

--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
@@ -28,7 +28,7 @@
  * @bug 8280481
  * @library /test/lib
  *
- * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="i386" | os.arch=="x86" | os.arch=="aarch64"
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="i386" | os.arch=="x86" | os.arch=="aarch64" | os.arch=="riscv64"
  *
  * @run driver compiler.sharedstubs.SharedStubToInterpTest
  */


### PR DESCRIPTION
Follow up [JDK-8280481](https://bugs.openjdk.org/browse/JDK-8280481).
Calls of Java methods have stubs to the interpreter for the cases when an invoked Java method is not compiled. Calls of static Java methods and final Java methods have statically bound information about a callee during compilation. C1 and C2 always generate a new stub for each call. As the generated stubs for calls of the same method are the same, they can be shared.

## Testing:

- hotspot/jdk tier1 on unmatched board
- hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java on qemu


## Results
#### Results from [Renaissance 0.14.0](https://github.com/renaissance-benchmarks/renaissance/releases/tag/v0.14.0)
Note: 'Nmethods with shared stubs' is the total number of nmethods counted during benchmark's run. 'Final # of nmethods' is a number of nmethods in CodeCache when JVM exited.

- riscv64
```
+------------------+-------------+----------------------------+---------------------+
| Benchmark        | Saved bytes | Nmethods with shared stubs | Final # of nmethods |
+------------------+-------------+----------------------------+---------------------+
| dotty            |     1099488 |                       4483 |               12447 |
| dec-tree         |      511296 |                       2310 |               18583 |
| naive-bayes      |      358128 |                       1714 |                8677 |
| log-regression   |      365136 |                       1662 |               14626 |
| als              |      444576 |                       2107 |                8464 |
| finagle-chirper  |      265584 |                       1558 |               11003 |
| movie-lens       |      397776 |                       2106 |                6842 |
| finagle-http     |      160656 |                        974 |                7243 |
| page-rank        |      246672 |                       1261 |               10293 |
| chi-square       |      196080 |                        992 |                8841 |
| akka-uct         |      138672 |                        595 |                4564 |
| reactors         |       57552 |                        328 |                2338 |
| scala-stm-bench7 |       42122 |                        254 |                2261 |
| philosophers     |       45744 |                        241 |                1945 |
| scala-doku       |       48624 |                        213 |                 794 |
| rx-scrabble      |       46128 |                        271 |                1945 |
| future-genetic   |       37248 |                        234 |                1818 |
| scrabble         |       30384 |                        170 |                1628 |
| par-mnemonics    |       28176 |                        137 |                1317 |
+------------------+-------------+----------------------------+---------------------+
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293011](https://bugs.openjdk.org/browse/JDK-8293011): riscv: Duplicated stubs to interpreter for static calls


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10057/head:pull/10057` \
`$ git checkout pull/10057`

Update a local copy of the PR: \
`$ git checkout pull/10057` \
`$ git pull https://git.openjdk.org/jdk pull/10057/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10057`

View PR using the GUI difftool: \
`$ git pr show -t 10057`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10057.diff">https://git.openjdk.org/jdk/pull/10057.diff</a>

</details>
