### PR TITLE
8291657: Javac assertion when compiling a method call with switch expression as argument

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
@@ -583,7 +583,7 @@ public class TransTypes extends TreeTranslator {
             selsuper.tsym == syms.enumSym;
         Type target = enumSwitch ? erasure(tree.selector.type) : syms.intType;
         tree.selector = translate(tree.selector, target);
-        tree.cases = translate(tree.cases);
+        tree.cases = translate(tree.cases, tree.type);
         tree.type = erasure(tree.type);
         result = retype(tree, tree.type, pt);
     }

--- a/test/langtools/tools/javac/patterns/T8291657.java
+++ b/test/langtools/tools/javac/patterns/T8291657.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8291657
+ * @summary Javac assertion when compiling a method call with switch expression as argument
+ * @compile --enable-preview -source ${jdk.version} T8291657.java
+ */
+public class T8291657 {
+    static class A { }
+    interface B { }
+    static void f(final B b) { }
+
+    static public B minimized(Object o) {
+        return (B) switch (o) {
+            default -> new A();
+        };
+    }
+
+    public static void main(final String... args) {
+        f((B) switch (new Object()) {
+            case Object obj -> new A() {};
+        });
+    }
+}


### PR DESCRIPTION
The following crashes on `Gen` when emitting code at `visitYield`.

        return (B) switch (o) {
            default -> new A();
        };

Why? Because the `yield` is retyped in `TransTypes` to `(B) new A()` and during `visitYield` in `Gen.java`, there is a check that essentially says: check the last type and assert if its a super-type of the current type.

That retype in `TransTypes` is exercised in one test regarding intersection types.

Now, if I write a redundant cast:

        return (B) (A) switch (o) {
            default -> new A();
        };

it works. because the `Yield` is not retyped. This PR translates the cases with the correct prototype (of the type of the switch itself -- `A` in the aforementioned examples).

WDYT?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291657](https://bugs.openjdk.org/browse/JDK-8291657): Javac assertion when compiling a method call with switch expression as argument


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10232/head:pull/10232` \
`$ git checkout pull/10232`

Update a local copy of the PR: \
`$ git checkout pull/10232` \
`$ git pull https://git.openjdk.org/jdk pull/10232/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10232`

View PR using the GUI difftool: \
`$ git pr show -t 10232`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10232.diff">https://git.openjdk.org/jdk/pull/10232.diff</a>

</details>
