### PR TITLE
8293251: Use stringStream::base() instead of as_string() when applicable

### DIFF
--- a/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
@@ -377,7 +377,7 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
 #ifndef PRODUCT
   stringStream ss;
   ss.print("upcall_stub_%s", entry->signature()->as_C_string());
-  const char* name = _masm->code_string(ss.as_string());
+  const char* name = _masm->code_string(ss.base());
 #else // PRODUCT
   const char* name = "upcall_stub";
 #endif // PRODUCT

--- a/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
@@ -377,7 +377,7 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
 #ifndef PRODUCT
   stringStream ss;
   ss.print("upcall_stub_%s", entry->signature()->as_C_string());
-  const char* name = _masm->code_string(ss.base());
+  const char* name = _masm->code_string(ss.internal_string());
 #else // PRODUCT
   const char* name = "upcall_stub";
 #endif // PRODUCT

--- a/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
@@ -377,7 +377,7 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
 #ifndef PRODUCT
   stringStream ss;
   ss.print("upcall_stub_%s", entry->signature()->as_C_string());
-  const char* name = _masm->code_string(ss.internal_string());
+  const char* name = _masm->code_string(ss.freeze());
 #else // PRODUCT
   const char* name = "upcall_stub";
 #endif // PRODUCT

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -140,7 +140,7 @@ BlockListBuilder::BlockListBuilder(Compilation* compilation, IRScope* scope, int
     stringStream title;
     title.print("BlockListBuilder ");
     scope->method()->print_name(&title);
-    CFGPrinter::print_cfg(_bci2block, title.internal_string(), false, false);
+    CFGPrinter::print_cfg(_bci2block, title.freeze(), false, false);
   }
 #endif
 }

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -140,7 +140,7 @@ BlockListBuilder::BlockListBuilder(Compilation* compilation, IRScope* scope, int
     stringStream title;
     title.print("BlockListBuilder ");
     scope->method()->print_name(&title);
-    CFGPrinter::print_cfg(_bci2block, title.as_string(), false, false);
+    CFGPrinter::print_cfg(_bci2block, title.base(), false, false);
   }
 #endif
 }

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -140,7 +140,7 @@ BlockListBuilder::BlockListBuilder(Compilation* compilation, IRScope* scope, int
     stringStream title;
     title.print("BlockListBuilder ");
     scope->method()->print_name(&title);
-    CFGPrinter::print_cfg(_bci2block, title.base(), false, false);
+    CFGPrinter::print_cfg(_bci2block, title.internal_string(), false, false);
   }
 #endif
 }

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -975,7 +975,7 @@ Assert::Assert(Value x, Condition cond, bool unordered_is_true, Value y) : Instr
   ip2.print_instr(y);
 
   stringStream ss;
-  ss.print("Assertion %s %s %s in method %s", strStream1.as_string(), ip2.cond_name(cond), strStream2.as_string(), strStream.as_string());
+  ss.print("Assertion %s %s %s in method %s", strStream1.base(), ip2.cond_name(cond), strStream2.base(), strStream.base());
 
   _message = ss.as_string();
 }

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -975,7 +975,7 @@ Assert::Assert(Value x, Condition cond, bool unordered_is_true, Value y) : Instr
   ip2.print_instr(y);
 
   stringStream ss;
-  ss.print("Assertion %s %s %s in method %s", strStream1.base(), ip2.cond_name(cond), strStream2.base(), strStream.base());
+  ss.print("Assertion %s %s %s in method %s", strStream1.internal_string(), ip2.cond_name(cond), strStream2.internal_string(), strStream.internal_string());
 
   _message = ss.as_string();
 }

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -975,7 +975,7 @@ Assert::Assert(Value x, Condition cond, bool unordered_is_true, Value y) : Instr
   ip2.print_instr(y);
 
   stringStream ss;
-  ss.print("Assertion %s %s %s in method %s", strStream1.internal_string(), ip2.cond_name(cond), strStream2.internal_string(), strStream.internal_string());
+  ss.print("Assertion %s %s %s in method %s", strStream1.freeze(), ip2.cond_name(cond), strStream2.freeze(), strStream.freeze());
 
   _message = ss.as_string();
 }

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -147,7 +147,7 @@ void LIR_Assembler::emit_stubs(CodeStubList* stub_list) {
       stringStream st;
       s->print_name(&st);
       st.print(" slow case");
-      _masm->block_comment(st.as_string());
+      _masm->block_comment(st.base());
     }
 #endif
     s->emit_code(this);
@@ -262,7 +262,7 @@ void LIR_Assembler::emit_block(BlockBegin* block) {
   if (CommentedAssembly) {
     stringStream st;
     st.print_cr(" block B%d [%d, %d]", block->block_id(), block->bci(), block->end()->printable_bci());
-    _masm->block_comment(st.as_string());
+    _masm->block_comment(st.base());
   }
 #endif
 
@@ -292,7 +292,7 @@ void LIR_Assembler::emit_lir_list(LIR_List* list) {
           (op->code() == lir_leal && op->as_Op1()->patch_code() != lir_patch_none)) {
         stringStream st;
         op->print_on(&st);
-        _masm->block_comment(st.as_string());
+        _masm->block_comment(st.base());
       }
     }
     if (PrintLIRWithAssembly) {

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -147,7 +147,7 @@ void LIR_Assembler::emit_stubs(CodeStubList* stub_list) {
       stringStream st;
       s->print_name(&st);
       st.print(" slow case");
-      _masm->block_comment(st.base());
+      _masm->block_comment(st.internal_string());
     }
 #endif
     s->emit_code(this);
@@ -262,7 +262,7 @@ void LIR_Assembler::emit_block(BlockBegin* block) {
   if (CommentedAssembly) {
     stringStream st;
     st.print_cr(" block B%d [%d, %d]", block->block_id(), block->bci(), block->end()->printable_bci());
-    _masm->block_comment(st.base());
+    _masm->block_comment(st.internal_string());
   }
 #endif
 
@@ -292,7 +292,7 @@ void LIR_Assembler::emit_lir_list(LIR_List* list) {
           (op->code() == lir_leal && op->as_Op1()->patch_code() != lir_patch_none)) {
         stringStream st;
         op->print_on(&st);
-        _masm->block_comment(st.base());
+        _masm->block_comment(st.internal_string());
       }
     }
     if (PrintLIRWithAssembly) {

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -147,7 +147,7 @@ void LIR_Assembler::emit_stubs(CodeStubList* stub_list) {
       stringStream st;
       s->print_name(&st);
       st.print(" slow case");
-      _masm->block_comment(st.internal_string());
+      _masm->block_comment(st.freeze());
     }
 #endif
     s->emit_code(this);
@@ -262,7 +262,7 @@ void LIR_Assembler::emit_block(BlockBegin* block) {
   if (CommentedAssembly) {
     stringStream st;
     st.print_cr(" block B%d [%d, %d]", block->block_id(), block->bci(), block->end()->printable_bci());
-    _masm->block_comment(st.internal_string());
+    _masm->block_comment(st.freeze());
   }
 #endif
 
@@ -292,7 +292,7 @@ void LIR_Assembler::emit_lir_list(LIR_List* list) {
           (op->code() == lir_leal && op->as_Op1()->patch_code() != lir_patch_none)) {
         stringStream st;
         op->print_on(&st);
-        _masm->block_comment(st.internal_string());
+        _masm->block_comment(st.freeze());
       }
     }
     if (PrintLIRWithAssembly) {

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -559,7 +559,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
     tempst.print("C1 compiled method <%s>\n"
                  " at PC" INTPTR_FORMAT " for thread " INTPTR_FORMAT,
                  nm->method()->print_value_string(), p2i(pc), p2i(current));
-    Exceptions::log_exception(exception, tempst.base());
+    Exceptions::log_exception(exception, tempst.internal_string());
   }
   // for AbortVMOnException flag
   Exceptions::debug_check_abort(exception);
@@ -1463,7 +1463,7 @@ JRT_ENTRY(void, Runtime1::predicate_failed_trap(JavaThread* current))
     Method* inlinee = vfst.method();
     inlinee->print_short_name(&ss1);
     m->print_short_name(&ss2);
-    tty->print_cr("Predicate failed trap in method %s at bci %d inlined in %s at pc " INTPTR_FORMAT, ss1.base(), vfst.bci(), ss2.base(), p2i(caller_frame.pc()));
+    tty->print_cr("Predicate failed trap in method %s at bci %d inlined in %s at pc " INTPTR_FORMAT, ss1.internal_string(), vfst.bci(), ss2.internal_string(), p2i(caller_frame.pc()));
   }
 
 

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -553,13 +553,13 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
   // debugging support
   // tracing
   if (log_is_enabled(Info, exceptions)) {
-    ResourceMark rm;
+    ResourceMark rm; // print_value_string
     stringStream tempst;
     assert(nm->method() != NULL, "Unexpected NULL method()");
     tempst.print("C1 compiled method <%s>\n"
                  " at PC" INTPTR_FORMAT " for thread " INTPTR_FORMAT,
                  nm->method()->print_value_string(), p2i(pc), p2i(current));
-    Exceptions::log_exception(exception, tempst.as_string());
+    Exceptions::log_exception(exception, tempst.base());
   }
   // for AbortVMOnException flag
   Exceptions::debug_check_abort(exception);
@@ -1463,7 +1463,7 @@ JRT_ENTRY(void, Runtime1::predicate_failed_trap(JavaThread* current))
     Method* inlinee = vfst.method();
     inlinee->print_short_name(&ss1);
     m->print_short_name(&ss2);
-    tty->print_cr("Predicate failed trap in method %s at bci %d inlined in %s at pc " INTPTR_FORMAT, ss1.as_string(), vfst.bci(), ss2.as_string(), p2i(caller_frame.pc()));
+    tty->print_cr("Predicate failed trap in method %s at bci %d inlined in %s at pc " INTPTR_FORMAT, ss1.base(), vfst.bci(), ss2.base(), p2i(caller_frame.pc()));
   }
 
 

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -559,7 +559,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
     tempst.print("C1 compiled method <%s>\n"
                  " at PC" INTPTR_FORMAT " for thread " INTPTR_FORMAT,
                  nm->method()->print_value_string(), p2i(pc), p2i(current));
