### PR TITLE
8293295: Add type check asserts to java_lang_ref_Reference accessors

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -988,6 +988,8 @@ class java_lang_ref_Reference: AllStatic {
   static bool is_referent_field(oop obj, ptrdiff_t offset);
   static inline bool is_final(oop ref);
   static inline bool is_phantom(oop ref);
+  static inline bool is_weak(oop ref);
+  static inline bool is_soft(oop ref);
 
   static int referent_offset()    { CHECK_INIT(_referent_offset); }
   static int queue_offset()       { CHECK_INIT(_queue_offset); }

--- a/src/hotspot/share/classfile/javaClasses.inline.hpp
+++ b/src/hotspot/share/classfile/javaClasses.inline.hpp
@@ -27,6 +27,7 @@
 
 #include "classfile/javaClasses.hpp"
 
+#include "memory/referenceType.hpp"
 #include "oops/access.inline.hpp"
 #include "oops/instanceKlass.inline.hpp"
 #include "oops/method.hpp"
@@ -132,12 +133,12 @@ bool java_lang_String::is_instance(oop obj) {
 // Accessors
 
 oop java_lang_ref_Reference::weak_referent_no_keepalive(oop ref) {
-  assert(!java_lang_ref_Reference::is_phantom(ref), "must be Weak or Soft Reference");
+  assert(java_lang_ref_Reference::is_weak(ref) || java_lang_ref_Reference::is_soft(ref), "must be Weak or Soft Reference");
   return ref->obj_field_access<ON_WEAK_OOP_REF | AS_NO_KEEPALIVE>(_referent_offset);
 }
 
 oop java_lang_ref_Reference::weak_referent(oop ref) {
-  assert(!java_lang_ref_Reference::is_phantom(ref), "must be Weak or Soft Reference");
+  assert(java_lang_ref_Reference::is_weak(ref) || java_lang_ref_Reference::is_soft(ref), "must be Weak or Soft Reference");
   return ref->obj_field_access<ON_WEAK_OOP_REF>(_referent_offset);
 }
 
@@ -196,6 +197,14 @@ bool java_lang_ref_Reference::is_final(oop ref) {
 
 bool java_lang_ref_Reference::is_phantom(oop ref) {
   return InstanceKlass::cast(ref->klass())->reference_type() == REF_PHANTOM;
+}
+
+bool java_lang_ref_Reference::is_weak(oop ref) {
+  return InstanceKlass::cast(ref->klass())->reference_type() == REF_WEAK;
+}
+
+bool java_lang_ref_Reference::is_soft(oop ref) {
+  return InstanceKlass::cast(ref->klass())->reference_type() == REF_SOFT;
 }
 
 inline oop java_lang_Thread::continuation(oop java_thread) {

--- a/src/hotspot/share/classfile/javaClasses.inline.hpp
+++ b/src/hotspot/share/classfile/javaClasses.inline.hpp
@@ -132,14 +132,17 @@ bool java_lang_String::is_instance(oop obj) {
 // Accessors
 
 oop java_lang_ref_Reference::weak_referent_no_keepalive(oop ref) {
+  assert(!java_lang_ref_Reference::is_phantom(ref), "must be Weak or Soft Reference");
   return ref->obj_field_access<ON_WEAK_OOP_REF | AS_NO_KEEPALIVE>(_referent_offset);
 }
 
 oop java_lang_ref_Reference::weak_referent(oop ref) {
+  assert(!java_lang_ref_Reference::is_phantom(ref), "must be Weak or Soft Reference");
   return ref->obj_field_access<ON_WEAK_OOP_REF>(_referent_offset);
 }
 
 oop java_lang_ref_Reference::phantom_referent_no_keepalive(oop ref) {
+  assert(java_lang_ref_Reference::is_phantom(ref), "must be Phantom Reference");
   return ref->obj_field_access<ON_PHANTOM_OOP_REF | AS_NO_KEEPALIVE>(_referent_offset);
 }
 


### PR DESCRIPTION
From a discussion in [JDK-8293207](https://bugs.openjdk.org/browse/JDK-8293207) / #10117 it was brought up that the Weak/Soft and Phantom specific accessor in java_lang_ref_Reference does not assert that the type is valid.

Testing: Oracle platforms tier 1-4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293295](https://bugs.openjdk.org/browse/JDK-8293295): Add type check asserts to java_lang_ref_Reference accessors


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10139/head:pull/10139` \
`$ git checkout pull/10139`

Update a local copy of the PR: \
`$ git checkout pull/10139` \
`$ git pull https://git.openjdk.org/jdk pull/10139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10139`

View PR using the GUI difftool: \
`$ git pr show -t 10139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10139.diff">https://git.openjdk.org/jdk/pull/10139.diff</a>

</details>
