### PR TITLE
8293282: LoadLibraryUnloadTest.java fails with "Too few cleared WeakReferences"

### DIFF
--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
@@ -162,14 +162,14 @@ public class LoadLibraryUnload {
         exceptions.clear();
         // Wait for the canary for each of the libraries to be GC'd
         // before exiting the test.
+        int dequeueCount = 0;
         for (int i = 0; i < LOADER_COUNT; i++) {
             System.gc();
-            var res = refQueue.remove(Utils.adjustTimeout(30 * 1000L));
-            System.out.println(i + " dequeued: " + res);
-            if (res == null) {
-                Asserts.fail("Too few cleared WeakReferences");
-            }
+            if (refQueue.remove(Utils.adjustTimeout(10 * 1000L)) != null)
+                dequeueCount++;
         }
+        Asserts.assertEquals(dequeueCount, LOADER_COUNT, "Too few cleared WeakReferences");
+
         // Ensure the WeakReferences are strongly referenced until they can be dequeued
         Reference.reachabilityFence(wCanary);
     }

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
@@ -113,13 +113,12 @@ public class LoadLibraryUnload {
         List<Thread> threads = new ArrayList<>();
         Object[] canary = new Object[LOADER_COUNT];
         final WeakReference<Object> wCanary[] = new WeakReference[LOADER_COUNT];
-        ReferenceQueue<Object> refQueue = new ReferenceQueue<>();
 
         for (int i = 0 ; i < LOADER_COUNT ; i++) {
             // LOADER_COUNT loaders and 2X threads in total.
             // winner loads the library in 2 threads
             canary[i] = new Object();
-            wCanary[i] = new WeakReference<>(canary[i], refQueue);
+            wCanary[i] = new WeakReference<>(canary[i], null);
 
             Class<?> clazz = new TestLoader().loadClass("p.Class1");
             threads.add(new Thread(new LoadLibraryFromClass(clazz, canary[i])));

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
@@ -34,12 +34,12 @@
  *          when the native library is loaded from a custom class loader.
  * @library /test/lib
  * @build LoadLibraryUnload p.Class1
- * @run main/othervm/native -Xcheck:jni LoadLibraryUnloadTest
+ * @run main/othervm/native LoadLibraryUnloadTest
  */
 
 import jdk.test.lib.Asserts;
 import jdk.test.lib.JDKToolFinder;
-import jdk.test.lib.process.*;
+import jdk.test.lib.process.OutputAnalyzer;
 
 import java.lang.ProcessBuilder;
 import java.lang.Process;
@@ -50,7 +50,6 @@ public class LoadLibraryUnloadTest {
 
     private static String testClassPath = System.getProperty("test.classes");
     private static String testLibraryPath = System.getProperty("test.nativepath");
-    private static String classPathSeparator = System.getProperty("path.separator");
 
     private static Process runJavaCommand(String... command) throws Throwable {
         String java = JDKToolFinder.getJDKTool("java");

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
@@ -28,7 +28,7 @@
  */
 /*
  * @test
- * @bug 8266310 8289919
+ * @bug 8266310 8289919 8293282
  * @summary Checks that JNI_OnLoad is invoked only once when multiple threads
  *          call System.loadLibrary concurrently, and JNI_OnUnload is invoked
  *          when the native library is loaded from a custom class loader.


### PR DESCRIPTION
Modify the LoadLibraryUnload test to call gc() more a few times, allowing multiple gc cycles to queue the expected refs.
Short the timeout on each cycle to 10 sec.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293282](https://bugs.openjdk.org/browse/JDK-8293282): LoadLibraryUnloadTest.java fails with "Too few cleared WeakReferences"


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10223/head:pull/10223` \
`$ git checkout pull/10223`

Update a local copy of the PR: \
`$ git checkout pull/10223` \
`$ git pull https://git.openjdk.org/jdk pull/10223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10223`

View PR using the GUI difftool: \
`$ git pr show -t 10223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10223.diff">https://git.openjdk.org/jdk/pull/10223.diff</a>

</details>
