### PR TITLE
8283010: serviceability/sa/ClhsdbThread.java failed with "'Base of Stack:' missing from stdout/stderr "

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbThread.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.Platform;
 import jtreg.SkippedException;
 
 /**
@@ -96,10 +97,17 @@ public class ClhsdbThread {
             System.out.println("Thread Id obtained is: " + threadIdObtained);
 
             String cmd = "thread " + threadIdObtained;
-            expStrMap.put(cmd, List.of(
-                "Base of Stack:",
-                "State:",
-                "Last_Java_SP"));
+            if (Platform.isWindows()) {
+                // On windows thread IDs are not guaranteed to be the same each time you attach,
+                // so the ID we gleaned above for the Finalizer thread may not actually be for
+                // the Finalizer thread when we attach for the following "thread" command, so we
+                // choose not to check the result on Windows.
+            } else {
+                expStrMap.put(cmd, List.of(
+                    "Base of Stack:",
+                    "State:",
+                    "Last_Java_SP"));
+            }
             cmds = List.of(cmd);
             test.run(theApp.getPid(), cmds, expStrMap, null);
         } catch (SkippedException se) {


### PR DESCRIPTION
Each time you attach to a target JVM on Windows, thread Id's can change (although they rarely do). For this reason you can't reliably do what this test is doing, which is attach, run jstack to get the threadId of a thread, detach, attach again and run the `thread` command using the threadId. It might not be valid any more. For this reason I am changing the test to ignore the result of the `thread` command when running on windows. This is the same fix as was done for [JDK-8280770](https://bugs.openjdk.org/browse/JDK-8280770)

I'd like to push this as a trivial change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283010](https://bugs.openjdk.org/browse/JDK-8283010): serviceability/sa/ClhsdbThread.java failed with "'Base of Stack:' missing from stdout/stderr "


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10185/head:pull/10185` \
`$ git checkout pull/10185`

Update a local copy of the PR: \
`$ git checkout pull/10185` \
`$ git pull https://git.openjdk.org/jdk pull/10185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10185`

View PR using the GUI difftool: \
`$ git pr show -t 10185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10185.diff">https://git.openjdk.org/jdk/pull/10185.diff</a>

</details>
