### PR TITLE
JDK-8292990 Improve test coverage for XPath Axes: parent

### DIFF
--- a/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathExpParentTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathExpParentTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package xpath;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
+
+/*
+ * @test
+ * @bug     8292990
+ * @summary Tests the XPath parent axis
+ * @library /javax/xml/jaxp/unittest
+ * @build xpath.XPathTestBase
+ *
+ * @run testng xpath.XPathExpParentTest
+ */
+public class XPathExpParentTest extends XPathTestBase {
+    private static final Document doc = getDocument();
+
+    /*
+     * DataProvider for XPath expressions which should provide one and only
+     * one parent node.
+     * Data columns:
+     *  see parameters of the test "testOneParentNodeExp"
+     */
+    @DataProvider(name = "oneParentNode")
+    public Object[][] getOneParentNodeExp() {
+        return new Object[][]{
+                {"//Customer/parent::*", "//Customers"},
+                {"//Customer/text()/parent::*", "//Customer"},
+                {"//Customer/@id/parent::*", "//Customer"},
+                {"/Customers/Customer[1]/namespace::*/parent::*", "//Customer"},
+                {"/Customers/comment()/parent::*", "//Customers"},
+                {"//Customer/..", "//Customers"},
+                {"//Customer/text()/..", "//Customer"},
+                {"//Customer/@id/..", "//Customer"},
+                {"/Customers/Customer[1]/namespace::*/..", "//Customer"},
+                {"/Customers/comment()/..", "//Customers"},
+        };
+    }
+
+    /*
+     * DataProvider for XPath expressions which should provide no parent node.
+     * Data columns:
+     *  see parameters of the test "testZeroParentNodeExp"
+     */
+    @DataProvider(name = "noParentNode")
+    public Object[][] getZeroParentNodeExp() {
+        return new Object[][]{
+                {"/Customers/parent::*"},
+        };
+    }
+
+    /**
+     * Verifies that XPath expressions provide one and only parent node.
+     *
+     * @param exp       XPath expression
+     * @param parentExp XPath parent node expression
+     * @throws Exception if test failed
+     */
+    @Test(dataProvider = "oneParentNode")
+    void testOneParentNodeExp(String exp, String parentExp)
+            throws Exception {
+        XPath xPath = XPathFactory.newInstance().newXPath();
+
+        Node parent = xPath.evaluateExpression(parentExp, doc, Node.class);
+
+        testExp(doc, exp, parent, Node.class);
+    }
+
+    /**
+     * Verifies that XPath expressions provide no parent node.
+     *
+     * @param exp       XPath expression
+     * @throws Exception if test failed
+     */
+    @Test(dataProvider = "noParentNode")
+    void testZeroParentNodeExp(String exp)
+            throws Exception {
+        XPath xPath = XPathFactory.newInstance().newXPath();
+
+        Node parent = xPath.evaluateExpression(exp, doc, Node.class);
+
+        Assert.assertNull(parent);
+    }
+}

--- a/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathExpParentTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathExpParentTest.java
@@ -147,7 +147,7 @@ public class XPathExpParentTest extends XPathTestBase {
     }
 
     /**
-     * Verifies that XPath relative expressions provide a same node as the context node.
+     * Verifies that XPath relative expressions provide the same node as the context node.
      *
      * @param exp         XPath expression that provides a context node
      * @param relativeExp XPath relative expression that is evaluated relatively to the context node

--- a/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathExpParentTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathExpParentTest.java
@@ -53,19 +53,20 @@ public class XPathExpParentTest extends XPathTestBase {
     public Object[][] getOneParentNodeExp() {
         return new Object[][]{
                 {"//Customer/parent::*", "//Customers"},
-                {"//Customer[1]/text()/parent::*", "//Customer"},
-                {"//Customer[1]/@id/parent::*", "//Customer"},
+                {"//Customer[1]/text()/parent::*", "(//Customer)[1]"},
+                {"//Customer[1]/@id/parent::*", "(//Customer)[1]"},
                 {"//Customer[1]/namespace::*/parent::*", "//Customers"},
                 {"/Customers/comment()/parent::*", "//Customers"},
                 {"//Customer[1]/..", "//Customers"},
-                {"//Customer[1]/text()/..", "//Customer"},
-                {"//Customer[1]/@id/..", "//Customer"},
+                {"//Customer[1]/text()/..", "(//Customer)[1]"},
+                {"//Customer[1]/@id/..", "(//Customer)[1]"},
                 {"//Customer[1]/namespace::*/..", "//Customers"},
                 {"/Customers/comment()/..", "//Customers"},
-                {"//*[parent::Customers][1]", "//Customer"},
-                {"//*[parent::Customers and @id='x1']", "//Customer"},
+                {"//*[parent::Customers][1]", "(//Customer)[1]"},
+                {"//*[parent::Customers and @id='x1']", "(//Customer)[1]"},
 
-                // document root
+                // ".." is short for parent::node(). A node test node() is true for any node of
+                // any type including the document root node.
                 {"/Customers/parent::node()", "/"},
                 {"/Customers/..", "/"},
         };
@@ -79,11 +80,15 @@ public class XPathExpParentTest extends XPathTestBase {
     @DataProvider(name = "noParentNode")
     public Object[][] getZeroParentNodeExp() {
         return new Object[][]{
-                // parent::* never return document root
+                // A node test * is true for any node of the principle node type which contains
+                // attribute nodes, namespace nodes and element nodes. parent::* never includes the
+                // document root node.
                 {"/Customers/parent::*"},
 
-                // parent of document root
+                // "/" selects the document root which has no parent. Expressions below validate
+                // no parent is found on the document root node.
                 {"/.."},
+                {"/parent::node()"}
         };
     }
 
@@ -142,10 +147,10 @@ public class XPathExpParentTest extends XPathTestBase {
     }
 
     /**
-     * Verifies that XPath relative expressions provide a parent node.
+     * Verifies that XPath relative expressions provide a same node as the context node.
      *
-     * @param exp         XPath expression
-     * @param relativeExp XPath relative expression
+     * @param exp         XPath expression that provides a context node
+     * @param relativeExp XPath relative expression that is evaluated relatively to the context node
      * @throws Exception if test failed
      */
     @Test(dataProvider = "relativeParent")

--- a/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathTestBase.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathTestBase.java
@@ -68,6 +68,7 @@ class XPathTestBase {
 
     static final String RAW_XML
             = "<Customers xmlns:foo=\"foo\" xml:lang=\"en\">"
+            + "<!-- This is a comment -->"
             + "    <Customer id=\"x1\">"
             + "        <Name>name1</Name>"
             + "        <Phone>1111111111</Phone>"


### PR DESCRIPTION
The goal of this task is validating the parent axis contains the parent of the context node. Context nodes include 
- root node 
- element nodes 
- text nodes 
- attribute nodes 
- namespace nodes 
- comment nodes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292990](https://bugs.openjdk.org/browse/JDK-8292990): Improve test coverage for XPath Axes: parent


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to [637b5899](https://git.openjdk.org/jdk/pull/10107/files/637b5899dfb0597847d9682f4ec68f871a0b3989)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10107/head:pull/10107` \
`$ git checkout pull/10107`

Update a local copy of the PR: \
`$ git checkout pull/10107` \
`$ git pull https://git.openjdk.org/jdk pull/10107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10107`

View PR using the GUI difftool: \
`$ git pr show -t 10107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10107.diff">https://git.openjdk.org/jdk/pull/10107.diff</a>

</details>
