### PR TITLE
8293361: GHA: dump config.log in case of configure failure

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -37,6 +37,9 @@ on:
       apt-gcc-cross-version:
         required: true
         type: string
+      extra-conf-options:
+        required: false
+        type: string
 
 jobs:
   build-cross-compile:
@@ -142,6 +145,10 @@ jobs:
           --with-build-jdk=${{ steps.buildjdk.outputs.jdk-path }}
           CC=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-gcc-${{ inputs.gcc-major-version }}
           CXX=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-g++-${{ inputs.gcc-major-version }}
+          ${{ inputs.extra-conf-options }} || (
+          echo "Dumping config.log:" &&
+          cat config.log &&
+          exit 1)
 
       - name: 'Build'
         id: build

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -122,7 +122,10 @@ jobs:
           --with-gtest=${{ steps.gtest.outputs.path }}
           --enable-jtreg-failure-handler
           --with-zlib=system
-          ${{ inputs.extra-conf-options }}
+          ${{ inputs.extra-conf-options }} || (
+          echo "Dumping config.log:" &&
+          cat config.log &&
+          exit 1)
 
       - name: 'Build'
         id: build

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -97,7 +97,10 @@ jobs:
           --with-gtest=${{ steps.gtest.outputs.path }}
           --enable-jtreg-failure-handler
           --with-zlib=system
-          ${{ inputs.extra-conf-options }}
+          ${{ inputs.extra-conf-options }} || (
+          echo "Dumping config.log:" &&
+          cat config.log &&
+          exit 1)
 
       - name: 'Build'
         id: build

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -110,7 +110,10 @@ jobs:
           --with-gtest=${{ steps.gtest.outputs.path }}
           --enable-jtreg-failure-handler
           --with-msvc-toolset-version=${{ inputs.msvc-toolset-version }}
-          ${{ inputs.extra-conf-options }}
+          ${{ inputs.extra-conf-options }} || (
+          echo "Dumping config.log:" &&
+          cat config.log &&
+          exit 1)
         env:
           # We need a minimal PATH on Windows
           # Set PATH to "", so just GITHUB_PATH is included


### PR DESCRIPTION
If configure fails in GHA it is very hard to debug. Dumping the contents of config.log helps.