### PR TITLE
8288180: C2: VectorPhase must ensure that SafePointNode memory input is a MergeMemNode

### DIFF
--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -163,6 +163,17 @@ static JVMState* clone_jvms(Compile* C, SafePointNode* sfpt) {
   for (uint i = 0; i < size; i++) {
     map->init_req(i, sfpt->in(i));
   }
+  Node* mem = map->memory();
+  if (!mem->is_MergeMem()) {
+    // Since we are not in parsing, the SafeNode does not guarantee that the memory
+    // input is necessarily a MergeMemNode. But we need to ensure that there is that
+    // MereMemNode, since the GraphKit assumes the memory input of the map to be a
+    // MergeMemNode, so that it can directly access the memory slices.
+    PhaseGVN& gvn = *C->initial_gvn();
+    Node* mergemem = MergeMemNode::make(mem);
+    gvn.set_type_bottom(mergemem);
+    map->set_memory(mergemem);
+  }
   new_jvms->set_map(map);
   return new_jvms;
 }

--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -165,9 +165,9 @@ static JVMState* clone_jvms(Compile* C, SafePointNode* sfpt) {
   }
   Node* mem = map->memory();
   if (!mem->is_MergeMem()) {
-    // Since we are not in parsing, the SafeNode does not guarantee that the memory
+    // Since we are not in parsing, the SafePointNode does not guarantee that the memory
     // input is necessarily a MergeMemNode. But we need to ensure that there is that
-    // MereMemNode, since the GraphKit assumes the memory input of the map to be a
+    // MergeMemNode, since the GraphKit assumes the memory input of the map to be a
     // MergeMemNode, so that it can directly access the memory slices.
     PhaseGVN& gvn = *C->initial_gvn();
     Node* mergemem = MergeMemNode::make(mem);

--- a/test/hotspot/jtreg/compiler/vectorapi/TestLoopStoreVector.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestLoopStoreVector.java
@@ -36,6 +36,16 @@ import jdk.incubator.vector.VectorSpecies;
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+OptimizeFill compiler.vectorapi.TestLoopStoreVector
  */
 
+/*
+ * @test
+ * @bug 8288180
+ * @summary VectorPhase must ensure that SafePointNode's memory input is MergeMemNode, required for GraphKit
+ * @modules jdk.incubator.vector
+ *
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+OptimizeFill -XX:+StressReflectiveCode compiler.vectorapi.TestLoopStoreVector
+ */
+
+
 public class TestLoopStoreVector {
     static final VectorSpecies<Integer> SPECIESi = IntVector.SPECIES_PREFERRED;
     static final VectorSpecies<Long> SPECIESl = LongVector.SPECIES_PREFERRED;


### PR DESCRIPTION
**Context:**
The `GraphKit` seems to assume that the memory input of the map (`SafePointNode`) is always a `MergeMemNode`. It requires this so that it can easily access the memory slices.

**Analysis:**
However, the `VectorPhase` also generates some `GraphKit` instances, for example in `PhaseVector::expand_vbox_alloc_node`. But at that point we are not in parsing, and the `SafePointNode` might have a folded memory state (not `MergeMemNode`). The assert in `GrahpKit::merged_memory` can thus be triggered.

In this particular failure case, the `SafePointNode` was constructed/initialized with memory as a memory-phi, which was the result of a previous `GraphKit::reset_memory` call, which in turn folded the memory (the `MergeMemNode` had only one input, the memory-phi). This on its own does not necessarily trigger our assert. In many cases, the new `GraphKit` first transforms the memory input and calls `GraphKit::set_all_memory`, which makes sure there is a `MergeMemNode`. But in our failure case, `GraphKit::set_all_memory` is never called before we call `GraphKit::merged_memory`.

**Side-Note:**
The flag (`StressReflectiveCode`) was relevant because it disabled `GraphKit::get_layout_helper` from taking a constant layout helper for `T_LONG`, and instead it had to create a load (which then called `GraphKit::merged_memory`).

**Suggested Solution:**
`VectorPhase` must ensure that the map's memory input is `MergeMemNode`. We can do this in `clone_jvms`, which is called before we instanciate the `GraphKit`.

I added a regression test, which fails without the fix, and passes with it.
Ran regression tests, passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288180](https://bugs.openjdk.org/browse/JDK-8288180): C2: VectorPhase must ensure that SafePointNode memory input is a MergeMemNode


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**) ⚠️ Review applies to [5fcc329a](https://git.openjdk.org/jdk/pull/10215/files/5fcc329abc9ca447c4c3f8a4ab6b94a0db39ef00)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [5fcc329a](https://git.openjdk.org/jdk/pull/10215/files/5fcc329abc9ca447c4c3f8a4ab6b94a0db39ef00)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10215/head:pull/10215` \
`$ git checkout pull/10215`

Update a local copy of the PR: \
`$ git checkout pull/10215` \
`$ git pull https://git.openjdk.org/jdk pull/10215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10215`

View PR using the GUI difftool: \
`$ git pr show -t 10215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10215.diff">https://git.openjdk.org/jdk/pull/10215.diff</a>

</details>
