### PR TITLE
8293098: GHA: Harmonize GCC version handling for host and cross builds

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -29,17 +29,14 @@ on:
   workflow_call:
     inputs:
       gcc-major-version:
-        required: false
+        required: true
         type: string
-        default: '10'
       apt-gcc-version:
-        required: false
+        required: true
         type: string
-        default: '10.3.0-1ubuntu1~20.04'
       apt-gcc-cross-suffix:
-        required: false
+        required: true
         type: string
-        default: 'cross1'
 
 jobs:
   build-cross-compile:

--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -34,7 +34,7 @@ on:
       apt-gcc-version:
         required: true
         type: string
-      apt-gcc-cross-suffix:
+      apt-gcc-cross-version:
         required: true
         type: string
 
@@ -92,8 +92,8 @@ jobs:
           sudo apt-get install \
               gcc-${{ inputs.gcc-major-version }}=${{ inputs.apt-gcc-version }} \
               g++-${{ inputs.gcc-major-version }}=${{ inputs.apt-gcc-version }} \
-              gcc-${{ inputs.gcc-major-version }}-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}=${{ inputs.apt-gcc-version }}${{ inputs.apt-gcc-cross-suffix }} \
-              g++-${{ inputs.gcc-major-version }}-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}=${{ inputs.apt-gcc-version }}${{ inputs.apt-gcc-cross-suffix }} \
+              gcc-${{ inputs.gcc-major-version }}-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}=${{ inputs.apt-gcc-cross-version }} \
+              g++-${{ inputs.gcc-major-version }}-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}=${{ inputs.apt-gcc-cross-version }} \
               libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ inputs.gcc-major-version }} 100 --slave /usr/bin/g++ g++ /usr/bin/g++-${{ inputs.gcc-major-version }}
 

--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -143,8 +143,8 @@ jobs:
           --openjdk-target=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}
           --with-sysroot=sysroot
           --with-build-jdk=${{ steps.buildjdk.outputs.jdk-path }}
-          CC=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-gcc-10
-          CXX=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-g++-10
+          CC=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-gcc-${{ inputs.gcc-major-version }}
+          CXX=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-g++-${{ inputs.gcc-major-version }}
 
       - name: 'Build'
         id: build

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -42,6 +42,9 @@ on:
         required: false
         type: string
         default: '[ "debug", "release" ]'
+      gcc-major-version:
+        required: true
+        type: string
       apt-gcc-version:
         required: true
         type: string
@@ -101,8 +104,8 @@ jobs:
           fi
           sudo apt-get update
           sudo apt-get install --only-upgrade apt
-          sudo apt-get install gcc-${{ inputs.apt-gcc-version }} g++-${{ inputs.apt-gcc-version }} libxrandr-dev${{ steps.arch.outputs.suffix }} libxtst-dev${{ steps.arch.outputs.suffix }} libcups2-dev${{ steps.arch.outputs.suffix }} libasound2-dev${{ steps.arch.outputs.suffix }} ${{ inputs.apt-extra-packages }}
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+          sudo apt-get install gcc-${{ inputs.gcc-major-version }}=${{ inputs.apt-gcc-version }} g++-${{ inputs.gcc-major-version }}=${{ inputs.apt-gcc-version }} libxrandr-dev${{ steps.arch.outputs.suffix }} libxtst-dev${{ steps.arch.outputs.suffix }} libcups2-dev${{ steps.arch.outputs.suffix }} libasound2-dev${{ steps.arch.outputs.suffix }} ${{ inputs.apt-extra-packages }}
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ inputs.gcc-major-version }} 100 --slave /usr/bin/g++ g++ /usr/bin/g++-${{ inputs.gcc-major-version }}
 
       - name: 'Configure'
         run: >

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -45,6 +45,10 @@ on:
       gcc-major-version:
         required: true
         type: string
+      gcc-package-suffix:
+        required: false
+        type: string
+        default: ''
       apt-gcc-version:
         required: true
         type: string
@@ -104,7 +108,7 @@ jobs:
           fi
           sudo apt-get update
           sudo apt-get install --only-upgrade apt
-          sudo apt-get install gcc-${{ inputs.gcc-major-version }}=${{ inputs.apt-gcc-version }} g++-${{ inputs.gcc-major-version }}=${{ inputs.apt-gcc-version }} libxrandr-dev${{ steps.arch.outputs.suffix }} libxtst-dev${{ steps.arch.outputs.suffix }} libcups2-dev${{ steps.arch.outputs.suffix }} libasound2-dev${{ steps.arch.outputs.suffix }} ${{ inputs.apt-extra-packages }}
+          sudo apt-get install gcc-${{ inputs.gcc-major-version }}${{ inputs.gcc-package-suffix }}=${{ inputs.apt-gcc-version }} g++-${{ inputs.gcc-major-version }}${{ inputs.gcc-package-suffix }}=${{ inputs.apt-gcc-version }} libxrandr-dev${{ steps.arch.outputs.suffix }} libxtst-dev${{ steps.arch.outputs.suffix }} libcups2-dev${{ steps.arch.outputs.suffix }} libasound2-dev${{ steps.arch.outputs.suffix }} ${{ inputs.apt-extra-packages }}
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ inputs.gcc-major-version }} 100 --slave /usr/bin/g++ g++ /usr/bin/g++-${{ inputs.gcc-major-version }}
 
       - name: 'Configure'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -206,7 +206,7 @@ jobs:
     with:
       gcc-major-version: '10'
       apt-gcc-version: '10.3.0-1ubuntu1~20.04'
