### PR TITLE
8293164: Remove unimplemented Generation::print_heap_change

### DIFF
--- a/src/hotspot/share/gc/shared/generation.hpp
+++ b/src/hotspot/share/gc/shared/generation.hpp
@@ -400,8 +400,6 @@ class Generation: public CHeapObj<mtGC> {
   // the block is an object.
   virtual bool block_is_obj(const HeapWord* addr) const;
 
-  void print_heap_change(size_t prev_used) const;
-
   virtual void print() const;
   virtual void print_on(outputStream* st) const;
 


### PR DESCRIPTION
Trivial change of removing dead code.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293164](https://bugs.openjdk.org/browse/JDK-8293164): Remove unimplemented Generation::print_heap_change


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10098/head:pull/10098` \
`$ git checkout pull/10098`

Update a local copy of the PR: \
`$ git checkout pull/10098` \
`$ git pull https://git.openjdk.org/jdk pull/10098/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10098`

View PR using the GUI difftool: \
`$ git pr show -t 10098`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10098.diff">https://git.openjdk.org/jdk/pull/10098.diff</a>

</details>
