### PR TITLE
JDK-8293577: sun/tools/jstatd/TestJstatdRmiPort.java fails with There is already RMI registry on the default port

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -721,7 +721,7 @@ sun/util/locale/provider/CalendarDataRegression.java            8268379 macosx-x
 sun/tools/jhsdb/BasicLauncherTest.java                          8228649 linux-ppc64,linux-ppc64le
 
 sun/tools/jstatd/TestJstatdDefaults.java                        8081569,8226420 windows-all
-sun/tools/jstatd/TestJstatdRmiPort.java                         8226420,8251259 windows-all
+sun/tools/jstatd/TestJstatdRmiPort.java                         8226420,8251259,8293577 generic-all
 sun/tools/jstatd/TestJstatdServer.java                          8081569,8226420 windows-all
 
 sun/tools/jstat/jstatLineCounts1.sh                             8268211 linux-aarch64


### PR DESCRIPTION
We see sometimes failures similar to
https://bugs.openjdk.org/browse/JDK-8226420
on Linux and macOS as well in our nightly tests.
Looks like sometimes the port 1099 is already in use.
The test was problemlisted for Windows, but should most likely be problem listed as well (or marked intermittent) on Linux/macOS.