### PR TITLE
JDK-8293003: Review running time of Warn5 regression test

### DIFF
--- a/test/langtools/tools/javac/varargs/warning/Warn4.java
+++ b/test/langtools/tools/javac/varargs/warning/Warn4.java
@@ -217,11 +217,13 @@ public class Warn4 extends ComboInstance<Warn4> {
         return sigs[0].isApplicableTo(sigs[1]);
     }
 
-    final String template = "import java.util.List;\n" +
-                            "class Test {\n" +
-                            "   #{TRUSTME} #{SUPPRESS[0]} #{MOD} #{MTH[0].VARARG}\n" +
-                            "   #{SUPPRESS[1]} #{MTH[1].CLIENT}\n" +
-                            "}";
+    final String template = """
+        import java.util.List;
+        class Test {
+           #{TRUSTME} #{SUPPRESS[0]} #{MOD} #{MTH[0].VARARG}
+           #{SUPPRESS[1]} #{MTH[1].CLIENT}
+        }
+        """;
 
     @Override
     public void doWork() throws IOException {

--- a/test/langtools/tools/javac/varargs/warning/Warn5.java
+++ b/test/langtools/tools/javac/varargs/warning/Warn5.java
@@ -125,9 +125,10 @@ public class Warn5 extends ComboInstance<Warn5> {
         }
     }
 
+    // Handling of varargs warnings changed in JDK 9 compared to JDK 8
+    // and then remained consistent; test 8 and then current release.
     enum SourceLevel {
         JDK_8("8"),
-        JDK_9("9"),
         LATEST(Integer.toString(javax.lang.model.SourceVersion.latest().runtimeVersion().feature()));
 
         String sourceKey;
@@ -159,12 +160,15 @@ public class Warn5 extends ComboInstance<Warn5> {
         }
     }
 
+    // javac does not currently perform analysis of the method body
+    // with respect to the validity of the @SafeVargs annotation. If
+    // that changes, the body tests should be expanded.
     enum BodyKind implements ComboParameter {
-        ASSIGN("Object o = x;", true),
-        CAST("Object o = (Object)x;", true),
+        // ASSIGN("Object o = x;", true),
+        // CAST("Object o = (Object)x;", true),
         METH("test(x);", true),
         PRINT("System.out.println(x.toString());", false),
-        ARRAY_ASSIGN("Object[] o = x;", true),
+        // ARRAY_ASSIGN("Object[] o = x;", true),
         ARRAY_CAST("Object[] o = (Object[])x;", true),
         ARRAY_METH("testArr(x);", true);
 
@@ -222,13 +226,15 @@ public class Warn5 extends ComboInstance<Warn5> {
         return (methKind != MethodKind.CONSTRUCTOR || modKind == ModifierKind.NONE);
     }
 
-    String template = "import com.sun.tools.javac.api.*;\n" +
-                      "import java.util.List;\n" +
-                      "class Test {\n" +
-                      "   static void test(Object o) {}\n" +
-                      "   static void testArr(Object[] o) {}\n" +
-                      "   #{TRUSTME} #{SUPPRESS} #{MOD} #{SIG} { #{BODY} }\n" +
-                      "}\n";
+    String template = """
+        import com.sun.tols.javac.api.*;
+        import java.util.List;
+        class Test {
+           static void test(Object o) {}
+           static void testArr(Object[] o) {}
+           #{TRUSTME} #{SUPPRESS} #{MOD} #{SIG} { #{BODY} }
+        }
+        """;
 
     @Override
     public void doWork() throws IOException {
@@ -265,7 +271,7 @@ public class Warn5 extends ComboInstance<Warn5> {
             (methKind == MethodKind.CONSTRUCTOR ||
              (methKind == MethodKind.METHOD &&
               modKind == ModifierKind.FINAL || modKind == ModifierKind.STATIC ||
-              (modKind == ModifierKind.PRIVATE && sourceLevel.compareTo(SourceLevel.JDK_9) >= 0)))) {
+              (modKind == ModifierKind.PRIVATE && sourceLevel.compareTo(SourceLevel.JDK_8) > 0)))) {
             expectedWarnings.add(WarningKind.UNSAFE_BODY);
         }
 
@@ -279,7 +285,7 @@ public class Warn5 extends ComboInstance<Warn5> {
         if (trustMe == TrustMe.TRUST &&
             (!sig.isVarargs ||
              ((modKind == ModifierKind.NONE ||
-               modKind == ModifierKind.PRIVATE && sourceLevel.compareTo(SourceLevel.JDK_9) < 0 ) &&
+               modKind == ModifierKind.PRIVATE && sourceLevel.compareTo(SourceLevel.JDK_8) <= 0 ) &&
               methKind == MethodKind.METHOD))) {
             expectedWarnings.add(WarningKind.MALFORMED_SAFEVARARGS);
         }
@@ -288,7 +294,7 @@ public class Warn5 extends ComboInstance<Warn5> {
             xlint != XlintOption.NONE &&
             suppressLevel != SuppressLevel.VARARGS &&
             (modKind == ModifierKind.FINAL || modKind == ModifierKind.STATIC ||
-             (modKind == ModifierKind.PRIVATE && sourceLevel.compareTo(SourceLevel.JDK_9) >= 0) ||
+             (modKind == ModifierKind.PRIVATE && sourceLevel.compareTo(SourceLevel.JDK_8) > 0) ||
              methKind == MethodKind.CONSTRUCTOR) &&
             sig.isVarargs &&
             sig.isReifiableArg) {


### PR DESCRIPTION
Refactoring of the Warn5 regression test to reduce its running time by more than 50%.

Included a small refactoring in Warn4 to use text blocks too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293003](https://bugs.openjdk.org/browse/JDK-8293003): Review running time of Warn5 regression test


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10130/head:pull/10130` \
`$ git checkout pull/10130`

Update a local copy of the PR: \
`$ git checkout pull/10130` \
`$ git pull https://git.openjdk.org/jdk pull/10130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10130`

View PR using the GUI difftool: \
`$ git pr show -t 10130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10130.diff">https://git.openjdk.org/jdk/pull/10130.diff</a>

</details>
