### PR TITLE
5074006: Swing JOptionPane shows </html> tag as a string after newline

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
@@ -458,11 +458,11 @@ public class BasicOptionPaneUI extends OptionPaneUI {
             }
             if (s.contains("<html>")) {
                 /* line break in html text is done by <br> tag
-		 * and not by /n so it's incorrect to address newline
-		 * same as non-html text.
-		 * Text between <html> </html> tags are extracted
-		 * and rendered as JLabel text
-		 */
+                 * and not by /n so it's incorrect to address newline
+                 * same as non-html text.
+                 * Text between <html> </html> tags are extracted
+                 * and rendered as JLabel text
+                 */
                 int index1 = s.indexOf("<html>");
                 int index2 = s.indexOf("</html>");
                 String str = "";

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
@@ -457,12 +457,18 @@ public class BasicOptionPaneUI extends OptionPaneUI {
                 nll = 1;
             }
             if (s.contains("<html>")) {
+                /* line break in html text is done by <br> tag
+		 * and not by /n so it's incorrect to address newline
+		 * same as non-html text.
+		 * Text between <html> </html> tags are extracted
+		 * and rendered as JLabel text
+		 */
                 int index1 = s.indexOf("<html>");
                 int index2 = s.indexOf("</html>");
                 String str = "";
                 if (index2 >= 0) {
                     str = s.substring(index2 + "</html>".length());
-                    s = s.substring(index1, index2);
+                    s = s.substring(index1, index2 + + "</html>".length());
                 }
                 JLabel label;
                 label = new JLabel(s, JLabel.LEADING);

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
@@ -486,9 +486,12 @@ public class BasicOptionPaneUI extends OptionPaneUI {
                                          maxll,false);
                     return;
                 }
-                addMessageComponents(container, cons, s.substring(nl + nll), maxll,
-                                     false);
-
+                String str = s.substring(nl + nll);
+                if (str.contains("</html>")) {
+                    str = str.replace("</html>", "");
+                }
+                addMessageComponents(container, cons, str, maxll,
+                            false);
             } else if (len > maxll) {
                 Container c = Box.createVerticalBox();
                 c.setName("OptionPane.verticalBox");

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
@@ -456,54 +456,69 @@ public class BasicOptionPaneUI extends OptionPaneUI {
             } else if ((nl = s.indexOf('\n')) >= 0) {
                 nll = 1;
             }
-            if (nl >= 0) {
-                // break up newlines
-                if (nl == 0) {
-                    @SuppressWarnings("serial") // anonymous class
-                    JPanel breakPanel = new JPanel() {
-                        public Dimension getPreferredSize() {
-                            Font f = getFont();
-
-                            if (f != null) {
-                                return new Dimension(1, f.getSize() + 2);
-                            }
-                            return new Dimension(0, 0);
-                        }
-                    };
-                    breakPanel.setName("OptionPane.break");
-                    addMessageComponents(container, cons, breakPanel, maxll,
-                                         true);
-                } else {
-                    addMessageComponents(container, cons, s.substring(0, nl),
-                                      maxll, false);
+            if (s.contains("<html>")) {
+                int index1 = s.indexOf("<html>");
+                int index2 = s.indexOf("</html>");
+                String str = "";
+                if (index2 >= 0) {
+                    str = s.substring(index2 + "</html>".length());
+                    s = s.substring(index1, index2);
                 }
-                // Prevent recursion of more than
-                // 200 successive newlines in a message
-                // and indicate message is truncated via ellipsis
-                if (recursionCount++ > 200) {
-                    recursionCount = 0;
-                    addMessageComponents(container, cons, new String("..."),
-                                         maxll,false);
-                    return;
-                }
-                String str = s.substring(nl + nll);
-                if (str.contains("</html>")) {
-                    str = str.replace("</html>", "");
-                }
-                addMessageComponents(container, cons, str, maxll,
-                            false);
-            } else if (len > maxll) {
-                Container c = Box.createVerticalBox();
-                c.setName("OptionPane.verticalBox");
-                burstStringInto(c, s, maxll);
-                addMessageComponents(container, cons, c, maxll, true );
-
-            } else {
                 JLabel label;
-                label = new JLabel( s, JLabel.LEADING );
+                label = new JLabel(s, JLabel.LEADING);
                 label.setName("OptionPane.label");
                 configureMessageLabel(label);
                 addMessageComponents(container, cons, label, maxll, true);
+                if (!str.isEmpty()) {
+                    addMessageComponents(container, cons, str, maxll, false);
+                }
+            } else {
+                if (nl >= 0) {
+                    // break up newlines
+                    if (nl == 0) {
+                        @SuppressWarnings("serial") // anonymous class
+                                JPanel breakPanel = new JPanel() {
+                            public Dimension getPreferredSize() {
+                                Font f = getFont();
+
+                                if (f != null) {
+                                    return new Dimension(1, f.getSize() + 2);
+                                }
+                                return new Dimension(0, 0);
+                            }
+                        };
+                        breakPanel.setName("OptionPane.break");
+                        addMessageComponents(container, cons, breakPanel, maxll,
+                                true);
+                    } else {
+                        addMessageComponents(container, cons, s.substring(0, nl),
+                                maxll, false);
+                    }
+                    // Prevent recursion of more than
+                    // 200 successive newlines in a message
+                    // and indicate message is truncated via ellipsis
+                    if (recursionCount++ > 200) {
+                        recursionCount = 0;
+                        addMessageComponents(container, cons, new String("..."),
+                                maxll, false);
+                        return;
+                    }
+                    addMessageComponents(container, cons, s.substring(nl + nll), maxll,
+                            false);
+
+                } else if (len > maxll) {
+                    Container c = Box.createVerticalBox();
+                    c.setName("OptionPane.verticalBox");
+                    burstStringInto(c, s, maxll);
+                    addMessageComponents(container, cons, c, maxll, true);
+
+                } else {
+                    JLabel label;
+                    label = new JLabel(s, JLabel.LEADING);
+                    label.setName("OptionPane.label");
+                    configureMessageLabel(label);
+                    addMessageComponents(container, cons, label, maxll, true);
+                }
             }
         }
     }

--- a/test/jdk/javax/swing/JOptionPane/TestJOptionHTMLTag.java
+++ b/test/jdk/javax/swing/JOptionPane/TestJOptionHTMLTag.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/* @test
+ * @bug 5074006
+ * @key headful
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Swing JOptionPane shows <html> tag as a string after newline
+ * @run main/manual TestJOptionHTMLTag
+*/
+
+import javax.swing.JDialog;
+import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
+
+public class TestJOptionHTMLTag {
+    static String instructions
+            = """
+            INSTRUCTIONS:
+                A dialog will be shown.
+                If it does not contain </html> string, press Pass else press Fail.           		
+            """;
+    static PassFailJFrame passFailJFrame;
+
+    public static void main(String[] args) throws Exception {
+
+        SwingUtilities.invokeAndWait(() -> {
+            try {
+                String message = "<html>" + "This is a test\n" + "</html>";
+                JOptionPane optionPane = new JOptionPane();
+                optionPane.setMessage(message);
+                optionPane.setMessageType(JOptionPane.INFORMATION_MESSAGE);
+                JDialog dialog = new JDialog();
+                dialog.setContentPane(optionPane);
+                dialog.pack();
+                dialog.setVisible(true);
+
+                passFailJFrame = new PassFailJFrame(instructions);
+                PassFailJFrame.addTestWindow(dialog);
+                PassFailJFrame.positionTestWindow(dialog, PassFailJFrame.Position.HORIZONTAL);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        passFailJFrame.awaitAndCheck();
+    }
+}
+

--- a/test/jdk/javax/swing/JOptionPane/TestJOptionHTMLTag.java
+++ b/test/jdk/javax/swing/JOptionPane/TestJOptionHTMLTag.java
@@ -38,7 +38,7 @@ public class TestJOptionHTMLTag {
             = """
             INSTRUCTIONS:
                 A dialog will be shown.
-                If it does not contain </html> string, press Pass else press Fail.           		
+                If it does not contain </html> string, press Pass else press Fail.
             """;
     static PassFailJFrame passFailJFrame;
 


### PR DESCRIPTION
If JOptionPane's message contains both linefeed/cursor return and HTML tag ie, **<html\>" + "This is a test\n" + "<\/html\>**,
then  "<\/html\>" will be shown in the JOptionPane dialog box because after every new line it creates a new messageComponent so the characters after the newline ie "<\/html\>"tag will be considered as a new JLabel string and displayed.

Fix is to ignore closing html tag if appearing after newline from the displayed string.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-5074006](https://bugs.openjdk.org/browse/JDK-5074006): Swing JOptionPane shows </html> tag as a string after newline
 * [JDK-8042134](https://bugs.openjdk.org/browse/JDK-8042134): JOptionPane bungles HTML messages


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**) ⚠️ Review applies to [2b00d425](https://git.openjdk.org/jdk/pull/10081/files/2b00d4250e57648fcbb27cb96156b391accc31aa)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer) ⚠️ Review applies to [2b00d425](https://git.openjdk.org/jdk/pull/10081/files/2b00d4250e57648fcbb27cb96156b391accc31aa)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10081/head:pull/10081` \
`$ git checkout pull/10081`

Update a local copy of the PR: \
`$ git checkout pull/10081` \
`$ git pull https://git.openjdk.org/jdk pull/10081/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10081`

View PR using the GUI difftool: \
`$ git pr show -t 10081`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10081.diff">https://git.openjdk.org/jdk/pull/10081.diff</a>

</details>
