### PR TITLE
8293010: JDI ObjectReference/referringObjects/referringObjects001 fails assert(env->is_enabled(JVMTI_EVENT_OBJECT_FREE)) failed: checking

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -2246,7 +2246,7 @@ JvmtiEnv::GetLocalObject(jthread thread, jint depth, jint slot, jobject* value_p
   JvmtiVTMSTransitionDisabler disabler;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      current_thread, depth, slot);
@@ -2286,7 +2286,7 @@ JvmtiEnv::GetLocalInstance(jthread thread, jint depth, jobject* value_ptr){
   JvmtiVTMSTransitionDisabler disabler;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetReceiver op(this, Handle(current_thread, thread_obj),
                                    current_thread, depth);
@@ -2327,7 +2327,7 @@ JvmtiEnv::GetLocalInt(jthread thread, jint depth, jint slot, jint* value_ptr) {
   JvmtiVTMSTransitionDisabler disabler;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_INT);
@@ -2368,7 +2368,7 @@ JvmtiEnv::GetLocalLong(jthread thread, jint depth, jint slot, jlong* value_ptr) 
   JvmtiVTMSTransitionDisabler disabler;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_LONG);
@@ -2409,7 +2409,7 @@ JvmtiEnv::GetLocalFloat(jthread thread, jint depth, jint slot, jfloat* value_ptr
   JvmtiVTMSTransitionDisabler disabler;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_FLOAT);
@@ -2450,7 +2450,7 @@ JvmtiEnv::GetLocalDouble(jthread thread, jint depth, jint slot, jdouble* value_p
   JvmtiVTMSTransitionDisabler disabler;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_DOUBLE);
@@ -2492,7 +2492,7 @@ JvmtiEnv::SetLocalObject(jthread thread, jint depth, jint slot, jobject value) {
   val.l = value;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_OBJECT, val);
@@ -2528,7 +2528,7 @@ JvmtiEnv::SetLocalInt(jthread thread, jint depth, jint slot, jint value) {
   val.i = value;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_INT, val);
@@ -2564,7 +2564,7 @@ JvmtiEnv::SetLocalLong(jthread thread, jint depth, jint slot, jlong value) {
   val.j = value;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_LONG, val);
@@ -2600,7 +2600,7 @@ JvmtiEnv::SetLocalFloat(jthread thread, jint depth, jint slot, jfloat value) {
   val.f = value;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_FLOAT, val);
@@ -2636,7 +2636,7 @@ JvmtiEnv::SetLocalDouble(jthread thread, jint depth, jint slot, jdouble value) {
   val.d = value;
 
   jvmtiError err = JVMTI_ERROR_NONE;
-  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  oop thread_obj = current_thread_obj_or_resolve_external_guard(thread);
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_DOUBLE, val);

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1310,6 +1310,17 @@ JvmtiEnvBase::is_cthread_with_continuation(JavaThread* jt) {
   return cont_entry != NULL && is_cthread_with_mounted_vthread(jt);
 }
 
