### PR TITLE
8293492: ShenandoahControlThread missing from hs-err log and thread dump

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -54,7 +54,7 @@ ShenandoahControlThread::ShenandoahControlThread() :
   _requested_gc_cause(GCCause::_no_cause_specified),
   _degen_point(ShenandoahGC::_degenerated_outside_cycle),
   _allocs_seen(0) {
-
+  set_name("Shenandoah Control Thread");
   reset_gc_id();
   create_and_start();
   _periodic_task.enroll();
@@ -623,16 +623,6 @@ void ShenandoahControlThread::update_gc_id() {
 
 size_t ShenandoahControlThread::get_gc_id() {
   return Atomic::load(&_gc_id);
-}
-
-void ShenandoahControlThread::print() const {
-  print_on(tty);
-}
-
-void ShenandoahControlThread::print_on(outputStream* st) const {
-  st->print("Shenandoah Concurrent Thread");
-  Thread::print_on(st);
-  st->cr();
 }
 
 void ShenandoahControlThread::start() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
@@ -142,12 +142,6 @@ public:
   void start();
   void prepare_for_graceful_shutdown();
   bool in_graceful_shutdown();
-
-  const char* name() const { return "ShenandoahControlThread";}
-
-  // Printing
-  void print_on(outputStream* st) const;
-  void print() const;
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHCONTROLTHREAD_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1180,6 +1180,7 @@ void ShenandoahHeap::prepare_for_verify() {
 }
 
 void ShenandoahHeap::gc_threads_do(ThreadClosure* tcl) const {
+  tcl->do_thread(_control_thread);
   workers()->threads_do(tcl);
   if (_safepoint_workers != NULL) {
     _safepoint_workers->threads_do(tcl);


### PR DESCRIPTION
Please review this patch to add ShenandoahControlThread to the thread list in hs_err log file and thread dump.

With this change, the hs_err log file contains the entry for `ShenandoahControlThread` in "Other Threads" section:

```
Other Threads:
=>0x00007f84d41c5d50 VMThread "VM Thread" [stack: 0x00007f84d8e8e000,0x00007f84d8f8e000] [id=278151]
  0x00007f84d42d5e00 WatcherThread "VM Periodic Task Thread" [stack: 0x00007f84d8280000,0x00007f84d8380000] [id=278163]
  0x00007f84d4107d80 ConcurrentGCThread "Shenandoah Control Thread" [stack: 0x00007f84d933a000,0x00007f84d943a000] [id=278150]
  0x00007f84d40b4dc0 WorkerThread "Shenandoah GC Threads#0" [stack: 0x00007f84d97bc000,0x00007f84d98bc000] [id=278145]
  ...
```
and Thread.print command (using jcmd) also has the entry for the thread:

```
"VM Thread" os_prio=0 cpu=0.46ms elapsed=6.85s tid=0x00007fe6dc1ca750 nid=265830 runnable  

"Shenandoah Control Thread" os_prio=0 cpu=13.34ms elapsed=6.87s tid=0x00007fe6dc10c780 nid=265829 runnable

"Shenandoah GC Threads#0" os_prio=0 cpu=0.12ms elapsed=6.91s tid=0x00007fe6dc0b3730 nid=265827 runnable  

```

I also cleaned up the code a bit to be consistent naming this thread.

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293492](https://bugs.openjdk.org/browse/JDK-8293492): ShenandoahControlThread missing from hs-err log and thread dump


### Reviewers
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10205/head:pull/10205` \
`$ git checkout pull/10205`

Update a local copy of the PR: \
`$ git checkout pull/10205` \
`$ git pull https://git.openjdk.org/jdk pull/10205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10205`

View PR using the GUI difftool: \
`$ git pr show -t 10205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10205.diff">https://git.openjdk.org/jdk/pull/10205.diff</a>

</details>
