### PR TITLE
8293019: [JVMCI] change ratio of libgraal to C1 threads and use one isolate per libgraal thread

### DIFF
--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -485,8 +485,18 @@ void CompilationPolicy::initialize() {
     } else if (c2_only) {
       set_c2_count(count);
     } else {
-      set_c1_count(MAX2(count / 3, 1));
-      set_c2_count(MAX2(count - c1_count(), 1));
+#if INCLUDE_JVMCI
+      if (UseJVMCICompiler && UseJVMCINativeLibrary) {
+        int libjvmci_count = MAX2((int) (count * JVMCINativeLibraryThreadFraction), 1);
+        int c1_count = MAX2(count - libjvmci_count, 1);
+        set_c2_count(libjvmci_count);
+        set_c1_count(c1_count);
+      } else
+#endif
+      {
+        set_c1_count(MAX2(count / 3, 1));
+        set_c2_count(MAX2(count - c1_count(), 1));
+      }
     }
     assert(count == c1_count() + c2_count(), "inconsistent compiler thread count");
     set_increase_threshold_at_ratio();

--- a/src/hotspot/share/jvmci/jvmci_globals.cpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.cpp
@@ -122,6 +122,7 @@ bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
   CHECK_NOT_SET(JVMCIThreadsPerNativeLibraryRuntime, EnableJVMCI)
   CHECK_NOT_SET(JVMCICompilerIdleDelay,              EnableJVMCI)
   CHECK_NOT_SET(UseJVMCINativeLibrary,               EnableJVMCI)
+  CHECK_NOT_SET(JVMCINativeLibraryThreadFraction,    EnableJVMCI)
   CHECK_NOT_SET(JVMCILibPath,                        EnableJVMCI)
   CHECK_NOT_SET(JVMCINativeLibraryErrorFile,         EnableJVMCI)
   CHECK_NOT_SET(JVMCILibDumpJNIConfig,               EnableJVMCI)
@@ -181,6 +182,7 @@ bool JVMCIGlobals::enable_jvmci_product_mode(JVMFlagOrigin origin) {
     "JVMCILibPath",
     "JVMCILibDumpJNIConfig",
     "UseJVMCINativeLibrary",
+    "JVMCINativeLibraryThreadFraction",
     "JVMCINativeLibraryErrorFile",
     NULL
   };

--- a/src/hotspot/share/jvmci/jvmci_globals.hpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.hpp
@@ -136,10 +136,15 @@ class fileStream;
           "and methods the JVMCI shared library must provide")              \
                                                                             \
   product(bool, UseJVMCINativeLibrary, false, EXPERIMENTAL,                 \
-          "Execute JVMCI Java code from a shared library "                  \
+          "Execute JVMCI Java code from a shared library (\"libjvmci\") "   \
           "instead of loading it from class files and executing it "        \
           "on the HotSpot heap. Defaults to true if EnableJVMCIProduct is " \
           "true and a JVMCI native library is available.")                  \
+                                                                            \
+  product(double, JVMCINativeLibraryThreadFraction, 0.33, EXPERIMENTAL,     \
+          "The fraction of compiler threads used by libjvmci. "             \
+          "The remaining compiler threads are used by C1.")                 \
+          range(0.0, 1.0)                                                   \
                                                                             \
   product(ccstr, JVMCINativeLibraryErrorFile, NULL, EXPERIMENTAL,           \
           "If an error in the JVMCI native library occurs, save the "       \

--- a/src/hotspot/share/jvmci/jvmci_globals.hpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.hpp
@@ -58,9 +58,10 @@ class fileStream;
           "Use JVMCI as the default compiler. Defaults to true if "         \
           "EnableJVMCIProduct is true.")                                    \
                                                                             \
-  product(uint, JVMCIThreadsPerNativeLibraryRuntime, 0, EXPERIMENTAL,       \
+  product(uint, JVMCIThreadsPerNativeLibraryRuntime, 1, EXPERIMENTAL,       \
           "Max number of threads per JVMCI native runtime. "                \
-          "Specify 0 to force use of a single JVMCI native runtime. ")      \
+          "Specify 0 to force use of a single JVMCI native runtime. "       \
+          "Specify 1 to force a single JVMCI native runtime per thread. ")  \
           range(0, max_jint)                                                \
                                                                             \
   product(uint, JVMCICompilerIdleDelay, DEFAULT_COMPILER_IDLE_DELAY, EXPERIMENTAL, \


### PR DESCRIPTION
[JDK-8242440](https://bugs.openjdk.org/browse/JDK-8242440) allows the VM to use one isolate per libgraal thread (OIPLT). This has a number of benefits such better isolation of compiler crashes and avoids GC interference between isolates. Experimentation has shown that reducing the ratio of libgraal threads to C1 threads also helps keep the max RSS down. This PR makes OIPLT the default and adds a `JVMCINativeLibraryThreadFraction` flag for configuring the libgraal to C1 thread ratio. The default value for `JVMCINativeLibraryThreadFraction` is `0.33` which means there are 2 C1 threads per libgraal thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293019](https://bugs.openjdk.org/browse/JDK-8293019): [JVMCI] change ratio of libgraal to C1 threads and use one isolate per libgraal thread


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10094/head:pull/10094` \
`$ git checkout pull/10094`

Update a local copy of the PR: \
`$ git checkout pull/10094` \
`$ git pull https://git.openjdk.org/jdk pull/10094/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10094`

View PR using the GUI difftool: \
`$ git pr show -t 10094`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10094.diff">https://git.openjdk.org/jdk/pull/10094.diff</a>

</details>