-      apt-gcc-cross-suffix: 'cross1'
+      apt-gcc-cross-version: '10.3.0-1ubuntu1~20.04cross1'
     if: needs.select.outputs.linux-cross-compile == 'true'
 
   build-macos-x64:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,7 +135,8 @@ jobs:
     with:
       platform: linux-x86
       gcc-major-version: '10'
-      apt-gcc-version: '10-multilib'
+      gcc-package-suffix: '-multilib'
+      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
       apt-architecture: 'i386'
       # Some multilib libraries do not have proper inter-dependencies, so we have to
       # install their dependencies manually.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -202,6 +202,10 @@ jobs:
       - select
       - build-linux-x64
     uses: ./.github/workflows/build-cross-compile.yml
+    with:
+      gcc-major-version: '10'
+      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
+      apt-gcc-cross-suffix: 'cross1'
     if: needs.select.outputs.linux-cross-compile == 'true'
 
   build-macos-x64:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,7 +123,8 @@ jobs:
     uses: ./.github/workflows/build-linux.yml
     with:
       platform: linux-x64
-      apt-gcc-version: '10=10.3.0-1ubuntu1~20.04'
+      gcc-major-version: '10'
+      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
     # The linux-x64 jdk bundle is used as buildjdk for the cross-compile job
     if: needs.select.outputs.linux-x64 == 'true' || needs.select.outputs.linux-cross-compile == 'true'
 
@@ -133,6 +134,7 @@ jobs:
     uses: ./.github/workflows/build-linux.yml
     with:
       platform: linux-x86
+      gcc-major-version: '10'
       apt-gcc-version: '10-multilib'
       apt-architecture: 'i386'
       # Some multilib libraries do not have proper inter-dependencies, so we have to
@@ -149,7 +151,8 @@ jobs:
       platform: linux-x64
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
-      apt-gcc-version: '10=10.3.0-1ubuntu1~20.04'
+      gcc-major-version: '10'
+      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
       extra-conf-options: '--disable-precompiled-headers'
     if: needs.select.outputs.linux-x64-variants == 'true'
 
@@ -161,7 +164,8 @@ jobs:
       platform: linux-x64
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
-      apt-gcc-version: '10=10.3.0-1ubuntu1~20.04'
+      gcc-major-version: '10'
+      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
       extra-conf-options: '--with-jvm-variants=zero --disable-precompiled-headers'
     if: needs.select.outputs.linux-x64-variants == 'true'
 
@@ -173,7 +177,8 @@ jobs:
       platform: linux-x64
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
-      apt-gcc-version: '10=10.3.0-1ubuntu1~20.04'
+      gcc-major-version: '10'
+      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
       extra-conf-options: '--with-jvm-variants=minimal --disable-precompiled-headers'
     if: needs.select.outputs.linux-x64-variants == 'true'
 
@@ -186,7 +191,8 @@ jobs:
       make-target: 'hotspot'
       # Technically this is not the "debug" level, but we can't inject a new matrix state for just this job
       debug-levels: '[ "debug" ]'
-      apt-gcc-version: '10=10.3.0-1ubuntu1~20.04'
+      gcc-major-version: '10'
+      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
       extra-conf-options: '--with-debug-level=optimized --disable-precompiled-headers'
     if: needs.select.outputs.linux-x64-variants == 'true'
 


### PR DESCRIPTION
Caught this headache while trying to bump to Ubuntu 22.04, which required touching way too many surprising places. 

Current GHA scripts define `apt-gcc-version` a bit weirdly: host and cross builds version differ in carrying the "gcc-major-version" inside of it. That is, "host" builds do `apt-gcc-version: '10=10.3.0-1ubuntu1~20.04'`, while cross builds do `apt-gcc-version: default: '10.3.0-1ubuntu1~20.04'`

I propose we harmonize these to simplify GCC updates: split out the `gcc-major-version` for host builds, and pull the versions from cross builds into `main`, where all other versions belong. Additionally, this handles the x86_32 case that requires "-multilib" package, which is currently hacked through the "version" string.

Additional testing:
 - [ ] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293098](https://bugs.openjdk.org/browse/JDK-8293098): GHA: Harmonize GCC version handling for host and cross builds


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10083/head:pull/10083` \
`$ git checkout pull/10083`

Update a local copy of the PR: \
`$ git checkout pull/10083` \
`$ git pull https://git.openjdk.org/jdk pull/10083/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10083`

View PR using the GUI difftool: \
`$ git pr show -t 10083`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10083.diff">https://git.openjdk.org/jdk/pull/10083.diff</a>

</details>
