### PR TITLE
8293202 Document how to edit doc/testing, doc/building

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -112,6 +112,7 @@
 <li><a href="#developing-the-build-system-itself">Developing the Build System Itself</a></li>
 </ul></li>
 <li><a href="#contributing-to-the-jdk">Contributing to the JDK</a></li>
+<li><a href="#editing-this-document">Editing this document</a></li>
 </ul>
 </nav>
 <h2 id="tldr-instructions-for-the-impatient">TL;DR (Instructions for the Impatient)</h2>
@@ -1033,5 +1034,7 @@ test-support/</code></pre>
 <p>First of all: Thank you! We gladly welcome your contribution. However, please bear in mind that the JDK is a massive project, and we must ask you to follow our rules and guidelines to be able to accept your contribution.</p>
 <p>The official place to start is the <a href="http://openjdk.java.net/contribute/">'How to contribute' page</a>. There is also an official (but somewhat outdated and skimpy on details) <a href="http://openjdk.java.net/guide/">Developer's Guide</a>.</p>
 <p>If this seems overwhelming to you, the Adoption Group is there to help you! A good place to start is their <a href="https://wiki.openjdk.java.net/display/Adoption/New+Contributor">'New Contributor' page</a>, or start reading the comprehensive <a href="https://adoptopenjdk.gitbooks.io/adoptopenjdk-getting-started-kit/en/">Getting Started Kit</a>. The Adoption Group will also happily answer any questions you have about contributing. Contact them by <a href="http://mail.openjdk.java.net/mailman/listinfo/adoption-discuss">mail</a> or <a href="http://openjdk.java.net/irc/">IRC</a>.</p>
+<h2 id="editing-this-document">Editing this document</h2>
+<p>If you want to contribute changes to this document, edit <code>doc/building.md</code> and then run <code>make update-build-docs</code> to generate the same changes in <code>doc/building.html</code>.</p>
 </body>
 </html>

--- a/doc/building.md
+++ b/doc/building.md
@@ -1948,6 +1948,12 @@ contributing. Contact them by [mail](
 http://mail.openjdk.java.net/mailman/listinfo/adoption-discuss) or [IRC](
 http://openjdk.java.net/irc/).
 
+## Editing this document
+
+If you want to contribute changes to this document, edit `doc/building.md` and 
+then run `make update-build-docs` to generate the same changes in 
+`doc/building.html`.
+
 ---
 # Override styles from the base CSS file that are not ideal for this document.
 header-includes:

--- a/doc/testing.html
+++ b/doc/testing.html
@@ -46,6 +46,7 @@
 <li><a href="#pkcs11-tests">PKCS11 Tests</a></li>
 <li><a href="#client-ui-tests">Client UI Tests</a></li>
 </ul></li>
+<li><a href="#editing-this-document">Editing this document</a></li>
 </ul>
 </nav>
 <h2 id="using-make-test-the-run-test-framework">Using &quot;make test&quot; (the run-test framework)</h2>
@@ -254,5 +255,7 @@ $ make test JTREG=&quot;VM_OPTIONS=-Duser.language=en -Duser.country=US&quot; TE
 <h4 id="windows">Windows</h4>
 <p>Type <code>gpedit</code> in the Search and then click Edit group policy; navigate to User Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; File Explorer; in the right-side pane look for &quot;Turn off Windows key hotkeys&quot; and double click on it; enable or disable hotkeys.</p>
 <p>Note: restart is required to make the settings take effect.</p>
+<h2 id="editing-this-document">Editing this document</h2>
+<p>If you want to contribute changes to this document, edit <code>doc/testing.md</code> and then run <code>make update-build-docs</code> to generate the same changes in <code>doc/testing.html</code>.</p>
 </body>
 </html>

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -603,6 +603,12 @@ double click on it; enable or disable hotkeys.
 
 Note: restart is required to make the settings take effect.
 
+## Editing this document
+
+If you want to contribute changes to this document, edit `doc/testing.md` and 
+then run `make update-build-docs` to generate the same changes in 
+`doc/testing.html`.
+
 ---
 # Override some definitions in the global css file that are not optimal for
 # this document.


### PR DESCRIPTION
Added note to doc/testing and doc/building about the appropriate make target to regenerate them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293202](https://bugs.openjdk.org/browse/JDK-8293202): Document how to edit doc/testing, doc/building


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10115/head:pull/10115` \
`$ git checkout pull/10115`

Update a local copy of the PR: \
`$ git checkout pull/10115` \
`$ git pull https://git.openjdk.org/jdk pull/10115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10115`

View PR using the GUI difftool: \
`$ git pr show -t 10115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10115.diff">https://git.openjdk.org/jdk/pull/10115.diff</a>

</details>
