### PR TITLE
8293017: Improve hash calculation parallelism in jmod/jlink

### DIFF
--- a/src/java.base/share/classes/java/lang/module/Resolver.java
+++ b/src/java.base/share/classes/java/lang/module/Resolver.java
@@ -482,16 +482,15 @@ final class Resolver {
             }
         }
 
-        // Parallel hash computation, populating the cache for descriptors
+        // Parallel hash computation, populating the cache in ModuleReferenceImpl-s
         hashChecks.stream().parallel().forEach(hc -> hc.mref().computeHash(hc.hashes().algorithm()));
 
         // Check the hashing results
         for (HashCheck hc : hashChecks) {
             byte[] recordedHash = hc.hashes().hashFor(hc.dn());
             byte[] actualHash = hc.mref().computeHash(hc.hashes().algorithm());
-            if (actualHash == null) {
+            if (actualHash == null)
                 findFail("Unable to compute the hash of module %s", hc.dn());
-            }
             if (!Arrays.equals(recordedHash, actualHash)) {
                 HexFormat hex = HexFormat.of();
                 findFail("Hash of %s (%s) differs to expected hash (%s)" +

--- a/src/java.base/share/classes/jdk/internal/module/ModuleHashes.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleHashes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;


### PR DESCRIPTION
`jmod`/`jlink` are executed during build time to produce the `jmod` and the base modules image. On slow hardware (Raspberry Pi -class, for example) and/or slow VMs (debug, interpreter-only, for example) this takes a while. Profiling shows the considerable time is spent on hashing modules either for writing out the ModuleHash attribute or for verifying the hashes are good.

Those paths can be parallelized to make them quite faster.

The major contributors to module hashing are `java.base`, `jdk.desktop` and `jdk.localedata`, so we have a significant opportunity for parallelism here. 

Motivational improvements on `make clean-images images`:

```
# x86_64 Server, release

# Baseline
real	0m11.895s
user	1m4.526s
sys	0m10.715s

# Patched
real	0m10.701s   ; <--- 1.1x improvement
user	1m5.097s
sys	0m11.260s

# x86_64 Zero, release

# Baseline
real	5m20.335s
user	7m7.791s
sys	0m7.258s

# Patched
real	2m23.551s  ; <--- 2.23x improvement
user	7m14.442s
sys	0m7.856s
```

Additional testing: 
  - [x] Linux x86_64 fastdebug, `java/util/jar`
  - [x] Linux x86_64 fastdebug, `tools/jmod`
  - [x] Linux x86_64 fastdebug, `tools/jlink`
  - [x] Linux x86_64 fastdebug `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293017](https://bugs.openjdk.org/browse/JDK-8293017): Improve hash calculation parallelism in jmod/jlink


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10060/head:pull/10060` \
`$ git checkout pull/10060`

Update a local copy of the PR: \
`$ git checkout pull/10060` \
`$ git pull https://git.openjdk.org/jdk pull/10060/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10060`

View PR using the GUI difftool: \
`$ git pr show -t 10060`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10060.diff">https://git.openjdk.org/jdk/pull/10060.diff</a>

</details>
