### PR TITLE
8293579: tools/jpackage/share/jdk/jpackage/tests/UnicodeArgsTest.java fails on Japanese Windows platform

### DIFF
--- a/test/jdk/tools/jpackage/share/jdk/jpackage/tests/UnicodeArgsTest.java
+++ b/test/jdk/tools/jpackage/share/jdk/jpackage/tests/UnicodeArgsTest.java
@@ -50,7 +50,7 @@ public final class UnicodeArgsTest {
     public void test8246042(boolean onCommandLine) {
         final String testString;
 
-        String encoding = System.getProperty("file.encoding");
+        String encoding = System.getProperty("native.encoding");
         switch (encoding) {
         default:
             testString = new String(Character.toChars(0x00E9));

--- a/test/jdk/tools/jpackage/share/jdk/jpackage/tests/UnicodeArgsTest.java
+++ b/test/jdk/tools/jpackage/share/jdk/jpackage/tests/UnicodeArgsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,19 @@ public final class UnicodeArgsTest {
     @Parameter("false")
     @Test
     public void test8246042(boolean onCommandLine) {
-        final String testString = new String(Character.toChars(0x00E9));
+        final String testString;
+
+        String encoding = System.getProperty("file.encoding");
+        switch (encoding) {
+        default:
+            testString = new String(Character.toChars(0x00E9));
+            break;
+
+        case "MS932":
+        case "SJIS":
+            testString = new String(Character.toChars(0x3042));
+            break;
+        }
 
         TKit.trace(String.format("Test string code points: %s", testString
                 .codePoints()


### PR DESCRIPTION
Could you please review the JDK-8293579 bug fixes?

tools/jpackage/share/jdk/jpackage/tests/UnicodeArgsTest.java attempts to give 
the launcher the character which is encoded by Windows API WideCharToMultiByte() 
from UNICODE "é"(0x00e9) as an argument. However, this test fails because the 
code point "é"(0x00e9) cannot be treated on Japanese Windows.

WideCharToMultiByte() encodes characters as Shift-JIS on Japanese Windows, but 
the code point "é"(0x00e9) does not exist in Shift-JIS, and it is replaced with 
"e"(0x0065) as substitute. Therefore, "é"(0x00e9) and "e"(0x0065) are compared 
in this test and judged to be different characters, and return as failed.

So, in the Japanese encoding("MS932", "SJIS"), the test should be modified to 
give a character such as "あ"(0x3042) as the launcher's argument instead of 
"é"(0x00e9).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293579](https://bugs.openjdk.org/browse/JDK-8293579): tools/jpackage/share/jdk/jpackage/tests/UnicodeArgsTest.java fails on Japanese Windows platform


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10226/head:pull/10226` \
`$ git checkout pull/10226`

Update a local copy of the PR: \
`$ git checkout pull/10226` \
`$ git pull https://git.openjdk.org/jdk pull/10226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10226`

View PR using the GUI difftool: \
`$ git pr show -t 10226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10226.diff">https://git.openjdk.org/jdk/pull/10226.diff</a>

</details>
