### PR TITLE
8283224: Remove THREAD_NOT_ALIVE from possible JDWP error codes

### DIFF
--- a/src/java.se/share/data/jdwp/jdwp.spec
+++ b/src/java.se/share/data/jdwp/jdwp.spec
@@ -3164,7 +3164,7 @@ JDWP "Java(tm) Debug Wire Protocol"
     (Constant THREAD_NOT_SUSPENDED   =13  "If the specified thread has not been "
                                           "suspended by an event.")
     (Constant THREAD_SUSPENDED       =14  "Thread already suspended.")
-    (Constant THREAD_NOT_ALIVE       =15  "Thread has not been started or has terminated.")
+    (Constant THREAD_NOT_ALIVE       =15  "Not used.")
     (Constant INVALID_OBJECT         =20  "If this reference type has been unloaded "
                                           "and garbage collected.")
     (Constant INVALID_CLASS          =21  "Invalid class.")

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ThreadReferenceImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ThreadReferenceImpl.java
@@ -595,9 +595,6 @@ public class ThreadReferenceImpl extends ObjectReferenceImpl
             case JDWP.Error.THREAD_NOT_SUSPENDED:
                 throw new IncompatibleThreadStateException(
                          "Thread not suspended");
-            case JDWP.Error.THREAD_NOT_ALIVE:
-                throw new IncompatibleThreadStateException(
-                                     "Thread has not started or has finished");
             case JDWP.Error.NO_MORE_FRAMES:
                 throw new InvalidStackFrameException(
                          "No more frames on the stack");


### PR DESCRIPTION
THREAD_NOT_ALIVE originates from JVMTI. However, the debug agent converts it to INVALID_THREAD before passing it on to the debug agent client (the debugger, usually JDI), so debug agent users (JDI) should never see it. Currently ThreadReference.forceEarlyReturn() is the only API that even bothers to check for it, and it throws com.sun.jdi.IllegalThreadStateException, which is the same thing it already does for INVALID_THREAD.

In the JDWP spec I change the description of THREAD_NOT_ALIVE  to "Not used". If you have a suggestion for better wording, please let me now. (I was thinking maybe "Unused" would be better.

In the JDI ThreadReference.forceEarlyReturn implementation, I removed the code that checks for THREAD_NOT_ALIVE since it should never occur. There is no behavior change associated with this change, and there is no JDI spec update necessary. The spec already says IllegalThreadStateException means "the thread is not suspended", and not being alive implies not suspended.

Note the JDWP spec for ThreadReference.ForceEarlyReturn used to mention THREAD_NOT_ALIVE as a possible error code, but it was removed as part of the loom work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283224](https://bugs.openjdk.org/browse/JDK-8283224): Remove THREAD_NOT_ALIVE from possible JDWP error codes


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10189/head:pull/10189` \
`$ git checkout pull/10189`

Update a local copy of the PR: \
`$ git checkout pull/10189` \
`$ git pull https://git.openjdk.org/jdk pull/10189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10189`

View PR using the GUI difftool: \
`$ git pr show -t 10189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10189.diff">https://git.openjdk.org/jdk/pull/10189.diff</a>

</details>
