### PR TITLE
8293036: x86_64: Move Continuation-related stub methods to MacroAssembler

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -2091,6 +2091,10 @@ public:
 
 #endif // COMPILER2_OR_JVMCI
 
+  OopMap* continuation_enter_setup(int& stack_slots);
+  void fill_continuation_entry(Register reg_cont_obj, Register reg_flags);
+  void continuation_enter_cleanup();
+
 #endif // _LP64
 
   void vallones(XMMRegister dst, int vector_len);

--- a/src/hotspot/cpu/x86/macroAssembler_x86_64.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_64.cpp
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 #include "runtime/continuation.hpp"
 #include "runtime/continuationEntry.hpp"
+#include "runtime/javaThread.hpp"
 #include "macroAssembler_x86.hpp"
 
 //---------------------------- continuation_enter_setup ---------------------------

--- a/src/hotspot/cpu/x86/macroAssembler_x86_64.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_64.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "macroAssembler_x86.hpp"
+
+//---------------------------- continuation_enter_setup ---------------------------
+//
+// Arguments:
+//   None.
+//
+// Results:
+//   rsp: pointer to blank ContinuationEntry
+//
+// Kills:
+//   rax
+//
+OopMap* MacroAssembler::continuation_enter_setup(int& stack_slots) {
+  assert(ContinuationEntry::size() % VMRegImpl::stack_slot_size == 0, "");
+  assert(in_bytes(ContinuationEntry::cont_offset())  % VMRegImpl::stack_slot_size == 0, "");
+  assert(in_bytes(ContinuationEntry::chunk_offset()) % VMRegImpl::stack_slot_size == 0, "");
+
+  stack_slots += checked_cast<int>(ContinuationEntry::size()) / wordSize;
+  subptr(rsp, checked_cast<int32_t>(ContinuationEntry::size()));
+
+  int frame_size = (checked_cast<int>(ContinuationEntry::size()) + wordSize) / VMRegImpl::stack_slot_size;
+  OopMap* map = new OopMap(frame_size, 0);
+  ContinuationEntry::setup_oopmap(map);
+
+  movptr(rax, Address(r15_thread, JavaThread::cont_entry_offset()));
+  movptr(Address(rsp, ContinuationEntry::parent_offset()), rax);
+  movptr(Address(r15_thread, JavaThread::cont_entry_offset()), rsp);
+
+  return map;
+}
+
+//---------------------------- fill_continuation_entry ---------------------------
+//
+// Arguments:
+//   rsp: pointer to blank Continuation entry
+//   reg_cont_obj: pointer to the continuation
+//   reg_flags: flags
+//
+// Results:
+//   rsp: pointer to filled out ContinuationEntry
+//
+// Kills:
+//   rax
+//
+void MacroAssembler::fill_continuation_entry(Register reg_cont_obj, Register reg_flags) {
+  assert_different_registers(rax, reg_cont_obj, reg_flags);
+#ifdef ASSERT
+  movl(Address(rsp, ContinuationEntry::cookie_offset()), ContinuationEntry::cookie_value());
+#endif
+  movptr(Address(rsp, ContinuationEntry::cont_offset()), reg_cont_obj);
+  movl  (Address(rsp, ContinuationEntry::flags_offset()), reg_flags);
+  movptr(Address(rsp, ContinuationEntry::chunk_offset()), 0);
+  movl(Address(rsp, ContinuationEntry::argsize_offset()), 0);
+  movl(Address(rsp, ContinuationEntry::pin_count_offset()), 0);
+
+  movptr(rax, Address(r15_thread, JavaThread::cont_fastpath_offset()));
+  movptr(Address(rsp, ContinuationEntry::parent_cont_fastpath_offset()), rax);
+  movq(rax, Address(r15_thread, JavaThread::held_monitor_count_offset()));
+  movq(Address(rsp, ContinuationEntry::parent_held_monitor_count_offset()), rax);
+
+  movptr(Address(r15_thread, JavaThread::cont_fastpath_offset()), 0);
+  movq(Address(r15_thread, JavaThread::held_monitor_count_offset()), 0);
+}
+
+//---------------------------- continuation_enter_cleanup ---------------------------
+//
+// Arguments:
+//   rsp: pointer to the ContinuationEntry
+//
+// Results:
+//   rsp: pointer to the spilled rbp in the entry frame
+//
+// Kills:
+//   rbx
+//
+void MacroAssembler::continuation_enter_cleanup(MacroAssembler* masm) {
+#ifdef ASSERT
+  Label L_good_sp;
+  cmpptr(rsp, Address(r15_thread, JavaThread::cont_entry_offset()));
+  jcc(Assembler::equal, L_good_sp);
+  stop("Incorrect rsp at continuation_enter_cleanup");
+  bind(L_good_sp);
+#endif
+
+  movptr(rbx, Address(rsp, ContinuationEntry::parent_cont_fastpath_offset()));
+  movptr(Address(r15_thread, JavaThread::cont_fastpath_offset()), rbx);
+  movq(rbx, Address(rsp, ContinuationEntry::parent_held_monitor_count_offset()));
+  movq(Address(r15_thread, JavaThread::held_monitor_count_offset()), rbx);
+
+  movptr(rbx, Address(rsp, ContinuationEntry::parent_offset()));
+  movptr(Address(r15_thread, JavaThread::cont_entry_offset()), rbx);
+  addptr(rsp, checked_cast<int32_t>(ContinuationEntry::size()));
+}

