### PR TITLE
8276545: Fix handling of trap count overflow in Parse::Parse()

### DIFF
--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -469,8 +469,8 @@ Parse::Parse(JVMState* caller, ciMethod* parse_method, float expected_uses)
   for (uint reason = 0; reason < md->trap_reason_limit(); reason++) {
     uint md_count = md->trap_count(reason);
     if (md_count != 0) {
-      if (md_count == md->trap_count_limit())
-        md_count += md->overflow_trap_count();
+      if (md_count >= md->trap_count_limit())
+        md_count = md->trap_count_limit() + md->overflow_trap_count();
       uint total_count = C->trap_count(reason);
       uint old_count   = total_count;
       total_count += md_count;

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -470,7 +470,9 @@ Parse::Parse(JVMState* caller, ciMethod* parse_method, float expected_uses)
     uint md_count = md->trap_count(reason);
     if (md_count != 0) {
       if (md_count >= md->trap_count_limit())
+      {
         md_count = md->trap_count_limit() + md->overflow_trap_count();
+      }
       uint total_count = C->trap_count(reason);
       uint old_count   = total_count;
       total_count += md_count;

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -469,8 +469,7 @@ Parse::Parse(JVMState* caller, ciMethod* parse_method, float expected_uses)
   for (uint reason = 0; reason < md->trap_reason_limit(); reason++) {
     uint md_count = md->trap_count(reason);
     if (md_count != 0) {
-      if (md_count >= md->trap_count_limit())
-      {
+      if (md_count >= md->trap_count_limit()) {
         md_count = md->trap_count_limit() + md->overflow_trap_count();
       }
       uint total_count = C->trap_count(reason);


### PR DESCRIPTION
The API trap_count(reason) returns (uint)-1 == 0xFFFFFFFF in case of trap count overflow,
trap_count_limit()) returns (jubyte)-1 == 0xFF which leads to the failure of overflow check
if (md_count == md->trap_count_limit()) (which is 0xFFFFFFFF == 0xFF).

         uint md_count = md->trap_count(reason);
         if (md_count != 0) {
                   **if (md_count == md->trap_count_limit())**  // Trap count is overflown 
Trap count value is computed as 0xFFFFFFFF + overflowcount (diff after 0xFF) which is wrong.
md_count += md->overflow_trap_count();

Fix:

Overflow check should be either of below
if (md_count >= md->trap_count_limit()) or if (md_count == (uint)-1)

Total trap count as
md_count = md->trap_count_limit() + md->overflow_trap_count();

Test: local JTReg test for hotspot_all group.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276545](https://bugs.openjdk.org/browse/JDK-8276545): Fix handling of trap count overflow in Parse::Parse()


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10187/head:pull/10187` \
`$ git checkout pull/10187`

Update a local copy of the PR: \
`$ git checkout pull/10187` \
`$ git pull https://git.openjdk.org/jdk pull/10187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10187`

View PR using the GUI difftool: \
`$ git pr show -t 10187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10187.diff">https://git.openjdk.org/jdk/pull/10187.diff</a>

</details>
