### PR TITLE
8292675: Add identity transformation for removing redundant AndV/OrV nodes

### DIFF
--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1889,8 +1889,8 @@ static Node* redundant_logical_identity(Node* n) {
   // (OperationV (OperationV src1 src2 m1) src2 m1) => (OperationV src1 src2 m1)
   if (n->Opcode() == n1->Opcode()) {
     if (((!n->is_predicated_vector() && !n1->is_predicated_vector()) ||
-       (n->is_predicated_vector() && n1->is_predicated_vector() &&
-       n->in(3) == n1->in(3))) && (n->in(2) == n1->in(1) || n->in(2) == n1->in(2))) {
+         ( n->is_predicated_vector() &&  n1->is_predicated_vector() && n->in(3) == n1->in(3))) &&
+         ( n->in(2) == n1->in(1) || n->in(2) == n1->in(2))) {
       return n1;
     }
   }
@@ -1899,12 +1899,13 @@ static Node* redundant_logical_identity(Node* n) {
   if (n->Opcode() == n2->Opcode()) {
     // (OperationV src1 (OperationV src1 src2)) => OperationV(src1, src2)
     // (OperationV src2 (OperationV src1 src2)) => OperationV(src1, src2)
-    if (!n->is_predicated_vector() && !n2->is_predicated_vector() &&
-       (n->in(1) == n2->in(1) || n->in(1) == n2->in(2))) {
-      return n2;
     // (OperationV src1 (OperationV src1 src2 m1) m1) => OperationV(src1 src2 m1)
-    } else if (n->is_predicated_vector() && n2->is_predicated_vector() &&
-               n->in(3) == n2->in(3) && n->in(1) == n2->in(1)) {
+    // It is not possible to optimize - (OperationV src2 (OperationV src1 src2 m1) m1) as the
+    // results of both "OperationV" nodes are different for unmasked lanes
+    if ((!n->is_predicated_vector() && !n2->is_predicated_vector() &&
+         (n->in(1) == n2->in(1) || n->in(1) == n2->in(2))) ||
+         (n->is_predicated_vector() && n2->is_predicated_vector() && n->in(3) == n2->in(3) &&
+         n->in(1) == n2->in(1))) {
       return n2;
     }
   }

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1879,6 +1879,39 @@ Node* ReverseVNode::Identity(PhaseGVN* phase) {
   return reverse_operations_identity(this, in(1));
 }
 
+// Optimize away redundant AndV/OrV nodes when the operation
+// is applied on the same input node multiple times
+static Node* redundant_logical_identity(Node* n) {
+  Node* n1 = n->in(1);
+  // (OperationV (OperationV src1 src2) src1) => (OperationV src1 src2)
+  // (OperationV (OperationV src1 src2) src2) => (OperationV src1 src2)
+  // (OperationV (OperationV src1 src2 m1) src1 m1) => (OperationV src1 src2 m1)
+  // (OperationV (OperationV src1 src2 m1) src2 m1) => (OperationV src1 src2 m1)
+  if (n->Opcode() == n1->Opcode()) {
+    if (((!n->is_predicated_vector() && !n1->is_predicated_vector()) ||
+       (n->is_predicated_vector() && n1->is_predicated_vector() &&
+       n->in(3) == n1->in(3))) && (n->in(2) == n1->in(1) || n->in(2) == n1->in(2))) {
+      return n1;
+    }
+  }
+
+  Node* n2 = n->in(2);
+  if (n->Opcode() == n2->Opcode()) {
+    // (OperationV src1 (OperationV src1 src2)) => OperationV(src1, src2)
+    // (OperationV src2 (OperationV src1 src2)) => OperationV(src1, src2)
+    if (!n->is_predicated_vector() && !n2->is_predicated_vector() &&
+       (n->in(1) == n2->in(1) || n->in(1) == n2->in(2))) {
+      return n2;
+    // (OperationV src1 (OperationV src1 src2 m1) m1) => OperationV(src1 src2 m1)
+    } else if (n->is_predicated_vector() && n2->is_predicated_vector() &&
+               n->in(3) == n2->in(3) && n->in(1) == n2->in(1)) {
+      return n2;
+    }
+  }
+
+  return n;
+}
+
 Node* AndVNode::Identity(PhaseGVN* phase) {
   // (AndV src (Replicate m1))   => src
   // (AndVMask src (MaskAll m1)) => src
@@ -1912,7 +1945,7 @@ Node* AndVNode::Identity(PhaseGVN* phase) {
   if (in(1) == in(2)) {
     return in(1);
   }
-  return this;
+  return redundant_logical_identity(this);
 }
 
 Node* OrVNode::Identity(PhaseGVN* phase) {
@@ -1948,7 +1981,7 @@ Node* OrVNode::Identity(PhaseGVN* phase) {
   if (in(1) == in(2)) {
     return in(1);
   }
-  return this;
+  return redundant_logical_identity(this);
 }
 
 Node* XorVNode::Ideal(PhaseGVN* phase, bool can_reshape) {


### PR DESCRIPTION
Recently we found that the rotate left/right benchmarks with vectorapi
emit a redundant "and" instruction on both aarch64 and x86_64 machines
which can be done away with.  For example - and(and(a, b), b) generates
two "and" instructions which can be reduced to a single "and" operation-
and(a, b) since "and" (and "or") operations are commutative and
idempotent in nature.  This can help improve performance for all those
workloads which have multiple "and"/"or" operations with the same value
by reducing them to fewer "and"/"or" operations accordingly.

This patch adds the following transformations for vector logical
operations - AndV and OrV :

```
(OpV (OpV a b) b) => (OpV a b)
(OpV (OpV a b) a) => (OpV a b)
(OpV (OpV a b m1) b m1) => (OpV a b m1)
(OpV (OpV a b m1) a m1) => (OpV a b m1)
(OpV a (OpV a b)) => (OpV a b)
(OpV b (OpV a b)) => (OpV a b)
(OpV a (OpV a b m) m) => (OpV a b m)
```
where Op = "And", "Or"

Links for benchmarks tested are given below :-
https://github.com/openjdk/panama-vector/blob/2aade73adeabdf6a924136b17fd96ccc95c1d160/test/micro/org/openjdk/bench/jdk/incubator/vector/operation/IntMaxVector.java#L728
https://github.com/openjdk/panama-vector/blob/2aade73adeabdf6a924136b17fd96ccc95c1d160/test/micro/org/openjdk/bench/jdk/incubator/vector/operation/IntMaxVector.java#L764
https://github.com/openjdk/panama-vector/blob/2aade73adeabdf6a924136b17fd96ccc95c1d160/test/micro/org/openjdk/bench/jdk/incubator/vector/operation/LongMaxVector.java#L728
https://github.com/openjdk/panama-vector/blob/2aade73adeabdf6a924136b17fd96ccc95c1d160/test/micro/org/openjdk/bench/jdk/incubator/vector/operation/LongMaxVector.java#L764

Before this patch, the disassembly for one these testcases
(IntMaxVector.ROR) for Neon is shown below :
 ```
  ldr     q16, [x12, #16]
  and     v16.16b, v16.16b, v20.16b
  and     v16.16b, v16.16b, v20.16b
  add     x12, x16, x11
  sub     v17.4s, v21.4s, v16.4s
  ...
  ...
```

After this patch, the disassembly for the same testcase above is shown
below :
```
  ldr     q16, [x12, #16]
  and     v16.16b, v16.16b, v20.16b
  add     x12, x16, x11
  sub     v17.4s, v21.4s, v16.4s
  ...
  ...
```

The other tests also emit an extra "and" instruction as shown above for
the vector ROR/ROL operations.

Below are the performance results for the vectorapi rotate tests (tests
given in the links above) with this patch on aarch64 and x86_64 machines
(for int and long types) -

```
Benchmark                aarch64   x86_64
IntMaxVector.ROL         25.57%    26.09%
IntMaxVector.ROR         23.75%    24.15%
LongMaxVector.ROL        28.91%    28.51%
LongMaxVector.ROR        16.51%    29.11%

```

The percentage indicates the percent gain/improvement in performance
(ops/ms) with this patch over the master build without this patch. The
machine descriptions are given below -
aarch64 - 128-bit aarch64 machine
x86_64  - 256-bit x86 machine

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292675](https://bugs.openjdk.org/browse/JDK-8292675): Add identity transformation for removing redundant AndV/OrV nodes


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Nick Gasson](https://openjdk.org/census#ngasson) (@nick-arm - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10163/head:pull/10163` \
`$ git checkout pull/10163`

Update a local copy of the PR: \
`$ git checkout pull/10163` \
`$ git pull https://git.openjdk.org/jdk pull/10163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10163`

View PR using the GUI difftool: \
`$ git pr show -t 10163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10163.diff">https://git.openjdk.org/jdk/pull/10163.diff</a>

</details>
