### PR TITLE
8293403: JfrResolution::on_jvmci_resolution crashes when caller is null

### DIFF
--- a/src/hotspot/share/jfr/instrumentation/jfrResolution.cpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrResolution.cpp
@@ -127,8 +127,10 @@ void JfrResolution::on_c2_resolution(const Parse * parse, const ciKlass * holder
 #if INCLUDE_JVMCI
 // JVMCI
 void JfrResolution::on_jvmci_resolution(const Method* caller, const Method* target, TRAPS) {
-  if (is_compiler_linking_event_writer(target->method_holder()->name(), target->name()) && !IS_METHOD_BLESSED(caller)) {
-    THROW_MSG(vmSymbols::java_lang_IllegalAccessError(), link_error_msg);
+  if (is_compiler_linking_event_writer(target->method_holder()->name(), target->name())) {
+    if (caller == nullptr || !IS_METHOD_BLESSED(caller)) {
+      THROW_MSG(vmSymbols::java_lang_IllegalAccessError(), link_error_msg);
+    }
   }
 }
 #endif

--- a/test/jdk/jdk/jfr/jvm/TestGetEventWriter.java
+++ b/test/jdk/jdk/jfr/jvm/TestGetEventWriter.java
@@ -371,6 +371,12 @@ public class TestGetEventWriter {
                     throw new AssertionError("Expected IllegalAccessError");
                 } catch (IllegalAccessError e) {
                 }
+                try {
+                    // Test looking up with null caller
+                    cp.lookupMethod(cpi, 184, null);
+                    throw new AssertionError("Expected IllegalAccessError");
+                } catch (IllegalAccessError e) {
+                }
 
                 // Ignore all subsequent instructions
                 return;


### PR DESCRIPTION
When the `caller` argument to `JfrResolution::on_jvmci_resolution` is null, the method should raise an `IllegalAccessError` instead of crashing with a SIGSEGV.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293403](https://bugs.openjdk.org/browse/JDK-8293403): JfrResolution::on_jvmci_resolution crashes when caller is null


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10180/head:pull/10180` \
`$ git checkout pull/10180`

Update a local copy of the PR: \
`$ git checkout pull/10180` \
`$ git pull https://git.openjdk.org/jdk pull/10180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10180`

View PR using the GUI difftool: \
`$ git pr show -t 10180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10180.diff">https://git.openjdk.org/jdk/pull/10180.diff</a>

</details>
