### PR TITLE
8292755: Non-default method in interface leads to a stack overflow in JShell

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1183,15 +1183,16 @@ public class Attr extends JCTree.Visitor {
                 }
                 if (isDefaultMethod || (tree.sym.flags() & (ABSTRACT | NATIVE)) == 0)
                     log.error(tree.pos(), Errors.MissingMethBodyOrDeclAbstract);
-            } else if ((tree.sym.flags() & (ABSTRACT|DEFAULT|PRIVATE)) == ABSTRACT) {
-                if ((owner.flags() & INTERFACE) != 0) {
-                    log.error(tree.body.pos(), Errors.IntfMethCantHaveBody);
-                } else {
-                    log.error(tree.pos(), Errors.AbstractMethCantHaveBody);
-                }
-            } else if ((tree.mods.flags & NATIVE) != 0) {
-                log.error(tree.pos(), Errors.NativeMethCantHaveBody);
             } else {
+                if ((tree.sym.flags() & (ABSTRACT|DEFAULT|PRIVATE)) == ABSTRACT) {
+                    if ((owner.flags() & INTERFACE) != 0) {
+                        log.error(tree.body.pos(), Errors.IntfMethCantHaveBody);
+                    } else {
+                        log.error(tree.pos(), Errors.AbstractMethCantHaveBody);
+                    }
+                } else if ((tree.mods.flags & NATIVE) != 0) {
+                    log.error(tree.pos(), Errors.NativeMethCantHaveBody);
+                }
                 // Add an implicit super() call unless an explicit call to
                 // super(...) or this(...) is given
                 // or we are compiling class java.lang.Object.

--- a/test/langtools/jdk/jshell/ClassesTest.java
+++ b/test/langtools/jdk/jshell/ClassesTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8145239 8129559 8080354 8189248 8010319 8246353 8247456 8282160
+ * @bug 8145239 8129559 8080354 8189248 8010319 8246353 8247456 8282160 8292755
  * @summary Tests for EvaluationState.classes
  * @build KullaTesting TestingInputStream ExpectedDiagnostic
  * @run testng ClassesTest
@@ -358,6 +358,20 @@ public class ClassesTest extends KullaTesting {
                    """,
                    added(VALID),
                    ste(classKey, Status.RECOVERABLE_NOT_DEFINED, Status.VALID, true, null));
+    }
+
+    public void testDefaultMethodInInterface() {
+        assertEvalFail("""
+                       interface C {
+                           public void run() {
+                               try {
+                                   throw IllegalStateException();
+                               } catch (Throwable t) {
+                                   throw new RuntimeException(t);
+                               }
+                           }
+                       }
+                       """);
     }
 
 }

--- a/test/langtools/tools/javac/recovery/MethodModifiers.java
+++ b/test/langtools/tools/javac/recovery/MethodModifiers.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8292755
+ * @summary Verify error recovery related to method modifiers.
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.jdeps/com.sun.tools.classfile
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main MethodModifiers
+ */
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+import toolbox.JavacTask;
+import toolbox.Task.Expect;
+import toolbox.Task.OutputKind;
+import toolbox.TestRunner;
+import toolbox.ToolBox;
+
+public class MethodModifiers extends TestRunner {
+
+    ToolBox tb;
+
+    public MethodModifiers() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public static void main(String[] args) throws Exception {
+        MethodModifiers t = new MethodModifiers();
+        t.runTests();
+    }
+
+    @Test
+    public void testNonDefaultMethodInterface() throws Exception {
+        String code = """
+                      interface Test {
+                          void test() {
+                              try {
+                                  unresolvable();
+                              } catch (Throwable t) {
+                                  throw new RuntimeException(t);
+                              }
+                          }
+                      }
+                      """;
+        Path curPath = Path.of(".");
+        List<String> actual = new JavacTask(tb)
+                .options("-XDrawDiagnostics",
+                         "-XDshould-stop.at=FLOW",
+                         "-XDdev")
+                .sources(code)
+                .outdir(curPath)
+                .run(Expect.FAIL)
+                .getOutputLines(OutputKind.DIRECT);
+
+        List<String> expected = List.of(
+                "Test.java:2:17: compiler.err.intf.meth.cant.have.body",
+                "Test.java:4:13: compiler.err.cant.resolve.location.args: kindname.method, unresolvable, , , (compiler.misc.location: kindname.interface, Test, null)",
+                "2 errors"
+        );
+
+        if (!Objects.equals(actual, expected)) {
+            error("Expected: " + expected + ", but got: " + actual);
+        }
+    }
+
+    @Test
+    public void testAbstractMethodWithBody() throws Exception {
+        String code = """
+                      abstract class Test {
+                          abstract void test() {
+                              try {
+                                  unresolvable();
+                              } catch (Throwable t) {
+                                  throw new RuntimeException(t);
+                              }
+                          }
+                      }
+                      """;
+        Path curPath = Path.of(".");
+        List<String> actual = new JavacTask(tb)
+                .options("-XDrawDiagnostics",
+                         "-XDshould-stop.at=FLOW",
+                         "-XDdev")
+                .sources(code)
+                .outdir(curPath)
+                .run(Expect.FAIL)
+                .getOutputLines(OutputKind.DIRECT);
+
+        List<String> expected = List.of(
+                "Test.java:2:19: compiler.err.abstract.meth.cant.have.body",
+                "Test.java:4:13: compiler.err.cant.resolve.location.args: kindname.method, unresolvable, , , (compiler.misc.location: kindname.class, Test, null)",
+                "2 errors"
+        );
+
+        if (!Objects.equals(actual, expected)) {
+            error("Expected: " + expected + ", but got: " + actual);
+        }
+    }
+
+    @Test
+    public void testNativeMethodWithBody() throws Exception {
+        String code = """
+                      class Test {
+                          native void test() {
+                              try {
+                                  unresolvable();
+                              } catch (Throwable t) {
+                                  throw new RuntimeException(t);
+                              }
+                          }
+                      }
+                      """;
+        Path curPath = Path.of(".");
+        List<String> actual = new JavacTask(tb)
+                .options("-XDrawDiagnostics",
+                         "-XDshould-stop.at=FLOW",
+                         "-XDdev")
+                .sources(code)
+                .outdir(curPath)
+                .run(Expect.FAIL)
+                .getOutputLines(OutputKind.DIRECT);
+
+        List<String> expected = List.of(
+                "Test.java:2:17: compiler.err.native.meth.cant.have.body",
+                "Test.java:4:13: compiler.err.cant.resolve.location.args: kindname.method, unresolvable, , , (compiler.misc.location: kindname.class, Test, null)",
+                "2 errors"
+        );
+
+        if (!Objects.equals(actual, expected)) {
+            error("Expected: " + expected + ", but got: " + actual);
+        }
+    }
+
+}


### PR DESCRIPTION
Consider this snippet sent to JShell:
```
interface I {
    void test() {
        try {
        } catch (IllegalStateException ex) {
            throw new RuntimeException(ex);
        }
    }
}
```

This leads to a crash:
```
Exception in thread "main" java.lang.InternalError: Exception during analyze - java.lang.StackOverflowError
        at jdk.jshell/jdk.jshell.TaskFactory$AnalyzeTask.analyze(TaskFactory.java:415)
        at jdk.jshell/jdk.jshell.TaskFactory$AnalyzeTask.<init>(TaskFactory.java:406)
        at jdk.jshell/jdk.jshell.TaskFactory.lambda$analyze$1(TaskFactory.java:178)
        at jdk.jshell/jdk.jshell.TaskFactory.lambda$runTask$4(TaskFactory.java:213)
        at jdk.compiler/com.sun.tools.javac.api.JavacTaskPool.getTask(JavacTaskPool.java:193)
        at jdk.jshell/jdk.jshell.TaskFactory.runTask(TaskFactory.java:206)
        at jdk.jshell/jdk.jshell.TaskFactory.analyze(TaskFactory.java:175)
        at jdk.jshell/jdk.jshell.TaskFactory.analyze(TaskFactory.java:161)
        at jdk.jshell/jdk.jshell.Eval.compileAndLoad(Eval.java:1060)
        at jdk.jshell/jdk.jshell.Eval.declare(Eval.java:893)
        at jdk.jshell/jdk.jshell.Eval.eval(Eval.java:140)
        at jdk.jshell/jdk.jshell.JShell.eval(JShell.java:493)
        at jdk.jshell/jdk.internal.jshell.tool.JShellTool.processSource(JShellTool.java:3622)
        at jdk.jshell/jdk.internal.jshell.tool.JShellTool.processSourceCatchingReset(JShellTool.java:1347)
        at jdk.jshell/jdk.internal.jshell.tool.JShellTool.processInput(JShellTool.java:1245)
        at jdk.jshell/jdk.internal.jshell.tool.JShellTool.run(JShellTool.java:1216)
        at jdk.jshell/jdk.internal.jshell.tool.JShellTool.start(JShellTool.java:1000)
        at jdk.jshell/jdk.internal.jshell.tool.JShellToolBuilder.start(JShellToolBuilder.java:261)
        at jdk.jshell/jdk.internal.jshell.tool.JShellToolProvider.main(JShellToolProvider.java:120)
Caused by: java.lang.IllegalStateException: java.lang.StackOverflowError
        at jdk.compiler/com.sun.tools.javac.api.JavacTaskImpl.analyze(JavacTaskImpl.java:383)
        at jdk.jshell/jdk.jshell.TaskFactory$AnalyzeTask.analyze(TaskFactory.java:412)
        ... 18 more
Caused by: java.lang.StackOverflowError
        at jdk.compiler/com.sun.tools.javac.code.Types.isSubtype(Types.java:1077)
        at jdk.compiler/com.sun.tools.javac.code.Types.isSuperType(Types.java:1304)
        at jdk.compiler/com.sun.tools.javac.code.Types.isSubtype(Types.java:1086)
        at jdk.compiler/com.sun.tools.javac.code.Types.isSubtype(Types.java:1077)
        at jdk.compiler/com.sun.tools.javac.code.Types.isSuperType(Types.java:1304)
        at jdk.compiler/com.sun.tools.javac.code.Types.isSubtype(Types.java:1086)
        at jdk.compiler/com.sun.tools.javac.code.Types.isSubtype(Types.java:1077)
        at jdk.compiler/com.sun.tools.javac.code.Types.isSuperType(Types.java:1304)
        at jdk.compiler/com.sun.tools.javac.code.Types.isSubtype(Types.java:1086)
        at jdk.compiler/com.sun.tools.javac.code.Types.isSubtype(Types.java:1077)
        at jdk.compiler/com.sun.tools.javac.code.Types.isSuperType(Types.java:1304)
        at jdk.compiler/com.sun.tools.javac.code.Types.isSubtype(Types.java:1086)
        at jdk.compiler/com.sun.tools.javac.code.Types.isSubtype(Types.java:1077)
        at jdk.compiler/com.sun.tools.javac.code.Types.isSuperType(Types.java:1304)
        at jdk.compiler/com.sun.tools.javac.code.Types.isSubtype(Types.java:1086)
        at jdk.compiler/com.sun.tools.javac.code.Types.isSubtype(Types.java:1077)
...
```

The reason is as follows: when javac's `Attr` sees a method, it checks its modifiers, and if there's a e.g. non-default method with a body in an interface, it won't attribute the body. But, JShell asks javac to go to `Flow`, so `Attr.postAttr` will fill some stub data. But the stub data then lead `Flow` to the stack overflow when checking thrown exceptions.

The proposed fix is to attribute method bodies even if the modifiers are wrong. The proper errors are reported as before, of course, but in addition the body is attributed, so that JShell and other clients can work with the body.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292755](https://bugs.openjdk.org/browse/JDK-8292755): Non-default method in interface leads to a stack overflow in JShell


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10221/head:pull/10221` \
`$ git checkout pull/10221`

Update a local copy of the PR: \
`$ git checkout pull/10221` \
`$ git pull https://git.openjdk.org/jdk pull/10221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10221`

View PR using the GUI difftool: \
`$ git pr show -t 10221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10221.diff">https://git.openjdk.org/jdk/pull/10221.diff</a>

</details>