+// If (thread == NULL) then return current thread object.
+// Otherwise return JNIHandles::resolve_external_guard(thread).
+oop
+JvmtiEnvBase::current_thread_obj_or_resolve_external_guard(jthread thread) {
+  oop thread_obj = JNIHandles::resolve_external_guard(thread);
+  if (thread == NULL) {
+    thread_obj = get_vthread_or_thread_oop(JavaThread::current());
+  }
+  return thread_obj;
+}
+
 jvmtiError
 JvmtiEnvBase::get_threadOop_and_JavaThread(ThreadsList* t_list, jthread thread,
                                            JavaThread** jt_pp, oop* thread_oop_p) {

--- a/src/hotspot/share/prims/jvmtiEnvBase.hpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.hpp
@@ -167,6 +167,10 @@ class JvmtiEnvBase : public CHeapObj<mtInternal> {
     return byte_offset_of(JvmtiEnvBase, _jvmti_external);
   };
 
+  // If (thread == NULL) then return current thread object.
+  // Otherwise return JNIHandles::resolve_external_guard(thread).
+  static oop current_thread_obj_or_resolve_external_guard(jthread thread);
+
   static jvmtiError get_JavaThread(ThreadsList* tlist, jthread thread, JavaThread** jt_pp) {
     jvmtiError err = JVMTI_ERROR_NONE;
     if (thread == NULL) {

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -1697,7 +1697,9 @@ void JvmtiExport::post_object_free(JvmtiEnv* env, GrowableArray<jlong>* objects)
   if (javaThread->is_in_VTMS_transition()) {
     return; // no events should be posted if thread is in a VTMS transition
   }
-  assert(env->is_enabled(JVMTI_EVENT_OBJECT_FREE), "checking");
+  if (!env->is_enabled(JVMTI_EVENT_OBJECT_FREE)) {
+    return; // the event type has been already disabled
+  }
 
   EVT_TRIG_TRACE(JVMTI_EVENT_OBJECT_FREE, ("[?] Trg Object Free triggered" ));
   EVT_TRACE(JVMTI_EVENT_OBJECT_FREE, ("[?] Evt Object Free sent"));

--- a/src/hotspot/share/prims/jvmtiExtensions.cpp
+++ b/src/hotspot/share/prims/jvmtiExtensions.cpp
@@ -136,6 +136,10 @@ static jvmtiError JNICALL GetCarrierThread(const jvmtiEnv* env, ...) {
   ThreadsListHandle tlh(current_thread);
   JavaThread* java_thread;
   oop vthread_oop = NULL;
+
+  if (vthread == NULL) {
+    vthread = (jthread)JNIHandles::make_local(current_thread, JvmtiEnvBase::get_vthread_or_thread_oop(current_thread));
+  }
   jvmtiError err = JvmtiExport::cv_external_thread_to_JavaThread(tlh.list(), vthread, &java_thread, &vthread_oop);
   if (err != JVMTI_ERROR_NONE) {
     // We got an error code so we don't have a JavaThread *, but

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/GetSetLocalTest/libGetSetLocalTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/GetSetLocalTest/libGetSetLocalTest.cpp
@@ -312,8 +312,6 @@ static void
 test_GetSetLocal(jvmtiEnv *jvmti, JNIEnv* jni, jthread vthread, int depth, int frame_count, bool at_event) {
   Values values0 = { NULL, NULL, 1, 2L, (jfloat)3.2F, (jdouble)4.500000047683716 };
   Values values1 = { NULL, NULL, 2, 3L, (jfloat)4.2F, (jdouble)5.500000047683716 };
-  // jthread cthread = at_event ? get_carrier_thread(jvmti, jni, get_current_thread(jvmti, jni))
-  //                            : get_carrier_thread(jvmti, jni, vthread);
   jthread cthread = get_carrier_thread(jvmti, jni, vthread);
 
   values0.tt = vthread;

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/libVThreadTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/libVThreadTest.cpp
@@ -156,9 +156,7 @@ test_GetCarrierThread(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread, jthread vthr
 
   // #1: Test JVMTI GetCarrierThread extension function with NULL vthread
   err = GetCarrierThread(jvmti, jni, NULL, &vthread_thread);
-  if (err != JVMTI_ERROR_INVALID_THREAD) {
-    fatal(jni, "event handler: JVMTI GetCarrierThread with NULL vthread failed to return JVMTI_ERROR_INVALID_THREAD");
-  }
+  check_jvmti_status(jni, err, "event handler: error in JVMTI GetCarrierThread");
 
   // #2: Test JVMTI GetCarrierThread extension function with a bad vthread
   err = GetCarrierThread(jvmti, jni, thread, &vthread_thread);


### PR DESCRIPTION
The problem is that the following assert in the JvmtiExport::post_object_free is wrong:
`  assert(env->is_enabled(JVMTI_EVENT_OBJECT_FREE), "checking");`

Even though the condition was checked before, it can be changed later as it is racy by JVM TI design.
It has to be replaced with the check:
```
  if (!env->is_enabled(JVMTI_EVENT_OBJECT_FREE)) {
    return; // the event type has been already disabled
  }
```

In progress: mach5 nsk.jvmti and nsk.jdi test runs.