### PR TITLE
8287912: GTK L&F : Background of tree icons are red 

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKPainter.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKPainter.java
@@ -1275,8 +1275,10 @@ class GTKPainter extends SynthPainter {
                 ENGINE.startPainting(g, x, y, w, h, id, state);
                 // the string arg should alternate based on row being painted,
                 // but we currently don't pass that in.
-                ENGINE.paintFlatBox(g, context, id, gtkState, ShadowType.NONE,
-                        "cell_odd", x, y, w, h, ColorType.TEXT_BACKGROUND);
+                if (context.getComponent().isOpaque()) {
+                    ENGINE.paintFlatBox(g, context, id, gtkState, ShadowType.NONE,
+                            "cell_odd", x, y, w, h, ColorType.TEXT_BACKGROUND);
+                }
                 ENGINE.finishPainting();
             }
         }

--- a/test/jdk/javax/swing/JTree/TestTreeBackgroundColor.java
+++ b/test/jdk/javax/swing/JTree/TestTreeBackgroundColor.java
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.

--- a/test/jdk/javax/swing/JTree/TestTreeBackgroundColor.java
+++ b/test/jdk/javax/swing/JTree/TestTreeBackgroundColor.java
@@ -53,9 +53,9 @@ public class TestTreeBackgroundColor {
     private static JTree tree;
 
     public static void main(String[] args) throws Exception {
-    	UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
         Robot robot = new Robot();
-        robot.setAutoDelay(100);   
+        robot.setAutoDelay(100);
         try {
             SwingUtilities.invokeAndWait(new Runnable() {
                 public void run() {

--- a/test/jdk/javax/swing/JTree/TestTreeBackgroundColor.java
+++ b/test/jdk/javax/swing/JTree/TestTreeBackgroundColor.java
@@ -72,17 +72,16 @@ public class TestTreeBackgroundColor {
                             tree.getHeight()));
 
             boolean passed = false;
-            for (int x = 0; x < img.getWidth() - 1; ++x) {
-                for (int y = 0; y < img.getHeight() - 1; ++y) {
-                    Color c = new Color(img.getRGB(x, y));
-
-                    if (c.equals(Color.RED)) {
-                        passed = true;
-                    }
+            for (int x = 1; x < img.getWidth() - 1; ++x) {
+                Color c = new Color(img.getRGB(x, tree.getHeight()/2));
+                if (!c.equals(Color.RED)) {
+                    passed = false;
+                    break;
+                } else {
+                    passed = true;
                 }
             }
             if (!passed) {
-                ImageIO.write(img, "png", new File("TreeBackgroundColorTestFail.png"));
                 throw new RuntimeException("Test Case Failed : Tree Background Color is Not Red");
             }
         } finally {

--- a/test/jdk/javax/swing/JTree/TestTreeBackgroundColor.java
+++ b/test/jdk/javax/swing/JTree/TestTreeBackgroundColor.java
@@ -72,8 +72,8 @@ public class TestTreeBackgroundColor {
                             tree.getHeight()));
 
             boolean passed = false;
-            for (int x = 1; x < img.getWidth() - 1; ++x) {
-                Color c = new Color(img.getRGB(x, tree.getHeight()/2));
+            for (int x = img.getWidth()/2; x < img.getWidth() - 1; ++x) {
+                Color c = new Color(img.getRGB(x, img.getHeight()/4));
                 if (!c.equals(Color.RED)) {
                     passed = false;
                     break;
@@ -82,6 +82,7 @@ public class TestTreeBackgroundColor {
                 }
             }
             if (!passed) {
+                ImageIO.write(img, "png", new File("TreeBackgroundColorFail.png"));
                 throw new RuntimeException("Test Case Failed : Tree Background Color is Not Red");
             }
         } finally {
@@ -94,7 +95,7 @@ public class TestTreeBackgroundColor {
     }
 
     private static void createAndShowUI() {
-        frame = new JFrame();
+        frame = new JFrame("Test Tree Background Color");
         panel = new JPanel();
         tree = new JTree();
         panel.setBackground(Color.red);

--- a/test/jdk/javax/swing/JTree/TestTreeBackgroundColor.java
+++ b/test/jdk/javax/swing/JTree/TestTreeBackgroundColor.java
@@ -1,0 +1,112 @@
+
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8287912
+ * @key headful
+ * @requires (os.family == "linux")
+ * @summary Verifies if tree background color is red when
+ * setOpaque(false) method is called for tree component
+ * @run main TestTreeBackgroundColor
+ */
+
+import java.awt.Color;
+import java.awt.GridLayout;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import javax.imageio.ImageIO;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class TestTreeBackgroundColor {
+
+    private static JFrame frame;
+    private static JPanel panel;
+    private static JTree tree;
+
+    public static void main(String[] args) throws Exception {
+    	UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);   
+        try {
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    createAndShowUI();
+                }
+            });
+
+            robot.waitForIdle();
+            robot.delay(1000);
+            Point pt = tree.getLocationOnScreen();
+            BufferedImage img =
+                    robot.createScreenCapture(new Rectangle(pt.x, pt.y,
+                            tree.getWidth(),
+                            tree.getHeight()));
+
+            boolean passed = false;
+            for (int x = 0; x < img.getWidth() - 1; ++x) {
+                for (int y = 0; y < img.getHeight() - 1; ++y) {
+                    Color c = new Color(img.getRGB(x, y));
+
+                    if (c.equals(Color.RED)) {
+                        passed = true;
+                    }
+                }
+            }
+            if (!passed) {
+                ImageIO.write(img, "png", new File("TreeBackgroundColorTestFail.png"));
+                throw new RuntimeException("Test Case Failed : Tree Background Color is Not Red");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createAndShowUI() {
+        frame = new JFrame();
+        panel = new JPanel();
+        tree = new JTree();
+        panel.setBackground(Color.red);
+        panel.setLayout(new GridLayout(1, 1));
+        tree.setOpaque(false);
+        panel.add(tree);
+        frame.getContentPane().add(panel);
+        frame.pack();
+        frame.setSize(250, 200);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+}
+


### PR DESCRIPTION
The background of tree icons are not red in GTK LAF when setOpaque is set to false for tree component.
It has been observed that while painting tree cell background in GTK LAF, a rectangular area is also painted with background color (white). 

Proposed solution is to check the opacity of tree component before drawing tree cell background. If the opacity is set to "false" then the background shouldn't be painted.

An automated test case has been added and checked in CI, link is added in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287912](https://bugs.openjdk.org/browse/JDK-8287912): GTK L&F : Background of tree icons are red


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10112/head:pull/10112` \
`$ git checkout pull/10112`

Update a local copy of the PR: \
`$ git checkout pull/10112` \
`$ git pull https://git.openjdk.org/jdk pull/10112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10112`

View PR using the GUI difftool: \
`$ git pr show -t 10112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10112.diff">https://git.openjdk.org/jdk/pull/10112.diff</a>

</details>
