### PR TITLE
8293143: Workaround for JDK-8292217 when doing "step over" of bytecode with unresolved cp reference

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
@@ -334,9 +334,14 @@ deferEventReport(JNIEnv *env, jthread thread,
                 jlocation end;
                 error = methodLocation(method, &start, &end);
                 if (error == JVMTI_ERROR_NONE) {
-                    deferring = isBreakpointSet(clazz, method, start) ||
-                                threadControl_getInstructionStepMode(thread)
-                                    == JVMTI_ENABLE;
+                    if (isBreakpointSet(clazz, method, start)) {
+                        deferring = JNI_TRUE;
+                    } else {
+                        StepRequest* step = threadControl_getStepRequest(thread);
+                        if (step->pending && step->depth == JDWP_STEP_DEPTH(INTO)) {
+                            deferring = JNI_TRUE;
+                        }
+                    }
                     if (!deferring) {
                         threadControl_saveCLEInfo(env, thread, ei,
                                                   clazz, method, start);

--- a/test/jdk/com/sun/jdi/CLETest.java
+++ b/test/jdk/com/sun/jdi/CLETest.java
@@ -215,10 +215,15 @@ public class CLETest extends TestScaffold {
             // more than one Event in it.
             if (set.size() != 1) {
                 testcaseFailed = true;
-                // For now, we expect these two test cases to fail due to 8292217,
-                // so don't fail the overall test run as a result of these failures.
-                // testFailed = true;
-                System.out.println("TESTCASE #" + testcase + " FAILED (ignoring): too many events in EventSet: " + set.size());
+                // For now, we expect the 2nd test cases to fail due to 8292217,
+                // so don't fail the overall test run as a result of this failure.
+                // There is a workaround in place that allows the 1st test case to pass.
+                if (testcase == 1) {
+                    testFailed = true;
+                }
+                System.out.println("TESTCASE #" + testcase + " FAILED" +
+                                   (testcase == 2 ? "(ignoring)" : "") +
+                                   ": too many events in EventSet: " + set.size());
             }
             break;
         }


### PR DESCRIPTION
There is a workaround we can do for [JDK-8292217](https://bugs.openjdk.org/browse/JDK-8292217) for the use case where a step over or step out is being done. This workaround can't be made to also work for the step into case. From [JDK-8292217](https://bugs.openjdk.org/browse/JDK-8292217)

"There is a workaround that fixes this issue when doing a STEP_OVER or STEP_OUT. Rather than the debug agent checking if it has enabled JVMTI single stepping, instead it checks some fields in the ThreadNode that say if single stepping is pending, and it is for a STEP_INTO. If it is not STEP_INTO, then it can assume that no StepEvent will occur at the same location and therefor the MethodEntryEvent should not be deferred. So this limits the bug to only happening when doing a STEP_INTO. "

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293143](https://bugs.openjdk.org/browse/JDK-8293143): Workaround for JDK-8292217 when doing "step over" of bytecode with unresolved cp reference


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10091/head:pull/10091` \
`$ git checkout pull/10091`

Update a local copy of the PR: \
`$ git checkout pull/10091` \
`$ git pull https://git.openjdk.org/jdk pull/10091/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10091`

View PR using the GUI difftool: \
`$ git pr show -t 10091`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10091.diff">https://git.openjdk.org/jdk/pull/10091.diff</a>

</details>
