### PR TITLE
8230374: maxOutputSize, instead of javatest.maxOutputSize, should be used in TEST.properties

### DIFF
--- a/test/jdk/jdk/lambda/TEST.properties
+++ b/test/jdk/jdk/lambda/TEST.properties
@@ -2,5 +2,5 @@
 
 TestNG.dirs = .
 
-javatest.maxOutputSize = 250000
+maxOutputSize = 250000
 modules = jdk.compiler jdk.zipfs


### PR DESCRIPTION
Rewrote javatest.maxOutputSize as maxOutputSize in the TEST.properties file in test/jdk/jdk/lambda to match the same declarations in other TEST.properties files. The jtreg specification with the correct syntax for maxOutputSize is at https://openjdk.org/jtreg/tag-spec.html.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8230374](https://bugs.openjdk.org/browse/JDK-8230374): maxOutputSize, instead of javatest.maxOutputSize, should be used in TEST.properties


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10071/head:pull/10071` \
`$ git checkout pull/10071`

Update a local copy of the PR: \
`$ git checkout pull/10071` \
`$ git pull https://git.openjdk.org/jdk pull/10071/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10071`

View PR using the GUI difftool: \
`$ git pr show -t 10071`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10071.diff">https://git.openjdk.org/jdk/pull/10071.diff</a>

</details>
