### PR TITLE
8293333: Broken links in JDI specification

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -929,13 +929,13 @@ JvmtiEnv::GetAllThreads(jint* threads_count_ptr, jthread** threads_ptr) {
 jvmtiError
 JvmtiEnv::SuspendThread(jthread thread) {
   JavaThread* current = JavaThread::current();
-  ThreadsListHandle tlh(current);
 
   jvmtiError err;
   JavaThread* java_thread = NULL;
   oop thread_oop = NULL;
   {
     JvmtiVTMSTransitionDisabler disabler(true);
+    ThreadsListHandle tlh(current);
 
     err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_oop);
     if (err != JVMTI_ERROR_NONE) {
@@ -960,13 +960,13 @@ JvmtiEnv::SuspendThread(jthread thread) {
 jvmtiError
 JvmtiEnv::SuspendThreadList(jint request_count, const jthread* request_list, jvmtiError* results) {
   JavaThread* current = JavaThread::current();
-  ThreadsListHandle tlh(current);
   HandleMark hm(current);
   Handle self_tobj = Handle(current, NULL);
   int self_idx = -1;
 
   {
     JvmtiVTMSTransitionDisabler disabler(true);
+    ThreadsListHandle tlh(current);
 
     for (int i = 0; i < request_count; i++) {
       JavaThread *java_thread = NULL;
@@ -1013,18 +1013,19 @@ JvmtiEnv::SuspendAllVirtualThreads(jint except_count, const jthread* except_list
     return JVMTI_ERROR_NONE; // Nothing to do when there are no virtual threads;
   }
   JavaThread* current = JavaThread::current();
-  ThreadsListHandle tlh(current);
-  jvmtiError err = JvmtiEnvBase::check_thread_list(except_count, except_list);
-  if (err != JVMTI_ERROR_NONE) {
-    return err;
-  }
   HandleMark hm(current);
   Handle self_tobj = Handle(current, NULL);
 
   {
     ResourceMark rm(current);
     JvmtiVTMSTransitionDisabler disabler(true);
+    ThreadsListHandle tlh(current);
     GrowableArray<jthread>* elist = new GrowableArray<jthread>(except_count);
+
+    jvmtiError err = JvmtiEnvBase::check_thread_list(except_count, except_list);
+    if (err != JVMTI_ERROR_NONE) {
+      return err;
+    }
 
     // Collect threads from except_list for which resumed status must be restored.
     for (int idx = 0; idx < except_count; idx++) {

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1778,8 +1778,8 @@ bool JavaThread::java_suspend() {
   assert(!is_VTMS_transition_disabler(), "no suspend allowed for VTMS transition disablers");
 #endif
 
-  guarantee(Thread::is_JavaThread_protected_by_TLH(/* target */ this),
-            "missing ThreadsListHandle in calling context.");
+  guarantee(Thread::is_JavaThread_protected(/* target */ this),
+            "target JavaThread is not protected in calling context.");
   return this->handshake_state()->suspend();
 }
 

--- a/src/jdk.jdi/share/classes/com/sun/jdi/ClassLoaderReference.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ClassLoaderReference.java
@@ -93,7 +93,7 @@ public interface ClassLoaderReference extends ObjectReference {
      * classes which this class loader can find by name. The list
      * has length 0 if no classes are visible to this classloader.
      *
-     * @see <a href="{@docRoot}/../specs/jvmti/jvmti.html#GetClassLoaderClasses">
+     * @see <a href="{@docRoot}/../specs/jvmti.html#GetClassLoaderClasses">
      *     JVM TI GetClassLoaderClasses</a>
      */
     List<ReferenceType> visibleClasses();

--- a/src/jdk.jdi/share/classes/com/sun/jdi/VirtualMachine.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/VirtualMachine.java
@@ -144,7 +144,7 @@ public interface VirtualMachine extends Mirror {
      *
      * @return a list of {@link ReferenceType} objects, each mirroring
      * a loaded type in the target VM.
-     * @see <a href="{@docRoot}/../specs/jvmti/jvmti.html#GetLoadedClasses">
+     * @see <a href="{@docRoot}/../specs/jvmti.html#GetLoadedClasses">
      * JVM TI GetLoadedClasses</a> regarding how class and interface creation can be triggered
      */
     List<ReferenceType> allClasses();


### PR DESCRIPTION
The `com/sun/jdi/ClassLoaderReference.java` and `com/sun/jdi/VirtualMachine.java` have incorrect links to the JVM TI spec with unneeded extra folder name `jvmti`.

The fix is to remove unneeded part from the links:
```
--- a/src/jdk.jdi/share/classes/com/sun/jdi/ClassLoaderReference.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ClassLoaderReference.java
@@ -93,7 +93,7 @@ public interface ClassLoaderReference extends ObjectReference {
      * classes which this class loader can find by name. The list
      * has length 0 if no classes are visible to this classloader.
      *
-     * @see <a href="{@docRoot}/../specs/jvmti/jvmti.html#GetClassLoaderClasses">
+     * @see <a href="{@docRoot}/../specs/jvmti.html#GetClassLoaderClasses">
      *     JVM TI GetClassLoaderClasses</a>
      */
     List<ReferenceType> visibleClasses();
diff --git a/src/jdk.jdi/share/classes/com/sun/jdi/VirtualMachine.java b/src/jdk.jdi/share/classes/com/sun/jdi/VirtualMachine.java
index 12cdd566989..64c91c8d1bb 100644
--- a/src/jdk.jdi/share/classes/com/sun/jdi/VirtualMachine.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/VirtualMachine.java
@@ -144,7 +144,7 @@ public interface VirtualMachine extends Mirror {
      *
      * @return a list of {@link ReferenceType} objects, each mirroring
      * a loaded type in the target VM.
-     * @see <a href="{@docRoot}/../specs/jvmti/jvmti.html#GetLoadedClasses">
+     * @see <a href="{@docRoot}/../specs/jvmti.html#GetLoadedClasses">
      * JVM TI GetLoadedClasses</a> regarding how class and interface creation can be triggered
      */
     List<ReferenceType> allClasses();
```