### PR TITLE
8292995: improve the SA page cache

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdDebuggerLocal.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdDebuggerLocal.java
@@ -204,18 +204,8 @@ public class BsdDebuggerLocal extends DebuggerBase implements BsdDebugger {
         };
 
         if (useCache) {
-            // FIXME: re-test necessity of cache on Bsd, where data
-            // fetching is faster
-            // Cache portion of the remote process's address space.
-            // Fetching data over the socket connection to dbx is slow.
-            // Might be faster if we were using a binary protocol to talk to
-            // dbx, but would have to test. For now, this cache works best
-            // if it covers the entire heap of the remote process. FIXME: at
-            // least should make this tunable from the outside, i.e., via
-            // the UI. This is a cache of 4096 4K pages, or 16 MB. The page
-            // size must be adjusted to be the hardware's page size.
-            // (FIXME: should pick this up from the debugger.)
-            initCache(4096, parseCacheNumPagesProperty(4096));
+            // This is a cache of 64k of 4K pages, or 256 MB.
+            initCache(4096, parseCacheNumPagesProperty(1024 * 64));
         }
 
         isDarwin = getOS().equals("darwin");

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxDebuggerLocal.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxDebuggerLocal.java
@@ -223,18 +223,8 @@ public class LinuxDebuggerLocal extends DebuggerBase implements LinuxDebugger {
         };
 
         if (useCache) {
-            // FIXME: re-test necessity of cache on Linux, where data
-            // fetching is faster
-            // Cache portion of the remote process's address space.
-            // Fetching data over the socket connection to dbx is slow.
-            // Might be faster if we were using a binary protocol to talk to
-            // dbx, but would have to test. For now, this cache works best
-            // if it covers the entire heap of the remote process. FIXME: at
-            // least should make this tunable from the outside, i.e., via
-            // the UI. This is a cache of 4096 4K pages, or 16 MB. The page
-            // size must be adjusted to be the hardware's page size.
-            // (FIXME: should pick this up from the debugger.)
-            initCache(4096, parseCacheNumPagesProperty(4096));
+            // This is a cache of 64k of 4K pages, or 256 MB.
+            initCache(4096, parseCacheNumPagesProperty(1024 * 64));
         }
 
         workerThread = new LinuxDebuggerLocalWorkerThread(this);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/remote/RemoteDebuggerClient.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/remote/RemoteDebuggerClient.java
