### PR TITLE
8288129: Shenandoah: Skynet test crashed with iu + aggressive

### DIFF
--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahIUMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahIUMode.cpp
@@ -51,9 +51,6 @@ void ShenandoahIUMode::initialize_flags() const {
     FLAG_SET_DEFAULT(ShenandoahSATBBarrier, false);
   }
 
-  // Disable Loom
-  SHENANDOAH_ERGO_DISABLE_FLAG(VMContinuations);
-
   SHENANDOAH_ERGO_ENABLE_FLAG(ExplicitGCInvokesConcurrent);
   SHENANDOAH_ERGO_ENABLE_FLAG(ShenandoahImplicitGCInvokesConcurrent);
 

--- a/src/hotspot/share/oops/access.hpp
+++ b/src/hotspot/share/oops/access.hpp
@@ -118,7 +118,7 @@ class Access: public AllStatic {
   template <DecoratorSet expected_mo_decorators>
   static void verify_heap_oop_decorators() {
     const DecoratorSet heap_oop_decorators = AS_DECORATOR_MASK | ON_DECORATOR_MASK |
-                                             IN_HEAP | IS_ARRAY | IS_NOT_NULL;
+                                             IN_HEAP | IS_ARRAY | IS_NOT_NULL | IS_DEST_UNINITIALIZED;
     verify_decorators<expected_mo_decorators | heap_oop_decorators>();
   }
 

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -147,12 +147,15 @@ class oopDesc {
   }
 
   // Access to fields in a instanceOop through these methods.
-  template <DecoratorSet decorator>
+  template<DecoratorSet decorators>
   oop obj_field_access(int offset) const;
   oop obj_field(int offset) const;
+
   void obj_field_put(int offset, oop value);
   void obj_field_put_raw(int offset, oop value);
   void obj_field_put_volatile(int offset, oop value);
+  template<DecoratorSet decorators>
+  void obj_field_put_access(int offset, oop value);
 
   Metadata* metadata_field(int offset) const;
   void metadata_field_put(int offset, Metadata* value);

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -207,6 +207,8 @@ inline oop  oopDesc::obj_field_access(int offset) const             { return Hea
 inline oop  oopDesc::obj_field(int offset) const                    { return HeapAccess<>::oop_load_at(as_oop(), offset);  }
 
 inline void oopDesc::obj_field_put(int offset, oop value)           { HeapAccess<>::oop_store_at(as_oop(), offset, value); }
+template <DecoratorSet decorators>
+inline void oopDesc::obj_field_put_access(int offset, oop value)    { HeapAccess<decorators>::oop_store_at(as_oop(), offset, value); }
 
 inline jbyte oopDesc::byte_field(int offset) const                  { return *field_addr<jbyte>(offset);  }
 inline void  oopDesc::byte_field_put(int offset, jbyte value)       { *field_addr<jbyte>(offset) = value; }

--- a/src/hotspot/share/oops/stackChunkOop.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.hpp
@@ -71,6 +71,8 @@ public:
   inline bool is_parent_null() const;
   template<typename P>
   inline void set_parent_raw(oop value);
+  template<DecoratorSet decorators>
+  inline void set_parent_access(oop value);
 
   inline int stack_size() const;
 
@@ -96,6 +98,8 @@ public:
   inline void set_cont(oop value);
   template<typename P>
   inline void set_cont_raw(oop value);
+  template<DecoratorSet decorators>
+  inline void set_cont_access(oop value);
 
   inline int bottom() const;
 

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -52,6 +52,8 @@ inline bool stackChunkOopDesc::is_parent_null() const          { return jdk_inte
 inline void stackChunkOopDesc::set_parent(stackChunkOop value) { jdk_internal_vm_StackChunk::set_parent(this, value); }
 template<typename P>
 inline void stackChunkOopDesc::set_parent_raw(oop value)       { jdk_internal_vm_StackChunk::set_parent_raw<P>(this, value); }
+template<DecoratorSet decorators>
+inline void stackChunkOopDesc::set_parent_access(oop value)    { jdk_internal_vm_StackChunk::set_parent_access<decorators>(this, value); }
 
 inline int stackChunkOopDesc::stack_size() const        { return jdk_internal_vm_StackChunk::size(as_oop()); }
 
@@ -90,9 +92,11 @@ inline oop stackChunkOopDesc::cont() const              {
   obj = (oop)NativeAccess<>::oop_load(&obj);
   return obj;
 }
-inline void stackChunkOopDesc::set_cont(oop value)      { jdk_internal_vm_StackChunk::set_cont(this, value); }
+inline void stackChunkOopDesc::set_cont(oop value)        { jdk_internal_vm_StackChunk::set_cont(this, value); }
 template<typename P>
-inline void stackChunkOopDesc::set_cont_raw(oop value)  {  jdk_internal_vm_StackChunk::set_cont_raw<P>(this, value); }
+inline void stackChunkOopDesc::set_cont_raw(oop value)    {  jdk_internal_vm_StackChunk::set_cont_raw<P>(this, value); }
+template<DecoratorSet decorators>
+inline void stackChunkOopDesc::set_cont_access(oop value) { jdk_internal_vm_StackChunk::set_cont_access<decorators>(this, value); }
 
 inline int stackChunkOopDesc::bottom() const { return stack_size() - argsize(); }
 

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -1282,8 +1282,8 @@ stackChunkOop Freeze<ConfigT>::allocate_chunk(size_t stack_size) {
   assert(chunk->is_gc_mode() == false, "");
 
   // fields are uninitialized
-  chunk->set_parent_raw<typename ConfigT::OopT>(_cont.last_nonempty_chunk());
-  chunk->set_cont_raw<typename ConfigT::OopT>(_cont.continuation());
+  chunk->set_parent_access<IS_DEST_UNINITIALIZED>(_cont.last_nonempty_chunk());
+  chunk->set_cont_access<IS_DEST_UNINITIALIZED>(_cont.continuation());
 
   assert(chunk->parent() == nullptr || chunk->parent()->is_stackChunk(), "");
 

--- a/src/hotspot/share/runtime/continuationJavaClasses.hpp
+++ b/src/hotspot/share/runtime/continuationJavaClasses.hpp
@@ -109,6 +109,8 @@ class jdk_internal_vm_StackChunk: AllStatic {
   static inline bool is_parent_null(oop chunk); // bypasses barriers for a faster test
   template<typename P>
   static inline void set_parent_raw(oop chunk, oop value);
+  template<DecoratorSet decorators>
+  static inline void set_parent_access(oop chunk, oop value);
 
   static inline int size(oop chunk);
   static inline void set_size(HeapWord* chunk, int value);
@@ -136,6 +138,8 @@ class jdk_internal_vm_StackChunk: AllStatic {
   static inline oop cont_raw(oop chunk);
   template<typename P>
   static inline void set_cont_raw(oop chunk, oop value);
+  template<DecoratorSet decorators>
+  static inline void set_cont_access(oop chunk, oop value);
 };
 
 #endif // SHARE_RUNTIME_CONTINUATIONJAVACLASSES_HPP

--- a/src/hotspot/share/runtime/continuationJavaClasses.inline.hpp
+++ b/src/hotspot/share/runtime/continuationJavaClasses.inline.hpp
@@ -97,6 +97,11 @@ inline void jdk_internal_vm_StackChunk::set_parent_raw(oop chunk, oop value) {
   RawAccess<>::oop_store(chunk->field_addr<P>(_parent_offset), value);
 }
 
+template<DecoratorSet decorators>
+inline void jdk_internal_vm_StackChunk::set_parent_access(oop chunk, oop value) {
+  chunk->obj_field_put_access<decorators>(_parent_offset, value);
+}
+
 inline oop jdk_internal_vm_StackChunk::cont(oop chunk) {
   return chunk->obj_field(_cont_offset);
 }
@@ -113,6 +118,11 @@ inline oop jdk_internal_vm_StackChunk::cont_raw(oop chunk) {
 template<typename P>
 inline void jdk_internal_vm_StackChunk::set_cont_raw(oop chunk, oop value) {
   RawAccess<>::oop_store(chunk->field_addr<P>(_cont_offset), value);
+}
+
+template<DecoratorSet decorators>
+inline void jdk_internal_vm_StackChunk::set_cont_access(oop chunk, oop value) {
+  chunk->obj_field_put_access<decorators>(_cont_offset, value);
 }
 
 inline int jdk_internal_vm_StackChunk::size(oop chunk) {


### PR DESCRIPTION
Another attempt to fix the crash when running Loom with Shenandoah in iu+aggressive mode.

Explanation for the problem can be seen in https://github.com/openjdk/jdk/pull/9982#issue-1348107961 but instead of adding barriers for the oops in stack chunk header in `do_barriers()`, this fix uses Access API (`oopDesc::obj_field_put_access`) with `IS_DEST_UNINITIALIZED` decorator as suggested in https://github.com/openjdk/jdk/pull/9982#issuecomment-1231843259. The Access API invokes appropriate barriers based on the GC policy and the decorator. For SATB barriers it is a no-op. For IU mode it invokes the iu write barrier.
The Access API is same as in ZGC [1], [2]

[1] https://github.com/openjdk/zgc/blob/f0b25d9339104a80f903d889a7939dd623c76867/src/hotspot/share/oops/oop.inline.hpp#L215
[2] https://github.com/openjdk/zgc/blob/f0b25d9339104a80f903d889a7939dd623c76867/src/hotspot/share/classfile/javaClasses.inline.hpp#L286

Test with fastdebug build:

- [x] hotspot_loom
- [x] jdk_loom
- [x] hotspot_loom in Shenandoah IU mode
- [x] jdk_loom in Shenandoah IU mode
- [x] hotspot_loom in Shenandoah IU + aggressive
- [x] jdk_loom in Shenandoah IU + aggressive

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288129](https://bugs.openjdk.org/browse/JDK-8288129): Shenandoah: Skynet test crashed with iu + aggressive


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10089/head:pull/10089` \
`$ git checkout pull/10089`

Update a local copy of the PR: \
`$ git checkout pull/10089` \
`$ git pull https://git.openjdk.org/jdk pull/10089/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10089`

View PR using the GUI difftool: \
`$ git pr show -t 10089`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10089.diff">https://git.openjdk.org/jdk/pull/10089.diff</a>

</details>
