### PR TITLE
8293512: ProblemList serviceability/tmtools/jstat/GcNewTest.java in -Xcomp mode

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -36,3 +36,5 @@ vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8265295 lin
 serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
 
 serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java 8288430 generic-all
+
+serviceability/tmtools/jstat/GcNewTest.java 8293218 linux-x64,macosx-x64

--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -38,3 +38,4 @@ serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
 serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java 8288430 generic-all
 
 serviceability/tmtools/jstat/GcNewTest.java 8293218 linux-x64,macosx-x64
+gc/cslocker/TestCSLocker.java 8293289 linux-x64,macosx-x64

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -524,6 +524,7 @@ java/lang/management/ThreadMXBean/ThreadMXBeanStateTest.java    8247426 generic-
 sun/management/jdp/JdpDefaultsTest.java                         8241865 linux-aarch64,macosx-all
 sun/management/jdp/JdpJmxRemoteDynamicPortTest.java             8241865 macosx-all
 sun/management/jdp/JdpSpecificAddressTest.java                  8241865 macosx-all
+sun/management/jmxremote/bootstrap/RmiBootstrapTest.java        8293335 linux-x64
 
 ############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -525,6 +525,7 @@ sun/management/jdp/JdpDefaultsTest.java                         8241865 linux-aa
 sun/management/jdp/JdpJmxRemoteDynamicPortTest.java             8241865 macosx-all
 sun/management/jdp/JdpSpecificAddressTest.java                  8241865 macosx-all
 sun/management/jmxremote/bootstrap/RmiBootstrapTest.java        8293335 linux-x64
+sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.java    8293343 linux-aarch64,macosx-x64
 
 ############################################################################
 


### PR DESCRIPTION
Trivial fixes to ProblemList 4 tests that fail in the upper Tiers:

[JDK-8293512](https://bugs.openjdk.org/browse/JDK-8293512) ProblemList serviceability/tmtools/jstat/GcNewTest.java in -Xcomp mode

[JDK-8293516](https://bugs.openjdk.org/browse/JDK-8293516) ProblemList gc/cslocker/TestCSLocker.java in -Xcomp mode

[JDK-8293517](https://bugs.openjdk.org/browse/JDK-8293517) ProblemList sun/management/jmxremote/bootstrap/RmiBootstrapTest.java#id1 on linux-x64

[JDK-8293518](https://bugs.openjdk.org/browse/JDK-8293518) ProblemList sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8293512](https://bugs.openjdk.org/browse/JDK-8293512): ProblemList serviceability/tmtools/jstat/GcNewTest.java in -Xcomp mode
 * [JDK-8293516](https://bugs.openjdk.org/browse/JDK-8293516): ProblemList gc/cslocker/TestCSLocker.java in -Xcomp mode
 * [JDK-8293517](https://bugs.openjdk.org/browse/JDK-8293517): ProblemList sun/management/jmxremote/bootstrap/RmiBootstrapTest.java#id1 on linux-x64
 * [JDK-8293518](https://bugs.openjdk.org/browse/JDK-8293518): ProblemList sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.java


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10209/head:pull/10209` \
`$ git checkout pull/10209`

Update a local copy of the PR: \
`$ git checkout pull/10209` \
`$ git pull https://git.openjdk.org/jdk pull/10209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10209`

View PR using the GUI difftool: \
`$ git pr show -t 10209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10209.diff">https://git.openjdk.org/jdk/pull/10209.diff</a>

</details>
