### PR TITLE
8293037

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/Debugger.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/Debugger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -132,7 +132,4 @@ public interface Debugger extends SymbolLookup, ThreadAccess {
 
   public ReadResult readBytesFromProcess(long address, long numBytes)
     throws DebuggerException;
-
-  public void writeBytesToProcess(long address, long numBytes, byte[] data)
-    throws UnmappedAddressException, DebuggerException;
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/DebuggerBase.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/DebuggerBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -232,15 +232,6 @@ public abstract class DebuggerBase implements Debugger {
     }
   }
 
-  /** May be called by subclasses directly but may not be overridden */
-  protected final void writeBytes(long address, long numBytes, byte[] data)
-    throws UnmappedAddressException, DebuggerException {
-    if (cache != null) {
-      cache.clear(address, numBytes);
-    }
-    writeBytesToProcess(address, numBytes, data);
-  }
-
   public boolean readJBoolean(long address)
     throws UnmappedAddressException, UnalignedAddressException {
     checkJavaConfigured();
@@ -385,78 +376,6 @@ public abstract class DebuggerBase implements Debugger {
     }
   }
 
-  public void writeJBoolean(long address, boolean value)
-    throws UnmappedAddressException, UnalignedAddressException {
-    checkJavaConfigured();
-    utils.checkAlignment(address, jbooleanSize);
-    byte[] data = utils.jbooleanToData(value);
-    writeBytes(address, jbooleanSize, data);
-  }
-
-  public void writeJByte(long address, byte value)
-    throws UnmappedAddressException, UnalignedAddressException {
-    checkJavaConfigured();
-    utils.checkAlignment(address, jbyteSize);
-    byte[] data = utils.jbyteToData(value);
-    writeBytes(address, jbyteSize, data);
-  }
-
-  public void writeJChar(long address, char value)
-    throws UnmappedAddressException, UnalignedAddressException {
-    checkJavaConfigured();
-    utils.checkAlignment(address, jcharSize);
-    byte[] data = utils.jcharToData(value);
-    writeBytes(address, jcharSize, data);
-  }
-
-  public void writeJDouble(long address, double value)
-    throws UnmappedAddressException, UnalignedAddressException {
-    checkJavaConfigured();
-    utils.checkAlignment(address, jdoubleSize);
-    byte[] data = utils.jdoubleToData(value);
-    writeBytes(address, jdoubleSize, data);
-  }
-
-  public void writeJFloat(long address, float value)
-    throws UnmappedAddressException, UnalignedAddressException {
-    checkJavaConfigured();
-    utils.checkAlignment(address, jfloatSize);
-    byte[] data = utils.jfloatToData(value);
-    writeBytes(address, jfloatSize, data);
-  }
-
-  public void writeJInt(long address, int value)
-    throws UnmappedAddressException, UnalignedAddressException {
-    checkJavaConfigured();
-    utils.checkAlignment(address, jintSize);
-    byte[] data = utils.jintToData(value);
-    writeBytes(address, jintSize, data);
-  }
-
-  public void writeJLong(long address, long value)
-    throws UnmappedAddressException, UnalignedAddressException {
-    checkJavaConfigured();
-    utils.checkAlignment(address, jlongSize);
-    byte[] data = utils.jlongToData(value);
-    writeBytes(address, jlongSize, data);
-  }
-
-  public void writeJShort(long address, short value)
-    throws UnmappedAddressException, UnalignedAddressException {
-    checkJavaConfigured();
-    utils.checkAlignment(address, jshortSize);
-    byte[] data = utils.jshortToData(value);
-    writeBytes(address, jshortSize, data);
-  }
-
-  public void writeCInteger(long address, long numBytes, long value)
-    throws UnmappedAddressException, UnalignedAddressException {
-    checkConfigured();
-    utils.checkAlignment(address, numBytes);
-    byte[] data = utils.cIntegerToData(numBytes, value);
-    writeBytes(address, numBytes, data);
-  }
-
   protected long readAddressValue(long address)
     throws UnmappedAddressException, UnalignedAddressException {
     return readCInteger(address, machDesc.getAddressSize(), true);
@@ -479,11 +398,6 @@ public abstract class DebuggerBase implements Debugger {
       value = (long)(narrowKlassBase + (long)(value << narrowKlassShift));
     }
     return value;
-  }
-
-  protected void writeAddressValue(long address, long value)
-    throws UnmappedAddressException, UnalignedAddressException {
-    writeCInteger(address, machDesc.getAddressSize(), value);
   }
 
   /** Can be called by subclasses but can not be overridden */

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdDebuggerLocal.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdDebuggerLocal.java
@@ -603,12 +603,6 @@ public class BsdDebuggerLocal extends DebuggerBase implements BsdDebugger {
         }
     }
 
-    public void writeBytesToProcess(long address, long numBytes, byte[] data)
-        throws UnmappedAddressException, DebuggerException {
-        // FIXME
-        throw new DebuggerException("Unimplemented");
-    }
-
     /** this functions used for core file reading and called from native attach0,
         it returns an array of long integers as
         [thread_id, stack_start, stack_end, thread_id, stack_start, stack_end, ....] for

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/dummy/DummyDebugger.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/dummy/DummyDebugger.java
@@ -126,11 +126,6 @@ public class DummyDebugger extends DebuggerBase {
     throw new DebuggerException("Unimplemented");
   }
 
-  public void writeBytesToProcess(long a, long b, byte[] buf)
-                               throws DebuggerException {
-    throw new DebuggerException("Unimplemented");
-  }
-
   //----------------------------------------------------------------------
   // Package-internal routines
   //

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxDebuggerLocal.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxDebuggerLocal.java
@@ -660,12 +660,6 @@ public class LinuxDebuggerLocal extends DebuggerBase implements LinuxDebugger {
         }
     }
 
-    public void writeBytesToProcess(long address, long numBytes, byte[] data)
-        throws UnmappedAddressException, DebuggerException {
-        // FIXME
-        throw new DebuggerException("Unimplemented");
-    }
-
     static {
         System.loadLibrary("saproc");
         init0();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/remote/RemoteDebuggerClient.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/remote/RemoteDebuggerClient.java
@@ -412,10 +412,6 @@ public class RemoteDebuggerClient extends DebuggerBase implements JVMDebugger {
     }
   }
 
-  public void writeBytesToProcess(long a, long b, byte[] c) {
-     throw new DebuggerException("Unimplemented!");
-  }
-
   public String execCommandOnServer(String command, Map<String, Object> options) {
     try {
       return remoteDebugger.execCommandOnServer(command, options);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/WindbgDebuggerLocal.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/WindbgDebuggerLocal.java
@@ -501,12 +501,6 @@ public class WindbgDebuggerLocal extends DebuggerBase implements WindbgDebugger 
     return null;
   }
 
-  public void writeBytesToProcess(long address, long numBytes, byte[] data)
-    throws UnmappedAddressException, DebuggerException {
-    // FIXME
-    throw new DebuggerException("Unimplemented");
-  }
-
   private static String  imagePath;
   private static String  symbolPath;
   private static boolean useNativeLookup;


### PR DESCRIPTION
DebuggerBase.writeBytes() is not needed. It is only called by a number of other "write" methods, such as writeJBoolean(), but these methods are never called, so they can be removed along with writeBytes(). Lastly, writeBytes() calls writeBytesToProcess() which has no other callers, so it too can be removed. All it currently does is throw an exception. I imagine there may have been some use for this "write" capability 20+ years ago on Solaris/x86, or maybe it was part of future plans that never panned out. In any case, it's all just baggage now that can be removed.