### PR TITLE
8293478: [java.desktop/macOS] Condense SDRenderType usages in QuartzRenderer.m

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/QuartzRenderer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/QuartzRenderer.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/QuartzSurfaceData.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/QuartzSurfaceData.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/QuartzSurfaceData.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/QuartzSurfaceData.m
@@ -1115,21 +1115,11 @@ SDRenderType SetUpPaint(JNIEnv *env, QuartzSDOps *qsdo, SDRenderType renderType)
 SDRenderType DoShapeUsingCG(CGContextRef cgRef, jint *types, jfloat *coords, jint numtypes, BOOL fill, CGFloat offsetX, CGFloat offsetY)
 {
 //fprintf(stderr, "DoShapeUsingCG fill=%d\n", (jint)fill);
-    SDRenderType renderType = SD_Nothing;
 
     if (gAdjustForJavaDrawing != YES)
     {
         offsetX = 0.0f;
         offsetY = 0.0f;
-    }
-
-    if (fill == YES)
-    {
-        renderType = SD_Fill;
-    }
-    else
-    {
-        renderType = SD_Stroke;
     }
 
     if (numtypes > 0)
@@ -1206,7 +1196,7 @@ SDRenderType DoShapeUsingCG(CGContextRef cgRef, jint *types, jfloat *coords, jin
         }
     }
 
-    return renderType;
+    return fill ? SD_Fill : SD_Stroke;
 }
 
 void CompleteCGContext(JNIEnv *env, QuartzSDOps *qsdo)


### PR DESCRIPTION
The `SDRenderType` enum is often returned using a variable declared at the start of functions. These can be inlined in the `return` itself. Using a ternary operator condenses what may be 12 lines into one, in the most extreme cases. `doRectUsingCG` and `doPolyUsingCG` were both modified more than the rest, but are still basically the same.

Example change:
```objc
SDRenderType renderType = SD_Nothing;

if (fill == YES)
{
    renderType = SD_Fill;
}
else
{
    renderType = SD_Stroke;
}

// draw logic

return renderType;
```

```objc
// draw logic

return fill ? SD_Fill : SD_Stroke;
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293478](https://bugs.openjdk.org/browse/JDK-8293478): [java.desktop/macOS] Condense SDRenderType usages in QuartzRenderer.m


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10174/head:pull/10174` \
`$ git checkout pull/10174`

Update a local copy of the PR: \
`$ git checkout pull/10174` \
`$ git pull https://git.openjdk.org/jdk pull/10174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10174`

View PR using the GUI difftool: \
`$ git pr show -t 10174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10174.diff">https://git.openjdk.org/jdk/pull/10174.diff</a>

</details>
