### PR TITLE
8293326: jdk/sun/security/tools/jarsigner/compatibility/SignTwice.java slow on Windows

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
+++ b/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
@@ -67,6 +67,7 @@ import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.util.JarUtils;
@@ -1034,13 +1035,19 @@ public class Compatibility {
             throws Throwable {
         long start = System.currentTimeMillis();
         try {
+            String[] cmd;
+            if (Platform.isWindows()) {
+                cmd = new String[args.length + 3];
+                System.arraycopy(args, 0, cmd, 3, args.length);
+            } else {
+                cmd = new String[args.length + 4];
+                cmd[3] = "-J-Djava.security.egd=file:/dev/./urandom";
+                System.arraycopy(args, 0, cmd, 4, args.length);
+            }
 
-            String[] cmd = new String[args.length + 4];
             cmd[0] = toolPath;
             cmd[1] = "-J-Duser.language=en";
             cmd[2] = "-J-Duser.country=US";
-            cmd[3] = "-J-Djava.security.egd=file:/dev/./urandom";
-            System.arraycopy(args, 0, cmd, 4, args.length);
             return ProcessTools.executeCommand(cmd);
 
         } finally {


### PR DESCRIPTION
This patch enables SignTwice test to complete faster on Windows machines.

The test starts `keytool` and `jarsigner` a number of times, passing `-J-Djava.security.egd=file:/dev/./urandom` to the started process, presumably to avoid blocking on VMs with insufficient entropy. This works fine on machines where `/dev/./urandom` is actually present. On Windows it makes the JVM use `ThreadedSeedGenerator`, which is very slow compared to the other options.

The fix removes `java.security.egd` setting on Windows machines.

Alternatively we could change the egd to use `file:/dev/urandom` (without the `/./` part); this also fixes the Windows problem. Is the `/./` part still needed? If I understand correctly, it was a workaround for some JDK7 bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293326](https://bugs.openjdk.org/browse/JDK-8293326): jdk/sun/security/tools/jarsigner/compatibility/SignTwice.java slow on Windows


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)
 * [Bradford Wetmore](https://openjdk.org/census#wetmore) (@bradfordwetmore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10160/head:pull/10160` \
`$ git checkout pull/10160`

Update a local copy of the PR: \
`$ git checkout pull/10160` \
`$ git pull https://git.openjdk.org/jdk pull/10160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10160`

View PR using the GUI difftool: \
`$ git pr show -t 10160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10160.diff">https://git.openjdk.org/jdk/pull/10160.diff</a>

</details>