-    Exceptions::log_exception(exception, tempst.internal_string());
+    Exceptions::log_exception(exception, tempst.freeze());
   }
   // for AbortVMOnException flag
   Exceptions::debug_check_abort(exception);
@@ -1463,7 +1463,7 @@ JRT_ENTRY(void, Runtime1::predicate_failed_trap(JavaThread* current))
     Method* inlinee = vfst.method();
     inlinee->print_short_name(&ss1);
     m->print_short_name(&ss2);
-    tty->print_cr("Predicate failed trap in method %s at bci %d inlined in %s at pc " INTPTR_FORMAT, ss1.internal_string(), vfst.bci(), ss2.internal_string(), p2i(caller_frame.pc()));
+    tty->print_cr("Predicate failed trap in method %s at bci %d inlined in %s at pc " INTPTR_FORMAT, ss1.freeze(), vfst.bci(), ss2.freeze(), p2i(caller_frame.pc()));
   }
 
 

--- a/src/hotspot/share/classfile/classLoaderDataGraph.cpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.cpp
@@ -439,10 +439,10 @@ void ClassLoaderDataGraph::print_dictionary(outputStream* st) {
 
 void ClassLoaderDataGraph::print_table_statistics(outputStream* st) {
   FOR_ALL_DICTIONARY(cld) {
-    ResourceMark rm;
+    ResourceMark rm; // loader_name_and_id
     stringStream tempst;
     tempst.print("System Dictionary for %s class loader", cld->loader_name_and_id());
-    cld->dictionary()->print_table_statistics(st, tempst.as_string());
+    cld->dictionary()->print_table_statistics(st, tempst.base());
   }
 }
 

--- a/src/hotspot/share/classfile/classLoaderDataGraph.cpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.cpp
@@ -442,7 +442,7 @@ void ClassLoaderDataGraph::print_table_statistics(outputStream* st) {
     ResourceMark rm; // loader_name_and_id
     stringStream tempst;
     tempst.print("System Dictionary for %s class loader", cld->loader_name_and_id());
-    cld->dictionary()->print_table_statistics(st, tempst.base());
+    cld->dictionary()->print_table_statistics(st, tempst.internal_string());
   }
 }
 

