### PR TITLE
8292590: Product JVM crashes with FLAG_SET_XXX on non-product Flag

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3880,11 +3880,13 @@ static void apply_debugger_ergo() {
   }
 #endif
 
+#ifndef PRODUCT
   if (UseDebuggerErgo) {
     // Turn on sub-flags
     FLAG_SET_ERGO_IF_DEFAULT(UseDebuggerErgo1, true);
     FLAG_SET_ERGO_IF_DEFAULT(UseDebuggerErgo2, true);
   }
+#endif
 
   if (UseDebuggerErgo2) {
     // Debugging with limited number of CPUs

--- a/src/hotspot/share/runtime/globals_extension.hpp
+++ b/src/hotspot/share/runtime/globals_extension.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,6 +59,15 @@ enum JVMFlagsEnum : int {
 
 #define DEFINE_FLAG_MEMBER_SETTER(type, name, ...) FLAG_MEMBER_SETTER_(type, name)
 
+#ifdef PRODUCT
+ALL_FLAGS(IGNORE_FLAG,               // develop     : declared as const
+          IGNORE_FLAG,               // develop-pd  : declared as const
+          DEFINE_FLAG_MEMBER_SETTER,
+          DEFINE_FLAG_MEMBER_SETTER,
+          IGNORE_FLAG,               // not-product : is not declared
+          IGNORE_RANGE,
+          IGNORE_CONSTRAINT)
+#else
 ALL_FLAGS(DEFINE_FLAG_MEMBER_SETTER,
           DEFINE_FLAG_MEMBER_SETTER,
           DEFINE_FLAG_MEMBER_SETTER,
@@ -66,6 +75,7 @@ ALL_FLAGS(DEFINE_FLAG_MEMBER_SETTER,
           DEFINE_FLAG_MEMBER_SETTER,
           IGNORE_RANGE,
           IGNORE_CONSTRAINT)
+#endif
 
 #define FLAG_IS_DEFAULT(name)         (JVMFlag::is_default(FLAG_MEMBER_ENUM(name)))
 #define FLAG_IS_ERGO(name)            (JVMFlag::is_ergo(FLAG_MEMBER_ENUM(name)))


### PR DESCRIPTION
The function `FLAG_MEMBER_SETTER(name)` is no longer declared for non-product flags (`develop` or `notproduct`) in a product build. If you use use `FLAG_SET_XXX` with such a flag in a product build, you'd get a C++ compile error.

This is validated by the change in arguments.cpp, which used to set the `notproduct` flag `UseDebuggerErgo1` in product builds. Now this code must be put inside `#ifndef PRODUCT`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292590](https://bugs.openjdk.org/browse/JDK-8292590): Product JVM crashes with FLAG_SET_XXX on non-product Flag


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10072/head:pull/10072` \
`$ git checkout pull/10072`

Update a local copy of the PR: \
`$ git checkout pull/10072` \
`$ git pull https://git.openjdk.org/jdk pull/10072/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10072`

View PR using the GUI difftool: \
`$ git pr show -t 10072`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10072.diff">https://git.openjdk.org/jdk/pull/10072.diff</a>

</details>
