### PR TITLE
JDK-8293343 sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.java failed with "Agent communication error: java.io.EOFException"

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -524,8 +524,6 @@ java/lang/management/ThreadMXBean/ThreadMXBeanStateTest.java    8247426 generic-
 sun/management/jdp/JdpDefaultsTest.java                         8241865 linux-aarch64,macosx-all
 sun/management/jdp/JdpJmxRemoteDynamicPortTest.java             8241865 macosx-all
 sun/management/jdp/JdpSpecificAddressTest.java                  8241865 macosx-all
-sun/management/jmxremote/bootstrap/RmiBootstrapTest.java#id1    8293335 linux-x64
-sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.java    8293343 linux-aarch64,macosx-x64
 
 ############################################################################
 

--- a/test/jdk/sun/management/jmxremote/bootstrap/RmiBootstrapTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/RmiBootstrapTest.java
@@ -58,7 +58,7 @@ import java.util.Set;
  *
  * @library /test/lib
  *
- * @run main/timeout=300 RmiBootstrapTest .*_test.*.in
+ * @run main/othervm/timeout=300 RmiBootstrapTest .*_test.*.in
  * */
 
 /*
@@ -69,7 +69,7 @@ import java.util.Set;
  *
  * @library /test/lib
  *
- * @run main/timeout=300 RmiBootstrapTest .*_ssltest.*.in
+ * @run main/othervm/timeout=300 RmiBootstrapTest .*_ssltest.*.in
  * */
 
 /**

--- a/test/jdk/sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.java
@@ -48,7 +48,7 @@ import javax.management.remote.JMXConnectorServer;
  *
  * @library /test/lib
  *
- * @run main/timeout=300 RmiSslNoKeyStoreTest .*_ssltest.*.in
+ * @run main/othervm/timeout=300 RmiSslNoKeyStoreTest .*_ssltest.*.in
  * */
 
 /**

--- a/test/jdk/sun/management/jmxremote/bootstrap/RmiTestBase.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/RmiTestBase.java
@@ -141,7 +141,7 @@ public class RmiTestBase {
 
         grantFilesAccess(propertyFiles, AccessControl.OWNER);
 
-        return Collections.unmodifiableList(files);
+        return Collections.unmodifiableList(propertyFiles);
     }
 
     /**


### PR DESCRIPTION
This task provides a fix for java.io.EOFException on RmiSslNoKeyStoreTest and RmiBootstrapTest.

The EOFException is only seen when tests are run in concurrent mode. It could be caused by a bug in prepareTestFiles() which creates a race condition that RmiBootstrapTest/RmiSslNoKeyStoreTest changes the file permissions while the other one reading the same files. 

In addition, tests are failing intermittently for SocketException with agentvm mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8293343](https://bugs.openjdk.org/browse/JDK-8293343): sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.java failed with "Agent communication error: java.io.EOFException"
 * [JDK-8293335](https://bugs.openjdk.org/browse/JDK-8293335): sun/management/jmxremote/bootstrap/RmiBootstrapTest.java#id1failed with "Agent communication error: java.io.EOFException"


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10224/head:pull/10224` \
`$ git checkout pull/10224`

Update a local copy of the PR: \
`$ git checkout pull/10224` \
`$ git pull https://git.openjdk.org/jdk pull/10224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10224`

View PR using the GUI difftool: \
`$ git pr show -t 10224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10224.diff">https://git.openjdk.org/jdk/pull/10224.diff</a>

</details>
