### PR TITLE
8293508: ProblemList gc/metaspace/TestMetaspacePerfCounters.java#Epsilon-64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -83,6 +83,7 @@ gc/stress/gclocker/TestGCLockerWithG1.java 8180622 generic-all
 gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java 8192647 generic-all
 gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8241293 macosx-x64
 gc/stress/TestStressG1Humongous.java 8286554 windows-x64
+gc/metaspace/TestMetaspacePerfCounters.java#Epsilon-64 8293503 macosx-all,windows-x64
 
 #############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList gc/metaspace/TestMetaspacePerfCounters.java#Epsilon-64
on macosx-all and windows-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293508](https://bugs.openjdk.org/browse/JDK-8293508): ProblemList gc/metaspace/TestMetaspacePerfCounters.java#Epsilon-64


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10207/head:pull/10207` \
`$ git checkout pull/10207`

Update a local copy of the PR: \
`$ git checkout pull/10207` \
`$ git pull https://git.openjdk.org/jdk pull/10207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10207`

View PR using the GUI difftool: \
`$ git pr show -t 10207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10207.diff">https://git.openjdk.org/jdk/pull/10207.diff</a>

</details>
