### PR TITLE
8293090: Remove unused par_oop_since_save_marks_iterate_done

### DIFF
--- a/src/hotspot/share/gc/shared/generation.hpp
+++ b/src/hotspot/share/gc/shared/generation.hpp
@@ -249,12 +249,6 @@ class Generation: public CHeapObj<mtGC> {
   // avoid repeating the virtual call to retrieve it.
   virtual oop promote(oop obj, size_t obj_size);
 
-  // Informs the current generation that all oop_since_save_marks_iterates
-  // performed by "thread_num" in the current collection, if any, have been
-  // completed; any supporting data structures can be reset.  Default is to
-  // do nothing.
-  virtual void par_oop_since_save_marks_iterate_done(int thread_num) {}
-
   // Returns "true" iff collect() should subsequently be called on this
   // this generation. See comment below.
   // This is a generic implementation which can be overridden.


### PR DESCRIPTION
Trivial change of removing dead code.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293090](https://bugs.openjdk.org/browse/JDK-8293090): Remove unused par_oop_since_save_marks_iterate_done


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10078/head:pull/10078` \
`$ git checkout pull/10078`

Update a local copy of the PR: \
`$ git checkout pull/10078` \
`$ git pull https://git.openjdk.org/jdk pull/10078/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10078`

View PR using the GUI difftool: \
`$ git pr show -t 10078`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10078.diff">https://git.openjdk.org/jdk/pull/10078.diff</a>

</details>
