### PR TITLE
8293445: clhsdb "thread" command gives incorrect error message for bad threadID

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -1726,7 +1726,7 @@ public class CommandProcessor {
                         }
                     }
                     if (!all) {
-                        out.println("Couldn't find thread " + name);
+                        out.println("Couldn't find thread " + id);
                     }
                 }
             }


### PR DESCRIPTION
As pointed out in [JDK-8283010](https://bugs.openjdk.org/browse/JDK-8283010), when a bad threadID is passed to the clhsdb "thread" command, the error message is incorrect:

hsdb> thread 18
Couldn't find thread thread

It should say "thread 18", not "thread thread". The code looks like:

                        out.println("Couldn't find thread " + name);

"name" is the name of the command. It should instead use "id".

I'd like to push this as a trivial change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293445](https://bugs.openjdk.org/browse/JDK-8293445): clhsdb "thread" command gives incorrect error message for bad threadID


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10186/head:pull/10186` \
`$ git checkout pull/10186`

Update a local copy of the PR: \
`$ git checkout pull/10186` \
`$ git pull https://git.openjdk.org/jdk pull/10186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10186`

View PR using the GUI difftool: \
`$ git pr show -t 10186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10186.diff">https://git.openjdk.org/jdk/pull/10186.diff</a>

</details>