@@ -44,7 +44,7 @@ public class RemoteDebuggerClient extends DebuggerBase implements JVMDebugger {
   private RemoteDebugger remoteDebugger;
   private RemoteThreadFactory threadFactory;
   private boolean unalignedAccessesOkay = false;
-  private static final int cacheSize = 16 * 1024 * 1024; // 16 MB
+  private static final int cacheSize = 256 * 1024 * 1024; // 256 MB
 
   public RemoteDebuggerClient(RemoteDebugger remoteDebugger) throws DebuggerException {
     super();
@@ -52,24 +52,17 @@ public class RemoteDebuggerClient extends DebuggerBase implements JVMDebugger {
       this.remoteDebugger = remoteDebugger;
       machDesc = remoteDebugger.getMachineDescription();
       utils = new DebuggerUtilities(machDesc.getAddressSize(), machDesc.isBigEndian());
-      int cacheNumPages;
-      int cachePageSize;
+      int cachePageSize = 4096;
+      int cacheNumPages = parseCacheNumPagesProperty(cacheSize / cachePageSize);
       String cpu = remoteDebugger.getCPU();
-      // page size. (FIXME: should pick this up from the remoteDebugger.)
       if (cpu.equals("x86")) {
         threadFactory = new RemoteX86ThreadFactory(this);
-        cachePageSize = 4096;
-        cacheNumPages = parseCacheNumPagesProperty(cacheSize / cachePageSize);
         unalignedAccessesOkay = true;
       } else if (cpu.equals("amd64") || cpu.equals("x86_64")) {
         threadFactory = new RemoteAMD64ThreadFactory(this);
-        cachePageSize = 4096;
-        cacheNumPages = parseCacheNumPagesProperty(cacheSize / cachePageSize);
         unalignedAccessesOkay = true;
       } else if (cpu.equals("ppc64")) {
         threadFactory = new RemotePPC64ThreadFactory(this);
-        cachePageSize = 4096;
-        cacheNumPages = parseCacheNumPagesProperty(cacheSize / cachePageSize);
         unalignedAccessesOkay = true;
       } else {
         try {
@@ -81,8 +74,6 @@ public class RemoteDebuggerClient extends DebuggerBase implements JVMDebugger {
         } catch (Exception e) {
           throw new DebuggerException("Thread access for CPU architecture " + cpu + " not yet supported");
         }
-        cachePageSize = 4096;
-        cacheNumPages = parseCacheNumPagesProperty(cacheSize / cachePageSize);
         unalignedAccessesOkay = false;
       }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/WindbgDebuggerLocal.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/WindbgDebuggerLocal.java
@@ -120,7 +120,7 @@ public class WindbgDebuggerLocal extends DebuggerBase implements WindbgDebugger 
     }
 
     if (useCache) {
-        initCache(4096, parseCacheNumPagesProperty(1024 * 64));
+      initCache(4096, parseCacheNumPagesProperty(1024 * 64));
     }
   }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/WindbgDebuggerLocal.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/WindbgDebuggerLocal.java
@@ -120,19 +120,8 @@ public class WindbgDebuggerLocal extends DebuggerBase implements WindbgDebugger 
     }
 
     if (useCache) {
-      // Cache portion of the remote process's address space.
-      // Fetching data over the socket connection to dbx is slow.
-      // Might be faster if we were using a binary protocol to talk to
-      // dbx, but would have to test. For now, this cache works best
-      // if it covers the entire heap of the remote process. FIXME: at
-      // least should make this tunable from the outside, i.e., via
-      // the UI. This is a cache of 4096 4K pages, or 16 MB. The page
-      // size must be adjusted to be the hardware's page size.
-      // (FIXME: should pick this up from the debugger.)
-      initCache(4096, 4096);
+        initCache(4096, parseCacheNumPagesProperty(1024 * 64));
     }
-    // FIXME: add instantiation of thread factory
-
   }
 
   /** From the Debugger interface via JVMDebugger */


### PR DESCRIPTION
The page caching support in SA is woefully dated. I think it has stayed the same for over 20 years when it was originally done for solarix-x86. This code has been replicated for every port. Currently all ports only have a 16mb cache. They use 4k pages and there are 4k of them.

I think the 4k page size is fine. The following comment appears in all the ports:

            // ... This is a cache of 4096 4K pages, or 16 MB. The page
            // size must be adjusted to be the hardware's page size.
            // (FIXME: should pick this up from the debugger.)

I disagree with this. Matching the possibly very large hardware page size (I think maybe they meant OS page size) would require the SA page cache to be very very large, using a lot of java heap space. It would also require a lot of unnecessary copying from the debuggee process's memory. There's no reason for the SA cache's page size to match the OS page size.

However, 16mb seems very small. I tried 256mb and this gave about a 10% performance improvement in a heap dump, and is still fairly small, so I think it is a reasonable adjustment.

Another comment you see in all the ports (copied from solaris-x86) is:

            // FIXME: re-test necessity of cache on Linux, where data
            // fetching is faster
            // Cache portion of the remote process's address space.
            // Fetching data over the socket connection to dbx is slow.
            // Might be faster if we were using a binary protocol to talk to
            // dbx, but would have to test. For now, this cache works best
            // if it covers the entire heap of the remote process. FIXME: at

At least on linux the cache is definitely needed. I turned it off and a heap dump took 9x longer. Also I think covering the entire heap is overkill, and I doubt was ever being done given how small the cache is. So I think this comment can just be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292995](https://bugs.openjdk.org/browse/JDK-8292995): improve the SA page cache


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to [9f528186](https://git.openjdk.org/jdk/pull/10069/files/9f5281866c581f231102934402865d8d231a58f2)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [9f528186](https://git.openjdk.org/jdk/pull/10069/files/9f5281866c581f231102934402865d8d231a58f2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10069/head:pull/10069` \
`$ git checkout pull/10069`

Update a local copy of the PR: \
`$ git checkout pull/10069` \
`$ git pull https://git.openjdk.org/jdk pull/10069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10069`

View PR using the GUI difftool: \
`$ git pr show -t 10069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10069.diff">https://git.openjdk.org/jdk/pull/10069.diff</a>

</details>
