### PR TITLE
8293595: tstrings::any() is missing an overload

### DIFF
--- a/src/jdk.jpackage/share/native/common/tstrings.h
+++ b/src/jdk.jpackage/share/native/common/tstrings.h
@@ -377,15 +377,15 @@ namespace tstrings {
 
         // need this specialization instead std::wstring::pointer,
         // otherwise LPWSTR is handled as abstract pointer (void*)
-        any& operator << (LPWSTR v) {
-            data << (v ? v : L"NULL");
+        any& operator << (LPWSTR msg) {
+            data << (msg ? msg : L"NULL");
             return *this;
         }
 
         // need this specialization instead std::wstring::const_pointer,
         // otherwise LPCWSTR is handled as abstract pointer (const void*)
-        any& operator << (LPCWSTR v) {
-            data << (v ? v : L"NULL");
+        any& operator << (LPCWSTR msg) {
+            data << (msg ? msg : L"NULL");
             return *this;
         }
 

--- a/src/jdk.jpackage/share/native/common/tstrings.h
+++ b/src/jdk.jpackage/share/native/common/tstrings.h
@@ -356,6 +356,11 @@ namespace tstrings {
             data << fromUtf8(msg);
         }
 
+        any& operator << (const std::string& msg) {
+            data << fromUtf8(msg);
+            return *this;
+        }
+
 #ifdef TSTRINGS_WITH_WCHAR
         any(std::wstring::const_pointer msg) {
             data << msg;
@@ -365,8 +370,8 @@ namespace tstrings {
             data << msg;
         }
 
-        any& operator << (const std::wstring& v) {
-            data << v;
+        any& operator << (const std::wstring& msg) {
+            data << msg;
             return *this;
         }
 


### PR DESCRIPTION
tstrings::any() has an overload for std::wstring (if required) but is missing the corresponding operator overload for std::string, leaving only the templated one as a fallback, which will expand into a std::wostringstream << std::string operation. This isn't particularly safe on Windows, considering that JDK-8292008 and JDK-8247283 have been recently merged, and can sporadically cause build failures. This change simply adds the missing overload with the appropriate format handling that jpackage expects from std::string. Also contains minor name changes to fit the rest of the parameter names in the other overloads.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293595](https://bugs.openjdk.org/browse/JDK-8293595): tstrings::any() is missing an overload


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10231/head:pull/10231` \
`$ git checkout pull/10231`

Update a local copy of the PR: \
`$ git checkout pull/10231` \
`$ git pull https://git.openjdk.org/jdk pull/10231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10231`

View PR using the GUI difftool: \
`$ git pr show -t 10231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10231.diff">https://git.openjdk.org/jdk/pull/10231.diff</a>

</details>
