### PR TITLE
8293006: sun/tools/jhsdb/JStackStressTest.java fails with "UnalignedAddressException: 8baadbabe"

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHeap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -190,7 +190,7 @@ public class ObjectHeap {
       System.err.println("Oop's klass is " + klass);
     }
 
-    throw new UnknownOopException();
+    throw new UnknownOopException(handle.toString());
   }
 
   // Print all objects in the object heap

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaThread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaThread.java
@@ -354,7 +354,7 @@ public class JavaThread extends Thread {
       VMOopHandle vmOopHandle = VMObjectFactory.newObject(VMOopHandle.class, addr);
       obj = vmOopHandle.resolve();
     } catch (Exception e) {
-        System.out.println("WARNING: could not get Thread object: " + e);
+      System.out.println("WARNING: could not get Thread object: " + e);
     }
     return obj;
   }
@@ -513,7 +513,7 @@ public class JavaThread extends Thread {
 
       Oop threadOop = this.getThreadObj();
       if (threadOop == null) {
-          System.out.println("Could not get the java Thread object. Thread info will be limitted.");
+          System.out.println("Could not get the java Thread object. Thread info will be limited.");
       } else {
           // Some of these accesses can throw an Exception if we are in the
           // middle of a GC, so be cautious.
@@ -543,11 +543,11 @@ public class JavaThread extends Thread {
       out.print(" tid=");
       out.print(this.getAddress());
       out.print(" nid=");
-      out.print(String.format("%d ",this.getOSThread().threadId()));
+      out.print(String.format("%d ", this.getOSThread().threadId()));
       out.print(getOSThread().getThreadState().getPrintVal());
       out.print(" [");
       if (this.getLastJavaSP() == null) {
-          out.print(String.format(ADDRESS_FORMAT,0L));
+          out.print(String.format(ADDRESS_FORMAT, 0L));
       } else {
           out.print(this.getLastJavaSP().andWithMask(~0xFFF));
       }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaThread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaThread.java
@@ -354,7 +354,7 @@ public class JavaThread extends Thread {
       VMOopHandle vmOopHandle = VMObjectFactory.newObject(VMOopHandle.class, addr);
       obj = vmOopHandle.resolve();
     } catch (Exception e) {
-      e.printStackTrace();
+        System.out.println("WARNING: could not get Thread object: " + e);
     }
     return obj;
   }
@@ -406,7 +406,11 @@ public class JavaThread extends Thread {
   public Oop getCurrentParkBlocker() {
     Oop threadObj = getThreadObj();
     if (threadObj != null) {
-      return OopUtilities.threadOopGetParkBlocker(threadObj);
+      try {
+        return OopUtilities.threadOopGetParkBlocker(threadObj);
+      } catch (Exception e) {
+        System.out.println("Could not get current park blocker: " + e);
+      }
     }
     return null;
   }
@@ -502,32 +506,57 @@ public class JavaThread extends Thread {
   }
 
   public void printThreadInfoOn(PrintStream out){
-    Oop threadOop = this.getThreadObj();
+      String threadName = "<unknown>";
+      boolean daemon = false;
+      int priority = java.lang.Thread.MIN_PRIORITY - 1;
+      String statusName = "<unknown>";
 
-    out.print("\"");
-    out.print(this.getThreadName());
-    out.print("\" #");
-    out.print(OopUtilities.threadOopGetTID(threadOop));
-    if(OopUtilities.threadOopGetDaemon(threadOop)){
-      out.print(" daemon");
-    }
-    out.print(" prio=");
-    out.print(OopUtilities.threadOopGetPriority(threadOop));
-    out.print(" tid=");
-    out.print(this.getAddress());
-    out.print(" nid=");
-    out.print(String.format("%d ",this.getOSThread().threadId()));
-    out.print(getOSThread().getThreadState().getPrintVal());
-    out.print(" [");
-    if(this.getLastJavaSP() == null){
-      out.print(String.format(ADDRESS_FORMAT,0L));
-    } else {
-      out.print(this.getLastJavaSP().andWithMask(~0xFFF));
-    }
-    out.println("]");
-    out.print("   java.lang.Thread.State: ");
-    out.println(OopUtilities.threadOopGetThreadStatusName(threadOop));
-    out.print("   JavaThread state: _thread_");
-    out.println(this.getThreadState().toString().toLowerCase());
+      Oop threadOop = this.getThreadObj();
+      if (threadOop == null) {
+          System.out.println("Could not get the java Thread object. Thread info will be limitted.");
+      } else {
+          // Some of these accesses can throw an Exception if we are in the
+          // middle of a GC, so be cautious.
+          try {
+              threadName = this.getThreadName();
+          } catch (Exception e) {}
+          try {
+              // These all rely on the FieldHolder object, so if one fails, they all fail.
+              daemon = OopUtilities.threadOopGetDaemon(threadOop);
+              priority = OopUtilities.threadOopGetPriority(threadOop);
+              statusName = OopUtilities.threadOopGetThreadStatusName(threadOop);
+          } catch (Exception e) {}
+          out.print("\"");
+          out.print(threadName);
+          out.print("\" #");
+          out.print(OopUtilities.threadOopGetTID(threadOop));
+          if (daemon) {
+              out.print(" daemon");
+          }
+          out.print(" prio=");
+          if (priority == java.lang.Thread.MIN_PRIORITY - 1) {
+              out.print("<unknown>");
+          } else {
+              out.print(priority);
+          }
+      }
+      out.print(" tid=");
+      out.print(this.getAddress());
+      out.print(" nid=");
+      out.print(String.format("%d ",this.getOSThread().threadId()));
+      out.print(getOSThread().getThreadState().getPrintVal());
+      out.print(" [");
+      if (this.getLastJavaSP() == null) {
+          out.print(String.format(ADDRESS_FORMAT,0L));
+      } else {
+          out.print(this.getLastJavaSP().andWithMask(~0xFFF));
+      }
+      out.println("]");
+      if (threadOop != null) {
+          out.print("   java.lang.Thread.State: ");
+          out.println(statusName);
+      }
+      out.print("   JavaThread state: _thread_");
+      out.println(this.getThreadState().toString().toLowerCase());
   }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaVFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaVFrame.java
@@ -61,7 +61,12 @@ public abstract class JavaVFrame extends VFrame {
                  lockState, hobj.asLongValue());
 
       Klass klass = Oop.getKlassForOopHandle(hobj);
-      String klassName = klass.getName().asString();
+      String klassName;
+      if (klass != null) {
+          klassName = klass.getName().asString();
+      } else {
+          klassName = "<unknown class>";
+      }
       tty.print("(a ");
       if (klassName.equals("java/lang/Class")) {
         Oop obj = VM.getVM().getObjectHeap().newOop(hobj);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaVFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaVFrame.java
@@ -63,9 +63,9 @@ public abstract class JavaVFrame extends VFrame {
       Klass klass = Oop.getKlassForOopHandle(hobj);
       String klassName;
       if (klass != null) {
-          klassName = klass.getName().asString();
+        klassName = klass.getName().asString();
       } else {
-          klassName = "<unknown class>";
+        klassName = "<unknown class>";
       }
       tty.print("(a ");
       if (klassName.equals("java/lang/Class")) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,7 @@ public class PStack extends Tool {
          try {
             DeadlockDetector.print(out);
          } catch (Exception exp) {
-            out.println("can't print deadlock information: " + exp.getMessage());
+            out.println("can't print deadlock information: " + exp);
          }
 
          List<ThreadProxy> l = cdbg.getThreadList();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/StackTrace.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/StackTrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ public class StackTrace extends Tool {
             DeadlockDetector.print(tty);
         } catch (Exception exp) {
             exp.printStackTrace();
-            tty.println("Can't print deadlocks:" + exp.getMessage());
+            tty.println("Can't print deadlocks: " + exp);
         }
 
         try {
@@ -111,11 +111,15 @@ public class StackTrace extends Tool {
                             }
 
                             tty.println(")");
-                            vf.printLockInfo(tty, count++);
+                            try {
+                                vf.printLockInfo(tty, count++);
+                            } catch (Exception e) {
+                                tty.println("\nCould not print lock info: " + e);
+                            }
                         }
                     } catch (Exception e) {
-                        tty.println("Error occurred during stack walking:");
-                        e.printStackTrace();
+                        tty.println("\nError occurred during stack walking:");
+                        e.printStackTrace(tty);
                     }
                     tty.println();
                     if (concurrentLocks) {


### PR DESCRIPTION
The root cause of this CR is that we are trying to access the java heap during the middle of a GC. This particular test is prone to that happening since it runs jstack 4 times on the debuggee as it starts up (the debuggee is jshell, so it does a lot of initialization on startup).

SA needs to deal with potentially bad references to java objects. These might come from VM structs (such as the JavaThread reference to its java Thread instance), or a java object reference from a field of another java objects. There's always the possibility that these can be invalid. We work around this in most of our testing by getting the debuggee into a steady state so no GC can be in progress.

For the most part SA is pretty good about dealing with these bad object references, and fails gracefully with an exception, but otherwise continues to run. However, this test exposed some holes that resulted in (1) way to many exception stack traces and (2) exiting the SA tool rather than trying to continue.

The main fix is in JavaThread.printThreadInfo() where we now do a better job of dealing with exceptions if any of the java objects references are not valid. Even without access to the Thread instance, we can still produce a stack trace, but it will be missing things like the thread name and priority. This is a lot better than just giving up with the first exception.

The other changes are for the most part just improvements in the error output, and getting rid of the printStackTrace() that was cluttering up the output.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293006](https://bugs.openjdk.org/browse/JDK-8293006): sun/tools/jhsdb/JStackStressTest.java fails with "UnalignedAddressException: 8baadbabe"


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to [02105d7e](https://git.openjdk.org/jdk/pull/10088/files/02105d7e3c855c6d70e770a89dfc7a2e76e8d206)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [02105d7e](https://git.openjdk.org/jdk/pull/10088/files/02105d7e3c855c6d70e770a89dfc7a2e76e8d206)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10088/head:pull/10088` \
`$ git checkout pull/10088`

Update a local copy of the PR: \
`$ git checkout pull/10088` \
`$ git pull https://git.openjdk.org/jdk pull/10088/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10088`

View PR using the GUI difftool: \
`$ git pr show -t 10088`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10088.diff">https://git.openjdk.org/jdk/pull/10088.diff</a>

</details>
