### PR TITLE
JDK-8293472: Incorrect container resource limit detection if manual cgroup fs mounts present

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -325,6 +325,7 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
     // as to avoid memory stomping of the _mount_path pointer later on in the cgroup v1
     // block in the hybrid case.
     if (is_cgroupsV2 && sscanf(p, "%*d %*d %*d:%*d %s %s %*[^-]- %s %*s %*s", tmproot, tmpmount, tmp_fs_type) == 3) {
+      // we likely have an early match return (e.g. cgroup fs match), be sure we have cgroup2 as fstype
       if (strcmp("cgroup2", tmp_fs_type) == 0) {
         cgroupv2_mount_point_found = true;
         any_cgroup_mounts_found = true;

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -123,19 +123,22 @@ CgroupSubsystem* CgroupSubsystemFactory::create() {
   return new CgroupV1Subsystem(cpuset, cpu, cpuacct, pids, memory);
 }
 
-void CgroupSubsystemFactory::set_controller_mount_path(CgroupInfo* cg_infos, int controller, char* mount_path) {
+void CgroupSubsystemFactory::set_controller_mount_path(CgroupInfo* cg_infos,
+                                                       int controller,
+                                                       char* name,
+                                                       char* mount_path) {
   if (cg_infos[controller]._mount_path != NULL) {
     // On some systems duplicate controllers get mounted in addition to
     // the main cgroup controllers most likely under /sys/fs/cgroup. In that
     // case pick the one under /sys/fs/cgroup and discard others.
     if (strstr(cg_infos[controller]._mount_path, "/sys/fs/cgroup") != cg_infos[controller]._mount_path) {
       log_warning(os, container)("Duplicate %s controllers detected. Picking %s, skipping %s.",
-                                 cg_infos[controller]._name, mount_path, cg_infos[controller]._mount_path);
+                                 name, mount_path, cg_infos[controller]._mount_path);
       os::free(cg_infos[controller]._mount_path);
       cg_infos[controller]._mount_path = os::strdup(mount_path);
     } else {
       log_warning(os, container)("Duplicate %s controllers detected. Picking %s, skipping %s.",
-                                 cg_infos[controller]._name, cg_infos[controller]._mount_path, mount_path);
+                                 name, cg_infos[controller]._mount_path, mount_path);
     }
   } else {
     cg_infos[controller]._mount_path = os::strdup(mount_path);
@@ -351,28 +354,28 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
       while ((token = strsep(&cptr, ",")) != NULL) {
         if (strcmp(token, "memory") == 0) {
           any_cgroup_mounts_found = true;
-          set_controller_mount_path(cg_infos, MEMORY_IDX, tmpmount);
+          set_controller_mount_path(cg_infos, MEMORY_IDX, token, tmpmount);
           cg_infos[MEMORY_IDX]._root_mount_path = os::strdup(tmproot);
           cg_infos[MEMORY_IDX]._data_complete = true;
         } else if (strcmp(token, "cpuset") == 0) {
           any_cgroup_mounts_found = true;
-          set_controller_mount_path(cg_infos, CPUSET_IDX, tmpmount);
+          set_controller_mount_path(cg_infos, CPUSET_IDX, token, tmpmount);
           cg_infos[CPUSET_IDX]._root_mount_path = os::strdup(tmproot);
           cg_infos[CPUSET_IDX]._data_complete = true;
         } else if (strcmp(token, "cpu") == 0) {
           any_cgroup_mounts_found = true;
-          set_controller_mount_path(cg_infos, CPU_IDX, tmpmount);
+          set_controller_mount_path(cg_infos, CPU_IDX, token, tmpmount);
           cg_infos[CPU_IDX]._mount_path = os::strdup(tmpmount);
           cg_infos[CPU_IDX]._root_mount_path = os::strdup(tmproot);
           cg_infos[CPU_IDX]._data_complete = true;
         } else if (strcmp(token, "cpuacct") == 0) {
           any_cgroup_mounts_found = true;
-          set_controller_mount_path(cg_infos, CPUACCT_IDX, tmpmount);
+          set_controller_mount_path(cg_infos, CPUACCT_IDX, token, tmpmount);
           cg_infos[CPUACCT_IDX]._root_mount_path = os::strdup(tmproot);
           cg_infos[CPUACCT_IDX]._data_complete = true;
         } else if (strcmp(token, "pids") == 0) {
           any_cgroup_mounts_found = true;
-          set_controller_mount_path(cg_infos, PIDS_IDX, tmpmount);
+          set_controller_mount_path(cg_infos, PIDS_IDX, token, tmpmount);
           cg_infos[PIDS_IDX]._root_mount_path = os::strdup(tmproot);
           cg_infos[PIDS_IDX]._data_complete = true;
         }

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -365,7 +365,6 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
         } else if (strcmp(token, "cpu") == 0) {
           any_cgroup_mounts_found = true;
           set_controller_mount_path(cg_infos, CPU_IDX, token, tmpmount);
-          cg_infos[CPU_IDX]._mount_path = os::strdup(tmpmount);
           cg_infos[CPU_IDX]._root_mount_path = os::strdup(tmproot);
           cg_infos[CPU_IDX]._data_complete = true;
         } else if (strcmp(token, "cpuacct") == 0) {

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -123,11 +123,11 @@ CgroupSubsystem* CgroupSubsystemFactory::create() {
   return new CgroupV1Subsystem(cpuset, cpu, cpuacct, pids, memory);
 }
 
-void CgroupSubsystemFactory::set_controller_pathes(CgroupInfo* cg_infos,
-                                                   int controller,
-                                                   char* name,
-                                                   char* mount_path,
-                                                   char* root_path) {
+void CgroupSubsystemFactory::set_controller_paths(CgroupInfo* cg_infos,
+                                                  int controller,
+                                                  const char* name,
+                                                  char* mount_path,
+                                                  char* root_path) {
   if (cg_infos[controller]._mount_path != NULL) {
     // On some systems duplicate controllers get mounted in addition to
     // the main cgroup controllers most likely under /sys/fs/cgroup. In that
@@ -314,7 +314,6 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
   bool cgroupv2_mount_point_found = false;
   bool any_cgroup_mounts_found = false;
   while ((p = fgets(buf, MAXPATHLEN, mntinfo)) != NULL) {
-    char tmp_mount_point[MAXPATHLEN+1];
     char tmp_fs_type[MAXPATHLEN+1];
     char tmproot[MAXPATHLEN+1];
     char tmpmount[MAXPATHLEN+1];
@@ -325,32 +324,12 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
     // Cgroup v2 relevant info. We only look for the _mount_path iff is_cgroupsV2 so
     // as to avoid memory stomping of the _mount_path pointer later on in the cgroup v1
     // block in the hybrid case.
-    //
-    if (is_cgroupsV2 && sscanf(p, "%*d %*d %*d:%*d %*s %s %*[^-]- %s %*s %*s", tmp_mount_point, tmp_fs_type) == 2) {
-      // On some systems duplicate controllers get mounted in addition to
-      // the main cgroup controllers most likely under /sys/fs/cgroup. In that
-      // case pick the first one under /sys/fs/cgroup and discard others.
-      if (cgroupv2_mount_point_found && strcmp("cgroup2", tmp_fs_type) == 0) {
-        if (strstr(cg_infos[0]._mount_path, "/sys/fs/cgroup") != cg_infos[0]._mount_path &&
-            strstr(tmp_mount_point, "/sys/fs/cgroup") == tmp_mount_point) {
-          log_debug(os, container)("Duplicate cgroupv2 controllers detected. Picking %s, skipping %s.",
-                                   tmp_mount_point, cg_infos[0]._mount_path);
-          for (int i = 0; i < CG_INFO_LENGTH; i++) {
-            os::free(cg_infos[i]._mount_path);
-            cg_infos[i]._mount_path = os::strdup(tmp_mount_point);
-          }
-        } else {
-          log_debug(os, container)("Duplicate cgroupv2 controllers detected. Picking %s, skipping %s.",
-                                   cg_infos[0]._mount_path, tmp_mount_point);
-        }
-      }
-      // we likely have an early match return (e.g. cgroup fs match), be sure we have cgroup2 as fstype
-      if (!cgroupv2_mount_point_found && strcmp("cgroup2", tmp_fs_type) == 0) {
+    if (is_cgroupsV2 && sscanf(p, "%*d %*d %*d:%*d %s %s %*[^-]- %s %*s %*s", tmproot, tmpmount, tmp_fs_type) == 3) {
+      if (strcmp("cgroup2", tmp_fs_type) == 0) {
         cgroupv2_mount_point_found = true;
         any_cgroup_mounts_found = true;
         for (int i = 0; i < CG_INFO_LENGTH; i++) {
-          assert(cg_infos[i]._mount_path == NULL, "_mount_path memory stomping");
-          cg_infos[i]._mount_path = os::strdup(tmp_mount_point);
+          set_controller_paths(cg_infos, i, "(cg2, unified)", tmpmount, tmproot);
         }
       }
     }
@@ -375,23 +354,23 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
       while ((token = strsep(&cptr, ",")) != NULL) {
         if (strcmp(token, "memory") == 0) {
           any_cgroup_mounts_found = true;
-          set_controller_pathes(cg_infos, MEMORY_IDX, token, tmpmount, tmproot);
+          set_controller_paths(cg_infos, MEMORY_IDX, token, tmpmount, tmproot);
           cg_infos[MEMORY_IDX]._data_complete = true;
         } else if (strcmp(token, "cpuset") == 0) {
           any_cgroup_mounts_found = true;
-          set_controller_pathes(cg_infos, CPUSET_IDX, token, tmpmount, tmproot);
+          set_controller_paths(cg_infos, CPUSET_IDX, token, tmpmount, tmproot);
           cg_infos[CPUSET_IDX]._data_complete = true;
         } else if (strcmp(token, "cpu") == 0) {
           any_cgroup_mounts_found = true;
-          set_controller_pathes(cg_infos, CPU_IDX, token, tmpmount, tmproot);
+          set_controller_paths(cg_infos, CPU_IDX, token, tmpmount, tmproot);
           cg_infos[CPU_IDX]._data_complete = true;
         } else if (strcmp(token, "cpuacct") == 0) {
           any_cgroup_mounts_found = true;
-          set_controller_pathes(cg_infos, CPUACCT_IDX, token, tmpmount, tmproot);
+          set_controller_paths(cg_infos, CPUACCT_IDX, token, tmpmount, tmproot);
           cg_infos[CPUACCT_IDX]._data_complete = true;
         } else if (strcmp(token, "pids") == 0) {
           any_cgroup_mounts_found = true;
-          set_controller_pathes(cg_infos, PIDS_IDX, token, tmpmount, tmproot);
+          set_controller_paths(cg_infos, PIDS_IDX, token, tmpmount, tmproot);
           cg_infos[PIDS_IDX]._data_complete = true;
         }
       }

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
@@ -313,6 +313,7 @@ class CgroupSubsystemFactory: AllStatic {
 
     static void set_controller_mount_path(CgroupInfo* cg_infos,
                                           int controller,
+                                          char* name,
                                           char* mount_path);
     // Determine the cgroup type (version 1 or version 2), given
     // relevant paths to files. Sets 'flags' accordingly.

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
@@ -311,6 +311,9 @@ class CgroupSubsystemFactory: AllStatic {
     }
 #endif
 
+    static void set_controller_mount_path(CgroupInfo* cg_infos,
+                                          int controller,
+                                          char* mount_path);
     // Determine the cgroup type (version 1 or version 2), given
     // relevant paths to files. Sets 'flags' accordingly.
     static bool determine_type(CgroupInfo* cg_infos,

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
@@ -311,11 +311,11 @@ class CgroupSubsystemFactory: AllStatic {
     }
 #endif
 
-    static void set_controller_pathes(CgroupInfo* cg_infos,
-                                      int controller,
-                                      char* name,
-                                      char* mount_path,
-                                      char* root_path);
+    static void set_controller_paths(CgroupInfo* cg_infos,
+                                     int controller,
+                                     const char* name,
+                                     char* mount_path,
+                                     char* root_path);
     // Determine the cgroup type (version 1 or version 2), given
     // relevant paths to files. Sets 'flags' accordingly.
     static bool determine_type(CgroupInfo* cg_infos,

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
@@ -311,10 +311,11 @@ class CgroupSubsystemFactory: AllStatic {
     }
 #endif
 
-    static void set_controller_mount_path(CgroupInfo* cg_infos,
-                                          int controller,
-                                          char* name,
-                                          char* mount_path);
+    static void set_controller_pathes(CgroupInfo* cg_infos,
+                                      int controller,
+                                      char* name,
+                                      char* mount_path,
+                                      char* root_path);
     // Determine the cgroup type (version 1 or version 2), given
     // relevant paths to files. Sets 'flags' accordingly.
     static bool determine_type(CgroupInfo* cg_infos,

--- a/test/hotspot/jtreg/containers/cgroup/CgroupSubsystemFactory.java
+++ b/test/hotspot/jtreg/containers/cgroup/CgroupSubsystemFactory.java
@@ -67,6 +67,12 @@ public class CgroupSubsystemFactory {
     private Path cgroupv1MntInfoNonZeroHierarchy;
     private Path cgroupv1MntInfoDoubleCpuset;
     private Path cgroupv1MntInfoDoubleCpuset2;
+    private Path cgroupv1MntInfoDoubleMemory;
+    private Path cgroupv1MntInfoDoubleMemory2;
+    private Path cgroupv1MntInfoDoubleCpu;
+    private Path cgroupv1MntInfoDoubleCpu2;
+    private Path cgroupv1MntInfoDoublePids;
+    private Path cgroupv1MntInfoDoublePids2;
     private Path cgroupv1MntInfoSystemdOnly;
     private String mntInfoEmpty = "";
     private Path cgroupV1SelfCgroup;
@@ -160,6 +166,15 @@ public class CgroupSubsystemFactory {
     private String mntInfoCgroupv1MoreCpusetLine = "121 32 0:37 / /cpusets rw,relatime shared:69 - cgroup none rw,cpuset\n";
     private String mntInfoCgroupv1DoubleCpuset = mntInfoCgroupv1MoreCpusetLine + mntInfoHybrid;
     private String mntInfoCgroupv1DoubleCpuset2 =  mntInfoHybrid + mntInfoCgroupv1MoreCpusetLine;
+    private String mntInfoCgroupv1MoreMemoryLine = "1100 1098 0:28 / /memory rw,nosuid,nodev,noexec,relatime master:6 - cgroup cgroup rw,memory\n";
+    private String mntInfoCgroupv1DoubleMemory = mntInfoCgroupv1MoreMemoryLine + mntInfoHybrid;
+    private String mntInfoCgroupv1DoubleMemory2 = mntInfoHybrid + mntInfoCgroupv1MoreMemoryLine;
+    private String mntInfoCgroupv1DoubleCpuLine = "1101 1098 0:29 / /cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:7 - cgroup cgroup rw,cpu,cpuacct\n";
+    private String mntInfoCgroupv1DoubleCpu = mntInfoCgroupv1DoubleCpuLine + mntInfoHybrid;
+    private String mntInfoCgroupv1DoubleCpu2 = mntInfoHybrid + mntInfoCgroupv1DoubleCpuLine;
+    private String mntInfoCgroupv1DoublePidsLine = "1107 1098 0:35 / /pids rw,nosuid,nodev,noexec,relatime master:13 - cgroup cgroup rw,pids\n";
+    private String mntInfoCgroupv1DoublePids = mntInfoCgroupv1DoublePidsLine + mntInfoHybrid;
+    private String mntInfoCgroupv1DoublePids2 = mntInfoHybrid + mntInfoCgroupv1DoublePidsLine;
     private String cgroupsNonZeroHierarchy =
             "#subsys_name hierarchy   num_cgroups enabled\n" +
             "cpuset  3   1   1\n" +
@@ -244,6 +259,24 @@ public class CgroupSubsystemFactory {
             cgroupv1MntInfoDoubleCpuset2 = Paths.get(existingDirectory.toString(), "mnt_info_cgroupv1_double_cpuset2");
             Files.writeString(cgroupv1MntInfoDoubleCpuset2, mntInfoCgroupv1DoubleCpuset2);
 
+            cgroupv1MntInfoDoubleMemory = Paths.get(existingDirectory.toString(), "mnt_info_cgroupv1_double_memory");
+            Files.writeString(cgroupv1MntInfoDoubleMemory, mntInfoCgroupv1DoubleMemory);
+
+            cgroupv1MntInfoDoubleMemory2 = Paths.get(existingDirectory.toString(), "mnt_info_cgroupv1_double_memory2");
+            Files.writeString(cgroupv1MntInfoDoubleMemory2, mntInfoCgroupv1DoubleMemory2);
+
+            cgroupv1MntInfoDoubleCpu = Paths.get(existingDirectory.toString(), "mnt_info_cgroupv1_double_cpu");
+            Files.writeString(cgroupv1MntInfoDoubleCpu, mntInfoCgroupv1DoubleCpu);
+
+            cgroupv1MntInfoDoubleCpu2 = Paths.get(existingDirectory.toString(), "mnt_info_cgroupv1_double_cpu2");
+            Files.writeString(cgroupv1MntInfoDoubleCpu2, mntInfoCgroupv1DoubleCpu2);
+
+            cgroupv1MntInfoDoublePids = Paths.get(existingDirectory.toString(), "mnt_info_cgroupv1_double_pids");
+            Files.writeString(cgroupv1MntInfoDoublePids, mntInfoCgroupv1DoublePids);
+
+            cgroupv1MntInfoDoublePids2 = Paths.get(existingDirectory.toString(), "mnt_info_cgroupv1_double_pids2");
+            Files.writeString(cgroupv1MntInfoDoublePids2, mntInfoCgroupv1DoublePids2);
+
             cgroupv1MntInfoSystemdOnly = Paths.get(existingDirectory.toString(), "mnt_info_cgroupv1_systemd_only");
             Files.writeString(cgroupv1MntInfoSystemdOnly, mntInfoCgroupsV1SystemdOnly);
 
@@ -291,14 +324,14 @@ public class CgroupSubsystemFactory {
         System.out.println("testCgroupv1JoinControllerMounts PASSED!");
     }
 
-    public void testCgroupv1MultipleCpusetMounts(WhiteBox wb, Path mountInfo) {
+    public void testCgroupv1MultipleControllerMounts(WhiteBox wb, Path mountInfo) {
         String procCgroups = cgroupv1CgInfoNonZeroHierarchy.toString();
         String procSelfCgroup = cgroupV1SelfCgroup.toString();
         String procSelfMountinfo = mountInfo.toString();
         int retval = wb.validateCgroup(procCgroups, procSelfCgroup, procSelfMountinfo);
-        Asserts.assertEQ(CGROUPS_V1, retval, "Multiple cpuset controllers, but only one in /sys/fs/cgroup");
+        Asserts.assertEQ(CGROUPS_V1, retval, "Multiple controller controllers, but only one in /sys/fs/cgroup");
         Asserts.assertTrue(isValidCgroup(retval));
-        System.out.println("testCgroupv1MultipleCpusetMounts PASSED!");
+        System.out.println("testCgroupv1MultipleControllerMounts PASSED!");
     }
 
     public void testCgroupv1SystemdOnly(WhiteBox wb) {
@@ -393,8 +426,14 @@ public class CgroupSubsystemFactory {
             test.testCgroupV1HybridMntInfoOrder(wb);
             test.testCgroupv1MissingMemoryController(wb);
             test.testCgroupv2NoCgroup2Fs(wb);
-            test.testCgroupv1MultipleCpusetMounts(wb, test.cgroupv1MntInfoDoubleCpuset);
-            test.testCgroupv1MultipleCpusetMounts(wb, test.cgroupv1MntInfoDoubleCpuset2);
+            test.testCgroupv1MultipleControllerMounts(wb, test.cgroupv1MntInfoDoubleCpuset);
+            test.testCgroupv1MultipleControllerMounts(wb, test.cgroupv1MntInfoDoubleCpuset2);
+            test.testCgroupv1MultipleControllerMounts(wb, test.cgroupv1MntInfoDoubleMemory);
+            test.testCgroupv1MultipleControllerMounts(wb, test.cgroupv1MntInfoDoubleMemory2);
+            test.testCgroupv1MultipleControllerMounts(wb, test.cgroupv1MntInfoDoubleCpu);
+            test.testCgroupv1MultipleControllerMounts(wb, test.cgroupv1MntInfoDoubleCpu2);
+            test.testCgroupv1MultipleControllerMounts(wb, test.cgroupv1MntInfoDoublePids);
+            test.testCgroupv1MultipleControllerMounts(wb, test.cgroupv1MntInfoDoublePids2);
             test.testCgroupv1JoinControllerCombo(wb);
             test.testNonZeroHierarchyOnlyFreezer(wb);
         } finally {

--- a/test/hotspot/jtreg/containers/cgroup/CgroupSubsystemFactory.java
+++ b/test/hotspot/jtreg/containers/cgroup/CgroupSubsystemFactory.java
@@ -329,7 +329,7 @@ public class CgroupSubsystemFactory {
         String procSelfCgroup = cgroupV1SelfCgroup.toString();
         String procSelfMountinfo = mountInfo.toString();
         int retval = wb.validateCgroup(procCgroups, procSelfCgroup, procSelfMountinfo);
-        Asserts.assertEQ(CGROUPS_V1, retval, "Multiple controller controllers, but only one in /sys/fs/cgroup");
+        Asserts.assertEQ(CGROUPS_V1, retval, "Multiple controllers, but only one in /sys/fs/cgroup");
         Asserts.assertTrue(isValidCgroup(retval));
         System.out.println("testCgroupv1MultipleControllerMounts PASSED!");
     }

--- a/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
+++ b/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
@@ -87,18 +87,10 @@ public class DockerBasicTest {
     private static void testJavaVersionWithCgMounts() throws Exception {
         DockerRunOptions opts =
             new DockerRunOptions(imageNameAndTag, "/jdk/bin/java", "-version")
-            .addJavaOpts("-Xlog:os+container=trace")
             .addDockerOpts("-v", "/sys/fs/cgroup:/cgroups-in:ro");
 
         DockerTestUtils.dockerRunJava(opts)
             .shouldHaveExitValue(0)
-            .shouldContain("[debug][os,container] Duplicate memory controllers detected. Picking /sys/fs/cgroup/memory, skipping /cgroups-in/memory")
-            .shouldContain("[debug][os,container] Duplicate cpu controllers detected. Picking /sys/fs/cgroup/cpu,cpuacct, skipping /cgroups-in/cpu,cpuacct")
-            .shouldContain("[debug][os,container] Duplicate cpuacct controllers detected. Picking /sys/fs/cgroup/cpu,cpuacct, skipping /cgroups-in/cpu,cpuacct")
-            .shouldContain("[debug][os,container] Duplicate cpuset controllers detected. Picking /sys/fs/cgroup/cpuset, skipping /cgroups-in/cpuset")
-            .shouldContain("[debug][os,container] Duplicate pids controllers detected. Picking /sys/fs/cgroup/pids, skipping /cgroups-in/pids")
-            .shouldContain("Path to /cpu.cfs_quota_us is /sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us")
-            .shouldContain("Path to /cpu.cfs_period_us is /sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us")
-            .shouldContain("Path to /memory.limit_in_bytes is /sys/fs/cgroup/memory/memory.limit_in_bytes");
+            .shouldNotContain("[os,container]");
     }
 }

--- a/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
+++ b/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
@@ -53,6 +53,7 @@ public class DockerBasicTest {
         try {
             testJavaVersion();
             testHelloDocker();
+            testJavaVersionWithCgMounts();
         } finally {
             if (!DockerTestUtils.RETAIN_IMAGE_AFTER_TEST) {
                 DockerTestUtils.removeDockerImage(imageNameAndTag);
@@ -80,5 +81,24 @@ public class DockerBasicTest {
         DockerTestUtils.dockerRunJava(opts)
             .shouldHaveExitValue(0)
             .shouldContain("Hello Docker");
+    }
+
+
+    private static void testJavaVersionWithCgMounts() throws Exception {
+        DockerRunOptions opts =
+            new DockerRunOptions(imageNameAndTag, "/jdk/bin/java", "-version")
+            .addJavaOpts("-Xlog:os+container=trace")
+            .addDockerOpts("-v", "/sys/fs/cgroup:/cgroups-in:ro");
+
+        DockerTestUtils.dockerRunJava(opts)
+            .shouldHaveExitValue(0)
+            .shouldContain("[debug][os,container] Duplicate memory controllers detected. Picking /sys/fs/cgroup/memory, skipping /cgroups-in/memory")
+            .shouldContain("[debug][os,container] Duplicate cpu controllers detected. Picking /sys/fs/cgroup/cpu,cpuacct, skipping /cgroups-in/cpu,cpuacct")
+            .shouldContain("[debug][os,container] Duplicate cpuacct controllers detected. Picking /sys/fs/cgroup/cpu,cpuacct, skipping /cgroups-in/cpu,cpuacct")
+            .shouldContain("[debug][os,container] Duplicate cpuset controllers detected. Picking /sys/fs/cgroup/cpuset, skipping /cgroups-in/cpuset")
+            .shouldContain("[debug][os,container] Duplicate pids controllers detected. Picking /sys/fs/cgroup/pids, skipping /cgroups-in/pids")
+            .shouldContain("Path to /cpu.cfs_quota_us is /sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us")
+            .shouldContain("Path to /cpu.cfs_period_us is /sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us")
+            .shouldContain("Path to /memory.limit_in_bytes is /sys/fs/cgroup/memory/memory.limit_in_bytes");
     }
 }

--- a/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
+++ b/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
@@ -93,6 +93,6 @@ public class DockerBasicTest {
         // code and should not cause any error/warning output.
         DockerTestUtils.dockerRunJava(opts)
             .shouldHaveExitValue(0)
-            .shouldNotContain("[os,container]");
+            .shouldNotMatch("os,container*");
     }
 }

--- a/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
+++ b/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
@@ -89,6 +89,8 @@ public class DockerBasicTest {
             new DockerRunOptions(imageNameAndTag, "/jdk/bin/java", "-version")
             .addDockerOpts("-v", "/sys/fs/cgroup:/cgroups-in:ro");
 
+        // Duplicated cgroup mounts should be handled by the container detection
+        // code and should not cause any error/warning output.
         DockerTestUtils.dockerRunJava(opts)
             .shouldHaveExitValue(0)
             .shouldNotContain("[os,container]");

--- a/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
+++ b/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
@@ -93,6 +93,6 @@ public class DockerBasicTest {
         // code and should not cause any error/warning output.
         DockerTestUtils.dockerRunJava(opts)
             .shouldHaveExitValue(0)
-            .shouldNotMatch("os,container*");
+            .shouldNotMatch("\\[os,container *\\]");
     }
 }

--- a/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
@@ -178,6 +178,7 @@ public class TestCPUAwareness {
             .shouldMatch("active_processor_count.*" + expectedAPC);
     }
 
+
     private static void testAPCCombo(String cpuset, int quota, int period, int shares,
                                      int expectedAPC) throws Exception {
         Common.logNewTestCase("test APC Combo");

--- a/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
@@ -74,10 +74,7 @@ public class TestCPUAwareness {
             testCpuQuotaAndPeriod(100*1000, 100*1000, false);
             testCpuQuotaAndPeriod(150*1000, 100*1000, false);
             testCpuQuotaAndPeriod(400*1000, 100*1000, false);
-            testCpuQuotaAndPeriod(50*1000, 100*1000, true);
-            testCpuQuotaAndPeriod(100*1000, 100*1000, true);
-            testCpuQuotaAndPeriod(150*1000, 100*1000, true);
-            testCpuQuotaAndPeriod(400*1000, 100*1000, true);
+            testCpuQuotaAndPeriod(50*1000, 100*1000, true /* additional cgroup mount */);
 
             testOperatingSystemMXBeanAwareness("0.5", "1");
             testOperatingSystemMXBeanAwareness("1.0", "1");

--- a/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
@@ -70,10 +70,14 @@ public class TestCPUAwareness {
             testActiveProcessorCount(2, 2);
 
             // cpu quota and period
-            testCpuQuotaAndPeriod(50*1000, 100*1000);
-            testCpuQuotaAndPeriod(100*1000, 100*1000);
-            testCpuQuotaAndPeriod(150*1000, 100*1000);
-            testCpuQuotaAndPeriod(400*1000, 100*1000);
+            testCpuQuotaAndPeriod(50*1000, 100*1000, false);
+            testCpuQuotaAndPeriod(100*1000, 100*1000, false);
+            testCpuQuotaAndPeriod(150*1000, 100*1000, false);
+            testCpuQuotaAndPeriod(400*1000, 100*1000, false);
+            testCpuQuotaAndPeriod(50*1000, 100*1000, true);
+            testCpuQuotaAndPeriod(100*1000, 100*1000, true);
+            testCpuQuotaAndPeriod(150*1000, 100*1000, true);
+            testCpuQuotaAndPeriod(400*1000, 100*1000, true);
 
             testOperatingSystemMXBeanAwareness("0.5", "1");
             testOperatingSystemMXBeanAwareness("1.0", "1");
@@ -153,7 +157,7 @@ public class TestCPUAwareness {
     }
 
 
-    private static void testCpuQuotaAndPeriod(int quota, int period)
+    private static void testCpuQuotaAndPeriod(int quota, int period, boolean addCgmounts)
         throws Exception {
         Common.logNewTestCase("test cpu quota and period: ");
         System.out.println("quota = " + quota);
@@ -167,12 +171,15 @@ public class TestCPUAwareness {
             .addDockerOpts("--cpu-period=" + period)
             .addDockerOpts("--cpu-quota=" + quota);
 
+        if (addCgmounts) {
+            opts = opts.addDockerOpts("--volume", "/sys/fs/cgroup:/cgroups-in:ro");
+        }
+
         Common.run(opts)
             .shouldMatch("CPU Period is.*" + period)
             .shouldMatch("CPU Quota is.*" + quota)
             .shouldMatch("active_processor_count.*" + expectedAPC);
     }
-
 
     private static void testAPCCombo(String cpuset, int quota, int period, int shares,
                                      int expectedAPC) throws Exception {

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -63,10 +63,15 @@ public class TestMemoryAwareness {
         DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
-            testMemoryLimit("100m", "104857600");
-            testMemoryLimit("500m", "524288000");
-            testMemoryLimit("1g", "1073741824");
-            testMemoryLimit("4g", "4294967296");
+            testMemoryLimit("100m", "104857600", false);
+            testMemoryLimit("500m", "524288000", false);
+            testMemoryLimit("1g", "1073741824", false);
+            testMemoryLimit("4g", "4294967296", false);
+            testMemoryLimit("100m", "104857600", true);
+            testMemoryLimit("500m", "524288000", true);
+            testMemoryLimit("1g", "1073741824", true);
+            testMemoryLimit("4g", "4294967296", true);
+
 
             testMemorySoftLimit("500m", "524288000");
             testMemorySoftLimit("1g", "1073741824");
@@ -98,13 +103,17 @@ public class TestMemoryAwareness {
     }
 
 
-    private static void testMemoryLimit(String valueToSet, String expectedTraceValue)
+    private static void testMemoryLimit(String valueToSet, String expectedTraceValue, boolean addCgmounts)
             throws Exception {
 
         Common.logNewTestCase("memory limit: " + valueToSet);
 
         DockerRunOptions opts = Common.newOpts(imageName)
             .addDockerOpts("--memory", valueToSet);
+
+        if (addCgmounts) {
+            opts = opts.addDockerOpts("--volume", "/sys/fs/cgroup:/cgroups-in:ro");
+        }
 
         Common.run(opts)
             .shouldMatch("Memory Limit is:.*" + expectedTraceValue);

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -67,11 +67,7 @@ public class TestMemoryAwareness {
             testMemoryLimit("500m", "524288000", false);
             testMemoryLimit("1g", "1073741824", false);
             testMemoryLimit("4g", "4294967296", false);
-            testMemoryLimit("100m", "104857600", true);
-            testMemoryLimit("500m", "524288000", true);
-            testMemoryLimit("1g", "1073741824", true);
-            testMemoryLimit("4g", "4294967296", true);
-
+            testMemoryLimit("100m", "104857600", true /* additional cgroup mount */);
 
             testMemorySoftLimit("500m", "524288000");
             testMemorySoftLimit("1g", "1073741824");


### PR DESCRIPTION
Similar to [JDK-8253435](https://bugs.openjdk.org/browse/JDK-8253435), when setting the mount path of cgroup controller "memory/cpu/cpuacct/pids", it should also discard duplicate items.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293472](https://bugs.openjdk.org/browse/JDK-8293472): Incorrect container resource limit detection if manual cgroup fs mounts present


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to [c4109d65](https://git.openjdk.org/jdk/pull/10193/files/c4109d65e95daae20aa178658495bd69f1688cd1)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10193/head:pull/10193` \
`$ git checkout pull/10193`

Update a local copy of the PR: \
`$ git checkout pull/10193` \
`$ git pull https://git.openjdk.org/jdk pull/10193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10193`

View PR using the GUI difftool: \
`$ git pr show -t 10193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10193.diff">https://git.openjdk.org/jdk/pull/10193.diff</a>

</details>
