### PR TITLE
JDK-8293313: NMT: Add "Fake OOM" mode to MallocLimit

### DIFF
--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -32,6 +32,7 @@
 #include "runtime/globals.hpp"
 #include "runtime/java.hpp"
 #include "runtime/os.hpp"
+#include "services/mallocLimit.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/vmEnums.hpp"
 
@@ -657,15 +658,9 @@ class Arguments : AllStatic {
     assert(Arguments::is_dumping_archive(), "dump time only");
   }
 
-  // Parse diagnostic NMT switch "MallocLimit" and return the found limits.
-  // 1) If option is not given, it will set all limits to 0 (aka "no limit").
-  // 2) If option is given in the global form (-XX:MallocLimit=<size>), it
-  //    will return the size in *total_limit.
-  // 3) If option is given in its per-NMT-category form (-XX:MallocLimit=<category>:<size>[,<category>:<size>]),
-  //    it will return all found limits in the limits array.
-  // 4) If option is malformed, it will exit the VM.
-  // For (2) and (3), limits not affected by the switch will be set to 0.
-  static void parse_malloc_limits(size_t* total_limit, size_t limits[mt_number_of_types]);
+  // Parse diagnostic NMT switch "MallocLimit" and return the found limits in the MallocLimitInfo structure.
+  // If option string is malformed, it will exit the VM.
+  static void parse_malloc_limits(MallocLimitInfo* limits);
 
   DEBUG_ONLY(static bool verify_special_jvm_flags(bool check_globals);)
 };

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1342,11 +1342,11 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   product(ccstr, MallocLimit, nullptr, DIAGNOSTIC,                          \
           "Limit malloc allocation size from VM. Reaching the limit will "  \
-          "trigger a fatal error. This feature requires "                   \
+          "trigger a fatal error or mimick a native OOM. This feature requires " \
           "NativeMemoryTracking=summary or NativeMemoryTracking=detail."    \
           "Usage:"                                                          \
-          "- MallocLimit=<size> to set a total limit. "                     \
-          "- MallocLimit=<NMT category>:<size>[,<NMT category>:<size>...] " \
+          "- MallocLimit=<size>[,oom] to set a total limit. "               \
+          "- MallocLimit=<NMT category>:<size>[,<NMT category>:<size>...][,oom] " \
           "  to set one or more category-specific limits."                  \
           "Example: -XX:MallocLimit=compiler:500m")                         \
                                                                             \

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -664,6 +664,9 @@ void* os::malloc(size_t size, MEMFLAGS memflags, const NativeCallStack& stack) {
   }
 
   void* const inner_ptr = MemTracker::record_malloc((address)outer_ptr, size, memflags, stack);
+  if (inner_ptr == NULL) { // MallocLimit?
+    return NULL;
+  }
 
   if (DumpSharedSpaces) {
     // Need to deterministically fill all the alignment gaps in C++ structures.
@@ -714,6 +717,9 @@ void* os::realloc(void *memblock, size_t size, MEMFLAGS memflags, const NativeCa
   }
 
   void* const new_inner_ptr = MemTracker::record_malloc(new_outer_ptr, size, memflags, stack);
+  if (new_inner_ptr == NULL) { // MallocLimit?
+    return NULL;
+  }
 
   DEBUG_ONLY(break_if_ptr_caught(new_inner_ptr);)
 

--- a/src/hotspot/share/services/mallocLimit.cpp
+++ b/src/hotspot/share/services/mallocLimit.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+#include "precompiled.hpp"
+
+#include "services/mallocLimit.hpp"
+#include "services/nmtCommon.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/ostream.hpp"
+
+MallocLimitInfo::MallocLimitInfo() { reset(); }
+
+void MallocLimitInfo::reset() {
+  _total_limit = 0;
+  for (int i = 0; i < mt_number_of_types; i ++) {
+    _limits_per_category[i] = 0;
+  }
+  _fake_oom = false;
+}
+
+void MallocLimitInfo::print(outputStream* st) const {
+  if (_total_limit > 0) {
+    st->print_cr("MallocLimit: total limit: " SIZE_FORMAT "%s",
+                 byte_size_in_proper_unit(_total_limit),
+                 proper_unit_for_byte_size(_total_limit));
+  } else {
+    for (int i = 0; i < mt_number_of_types; i ++) {
+      size_t catlim = _limits_per_category[i];
+      if (catlim > 0) {
+        st->print_cr("MallocLimit: category \"%s\" limit: " SIZE_FORMAT "%s",
+                     NMTUtil::flag_to_name((MEMFLAGS)i),
+                     byte_size_in_proper_unit(catlim),
+                     proper_unit_for_byte_size(catlim));
+      }
+    }
+  }
+  if (_fake_oom) {
+    st->print_raw("MallocLimit: fake-oom mode");
+  }
+}

--- a/src/hotspot/share/services/mallocLimit.hpp
+++ b/src/hotspot/share/services/mallocLimit.hpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_SERVICES_MALLOCLIMIT_HPP
+#define SHARE_SERVICES_MALLOCLIMIT_HPP
+
+#include "memory/allocation.hpp" // for MEMFLAGS
+#include "utilities/globalDefinitions.hpp"
+
+class Arguments;
+class outputStream;
+
+// This class contains the parsed MallocLimit argument.
+class MallocLimitInfo {
+  friend class Arguments;
+
+  // If _total_limit != 0, category limits are ignored.
+  size_t _limits_per_category[mt_number_of_types];
+  size_t _total_limit;
+  bool _fake_oom;
+
+public:
+  NONCOPYABLE(MallocLimitInfo);
+
+  MallocLimitInfo();
+
+  void reset();
+
+  size_t total_limit() const { return _total_limit; }
+  bool is_global_limit() const { return total_limit() > 0; }
+
+  size_t get_limit_for_category(MEMFLAGS f) const {
+    return _limits_per_category[(int)f];
+  }
+
+  bool should_fake_oom() const { return _fake_oom; }
+
+  void print(outputStream* st) const;
+};
+
+#endif // SHARE_SERVICES_MALLOCLIMIT_HPP


### PR DESCRIPTION
* still work in progress *

This RFE adds the optional ability for `-XX:MallocLimit` to, instead of exiting the VM with a fatal error, fake a native OOM on this and all future malloc calls.

The user controls this by appending the option "oom" to the malloc limit argument:

```
-XX:MallocLimit=2g # will cause fatal error upon reaching limit
-XX:MallocLimit=2g,oom # will cause malloc to return NULL, mimicking a real malloc OOM
```

That makes it possible to test hotspot robustness in the face of real malloc OOMs, and is the prerequisite for removing the old `MallocMaxTestWords` machinery.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293313](https://bugs.openjdk.org/browse/JDK-8293313): NMT: Add "Fake OOM" mode to MallocLimit


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10144/head:pull/10144` \
`$ git checkout pull/10144`

Update a local copy of the PR: \
`$ git checkout pull/10144` \
`$ git pull https://git.openjdk.org/jdk pull/10144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10144`

View PR using the GUI difftool: \
`$ git pr show -t 10144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10144.diff">https://git.openjdk.org/jdk/pull/10144.diff</a>

</details>
