### PR TITLE
8293340: Remove unused _code in {Zero,Template}InterpreterGenerator

### DIFF
--- a/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
+++ b/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
@@ -65,7 +65,7 @@ void ZeroInterpreter::initialize_code() {
   // generate interpreter
   { ResourceMark rm;
     TraceTime timer("Interpreter generation", TRACETIME_LOG(Info, startuptime));
-    ZeroInterpreterGenerator g(_code);
+    ZeroInterpreterGenerator g;
     if (PrintInterpreter) print();
   }
 }

--- a/src/hotspot/share/interpreter/abstractInterpreter.cpp
+++ b/src/hotspot/share/interpreter/abstractInterpreter.cpp
@@ -96,7 +96,7 @@ address    AbstractInterpreter::_native_abi_to_tosca    [AbstractInterpreter::nu
 //------------------------------------------------------------------------------------------------------------------------
 // Generation of complete interpreter
 
-AbstractInterpreterGenerator::AbstractInterpreterGenerator(StubQueue* _code) {
+AbstractInterpreterGenerator::AbstractInterpreterGenerator() {
   _masm                      = NULL;
 }
 

--- a/src/hotspot/share/interpreter/abstractInterpreter.hpp
+++ b/src/hotspot/share/interpreter/abstractInterpreter.hpp
@@ -295,7 +295,7 @@ class AbstractInterpreterGenerator: public StackObj {
   InterpreterMacroAssembler* _masm;
 
  public:
-  AbstractInterpreterGenerator(StubQueue* _code);
+  AbstractInterpreterGenerator();
 };
 
 #endif // SHARE_INTERPRETER_ABSTRACTINTERPRETER_HPP

--- a/src/hotspot/share/interpreter/templateInterpreter.cpp
+++ b/src/hotspot/share/interpreter/templateInterpreter.cpp
@@ -63,7 +63,7 @@ void TemplateInterpreter::initialize_code() {
   // generate interpreter
   { ResourceMark rm;
     TraceTime timer("Interpreter generation", TRACETIME_LOG(Info, startuptime));
-    TemplateInterpreterGenerator g(_code);
+    TemplateInterpreterGenerator g;
     // Free the unused memory not occupied by the interpreter and the stubs
     _code->deallocate_unused_tail();
   }

--- a/src/hotspot/share/interpreter/templateInterpreterGenerator.cpp
+++ b/src/hotspot/share/interpreter/templateInterpreterGenerator.cpp
@@ -34,7 +34,7 @@
 
 #define __ Disassembler::hook<InterpreterMacroAssembler>(__FILE__, __LINE__, _masm)->
 
-TemplateInterpreterGenerator::TemplateInterpreterGenerator(StubQueue* _code): AbstractInterpreterGenerator(_code) {
+TemplateInterpreterGenerator::TemplateInterpreterGenerator(): AbstractInterpreterGenerator() {
   _unimplemented_bytecode    = NULL;
   _illegal_bytecode_sequence = NULL;
   generate_all();

--- a/src/hotspot/share/interpreter/templateInterpreterGenerator.hpp
+++ b/src/hotspot/share/interpreter/templateInterpreterGenerator.hpp
@@ -127,7 +127,7 @@ class TemplateInterpreterGenerator: public AbstractInterpreterGenerator {
 #endif // PPC
 
  public:
-  TemplateInterpreterGenerator(StubQueue* _code);
+  TemplateInterpreterGenerator();
 };
 
 #endif // !ZERO

--- a/src/hotspot/share/interpreter/zero/zeroInterpreterGenerator.cpp
+++ b/src/hotspot/share/interpreter/zero/zeroInterpreterGenerator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2007, 2008, 2009, 2010, 2011 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -32,7 +32,7 @@
 #include "oops/method.hpp"
 #include "zeroInterpreterGenerator.hpp"
 
-ZeroInterpreterGenerator::ZeroInterpreterGenerator(StubQueue* _code): AbstractInterpreterGenerator(_code) {
+ZeroInterpreterGenerator::ZeroInterpreterGenerator(): AbstractInterpreterGenerator() {
   generate_all();
 }
 

--- a/src/hotspot/share/interpreter/zero/zeroInterpreterGenerator.hpp
+++ b/src/hotspot/share/interpreter/zero/zeroInterpreterGenerator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ class ZeroInterpreterGenerator: public AbstractInterpreterGenerator {
   address generate_Reference_get_entry();
 
  public:
-  ZeroInterpreterGenerator(StubQueue* _code);
+  ZeroInterpreterGenerator();
 
  protected:
   MacroAssembler* assembler() const {


### PR DESCRIPTION
Hi all,
The _code arg in TemplateInterpreterGenerator is unused 
Remove `_code`
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293340](https://bugs.openjdk.org/browse/JDK-8293340): Remove unused _code in {Zero,Template}InterpreterGenerator


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10156/head:pull/10156` \
`$ git checkout pull/10156`

Update a local copy of the PR: \
`$ git checkout pull/10156` \
`$ git pull https://git.openjdk.org/jdk pull/10156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10156`

View PR using the GUI difftool: \
`$ git pr show -t 10156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10156.diff">https://git.openjdk.org/jdk/pull/10156.diff</a>

</details>
