### PR TITLE
8293065: Zero build failure on AArch64 and RISCV64 after JDK-8293007

### DIFF
--- a/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
@@ -130,7 +130,7 @@ void BarrierSetNMethod::arm_all_nmethods() {
   BarrierSetNMethodArmClosure cl(_current_phase);
   Threads::threads_do(&cl);
 
-#if defined(AARCH64) || defined(RISCV)
+#if (defined(AARCH64) || defined(RISCV64)) && !defined(ZERO)
   // We clear the patching epoch when disarming nmethods, so that
   // the counter won't overflow.
   BarrierSetAssembler::clear_patching_epoch();


### PR DESCRIPTION
[JDK-8293007](https://bugs.openjdk.org/browse/JDK-8293007) changes the `AARCH64_PORT_ONLY` macro into `AARCH64`, which is not an equivalent replacement.
This patch also fixes the same zero build failure on RISCV64.

Testing:

- Linux AArch64 zero release build
- Linux AArch64 server release build
- Linux RISCV64 zero release build
- Linux RISCV64 server release build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293065](https://bugs.openjdk.org/browse/JDK-8293065): Zero build failure on AArch64 and RISCV64 after JDK-8293007


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Yadong Wang](https://openjdk.org/census#yadongwang) (@yadongw - Author)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10075/head:pull/10075` \
`$ git checkout pull/10075`

Update a local copy of the PR: \
`$ git checkout pull/10075` \
`$ git pull https://git.openjdk.org/jdk pull/10075/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10075`

View PR using the GUI difftool: \
`$ git pr show -t 10075`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10075.diff">https://git.openjdk.org/jdk/pull/10075.diff</a>

</details>
