### PR TITLE
8175382: clhsdb pmap should print the end addresses of the load modules

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PMap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,8 +72,11 @@ public class PMap extends Tool {
          }
          while (itr.hasNext()) {
             LoadObject lo = itr.next();
-            out.print(lo.getBase() + "\t");
-            out.print(lo.getSize()/1024 + "K\t");
+            long base = lo.getBase().asLongValue();
+            long size = lo.getSize();
+            long end = base + size;
+            out.print("0x" + Long.toHexString(base) + "-0x" + Long.toHexString(end) + "\t");
+            out.print(size/1024 + "K\t");
             out.println(lo.getName());
          }
       } else {


### PR DESCRIPTION
The clhsdb 'pmap' command prints the start addresses and the sizes of the various load modules. It would be more intuitive to have the end address printed as the VM.dynlibs jcmd does. 

Before:

0x00007f8839c38000 5920K /usr/lib64/libc-2.17.so
0x00007f883a006000 4072K /usr/lib64/libdl-2.17.so
0x00007f883a20a000 4056K /usr/lib64/libpthread-2.17.so
0x00007f883a426000 3944K /usr/lib64/libz.so.1.2.7

After:

0x7f0f8e482000-0x7f0f8ea00000 5624K /usr/lib64/libc-2.17.so
0x7f0f8e850000-0x7f0f8ec00000 3776K /usr/lib64/libdl-2.17.so
0x7f0f8ea54000-0x7f0f8ee00000 3760K /usr/lib64/libpthread-2.17.so
0x7f0f8ec70000-0x7f0f8f000000 3648K /usr/lib64/libz.so.1.2.7

Note that VM.dynlibs doesn't use the 0x prefix. I considered doing the same for pmap, but it did cause one test failure that was searching for the address starting with 0x, so I decided to leave it in. Notice I also dropped the leading 0's to keep things a big more compact (VM.dynlibs does the same).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8175382](https://bugs.openjdk.org/browse/JDK-8175382): clhsdb pmap should print the end addresses of the load modules


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Yasumasa Suenaga](https://openjdk.org/census#ysuenaga) (@YaSuenag - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10087/head:pull/10087` \
`$ git checkout pull/10087`

Update a local copy of the PR: \
`$ git checkout pull/10087` \
`$ git pull https://git.openjdk.org/jdk pull/10087/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10087`

View PR using the GUI difftool: \
`$ git pr show -t 10087`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10087.diff">https://git.openjdk.org/jdk/pull/10087.diff</a>

</details>
