### PR TITLE
8293028: Remove GenCollectedHeap::handle_failed_promotion

### DIFF
--- a/src/hotspot/share/gc/shared/genCollectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.hpp
@@ -384,15 +384,6 @@ public:
     _incremental_collection_failed = false;
   }
 
-  // Promotion of obj into gen failed.  Try to promote obj to higher
-  // gens in ascending order; return the new location of obj if successful.
-  // Otherwise, try expand-and-allocate for obj in both the young and old
-  // generation; return the new location of obj if successful.  Otherwise, return NULL.
-  oop handle_failed_promotion(Generation* old_gen,
-                              oop obj,
-                              size_t obj_size);
-
-
 private:
   // Return true if an allocation should be attempted in the older generation
   // if it fails in the younger generation.  Return false, otherwise.


### PR DESCRIPTION
Trivial change of removing dead code.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293028](https://bugs.openjdk.org/browse/JDK-8293028): Remove GenCollectedHeap::handle_failed_promotion


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10063/head:pull/10063` \
`$ git checkout pull/10063`

Update a local copy of the PR: \
`$ git checkout pull/10063` \
`$ git pull https://git.openjdk.org/jdk pull/10063/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10063`

View PR using the GUI difftool: \
`$ git pr show -t 10063`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10063.diff">https://git.openjdk.org/jdk/pull/10063.diff</a>

</details>
