### PR TITLE
6529151: NullPointerException in swing.plaf.synth.SynthLookAndFeel$Handler

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
@@ -1000,6 +1000,9 @@ public class SynthLookAndFeel extends BasicLookAndFeel {
                 SynthStyle style = context.getStyle();
                 int state = context.getComponentState();
 
+                if (style == null) {
+                    return;
+                }
                 // Get the current background color.
                 Color currBG = style.getColor(context, ColorType.BACKGROUND);
 

--- a/test/jdk/javax/swing/plaf/synth/RepaintNPE.java
+++ b/test/jdk/javax/swing/plaf/synth/RepaintNPE.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 6529151
+ * @summary  Verifies no NPE is thrown in SynthLookAndFeel$Handler
+ * @run main RepaintNPE
+ */
+import java.awt.Container;
+import java.awt.Component;
+import java.awt.Robot;
+import java.awt.Point;
+import java.awt.event.InputEvent;
+import java.lang.reflect.Method;
+
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.plaf.ComponentUI;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class RepaintNPE
+{
+    private static JFrame frame;
+    private static JButton showDialogButton = null;
+
+    private static class DumbDialog extends JDialog {
+
+        public DumbDialog ( JFrame parent )
+        {
+            super ( parent, "DumbDialog", true );
+
+            setDefaultCloseOperation ( DISPOSE_ON_CLOSE );
+
+            JEditorPane editorPane = new JEditorPane();
+            editorPane.setContentType ( "text/html" );
+            editorPane.setEditable ( false );
+
+            JScrollPane scrollPane = new JScrollPane ( editorPane );
+            add( scrollPane );
+            setSize( 400, 400 );
+            setVisible( true );
+        }
+
+        public void dispose() {
+            super.dispose();
+            myDispose( this );
+        }
+
+        private void myDispose( Container container ) {
+            Component[] components = container.getComponents ();
+
+            for ( Component comp : components ) {
+                // Special dispose for JComponent's remove UI
+                if (comp instanceof JComponent) {
+                    JComponent jComp = (JComponent)comp;
+
+                    try
+                    {
+                        Method method = jComp.getClass().getMethod ( "getUI" );
+                        ComponentUI compUI =
+                                 (ComponentUI)method.invoke ( jComp );
+                        compUI.uninstallUI ( jComp );
+                    } catch ( Throwable t ) {}
+
+                    // Recurse children
+                    myDispose( jComp );
+                }
+            }
+        }
+
+    }
+
+    public static void main ( String args [] ) throws Exception
+    {
+        Robot robot = new Robot();
+        UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
+        SwingUtilities.invokeAndWait ( () -> {
+            frame = new JFrame();
+
+            showDialogButton = new JButton( "Show Dialog" );
+            showDialogButton.addActionListener((e) -> {
+                if ( e.getSource() == showDialogButton ) {
+                    new DumbDialog ( frame );
+                }
+            });
+            frame.add ( showDialogButton );
+            frame.setSize( 100, 100 );
+            frame.setLocationRelativeTo(null);
+            frame.setUndecorated(true);
+            frame.setVisible( true );
+        });
+        robot.waitForIdle();
+        robot.delay(1000);
+        Point loc = frame.getLocationOnScreen();
+        robot.mouseMove(loc.x+10, loc.y+10);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.delay(1000);
+        SwingUtilities.invokeAndWait(() -> frame.dispose());
+    }
+}

--- a/test/jdk/javax/swing/plaf/synth/RepaintNPE.java
+++ b/test/jdk/javax/swing/plaf/synth/RepaintNPE.java
@@ -23,6 +23,7 @@
 /*
  * @test
  * @bug 6529151
+ * @key headful
  * @summary  Verifies no NPE is thrown in SynthLookAndFeel$Handler
  * @run main RepaintNPE
  */

--- a/test/jdk/javax/swing/plaf/synth/RepaintNPE.java
+++ b/test/jdk/javax/swing/plaf/synth/RepaintNPE.java
@@ -31,7 +31,6 @@ import java.awt.Component;
 import java.awt.Robot;
 import java.awt.Point;
 import java.awt.event.InputEvent;
-import java.lang.reflect.Method;
 
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -81,9 +80,7 @@ public class RepaintNPE
 
                     try
                     {
-                        Method method = jComp.getClass().getMethod ( "getUI" );
-                        ComponentUI compUI =
-                                 (ComponentUI)method.invoke ( jComp );
+                        ComponentUI compUI = jComp.getUI();
                         compUI.uninstallUI ( jComp );
                     } catch ( Throwable t ) {}
 


### PR DESCRIPTION
NPE is thrown for closed/disposed JDialogs after uninstalling the UI which is because for SynthEditorPaneUI even though is disposed of, Nimbus propertyHandler tries to get the style of this disposed component resulting in NPE, 
which is fixed by a null check to prevent deferencing style object to get the color.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6529151](https://bugs.openjdk.org/browse/JDK-6529151): NullPointerException in swing.plaf.synth.SynthLookAndFeel$Handler


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to [f62d58b9](https://git.openjdk.org/jdk/pull/10167/files/f62d58b966f2c27985b2625295e1d397fd0cb62a)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Author) ⚠️ Review applies to [f62d58b9](https://git.openjdk.org/jdk/pull/10167/files/f62d58b966f2c27985b2625295e1d397fd0cb62a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10167/head:pull/10167` \
`$ git checkout pull/10167`

Update a local copy of the PR: \
`$ git checkout pull/10167` \
`$ git pull https://git.openjdk.org/jdk pull/10167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10167`

View PR using the GUI difftool: \
`$ git pr show -t 10167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10167.diff">https://git.openjdk.org/jdk/pull/10167.diff</a>

</details>
