### PR TITLE
8293201: Library detection in runtime/ErrorHandling/TestDwarf.java fails on some systems

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
@@ -176,7 +176,7 @@ public class TestDwarf {
      * There are some valid cases where we cannot find source information. Check these.
      */
     private static void checkNoSourceLine(String crashOutputString, String line) {
-        Pattern pattern = Pattern.compile("[CV][\\s\\t]+\\[([a-zA-Z0-9_.]+)\\+0x.+][\\s\\t]+.*\\+0x");
+        Pattern pattern = Pattern.compile("[CV][\\s\\t]+\\[([a-zA-Z0-9_.]+)\\+0x.+]");
         Matcher matcher = pattern.matcher(line);
         Asserts.assertTrue(matcher.find(), "Must find library in \"" + line + "\"");
         // Check if there are symbols available for library. If not, then we cannot find any source information for this library.


### PR DESCRIPTION
When building x86_32 on Ubuntu 22.04, the test fails to find the library name in `"C  [libc.so.6+0x85ff1]"`, because the regexp seems too broad. Since we are matching with the unanchored regexp, we can just try and find the smaller prefix, which still matches the library name.

But the original regexp seems odd to begin with. Why do we match `0x` twice? Why do we have the escaped `\\[`, followed by trailing `]` (the last one in the patch now), which is not escaped? This is a question for you, @chhagedorn :)

Additional testing:
 - [x] Ubuntu 22.04 x86_32 build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293201](https://bugs.openjdk.org/browse/JDK-8293201): Library detection in runtime/ErrorHandling/TestDwarf.java fails on some systems


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10113/head:pull/10113` \
`$ git checkout pull/10113`

Update a local copy of the PR: \
`$ git checkout pull/10113` \
`$ git pull https://git.openjdk.org/jdk pull/10113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10113`

View PR using the GUI difftool: \
`$ git pr show -t 10113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10113.diff">https://git.openjdk.org/jdk/pull/10113.diff</a>

</details>