--- a/src/hotspot/cpu/x86/macroAssembler_x86_64.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_64.cpp
@@ -23,6 +23,8 @@
  */
 
 #include "precompiled.hpp"
+#include "runtime/continuation.hpp"
+#include "runtime/continuationEntry.hpp"
 #include "macroAssembler_x86.hpp"
 
 //---------------------------- continuation_enter_setup ---------------------------
@@ -99,7 +101,7 @@ void MacroAssembler::fill_continuation_entry(Register reg_cont_obj, Register reg
 // Kills:
 //   rbx
 //
-void MacroAssembler::continuation_enter_cleanup(MacroAssembler* masm) {
+void MacroAssembler::continuation_enter_cleanup() {
 #ifdef ASSERT
   Label L_good_sp;
   cmpptr(rsp, Address(r15_thread, JavaThread::cont_entry_offset()));

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -1321,13 +1321,13 @@ static void gen_continuation_enter(MacroAssembler* masm,
     __ enter();
 
     stack_slots = 2; // will be adjusted in setup
-    OopMap* map = __ continuation_enter_setup(masm, stack_slots);
+    OopMap* map = __ continuation_enter_setup(stack_slots);
     // The frame is complete here, but we only record it for the compiled entry, so the frame would appear unsafe,
     // but that's okay because at the very worst we'll miss an async sample, but we're in interp_only_mode anyway.
 
     __ verify_oop(reg_cont_obj);
 
-    __ fill_continuation_entry(masm, reg_cont_obj, reg_is_virtual);
+    __ fill_continuation_entry(reg_cont_obj, reg_is_virtual);
 
     // If continuation, call to thaw. Otherwise, resolve the call and exit.
     __ testptr(reg_is_cont, reg_is_cont);
@@ -1356,14 +1356,14 @@ static void gen_continuation_enter(MacroAssembler* masm,
   __ enter();
 
   stack_slots = 2; // will be adjusted in setup
-  OopMap* map = __ continuation_enter_setup(masm, stack_slots);
+  OopMap* map = __ continuation_enter_setup(stack_slots);
 
   // Frame is now completed as far as size and linkage.
   frame_complete = __ pc() - start;
 
   __ verify_oop(reg_cont_obj);
 
-  __ fill_continuation_entry(masm, reg_cont_obj, reg_is_virtual);
+  __ fill_continuation_entry(reg_cont_obj, reg_is_virtual);
 
   // If isContinue, call to thaw. Otherwise, call Continuation.enter(Continuation c, boolean isContinue)
   __ testptr(reg_is_cont, reg_is_cont);
@@ -1406,7 +1406,7 @@ static void gen_continuation_enter(MacroAssembler* masm,
 
   __ bind(L_exit);
 
-  __ continuation_enter_cleanup(masm);
+  __ continuation_enter_cleanup();
   __ pop(rbp);
   __ ret(0);
 
@@ -1414,7 +1414,7 @@ static void gen_continuation_enter(MacroAssembler* masm,
 
   exception_offset = __ pc() - start;
 
-  __ continuation_enter_cleanup(masm);
+  __ continuation_enter_cleanup();
   __ pop(rbp);
 
   __ movptr(c_rarg0, r15_thread);

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -1253,11 +1253,6 @@ static void verify_oop_args(MacroAssembler* masm,
   }
 }
 
-// defined in stubGenerator_x86_64.cpp
-OopMap* continuation_enter_setup(MacroAssembler* masm, int& stack_slots);
-void fill_continuation_entry(MacroAssembler* masm, Register reg_cont_obj, Register reg_flags);
-void continuation_enter_cleanup(MacroAssembler* masm);
-
 static void check_continuation_enter_argument(VMReg actual_vmreg,
                                               Register expected_reg,
                                               const char* name) {
@@ -1326,13 +1321,13 @@ static void gen_continuation_enter(MacroAssembler* masm,
     __ enter();
 
     stack_slots = 2; // will be adjusted in setup
-    OopMap* map = continuation_enter_setup(masm, stack_slots);
+    OopMap* map = __ continuation_enter_setup(masm, stack_slots);
     // The frame is complete here, but we only record it for the compiled entry, so the frame would appear unsafe,
     // but that's okay because at the very worst we'll miss an async sample, but we're in interp_only_mode anyway.
 
     __ verify_oop(reg_cont_obj);
 
-    fill_continuation_entry(masm, reg_cont_obj, reg_is_virtual);
+    __ fill_continuation_entry(masm, reg_cont_obj, reg_is_virtual);
 
     // If continuation, call to thaw. Otherwise, resolve the call and exit.
     __ testptr(reg_is_cont, reg_is_cont);
@@ -1361,14 +1356,14 @@ static void gen_continuation_enter(MacroAssembler* masm,
   __ enter();
 
   stack_slots = 2; // will be adjusted in setup
-  OopMap* map = continuation_enter_setup(masm, stack_slots);
+  OopMap* map = __ continuation_enter_setup(masm, stack_slots);
 
   // Frame is now completed as far as size and linkage.
   frame_complete = __ pc() - start;
 
   __ verify_oop(reg_cont_obj);
 
-  fill_continuation_entry(masm, reg_cont_obj, reg_is_virtual);
+  __ fill_continuation_entry(masm, reg_cont_obj, reg_is_virtual);
 
   // If isContinue, call to thaw. Otherwise, call Continuation.enter(Continuation c, boolean isContinue)
   __ testptr(reg_is_cont, reg_is_cont);
@@ -1411,7 +1406,7 @@ static void gen_continuation_enter(MacroAssembler* masm,
 
   __ bind(L_exit);
 
-  continuation_enter_cleanup(masm);
+  __ continuation_enter_cleanup(masm);
   __ pop(rbp);
   __ ret(0);
 
@@ -1419,7 +1414,7 @@ static void gen_continuation_enter(MacroAssembler* masm,
 
   exception_offset = __ pc() - start;
 
-  continuation_enter_cleanup(masm);
+  __ continuation_enter_cleanup(masm);
   __ pop(rbp);
 
   __ movptr(c_rarg0, r15_thread);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -7446,7 +7446,7 @@ address generate_avx_ghash_processBlocks() {
     __ jcc(Assembler::notZero, L_pinned);
 
     __ movptr(rsp, Address(r15_thread, JavaThread::cont_entry_offset()));
-    __ continuation_enter_cleanup(_masm);
+    __ continuation_enter_cleanup();
     __ pop(rbp);
     __ ret(0);
 


### PR DESCRIPTION
Move Continuation-related methods from `stubGenerator_x86_64.cpp` under `MacroAssembler`.

Testing: hs-tier1 - hs-tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293036](https://bugs.openjdk.org/browse/JDK-8293036): x86_64: Move Continuation-related stub methods to MacroAssembler


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10066/head:pull/10066` \
`$ git checkout pull/10066`

Update a local copy of the PR: \
`$ git checkout pull/10066` \
`$ git pull https://git.openjdk.org/jdk pull/10066/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10066`

View PR using the GUI difftool: \
`$ git pr show -t 10066`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10066.diff">https://git.openjdk.org/jdk/pull/10066.diff</a>

</details>
