### PR TITLE
8293010: JDI ObjectReference/referringObjects/referringObjects001 fails: assert(env->is_enabled(JVMTI_EVENT_OBJECT_FREE)) failed: checking

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -1697,7 +1697,9 @@ void JvmtiExport::post_object_free(JvmtiEnv* env, GrowableArray<jlong>* objects)
   if (javaThread->is_in_VTMS_transition()) {
     return; // no events should be posted if thread is in a VTMS transition
   }
-  assert(env->is_enabled(JVMTI_EVENT_OBJECT_FREE), "checking");
+  if (!env->is_enabled(JVMTI_EVENT_OBJECT_FREE)) {
+    return; // the event type has been already disabled
+  }
 
   EVT_TRIG_TRACE(JVMTI_EVENT_OBJECT_FREE, ("[?] Trg Object Free triggered" ));
   EVT_TRACE(JVMTI_EVENT_OBJECT_FREE, ("[?] Evt Object Free sent"));


### PR DESCRIPTION
The problem is that the following assert in the JvmtiExport::post_object_free is wrong:
`  assert(env->is_enabled(JVMTI_EVENT_OBJECT_FREE), "checking");`

Even though the condition was checked before, it can be changed later as it is racy by JVM TI design.
It has to be replaced with the check:
```
  if (!env->is_enabled(JVMTI_EVENT_OBJECT_FREE)) {
    return; // the event type has been already disabled
  }
```

In progress: mach5 nsk.jvmti and nsk.jdi test runs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293010](https://bugs.openjdk.org/browse/JDK-8293010): JDI ObjectReference/referringObjects/referringObjects001 fails: assert(env->is_enabled(JVMTI_EVENT_OBJECT_FREE)) failed: checking


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10109/head:pull/10109` \
`$ git checkout pull/10109`

Update a local copy of the PR: \
`$ git checkout pull/10109` \
`$ git pull https://git.openjdk.org/jdk pull/10109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10109`

View PR using the GUI difftool: \
`$ git pr show -t 10109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10109.diff">https://git.openjdk.org/jdk/pull/10109.diff</a>

</details>
