### PR TITLE
8292892: Javadoc index descriptions are not deterministic

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlIndexBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlIndexBuilder.java
@@ -131,7 +131,7 @@ public class HtmlIndexBuilder extends IndexBuilder {
             case FIELD:
             case ENUM_CONSTANT:
                 TypeElement containingType = item.getContainingTypeElement();
-                item.setContainingPackage(utils.getPackageName(utils.containingPackage(element)));
+                item.setContainingPackage(utils.getPackageName(utils.containingPackage(containingType)));
                 item.setContainingClass(utils.getSimpleName(containingType));
                 if (configuration.showModules && addModuleInfo) {
                     item.setContainingModule(utils.getFullyQualifiedName(utils.containingModule(element)));

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexBuilder.java
@@ -327,7 +327,20 @@ public class IndexBuilder {
         return (ii1, ii2) -> {
             // If both are element items, compare the elements
             if (ii1.isElementItem() && ii2.isElementItem()) {
-                return elementComparator.compare(ii1.getElement(), ii2.getElement());
+                int d = elementComparator.compare(ii1.getElement(), ii2.getElement());
+                if (d == 0) {
+                    /*
+                     * Members inherited from classes with package access are
+                     * documented as though they were declared in the inheriting
+                     * subclass (see JDK-4780441).
+                     */
+                    Element subclass1 = ii1.getContainingTypeElement();
+                    Element subclass2 = ii2.getContainingTypeElement();
+                    if (subclass1 != null && subclass2 != null) {
+                        d = elementComparator.compare(subclass1, subclass2);
+                    }
+                }
+                return d;
             }
 
             // If one is an element item, compare labels; if equal, put element item last

--- a/test/langtools/jdk/javadoc/doclet/testIndexInherited/TestIndexInherited.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndexInherited/TestIndexInherited.java
@@ -41,19 +41,19 @@ import javadoc.tester.JavadocTester;
 public class TestIndexInherited extends JavadocTester {
 
     /**
-     * The name of the HTML index file.
+     * Name of the HTML index file.
      */
     private static final String INDEX_FILE = "index-all.html";
 
     /**
-     * The name of the JavaScript member search index file.
+     * Name of the JavaScript member search index file.
      */
     private static final String SEARCH_FILE = "member-search-index.js";
 
     /**
      * Index entries for members inherited by the subclasses.
      */
-    private static final String[] INDEX_SUBCLASSES = {"""
+    private static final String[] INDEX_INHERITED = {"""
         <dt><a href="pkg1/ClassB.html#methodA()" class="member-name-link">methodA()</a> \
         - Method in class pkg1.<a href="pkg1/ClassB.html" title="class in pkg1">ClassB</a></dt>
         """, """
@@ -70,16 +70,16 @@ public class TestIndexInherited extends JavadocTester {
     /**
      * Search entries for members inherited by the subclasses.
      */
-    private static final String[] SEARCH_SUBCLASSES = {"""
+    private static final String[] SEARCH_INHERITED = {"""
         {"p":"pkg1","c":"ClassB","l":"methodA()"}""", """
         {"p":"pkg2","c":"ClassC","l":"methodA()"}""", """
         {"p":"pkg1","c":"ClassB","l":"STRING_A"}""", """
         {"p":"pkg2","c":"ClassC","l":"STRING_A"}"""};
 
     /**
-     * Index entries for members declared in the superclass.
+     * Index entries for members declared by the superclass.
      */
-    private static final String[] INDEX_SUPERCLASS = {"""
+    private static final String[] INDEX_DECLARED = {"""
         <dt><a href="pkg1/ClassA.html#methodA()" class="member-name-link">methodA()</a> \
         - Method in interface pkg1.<a href="pkg1/ClassA.html" title="interface in pkg1">ClassA</a></dt>
         """, """
@@ -88,14 +88,14 @@ public class TestIndexInherited extends JavadocTester {
         """};
 
     /**
-     * Search entries for members declared in the superclass.
+     * Search entries for members declared by the superclass.
      */
-    private static final String[] SEARCH_SUPERCLASS = {"""
+    private static final String[] SEARCH_DECLARED = {"""
         {"p":"pkg1","c":"ClassA","l":"methodA()"}""", """
         {"p":"pkg1","c":"ClassA","l":"STRING_A"}"""};
 
     /**
-     * The default constructor.
+     * Sole constructor.
      */
     public TestIndexInherited() {
     }
@@ -107,53 +107,61 @@ public class TestIndexInherited extends JavadocTester {
      * @throws Exception if an errors occurs while executing a test method
      */
     public static void main(String... args) throws Exception {
-        TestIndexInherited tester = new TestIndexInherited();
-        tester.runTests(m -> new Object[]{Path.of(m.getName())});
+        var tester = new TestIndexInherited();
+        tester.runTests();
     }
 
     /**
-     * Tests entries in the subclasses, loaded in alphabetical order.
+     * Checks that the index includes the inherited members of both public
+     * subclasses, loaded in alphabetical order, and that there is absolutely no
+     * mention of the non-public superclass.
      *
-     * @param base the base directory for test output
+     * @param base the base directory for this method's output
      */
     @Test
-    public void testSubclasses1(Path base) {
+    public void testForInherited1(Path base) {
         String dir = base.resolve("out").toString();
         javadoc("-d", dir, "-sourcepath", testSrc, "pkg1", "pkg2");
         checkExit(Exit.OK);
-        checkOrder(INDEX_FILE, INDEX_SUBCLASSES);
-        checkOrder(SEARCH_FILE, SEARCH_SUBCLASSES);
+        checkOrder(INDEX_FILE, INDEX_INHERITED);
+        checkOrder(SEARCH_FILE, SEARCH_INHERITED);
         checkOutput(INDEX_FILE, false, "ClassA");
         checkOutput(SEARCH_FILE, false, "ClassA");
     }
 
     /**
-     * Tests entries in the subclasses, loaded in reverse alphabetical order.
+     * Checks that the index includes the inherited members of both public
+     * subclasses, loaded in reverse alphabetical order, and that there is
+     * absolutely no mention of the non-public superclass.
      *
-     * @param base the base directory for test output
+     * @param base the base directory for this method's output
      */
     @Test
-    public void testSubclasses2(Path base) {
+    public void testForInherited2(Path base) {
         String dir = base.resolve("out").toString();
         javadoc("-d", dir, "-sourcepath", testSrc, "pkg2", "pkg1");
         checkExit(Exit.OK);
-        checkOrder(INDEX_FILE, INDEX_SUBCLASSES);
-        checkOrder(SEARCH_FILE, SEARCH_SUBCLASSES);
+        checkOrder(INDEX_FILE, INDEX_INHERITED);
+        checkOrder(SEARCH_FILE, SEARCH_INHERITED);
         checkOutput(INDEX_FILE, false, "ClassA");
         checkOutput(SEARCH_FILE, false, "ClassA");
     }
 
     /**
-     * Tests entries in the superclass.
+     * Checks that the index includes the declared members of the non-public
+     * superclass when the Javadoc <i>private</i> option is specified, and that
+     * it no longer includes the inherited members of either public subclass.
      *
-     * @param base the base directory for test output
+     * @param base the base directory for this method's output
      */
     @Test
-    public void testSuperclass(Path base) {
+    public void testForDeclared(Path base) {
         String dir = base.resolve("out").toString();
         javadoc("-d", dir, "-sourcepath", testSrc, "-private", "pkg1", "pkg2");
         checkExit(Exit.OK);
-        checkOrder(INDEX_FILE, INDEX_SUPERCLASS);
-        checkOrder(SEARCH_FILE, SEARCH_SUPERCLASS);
+        checkOrder(INDEX_FILE, INDEX_DECLARED);
+        checkOrder(SEARCH_FILE, SEARCH_DECLARED);
+        checkOutput(INDEX_FILE, false, INDEX_INHERITED);
+        checkOutput(SEARCH_FILE, false, SEARCH_INHERITED);
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testIndexInherited/TestIndexInherited.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndexInherited/TestIndexInherited.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ /*
+ * @test
+ * @bug      8292892
+ * @summary  Tests that members inherited from classes with package access are
+ *           documented in the index as though they were declared in the
+ *           inheriting class.
+ * @library  ../../lib
+ * @modules  jdk.javadoc/jdk.javadoc.internal.tool
+ * @build    javadoc.tester.*
+ * @run main TestIndexInherited
+ */
+import java.nio.file.Path;
+import javadoc.tester.JavadocTester;
+
+/**
+ * Tests the index for members inherited from a class with package access.
+ */
+public class TestIndexInherited extends JavadocTester {
+
+    /**
+     * The name of the HTML index file.
+     */
+    private static final String INDEX_FILE = "index-all.html";
+
+    /**
+     * The name of the JavaScript member search index file.
+     */
+    private static final String SEARCH_FILE = "member-search-index.js";
+
+    /**
+     * Index entries for members inherited by the subclasses.
+     */
+    private static final String[] INDEX_SUBCLASSES = {"""
+        <dt><a href="pkg1/ClassB.html#methodA()" class="member-name-link">methodA()</a> \
+        - Method in class pkg1.<a href="pkg1/ClassB.html" title="class in pkg1">ClassB</a></dt>
+        """, """
+        <dt><a href="pkg2/ClassC.html#methodA()" class="member-name-link">methodA()</a> \
+        - Method in class pkg2.<a href="pkg2/ClassC.html" title="class in pkg2">ClassC</a></dt>
+        """, """
+        <dt><a href="pkg1/ClassB.html#STRING_A" class="member-name-link">STRING_A</a> \
+        - Static variable in class pkg1.<a href="pkg1/ClassB.html" title="class in pkg1">ClassB</a></dt>
+        """, """
+        <dt><a href="pkg2/ClassC.html#STRING_A" class="member-name-link">STRING_A</a> \
+        - Static variable in class pkg2.<a href="pkg2/ClassC.html" title="class in pkg2">ClassC</a></dt>
+        """};
+
+    /**
+     * Search entries for members inherited by the subclasses.
+     */
+    private static final String[] SEARCH_SUBCLASSES = {"""
+        {"p":"pkg1","c":"ClassB","l":"methodA()"}""", """
+        {"p":"pkg2","c":"ClassC","l":"methodA()"}""", """
+        {"p":"pkg1","c":"ClassB","l":"STRING_A"}""", """
+        {"p":"pkg2","c":"ClassC","l":"STRING_A"}"""};
+
+    /**
+     * Index entries for members declared in the superclass.
+     */
+    private static final String[] INDEX_SUPERCLASS = {"""
+        <dt><a href="pkg1/ClassA.html#methodA()" class="member-name-link">methodA()</a> \
+        - Method in interface pkg1.<a href="pkg1/ClassA.html" title="interface in pkg1">ClassA</a></dt>
+        """, """
+        <dt><a href="pkg1/ClassA.html#STRING_A" class="member-name-link">STRING_A</a> \
+        - Static variable in interface pkg1.<a href="pkg1/ClassA.html" title="interface in pkg1">ClassA</a></dt>
+        """};
+
+    /**
+     * Search entries for members declared in the superclass.
+     */
+    private static final String[] SEARCH_SUPERCLASS = {"""
+        {"p":"pkg1","c":"ClassA","l":"methodA()"}""", """
+        {"p":"pkg1","c":"ClassA","l":"STRING_A"}"""};
+
+    /**
+     * The default constructor.
+     */
+    public TestIndexInherited() {
+    }
+
+    /**
+     * Runs the test methods.
+     *
+     * @param args the command-line arguments
+     * @throws Exception if an errors occurs while executing a test method
+     */
+    public static void main(String... args) throws Exception {
+        TestIndexInherited tester = new TestIndexInherited();
+        tester.runTests(m -> new Object[]{Path.of(m.getName())});
+    }
+
+    /**
+     * Tests entries in the subclasses, loaded in alphabetical order.
+     *
+     * @param base the base directory for test output
+     */
+    @Test
+    public void testSubclasses1(Path base) {
+        String dir = base.resolve("out").toString();
+        javadoc("-d", dir, "-sourcepath", testSrc, "pkg1", "pkg2");
+        checkExit(Exit.OK);
+        checkOrder(INDEX_FILE, INDEX_SUBCLASSES);
+        checkOrder(SEARCH_FILE, SEARCH_SUBCLASSES);
+        checkOutput(INDEX_FILE, false, "ClassA");
+        checkOutput(SEARCH_FILE, false, "ClassA");
+    }
+
+    /**
+     * Tests entries in the subclasses, loaded in reverse alphabetical order.
+     *
+     * @param base the base directory for test output
+     */
+    @Test
+    public void testSubclasses2(Path base) {
+        String dir = base.resolve("out").toString();
+        javadoc("-d", dir, "-sourcepath", testSrc, "pkg2", "pkg1");
+        checkExit(Exit.OK);
+        checkOrder(INDEX_FILE, INDEX_SUBCLASSES);
+        checkOrder(SEARCH_FILE, SEARCH_SUBCLASSES);
+        checkOutput(INDEX_FILE, false, "ClassA");
+        checkOutput(SEARCH_FILE, false, "ClassA");
+    }
+
+    /**
+     * Tests entries in the superclass.
+     *
+     * @param base the base directory for test output
+     */
+    @Test
+    public void testSuperclass(Path base) {
+        String dir = base.resolve("out").toString();
+        javadoc("-d", dir, "-sourcepath", testSrc, "-private", "pkg1", "pkg2");
+        checkExit(Exit.OK);
+        checkOrder(INDEX_FILE, INDEX_SUPERCLASS);
+        checkOrder(SEARCH_FILE, SEARCH_SUPERCLASS);
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testIndexInherited/pkg1/ClassA.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndexInherited/pkg1/ClassA.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package pkg1;
+
+/**
+ * A class with package access, inaccessible to classes outside its package.
+ */
+interface ClassA {
+
+    /**
+     * A string constant with package access.
+     */
+    static final String STRING_A = "A string in pkg1 with package access.";
+
+    /**
+     * A method with package access.
+     */
+    default void methodA() {
+        System.out.println(ClassA.class.getName() + ": " + STRING_A);
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testIndexInherited/pkg1/ClassB.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndexInherited/pkg1/ClassB.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package pkg1;
+
+/**
+ * A public subclass in the same package as its superclass.
+ */
+public class ClassB implements ClassA {
+
+    /**
+     * The default constructor.
+     */
+    public ClassB() {
+    }
+
+    /**
+     * A public method.
+     */
+    public void methodB() {
+        System.out.println(ClassB.class.getName() + ": " + STRING_A);
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testIndexInherited/pkg1/ClassB.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndexInherited/pkg1/ClassB.java
@@ -28,7 +28,7 @@ package pkg1;
 public class ClassB implements ClassA {
 
     /**
-     * The default constructor.
+     * The sole constructor.
      */
     public ClassB() {
     }

--- a/test/langtools/jdk/javadoc/doclet/testIndexInherited/pkg2/ClassC.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndexInherited/pkg2/ClassC.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package pkg2;
+
+import pkg1.ClassB;
+
+/**
+ * A public subclass in a different package than its superclass.
+ */
+public class ClassC extends ClassB {
+
+    /**
+     * The default constructor.
+     */
+    public ClassC() {
+    }
+
+    /**
+     * A public method.
+     */
+    public void methodC() {
+        methodA();
+        methodB();
+        System.out.println(ClassC.class.getName() + ": " + STRING_A);
+    }
+
+    /**
+     * The main method.
+     *
+     * @param args the command-line arguments
+     */
+    public static void main(String[] args) {
+        new ClassC().methodC();
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testIndexInherited/pkg2/ClassC.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndexInherited/pkg2/ClassC.java
@@ -30,7 +30,7 @@ import pkg1.ClassB;
 public class ClassC extends ClassB {
 
     /**
-     * The default constructor.
+     * The sole constructor.
      */
     public ClassC() {
     }


### PR DESCRIPTION
Please review these changes to the Javadoc index builders. This pull request adds 423 missing entries to the index of the JDK API Specification, corrects their package names in the member search index, and makes their descriptions deterministic. I'll follow up with more information in a separate comment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292892](https://bugs.openjdk.org/browse/JDK-8292892): Javadoc index descriptions are not deterministic


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10070/head:pull/10070` \
`$ git checkout pull/10070`

Update a local copy of the PR: \
`$ git checkout pull/10070` \
`$ git pull https://git.openjdk.org/jdk pull/10070/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10070`

View PR using the GUI difftool: \
`$ git pr show -t 10070`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10070.diff">https://git.openjdk.org/jdk/pull/10070.diff</a>

</details>
