### PR TITLE
8289613: Drop use of Thread.stop in jshell

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -186,7 +186,8 @@ module java.base {
     exports jdk.internal.org.objectweb.asm to
         jdk.jartool,
         jdk.jfr,
-        jdk.jlink;
+        jdk.jlink,
+        jdk.jshell;
     exports jdk.internal.org.objectweb.asm.tree to
         jdk.jfr,
         jdk.jlink;

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/LocalExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/LocalExecutionControl.java
@@ -163,7 +163,6 @@ public class LocalExecutionControl extends DirectExecutionControl {
     }
 
     @Override
-    @SuppressWarnings({"deprecation", "removal"})
     public void stop() throws EngineTerminationException, InternalException {
         synchronized (STOP_LOCK) {
             if (!userCodeRunning) {

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/LocalExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/LocalExecutionControl.java
@@ -93,10 +93,10 @@ public class LocalExecutionControl extends DirectExecutionControl {
     }
 
     private static ClassBytecodes genCancelClass() {
-        var cancelWriter = new ClassWriter(ClassWriter.COMPUTE_FRAMES|ClassWriter.COMPUTE_MAXS);
+        var cancelWriter = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
         cancelWriter.visit(Opcodes.V19, Opcodes.ACC_PUBLIC, "REPL/$Cancel$", null, "java/lang/Object", null);
-        cancelWriter.visitField(Opcodes.ACC_PUBLIC|Opcodes.ACC_STATIC|Opcodes.ACC_VOLATILE, "allStop", "Z", null, null);
-        var checkVisitor = cancelWriter.visitMethod(Opcodes.ACC_PUBLIC|Opcodes.ACC_STATIC, "stopCheck", "()V", null, null);
+        cancelWriter.visitField(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_VOLATILE, "allStop", "Z", null, null);
+        var checkVisitor = cancelWriter.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "stopCheck", "()V", null, null);
             checkVisitor.visitCode();
             checkVisitor.visitFieldInsn(Opcodes.GETSTATIC, "REPL/$Cancel$", "allStop", "Z");
             var skip = new Label();
@@ -116,7 +116,7 @@ public class LocalExecutionControl extends DirectExecutionControl {
     @Override
     protected String invoke(Method doitMethod) throws Exception {
         if (allStop == null) {
-            super.load(new ClassBytecodes[]{genCancelClass()});
+            super.load(new ClassBytecodes[]{ genCancelClass() });
             allStop = findClass("REPL.$Cancel$").getDeclaredField("allStop");
         }
         allStop.set(null, false);
@@ -196,8 +196,8 @@ public class LocalExecutionControl extends DirectExecutionControl {
             }
             try {
                 allStop.set(null, true);
-            } catch (IllegalArgumentException| IllegalAccessException ex) {
-                throw new InternalException(ex.getMessage());
+            } catch (IllegalArgumentException | IllegalAccessException ex) {
+                throw new InternalException("Exception on local stop: " + ex);
             }
             Thread[] threads;
             int len, threadCount;


### PR DESCRIPTION
LocalExecutionControl in jdk.jshell actually uses Thread::stop to cancel execution of (long-running or infinite loops) user code in JShell, however Thread::stop is deprecated and planned for removal.

Proposed patch instruments all user code to call LocalExecutionControl::stopCheck method before every branch instruction.
Thread::stop call is replaced by setting global field LocalExecutionControl.allStop to true and stopCheck method then throws ThreadDead when called from the instrumented code.

Proposed patch requires jdk.jshell access to java.base jdk.internal.org.objectweb.asm package. 

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289613](https://bugs.openjdk.org/browse/JDK-8289613): Drop use of Thread.stop in jshell


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10166/head:pull/10166` \
`$ git checkout pull/10166`

Update a local copy of the PR: \
`$ git checkout pull/10166` \
`$ git pull https://git.openjdk.org/jdk pull/10166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10166`

View PR using the GUI difftool: \
`$ git pr show -t 10166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10166.diff">https://git.openjdk.org/jdk/pull/10166.diff</a>

</details>
