### PR TITLE
JDK-8293180: JQuery UI license file not updated

### DIFF
--- a/src/jdk.javadoc/share/legal/jqueryUI.md
+++ b/src/jdk.javadoc/share/legal/jqueryUI.md
@@ -1,4 +1,4 @@
-## jQuery UI v1.12.1
+## jQuery UI v1.13.1
 
 ### jQuery UI License
 ```


### PR DESCRIPTION
Update the version string in src/jdk.javadoc/share/legal/jqueryUI.md to `v1.13.1`. This was forgotten in JDK-8284367. The text of the license has not changed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293180](https://bugs.openjdk.org/browse/JDK-8293180): JQuery UI license file not updated ⚠️ Issue is not open.


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10172/head:pull/10172` \
`$ git checkout pull/10172`

Update a local copy of the PR: \
`$ git checkout pull/10172` \
`$ git pull https://git.openjdk.org/jdk pull/10172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10172`

View PR using the GUI difftool: \
`$ git pr show -t 10172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10172.diff">https://git.openjdk.org/jdk/pull/10172.diff</a>

</details>
