### PR TITLE
8293219: Microsoft toolchain selection picks 32-bit tools over 64-bit

### DIFF
--- a/make/autoconf/toolchain_microsoft.m4
+++ b/make/autoconf/toolchain_microsoft.m4
@@ -83,20 +83,18 @@ AC_DEFUN([TOOLCHAIN_CHECK_POSSIBLE_VISUAL_STUDIO_ROOT],
 
       AC_MSG_NOTICE([Found Visual Studio installation at $VS_BASE using $METHOD])
       if test "x$TARGET_CPU" = xx86; then
-        VCVARSFILES="vc/bin/vcvars32.bat vc/auxiliary/build/vcvars32.bat"
+        VCVARSFILES="vcvars32.bat vcvarsamd64_x86.bat"
       elif test "x$TARGET_CPU" = xx86_64; then
-        VCVARSFILES="vc/bin/amd64/vcvars64.bat vc/bin/x86_amd64/vcvarsx86_amd64.bat \
-            vc/auxiliary/build/vcvarsx86_amd64.bat vc/auxiliary/build/vcvars64.bat"
+        VCVARSFILES="vcvars64.bat vcvarsx86_amd64.bat"
       elif test "x$TARGET_CPU" = xaarch64; then
         # for host x86-64, target aarch64
         # aarch64 requires Visual Studio 16.8 or higher
-        VCVARSFILES="vc/auxiliary/build/vcvarsamd64_arm64.bat \
-            vc/auxiliary/build/vcvarsx86_arm64.bat"
+        VCVARSFILES="vcvarsamd64_arm64.bat vcvarsx86_arm64.bat"
       fi
 
       for VCVARSFILE in $VCVARSFILES; do
-        if test -f "$VS_BASE/$VCVARSFILE"; then
-          VS_ENV_CMD="$VS_BASE/$VCVARSFILE"
+        if test -f "$VS_BASE/vc/auxiliary/build/$VCVARSFILE"; then
+          VS_ENV_CMD="$VS_BASE/vc/auxiliary/build/$VCVARSFILE"
           break
         fi
       done


### PR DESCRIPTION
The logic in toolchain_windows.m4 happens to prefer the 32-bit version of the tools. This is incorrect, since we only support building on 64-bit Windows. 

Also, since dropping VS2017, we can remove some old bat files we do no longer have to look for.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293219](https://bugs.openjdk.org/browse/JDK-8293219): Microsoft toolchain selection picks 32-bit tools over 64-bit


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10121/head:pull/10121` \
`$ git checkout pull/10121`

Update a local copy of the PR: \
`$ git checkout pull/10121` \
`$ git pull https://git.openjdk.org/jdk pull/10121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10121`

View PR using the GUI difftool: \
`$ git pr show -t 10121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10121.diff">https://git.openjdk.org/jdk/pull/10121.diff</a>

</details>
