### PR TITLE
8293023: Change CardTable::is_in_young signature

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardTable.cpp
+++ b/src/hotspot/share/gc/g1/g1CardTable.cpp
@@ -72,7 +72,7 @@ void G1CardTable::initialize(G1RegionToSpaceMapper* mapper) {
   log_trace(gc, barrier)("    _byte_map_base: " INTPTR_FORMAT,  p2i(_byte_map_base));
 }
 
-bool G1CardTable::is_in_young(oop obj) const {
-  volatile CardValue* p = byte_for(obj);
-  return *p == G1CardTable::g1_young_card_val();
+bool G1CardTable::is_in_young(const void* p) const {
+  volatile CardValue* card = byte_for(p);
+  return *card == G1CardTable::g1_young_card_val();
 }

--- a/src/hotspot/share/gc/g1/g1CardTable.hpp
+++ b/src/hotspot/share/gc/g1/g1CardTable.hpp
@@ -122,7 +122,7 @@ public:
 
   virtual void resize_covered_region(MemRegion new_region) { ShouldNotReachHere(); }
 
-  virtual bool is_in_young(oop obj) const;
+  bool is_in_young(const void* p) const override;
 };
 
 #endif // SHARE_GC_G1_G1CARDTABLE_HPP

--- a/src/hotspot/share/gc/g1/g1CardTable.hpp
+++ b/src/hotspot/share/gc/g1/g1CardTable.hpp
@@ -41,7 +41,7 @@ class G1CardTableChangedListener : public G1MappingChangedListener {
 
   void set_card_table(G1CardTable* card_table) { _card_table = card_table; }
 
-  virtual void on_commit(uint start_idx, size_t num_regions, bool zero_filled);
+  void on_commit(uint start_idx, size_t num_regions, bool zero_filled) override;
 };
 
 class G1CardTable : public CardTable {
@@ -117,10 +117,10 @@ public:
   // Returns how many bytes of the heap a single byte of the Card Table corresponds to.
   static size_t heap_map_factor() { return _card_size; }
 
-  void initialize() {}
+  void initialize() override {}
   void initialize(G1RegionToSpaceMapper* mapper);
 
-  virtual void resize_covered_region(MemRegion new_region) { ShouldNotReachHere(); }
+  void resize_covered_region(MemRegion new_region) override { ShouldNotReachHere(); }
 
   bool is_in_young(const void* p) const override;
 };

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -183,7 +183,7 @@ class ParallelScavengeHeap : public CollectedHeap {
 
   bool is_in_reserved(const void* p) const;
 
-  bool is_in_young(const oop p) const;
+  bool is_in_young(const void* p) const;
 
   virtual bool requires_barriers(stackChunkOop obj) const;
 

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.inline.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.inline.hpp
@@ -43,11 +43,11 @@ inline void ParallelScavengeHeap::invoke_scavenge() {
   PSScavenge::invoke();
 }
 
-inline bool ParallelScavengeHeap::is_in_young(const oop p) const {
+inline bool ParallelScavengeHeap::is_in_young(const void* p) const {
   // Assumes the old gen address range is lower than that of the young gen.
-  bool result = cast_from_oop<HeapWord*>(p) >= young_gen()->reserved().start();
+  bool result = p >= young_gen()->reserved().start();
   assert(result == young_gen()->is_in_reserved(p),
-         "incorrect test - result=%d, p=" PTR_FORMAT, result, p2i((void*)p));
+         "incorrect test - result=%d, p=" PTR_FORMAT, result, p2i(p));
   return result;
 }
 #endif // SHARE_GC_PARALLEL_PARALLELSCAVENGEHEAP_INLINE_HPP

--- a/src/hotspot/share/gc/parallel/psCardTable.cpp
+++ b/src/hotspot/share/gc/parallel/psCardTable.cpp
@@ -400,6 +400,6 @@ bool PSCardTable::addr_is_marked_precise(void *addr) {
   return false;
 }
 
-bool PSCardTable::is_in_young(oop obj) const {
-  return ParallelScavengeHeap::heap()->is_in_young(obj);
+bool PSCardTable::is_in_young(const void* p) const {
+  return ParallelScavengeHeap::heap()->is_in_young(p);
 }

--- a/src/hotspot/share/gc/parallel/psCardTable.hpp
+++ b/src/hotspot/share/gc/parallel/psCardTable.hpp
@@ -87,7 +87,7 @@ class PSCardTable: public CardTable {
   }
 
   // ReduceInitialCardMarks support
-  bool is_in_young(oop obj) const;
+  bool is_in_young(const void* p) const override;
 
 #ifdef ASSERT
   bool is_valid_card_address(CardValue* addr) {

--- a/src/hotspot/share/gc/shared/cardTable.hpp
+++ b/src/hotspot/share/gc/shared/cardTable.hpp
@@ -244,7 +244,7 @@ public:
   // before the beginning of the actual _byte_map.
   CardValue* byte_map_base() const { return _byte_map_base; }
 
-  virtual bool is_in_young(oop obj) const = 0;
+  virtual bool is_in_young(const void* p) const = 0;
 
   // Print a description of the memory for the card table
   virtual void print_on(outputStream* st) const;

--- a/src/hotspot/share/gc/shared/cardTableRS.cpp
+++ b/src/hotspot/share/gc/shared/cardTableRS.cpp
@@ -458,6 +458,6 @@ void CardTableRS::non_clean_card_iterate(Space* sp,
   clear_cl.do_MemRegion(mr);
 }
 
-bool CardTableRS::is_in_young(oop obj) const {
-  return GenCollectedHeap::heap()->is_in_young(obj);
+bool CardTableRS::is_in_young(const void* p) const {
+  return GenCollectedHeap::heap()->is_in_young(p);
 }

--- a/src/hotspot/share/gc/shared/cardTableRS.hpp
+++ b/src/hotspot/share/gc/shared/cardTableRS.hpp
@@ -76,7 +76,7 @@ public:
                               OopIterateClosure* cl,
                               CardTableRS* ct);
 
-  virtual bool is_in_young(oop obj) const;
+  bool is_in_young(const void* p) const override;
 };
 
 class ClearNoncleanCardWrapper: public MemRegionClosure {

--- a/src/hotspot/share/gc/shared/cardTableRS.hpp
+++ b/src/hotspot/share/gc/shared/cardTableRS.hpp
@@ -61,7 +61,7 @@ public:
   }
 
   void verify();
-  void initialize();
+  void initialize() override;
 
   void clear_into_younger(Generation* old_gen);
 
@@ -95,7 +95,7 @@ private:
 
 public:
   ClearNoncleanCardWrapper(DirtyCardToOopClosure* dirty_card_closure, CardTableRS* ct);
-  void do_MemRegion(MemRegion mr);
+  void do_MemRegion(MemRegion mr) override;
 };
 
 #endif // SHARE_GC_SHARED_CARDTABLERS_HPP

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -882,8 +882,8 @@ void GenCollectedHeap::do_full_collection(bool clear_all_soft_refs,
   }
 }
 
