### PR TITLE
8293197: Avoid double racy reads from non-volatile fields in SharedSecrets

### DIFF
--- a/src/java.base/share/classes/jdk/internal/access/SharedSecrets.java
+++ b/src/java.base/share/classes/jdk/internal/access/SharedSecrets.java
@@ -108,12 +108,14 @@ public class SharedSecrets {
     }
 
     public static JavaUtilConcurrentTLRAccess getJavaUtilConcurrentTLRAccess() {
-        if (javaUtilConcurrentTLRAccess == null) {
+        var access = javaUtilConcurrentTLRAccess;
+        if (access == null) {
             try {
                 Class.forName("java.util.concurrent.ThreadLocalRandom$Access", true, null);
+                access = javaUtilConcurrentTLRAccess;
             } catch (ClassNotFoundException e) {}
         }
-        return javaUtilConcurrentTLRAccess;
+        return access;
     }
 
     public static void setJavaUtilConcurrentFJPAccess(JavaUtilConcurrentFJPAccess access) {
@@ -121,10 +123,12 @@ public class SharedSecrets {
     }
 
     public static JavaUtilConcurrentFJPAccess getJavaUtilConcurrentFJPAccess() {
-        if (javaUtilConcurrentFJPAccess == null) {
+        JavaUtilConcurrentFJPAccess access = javaUtilConcurrentFJPAccess;
+        if (access == null) {
             ensureClassInitialized(ForkJoinPool.class);
+            access = javaUtilConcurrentFJPAccess;
         }
-        return javaUtilConcurrentFJPAccess;
+        return access;
     }
 
     public static JavaUtilJarAccess javaUtilJarAccess() {
@@ -463,10 +467,12 @@ public class SharedSecrets {
     }
 
     public static JavaSecuritySpecAccess getJavaSecuritySpecAccess() {
-        if (javaSecuritySpecAccess == null) {
+        var access = javaSecuritySpecAccess;
+        if (access == null) {
             ensureClassInitialized(EncodedKeySpec.class);
+            access = javaSecuritySpecAccess;
         }
-        return javaSecuritySpecAccess;
+        return access;
     }
 
     public static void setJavaxCryptoSpecAccess(JavaxCryptoSpecAccess jcsa) {
@@ -474,10 +480,12 @@ public class SharedSecrets {
     }
 
     public static JavaxCryptoSpecAccess getJavaxCryptoSpecAccess() {
-        if (javaxCryptoSpecAccess == null) {
+        var access = javaxCryptoSpecAccess;
+        if (access == null) {
             ensureClassInitialized(SecretKeySpec.class);
+            access = javaxCryptoSpecAccess;
         }
-        return javaxCryptoSpecAccess;
+        return access;
     }
 
     public static void setJavaxCryptoSealedObjectAccess(JavaxCryptoSealedObjectAccess jcsoa) {

--- a/src/java.base/share/classes/jdk/internal/access/SharedSecrets.java
+++ b/src/java.base/share/classes/jdk/internal/access/SharedSecrets.java
@@ -123,7 +123,7 @@ public class SharedSecrets {
     }
 
     public static JavaUtilConcurrentFJPAccess getJavaUtilConcurrentFJPAccess() {
-        JavaUtilConcurrentFJPAccess access = javaUtilConcurrentFJPAccess;
+        var access = javaUtilConcurrentFJPAccess;
         if (access == null) {
             ensureClassInitialized(ForkJoinPool.class);
             access = javaUtilConcurrentFJPAccess;


### PR DESCRIPTION
After integration of [JDK-8259021](https://bugs.openjdk.org/browse/JDK-8259021) a few more fields were added to `SharedSecrets` class. It make sense to update their reading code to use the same idiom.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293197](https://bugs.openjdk.org/browse/JDK-8293197): Avoid double racy reads from non-volatile fields in SharedSecrets


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10076/head:pull/10076` \
`$ git checkout pull/10076`

Update a local copy of the PR: \
`$ git checkout pull/10076` \
`$ git pull https://git.openjdk.org/jdk pull/10076/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10076`

View PR using the GUI difftool: \
`$ git pr show -t 10076`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10076.diff">https://git.openjdk.org/jdk/pull/10076.diff</a>

</details>
