### PR TITLE
8293012: ConstantPool::print_on can crash if _cache is NULL

### DIFF
--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -2271,9 +2271,10 @@ void ConstantPool::print_on(outputStream* st) const {
     st->print_cr(" - holder: " INTPTR_FORMAT, p2i(pool_holder()));
   }
   st->print_cr(" - cache: " INTPTR_FORMAT, p2i(cache()));
-  st->print_cr(" - resolved_references: " INTPTR_FORMAT, p2i(resolved_references()));
+  st->print_cr(" - resolved_references: " INTPTR_FORMAT, p2i(resolved_references_or_null()));
   st->print_cr(" - reference_map: " INTPTR_FORMAT, p2i(reference_map()));
   st->print_cr(" - resolved_klasses: " INTPTR_FORMAT, p2i(resolved_klasses()));
+  st->print_cr(" - cp length: %d", length());
 
   for (int index = 1; index < length(); index++) {      // Index 0 is unused
     ((ConstantPool*)this)->print_entry_on(index, st);


### PR DESCRIPTION
Please review this simple fix to avoid a crash when debugging the constant pool.

Testing: tier1 sanity

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293012](https://bugs.openjdk.org/browse/JDK-8293012): ConstantPool::print_on can crash if _cache is NULL


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10059/head:pull/10059` \
`$ git checkout pull/10059`

Update a local copy of the PR: \
`$ git checkout pull/10059` \
`$ git pull https://git.openjdk.org/jdk pull/10059/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10059`

View PR using the GUI difftool: \
`$ git pr show -t 10059`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10059.diff">https://git.openjdk.org/jdk/pull/10059.diff</a>

</details>
