### PR TITLE
8288717: Add a means to close idle connections in HTTP/2 connection pool

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/ConnectionPool.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ConnectionPool.java
@@ -45,14 +45,13 @@ import java.util.stream.Collectors;
 import jdk.internal.net.http.common.FlowTube;
 import jdk.internal.net.http.common.Logger;
 import jdk.internal.net.http.common.Utils;
-import static jdk.internal.net.http.HttpClientImpl.KEEP_ALIVE_TIMEOUT;
+import static jdk.internal.net.http.HttpClientImpl.KEEP_ALIVE_TIMEOUT; //seconds
 
 /**
  * Http 1.1 connection pool.
  */
 final class ConnectionPool {
 
-    static final long KEEP_ALIVE = KEEP_ALIVE_TIMEOUT; // seconds
     static final long MAX_POOL_SIZE = Utils.getIntegerNetProperty(
             "jdk.httpclient.connectionPoolSize", 0); // unbounded
     final Logger debug = Utils.getDebugLogger(this::dbgString, Utils.DEBUG);
@@ -152,7 +151,7 @@ final class ConnectionPool {
      * Returns the connection to the pool.
      */
     void returnToPool(HttpConnection conn) {
-        returnToPool(conn, Instant.now(), KEEP_ALIVE);
+        returnToPool(conn, Instant.now(), KEEP_ALIVE_TIMEOUT);
     }
 
     // Called also by whitebox tests
@@ -362,7 +361,7 @@ final class ConnectionPool {
         // should only be called while holding a synchronization
         // lock on the ConnectionPool
         void add(HttpConnection conn) {
-            add(conn, Instant.now(), KEEP_ALIVE);
+            add(conn, Instant.now(), KEEP_ALIVE_TIMEOUT);
         }
 
         // Used by whitebox test.

--- a/src/java.net.http/share/classes/jdk/internal/net/http/ConnectionPool.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ConnectionPool.java
@@ -45,14 +45,14 @@ import java.util.stream.Collectors;
 import jdk.internal.net.http.common.FlowTube;
 import jdk.internal.net.http.common.Logger;
 import jdk.internal.net.http.common.Utils;
+import static jdk.internal.net.http.HttpClientImpl.KEEP_ALIVE_TIMEOUT;
 
 /**
  * Http 1.1 connection pool.
  */
 final class ConnectionPool {
 
-    static final long KEEP_ALIVE = Utils.getIntegerNetProperty(
-            "jdk.httpclient.keepalive.timeout", 600); // seconds
+    static final long KEEP_ALIVE = KEEP_ALIVE_TIMEOUT; // seconds
     static final long MAX_POOL_SIZE = Utils.getIntegerNetProperty(
             "jdk.httpclient.connectionPoolSize", 0); // unbounded
     final Logger debug = Utils.getDebugLogger(this::dbgString, Utils.DEBUG);

--- a/src/java.net.http/share/classes/jdk/internal/net/http/ConnectionPool.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ConnectionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ import jdk.internal.net.http.common.Utils;
 final class ConnectionPool {
 
     static final long KEEP_ALIVE = Utils.getIntegerNetProperty(
-            "jdk.httpclient.keepalive.timeout", 1200); // seconds
+            "jdk.httpclient.keepalive.timeout", 600); // seconds
     static final long MAX_POOL_SIZE = Utils.getIntegerNetProperty(
             "jdk.httpclient.connectionPoolSize", 0); // unbounded
     final Logger debug = Utils.getDebugLogger(this::dbgString, Utils.DEBUG);

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -733,9 +733,7 @@ class Http2Connection  {
             closed = true;
         }
         if (Log.errors()) {
-            if (idleConnectionTimeoutEvent != null && idleConnectionTimeoutEvent.isFired()) {
-                Log.logError("idleConnectionTimeout timeout fired, shutting down connection: {0}", t.getMessage());
-            } else if (!(t instanceof EOFException) || isActive()) {
+            if (!(t instanceof EOFException) || isActive()) {
                 Log.logError(t);
             } else if (t != null) {
                 Log.logError("Shutting down connection: {0}", t.getMessage());

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -111,7 +111,7 @@ final class HttpClientImpl extends HttpClient implements Trackable {
     final Logger debugtimeout = Utils.getDebugLogger(this::dbgString, DEBUGTIMEOUT);
     static final AtomicLong CLIENT_IDS = new AtomicLong();
     private final AtomicLong CONNECTION_IDS = new AtomicLong();
-    static final int DEFAULT_KEEP_ALIVE_TIMEOUT = 600;
+    static final int DEFAULT_KEEP_ALIVE_TIMEOUT = 1200;
     static final long KEEP_ALIVE_TIMEOUT = getTimeoutProp("jdk.httpclient.keepalive.timeout", DEFAULT_KEEP_ALIVE_TIMEOUT);
     // Defaults to value used for HTTP/1 Keep-Alive Timeout. Can be overridden by jdk.httpclient.keepalive.timeout.h2 property.
     static final long IDLE_CONNECTION_TIMEOUT = getTimeoutProp("jdk.httpclient.keepalive.timeout.h2", KEEP_ALIVE_TIMEOUT);

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -1522,7 +1522,7 @@ final class HttpClientImpl extends HttpClient implements Trackable {
         return Optional.ofNullable(connectTimeout);
     }
 
-    public Optional<Duration> idleConnectionTimeout() {
+    Optional<Duration> idleConnectionTimeout() {
         return Optional.ofNullable(getIdleConnectionTimeoutProp());
     }
 
@@ -1692,9 +1692,14 @@ final class HttpClientImpl extends HttpClient implements Trackable {
 
     private Duration getIdleConnectionTimeoutProp() {
         // Http 2 in prop name somewhere
-        String s = Utils.getNetProperty("jdk.httpclient.idleConnectionTimeout");
-        if (s != null)
-            return Duration.ofMillis(Long.parseLong(s));
+        String s = Utils.getNetProperty("jdk.httpclient.keepalive.timeout");
+        if (s != null) {
+            try {
+                long val = Long.parseLong(s);
+                if (val >= 0)
+                    return Duration.ofMillis(Long.parseLong(s));
+            } catch (NumberFormatException ignored) {}
+        }
         return null;
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -1691,13 +1691,12 @@ final class HttpClientImpl extends HttpClient implements Trackable {
     }
 
     private Duration getIdleConnectionTimeoutProp() {
-        // Http 2 in prop name somewhere
         String s = Utils.getNetProperty("jdk.httpclient.keepalive.timeout");
         if (s != null) {
             try {
                 long val = Long.parseLong(s);
                 if (val >= 0)
-                    return Duration.ofMillis(Long.parseLong(s));
+                    return Duration.ofSeconds(Long.parseLong(s));
             } catch (NumberFormatException ignored) {}
         }
         return null;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -1705,10 +1705,11 @@ final class HttpClientImpl extends HttpClient implements Trackable {
         try {
             if (s != null) {
                 long timeoutVal = Long.parseLong(s);
-                System.err.println(timeoutVal);
                 if (timeoutVal >= 0) return timeoutVal;
             }
-        } catch (NumberFormatException ignored) {}
+        } catch (NumberFormatException ignored) {
+            Log.logTrace("Invalid value set for " + prop + " property: " + ignored.toString());
+        }
         return def;
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -1692,7 +1692,7 @@ final class HttpClientImpl extends HttpClient implements Trackable {
 
     private Duration getIdleConnectionTimeoutProp() {
         // Http 2 in prop name somewhere
-        String s = Utils.getNetProperty("jdk.httpclient.http2IdleConnectionTimeout");
+        String s = Utils.getNetProperty("jdk.httpclient.idleConnectionTimeout");
         if (s != null)
             return Duration.ofMillis(Long.parseLong(s));
         return null;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -1522,6 +1522,10 @@ final class HttpClientImpl extends HttpClient implements Trackable {
         return Optional.ofNullable(connectTimeout);
     }
 
+    public Optional<Duration> idleConnectionTimeout() {
+        return Optional.ofNullable(getIdleConnectionTimeoutProp());
+    }
+
     @Override
     public Optional<ProxySelector> proxy() {
         return Optional.ofNullable(userProxySelector);
@@ -1684,6 +1688,14 @@ final class HttpClientImpl extends HttpClient implements Trackable {
     // the SSL connections managed by this client.
     BufferSupplier getSSLBufferSupplier() {
         return sslBufferSupplier;
+    }
+
+    private Duration getIdleConnectionTimeoutProp() {
+        // Http 2 in prop name somewhere
+        String s = Utils.getNetProperty("jdk.httpclient.http2IdleConnectionTimeout");
+        if (s != null)
+            return Duration.ofMillis(Long.parseLong(s));
+        return null;
     }
 
     // An implementation of BufferSupplier that manages a pool of

--- a/test/jdk/java/net/httpclient/http2/IdleConnectionTimeoutTest.java
+++ b/test/jdk/java/net/httpclient/http2/IdleConnectionTimeoutTest.java
@@ -24,9 +24,9 @@
 /*
  * @test
  * @bug 8288717
- * @summary Tests that when the idleConnectionTimeout property is specified,
- *          an HTTP/2 connection will close within the specified interval if
- *          there are no active streams on the connection.
+ * @summary Tests that when the idleConnectionTimeoutEvent is configured in HTTP/2,
+ *          an HTTP/2 connection will close within the specified interval if there
+ *          are no active streams on the connection.
  * @library /test/lib server
  * @modules java.base/sun.net.www.http
  *          java.net.http/jdk.internal.net.http.common

--- a/test/jdk/java/net/httpclient/http2/IdleConnectionTimeoutTest.java
+++ b/test/jdk/java/net/httpclient/http2/IdleConnectionTimeoutTest.java
@@ -32,8 +32,8 @@
  *          java.net.http/jdk.internal.net.http.common
  *          java.net.http/jdk.internal.net.http.frame
  *          java.net.http/jdk.internal.net.http.hpack
- * @run testng/othervm -Djdk.httpclient.keepalive.timeout=800 IdleConnectionTimeoutTest
- * @run testng/othervm -Djdk.httpclient.keepalive.timeout=100 IdleConnectionTimeoutTest
+ * @run testng/othervm -Djdk.httpclient.keepalive.timeout=8 IdleConnectionTimeoutTest
+ * @run testng/othervm -Djdk.httpclient.keepalive.timeout=1 IdleConnectionTimeoutTest
  * @run testng/othervm  IdleConnectionTimeoutTest
  */
 
@@ -90,16 +90,14 @@ public class IdleConnectionTimeoutTest {
         HttpRequest hreq;
         HttpResponse<String> hresp;
         if (timeoutVal != null) {
-            if (timeoutVal.equals("100")) {
-                testLog.println("This one");
+            if (timeoutVal.equals("1")) {
                 hreq = HttpRequest.newBuilder(timeoutUri).version(HTTP_2).GET().build();
-                sleepTime = 800;
+                sleepTime = 8000;
                 hresp = runRequest(hc, hreq, sleepTime);
                 assertEquals(hresp.statusCode(), 200, "idleConnectionTimeoutEvent was expected but did not occur");
-            } else if (timeoutVal.equals("800")) {
-                testLog.println("This two");
+            } else if (timeoutVal.equals("8")) {
                 hreq = HttpRequest.newBuilder(noTimeoutUri).version(HTTP_2).GET().build();
-                sleepTime = 100;
+                sleepTime = 1000;
                 hresp = runRequest(hc, hreq, sleepTime);
                 assertEquals(hresp.statusCode(), 200, "idleConnectionTimeoutEvent was not expected but occurred");
             }

--- a/test/jdk/java/net/httpclient/http2/IdleConnectionTimeoutTest.java
+++ b/test/jdk/java/net/httpclient/http2/IdleConnectionTimeoutTest.java
@@ -32,12 +32,26 @@
  *          java.net.http/jdk.internal.net.http.common
  *          java.net.http/jdk.internal.net.http.frame
  *          java.net.http/jdk.internal.net.http.hpack
- * @run testng/othervm -Djdk.httpclient.HttpClient.log=errors -Djdk.httpclient.keepalive.timeout.h2=2 IdleConnectionTimeoutTest
- * @run testng/othervm -Djdk.httpclient.HttpClient.log=errors -Djdk.httpclient.keepalive.timeout.h2=1 IdleConnectionTimeoutTest
+ *
+ * @run testng/othervm -Djdk.httpclient.HttpClient.log=errors -Djdk.httpclient.keepalive.timeout=1
+ *                                                             IdleConnectionTimeoutTest
+ * @run testng/othervm -Djdk.httpclient.HttpClient.log=errors -Djdk.httpclient.keepalive.timeout=2
+ *                                                             IdleConnectionTimeoutTest
+ *
+ * @run testng/othervm -Djdk.httpclient.HttpClient.log=errors -Djdk.httpclient.keepalive.timeout.h2=1
+ *                                                             IdleConnectionTimeoutTest
+ * @run testng/othervm -Djdk.httpclient.HttpClient.log=errors -Djdk.httpclient.keepalive.timeout.h2=2
+ *                                                             IdleConnectionTimeoutTest
+ *
+ * @run testng/othervm -Djdk.httpclient.HttpClient.log=errors -Djdk.httpclient.keepalive.timeout.h2=1
+ *                                                            -Djdk.httpclient.keepalive.timeout=2
+ *                                                             IdleConnectionTimeoutTest
+ *
  * @run testng/othervm -Djdk.httpclient.HttpClient.log=errors IdleConnectionTimeoutTest
- * @run testng/othervm -Djdk.httpclient.HttpClient.log=errors -Djdk.httpclient.keepalive.timeout.h2=abc IdleConnectionTimeoutTest
- * @run testng/othervm -Djdk.httpclient.HttpClient.log=errors -Djdk.httpclient.keepalive.timeout.h2=-1 IdleConnectionTimeoutTest
- * @run testng/othervm -Djdk.httpclient.HttpClient.log=errors -Djdk.httpclient.keepalive.timeout.h2=1 -Djdk.httpclient.keepalive.timeout=2 IdleConnectionTimeoutTest
+ * @run testng/othervm -Djdk.httpclient.HttpClient.log=errors -Djdk.httpclient.keepalive.timeout.h2=-1
+ *                                                             IdleConnectionTimeoutTest
+ * @run testng/othervm -Djdk.httpclient.HttpClient.log=errors,trace -Djdk.httpclient.keepalive.timeout.h2=abc
+ *                                                                   IdleConnectionTimeoutTest
  */
 
 import org.testng.annotations.BeforeTest;

--- a/test/jdk/java/net/httpclient/http2/IdleConnectionTimeoutTest.java
+++ b/test/jdk/java/net/httpclient/http2/IdleConnectionTimeoutTest.java
@@ -57,6 +57,7 @@ public class IdleConnectionTimeoutTest {
     Http2TestServer http2TestServer;
     URI timeoutUri;
     URI noTimeoutUri;
+    final String IDLE_CONN_PROPERTY = "jdk.httpclient.idleConnectionTimeout";
     final String TIMEOUT_PATH = "/serverTimeoutHandler";
     final String NO_TIMEOUT_PATH = "/noServerTimeoutHandler";
     static boolean expectTimeout;
@@ -82,7 +83,7 @@ public class IdleConnectionTimeoutTest {
     @Test
     public void testTimeoutFires() throws InterruptedException {
         expectTimeout = true;
-        System.setProperty("jdk.httpclient.http2IdleConnectionTimeout", "100");
+        System.setProperty(IDLE_CONN_PROPERTY, "100");
         HttpClient hc = HttpClient.newBuilder().version(HTTP_2).build();
         HttpRequest hreq = HttpRequest.newBuilder(timeoutUri).version(HTTP_2).GET().build();
 
@@ -104,7 +105,7 @@ public class IdleConnectionTimeoutTest {
     @Test
     public void testTimeoutDoesNotFire() throws InterruptedException {
         expectTimeout = false;
-        System.setProperty("jdk.httpclient.idleConnectionTimeout", "800");
+        System.setProperty(IDLE_CONN_PROPERTY, "800");
         HttpClient hc = HttpClient.newBuilder().version(HTTP_2).build();
         HttpRequest hreq = HttpRequest.newBuilder(noTimeoutUri).version(HTTP_2).GET().build();
 

--- a/test/jdk/java/net/httpclient/http2/IdleConnectionTimeoutTest.java
+++ b/test/jdk/java/net/httpclient/http2/IdleConnectionTimeoutTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8263031
+ * @summary Tests that the HttpClient can correctly receive a Push Promise
+ *          Frame with the END_HEADERS flag unset followed by one or more
+ *          Continuation Frames.
+ * @library /test/lib server
+ * @build jdk.test.lib.net.SimpleSSLContext
+ * @modules java.base/sun.net.www.http
+ *          java.net.http/jdk.internal.net.http.common
+ *          java.net.http/jdk.internal.net.http.frame
+ *          java.net.http/jdk.internal.net.http.hpack
+ * @run testng/othervm IdleConnectionTimeoutTest
+ */
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.CompletableFuture;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.net.http.HttpClient.Version.HTTP_2;
+import static org.testng.Assert.assertEquals;
+
+public class IdleConnectionTimeoutTest {
+
+    Http2TestServer http2TestServer;
+    URI timeoutUri;
+    URI noTimeoutUri;
+    final String TIMEOUT_PATH = "/serverTimeoutHandler";
+    final String NO_TIMEOUT_PATH = "/noServerTimeoutHandler";
+    static boolean expectTimeout;
+    static final PrintStream testLog = System.err;
+
+    @BeforeTest
+    public void setup() throws Exception {
+        http2TestServer = new Http2TestServer(false, 0);
+        http2TestServer.addHandler(new ServerTimeoutHandler(), TIMEOUT_PATH);
+        http2TestServer.addHandler(new ServerNoTimeoutHandler(), NO_TIMEOUT_PATH);
+
+        http2TestServer.start();
+        int port = http2TestServer.getAddress().getPort();
+        timeoutUri = new URI("http://localhost:" + port + TIMEOUT_PATH);
+        noTimeoutUri = new URI("http://localhost:" + port + NO_TIMEOUT_PATH);
+    }
+
+    /*
+       If the InetSocketAddress of the first remote connection is not equal to the address of the
+       second remote connection, then the idleConnectionTimeoutEvent has occurred and a new connection
+       was made to carry out the second request by the client. Otherwise, the old connection was reused.
+    */
+    @Test
+    public void testTimeoutFires() throws InterruptedException {
+        expectTimeout = true;
+        System.setProperty("jdk.httpclient.http2IdleConnectionTimeout", "100");
+        HttpClient hc = HttpClient.newBuilder().version(HTTP_2).build();
+        HttpRequest hreq = HttpRequest.newBuilder(timeoutUri).version(HTTP_2).GET().build();
+
+        CompletableFuture<HttpResponse<String>> request = hc.sendAsync(hreq, HttpResponse.BodyHandlers.ofString(UTF_8));
+        HttpResponse<String> hresp = request.join();
+        assertEquals(hresp.statusCode(), 200);
+        // Sleep for 4x the timeout value to ensure that it occurs
+        Thread.sleep(800);
+
+        request = hc.sendAsync(hreq, HttpResponse.BodyHandlers.ofString(UTF_8));
+        hresp = request.join();
+        assertEquals(hresp.statusCode(), 200);
+    }
+
+    /*
+        The opposite of testTimeoutFires(), if the same connection is used for both requests then the
+        idleConnectionTimeoutEvent did not occur.
+     */
+    @Test
+    public void testTimeoutDoesNotFire() throws InterruptedException {
+        expectTimeout = false;
+        System.setProperty("jdk.httpclient.idleConnectionTimeout", "800");
+        HttpClient hc = HttpClient.newBuilder().version(HTTP_2).build();
+        HttpRequest hreq = HttpRequest.newBuilder(noTimeoutUri).version(HTTP_2).GET().build();
+
+        CompletableFuture<HttpResponse<String>> request = hc.sendAsync(hreq, HttpResponse.BodyHandlers.ofString(UTF_8));
+        HttpResponse<String> hresp = request.join();
+        assertEquals(hresp.statusCode(), 200);
+        // Sleep for 1/8th of the timeout value to ensure it does not occur
+        Thread.sleep(100);
+
+        request = hc.sendAsync(hreq, HttpResponse.BodyHandlers.ofString(UTF_8));
+        hresp = request.join();
+        assertEquals(hresp.statusCode(), 200);
+    }
+
+    static class ServerTimeoutHandler implements Http2Handler {
+
+        InetSocketAddress remote;
+
+        @Override
+        public void handle(Http2TestExchange exchange) throws IOException {
+            if (remote == null) {
+                remote = exchange.getRemoteAddress();
+                exchange.sendResponseHeaders(200, 0);
+            } else if (!remote.equals(exchange.getRemoteAddress())) {
+                testLog.println("ServerTimeoutHandler: New Connection was used, idleConnectionTimeoutEvent fired."
+                        + " First remote: " + remote + ", Second Remote: " + exchange.getRemoteAddress());
+                exchange.sendResponseHeaders(200, 0);
+            } else {
+                exchange.sendResponseHeaders(400, 0);
+            }
+        }
+    }
+
+    static class ServerNoTimeoutHandler implements Http2Handler {
+
+        InetSocketAddress oldRemote;
+
+        @Override
+        public void handle(Http2TestExchange exchange) throws IOException {
+            InetSocketAddress newRemote = exchange.getRemoteAddress();
+            if (oldRemote == null) {
+                oldRemote = newRemote;
+                exchange.sendResponseHeaders(200, 0);
+            } else if (oldRemote.equals(newRemote)) {
+                testLog.println("ServerTimeoutHandler: Same Connection was used, idleConnectionTimeoutEvent did not fire."
+                        + " First remote: " + oldRemote + ", Second Remote: " + newRemote);
+                exchange.sendResponseHeaders(200, 0);
+            } else {
+                exchange.sendResponseHeaders(400, 0);
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Issue**
When using HTTP/2 with the HttpClient, it can often be necessary to close an idle Http2 Connection before a server sends a GOAWAY frame. For example, a server or cloud based tool could close a TCP connection silently when it is idle for too long resulting in ConnectionResetException being thrown by the HttpClient.

**Proposed Solution**
A new system property, `jdk.httpclient.idleConnectionTimeout`, was added and is used to specify in Milliseconds how long an idle connection (idle connections are those which have no currently active streams) for the HttpClient before the connection is closed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request to be approved

### Issues
 * [JDK-8288717](https://bugs.openjdk.org/browse/JDK-8288717): Add a means to close idle connections in HTTP/2 connection pool
 * [JDK-8295649](https://bugs.openjdk.org/browse/JDK-8295649): Add a means to close idle connections in HTTP/2 connection pool (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10183/head:pull/10183` \
`$ git checkout pull/10183`

Update a local copy of the PR: \
`$ git checkout pull/10183` \
`$ git pull https://git.openjdk.org/jdk pull/10183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10183`

View PR using the GUI difftool: \
`$ git pr show -t 10183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10183.diff">https://git.openjdk.org/jdk/pull/10183.diff</a>

</details>
