### PR TITLE
8293088: Fix compilation with the new Visual Studio preprocessor

### DIFF
--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipeline.h
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipeline.h
@@ -62,7 +62,7 @@
     #include "Trace.h"
 
     #define DebugPrintD3DError(res, msg) \
-        J2dTraceLn1(J2D_TRACE_ERROR, "D3D Error: " ## msg ## " res=%d", res)
+        J2dTraceLn1(J2D_TRACE_ERROR, "D3D Error: " msg " res=%d", res)
 
 #endif /*D3D_PPL_DLL*/
 
@@ -87,9 +87,9 @@ do {                      \
 #define SAFE_PRINTLN(RES) \
 do {                      \
     if ((RES)!= NULL) {   \
-        J2dTraceLn1(J2D_TRACE_VERBOSE, "  " ## #RES ## "=0x%x", (RES)); \
+        J2dTraceLn1(J2D_TRACE_VERBOSE, "  " #RES "=0x%x", (RES)); \
     } else {              \
-        J2dTraceLn(J2D_TRACE_VERBOSE, "  " ## #RES ## "=NULL"); \
+        J2dTraceLn(J2D_TRACE_VERBOSE, "  " #RES "=NULL"); \
     }                     \
 } while (0);
 #else // DEBUG
@@ -114,12 +114,12 @@ do {                      \
 
 #define RETURN_STATUS_IF_EXP_FAILED(EXPR) \
     if (FAILED(res = (EXPR))) {                    \
-        DebugPrintD3DError(res, " " ## #EXPR ## " failed in " ## __FILE__); \
+        DebugPrintD3DError(res, " " #EXPR " failed in " __FILE__); \
         return res;                   \
     } else do { } while (0)
 
 #define RETURN_STATUS_IF_FAILED(status) \
     if (FAILED((status))) {                    \
-        DebugPrintD3DError((status), " failed in " ## __FILE__ ## ", return;");\
+        DebugPrintD3DError((status), " failed in " __FILE__ ", return;");\
         return (status);                   \
     } else do { } while (0)

--- a/src/java.security.jgss/windows/native/libsspi_bridge/sspi.cpp
+++ b/src/java.security.jgss/windows/native/libsspi_bridge/sspi.cpp
@@ -55,7 +55,7 @@
 // A debugging macro
 #define PP(fmt, ...) \
         if (trace) { \
-            fprintf(stderr, "[SSPI:%ld] "fmt"\n", __LINE__, ##__VA_ARGS__); \
+            fprintf(stderr, "[SSPI:%ld] " fmt "\n", __LINE__, ##__VA_ARGS__); \
             fflush(stderr); \
         }
 #define SEC_SUCCESS(status) ((*minor_status = (status)), (status) >= SEC_E_OK)


### PR DESCRIPTION
Fix compilation with Zc:preprocessor enabled. 

The flag itself will be enabled in [JDK-8247283](https://bugs.openjdk.org/browse/JDK-8247283); I enabled the flag using instructions found in Magnus's comment on that issue.

Windows 10 SDK version 2104 (10.0.20348.0) is required for successful compilation. Compilation fails with a warning (treated as error by default) with older versions of Windows 10 SDK.

I verified that the compilation completes successfully with this patch, both in debug and in release mode, both with and without Zc:preprocessor.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293088](https://bugs.openjdk.org/browse/JDK-8293088): Fix compilation with the new Visual Studio preprocessor


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10080/head:pull/10080` \
`$ git checkout pull/10080`

Update a local copy of the PR: \
`$ git checkout pull/10080` \
`$ git pull https://git.openjdk.org/jdk pull/10080/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10080`

View PR using the GUI difftool: \
`$ git pr show -t 10080`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10080.diff">https://git.openjdk.org/jdk/pull/10080.diff</a>

</details>
