### PR TITLE
8293497: Build failure due to MaxVectorSize was not declared when C2 is disabled after JDK-8293254

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_arraycopy.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_arraycopy.cpp
@@ -33,6 +33,9 @@
 #ifdef COMPILER2
 #include "opto/c2_globals.hpp"
 #endif
+#if INCLUDE_JVMCI
+#include "jvmci/jvmci_globals.hpp"
+#endif
 
 #define __ _masm->
 


### PR DESCRIPTION
Hi all,

Please review this trivial fix which fixes the build failure when C2 is disabled due to the definition of `MaxVectorSize` is missing.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293497](https://bugs.openjdk.org/browse/JDK-8293497): Build failure due to MaxVectorSize was not declared when C2 is disabled after JDK-8293254


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10202/head:pull/10202` \
`$ git checkout pull/10202`

Update a local copy of the PR: \
`$ git checkout pull/10202` \
`$ git pull https://git.openjdk.org/jdk pull/10202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10202`

View PR using the GUI difftool: \
`$ git pr show -t 10202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10202.diff">https://git.openjdk.org/jdk/pull/10202.diff</a>

</details>
