### PR TITLE
8234315: GTK LAF does not gray out disabled JMenu

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
@@ -2354,6 +2354,9 @@ static gint gtk3_get_color_for_state(JNIEnv *env, WidgetType widget_type,
         if ((widget_type == TEXT_FIELD || widget_type == PASSWORD_FIELD || widget_type == SPINNER_TEXT_FIELD ||
             widget_type == FORMATTED_TEXT_FIELD) && state_type == GTK_STATE_SELECTED && color_type == TEXT_BACKGROUND) {
             widget_type = TEXT_AREA;
+        } else if (widget_type == MENU_BAR && state_type == GTK_STATE_INSENSITIVE
+            && color_type == FOREGROUND) {
+            widget_type = MENU;
         }
     }
 

--- a/test/jdk/javax/swing/JMenu/TestDisabledMenuForegroundColor.java
+++ b/test/jdk/javax/swing/JMenu/TestDisabledMenuForegroundColor.java
@@ -50,33 +50,33 @@ public class TestDisabledMenuForegroundColor {
     private static JMenu fileMenu;
 
     public static void main(String[] args) throws Exception {
-    	UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
         Robot robot = new Robot();
-        robot.setAutoDelay(100);   
+        robot.setAutoDelay(100);
         try {
             SwingUtilities.invokeAndWait(() -> {
-		        createAndShowUI();
+                createAndShowUI();
             });
 
             robot.waitForIdle();
             robot.delay(1000);
-	        Point pt = fileMenu.getLocationOnScreen();
+            Point pt = fileMenu.getLocationOnScreen();
             BufferedImage enabledImg =
                     robot.createScreenCapture(new Rectangle(pt.x, pt.y,
                                               fileMenu.getWidth(),
                                               fileMenu.getHeight()));
-	        fileMenu.setEnabled(false);
-	        robot.waitForIdle();
+            fileMenu.setEnabled(false);
+            robot.waitForIdle();
             robot.delay(1000);
-	        BufferedImage disabledImg =
+            BufferedImage disabledImg =
                     robot.createScreenCapture(new Rectangle(pt.x, pt.y,
                                               fileMenu.getWidth(),
                                               fileMenu.getHeight()));
-	        boolean passed = compareImage(enabledImg,disabledImg);
-	    
+            boolean passed = compareImage(enabledImg,disabledImg);
+
             if (!passed) {
                 ImageIO.write(enabledImg, "png", new File("JMenuEnabledImg.png"));
-	    	    ImageIO.write(disabledImg, "png", new File("JMenuDisabledImg.png"));
+                ImageIO.write(disabledImg, "png", new File("JMenuDisabledImg.png"));
                 throw new RuntimeException("Disabled JMenu foreground color not grayed out");
             }
         } finally {
@@ -87,27 +87,27 @@ public class TestDisabledMenuForegroundColor {
             });
         }
     }
-    
+
     private static void createAndShowUI() {
-    	frame = new JFrame("Test Disabled Menu Foreground Color");  
-	    menuBar  = new JMenuBar();
-	    fileMenu = new JMenu("File");
-	    fileMenu.setEnabled(true);
+        frame = new JFrame("Test Disabled Menu Foreground Color");
+        menuBar  = new JMenuBar();
+        fileMenu = new JMenu("File");
+        fileMenu.setEnabled(true);
         menuBar.add(fileMenu);
-        frame.setJMenuBar(menuBar);       
+        frame.setJMenuBar(menuBar);
         frame.pack();
         frame.setSize(250, 200);
         frame.setLocationRelativeTo(null);
-        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);  
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.setVisible(true);
     }
-    
+
     /*
     * Compare JMenu enabled and disabled state image and if both images
     * width and height are equal but pixel's RGB values are not equal,
     * method returns true; false otherwise.
     */