-bool GenCollectedHeap::is_in_young(oop p) const {
-  bool result = cast_from_oop<HeapWord*>(p) < _old_gen->reserved().start();
+bool GenCollectedHeap::is_in_young(const void* p) const {
+  bool result = p < _old_gen->reserved().start();
   assert(result == _young_gen->is_in_reserved(p),
          "incorrect test - result=%d, p=" INTPTR_FORMAT, result, p2i((void*)p));
   return result;

--- a/src/hotspot/share/gc/shared/genCollectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.hpp
@@ -196,10 +196,9 @@ public:
   // restrict their use to assertion checking or verification only.
   bool is_in(const void* p) const;
 
-  // Returns true if the reference is to an object in the reserved space
-  // for the young generation.
+  // Returns true if p points into the reserved space for the young generation.
   // Assumes the young gen address range is less than that of the old gen.
-  bool is_in_young(oop p) const;
+  bool is_in_young(const void* p) const;
 
   virtual bool requires_barriers(stackChunkOop obj) const;
 


### PR DESCRIPTION
This PR consists of 2 commits:

1. The actual change of the signature.
2. Adding the missing `override` in changed files.

The second commit is auto generated using `make CONF=debug compile-commands-hotspot; clang-tidy --fix -checks=modernize-use-override -p build/linux-x64-debug <file>`.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293023](https://bugs.openjdk.org/browse/JDK-8293023): Change CardTable::is_in_young signature


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10061/head:pull/10061` \
`$ git checkout pull/10061`

Update a local copy of the PR: \
`$ git checkout pull/10061` \
`$ git pull https://git.openjdk.org/jdk pull/10061/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10061`

View PR using the GUI difftool: \
`$ git pr show -t 10061`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10061.diff">https://git.openjdk.org/jdk/pull/10061.diff</a>

</details>
