### PR TITLE
8293154: TemporalQueries java doc error

### DIFF
--- a/src/java.base/share/classes/java/time/temporal/TemporalQueries.java
+++ b/src/java.base/share/classes/java/time/temporal/TemporalQueries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -301,7 +301,7 @@ public final class TemporalQueries {
      * The query implementation examines the {@link ChronoField#EPOCH_DAY EPOCH_DAY}
      * field and uses it to create a {@code LocalDate}.
      * <p>
-     * The method {@link ZoneOffset#from(TemporalAccessor)} can be used as a
+     * The method {@link LocalDate#from(TemporalAccessor)} can be used as a
      * {@code TemporalQuery} via a method reference, {@code LocalDate::from}.
      * This query and {@code LocalDate::from} will return the same result if the
      * temporal object contains a date. If the temporal object does not contain
@@ -324,7 +324,7 @@ public final class TemporalQueries {
      * The query implementation examines the {@link ChronoField#NANO_OF_DAY NANO_OF_DAY}
      * field and uses it to create a {@code LocalTime}.
      * <p>
-     * The method {@link ZoneOffset#from(TemporalAccessor)} can be used as a
+     * The method {@link LocalTime#from(TemporalAccessor)} can be used as a
      * {@code TemporalQuery} via a method reference, {@code LocalTime::from}.
      * This query and {@code LocalTime::from} will return the same result if the
      * temporal object contains a time. If the temporal object does not contain


### PR DESCRIPTION
Simple doc fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293154](https://bugs.openjdk.org/browse/JDK-8293154): TemporalQueries java doc error


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10103/head:pull/10103` \
`$ git checkout pull/10103`

Update a local copy of the PR: \
`$ git checkout pull/10103` \
`$ git pull https://git.openjdk.org/jdk pull/10103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10103`

View PR using the GUI difftool: \
`$ git pr show -t 10103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10103.diff">https://git.openjdk.org/jdk/pull/10103.diff</a>

</details>
