### PR TITLE
8293109: Remove unused methods in Compiler

### DIFF
--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -716,31 +716,6 @@ void CompilationResourceObj::print_on(outputStream* st) const {
   st->print_cr("CompilationResourceObj(" INTPTR_FORMAT ")", p2i(this));
 }
 
-void Compilation::compile_only_this_method() {
-  ResourceMark rm;
-  fileStream stream(os::fopen("c1_compile_only", "wt"));
-  stream.print_cr("# c1 compile only directives");
-  compile_only_this_scope(&stream, hir()->top_scope());
-}
-
-void Compilation::compile_only_this_scope(outputStream* st, IRScope* scope) {
-  st->print("CompileOnly=");
-  scope->method()->holder()->name()->print_symbol_on(st);
-  st->print(".");
-  scope->method()->name()->print_symbol_on(st);
-  st->cr();
-}
-
-void Compilation::exclude_this_method() {
-  fileStream stream(os::fopen(".hotspot_compiler", "at"));
-  stream.print("exclude ");
-  method()->holder()->name()->print_symbol_on(&stream);
-  stream.print(" ");
-  method()->name()->print_symbol_on(&stream);
-  stream.cr();
-  stream.cr();
-}
-
 // Called from debugger to get the interval with 'reg_num' during register allocation.
 Interval* find_interval(int reg_num) {
   return Compilation::current()->allocator()->find_interval_at(reg_num);

--- a/src/hotspot/share/c1/c1_Compilation.hpp
+++ b/src/hotspot/share/c1/c1_Compilation.hpp
@@ -220,16 +220,6 @@ class Compilation: public StackObj {
   // timers
   static void print_timers();
 
-#ifndef PRODUCT
-  // debugging support.
-  // produces a file named c1compileonly in the current directory with
-  // directives to compile only the current method and it's inlines.
-  // The file can be passed to the command line option -XX:Flags=<filename>
-  void compile_only_this_method();
-  void compile_only_this_scope(outputStream* st, IRScope* scope);
-  void exclude_this_method();
-#endif // PRODUCT
-
   bool is_profiling() {
     return env()->comp_level() == CompLevel_full_profile ||
            env()->comp_level() == CompLevel_limited_profile;


### PR DESCRIPTION
Hi,

May I have a review regarding this PR? It removes some unused code which I found. All of this code is from "Initial load".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293109](https://bugs.openjdk.org/browse/JDK-8293109): Remove unused methods in Compiler


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10082/head:pull/10082` \
`$ git checkout pull/10082`

Update a local copy of the PR: \
`$ git checkout pull/10082` \
`$ git pull https://git.openjdk.org/jdk pull/10082/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10082`

View PR using the GUI difftool: \
`$ git pr show -t 10082`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10082.diff">https://git.openjdk.org/jdk/pull/10082.diff</a>

</details>
