### PR TITLE
8293496: ProblemList runtime/os/TestTracePageSizes.java on linux-x64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -90,12 +90,12 @@ gc/stress/TestStressG1Humongous.java 8286554 windows-x64
 
 runtime/cds/appcds/jigsaw/modulepath/ModulePathAndCP_JFR.java 8253437 windows-x64
 runtime/jni/terminatedThread/TestTerminatedThread.java 8219652 aix-ppc64
-runtime/os/TestTracePageSizes.java#no-options 8267460 linux-aarch64
-runtime/os/TestTracePageSizes.java#explicit-large-page-size 8267460 linux-aarch64
-runtime/os/TestTracePageSizes.java#compiler-options 8267460 linux-aarch64
-runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
-runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
-runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
+runtime/os/TestTracePageSizes.java#no-options 8267460,8293456 linux-all
+runtime/os/TestTracePageSizes.java#explicit-large-page-size 8267460,8293456 linux-all
+runtime/os/TestTracePageSizes.java#compiler-options 8267460,8293456 linux-all
+runtime/os/TestTracePageSizes.java#G1 8267460,8293456 linux-all
+runtime/os/TestTracePageSizes.java#Parallel 8267460,8293456 linux-all
+runtime/os/TestTracePageSizes.java#Serial 8267460,8293456 linux-all
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
 
 applications/jcstress/copy.java 8229852 linux-all


### PR DESCRIPTION
A trivial fix to ProblemList runtime/os/TestTracePageSizes.java on linux-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293496](https://bugs.openjdk.org/browse/JDK-8293496): ProblemList runtime/os/TestTracePageSizes.java on linux-x64


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10201/head:pull/10201` \
`$ git checkout pull/10201`

Update a local copy of the PR: \
`$ git checkout pull/10201` \
`$ git pull https://git.openjdk.org/jdk pull/10201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10201`

View PR using the GUI difftool: \
`$ git pr show -t 10201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10201.diff">https://git.openjdk.org/jdk/pull/10201.diff</a>

</details>
