### PR TITLE
JDK-8293402: hs-err file printer should reattempt stack trace printing if it fails

### DIFF
--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -688,7 +688,7 @@ extern "C" JNIEXPORT void pns(void* sp, void* fp, void* pc) { // print native st
   Thread* t = Thread::current_or_null();
   // Call generic frame constructor (certain arguments may be ignored)
   frame fr(sp, fp, pc);
-  VMError::print_native_stack(tty, fr, t, buf, sizeof(buf));
+  VMError::print_native_stack(tty, fr, t, false, buf, sizeof(buf));
 }
 
 //
@@ -708,7 +708,7 @@ extern "C" JNIEXPORT void pns2() { // print native stack
   } else {
     Thread* t = Thread::current_or_null();
     frame fr = os::current_frame();
-    VMError::print_native_stack(tty, fr, t, buf, sizeof(buf));
+    VMError::print_native_stack(tty, fr, t, false, buf, sizeof(buf));
   }
 }
 #endif

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -347,7 +347,7 @@ static frame next_frame(frame fr, Thread* t) {
   }
 }
 
-void VMError::print_native_stack(outputStream* st, frame fr, Thread* t, char* buf, int buf_size) {
+void VMError::print_native_stack(outputStream* st, frame fr, Thread* t, bool print_source_info, char* buf, int buf_size) {
 
   // see if it's a valid frame
   if (fr.pc()) {
@@ -362,7 +362,8 @@ void VMError::print_native_stack(outputStream* st, frame fr, Thread* t, char* bu
         if (count == 1 && _lineno != 0) {
           // We have source information of the first frame for internal errors. There is no need to parse it from the symbols.
           st->print("  (%s:%d)", get_filename_only(), _lineno);
-        } else if (Decoder::get_source_info(fr.pc(), filename, sizeof(filename), &line_no, count != 1)) {
+        } else if (print_source_info &&
+                   Decoder::get_source_info(fr.pc(), filename, sizeof(filename), &line_no, count != 1)) {
           st->print("  (%s:%d)", filename, line_no);
         }
       }
@@ -534,6 +535,8 @@ void VMError::report(outputStream* st, bool _verbose) {
 
   // don't allocate large buffer on stack
   static char buf[O_BUFLEN];
+
+  static bool print_native_stack_succeeded = false;
 
   BEGIN
 
@@ -832,7 +835,7 @@ void VMError::report(outputStream* st, bool _verbose) {
        st->cr();
      }
 
-  STEP("printing native stack")
+  STEP("printing native stack (with source info)")
 
    if (_verbose) {
      if (os::platform_print_native_stack(st, _context, buf, sizeof(buf))) {
@@ -842,9 +845,20 @@ void VMError::report(outputStream* st, bool _verbose) {
        frame fr = _context ? os::fetch_frame_from_context(_context)
                            : os::current_frame();
 
-       print_native_stack(st, fr, _thread, buf, sizeof(buf));
+       print_native_stack(st, fr, _thread, true, buf, sizeof(buf));
        _print_native_stack_used = true;
      }
+     print_native_stack_succeeded = true;
+   }
+
+  STEP("retry printing native stack (no source info)")
+
+   if (_verbose && !print_native_stack_succeeded) {
+     st->cr();
+     st->print_cr("Retrying call stack printing without source information...");
+     frame fr = _context ? os::fetch_frame_from_context(_context) : os::current_frame();
+     print_native_stack(st, fr, _thread, false, buf, sizeof(buf));
+     _print_native_stack_used = true;
    }
 
   STEP("printing Java stack")

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -105,7 +105,7 @@ class VMError : public AllStatic {
 
   // public for use by the internal non-product debugger.
   NOT_PRODUCT(public:)
-  static void print_native_stack(outputStream* st, frame fr, Thread* t,
+  static void print_native_stack(outputStream* st, frame fr, Thread* t, bool print_source_info,
                                  char* buf, int buf_size);
   NOT_PRODUCT(private:)
 


### PR DESCRIPTION
Hi,

may I have reviews for this small improvement.

The call stack may be the most important part of an hs-err file. We recently introduced printing of source information (https://bugs.openjdk.org/browse/JDK-8242181) which is nice but makes stack printing more vulnerable for two reasons:
- we may crash due to a programmer error (e.g. https://bugs.openjdk.org/browse/JDK-8293344)
- we may timeout on very slow machines/file systems when the source information are parsed from the debug info (we have seen those problems in the past)

Therefore, VMError should retry stack printing without source information if the first attempt to print failed.

Examples:

Step timeouts while retrieving source info:

```
 24 ---------------  T H R E A D  ---------------
 25 
 26 Current thread (0x00007f70ac028bd0):  JavaThread "main" [_thread_in_vm, id=565259, stack(0x00007f70b0587000,0x00007f70b0688000)]
 27 
 28 Stack: [0x00007f70b0587000,0x00007f70b0688000],  sp=0x00007f70b0686cf0,  free space=1023k
 29 Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
 30 V  [libjvm.so+0x1cd41c1]  VMError::controlled_crash(int)+0x241
 31 [timeout occurred during error reporting in step "printing native stack (with source info)"] after 30 s.
 32 
 33 Retrying call stack printing without source information...
 34 Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
 35 V  [libjvm.so+0x1cd41c1]  VMError::controlled_crash(int)+0x241
 36 V  [libjvm.so+0x11cbe45]  JNI_CreateJavaVM+0x5b5
 37 C  [libjli.so+0x4013]  JavaMain+0x93
 38 C  [libjli.so+0x800d]  ThreadJavaMain+0xd
 39 
```


Step crashes while retrieving source info:

```
 24 ---------------  T H R E A D  ---------------
 25 
 26 Current thread (0x00007fc000028bd0):  JavaThread "main" [_thread_in_vm, id=569254, stack(0x00007fc00573c000,0x00007fc00583d000)]
 27 
 28 Stack: [0x00007fc00573c000,0x00007fc00583d000],  sp=0x00007fc00583bcf0,  free space=1023k
 29 Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
 30 V  [libjvm.so+0x1cd41e1]  VMError::controlled_crash(int)+0x241
 31 [error occurred during error reporting (printing native stack (with source info)), id 0xb, SIGSEGV (0xb) at pc=0x00007fc006694d78]
 32 
 33 
 34 Retrying call stack printing without source information...
 35 Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
 36 V  [libjvm.so+0x1cd41e1]  VMError::controlled_crash(int)+0x241
 37 V  [libjvm.so+0x11cbe65]  JNI_CreateJavaVM+0x5b5
 38 C  [libjli.so+0x4013]  JavaMain+0x93
 39 C  [libjli.so+0x800d]  ThreadJavaMain+0xd
```


Thanks, Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293402](https://bugs.openjdk.org/browse/JDK-8293402): hs-err file printer should reattempt stack trace printing if it fails


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Dmitry Samersoff](https://openjdk.org/census#dsamersoff) (@dsamersoff - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10179/head:pull/10179` \
`$ git checkout pull/10179`

Update a local copy of the PR: \
`$ git checkout pull/10179` \
`$ git pull https://git.openjdk.org/jdk pull/10179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10179`

View PR using the GUI difftool: \
`$ git pr show -t 10179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10179.diff">https://git.openjdk.org/jdk/pull/10179.diff</a>

</details>
