### PR TITLE
8293315: Add back logging for Placeholders

### DIFF
--- a/src/hotspot/share/classfile/placeholders.cpp
+++ b/src/hotspot/share/classfile/placeholders.cpp
@@ -238,12 +238,12 @@ static const char* action_to_string(PlaceholderTable::classloadAction action) {
  return "";
 }
 
-inline void log(PlaceholderEntry* entry, const char* function, PlaceholderTable::classloadAction action) {
+inline void log(Symbol* name, PlaceholderEntry* entry, const char* function, PlaceholderTable::classloadAction action) {
   if (log_is_enabled(Debug, class, load, placeholders)) {
     LogTarget(Debug, class, load, placeholders) lt;
     ResourceMark rm;
     LogStream ls(lt);
-    ls.print("%s %s ", function, action_to_string(action));
+    ls.print("entry %s : %s %s ", name->as_C_string(), function, action_to_string(action));
     entry->print_on(&ls);
   }
 }
@@ -269,7 +269,7 @@ PlaceholderEntry* PlaceholderTable::find_and_add(Symbol* name,
     }
   }
   probe->add_seen_thread(thread, action);
-  log(probe, "find_and_add", action);
+  log(name, probe, "find_and_add", action);
   return probe;
 }
 
@@ -293,7 +293,7 @@ void PlaceholderTable::find_and_remove(Symbol* name, ClassLoaderData* loader_dat
   assert_locked_or_safepoint(SystemDictionary_lock);
   PlaceholderEntry* probe = get_entry(name, loader_data);
   if (probe != NULL) {
-    log(probe, "find_and_remove", action);
+    log(name, probe, "find_and_remove", action);
     probe->remove_seen_thread(thread, action);
     // If no other threads using this entry, and this thread is not using this entry for other states
     if ((probe->superThreadQ() == NULL) && (probe->loadInstanceThreadQ() == NULL)


### PR DESCRIPTION
I lost some information in the logging code for PlaceholderTable that I really want when I converted it to use a ResourceHashtable, so this minor patch adds it back.
Tested locally with -Xlog:class+load+placeholders=trace, and tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293315](https://bugs.openjdk.org/browse/JDK-8293315): Add back logging for Placeholders


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10145/head:pull/10145` \
`$ git checkout pull/10145`

Update a local copy of the PR: \
`$ git checkout pull/10145` \
`$ git pull https://git.openjdk.org/jdk pull/10145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10145`

View PR using the GUI difftool: \
`$ git pr show -t 10145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10145.diff">https://git.openjdk.org/jdk/pull/10145.diff</a>

</details>
