### PR TITLE
JDK-8293178: Remove obsolete properties from javadoc resource file

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/resources/javadoc.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/resources/javadoc.properties
@@ -316,10 +316,6 @@ main.not_a_doclet=\
 
 javadoc.class_not_found=Class {0} not found.
 
-javadoc.error.msg={0}: error - {1}
-javadoc.warning.msg={0}: warning - {1}
-javadoc.note.msg = {1}
-javadoc.note.pos.msg= {0}: {1}
 javadoc.version={0} {1}
 javadoc.fullversion={0} full version "{1}"
 

--- a/test/langtools/jdk/javadoc/tool/CheckResourceKeys.java
+++ b/test/langtools/jdk/javadoc/tool/CheckResourceKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -228,11 +228,9 @@ public class CheckResourceKeys {
 
             // special handling for code strings synthesized in
             // jdk.javadoc.internal.tool.JavadocLog
-            results.add("javadoc.error.msg");
-            results.add("javadoc.note.msg");
-            results.add("javadoc.note.pos.msg");
-            results.add("javadoc.warning.msg");
-
+            // see JavadocLog report(DiagnosticType dt, Set<DiagnosticFlag> flags,
+            //                       DiagnosticSource ds, DiagnosticPosition dp, String message)
+            // line: report(javadocDiags.create(dt, null, flags, ds, dp, "message", message));
             results.add("javadoc.err.message");
             results.add("javadoc.warn.message");
             results.add("javadoc.note.message");


### PR DESCRIPTION
Please review a trivial update to remove some obsolete properties from a javadoc resource file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293178](https://bugs.openjdk.org/browse/JDK-8293178): Remove obsolete properties from javadoc resource file


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10105/head:pull/10105` \
`$ git checkout pull/10105`

Update a local copy of the PR: \
`$ git checkout pull/10105` \
`$ git pull https://git.openjdk.org/jdk pull/10105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10105`

View PR using the GUI difftool: \
`$ git pr show -t 10105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10105.diff">https://git.openjdk.org/jdk/pull/10105.diff</a>

</details>
