### PR TITLE
8293165: GHA: Provide necessary x86_32 packages for runtime/ErrorHandling/TestDwarf.java

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,7 +140,7 @@ jobs:
       apt-architecture: 'i386'
       # Some multilib libraries do not have proper inter-dependencies, so we have to
       # install their dependencies manually.
-      apt-extra-packages: 'libfreetype6-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libc-i386'
+      apt-extra-packages: 'libfreetype6-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libc6-i386'
       extra-conf-options: '--with-target-bits=32'
     if: needs.select.outputs.linux-x86 == 'true'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,7 +140,7 @@ jobs:
       apt-architecture: 'i386'
       # Some multilib libraries do not have proper inter-dependencies, so we have to
       # install their dependencies manually.
-      apt-extra-packages: 'libfreetype6-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386'
+      apt-extra-packages: 'libfreetype6-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libc-i386'
       extra-conf-options: '--with-target-bits=32'
     if: needs.select.outputs.linux-x86 == 'true'
 


### PR DESCRIPTION
After [JDK-8242181](https://bugs.openjdk.org/browse/JDK-8242181), `runtime/ErrorHandling/TestDwarf.java` fails in GHA:

```
...
[dwarf] ##### Find filename and line number for offset 0x00085ff1 in library /lib32/libc.so.6 #####
[dwarf] Failed to load DWARF file for library /lib32/libc.so.6 or find DWARF sections directly inside it.
#
# Compiler replay data is saved as:
# /home/runner/work/jdk/jdk/build/run-test-prebuilt/test-support/jtreg_test_hotspot_jtreg_tier1_runtime/scratch/replay_pid5024.log
#
# If you would like to submit a bug report, please visit:
# https://bugreport.java.com/bugreport/crash.jsp
#

hs_err_file: hs_err_pid5024.log
----------System.err:(16/999)----------
java.lang.RuntimeException: Must find library in "C [libc.so.6+0x85ff1]": expected true, was false
at jdk.test.lib.Asserts.fail(Asserts.java:594)
at jdk.test.lib.Asserts.assertTrue(Asserts.java:486)
at TestDwarf.checkNoSourceLine(TestDwarf.java:181)
at TestDwarf.runAndCheck(TestDwarf.java:153)
at TestDwarf.test(TestDwarf.java:101)
at TestDwarf.main(TestDwarf.java:91)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:578)
at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
at java.base/java.lang.Thread.run(Thread.java:1589)
```

We might want to consider making this test more resilient for these cases, but it seems beneficial to let current GHA hosts run it too, by providing the packages carrying the missing .so file.

Additional testing:
 - [x] x86_32 GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293165](https://bugs.openjdk.org/browse/JDK-8293165): GHA: Provide necessary x86_32 packages for runtime/ErrorHandling/TestDwarf.java


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10099/head:pull/10099` \
`$ git checkout pull/10099`

Update a local copy of the PR: \
`$ git checkout pull/10099` \
`$ git pull https://git.openjdk.org/jdk pull/10099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10099`

View PR using the GUI difftool: \
`$ git pr show -t 10099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10099.diff">https://git.openjdk.org/jdk/pull/10099.diff</a>

</details>
