### PR TITLE
8293333: Broken links in JDI specification

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/jdi/ClassLoaderReference.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ClassLoaderReference.java
@@ -93,7 +93,7 @@ public interface ClassLoaderReference extends ObjectReference {
      * classes which this class loader can find by name. The list
      * has length 0 if no classes are visible to this classloader.
      *
-     * @see <a href="{@docRoot}/../specs/jvmti/jvmti.html#GetClassLoaderClasses">
+     * @see <a href="{@docRoot}/../specs/jvmti.html#GetClassLoaderClasses">
      *     JVM TI GetClassLoaderClasses</a>
      */
     List<ReferenceType> visibleClasses();

--- a/src/jdk.jdi/share/classes/com/sun/jdi/VirtualMachine.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/VirtualMachine.java
@@ -144,7 +144,7 @@ public interface VirtualMachine extends Mirror {
      *
      * @return a list of {@link ReferenceType} objects, each mirroring
      * a loaded type in the target VM.
-     * @see <a href="{@docRoot}/../specs/jvmti/jvmti.html#GetLoadedClasses">
+     * @see <a href="{@docRoot}/../specs/jvmti.html#GetLoadedClasses">
      * JVM TI GetLoadedClasses</a> regarding how class and interface creation can be triggered
      */
     List<ReferenceType> allClasses();


### PR DESCRIPTION
The JDI files `com/sun/jdi/ClassLoaderReference.java` and `com/sun/jdi/VirtualMachine.java` have incorrect links to the JVM TI spec with the extra folder name `jvmti`. 

The fix is to get rid unneeded part from the links:
```
--- a/src/jdk.jdi/share/classes/com/sun/jdi/ClassLoaderReference.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ClassLoaderReference.java
@@ -93,7 +93,7 @@ public interface ClassLoaderReference extends ObjectReference {
      * classes which this class loader can find by name. The list
      * has length 0 if no classes are visible to this classloader.
      *
-     * @see <a href="{@docRoot}/../specs/jvmti/jvmti.html#GetClassLoaderClasses">
+     * @see <a href="{@docRoot}/../specs/jvmti.html#GetClassLoaderClasses">
      *     JVM TI GetClassLoaderClasses</a>
      */
     List<ReferenceType> visibleClasses();
diff --git a/src/jdk.jdi/share/classes/com/sun/jdi/VirtualMachine.java b/src/jdk.jdi/share/classes/com/sun/jdi/VirtualMachine.java
index 12cdd566989..64c91c8d1bb 100644
--- a/src/jdk.jdi/share/classes/com/sun/jdi/VirtualMachine.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/VirtualMachine.java
@@ -144,7 +144,7 @@ public interface VirtualMachine extends Mirror {
      *
      * @return a list of {@link ReferenceType} objects, each mirroring
      * a loaded type in the target VM.
-     * @see <a href="{@docRoot}/../specs/jvmti/jvmti.html#GetLoadedClasses">
+     * @see <a href="{@docRoot}/../specs/jvmti.html#GetLoadedClasses">
      * JVM TI GetLoadedClasses</a> regarding how class and interface creation can be triggered
      */
     List<ReferenceType> allClasses();
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293333](https://bugs.openjdk.org/browse/JDK-8293333): Broken links in JDI specification


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10191/head:pull/10191` \
`$ git checkout pull/10191`

Update a local copy of the PR: \
`$ git checkout pull/10191` \
`$ git pull https://git.openjdk.org/jdk pull/10191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10191`

View PR using the GUI difftool: \
`$ git pr show -t 10191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10191.diff">https://git.openjdk.org/jdk/pull/10191.diff</a>

</details>
