### PR TITLE
8293514: ProblemList gc/metaspace/TestMetaspacePerfCounters.java#Epsilon-64 on all platforms

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -83,7 +83,7 @@ gc/stress/gclocker/TestGCLockerWithG1.java 8180622 generic-all
 gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java 8192647 generic-all
 gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8241293 macosx-x64
 gc/stress/TestStressG1Humongous.java 8286554 windows-x64
-gc/metaspace/TestMetaspacePerfCounters.java#Epsilon-64 8293503 macosx-all,windows-x64
+gc/metaspace/TestMetaspacePerfCounters.java#Epsilon-64 8293503 generic-all
 
 #############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList gc/metaspace/TestMetaspacePerfCounters.java#Epsilon-64 on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293514](https://bugs.openjdk.org/browse/JDK-8293514): ProblemList gc/metaspace/TestMetaspacePerfCounters.java#Epsilon-64 on all platforms


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10208/head:pull/10208` \
`$ git checkout pull/10208`

Update a local copy of the PR: \
`$ git checkout pull/10208` \
`$ git pull https://git.openjdk.org/jdk pull/10208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10208`

View PR using the GUI difftool: \
`$ git pr show -t 10208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10208.diff">https://git.openjdk.org/jdk/pull/10208.diff</a>

</details>
