### PR TITLE
8293051: Further refactor javac after removal of -source/-target/--release 7

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Source.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Source.java
@@ -207,15 +207,9 @@ public enum Source {
      */
     public enum Feature {
 
-        DIAMOND(MIN, Fragments.FeatureDiamond, DiagKind.NORMAL), // Used in Analyzer
         MODULES(JDK9, Fragments.FeatureModules, DiagKind.PLURAL),
         EFFECTIVELY_FINAL_VARIABLES_IN_TRY_WITH_RESOURCES(JDK9, Fragments.FeatureVarInTryWithResources, DiagKind.PLURAL),
         DEPRECATION_ON_IMPORT(MIN, JDK8),
-        POLY(JDK8),
-        LAMBDA(JDK8, Fragments.FeatureLambda, DiagKind.PLURAL),
-        DEFAULT_METHODS(JDK8, Fragments.FeatureDefaultMethods, DiagKind.PLURAL),
-        STRICT_METHOD_CLASH_CHECK(JDK8),
-        GRAPH_INFERENCE(JDK8), // Used in Analyzer
         PRIVATE_SAFE_VARARGS(JDK9),
         DIAMOND_WITH_ANONYMOUS_CLASS_CREATION(JDK9, Fragments.FeatureDiamondAndAnonClass, DiagKind.NORMAL),
         UNDERSCORE_IDENTIFIER(MIN, JDK8),

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -2795,11 +2795,7 @@ public class Types {
      * @return true if t is a subsignature of s.
      */
     public boolean isSubSignature(Type t, Type s) {
-        return isSubSignature(t, s, true);
-    }
-
-    public boolean isSubSignature(Type t, Type s, boolean strict) {
-        return hasSameArgs(t, s, strict) || hasSameArgs(t, erasure(s), strict);
+        return hasSameArgs(t, s, true) || hasSameArgs(t, erasure(s), true);
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Analyzer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Analyzer.java
@@ -140,13 +140,17 @@ public class Analyzer {
      * the {@code -XDfind} option.
      */
     enum AnalyzerMode {
-        DIAMOND("diamond", Feature.DIAMOND),
-        LAMBDA("lambda", Feature.LAMBDA),
-        METHOD("method", Feature.GRAPH_INFERENCE),
+        DIAMOND("diamond"),
+        LAMBDA("lambda"),
+        METHOD("method"),
         LOCAL("local", Feature.LOCAL_VARIABLE_TYPE_INFERENCE);
 
         final String opt;
         final Feature feature;
+
+        AnalyzerMode(String opt) {
+            this(opt, null);
+        }
 
         AnalyzerMode(String opt, Feature feature) {
             this.opt = opt;
@@ -169,7 +173,7 @@ public class Analyzer {
                 res = EnumSet.allOf(AnalyzerMode.class);
             }
             for (AnalyzerMode mode : values()) {
-                if (modes.contains("-" + mode.opt) || !mode.feature.allowedInSource(source)) {
+                if (modes.contains("-" + mode.opt) || (mode.feature != null && !mode.feature.allowedInSource(source))) {
                     res.remove(mode);
                 } else if (modes.contains(mode.opt)) {
                     res.add(mode);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -2575,7 +2575,7 @@ public class Check {
                 if (m2 == m1) continue;
                 //if (i) the signature of 'sym' is not a subsignature of m1 (seen as
                 //a member of 'site') and (ii) m1 has the same erasure as m2, issue an error
-                if (!types.isSubSignature(sym.type, types.memberType(site, m2), Feature.STRICT_METHOD_CLASH_CHECK.allowedInSource(source)) &&
+                if (!types.isSubSignature(sym.type, types.memberType(site, m2)) &&
                         types.hasSameArgs(m2.erasure(types), m1.erasure(types))) {
                     sym.flags_field |= CLASH;
                     if (m1 == sym) {
@@ -2620,7 +2620,7 @@ public class Check {
         for (Symbol s : types.membersClosure(site, true).getSymbolsByName(sym.name, cf)) {
             //if (i) the signature of 'sym' is not a subsignature of m1 (seen as
             //a member of 'site') and (ii) 'sym' has the same erasure as m1, issue an error
-            if (!types.isSubSignature(sym.type, types.memberType(site, s), Feature.STRICT_METHOD_CLASH_CHECK.allowedInSource(source))) {
+            if (!types.isSubSignature(sym.type, types.memberType(site, s))) {
                 if (types.hasSameArgs(s.erasure(types), sym.erasure(types))) {
                     log.error(pos,
                               Errors.NameClashSameErasureNoHide(sym, sym.location(), s, s.location()));

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
@@ -25,10 +25,8 @@
 
 package com.sun.tools.javac.comp;
 
-import com.sun.tools.javac.code.Source.Feature;
 import com.sun.tools.javac.code.Type.UndetVar.UndetVarListener;
 import com.sun.tools.javac.code.Types.TypeMapping;
-import com.sun.tools.javac.comp.Attr.CheckMode;
 import com.sun.tools.javac.resources.CompilerProperties.Fragments;
 import com.sun.tools.javac.resources.CompilerProperties.Notes;
 import com.sun.tools.javac.tree.JCTree;
@@ -89,9 +87,6 @@ public class Infer {
     JCDiagnostic.Factory diags;
     Log log;
 
-    /** should the graph solver be used? */
-    boolean allowGraphInference;
-
     /**
      * folder in which the inference dependency graphs should be written.
      */
@@ -119,9 +114,6 @@ public class Infer {
         diags = JCDiagnostic.Factory.instance(context);
         log = Log.instance(context);
         Options options = Options.instance(context);
-        Source source = Source.instance(context);
-        allowGraphInference = Feature.GRAPH_INFERENCE.allowedInSource(source)
-                && options.isUnset("useLegacyInference");
         dependenciesFolder = options.get("debug.dumpInferenceGraphsTo");
         pendingGraphs = List.nil();
 
@@ -182,11 +174,11 @@ public class Infer {
             resolveContext.methodCheck.argumentsAcceptable(env, deferredAttrContext,   //B2
                     argtypes, mt.getParameterTypes(), warn);
 
-            if (allowGraphInference && resultInfo != null && resultInfo.pt == anyPoly) {
+            if (resultInfo != null && resultInfo.pt == anyPoly) {
                 doIncorporation(inferenceContext, warn);
                 //we are inside method attribution - just return a partially inferred type
                 return new PartiallyInferredMethodType(mt, inferenceContext, env, warn);
-            } else if (allowGraphInference && resultInfo != null) {
+            } else if (resultInfo != null) {
 
                 //inject return constraints earlier
                 doIncorporation(inferenceContext, warn); //propagation
@@ -215,22 +207,8 @@ public class Infer {
             deferredAttrContext.complete();
 
             // minimize as yet undetermined type variables
-            if (allowGraphInference) {
-                inferenceContext.solve(warn);
-            } else {
-                inferenceContext.solveLegacy(true, warn, LegacyInferenceSteps.EQ_LOWER.steps); //minimizeInst
-            }
-
+            inferenceContext.solve(warn);
             mt = (MethodType)inferenceContext.asInstType(mt);
-
-            if (!allowGraphInference &&
-                    inferenceContext.restvars().nonEmpty() &&
-                    resultInfo != null &&
-                    !warn.hasNonSilentLint(Lint.LintCategory.UNCHECKED)) {
-                generateReturnConstraints(env.tree, resultInfo, mt, inferenceContext);
-                inferenceContext.solveLegacy(false, warn, LegacyInferenceSteps.EQ_UPPER.steps); //maximizeInst
-                mt = (MethodType)inferenceContext.asInstType(mt);
-            }
 
             if (resultInfo != null && rs.verboseResolutionMode.contains(VerboseResolutionMode.DEFERRED_INST)) {
                 log.note(env.tree.pos, Notes.DeferredMethodInst(msym, mt, resultInfo.pt));
@@ -239,7 +217,7 @@ public class Infer {
             // return instantiated version of method type
             return mt;
         } finally {
-            if (resultInfo != null || !allowGraphInference) {
+            if (resultInfo != null) {
                 inferenceContext.notifyChange();
             } else {
                 inferenceContext.notifyChange(inferenceContext.boundedVars());
@@ -410,21 +388,16 @@ public class Infer {
         } else if (to.hasTag(NONE)) {
             to = from.isPrimitive() ? from : syms.objectType;
         } else if (qtype.hasTag(UNDETVAR)) {
-            if (needsEagerInstantiation((UndetVar)qtype, to, inferenceContext) &&
-                    (allowGraphInference || !to.isPrimitive())) {
+            if (needsEagerInstantiation((UndetVar)qtype, to, inferenceContext)) {
                 to = generateReferenceToTargetConstraint(tree, (UndetVar)qtype, to, resultInfo, inferenceContext);
             }
         } else if (rsInfoInfContext.free(resultInfo.pt)) {
             //propagation - cache captured vars
             qtype = inferenceContext.asUndetVar(rsInfoInfContext.cachedCapture(tree, from, !resultInfo.checkMode.updateTreeType()));
         }
-        Assert.check(allowGraphInference || !rsInfoInfContext.free(to),
-                "legacy inference engine cannot handle constraints on both sides of a subtyping assertion");
         //we need to skip capture?
         Warner retWarn = new Warner();
-        if (!resultInfo.checkContext.compatible(qtype, rsInfoInfContext.asUndetVar(to), retWarn) ||
-                //unchecked conversion is not allowed in source 7 mode
-                (!allowGraphInference && retWarn.hasLint(Lint.LintCategory.UNCHECKED))) {
+        if (!resultInfo.checkContext.compatible(qtype, rsInfoInfContext.asUndetVar(to), retWarn)) {
             throw error(diags.fragment(Fragments.InferNoConformingInstanceExists(inferenceContext.restvars(), mt.getReturnType(), to)));
         }
         return from;
@@ -616,7 +589,7 @@ public class Infer {
     TypeMapping<Void> fromTypeVarFun = new StructuralTypeMapping<Void>() {
         @Override
         public Type visitTypeVar(TypeVar tv, Void aVoid) {
-            UndetVar uv = new UndetVar(tv, incorporationEngine(), types);
+            UndetVar uv = new UndetVar(tv, incorporationEngine, types);
             if ((tv.tsym.flags() & Flags.THROWS) != 0) {
                 uv.setThrow();
             }
@@ -808,28 +781,6 @@ public class Infer {
     }
 
     /**
-     * Custom check executed by the legacy incorporation engine. Newly added bounds are checked
-     * against existing eq bounds.
-     */
-    class EqCheckLegacy extends CheckBounds {
-        EqCheckLegacy(UndetVar uv, Type t, InferenceBound from) {
-            super(uv, t, InferenceContext::asInstType, InferenceContext::free, from);
-        }
-
-        @Override
-        public IncorporationAction dup(UndetVar that) {
-            return new EqCheckLegacy(that, t, from);
-        }
-
-        @Override
-        EnumSet<InferenceBound> boundsToCheck() {
-            return (from == InferenceBound.EQ) ?
-                            EnumSet.allOf(InferenceBound.class) :
-                            EnumSet.of(InferenceBound.EQ);
-        }
-    }
-
-    /**
      * Check that the inferred type conforms to all bounds.
      */
     class CheckInst extends CheckBounds {
@@ -1017,7 +968,7 @@ public class Infer {
      * This class models an incorporation engine. The engine is responsible for listening to
      * changes in inference variables and register incorporation actions accordingly.
      */
-    abstract class AbstractIncorporationEngine implements UndetVarListener {
+    class IncorporationEngine implements UndetVarListener {
 
         @Override
         public void varInstantiated(UndetVar uv) {
@@ -1030,31 +981,6 @@ public class Infer {
             uv.incorporationActions.addAll(getIncorporationActions(uv, ib, bound, update));
         }
 
-        abstract List<IncorporationAction> getIncorporationActions(UndetVar uv, InferenceBound ib, Type t, boolean update);
-    }
-
-    /**
-     * A legacy incorporation engine. Used for source <= 7.
-     */
-    AbstractIncorporationEngine legacyEngine = new AbstractIncorporationEngine() {
-
-        List<IncorporationAction> getIncorporationActions(UndetVar uv, InferenceBound ib, Type t, boolean update) {
-            ListBuffer<IncorporationAction> actions = new ListBuffer<>();
-            Type inst = uv.getInst();
-            if (inst != null) {
-                actions.add(new CheckInst(uv, ib));
-            }
-            actions.add(new EqCheckLegacy(uv, t, ib));
-            return actions.toList();
-        }
-    };
-
-    /**
-     * The standard incorporation engine. Used for source >= 8.
-     */
-    AbstractIncorporationEngine graphEngine = new AbstractIncorporationEngine() {
-
-        @Override
         List<IncorporationAction> getIncorporationActions(UndetVar uv, InferenceBound ib, Type t, boolean update) {
             ListBuffer<IncorporationAction> actions = new ListBuffer<>();
             Type inst = uv.getInst();
@@ -1075,14 +1001,9 @@ public class Infer {
 
             return actions.toList();
         }
-    };
-
-    /**
-     * Get the incorporation engine to be used in this compilation.
-     */
-    AbstractIncorporationEngine incorporationEngine() {
-        return allowGraphInference ? graphEngine : legacyEngine;
     }
+
+    IncorporationEngine incorporationEngine = new IncorporationEngine();
 
     /** max number of incorporation rounds. */
     static final int MAX_INCORPORATION_STEPS = 10000;
@@ -1356,7 +1277,7 @@ public class Infer {
         }
 
         /**
-         * Computes a path that goes from a given node to the leafs in the graph.
+         * Computes a path that goes from a given node to the leaves in the graph.
          * Typically this will start from a node containing a variable in
          * {@code varsToSolve}. For any given path, the cost is computed as the total
          * number of type-variables that should be eagerly instantiated across that path.
@@ -1495,21 +1416,6 @@ public class Infer {
         },
         /**
          * Like the former; the only difference is that this step can only be applied
-         * if all upper bounds are ground.
-         */
-        UPPER_LEGACY(InferenceBound.UPPER) {
-            @Override
-            public boolean accepts(UndetVar t, InferenceContext inferenceContext) {
-                return !inferenceContext.free(t.getBounds(ib)) && !t.isCaptured();
-            }
-
-            @Override
-            Type solve(UndetVar uv, InferenceContext inferenceContext) {
-                return UPPER.solve(uv, inferenceContext);
-            }
-        },
-        /**
-         * Like the former; the only difference is that this step can only be applied
          * if all upper/lower bounds are ground.
          */
         CAPTURED(InferenceBound.UPPER) {
@@ -1558,23 +1464,6 @@ public class Infer {
          */
         List<Type> filterBounds(UndetVar uv, InferenceContext inferenceContext) {
             return Type.filter(uv.getBounds(ib), new BoundFilter(inferenceContext));
-        }
-    }
-
-    /**
-     * This enumeration defines the sequence of steps to be applied when the
-     * solver works in legacy mode. The steps in this enumeration reflect
-     * the behavior of old inference routine (see JLS SE 7 15.12.2.7/15.12.2.8).
-     */
-    enum LegacyInferenceSteps {
-
-        EQ_LOWER(EnumSet.of(InferenceStep.EQ, InferenceStep.LOWER)),
-        EQ_UPPER(EnumSet.of(InferenceStep.EQ, InferenceStep.UPPER_LEGACY));
-
-        final EnumSet<InferenceStep> steps;
-
-        LegacyInferenceSteps(EnumSet<InferenceStep> steps) {
-            this.steps = steps;
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/InferenceContext.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/InferenceContext.java
@@ -510,13 +510,6 @@ public class InferenceContext {
         }, warn);
     }
 
-    /**
-     * Apply a set of inference steps
-     */
-    private List<Type> solveBasic(EnumSet<InferenceStep> steps) {
-        return solveBasic(inferencevars, steps);
-    }
-
     List<Type> solveBasic(List<Type> varsToSolve, EnumSet<InferenceStep> steps) {
         ListBuffer<Type> solvedVars = new ListBuffer<>();
         for (Type t : varsToSolve.intersect(restvars())) {
@@ -530,36 +523,6 @@ public class InferenceContext {
             }
         }
         return solvedVars.toList();
-    }
-
-    /**
-     * Instantiate inference variables in legacy mode (JLS 15.12.2.7, 15.12.2.8).
-     * During overload resolution, instantiation is done by doing a partial
-     * inference process using eq/lower bound instantiation. During check,
-     * we also instantiate any remaining vars by repeatedly using eq/upper
-     * instantiation, until all variables are solved.
-     */
-    public void solveLegacy(boolean partial, Warner warn, EnumSet<InferenceStep> steps) {
-        while (true) {
-            List<Type> solvedVars = solveBasic(steps);
-            if (restvars().isEmpty() || partial) {
-                //all variables have been instantiated - exit
-                break;
-            } else if (solvedVars.isEmpty()) {
-                //some variables could not be instantiated because of cycles in
-                //upper bounds - provide a (possibly recursive) default instantiation
-                infer.instantiateAsUninferredVars(restvars(), this);
-                break;
-            } else {
-                //some variables have been instantiated - replace newly instantiated
-                //variables in remaining upper bounds and continue
-                for (Type t : undetvars) {
-                    UndetVar uv = (UndetVar)t;
-                    uv.substBounds(solvedVars, asInstTypes(solvedVars), types);
-                }
-            }
-        }
-        infer.doIncorporation(this, warn);
     }
 
     @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
@@ -76,9 +76,6 @@ public class TransTypes extends TreeTranslator {
     private final Resolve resolve;
     private final CompileStates compileStates;
 
-    /** Switch: is complex graph inference supported? */
-    private final boolean allowGraphInference;
-
     protected TransTypes(Context context) {
         context.put(transTypesKey, this);
         compileStates = CompileStates.instance(context);
@@ -89,8 +86,6 @@ public class TransTypes extends TreeTranslator {
         types = Types.instance(context);
         make = TreeMaker.instance(context);
         resolve = Resolve.instance(context);
-        Source source = Source.instance(context);
-        allowGraphInference = Feature.GRAPH_INFERENCE.allowedInSource(source);
         annotate = Annotate.instance(context);
         attr = Attr.instance(context);
     }
@@ -671,8 +666,7 @@ public class TransTypes extends TreeTranslator {
         tree.meth = translate(tree.meth, null);
         Symbol meth = TreeInfo.symbol(tree.meth);
         Type mt = meth.erasure(types);
-        boolean useInstantiatedPtArgs =
-                allowGraphInference && !types.isSignaturePolymorphic((MethodSymbol)meth.baseSymbol());
+        boolean useInstantiatedPtArgs = !types.isSignaturePolymorphic((MethodSymbol)meth.baseSymbol());
         List<Type> argtypes = useInstantiatedPtArgs ?
                 tree.meth.type.getParameterTypes() :
                 mt.getParameterTypes();
@@ -706,7 +700,7 @@ public class TransTypes extends TreeTranslator {
                 erasure(tree.constructorType) :
                 null;
 
-        List<Type> argtypes = erasedConstructorType != null && allowGraphInference ?
+        List<Type> argtypes = erasedConstructorType != null ?
                 erasedConstructorType.getParameterTypes() :
                 tree.constructor.erasure(types).getParameterTypes();
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -1553,7 +1553,7 @@ public class JavaCompiler {
             env.tree = TransPatterns.instance(context).translateTopLevelClass(env, env.tree, localMake);
             compileStates.put(env, CompileState.TRANSPATTERNS);
 
-            if (Feature.LAMBDA.allowedInSource(source) && scanner.hasLambdas) {
+            if (scanner.hasLambdas) {
                 if (shouldStop(CompileState.UNLAMBDA))
                     return;
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -2002,7 +2002,6 @@ public class JavacParser implements Parser {
     }
 
     JCExpression lambdaExpressionOrStatementRest(List<JCVariableDecl> args, int pos) {
-        checkSourceLevel(Feature.LAMBDA);
         accept(ARROW);
 
         return token.kind == LBRACE ?
@@ -2138,7 +2137,6 @@ public class JavacParser implements Parser {
         if (token.kind == LT) {
             nextToken();
             if (token.kind == GT && diamondAllowed) {
-                checkSourceLevel(Feature.DIAMOND);
                 mode |= DIAMOND;
                 nextToken();
                 return List.nil();
@@ -3299,7 +3297,7 @@ public class JavacParser implements Parser {
             case SYNCHRONIZED: flag = Flags.SYNCHRONIZED; break;
             case STRICTFP    : flag = Flags.STRICTFP; break;
             case MONKEYS_AT  : flag = Flags.ANNOTATION; break;
-            case DEFAULT     : checkSourceLevel(Feature.DEFAULT_METHODS); flag = Flags.DEFAULT; break;
+            case DEFAULT     : flag = Flags.DEFAULT; break;
             case ERROR       : flag = 0; nextToken(); break;
             case IDENTIFIER  : {
                 if (isNonSealedClassStart(false)) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3011,7 +3011,6 @@ compiler.warn.preview.feature.use.plural=\
 compiler.warn.preview.feature.use.classfile=\
    class file for {0} uses preview features of Java SE {1}.
 
-
 compiler.misc.feature.modules=\
     modules
 
@@ -3020,15 +3019,6 @@ compiler.misc.feature.diamond.and.anon.class=\
 
 compiler.misc.feature.var.in.try.with.resources=\
     variables in try-with-resources
-
-compiler.misc.feature.diamond=\
-    diamond operator
-
-compiler.misc.feature.lambda=\
-    lambda expressions
-
-compiler.misc.feature.default.methods=\
-    default methods
 
 compiler.misc.feature.private.intf.methods=\
     private interface methods

--- a/test/jdk/java/lang/invoke/defineHiddenClass/src/HiddenInterface.java
+++ b/test/jdk/java/lang/invoke/defineHiddenClass/src/HiddenInterface.java
@@ -28,5 +28,6 @@
  */
 public interface HiddenInterface {
     default void test() {
+        record R() {}
     }
 }

--- a/test/langtools/jdk/jshell/ToolEnablePreviewTest.java
+++ b/test/langtools/jdk/jshell/ToolEnablePreviewTest.java
@@ -73,11 +73,11 @@ public class ToolEnablePreviewTest extends ReplToolTesting {
     @Test
     public void testCompilerTestFlagEnv() {
         test(new String[] {"-C", "-XDforcePreview"},
-                (a) -> assertCommandOutputContains(a, "Function<Integer,Integer> f = i -> i + i",
+                (a) -> assertCommandOutputContains(a, "Function<Integer,Integer> f = (var i) -> i + i",
                         "Error", "preview feature"),
                 (a) -> assertCommand(a, "/env --enable-preview",
                         "|  Setting new options and restoring state."),
-                (a) -> assertCommandOutputContains(a, "Function<Integer,Integer> f = i -> i + i",
+                (a) -> assertCommandOutputContains(a, "Function<Integer,Integer> f = (var i) -> i + i",
                         "f ==> ")
         );
     }
@@ -85,7 +85,7 @@ public class ToolEnablePreviewTest extends ReplToolTesting {
     @Test
     public void testCompilerTestFlag() {
         test(new String[] {"-C", "-XDforcePreview", "--enable-preview"},
-                (a) -> assertCommandOutputContains(a, "Function<Integer,Integer> f = i -> i + i",
+                (a) -> assertCommandOutputContains(a, "Function<Integer,Integer> f = (var i) -> i + i",
                         "f ==> "),
                 (a) -> assertCommandOutputContains(a, "f.apply(2)", "==> 4")
         );

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -65,7 +65,6 @@ compiler.misc.fatal.err.cant.locate.field               # Resolve, from Lower
 compiler.misc.fatal.err.cant.locate.meth                # Resolve, from Lower
 compiler.misc.fatal.err.cant.close                      # JavaCompiler
 compiler.misc.feature.not.supported.in.source.plural    # cannot happen (for now)
-compiler.misc.feature.default.methods                   # just preserved for testing (for now)
 compiler.misc.file.does.not.contain.package
 compiler.misc.illegal.start.of.class.file
 compiler.misc.inferred.do.not.conform.to.lower.bounds   # cannot happen?

--- a/test/langtools/tools/javac/diags/examples/PreviewFeatureDisabled.java
+++ b/test/langtools/tools/javac/diags/examples/PreviewFeatureDisabled.java
@@ -22,13 +22,13 @@
  */
 
 // key: compiler.err.preview.feature.disabled
-// key: compiler.misc.feature.diamond
+// key: compiler.misc.feature.case.null
 // options: -XDforcePreview
 
-import java.util.ArrayList;
-
 class PreviewFeatureDisabled {
-    void m() {
-        new ArrayList<>();
+    void m(String s) {
+        switch (s) {
+            case null:
+        }
     }
 }

--- a/test/langtools/tools/javac/diags/examples/PreviewFeatureDisabledPlural.java
+++ b/test/langtools/tools/javac/diags/examples/PreviewFeatureDisabledPlural.java
@@ -22,11 +22,13 @@
  */
 
 // key: compiler.err.preview.feature.disabled.plural
-// key: compiler.misc.feature.lambda
+// key: compiler.misc.feature.var.syntax.in.implicit.lambda
 // options: -XDforcePreview
+
+import java.util.function.Function;
 
 class PreviewFeatureDisabledPlural {
     void m() {
-        Runnable r = () -> {};
+        Function<String, String> f = (var s) -> s;
     }
 }

--- a/test/langtools/tools/javac/diags/examples/PreviewFeatureUse.java
+++ b/test/langtools/tools/javac/diags/examples/PreviewFeatureUse.java
@@ -21,17 +21,14 @@
  * questions.
  */
 
-//key: compiler.warn.preview.feature.use
 //key: compiler.warn.preview.feature.use.plural
-//key: compiler.misc.feature.diamond
-//key: compiler.misc.feature.lambda
+//key: compiler.misc.feature.var.syntax.in.implicit.lambda
 //options: -Xlint:preview -XDforcePreview -source ${jdk.version} --enable-preview
 
-import java.util.ArrayList;
+import java.util.function.Function;
 
 class PreviewFeatureUse {
     void test() {
-        new ArrayList<>();
-        Runnable r = () -> {};
+        Function<String, String> f = (var s) -> s;
     }
 }

--- a/test/langtools/tools/javac/diags/examples/PreviewFilename.java
+++ b/test/langtools/tools/javac/diags/examples/PreviewFilename.java
@@ -25,9 +25,8 @@
 // key: compiler.note.preview.recompile
 // options: -XDforcePreview  -source ${jdk.version} --enable-preview
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.function.Function;
 
 class PreviewFilename {
-    List<String> ls = new ArrayList<>();
+    Function<String, String> f = (var s) -> s;
 }

--- a/test/langtools/tools/javac/diags/examples/PreviewFilenameAdditional.java
+++ b/test/langtools/tools/javac/diags/examples/PreviewFilenameAdditional.java
@@ -22,15 +22,15 @@
  */
 
 // key: compiler.note.preview.filename.additional
-// key: compiler.warn.preview.feature.use
-// key: compiler.misc.feature.diamond
+// key: compiler.warn.preview.feature.use.plural
+// key: compiler.misc.feature.var.syntax.in.implicit.lambda
 // options: -Xlint:preview -Xmaxwarns 1 -XDforcePreview  -source ${jdk.version} --enable-preview
 
-import java.util.ArrayList;
+import java.util.function.Function;
 
 class PreviewFilenameAdditional {
     void test() {
-        new ArrayList<>();
-        new ArrayList<>();
+        Function<String, String> f = (var s) -> s;
+        Function<String, String> j = (var s) -> s;
     }
 }

--- a/test/langtools/tools/javac/diags/examples/PreviewPlural/PreviewPlural.java
+++ b/test/langtools/tools/javac/diags/examples/PreviewPlural/PreviewPlural.java
@@ -30,6 +30,6 @@ import java.util.ArrayList;
 class PreviewPlural {
     void test() {
         new PreviewPluralBar();
-        new ArrayList<>();
+        record R() {}
     }
 }

--- a/test/langtools/tools/javac/diags/examples/PreviewPlural/PreviewPluralBar.java
+++ b/test/langtools/tools/javac/diags/examples/PreviewPlural/PreviewPluralBar.java
@@ -22,5 +22,5 @@
  */
 
 class PreviewPluralBar {
-    Runnable r = () -> {};
+    record R() {}
 }

--- a/test/langtools/tools/javac/preview/classReaderTest/Bar.java
+++ b/test/langtools/tools/javac/preview/classReaderTest/Bar.java
@@ -22,5 +22,5 @@
  */
 
 public class Bar {
-    Runnable r = () -> {};
+    record R() {}
 }


### PR DESCRIPTION
This PR is a continuation of PR [1] which removed support for source and target 1.7 option in javac. This is is removing additional switches in javac that were providing support to legacy behavior related to source and target 1.7. What else could be missing?

TIA

[1] https://github.com/openjdk/jdk/pull/10074

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293051](https://bugs.openjdk.org/browse/JDK-8293051): Further refactor javac after removal of -source/-target/--release 7


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10150/head:pull/10150` \
`$ git checkout pull/10150`

Update a local copy of the PR: \
`$ git checkout pull/10150` \
`$ git pull https://git.openjdk.org/jdk pull/10150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10150`

View PR using the GUI difftool: \
`$ git pr show -t 10150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10150.diff">https://git.openjdk.org/jdk/pull/10150.diff</a>

</details>