-    
+
     private static boolean compareImage(BufferedImage img1, BufferedImage img2) {
         if (img1.getWidth() == img2.getWidth()
                 && img1.getHeight() == img2.getHeight()) {

--- a/test/jdk/javax/swing/JMenu/TestDisabledMenuForegroundColor.java
+++ b/test/jdk/javax/swing/JMenu/TestDisabledMenuForegroundColor.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8234315
+ * @key headful
+ * @requires (os.family == "linux")
+ * @summary Verifies if disabled menu foreground color grayed out
+ * @run main TestDisabledMenuForegroundColor
+ */
+
+import java.awt.Color;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import javax.imageio.ImageIO;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class TestDisabledMenuForegroundColor {
+
+    private static JFrame frame;
+    private static JMenuBar menuBar;
+    private static JMenu fileMenu;
+
+    public static void main(String[] args) throws Exception {
+    	UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);   
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+		        createAndShowUI();
+            });
+
+            robot.waitForIdle();
+            robot.delay(1000);
+	        Point pt = fileMenu.getLocationOnScreen();
+            BufferedImage enabledImg =
+                    robot.createScreenCapture(new Rectangle(pt.x, pt.y,
+                                              fileMenu.getWidth(),
+                                              fileMenu.getHeight()));
+	        fileMenu.setEnabled(false);
+	        robot.waitForIdle();
+            robot.delay(1000);
+	        BufferedImage disabledImg =
+                    robot.createScreenCapture(new Rectangle(pt.x, pt.y,
+                                              fileMenu.getWidth(),
+                                              fileMenu.getHeight()));
+	        boolean passed = compareImage(enabledImg,disabledImg);
+	    
+            if (!passed) {
+                ImageIO.write(enabledImg, "png", new File("JMenuEnabledImg.png"));
+	    	    ImageIO.write(disabledImg, "png", new File("JMenuDisabledImg.png"));
+                throw new RuntimeException("Disabled JMenu foreground color not grayed out");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+    
+    private static void createAndShowUI() {
+    	frame = new JFrame("Test Disabled Menu Foreground Color");  
+	    menuBar  = new JMenuBar();
+	    fileMenu = new JMenu("File");
+	    fileMenu.setEnabled(true);
+        menuBar.add(fileMenu);
+        frame.setJMenuBar(menuBar);       
+        frame.pack();
+        frame.setSize(250, 200);
+        frame.setLocationRelativeTo(null);
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);  
+        frame.setVisible(true);
+    }
+    
+    /*
+    * Compare JMenu enabled and disabled state image and if both images
+    * width and height are equal but pixel's RGB values are not equal,
+    * method returns true; false otherwise.
+    */
+    
+    private static boolean compareImage(BufferedImage img1, BufferedImage img2) {
+        if (img1.getWidth() == img2.getWidth()
+                && img1.getHeight() == img2.getHeight()) {
+            for (int x = 1; x < img1.getWidth()-1; ++x) {
+                for (int y = 1; y < img1.getHeight()-1; ++y) {
+                    if (img1.getRGB(x, y) != img2.getRGB(x, y)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        } else {
+            return false;
+        }
+    }
+}
+


### PR DESCRIPTION
Disabled JMenu foreground color was not grayed out in GTK LAF for version 3. The issue didn't occur in GTK-2. 
After analysis it has been found that the JMenu widget type was changed to JMenuBar and the color value returned for the foreground color in disabled state was close to black color (RGB 0,0,0) for menubar which is not differentiable from enabled state foreground color.

As a fix for this problem, if the menubar is in disabled state then the widget is changed to JMenu and color value returned for disabled menu is gray color.

An automated test case has been added and checked in CI, link is added in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8234315](https://bugs.openjdk.org/browse/JDK-8234315): GTK LAF does not gray out disabled JMenu


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10176/head:pull/10176` \
`$ git checkout pull/10176`

Update a local copy of the PR: \
`$ git checkout pull/10176` \
`$ git pull https://git.openjdk.org/jdk pull/10176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10176`

View PR using the GUI difftool: \
`$ git pr show -t 10176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10176.diff">https://git.openjdk.org/jdk/pull/10176.diff</a>

</details>
