### PR TITLE
8291586: Broken links in JVMTI specification

### DIFF
--- a/src/hotspot/share/prims/jvmti.xsl
+++ b/src/hotspot/share/prims/jvmti.xsl
@@ -1172,7 +1172,7 @@ typedef struct {
     </tr>
     <xsl:for-each select="//capabilityfield">
       <xsl:variable name="capa" select="@id"/>
-      <xsl:variable name="events" select="//event[capabilities/required/@id=$capa]"/>
+      <xsl:variable name="events" select="//event[capabilities/required/@id=$capa and not(ancestor::elide)]"/>
       <xsl:if test="count($events)">
         <tr>
           <th scope="row">


### PR DESCRIPTION
The Loom related spec of the extension VirtualThreadMount and VirtualThreadUnmount events in the jvmti.xml is surrounded by the elements `<elide> ... </elide>`, so these specs have to be ignored when the `jvmti.html `is generated. However the `jvmti.xsl` which does the XSL transformation misses to do that when the description of the JVM TI capabilities is collected.

The fix is a one-liner:
```
diff --git a/src/hotspot/share/prims/jvmti.xsl b/src/hotspot/share/prims/jvmti.xsl
index 5ef89f91daf..d54d2a371e6 100644
--- a/src/hotspot/share/prims/jvmti.xsl
+++ b/src/hotspot/share/prims/jvmti.xsl
@@ -1172,7 +1172,7 @@ typedef struct {
     </tr>
     <xsl:for-each select="//capabilityfield">
       <xsl:variable name="capa" select="@id"/>
-      <xsl:variable name="events" select="//event[capabilities/required/@id=$capa]"/>
+      <xsl:variable name="events" select="//event[capabilities/required/@id=$capa and not(ancestor::elide)]"/>
       <xsl:if test="count($events)">
         <tr>
           <th scope="row">
```

The correctness verification both the generated `jvmti.html` and `jvmti.h` was checked.
TBD: mach5 sanity builds and `nsk.jvmti` tests runs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291586](https://bugs.openjdk.org/browse/JDK-8291586): Broken links in JVMTI specification


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10153/head:pull/10153` \
`$ git checkout pull/10153`

Update a local copy of the PR: \
`$ git checkout pull/10153` \
`$ git pull https://git.openjdk.org/jdk pull/10153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10153`

View PR using the GUI difftool: \
`$ git pr show -t 10153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10153.diff">https://git.openjdk.org/jdk/pull/10153.diff</a>

</details>
