### PR TITLE
8293325: Minor improvements to macos catch_mach_exception_raise() error handling

### DIFF
--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
@@ -869,19 +869,25 @@ kern_return_t catch_mach_exception_raise(
   }
 
   // This message should denote a Unix soft signal, with
-  // 1. the exception type = EXC_SOFTWARE
-  // 2. codes[0] (which is the code) = EXC_SOFT_SIGNAL
-  // 3. codes[1] (which is the sub-code) = SIGSTOP
-  if (!(exception_type == EXC_SOFTWARE &&
-        codes[0] == EXC_SOFT_SIGNAL    &&
-        codes[num_codes -1] == SIGSTOP)) {
+  // 1. the exception type = EXC_SOFTWARE (5)
+  // 2. codes[0] (which is the code) = EXC_SOFT_SIGNAL (0x10003 / 65539)
+  // 3. codes[1] (which is the sub-code) = SIGSTOP (17)
+  if (exception_type != EXC_SOFTWARE || codes[0] != EXC_SOFT_SIGNAL) {
     print_error("catch_mach_exception_raise: Message doesn't denote a Unix "
                 "soft signal. exception_type = %d, codes[0] = %d, "
                 "codes[num_codes -1] = 0x%llx, num_codes = %d\n",
                 exception_type, codes[0], codes[num_codes - 1], num_codes);
     return GOT_UNKNOWN_EXC;
   }
-  return KERN_SUCCESS;
+  int sig = codes[num_codes -1];
+  if (sig == SIGSTOP) {
+    return KERN_SUCCESS;
+  } else {
+    // Sometimes we get SIGTRAP(4) or SIGILL(5) instead of SIGSTOP (17) on aarch64.
+    // We currently can't deal with them. See JDK-8288429.
+    print_error("catch_mach_exception_raise: signal is not SIGSTOP (%d)\n", sig);
+    return GOT_UNKNOWN_EXC;
+  }
 }
 
 kern_return_t catch_mach_exception_raise_state(


### PR DESCRIPTION
While trying to find a fix for [JDK-8288429](https://bugs.openjdk.org/browse/JDK-8288429) (no fix was found), I made some adjustments to the error handling in catch_mach_exception_raise() to make it a bit easier to understand the code, and to provide a more meaningful error message when the soft signal is invalid. This PR is for pushing those changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293325](https://bugs.openjdk.org/browse/JDK-8293325): Minor improvements to macos catch_mach_exception_raise() error handling


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10149/head:pull/10149` \
`$ git checkout pull/10149`

Update a local copy of the PR: \
`$ git checkout pull/10149` \
`$ git pull https://git.openjdk.org/jdk pull/10149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10149`

View PR using the GUI difftool: \
`$ git pr show -t 10149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10149.diff">https://git.openjdk.org/jdk/pull/10149.diff</a>

</details>
