### PR TITLE
8289400: Improve com/sun/jdi/TestScaffold error reporting

### DIFF
--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -454,8 +454,9 @@ abstract public class TestScaffold extends TargetAdapter {
     protected void failure(String str) {
         println(str);
         StackTraceElement[] trace = Thread.currentThread().getStackTrace();
-        for (StackTraceElement traceElement : trace)
+        for (StackTraceElement traceElement : trace) {
             System.err.println("\tat " + traceElement);
+        }
         testFailed = true;
     }
 

--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -453,6 +453,9 @@ abstract public class TestScaffold extends TargetAdapter {
 
     protected void failure(String str) {
         println(str);
+        StackTraceElement[] trace = Thread.currentThread().getStackTrace();
+        for (StackTraceElement traceElement : trace)
+            System.err.println("\tat " + traceElement);
         testFailed = true;
     }
 


### PR DESCRIPTION
com/sun/jdi tests report errors by calling TestScaffold.failure(msg), which prints the failure message and sets the testFailed flag. At some later point the failure is detected and an exception is thrown. The end result is the exception has just has a vanilla message that says something like "TestXXX failed", and the backtrace is not indicative of where the failure occurred. If you have tools that search logs looking for exceptions to determine the reason for the failure, you likely won't find any. Here's an example: 

```
[2ms] run args: [SuspendAfterDeathTarg]
[514ms] FAILED: got Breakpoint event before ThreadDeath event.
java.lang.Exception: SuspendAfterDeath: failed
at SuspendAfterDeath.runTests(SuspendAfterDeath.java:110)
at TestScaffold.startTests(TestScaffold.java:432)
at SuspendAfterDeath.main(SuspendAfterDeath.java:47)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:578)
at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
at java.base/java.lang.Thread.run(Thread.java:1589)
```

So the reason for the failure is clear (the "FAILED" message), but its stack trace is missing and the reason is not included in the exception message that is printed much later on. This PR adds printing of the stack trace at the time of the failure.

```
[2ms] run args: [SuspendAfterDeathTarg]
[514ms] FAILED: got Breakpoint event before ThreadDeath event.
        at TestScaffold.failure(TestScaffold.java:455)
        at SuspendAfterDeath.breakpointReached(SuspendAfterDeath.java:64)
        at TestScaffold$EventHandler.notifyEvent(TestScaffold.java:194)
        at TestScaffold$EventHandler.run(TestScaffold.java:278)
        at java.base/java.lang.Thread.run(Thread.java:1589) 
java.lang.Exception: SuspendAfterDeath: failed
at SuspendAfterDeath.runTests(SuspendAfterDeath.java:110)
at TestScaffold.startTests(TestScaffold.java:432)
at SuspendAfterDeath.main(SuspendAfterDeath.java:47)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:578)
at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
at java.base/java.lang.Thread.run(Thread.java:1589)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289400](https://bugs.openjdk.org/browse/JDK-8289400): Improve com/sun/jdi/TestScaffold error reporting


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10127/head:pull/10127` \
`$ git checkout pull/10127`

Update a local copy of the PR: \
`$ git checkout pull/10127` \
`$ git pull https://git.openjdk.org/jdk pull/10127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10127`

View PR using the GUI difftool: \
`$ git pr show -t 10127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10127.diff">https://git.openjdk.org/jdk/pull/10127.diff</a>

</details>
