### PR TITLE
8293207: Add assert to JVM_ReferenceRefersTo to clarify its API

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3283,6 +3283,7 @@ JVM_END
 JVM_ENTRY(jboolean, JVM_ReferenceRefersTo(JNIEnv* env, jobject ref, jobject o))
   oop ref_oop = JNIHandles::resolve_non_null(ref);
   // PhantomReference has it's own implementation of refersTo().
+  // See: JVM_PhantomReferenceRefersTo
   assert(!java_lang_ref_Reference::is_phantom(ref_oop), "precondition");
   oop referent = java_lang_ref_Reference::weak_referent_no_keepalive(ref_oop);
   return referent == JNIHandles::resolve(o);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3282,6 +3282,8 @@ JVM_END
 
 JVM_ENTRY(jboolean, JVM_ReferenceRefersTo(JNIEnv* env, jobject ref, jobject o))
   oop ref_oop = JNIHandles::resolve_non_null(ref);
+  // PhantomReference has it's own implementation of refersTo().
+  assert(!java_lang_ref_Reference::is_phantom(ref_oop), "precondition");
   oop referent = java_lang_ref_Reference::weak_referent_no_keepalive(ref_oop);
   return referent == JNIHandles::resolve(o);
 JVM_END


### PR DESCRIPTION
JVM_ReferenceRefersTo should only be used for soft/weak references and not phantom references, which has its own implementation. This is not clear from the name. `java_lang_ref_Reference::weak_referent_no_keepalive(ref_oop)` is only a valid call if `!java_lang_ref_Reference::is_phantom(ref_oop)`.

Adds an assert and comment to make this clear.

Testing: Oracle platforms tier 1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293207](https://bugs.openjdk.org/browse/JDK-8293207): Add assert to JVM_ReferenceRefersTo to clarify its API


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to [ff334b45](https://git.openjdk.org/jdk/pull/10117/files/ff334b45fdd62661336cd85b103f89794e5547ad)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to [ff334b45](https://git.openjdk.org/jdk/pull/10117/files/ff334b45fdd62661336cd85b103f89794e5547ad)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10117/head:pull/10117` \
`$ git checkout pull/10117`

Update a local copy of the PR: \
`$ git checkout pull/10117` \
`$ git pull https://git.openjdk.org/jdk pull/10117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10117`

View PR using the GUI difftool: \
`$ git pr show -t 10117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10117.diff">https://git.openjdk.org/jdk/pull/10117.diff</a>

</details>