--- a/src/hotspot/share/classfile/classLoaderDataGraph.cpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.cpp
@@ -442,7 +442,7 @@ void ClassLoaderDataGraph::print_table_statistics(outputStream* st) {
     ResourceMark rm; // loader_name_and_id
     stringStream tempst;
     tempst.print("System Dictionary for %s class loader", cld->loader_name_and_id());
-    cld->dictionary()->print_table_statistics(st, tempst.internal_string());
+    cld->dictionary()->print_table_statistics(st, tempst.freeze());
   }
 }
 

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1506,7 +1506,7 @@ void CodeCache::report_codemem_full(CodeBlobType code_blob_type, bool print) {
     }
     {
       ttyLocker ttyl;
-      tty->print("%s", s.internal_string());
+      tty->print("%s", s.freeze());
     }
 
     if (full_count == 1) {

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1476,14 +1476,13 @@ void CodeCache::report_codemem_full(CodeBlobType code_blob_type, bool print) {
   if ((full_count == 1) || print) {
     // Not yet reported for this heap, report
     if (SegmentedCodeCache) {
-      ResourceMark rm;
       stringStream msg1_stream, msg2_stream;
       msg1_stream.print("%s is full. Compiler has been disabled.",
                         get_code_heap_name(code_blob_type));
       msg2_stream.print("Try increasing the code heap size using -XX:%s=",
                  get_code_heap_flag_name(code_blob_type));
-      const char *msg1 = msg1_stream.as_string();
-      const char *msg2 = msg2_stream.as_string();
+      const char *msg1 = msg1_stream.base();
+      const char *msg2 = msg2_stream.base();
 
       log_warning(codecache)("%s", msg1);
       log_warning(codecache)("%s", msg2);
@@ -1498,7 +1497,6 @@ void CodeCache::report_codemem_full(CodeBlobType code_blob_type, bool print) {
       warning("%s", msg1);
       warning("%s", msg2);
     }
-    ResourceMark rm;
     stringStream s;
     // Dump code cache into a buffer before locking the tty.
     {
@@ -1507,7 +1505,7 @@ void CodeCache::report_codemem_full(CodeBlobType code_blob_type, bool print) {
     }
     {
       ttyLocker ttyl;
-      tty->print("%s", s.as_string());
+      tty->print("%s", s.base());
     }
 
     if (full_count == 1) {

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1506,7 +1506,7 @@ void CodeCache::report_codemem_full(CodeBlobType code_blob_type, bool print) {
     }
     {
       ttyLocker ttyl;
-      tty->print("%s", s.base());
+      tty->print("%s", s.internal_string());
     }
 
     if (full_count == 1) {

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1476,13 +1476,14 @@ void CodeCache::report_codemem_full(CodeBlobType code_blob_type, bool print) {
   if ((full_count == 1) || print) {
     // Not yet reported for this heap, report
     if (SegmentedCodeCache) {
+      ResourceMark rm;
       stringStream msg1_stream, msg2_stream;
       msg1_stream.print("%s is full. Compiler has been disabled.",
                         get_code_heap_name(code_blob_type));
       msg2_stream.print("Try increasing the code heap size using -XX:%s=",
                  get_code_heap_flag_name(code_blob_type));
-      const char *msg1 = msg1_stream.base();
-      const char *msg2 = msg2_stream.base();
+      const char *msg1 = msg1_stream.as_string();
+      const char *msg2 = msg2_stream.as_string();
 
       log_warning(codecache)("%s", msg1);
       log_warning(codecache)("%s", msg2);

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -552,7 +552,7 @@ void CompileQueue::print_tty() {
   print(&ss);
   {
     ttyLocker ttyl;
-    tty->print("%s", ss.internal_string());
+    tty->print("%s", ss.freeze());
   }
 }
 
@@ -2029,7 +2029,7 @@ static void codecache_print(bool detailed)
     CodeCache::print_summary(&s, detailed);
   }
   ttyLocker ttyl;
-  tty->print("%s", s.internal_string());
+  tty->print("%s", s.freeze());
 }
 
 // wrapper for CodeCache::print_summary() using outputStream
@@ -2355,7 +2355,7 @@ void CompileBroker::handle_full_code_cache(CodeBlobType code_blob_type) {
       // Lock to prevent tearing
       ttyLocker ttyl;
       xtty->begin_elem("code_cache_full");
-      xtty->print("%s", s.internal_string());
+      xtty->print("%s", s.freeze());
       xtty->stamp();
       xtty->end_elem();
     }

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -552,7 +552,7 @@ void CompileQueue::print_tty() {
   print(&ss);
   {
     ttyLocker ttyl;
-    tty->print("%s", ss.base());
+    tty->print("%s", ss.internal_string());
   }
 }
 
@@ -2029,7 +2029,7 @@ static void codecache_print(bool detailed)
     CodeCache::print_summary(&s, detailed);
   }
   ttyLocker ttyl;
-  tty->print("%s", s.base());
+  tty->print("%s", s.internal_string());
 }
 
 // wrapper for CodeCache::print_summary() using outputStream
@@ -2355,7 +2355,7 @@ void CompileBroker::handle_full_code_cache(CodeBlobType code_blob_type) {
       // Lock to prevent tearing
       ttyLocker ttyl;
       xtty->begin_elem("code_cache_full");
-      xtty->print("%s", s.base());
+      xtty->print("%s", s.internal_string());
       xtty->stamp();
       xtty->end_elem();
     }

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -547,13 +547,12 @@ void CompileQueue::print(outputStream* st) {
 }
 
 void CompileQueue::print_tty() {
-  ResourceMark rm;
   stringStream ss;
   // Dump the compile queue into a buffer before locking the tty
   print(&ss);
   {
     ttyLocker ttyl;
-    tty->print("%s", ss.as_string());
+    tty->print("%s", ss.base());
   }
 }
 
@@ -2023,7 +2022,6 @@ void CompileBroker::maybe_block() {
 // wrapper for CodeCache::print_summary()
 static void codecache_print(bool detailed)
 {
-  ResourceMark rm;
   stringStream s;
   // Dump code cache  into a buffer before locking the tty,
   {
@@ -2031,12 +2029,11 @@ static void codecache_print(bool detailed)
     CodeCache::print_summary(&s, detailed);
   }
   ttyLocker ttyl;
-  tty->print("%s", s.as_string());
+  tty->print("%s", s.base());
 }
 
 // wrapper for CodeCache::print_summary() using outputStream
 static void codecache_print(outputStream* out, bool detailed) {
-  ResourceMark rm;
   stringStream s;
 
   // Dump code cache into a buffer
@@ -2351,7 +2348,6 @@ void CompileBroker::handle_full_code_cache(CodeBlobType code_blob_type) {
   UseInterpreter = true;
   if (UseCompiler || AlwaysCompileLoopMethods ) {
     if (xtty != NULL) {
-      ResourceMark rm;
       stringStream s;
       // Dump code cache state into a buffer before locking the tty,
       // because log_state() will use locks causing lock conflicts.
@@ -2359,7 +2355,7 @@ void CompileBroker::handle_full_code_cache(CodeBlobType code_blob_type) {
       // Lock to prevent tearing
       ttyLocker ttyl;
       xtty->begin_elem("code_cache_full");
-      xtty->print("%s", s.as_string());
+      xtty->print("%s", s.base());
       xtty->stamp();
       xtty->end_elem();
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
@@ -48,7 +48,7 @@ void print_raw_memory(ShenandoahMessageBuffer &msg, void* loc) {
     stringStream ss;
     os::print_hex_dump(&ss, start, end, 4);
     msg.append("\n");
-    msg.append("Raw heap memory:\n%s", ss.internal_string());
+    msg.append("Raw heap memory:\n%s", ss.freeze());
   }
 }
 
@@ -71,8 +71,8 @@ void ShenandoahAsserts::print_obj(ShenandoahMessageBuffer& msg, oop obj) {
   msg.append("    %3s marked strong\n",              ctx->is_marked_strong(obj) ? "" : "not");
   msg.append("    %3s marked weak\n",                ctx->is_marked_weak(obj) ? "" : "not");
   msg.append("    %3s in collection set\n",          heap->in_collection_set(obj) ? "" : "not");
-  msg.append("  mark:%s\n", mw_ss.internal_string());
-  msg.append("  region: %s", ss.internal_string());
+  msg.append("  mark:%s\n", mw_ss.freeze());
+  msg.append("  region: %s", ss.freeze());
 }
 
 void ShenandoahAsserts::print_non_obj(ShenandoahMessageBuffer& msg, void* loc) {
@@ -84,12 +84,12 @@ void ShenandoahAsserts::print_non_obj(ShenandoahMessageBuffer& msg, void* loc) {
     r->print_on(&ss);
 
     msg.append("    %3s in collection set\n",    heap->in_collection_set_loc(loc) ? "" : "not");
-    msg.append("  region: %s", ss.internal_string());
+    msg.append("  region: %s", ss.freeze());
   } else {
     msg.append("  outside of Java heap\n");
     stringStream ss;
     os::print_location(&ss, (intptr_t) loc, false);
-    msg.append("  %s", ss.internal_string());
+    msg.append("  %s", ss.freeze());
   }
 }
 
@@ -101,7 +101,7 @@ void ShenandoahAsserts::print_obj_safe(ShenandoahMessageBuffer& msg, void* loc) 
     if (r != NULL) {
       stringStream ss;
       r->print_on(&ss);
-      msg.append("  region: %s", ss.internal_string());
+      msg.append("  region: %s", ss.freeze());
       print_raw_memory(msg, loc);
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
@@ -48,7 +48,7 @@ void print_raw_memory(ShenandoahMessageBuffer &msg, void* loc) {
     stringStream ss;
     os::print_hex_dump(&ss, start, end, 4);
     msg.append("\n");
-    msg.append("Raw heap memory:\n%s", ss.as_string());
+    msg.append("Raw heap memory:\n%s", ss.base());
   }
 }
 
@@ -71,8 +71,8 @@ void ShenandoahAsserts::print_obj(ShenandoahMessageBuffer& msg, oop obj) {
   msg.append("    %3s marked strong\n",              ctx->is_marked_strong(obj) ? "" : "not");
   msg.append("    %3s marked weak\n",                ctx->is_marked_weak(obj) ? "" : "not");
   msg.append("    %3s in collection set\n",          heap->in_collection_set(obj) ? "" : "not");
-  msg.append("  mark:%s\n", mw_ss.as_string());
-  msg.append("  region: %s", ss.as_string());
+  msg.append("  mark:%s\n", mw_ss.base());
+  msg.append("  region: %s", ss.base());
 }
 
 void ShenandoahAsserts::print_non_obj(ShenandoahMessageBuffer& msg, void* loc) {
@@ -84,12 +84,12 @@ void ShenandoahAsserts::print_non_obj(ShenandoahMessageBuffer& msg, void* loc) {
     r->print_on(&ss);
 
     msg.append("    %3s in collection set\n",    heap->in_collection_set_loc(loc) ? "" : "not");
-    msg.append("  region: %s", ss.as_string());
+    msg.append("  region: %s", ss.base());
   } else {
     msg.append("  outside of Java heap\n");
     stringStream ss;
     os::print_location(&ss, (intptr_t) loc, false);
-    msg.append("  %s", ss.as_string());
+    msg.append("  %s", ss.base());
   }
 }
 
@@ -101,7 +101,7 @@ void ShenandoahAsserts::print_obj_safe(ShenandoahMessageBuffer& msg, void* loc) 
     if (r != NULL) {
       stringStream ss;
       r->print_on(&ss);
-      msg.append("  region: %s", ss.as_string());
+      msg.append("  region: %s", ss.base());
       print_raw_memory(msg, loc);
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
@@ -48,7 +48,7 @@ void print_raw_memory(ShenandoahMessageBuffer &msg, void* loc) {
     stringStream ss;
     os::print_hex_dump(&ss, start, end, 4);
     msg.append("\n");
-    msg.append("Raw heap memory:\n%s", ss.base());
+    msg.append("Raw heap memory:\n%s", ss.internal_string());
   }
 }
 
@@ -71,8 +71,8 @@ void ShenandoahAsserts::print_obj(ShenandoahMessageBuffer& msg, oop obj) {
   msg.append("    %3s marked strong\n",              ctx->is_marked_strong(obj) ? "" : "not");
   msg.append("    %3s marked weak\n",                ctx->is_marked_weak(obj) ? "" : "not");
   msg.append("    %3s in collection set\n",          heap->in_collection_set(obj) ? "" : "not");
-  msg.append("  mark:%s\n", mw_ss.base());
-  msg.append("  region: %s", ss.base());
+  msg.append("  mark:%s\n", mw_ss.internal_string());
+  msg.append("  region: %s", ss.internal_string());
 }
 
 void ShenandoahAsserts::print_non_obj(ShenandoahMessageBuffer& msg, void* loc) {
@@ -84,12 +84,12 @@ void ShenandoahAsserts::print_non_obj(ShenandoahMessageBuffer& msg, void* loc) {
     r->print_on(&ss);
 
     msg.append("    %3s in collection set\n",    heap->in_collection_set_loc(loc) ? "" : "not");
-    msg.append("  region: %s", ss.base());
+    msg.append("  region: %s", ss.internal_string());
   } else {
     msg.append("  outside of Java heap\n");
     stringStream ss;
     os::print_location(&ss, (intptr_t) loc, false);
-    msg.append("  %s", ss.base());
+    msg.append("  %s", ss.internal_string());
   }
 }
 
@@ -101,7 +101,7 @@ void ShenandoahAsserts::print_obj_safe(ShenandoahMessageBuffer& msg, void* loc) 
     if (r != NULL) {
       stringStream ss;
       r->print_on(&ss);
-      msg.append("  region: %s", ss.base());
+      msg.append("  region: %s", ss.internal_string());
       print_raw_memory(msg, loc);
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -80,7 +80,7 @@ void ShenandoahHeapRegion::report_illegal_transition(const char *method) {
   stringStream ss;
   ss.print("Illegal region state transition from \"%s\", at %s\n  ", region_state_to_string(_state), method);
   print_on(&ss);
-  fatal("%s", ss.base());
+  fatal("%s", ss.internal_string());
 }
 
 void ShenandoahHeapRegion::make_regular_allocation() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -77,11 +77,10 @@ ShenandoahHeapRegion::ShenandoahHeapRegion(HeapWord* start, size_t index, bool c
 }
 
 void ShenandoahHeapRegion::report_illegal_transition(const char *method) {
-  ResourceMark rm;
   stringStream ss;
   ss.print("Illegal region state transition from \"%s\", at %s\n  ", region_state_to_string(_state), method);
   print_on(&ss);
-  fatal("%s", ss.as_string());
+  fatal("%s", ss.base());
 }
 
 void ShenandoahHeapRegion::make_regular_allocation() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -80,7 +80,7 @@ void ShenandoahHeapRegion::report_illegal_transition(const char *method) {
   stringStream ss;
   ss.print("Illegal region state transition from \"%s\", at %s\n  ", region_state_to_string(_state), method);
   print_on(&ss);
-  fatal("%s", ss.internal_string());
+  fatal("%s", ss.freeze());
 }
 
 void ShenandoahHeapRegion::make_regular_allocation() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahNMethod.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNMethod.cpp
@@ -250,7 +250,7 @@ void ShenandoahNMethod::assert_same_oops(bool allow_dead) {
       debug_stream.print_cr("-> " PTR_FORMAT, p2i(check.at(i)));
     }
     fatal("Must match #detected: %d, #recorded: %d, #total: %d, begin: " PTR_FORMAT ", end: " PTR_FORMAT "\n%s",
-          oops->length(), _oops_count, count, p2i(nm()->oops_begin()), p2i(nm()->oops_end()), debug_stream.base());
+          oops->length(), _oops_count, count, p2i(nm()->oops_begin()), p2i(nm()->oops_end()), debug_stream.internal_string());
   }
 }
 #endif

--- a/src/hotspot/share/gc/shenandoah/shenandoahNMethod.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNMethod.cpp
@@ -250,7 +250,7 @@ void ShenandoahNMethod::assert_same_oops(bool allow_dead) {
       debug_stream.print_cr("-> " PTR_FORMAT, p2i(check.at(i)));
     }
     fatal("Must match #detected: %d, #recorded: %d, #total: %d, begin: " PTR_FORMAT ", end: " PTR_FORMAT "\n%s",
-          oops->length(), _oops_count, count, p2i(nm()->oops_begin()), p2i(nm()->oops_end()), debug_stream.as_string());
+          oops->length(), _oops_count, count, p2i(nm()->oops_begin()), p2i(nm()->oops_end()), debug_stream.base());
   }
 }
 #endif

--- a/src/hotspot/share/gc/shenandoah/shenandoahNMethod.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNMethod.cpp
@@ -250,7 +250,7 @@ void ShenandoahNMethod::assert_same_oops(bool allow_dead) {
       debug_stream.print_cr("-> " PTR_FORMAT, p2i(check.at(i)));
     }
     fatal("Must match #detected: %d, #recorded: %d, #total: %d, begin: " PTR_FORMAT ", end: " PTR_FORMAT "\n%s",
-          oops->length(), _oops_count, count, p2i(nm()->oops_begin()), p2i(nm()->oops_end()), debug_stream.internal_string());
+          oops->length(), _oops_count, count, p2i(nm()->oops_begin()), p2i(nm()->oops_end()), debug_stream.freeze());
   }
 }
 #endif

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -768,7 +768,7 @@ void ShenandoahVerifier::verify_at_safepoint(const char *label,
         stringStream ss;
         r->print_on(&ss);
         fatal("%s: Live data should match: region-live = " SIZE_FORMAT ", verifier-live = " UINT32_FORMAT "\n%s",
-              label, reg_live, verf_live, ss.base());
+              label, reg_live, verf_live, ss.internal_string());
       }
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -765,11 +765,10 @@ void ShenandoahVerifier::verify_at_safepoint(const char *label,
 
       size_t reg_live = r->get_live_data_words();
       if (reg_live != verf_live) {
-        ResourceMark rm;
         stringStream ss;
         r->print_on(&ss);
         fatal("%s: Live data should match: region-live = " SIZE_FORMAT ", verifier-live = " UINT32_FORMAT "\n%s",
-              label, reg_live, verf_live, ss.as_string());
+              label, reg_live, verf_live, ss.base());
       }
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -768,7 +768,7 @@ void ShenandoahVerifier::verify_at_safepoint(const char *label,
         stringStream ss;
         r->print_on(&ss);
         fatal("%s: Live data should match: region-live = " SIZE_FORMAT ", verifier-live = " UINT32_FORMAT "\n%s",
-              label, reg_live, verf_live, ss.internal_string());
+              label, reg_live, verf_live, ss.freeze());
       }
     }
   }

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -963,7 +963,7 @@ C2V_VMENTRY_0(jint, installCode0, (JNIEnv *env, jobject,
       CodeCache::print_summary(&s, false);
     }
     ttyLocker ttyl;
-    tty->print_raw_cr(s.as_string());
+    tty->print_raw_cr(s.base());
   }
 
   if (result != JVMCI::ok) {

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -963,7 +963,7 @@ C2V_VMENTRY_0(jint, installCode0, (JNIEnv *env, jobject,
       CodeCache::print_summary(&s, false);
     }
     ttyLocker ttyl;
-    tty->print_raw_cr(s.internal_string());
+    tty->print_raw_cr(s.freeze());
   }
 
   if (result != JVMCI::ok) {

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -963,7 +963,7 @@ C2V_VMENTRY_0(jint, installCode0, (JNIEnv *env, jobject,
       CodeCache::print_summary(&s, false);
     }
     ttyLocker ttyl;
-    tty->print_raw_cr(s.base());
+    tty->print_raw_cr(s.internal_string());
   }
 
   if (result != JVMCI::ok) {

--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -248,7 +248,7 @@ const Type* CastIINode::Value(PhaseGVN* phase) const {
             } else {
               stringStream ss;
               test.dump_on(&ss);
-              fatal("unexpected comparison %s", ss.internal_string());
+              fatal("unexpected comparison %s", ss.freeze());
             }
             int lo_int = (int)lo_long;
             int hi_int = (int)hi_long;

--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -248,7 +248,7 @@ const Type* CastIINode::Value(PhaseGVN* phase) const {
             } else {
               stringStream ss;
               test.dump_on(&ss);
-              fatal("unexpected comparison %s", ss.as_string());
+              fatal("unexpected comparison %s", ss.base());
             }
             int lo_int = (int)lo_long;
             int hi_int = (int)hi_long;

--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -248,7 +248,7 @@ const Type* CastIINode::Value(PhaseGVN* phase) const {
             } else {
               stringStream ss;
               test.dump_on(&ss);
-              fatal("unexpected comparison %s", ss.base());
+              fatal("unexpected comparison %s", ss.internal_string());
             }
             int lo_int = (int)lo_long;
             int hi_int = (int)hi_long;

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4499,7 +4499,7 @@ void Compile::process_print_inlining() {
     assert(_print_inlining_list != NULL, "process_print_inlining should be called only once.");
     for (int i = 0; i < _print_inlining_list->length(); i++) {
       PrintInliningBuffer* pib = _print_inlining_list->at(i);
-      ss.print("%s", pib->ss()->internal_string());
+      ss.print("%s", pib->ss()->freeze());
       delete pib;
       DEBUG_ONLY(_print_inlining_list->at_put(i, NULL));
     }
@@ -4510,7 +4510,7 @@ void Compile::process_print_inlining() {
     print_inlining_stream_free();
     size_t end = ss.size();
     _print_inlining_output = NEW_ARENA_ARRAY(comp_arena(), char, end+1);
-    strncpy(_print_inlining_output, ss.internal_string(), end+1);
+    strncpy(_print_inlining_output, ss.freeze(), end+1);
     _print_inlining_output[end] = 0;
   }
 }

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4499,7 +4499,7 @@ void Compile::process_print_inlining() {
     assert(_print_inlining_list != NULL, "process_print_inlining should be called only once.");
     for (int i = 0; i < _print_inlining_list->length(); i++) {
       PrintInliningBuffer* pib = _print_inlining_list->at(i);
-      ss.print("%s", pib->ss()->base());
+      ss.print("%s", pib->ss()->internal_string());
       delete pib;
       DEBUG_ONLY(_print_inlining_list->at_put(i, NULL));
     }
@@ -4510,7 +4510,7 @@ void Compile::process_print_inlining() {
     print_inlining_stream_free();
     size_t end = ss.size();
     _print_inlining_output = NEW_ARENA_ARRAY(comp_arena(), char, end+1);
-    strncpy(_print_inlining_output, ss.base(), end+1);
+    strncpy(_print_inlining_output, ss.internal_string(), end+1);
     _print_inlining_output[end] = 0;
   }
 }

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4499,7 +4499,7 @@ void Compile::process_print_inlining() {
     assert(_print_inlining_list != NULL, "process_print_inlining should be called only once.");
     for (int i = 0; i < _print_inlining_list->length(); i++) {
       PrintInliningBuffer* pib = _print_inlining_list->at(i);
-      ss.print("%s", pib->ss()->as_string());
+      ss.print("%s", pib->ss()->base());
       delete pib;
       DEBUG_ONLY(_print_inlining_list->at_put(i, NULL));
     }

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -491,7 +491,7 @@ class Compile : public Phase {
   void print_inlining(ciMethod* method, int inline_level, int bci, const char* msg = NULL) {
     stringStream ss;
     CompileTask::print_inlining_inner(&ss, method, inline_level, bci, msg);
-    print_inlining_stream()->print("%s", ss.base());
+    print_inlining_stream()->print("%s", ss.internal_string());
   }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -491,7 +491,7 @@ class Compile : public Phase {
   void print_inlining(ciMethod* method, int inline_level, int bci, const char* msg = NULL) {
     stringStream ss;
     CompileTask::print_inlining_inner(&ss, method, inline_level, bci, msg);
-    print_inlining_stream()->print("%s", ss.as_string());
+    print_inlining_stream()->print("%s", ss.base());
   }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -491,7 +491,7 @@ class Compile : public Phase {
   void print_inlining(ciMethod* method, int inline_level, int bci, const char* msg = NULL) {
     stringStream ss;
     CompileTask::print_inlining_inner(&ss, method, inline_level, bci, msg);
-    print_inlining_stream()->print("%s", ss.internal_string());
+    print_inlining_stream()->print("%s", ss.freeze());
   }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -62,7 +62,7 @@ void trace_type_profile(Compile* C, ciMethod *method, int depth, int bci, ciMeth
     out->print(" \\-> TypeProfile (%d/%d counts) = ", receiver_count, site_count);
     stringStream ss;
     prof_klass->name()->print_symbol_on(&ss);
-    out->print("%s", ss.internal_string());
+    out->print("%s", ss.freeze());
     out->cr();
   }
 }

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -62,7 +62,7 @@ void trace_type_profile(Compile* C, ciMethod *method, int depth, int bci, ciMeth
     out->print(" \\-> TypeProfile (%d/%d counts) = ", receiver_count, site_count);
     stringStream ss;
     prof_klass->name()->print_symbol_on(&ss);
-    out->print("%s", ss.base());
+    out->print("%s", ss.internal_string());
     out->cr();
   }
 }

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -62,7 +62,7 @@ void trace_type_profile(Compile* C, ciMethod *method, int depth, int bci, ciMeth
     out->print(" \\-> TypeProfile (%d/%d counts) = ", receiver_count, site_count);
     stringStream ss;
     prof_klass->name()->print_symbol_on(&ss);
-    out->print("%s", ss.as_string());
+    out->print("%s", ss.base());
     out->cr();
   }
 }

--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -201,7 +201,7 @@ void IdealGraphPrinter::end_head() {
 void IdealGraphPrinter::print_attr(const char *name, intptr_t val) {
   stringStream stream;
   stream.print(INTX_FORMAT, val);
-  print_attr(name, stream.base());
+  print_attr(name, stream.internal_string());
 }
 
 void IdealGraphPrinter::print_attr(const char *name, const char *val) {
@@ -225,7 +225,7 @@ void IdealGraphPrinter::text(const char *s) {
 void IdealGraphPrinter::print_prop(const char *name, int val) {
   stringStream stream;
   stream.print("%d", val);
-  print_prop(name, stream.base());
+  print_prop(name, stream.internal_string());
 }
 
 void IdealGraphPrinter::print_prop(const char *name, const char *val) {
@@ -246,7 +246,7 @@ void IdealGraphPrinter::print_method(ciMethod *method, int bci, InlineTree *tree
   method->print_short_name(&shortStr);
 
   print_attr(METHOD_NAME_PROPERTY, str.base());
-  print_attr(METHOD_SHORT_NAME_PROPERTY, shortStr.base());
+  print_attr(METHOD_SHORT_NAME_PROPERTY, shortStr.internal_string());
   print_attr(METHOD_BCI_PROPERTY, bci);
 
   end_head();
@@ -305,7 +305,7 @@ void IdealGraphPrinter::begin_method() {
   // Add method name
   stringStream strStream;
   method->print_name(&strStream);
-  print_prop(METHOD_NAME_PROPERTY, strStream.base());
+  print_prop(METHOD_NAME_PROPERTY, strStream.internal_string());
 
   if (method->flags().is_public()) {
     print_prop(METHOD_IS_PUBLIC_PROPERTY, TRUE_VALUE);
@@ -318,7 +318,7 @@ void IdealGraphPrinter::begin_method() {
   if (C->is_osr_compilation()) {
       stringStream ss;
       ss.print("bci: %d, line: %d", C->entry_bci(), method->line_number_from_bci(C->entry_bci()));
-      print_prop(COMPILATION_OSR_PROPERTY, ss.base());
+      print_prop(COMPILATION_OSR_PROPERTY, ss.internal_string());
   }
 
   print_prop(COMPILATION_ID_PROPERTY, C->compile_id());
@@ -601,7 +601,7 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
         bciStream.print("%d ", caller->bci());
         caller = caller->caller();
       }
-      print_prop("bci", bciStream.base());
+      print_prop("bci", bciStream.internal_string());
       if (last != NULL && last->has_linenumber_table() && last_bci >= 0) {
         print_prop("line", last->line_number_from_bci(last_bci));
       }
@@ -611,7 +611,7 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
     if (node->debug_orig() != NULL) {
       stringStream dorigStream;
       node->dump_orig(&dorigStream, false);
-      print_prop("debug_orig", dorigStream.base());
+      print_prop("debug_orig", dorigStream.internal_string());
     }
 #endif
 

--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -201,7 +201,7 @@ void IdealGraphPrinter::end_head() {
 void IdealGraphPrinter::print_attr(const char *name, intptr_t val) {
   stringStream stream;
   stream.print(INTX_FORMAT, val);
-  print_attr(name, stream.as_string());
+  print_attr(name, stream.base());
 }
 
 void IdealGraphPrinter::print_attr(const char *name, const char *val) {
@@ -225,7 +225,7 @@ void IdealGraphPrinter::text(const char *s) {
 void IdealGraphPrinter::print_prop(const char *name, int val) {
   stringStream stream;
   stream.print("%d", val);
-  print_prop(name, stream.as_string());
+  print_prop(name, stream.base());
 }
 
 void IdealGraphPrinter::print_prop(const char *name, const char *val) {
@@ -245,8 +245,8 @@ void IdealGraphPrinter::print_method(ciMethod *method, int bci, InlineTree *tree
   stringStream shortStr;
   method->print_short_name(&shortStr);
 
-  print_attr(METHOD_NAME_PROPERTY, str.as_string());
-  print_attr(METHOD_SHORT_NAME_PROPERTY, shortStr.as_string());
+  print_attr(METHOD_NAME_PROPERTY, str.base());
+  print_attr(METHOD_SHORT_NAME_PROPERTY, shortStr.base());
   print_attr(METHOD_BCI_PROPERTY, bci);
 
   end_head();
@@ -305,7 +305,7 @@ void IdealGraphPrinter::begin_method() {
   // Add method name
   stringStream strStream;
   method->print_name(&strStream);
-  print_prop(METHOD_NAME_PROPERTY, strStream.as_string());
+  print_prop(METHOD_NAME_PROPERTY, strStream.base());
 
   if (method->flags().is_public()) {
     print_prop(METHOD_IS_PUBLIC_PROPERTY, TRUE_VALUE);
@@ -318,7 +318,7 @@ void IdealGraphPrinter::begin_method() {
   if (C->is_osr_compilation()) {
       stringStream ss;
       ss.print("bci: %d, line: %d", C->entry_bci(), method->line_number_from_bci(C->entry_bci()));
-      print_prop(COMPILATION_OSR_PROPERTY, ss.as_string());
+      print_prop(COMPILATION_OSR_PROPERTY, ss.base());
   }
 
   print_prop(COMPILATION_ID_PROPERTY, C->compile_id());
@@ -601,7 +601,7 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
         bciStream.print("%d ", caller->bci());
         caller = caller->caller();
       }
-      print_prop("bci", bciStream.as_string());
+      print_prop("bci", bciStream.base());
       if (last != NULL && last->has_linenumber_table() && last_bci >= 0) {
         print_prop("line", last->line_number_from_bci(last_bci));
       }
@@ -611,7 +611,7 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
     if (node->debug_orig() != NULL) {
       stringStream dorigStream;
       node->dump_orig(&dorigStream, false);
-      print_prop("debug_orig", dorigStream.as_string());
+      print_prop("debug_orig", dorigStream.base());
     }
 #endif
 

--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -245,7 +245,7 @@ void IdealGraphPrinter::print_method(ciMethod *method, int bci, InlineTree *tree
   stringStream shortStr;
   method->print_short_name(&shortStr);
 
-  print_attr(METHOD_NAME_PROPERTY, str.base());
+  print_attr(METHOD_NAME_PROPERTY, str.internal_string());
   print_attr(METHOD_SHORT_NAME_PROPERTY, shortStr.internal_string());
   print_attr(METHOD_BCI_PROPERTY, bci);
 

--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -201,7 +201,7 @@ void IdealGraphPrinter::end_head() {
 void IdealGraphPrinter::print_attr(const char *name, intptr_t val) {
   stringStream stream;
   stream.print(INTX_FORMAT, val);
-  print_attr(name, stream.internal_string());
+  print_attr(name, stream.freeze());
 }
 
 void IdealGraphPrinter::print_attr(const char *name, const char *val) {
@@ -225,7 +225,7 @@ void IdealGraphPrinter::text(const char *s) {
 void IdealGraphPrinter::print_prop(const char *name, int val) {
   stringStream stream;
   stream.print("%d", val);
-  print_prop(name, stream.internal_string());
+  print_prop(name, stream.freeze());
 }
 
 void IdealGraphPrinter::print_prop(const char *name, const char *val) {
@@ -245,8 +245,8 @@ void IdealGraphPrinter::print_method(ciMethod *method, int bci, InlineTree *tree
   stringStream shortStr;
   method->print_short_name(&shortStr);
 
-  print_attr(METHOD_NAME_PROPERTY, str.internal_string());
-  print_attr(METHOD_SHORT_NAME_PROPERTY, shortStr.internal_string());
+  print_attr(METHOD_NAME_PROPERTY, str.freeze());
+  print_attr(METHOD_SHORT_NAME_PROPERTY, shortStr.freeze());
   print_attr(METHOD_BCI_PROPERTY, bci);
 
   end_head();
@@ -305,7 +305,7 @@ void IdealGraphPrinter::begin_method() {
   // Add method name
   stringStream strStream;
   method->print_name(&strStream);
-  print_prop(METHOD_NAME_PROPERTY, strStream.internal_string());
+  print_prop(METHOD_NAME_PROPERTY, strStream.freeze());
 
   if (method->flags().is_public()) {
     print_prop(METHOD_IS_PUBLIC_PROPERTY, TRUE_VALUE);
@@ -318,7 +318,7 @@ void IdealGraphPrinter::begin_method() {
   if (C->is_osr_compilation()) {
       stringStream ss;
       ss.print("bci: %d, line: %d", C->entry_bci(), method->line_number_from_bci(C->entry_bci()));
-      print_prop(COMPILATION_OSR_PROPERTY, ss.internal_string());
+      print_prop(COMPILATION_OSR_PROPERTY, ss.freeze());
   }
 
   print_prop(COMPILATION_ID_PROPERTY, C->compile_id());
@@ -601,7 +601,7 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
         bciStream.print("%d ", caller->bci());
         caller = caller->caller();
       }
-      print_prop("bci", bciStream.internal_string());
+      print_prop("bci", bciStream.freeze());
       if (last != NULL && last->has_linenumber_table() && last_bci >= 0) {
         print_prop("line", last->line_number_from_bci(last_bci));
       }
@@ -611,7 +611,7 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
     if (node->debug_orig() != NULL) {
       stringStream dorigStream;
       node->dump_orig(&dorigStream, false);
-      print_prop("debug_orig", dorigStream.internal_string());
+      print_prop("debug_orig", dorigStream.freeze());
     }
 #endif
 

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -154,7 +154,7 @@ JVMState* LibraryIntrinsic::generate(JVMState* jvms) {
     msg_stream.print("Did not generate intrinsic %s%s at bci:%d in",
                      vmIntrinsics::name_at(intrinsic_id()),
                      is_virtual() ? " (virtual)" : "", bci);
-    const char *msg = msg_stream.internal_string();
+    const char *msg = msg_stream.freeze();
     log_debug(jit, inlining)("%s", msg);
     if (C->print_intrinsics() || C->print_inlining()) {
       tty->print("%s", msg);
@@ -215,7 +215,7 @@ Node* LibraryIntrinsic::generate_predicate(JVMState* jvms, int predicate) {
     msg_stream.print("Did not generate intrinsic %s%s at bci:%d in",
                      vmIntrinsics::name_at(intrinsic_id()),
                      is_virtual() ? " (virtual)" : "", bci);
-    const char *msg = msg_stream.internal_string();
+    const char *msg = msg_stream.freeze();
     log_debug(jit, inlining)("%s", msg);
     if (C->print_intrinsics() || C->print_inlining()) {
       C->print_inlining_stream()->print("%s", msg);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -154,7 +154,7 @@ JVMState* LibraryIntrinsic::generate(JVMState* jvms) {
     msg_stream.print("Did not generate intrinsic %s%s at bci:%d in",
                      vmIntrinsics::name_at(intrinsic_id()),
                      is_virtual() ? " (virtual)" : "", bci);
-    const char *msg = msg_stream.base();
+    const char *msg = msg_stream.internal_string();
     log_debug(jit, inlining)("%s", msg);
     if (C->print_intrinsics() || C->print_inlining()) {
       tty->print("%s", msg);
@@ -215,7 +215,7 @@ Node* LibraryIntrinsic::generate_predicate(JVMState* jvms, int predicate) {
     msg_stream.print("Did not generate intrinsic %s%s at bci:%d in",
                      vmIntrinsics::name_at(intrinsic_id()),
                      is_virtual() ? " (virtual)" : "", bci);
-    const char *msg = msg_stream.base();
+    const char *msg = msg_stream.internal_string();
     log_debug(jit, inlining)("%s", msg);
     if (C->print_intrinsics() || C->print_inlining()) {
       C->print_inlining_stream()->print("%s", msg);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -154,7 +154,7 @@ JVMState* LibraryIntrinsic::generate(JVMState* jvms) {
     msg_stream.print("Did not generate intrinsic %s%s at bci:%d in",
                      vmIntrinsics::name_at(intrinsic_id()),
                      is_virtual() ? " (virtual)" : "", bci);
-    const char *msg = msg_stream.as_string();
+    const char *msg = msg_stream.base();
     log_debug(jit, inlining)("%s", msg);
     if (C->print_intrinsics() || C->print_inlining()) {
       tty->print("%s", msg);
@@ -215,7 +215,7 @@ Node* LibraryIntrinsic::generate_predicate(JVMState* jvms, int predicate) {
     msg_stream.print("Did not generate intrinsic %s%s at bci:%d in",
                      vmIntrinsics::name_at(intrinsic_id()),
                      is_virtual() ? " (virtual)" : "", bci);
-    const char *msg = msg_stream.as_string();
+    const char *msg = msg_stream.base();
     log_debug(jit, inlining)("%s", msg);
     if (C->print_intrinsics() || C->print_inlining()) {
       C->print_inlining_stream()->print("%s", msg);

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1472,7 +1472,7 @@ void PhaseOutput::fill_buffer(CodeBuffer* cb, uint* blk_starts) {
     if (!block->is_connector()) {
       stringStream st;
       block->dump_head(C->cfg(), &st);
-      MacroAssembler(cb).block_comment(st.internal_string());
+      MacroAssembler(cb).block_comment(st.freeze());
     }
     jmp_target[i] = 0;
     jmp_offset[i] = 0;
@@ -1925,13 +1925,13 @@ void PhaseOutput::fill_buffer(CodeBuffer* cb, uint* blk_starts) {
       }
       if (C->method() != NULL) {
         tty->print_cr("----------------------- MetaData before Compile_id = %d ------------------------", C->compile_id());
-        tty->print_raw(method_metadata_str.internal_string());
+        tty->print_raw(method_metadata_str.freeze());
       } else if (C->stub_name() != NULL) {
         tty->print_cr("----------------------------- RuntimeStub %s -------------------------------", C->stub_name());
       }
       tty->cr();
       tty->print_cr("------------------------ OptoAssembly for Compile_id = %d -----------------------", C->compile_id());
-      tty->print_raw(dump_asm_str.internal_string());
+      tty->print_raw(dump_asm_str.freeze());
       tty->print_cr("--------------------------------------------------------------------------------");
       if (xtty != NULL) {
         xtty->tail("opto_assembly");

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1472,7 +1472,7 @@ void PhaseOutput::fill_buffer(CodeBuffer* cb, uint* blk_starts) {
     if (!block->is_connector()) {
       stringStream st;
       block->dump_head(C->cfg(), &st);
-      MacroAssembler(cb).block_comment(st.base());
+      MacroAssembler(cb).block_comment(st.internal_string());
     }
     jmp_target[i] = 0;
     jmp_offset[i] = 0;
@@ -1925,13 +1925,13 @@ void PhaseOutput::fill_buffer(CodeBuffer* cb, uint* blk_starts) {
       }
       if (C->method() != NULL) {
         tty->print_cr("----------------------- MetaData before Compile_id = %d ------------------------", C->compile_id());
-        tty->print_raw(method_metadata_str.base());
+        tty->print_raw(method_metadata_str.internal_string());
       } else if (C->stub_name() != NULL) {
         tty->print_cr("----------------------------- RuntimeStub %s -------------------------------", C->stub_name());
       }
       tty->cr();
       tty->print_cr("------------------------ OptoAssembly for Compile_id = %d -----------------------", C->compile_id());
-      tty->print_raw(dump_asm_str.base());
+      tty->print_raw(dump_asm_str.internal_string());
       tty->print_cr("--------------------------------------------------------------------------------");
       if (xtty != NULL) {
         xtty->tail("opto_assembly");

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1472,7 +1472,7 @@ void PhaseOutput::fill_buffer(CodeBuffer* cb, uint* blk_starts) {
     if (!block->is_connector()) {
       stringStream st;
       block->dump_head(C->cfg(), &st);
-      MacroAssembler(cb).block_comment(st.as_string());
+      MacroAssembler(cb).block_comment(st.base());
     }
     jmp_target[i] = 0;
     jmp_offset[i] = 0;
@@ -1925,13 +1925,13 @@ void PhaseOutput::fill_buffer(CodeBuffer* cb, uint* blk_starts) {
       }
       if (C->method() != NULL) {
         tty->print_cr("----------------------- MetaData before Compile_id = %d ------------------------", C->compile_id());
-        tty->print_raw(method_metadata_str.as_string());
+        tty->print_raw(method_metadata_str.base());
       } else if (C->stub_name() != NULL) {
         tty->print_cr("----------------------------- RuntimeStub %s -------------------------------", C->stub_name());
       }
       tty->cr();
       tty->print_cr("------------------------ OptoAssembly for Compile_id = %d -----------------------", C->compile_id());
-      tty->print_raw(dump_asm_str.as_string());
+      tty->print_raw(dump_asm_str.base());
       tty->print_cr("--------------------------------------------------------------------------------");
       if (xtty != NULL) {
         xtty->tail("opto_assembly");

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -1720,9 +1720,9 @@ NamedCounter* OptoRuntime::new_named_counter(JVMState* youngest_jvms, NamedCount
   }
   NamedCounter* c;
   if (tag == NamedCounter::RTMLockingCounter) {
-    c = new RTMLockingNamedCounter(st.base());
+    c = new RTMLockingNamedCounter(st.internal_string());
   } else {
-    c = new NamedCounter(st.base(), tag);
+    c = new NamedCounter(st.internal_string(), tag);
   }
 
   // atomically add the new counter to the head of the list.  We only
@@ -1756,5 +1756,5 @@ static void trace_exception(outputStream* st, oop exception_oop, address excepti
   tempst.print(" at " INTPTR_FORMAT,  p2i(exception_pc));
   tempst.print("]");
 
-  st->print_raw_cr(tempst.base());
+  st->print_raw_cr(tempst.internal_string());
 }

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -1720,9 +1720,9 @@ NamedCounter* OptoRuntime::new_named_counter(JVMState* youngest_jvms, NamedCount
   }
   NamedCounter* c;
   if (tag == NamedCounter::RTMLockingCounter) {
-    c = new RTMLockingNamedCounter(st.internal_string());
+    c = new RTMLockingNamedCounter(st.freeze());
   } else {
-    c = new NamedCounter(st.internal_string(), tag);
+    c = new NamedCounter(st.freeze(), tag);
   }
 
   // atomically add the new counter to the head of the list.  We only
@@ -1756,5 +1756,5 @@ static void trace_exception(outputStream* st, oop exception_oop, address excepti
   tempst.print(" at " INTPTR_FORMAT,  p2i(exception_pc));
   tempst.print("]");
 
-  st->print_raw_cr(tempst.internal_string());
+  st->print_raw_cr(tempst.freeze());
 }

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -1720,9 +1720,9 @@ NamedCounter* OptoRuntime::new_named_counter(JVMState* youngest_jvms, NamedCount
   }
   NamedCounter* c;
   if (tag == NamedCounter::RTMLockingCounter) {
-    c = new RTMLockingNamedCounter(st.as_string());
+    c = new RTMLockingNamedCounter(st.base());
   } else {
-    c = new NamedCounter(st.as_string(), tag);
+    c = new NamedCounter(st.base(), tag);
   }
 
   // atomically add the new counter to the head of the list.  We only
@@ -1756,5 +1756,5 @@ static void trace_exception(outputStream* st, oop exception_oop, address excepti
   tempst.print(" at " INTPTR_FORMAT,  p2i(exception_pc));
   tempst.print("]");
 
-  st->print_raw_cr(tempst.as_string());
+  st->print_raw_cr(tempst.base());
 }

--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -182,7 +182,7 @@ Handle VectorSupport::allocate_vector_payload(InstanceKlass* ik, frame* fr, Regi
   } else if (!payload->is_object() && !payload->is_constant_oop()) {
     stringStream ss;
     payload->print_on(&ss);
-    assert(false, "expected 'object' value for scalar-replaced boxed vector but got: %s", ss.as_string());
+    assert(false, "expected 'object' value for scalar-replaced boxed vector but got: %s", ss.base());
 #endif
   }
   return Handle(THREAD, nullptr);

--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -182,7 +182,7 @@ Handle VectorSupport::allocate_vector_payload(InstanceKlass* ik, frame* fr, Regi
   } else if (!payload->is_object() && !payload->is_constant_oop()) {
     stringStream ss;
     payload->print_on(&ss);
-    assert(false, "expected 'object' value for scalar-replaced boxed vector but got: %s", ss.base());
+    assert(false, "expected 'object' value for scalar-replaced boxed vector but got: %s", ss.internal_string());
 #endif
   }
   return Handle(THREAD, nullptr);

--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -182,7 +182,7 @@ Handle VectorSupport::allocate_vector_payload(InstanceKlass* ik, frame* fr, Regi
   } else if (!payload->is_object() && !payload->is_constant_oop()) {
     stringStream ss;
     payload->print_on(&ss);
-    assert(false, "expected 'object' value for scalar-replaced boxed vector but got: %s", ss.internal_string());
+    assert(false, "expected 'object' value for scalar-replaced boxed vector but got: %s", ss.freeze());
 #endif
   }
   return Handle(THREAD, nullptr);

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -2462,7 +2462,7 @@ WB_ENTRY(void, WB_VerifyFrames(JNIEnv* env, jobject wb, jboolean log, jboolean u
   }
   if (log) {
     tty->print_cr("[WhiteBox::VerifyFrames] Walking Frames");
-    tty->print_raw(st.as_string());
+    tty->print_raw(st.base());
     tty->print_cr("[WhiteBox::VerifyFrames] Done");
   }
 WB_END

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -2462,7 +2462,7 @@ WB_ENTRY(void, WB_VerifyFrames(JNIEnv* env, jobject wb, jboolean log, jboolean u
   }
   if (log) {
     tty->print_cr("[WhiteBox::VerifyFrames] Walking Frames");
-    tty->print_raw(st.base());
+    tty->print_raw(st.internal_string());
     tty->print_cr("[WhiteBox::VerifyFrames] Done");
   }
 WB_END

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -2462,7 +2462,7 @@ WB_ENTRY(void, WB_VerifyFrames(JNIEnv* env, jobject wb, jboolean log, jboolean u
   }
   if (log) {
     tty->print_cr("[WhiteBox::VerifyFrames] Walking Frames");
-    tty->print_raw(st.internal_string());
+    tty->print_raw(st.freeze());
     tty->print_cr("[WhiteBox::VerifyFrames] Done");
   }
 WB_END

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -161,7 +161,7 @@ void Deoptimization::UnrollBlock::print() {
     st.print(INTX_FORMAT " ", frame_sizes()[index]);
   }
   st.cr();
-  tty->print_raw(st.base());
+  tty->print_raw(st.internal_string());
 }
 
 
@@ -214,7 +214,7 @@ static void print_objects(JavaThread* deoptee_thread,
       k->oop_print_on(obj(), &st);
     }
   }
-  tty->print_raw(st.base());
+  tty->print_raw(st.internal_string());
 }
 
 static bool rematerialize_objects(JavaThread* thread, int exec_mode, CompiledMethod* compiled_method,
@@ -321,7 +321,7 @@ static void restore_eliminated_locks(JavaThread* thread, GrowableArray<compiledV
             }
           }
         }
-        tty->print_raw(st.base());
+        tty->print_raw(st.internal_string());
       }
 #endif // !PRODUCT
     }
@@ -1582,7 +1582,7 @@ vframeArray* Deoptimization::create_vframeArray(JavaThread* thread, frame fr, Re
       st.print(" - %s", code_name);
       st.print_cr(" @ bci=%d ", bci);
     }
-    tty->print_raw(st.base());
+    tty->print_raw(st.internal_string());
     tty->cr();
   }
 
@@ -2063,7 +2063,7 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
           class_name->print_symbol_on(&st);
         }
         st.cr();
-        tty->print_raw(st.base());
+        tty->print_raw(st.internal_string());
       }
       if (xtty != NULL) {
         // Log the precise location of the trap.

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -161,7 +161,7 @@ void Deoptimization::UnrollBlock::print() {
     st.print(INTX_FORMAT " ", frame_sizes()[index]);
   }
   st.cr();
-  tty->print_raw(st.internal_string());
+  tty->print_raw(st.freeze());
 }
 
 
@@ -214,7 +214,7 @@ static void print_objects(JavaThread* deoptee_thread,
       k->oop_print_on(obj(), &st);
     }
   }
-  tty->print_raw(st.internal_string());
+  tty->print_raw(st.freeze());
 }
 
 static bool rematerialize_objects(JavaThread* thread, int exec_mode, CompiledMethod* compiled_method,
@@ -321,7 +321,7 @@ static void restore_eliminated_locks(JavaThread* thread, GrowableArray<compiledV
             }
           }
         }
-        tty->print_raw(st.internal_string());
+        tty->print_raw(st.freeze());
       }
 #endif // !PRODUCT
     }
@@ -1582,7 +1582,7 @@ vframeArray* Deoptimization::create_vframeArray(JavaThread* thread, frame fr, Re
       st.print(" - %s", code_name);
       st.print_cr(" @ bci=%d ", bci);
     }
-    tty->print_raw(st.internal_string());
+    tty->print_raw(st.freeze());
     tty->cr();
   }
 
@@ -2063,7 +2063,7 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
           class_name->print_symbol_on(&st);
         }
         st.cr();
-        tty->print_raw(st.internal_string());
+        tty->print_raw(st.freeze());
       }
       if (xtty != NULL) {
         // Log the precise location of the trap.

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -161,7 +161,7 @@ void Deoptimization::UnrollBlock::print() {
     st.print(INTX_FORMAT " ", frame_sizes()[index]);
   }
   st.cr();
-  tty->print_raw(st.as_string());
+  tty->print_raw(st.base());
 }
 
 
@@ -214,7 +214,7 @@ static void print_objects(JavaThread* deoptee_thread,
       k->oop_print_on(obj(), &st);
     }
   }
-  tty->print_raw(st.as_string());
+  tty->print_raw(st.base());
 }
 
 static bool rematerialize_objects(JavaThread* thread, int exec_mode, CompiledMethod* compiled_method,
@@ -321,7 +321,7 @@ static void restore_eliminated_locks(JavaThread* thread, GrowableArray<compiledV
             }
           }
         }
-        tty->print_raw(st.as_string());
+        tty->print_raw(st.base());
       }
 #endif // !PRODUCT
     }
@@ -1582,7 +1582,7 @@ vframeArray* Deoptimization::create_vframeArray(JavaThread* thread, frame fr, Re
       st.print(" - %s", code_name);
       st.print_cr(" @ bci=%d ", bci);
     }
-    tty->print_raw(st.as_string());
+    tty->print_raw(st.base());
     tty->cr();
   }
 
@@ -2063,7 +2063,7 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
           class_name->print_symbol_on(&st);
         }
         st.cr();
-        tty->print_raw(st.as_string());
+        tty->print_raw(st.base());
       }
       if (xtty != NULL) {
         // Log the precise location of the trap.

--- a/src/hotspot/share/runtime/vframeArray.cpp
+++ b/src/hotspot/share/runtime/vframeArray.cpp
@@ -592,7 +592,7 @@ void vframeArray::unpack_to_stack(frame &unpack_frame, int exec_mode, int caller
     st.print_cr("DEOPT UNPACKING thread=" INTPTR_FORMAT " vframeArray=" INTPTR_FORMAT " mode=%d",
                 p2i(current), p2i(this), exec_mode);
     st.print_cr("   Virtual frames (outermost/oldest first):");
-    tty->print_raw(st.base());
+    tty->print_raw(st.internal_string());
   }
 
   // Do the unpacking of interpreter frames; the frame at index 0 represents the top activation, so it has no callee
@@ -630,7 +630,7 @@ void vframeArray::unpack_to_stack(frame &unpack_frame, int exec_mode, int caller
       st.print(" - %s", code_name);
       st.print(" @ bci=%d ", bci);
       st.print_cr("sp=" PTR_FORMAT, p2i(elem->iframe()->sp()));
-      tty->print_raw(st.base());
+      tty->print_raw(st.internal_string());
     }
     elem->unpack_on_stack(caller_actual_parameters,
                           callee_parameters,

--- a/src/hotspot/share/runtime/vframeArray.cpp
+++ b/src/hotspot/share/runtime/vframeArray.cpp
@@ -592,7 +592,7 @@ void vframeArray::unpack_to_stack(frame &unpack_frame, int exec_mode, int caller
     st.print_cr("DEOPT UNPACKING thread=" INTPTR_FORMAT " vframeArray=" INTPTR_FORMAT " mode=%d",
                 p2i(current), p2i(this), exec_mode);
     st.print_cr("   Virtual frames (outermost/oldest first):");
-    tty->print_raw(st.internal_string());
+    tty->print_raw(st.freeze());
   }
 
   // Do the unpacking of interpreter frames; the frame at index 0 represents the top activation, so it has no callee
@@ -630,7 +630,7 @@ void vframeArray::unpack_to_stack(frame &unpack_frame, int exec_mode, int caller
       st.print(" - %s", code_name);
       st.print(" @ bci=%d ", bci);
       st.print_cr("sp=" PTR_FORMAT, p2i(elem->iframe()->sp()));
-      tty->print_raw(st.internal_string());
+      tty->print_raw(st.freeze());
     }
     elem->unpack_on_stack(caller_actual_parameters,
                           callee_parameters,

--- a/src/hotspot/share/runtime/vframeArray.cpp
+++ b/src/hotspot/share/runtime/vframeArray.cpp
@@ -592,7 +592,7 @@ void vframeArray::unpack_to_stack(frame &unpack_frame, int exec_mode, int caller
     st.print_cr("DEOPT UNPACKING thread=" INTPTR_FORMAT " vframeArray=" INTPTR_FORMAT " mode=%d",
                 p2i(current), p2i(this), exec_mode);
     st.print_cr("   Virtual frames (outermost/oldest first):");
-    tty->print_raw(st.as_string());
+    tty->print_raw(st.base());
   }
 
   // Do the unpacking of interpreter frames; the frame at index 0 represents the top activation, so it has no callee
@@ -630,7 +630,7 @@ void vframeArray::unpack_to_stack(frame &unpack_frame, int exec_mode, int caller
       st.print(" - %s", code_name);
       st.print(" @ bci=%d ", bci);
       st.print_cr("sp=" PTR_FORMAT, p2i(elem->iframe()->sp()));
-      tty->print_raw(st.as_string());
+      tty->print_raw(st.base());
     }
     elem->unpack_on_stack(caller_actual_parameters,
                           callee_parameters,

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -358,6 +358,7 @@ void stringStream::grow(size_t new_capacity) {
 }
 
 void stringStream::write(const char* s, size_t len) {
+  assert(_internal_string_called == false, "Modification forbidden");
   assert(_capacity >= _written + 1, "Sanity");
   if (len == 0) {
     return;
@@ -397,6 +398,7 @@ void stringStream::zero_terminate() {
 }
 
 void stringStream::reset() {
+  assert(_internal_string_called == false, "Modification forbidden");
   _written = 0; _precount = 0; _position = 0;
   _newlines = 0;
   zero_terminate();

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -358,7 +358,7 @@ void stringStream::grow(size_t new_capacity) {
 }
 
 void stringStream::write(const char* s, size_t len) {
-  assert(_internal_string_called == false, "Modification forbidden");
+  assert(_is_frozen == false, "Modification forbidden");
   assert(_capacity >= _written + 1, "Sanity");
   if (len == 0) {
     return;
@@ -398,7 +398,7 @@ void stringStream::zero_terminate() {
 }
 
 void stringStream::reset() {
-  assert(_internal_string_called == false, "Modification forbidden");
+  assert(_is_frozen == false, "Modification forbidden");
   _written = 0; _precount = 0; _position = 0;
   _newlines = 0;
   zero_terminate();

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -358,6 +358,7 @@ void stringStream::grow(size_t new_capacity) {
 }
 
 void stringStream::write(const char* s, size_t len) {
+  assert(_use_after_base == false, "invariant");
   assert(_capacity >= _written + 1, "Sanity");
   if (len == 0) {
     return;
@@ -397,6 +398,7 @@ void stringStream::zero_terminate() {
 }
 
 void stringStream::reset() {
+  assert(_use_after_base == false, "invariant");
   _written = 0; _precount = 0; _position = 0;
   _newlines = 0;
   zero_terminate();

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -358,7 +358,6 @@ void stringStream::grow(size_t new_capacity) {
 }
 
 void stringStream::write(const char* s, size_t len) {
-  assert(_use_after_base == false, "invariant");
   assert(_capacity >= _written + 1, "Sanity");
   if (len == 0) {
     return;
@@ -398,7 +397,6 @@ void stringStream::zero_terminate() {
 }
 
 void stringStream::reset() {
-  assert(_use_after_base == false, "invariant");
   _written = 0; _precount = 0; _position = 0;
   _newlines = 0;
   zero_terminate();

--- a/src/hotspot/share/utilities/ostream.hpp
+++ b/src/hotspot/share/utilities/ostream.hpp
@@ -215,10 +215,8 @@ class stringStream : public outputStream {
   // Return number of characters written into buffer, excluding terminating zero and
   // subject to truncation in static buffer mode.
   size_t      size() const { return _written; }
-  // Borrow the currently allocated string.
-  // A stringStream may free the pointer returned
-  // if any of its methods are called, therefore
-  // take care in using this method.
+  // Returns internal buffer containing the accumulated string.
+  // Returned buffer is only guaranteed to be valid as long as stream is not modified
   const char* base() const { return _buffer; }
   void  reset();
   // copy to a resource, or C-heap, array as requested

--- a/src/hotspot/share/utilities/ostream.hpp
+++ b/src/hotspot/share/utilities/ostream.hpp
@@ -215,6 +215,10 @@ class stringStream : public outputStream {
   // Return number of characters written into buffer, excluding terminating zero and
   // subject to truncation in static buffer mode.
   size_t      size() const { return _written; }
+  // Borrow the currently allocated string.
+  // A stringStream may free the pointer returned
+  // if any of its methods are called, therefore
+  // take care in using this method.
   const char* base() const { return _buffer; }
   void  reset();
   // copy to a resource, or C-heap, array as requested

--- a/src/hotspot/share/utilities/ostream.hpp
+++ b/src/hotspot/share/utilities/ostream.hpp
@@ -192,7 +192,7 @@ class ttyUnlocker: StackObj {
 // for writing to strings; buffer will expand automatically.
 // Buffer will always be zero-terminated.
 class stringStream : public outputStream {
-  // Invariant: Do not alter stringStream after calling ::base()
+  DEBUG_ONLY(bool _internal_string_called = false);
   char*  _buffer;
   size_t _written;  // Number of characters written, excluding termin. zero
   size_t _capacity;
@@ -220,8 +220,14 @@ class stringStream : public outputStream {
   // Returns internal buffer containing the accumulated string.
   // Returned buffer is only guaranteed to be valid as long as stream is not modified
   const char* base() const { return _buffer; }
+  // Return internal buffer containing the accumulated string.
+  // Ensures that further modification of stringStream leads to assertion errors.
+  const char* internal_string() NOT_DEBUG(const) {
+    DEBUG_ONLY(_internal_string_called = true);
+    return _buffer;
+  };
   void  reset();
-  // copy to a resource, or C-heap, array as requested
+  // Copy to a resource, or C-heap, array as requested
   char* as_string(bool c_heap = false) const;
 };
 

--- a/src/hotspot/share/utilities/ostream.hpp
+++ b/src/hotspot/share/utilities/ostream.hpp
@@ -193,7 +193,6 @@ class ttyUnlocker: StackObj {
 // Buffer will always be zero-terminated.
 class stringStream : public outputStream {
   // Invariant: Do not alter stringStream after calling ::base()
-  DEBUG_ONLY(bool _use_after_base = false;)
   char*  _buffer;
   size_t _written;  // Number of characters written, excluding termin. zero
   size_t _capacity;

--- a/src/hotspot/share/utilities/ostream.hpp
+++ b/src/hotspot/share/utilities/ostream.hpp
@@ -192,7 +192,7 @@ class ttyUnlocker: StackObj {
 // for writing to strings; buffer will expand automatically.
 // Buffer will always be zero-terminated.
 class stringStream : public outputStream {
-  DEBUG_ONLY(bool _internal_string_called = false);
+  DEBUG_ONLY(bool _is_frozen = false);
   char*  _buffer;
   size_t _written;  // Number of characters written, excluding termin. zero
   size_t _capacity;
@@ -220,10 +220,11 @@ class stringStream : public outputStream {
   // Returns internal buffer containing the accumulated string.
   // Returned buffer is only guaranteed to be valid as long as stream is not modified
   const char* base() const { return _buffer; }
-  // Return internal buffer containing the accumulated string.
-  // Ensures that further modification of stringStream leads to assertion errors.
-  const char* internal_string() NOT_DEBUG(const) {
-    DEBUG_ONLY(_internal_string_called = true);
+  // Freezes stringStream (no further modifications possible) and returns pointer to it.
+  // No-op if stream is frozen already.
+  // Returns the internal buffer containing the accumulated string.
+  const char* freeze() NOT_DEBUG(const) {
+    DEBUG_ONLY(_is_frozen = true);
     return _buffer;
   };
   void  reset();

--- a/src/hotspot/share/utilities/ostream.hpp
+++ b/src/hotspot/share/utilities/ostream.hpp
@@ -28,6 +28,7 @@
 #include "memory/allocation.hpp"
 #include "runtime/timer.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/macros.hpp"
 
 DEBUG_ONLY(class ResourceMark;)
 
@@ -191,6 +192,8 @@ class ttyUnlocker: StackObj {
 // for writing to strings; buffer will expand automatically.
 // Buffer will always be zero-terminated.
 class stringStream : public outputStream {
+  // Invariant: Do not alter stringStream after calling ::base()
+  DEBUG_ONLY(bool _use_after_base = false;)
   char*  _buffer;
   size_t _written;  // Number of characters written, excluding termin. zero
   size_t _capacity;

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -573,7 +573,7 @@ void VMError::report(outputStream* st, bool _verbose) {
     if (_verbose && TestCrashInErrorHandler == TEST_RESOURCE_MARK_CRASH) {
       stringStream message;
       message.print("This is a message with no ResourceMark");
-      tty->print_cr("%s", message.as_string());
+      tty->print_cr("%s", message.base());
     }
 
   // TestUnresponsiveErrorHandler: We want to test both step timeouts and global timeout.

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -573,7 +573,7 @@ void VMError::report(outputStream* st, bool _verbose) {
     if (_verbose && TestCrashInErrorHandler == TEST_RESOURCE_MARK_CRASH) {
       stringStream message;
       message.print("This is a message with no ResourceMark");
-      tty->print_cr("%s", message.base());
+      tty->print_cr("%s", message.as_string());
     }
 
   // TestUnresponsiveErrorHandler: We want to test both step timeouts and global timeout.


### PR DESCRIPTION
Hi!

Please review this PR swapping out stringStream::as_string() with ::base() when applicable. With this change we avoid allocating a resource managed string copy. I also attempt to document the base function, as it is not safe to use any result returned from it if you subsequently call the stringStream's methods.

When I've left ResourceMarks in place I've also commented which calls requires them.

This passes tier1, tier2 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293251](https://bugs.openjdk.org/browse/JDK-8293251): Use stringStream::base() instead of as_string() when applicable


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10142/head:pull/10142` \
`$ git checkout pull/10142`

Update a local copy of the PR: \
`$ git checkout pull/10142` \
`$ git pull https://git.openjdk.org/jdk pull/10142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10142`

View PR using the GUI difftool: \
`$ git pr show -t 10142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10142.diff">https://git.openjdk.org/jdk/pull/10142.diff</a>

</details>
