### PR TITLE
8293456: runtime/os/TestTracePageSizes.java sub-tests fail with "AssertionError: No memory range found for address: NNNN"

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -668,7 +668,7 @@ abstract class UnixFileSystem
             // set to true when file and attributes copied
             boolean complete = false;
             try {
-                // set to true when data are copied
+                // set to true when data copied
                 boolean copied = false;
 
                 // Some forms of direct copy do not work on zero size files

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -668,8 +668,11 @@ abstract class UnixFileSystem
             // set to true when file and attributes copied
             boolean complete = false;
             try {
+                // set to true when data are copied
                 boolean copied = false;
-                if (!directCopyNotSupported) {
+
+                // Some forms of direct copy do not work on zero size files
+                if (!directCopyNotSupported && attrs.size() > 0) {
                     // copy bytes to target using platform function
                     long comp = Blocker.begin();
                     try {

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -90,12 +90,12 @@ gc/stress/TestStressG1Humongous.java 8286554 windows-x64
 
 runtime/cds/appcds/jigsaw/modulepath/ModulePathAndCP_JFR.java 8253437 windows-x64
 runtime/jni/terminatedThread/TestTerminatedThread.java 8219652 aix-ppc64
-runtime/os/TestTracePageSizes.java#no-options 8267460,8293456 linux-all
-runtime/os/TestTracePageSizes.java#explicit-large-page-size 8267460,8293456 linux-all
-runtime/os/TestTracePageSizes.java#compiler-options 8267460,8293456 linux-all
-runtime/os/TestTracePageSizes.java#G1 8267460,8293456 linux-all
-runtime/os/TestTracePageSizes.java#Parallel 8267460,8293456 linux-all
-runtime/os/TestTracePageSizes.java#Serial 8267460,8293456 linux-all
+runtime/os/TestTracePageSizes.java#no-options 8267460 linux-aarch64
+runtime/os/TestTracePageSizes.java#explicit-large-page-size 8267460 linux-aarch64
+runtime/os/TestTracePageSizes.java#compiler-options 8267460 linux-aarch64
+runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
+runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
+runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
 
 applications/jcstress/copy.java 8229852 linux-all


### PR DESCRIPTION
Do not use direct copy if the source size is zero as this may fail on some configurations but appear to succeed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293456](https://bugs.openjdk.org/browse/JDK-8293456): runtime/os/TestTracePageSizes.java sub-tests fail with "AssertionError: No memory range found for address: NNNN"


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10204/head:pull/10204` \
`$ git checkout pull/10204`

Update a local copy of the PR: \
`$ git checkout pull/10204` \
`$ git pull https://git.openjdk.org/jdk pull/10204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10204`

View PR using the GUI difftool: \
`$ git pr show -t 10204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10204.diff">https://git.openjdk.org/jdk/pull/10204.diff</a>

</details>
