### PR TITLE
8293288: bootcycle build failure after JDK-8173605

### DIFF
--- a/make/JrtfsJar.gmk
+++ b/make/JrtfsJar.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,7 @@ JIMAGE_PKGS := \
 
 $(eval $(call SetupJavaCompilation, BUILD_JRTFS, \
     COMPILER := bootjdk, \
+    DISABLED_WARNINGS := options, \
     TARGET_RELEASE := $(TARGET_RELEASE_JDK8), \
     SRC := $(TOPDIR)/src/java.base/share/classes, \
     EXCLUDE_FILES := module-info.java, \


### PR DESCRIPTION
Hi all,

bootcycle fails to build after JDK-8173605 due to the following two warnings
```
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
```

To suppress warnings about obsolete options, `-Xlint:-options` is added.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293288](https://bugs.openjdk.org/browse/JDK-8293288): bootcycle build failure after JDK-8173605


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10135/head:pull/10135` \
`$ git checkout pull/10135`

Update a local copy of the PR: \
`$ git checkout pull/10135` \
`$ git pull https://git.openjdk.org/jdk pull/10135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10135`

View PR using the GUI difftool: \
`$ git pr show -t 10135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10135.diff">https://git.openjdk.org/jdk/pull/10135.diff</a>

</details>
