### PR TITLE
8293163: G1: Rename G1HeapRegionAttr::is_humongous

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -581,7 +581,7 @@ public:
   inline void set_humongous_is_live(oop obj);
 
   // Register the given region to be part of the collection set.
-  inline void register_humongous_region_with_region_attr(uint index);
+  inline void register_humongous_candidate_region_with_region_attr(uint index);
 
   // We register a region with the fast "in collection set" test. We
   // simply set to true the array slot corresponding to this region.
@@ -1030,7 +1030,7 @@ public:
   inline bool is_in_cset(oop obj) const;
   inline bool is_in_cset(HeapWord* addr) const;
 
-  inline bool is_in_cset_or_humongous(const oop obj);
+  inline bool is_in_cset_or_humongous_candidate(const oop obj);
 
  private:
   // This array is used for a quick test on whether a reference points into

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -168,8 +168,8 @@ bool G1CollectedHeap::is_in_cset(const HeapRegion* hr) const {
   return _region_attr.is_in_cset(hr);
 }
 
-bool G1CollectedHeap::is_in_cset_or_humongous(const oop obj) {
-  return _region_attr.is_in_cset_or_humongous(cast_from_oop<HeapWord*>(obj));
+bool G1CollectedHeap::is_in_cset_or_humongous_candidate(const oop obj) {
+  return _region_attr.is_in_cset_or_humongous_candidate(cast_from_oop<HeapWord*>(obj));
 }
 
 G1HeapRegionAttr G1CollectedHeap::region_attr(const void* addr) const {
@@ -180,8 +180,8 @@ G1HeapRegionAttr G1CollectedHeap::region_attr(uint idx) const {
   return _region_attr.get_by_index(idx);
 }
 
-void G1CollectedHeap::register_humongous_region_with_region_attr(uint index) {
-  _region_attr.set_humongous(index, region_at(index)->rem_set()->is_tracked());
+void G1CollectedHeap::register_humongous_candidate_region_with_region_attr(uint index) {
+  _region_attr.set_humongous_candidate(index, region_at(index)->rem_set()->is_tracked());
 }
 
 void G1CollectedHeap::register_new_survivor_region_with_region_attr(HeapRegion* r) {
@@ -234,7 +234,7 @@ inline bool G1CollectedHeap::is_obj_dead_full(const oop obj) const {
 
 inline bool G1CollectedHeap::is_humongous_reclaim_candidate(uint region) {
   assert(_hrm.at(region)->is_starts_humongous(), "Must start a humongous object");
-  return _region_attr.is_humongous(region);
+  return _region_attr.is_humongous_candidate(region);
 }
 
 inline void G1CollectedHeap::set_humongous_is_live(oop obj) {
@@ -245,8 +245,8 @@ inline void G1CollectedHeap::set_humongous_is_live(oop obj) {
   // but this is benign because the transition is unidirectional, from
   // humongous-candidate to not, and the write, in evacuation, is
   // separated from the read, in post-evacuation.
-  if (_region_attr.is_humongous(region)) {
-    _region_attr.clear_humongous(region);
+  if (_region_attr.is_humongous_candidate(region)) {
+    _region_attr.clear_humongous_candidate(region);
   }
 }
 

--- a/src/hotspot/share/gc/g1/g1HeapRegionAttr.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionAttr.hpp
@@ -52,7 +52,7 @@ public:
   // The other values are used for objects in regions requiring various special handling,
   // eager reclamation of humongous objects or optional regions.
   static const region_type_t Optional     =  -4;    // The region is optional not in the current collection set.
-  static const region_type_t Humongous    =  -3;    // The region is a humongous candidate not in the current collection set.
+  static const region_type_t HumongousCandidate    =  -3;    // The region is a humongous candidate not in the current collection set.
   static const region_type_t NewSurvivor  =  -2;    // The region is a new (ly allocated) survivor region.
   static const region_type_t NotInCSet    =  -1;    // The region is not in the collection set.
   static const region_type_t Young        =   0;    // The region is in the collection set and a young region.
@@ -70,7 +70,7 @@ public:
   const char* get_type_str() const {
     switch (type()) {
       case Optional: return "Optional";
-      case Humongous: return "Humongous";
+      case HumongousCandidate: return "HumongousCandidate";
       case NewSurvivor: return "NewSurvivor";
       case NotInCSet: return "NotInCSet";
       case Young: return "Young";
@@ -83,16 +83,16 @@ public:
 
   void set_new_survivor()              { _type = NewSurvivor; }
   void set_old()                       { _type = Old; }
-  void clear_humongous()               {
-    assert(is_humongous() || !is_in_cset(), "must be");
+  void clear_humongous_candidate()               {
+    assert(is_humongous_candidate() || !is_in_cset(), "must be");
     _type = NotInCSet;
   }
   void set_remset_is_tracked(bool value)      { _remset_is_tracked = value ? 1 : 0; }
 
-  bool is_in_cset_or_humongous() const { return is_in_cset() || is_humongous(); }
+  bool is_in_cset_or_humongous_candidate() const { return is_in_cset() || is_humongous_candidate(); }
   bool is_in_cset() const              { return type() >= Young; }
 
-  bool is_humongous() const            { return type() == Humongous; }
+  bool is_humongous_candidate() const            { return type() == HumongousCandidate; }
   bool is_new_survivor() const         { return type() == NewSurvivor; }
   bool is_young() const                { return type() == Young; }
   bool is_old() const                  { return type() == Old; }
@@ -132,18 +132,18 @@ class G1HeapRegionAttrBiasedMappedArray : public G1BiasedMappedArray<G1HeapRegio
     get_ref_by_index(index)->set_new_survivor();
   }
 
-  void set_humongous(uintptr_t index, bool remset_is_tracked) {
+  void set_humongous_candidate(uintptr_t index, bool remset_is_tracked) {
     assert(get_by_index(index).is_default(),
            "Region attributes at index " INTPTR_FORMAT " should be default but is %s", index, get_by_index(index).get_type_str());
-    set_by_index(index, G1HeapRegionAttr(G1HeapRegionAttr::Humongous, remset_is_tracked));
+    set_by_index(index, G1HeapRegionAttr(G1HeapRegionAttr::HumongousCandidate, remset_is_tracked));
   }
 
-  void clear_humongous(uintptr_t index) {
-    get_ref_by_index(index)->clear_humongous();
+  void clear_humongous_candidate(uintptr_t index) {
+    get_ref_by_index(index)->clear_humongous_candidate();
   }
 
-  bool is_humongous(uintptr_t index) {
-    return get_ref_by_index(index)->is_humongous();
+  bool is_humongous_candidate(uintptr_t index) {
+    return get_ref_by_index(index)->is_humongous_candidate();
   }
 
   void set_remset_is_tracked(uintptr_t index, bool remset_is_tracked) {
@@ -162,7 +162,7 @@ class G1HeapRegionAttrBiasedMappedArray : public G1BiasedMappedArray<G1HeapRegio
     set_by_index(index, G1HeapRegionAttr(G1HeapRegionAttr::Old, remset_is_tracked));
   }
 
-  bool is_in_cset_or_humongous(HeapWord* addr) const { return at(addr).is_in_cset_or_humongous(); }
+  bool is_in_cset_or_humongous_candidate(HeapWord* addr) const { return at(addr).is_in_cset_or_humongous_candidate(); }
   bool is_in_cset(HeapWord* addr) const { return at(addr).is_in_cset(); }
   bool is_in_cset(const HeapRegion* hr) const { return get_by_index(hr->hrm_index()).is_in_cset(); }
   G1HeapRegionAttr at(HeapWord* addr) const { return get_by_address(addr); }

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -699,13 +699,13 @@ public:
         _failures = true;
         return true;
       }
-      if (hr->is_continues_humongous() && region_attr.is_humongous()) {
+      if (hr->is_continues_humongous() && region_attr.is_humongous_candidate()) {
         log_error(gc, verify)("## inconsistent region attr type %s for continues humongous region %u", region_attr.get_type_str(), i);
         _failures = true;
         return true;
       }
     } else {
-      if (region_attr.is_humongous()) {
+      if (region_attr.is_humongous_candidate()) {
         log_error(gc, verify)("## inconsistent region attr type %s for non-humongous region %u", region_attr.get_type_str(), i);
         _failures = true;
         return true;

--- a/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
@@ -64,7 +64,7 @@ inline void G1ScanClosureBase::prefetch_and_push(T* p, const oop obj) {
 
 template <class T>
 inline void G1ScanClosureBase::handle_non_cset_obj_common(G1HeapRegionAttr const region_attr, T* p, oop const obj) {
-  if (region_attr.is_humongous()) {
+  if (region_attr.is_humongous_candidate()) {
     _g1h->set_humongous_is_live(obj);
   } else if (region_attr.is_optional()) {
     _par_scan_state->remember_reference_into_optional_region(p);
@@ -245,7 +245,7 @@ void G1ParCopyClosure<barrier, should_mark>::do_oop_work(T* p) {
       do_cld_barrier(forwardee);
     }
   } else {
-    if (state.is_humongous()) {
+    if (state.is_humongous_candidate()) {
       _g1h->set_humongous_is_live(obj);
     } else if ((barrier != G1BarrierNoOptRoots) && state.is_optional()) {
       _par_scan_state->remember_root_into_optional_region(p);

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -195,7 +195,7 @@ void G1ParScanThreadState::do_oop_evac(T* p) {
   const G1HeapRegionAttr region_attr = _g1h->region_attr(obj);
   // References pushed onto the work stack should never point to a humongous region
   // as they are not added to the collection set due to above precondition.
-  assert(!region_attr.is_humongous(),
+  assert(!region_attr.is_humongous_candidate(),
          "Obj " PTR_FORMAT " should not refer to humongous region %u from " PTR_FORMAT,
          p2i(obj), _g1h->addr_to_region(obj), p2i(p));
 
@@ -327,7 +327,7 @@ HeapWord* G1ParScanThreadState::allocate_in_next_plab(G1HeapRegionAttr* dest,
                                                       bool previous_plab_refill_failed,
                                                       uint node_index) {
 
-  assert(dest->is_in_cset_or_humongous(), "Unexpected dest: %s region attr", dest->get_type_str());
+  assert(dest->is_in_cset_or_humongous_candidate(), "Unexpected dest: %s region attr", dest->get_type_str());
 
   // Right now we only have two types of regions (young / old) so
   // let's keep the logic here simple. We can generalize it when necessary.

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1322,7 +1322,7 @@ class G1MergeHeapRootsTask : public WorkerTask {
     virtual bool do_heap_region(HeapRegion* r) {
       G1CollectedHeap* g1h = G1CollectedHeap::heap();
 
-      if (!g1h->region_attr(r->hrm_index()).is_humongous() ||
+      if (!g1h->region_attr(r->hrm_index()).is_humongous_candidate() ||
           r->rem_set()->is_empty()) {
         return false;
       }

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -383,7 +383,7 @@ class G1PrepareEvacuationTask : public WorkerTask {
 
       uint index = hr->hrm_index();
       if (humongous_region_is_candidate(hr)) {
-        _g1h->register_humongous_region_with_region_attr(index);
+        _g1h->register_humongous_candidate_region_with_region_attr(index);
         _worker_humongous_candidates++;
         // We will later handle the remembered sets of these regions.
       } else {
@@ -808,7 +808,7 @@ public:
     assert(obj != NULL, "the caller should have filtered out NULL values");
 
     const G1HeapRegionAttr region_attr =_g1h->region_attr(obj);
-    if (!region_attr.is_in_cset_or_humongous()) {
+    if (!region_attr.is_in_cset_or_humongous_candidate()) {
       return;
     }
     if (region_attr.is_in_cset()) {
@@ -816,7 +816,7 @@ public:
       *p = obj->forwardee();
     } else {
       assert(!obj->is_forwarded(), "invariant" );
-      assert(region_attr.is_humongous(),
+      assert(region_attr.is_humongous_candidate(),
              "Only allowed G1HeapRegionAttr state is IsHumongous, but is %d", region_attr.type());
      _g1h->set_humongous_is_live(obj);
     }
@@ -844,7 +844,7 @@ public:
   template <class T> void do_oop_work(T* p) {
     oop obj = RawAccess<>::oop_load(p);
 
-    if (_g1h->is_in_cset_or_humongous(obj)) {
+    if (_g1h->is_in_cset_or_humongous_candidate(obj)) {
       // If the referent object has been forwarded (either copied
       // to a new location or to itself in the event of an
       // evacuation failure) then we need to update the reference


### PR DESCRIPTION
Simple renaming to avoid confusion.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293163](https://bugs.openjdk.org/browse/JDK-8293163): G1: Rename G1HeapRegionAttr::is_humongous


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Sangheon Kim](https://openjdk.org/census#sangheki) (@sangheon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10097/head:pull/10097` \
`$ git checkout pull/10097`

Update a local copy of the PR: \
`$ git checkout pull/10097` \
`$ git pull https://git.openjdk.org/jdk pull/10097/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10097`

View PR using the GUI difftool: \
`$ git pr show -t 10097`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10097.diff">https://git.openjdk.org/jdk/pull/10097.diff</a>

</details>
