### PR TITLE
5066842: PKCS8EncodedKeySpec needs getAlgorithm method

### DIFF
--- a/src/java.base/share/classes/java/security/spec/EncodedKeySpec.java
+++ b/src/java.base/share/classes/java/security/spec/EncodedKeySpec.java
@@ -106,9 +106,9 @@ public abstract class EncodedKeySpec implements KeySpec {
      * <p>
      * If this object is created with {@link #EncodedKeySpec(byte[])}, this method in
      * this base class returns {@code null}. A child class may parse the content of the encoded
-     * key and return its algorithm name if one can be recovered.
+     * key and return its algorithm name if it can be determined.
      *
-     * @return the name of the algorithm
+     * @return the name of the algorithm, or {@code null} if not available
      * @since 9
      */
     public String getAlgorithm() {

--- a/src/java.base/share/classes/java/security/spec/PKCS8EncodedKeySpec.java
+++ b/src/java.base/share/classes/java/security/spec/PKCS8EncodedKeySpec.java
@@ -64,13 +64,15 @@ public class PKCS8EncodedKeySpec extends EncodedKeySpec {
     /**
      * Creates a new {@code PKCS8EncodedKeySpec} with the given encoded key.
      * <p>
-     * This constructor parses the encoded key and recovers the algorithm
-     * name from its `privateKeyAlgorithm` field. If the name is one of the
+     * This constructor parses the encoded key and tries to determine the
+     * algorithm name from its `privateKeyAlgorithm` field. If the name is one of the
+     * standard algorithm names in the {@code KeyFactory} section in the
      * <a href="{@docRoot}/../specs/security/standard-names.html#keyfactory-algorithms">
-     * standard names listed in the Java Security Standard Algorithm Names Specification</a>,
+     * Java Security Standard Algorithm Names Specification</a>,
      * it will be returned. Otherwise, the object identifier inside the `privateKeyAlgorithm`
-     * field is returned in its string format (For example, "1.3.14.7.2.1.1").
-     * If the encoded key cannot be parsed correctly, the algorithm will be null.
+     * field is returned in its string format as a series of nonnegative
+     * integers separated by periods (For example, "1.3.14.7.2.1.1").
+     * If the encoded key cannot be parsed correctly, the algorithm is {@code null}.
      *
      * @param encodedKey the key, which is assumed to be
      * encoded according to the PKCS #8 standard. The contents of

--- a/src/java.base/share/classes/java/security/spec/X509EncodedKeySpec.java
+++ b/src/java.base/share/classes/java/security/spec/X509EncodedKeySpec.java
@@ -54,13 +54,15 @@ public class X509EncodedKeySpec extends EncodedKeySpec {
     /**
      * Creates a new {@code X509EncodedKeySpec} with the given encoded key.
      * <p>
-     * This constructor parses the encoded key and recovers the algorithm
-     * name from its `algorithm` field. If the name is one of the
+     * This constructor parses the encoded key and tries to determine the
+     * algorithm name from its `algorithm` field. If the name is one of the
+     * standard algorithm names in the {@code KeyFactory} section in the
      * <a href="{@docRoot}/../specs/security/standard-names.html#keyfactory-algorithms">
-     * standard names listed in the Java Security Standard Algorithm Names Specification</a>,
+     * Java Security Standard Algorithm Names Specification</a>,
      * it will be returned. Otherwise, the object identifier inside the `algorithm`
-     * field is returned in its string format (For example, "1.3.14.7.2.1.1").
-     * If the encoded key cannot be parsed correctly, the algorithm will be null.
+     * field is returned in its string format as a series of nonnegative
+     * integers separated by periods (For example, "1.3.14.7.2.1.1").
+     * If the encoded key cannot be parsed correctly, the algorithm is {@code null}.
      *
      * @param encodedKey the key, which is assumed to be
      * encoded according to the X.509 standard. The contents of the


### PR DESCRIPTION
Since the algorithm is already encoded inside a PKCS #8 data block, it is not necessary to provide an algorithm when a `PKCS8EncodedKeySpec` object is created. The same for `X509EncodedKeySpec`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request to be approved

### Issue
 * [JDK-5066842](https://bugs.openjdk.org/browse/JDK-5066842): PKCS8EncodedKeySpec needs getAlgorithm method


### Reviewers
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10131/head:pull/10131` \
`$ git checkout pull/10131`

Update a local copy of the PR: \
`$ git checkout pull/10131` \
`$ git pull https://git.openjdk.org/jdk pull/10131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10131`

View PR using the GUI difftool: \
`$ git pr show -t 10131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10131.diff">https://git.openjdk.org/jdk/pull/10131.diff</a>

</details>
