### PR TITLE
8288473: Remove unused frame::set_pc_preserve_deopt methods

### DIFF
--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -217,7 +217,7 @@ address frame::raw_pc() const {
 // Change the pc in a frame object. This does not change the actual pc in
 // actual frame. To do that use patch_pc.
 //
-void frame::set_pc(address   newpc ) {
+void frame::set_pc(address newpc) {
 #ifdef ASSERT
   if (_cb != NULL && _cb->is_nmethod()) {
     assert(!((nmethod*)_cb)->is_deopt_pc(_pc), "invariant violation");
@@ -229,21 +229,6 @@ void frame::set_pc(address   newpc ) {
   _pc = newpc;
   _cb = CodeCache::find_blob(_pc);
 
-}
-
-void frame::set_pc_preserve_deopt(address newpc) {
-  set_pc_preserve_deopt(newpc, CodeCache::find_blob(newpc));
-}
-
-void frame::set_pc_preserve_deopt(address newpc, CodeBlob* cb) {
-#ifdef ASSERT
-  if (_cb != NULL && _cb->is_nmethod()) {
-    assert(!((nmethod*)_cb)->is_deopt_pc(_pc), "invariant violation");
-  }
-#endif // ASSERT
-
-  _pc = newpc;
-  _cb = cb;
 }
 
 // type testers

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -120,8 +120,6 @@ class frame {
   address raw_pc() const;
 
   void set_pc(address newpc);
-  void set_pc_preserve_deopt(address newpc);
-  void set_pc_preserve_deopt(address newpc, CodeBlob* cb);
 
   intptr_t* sp() const           { assert_absolute(); return _sp; }
   void set_sp( intptr_t* newsp ) { _sp = newsp; }


### PR DESCRIPTION
Please review this trivial change to remove unused functions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288473](https://bugs.openjdk.org/browse/JDK-8288473): Remove unused frame::set_pc_preserve_deopt methods


### Reviewers
 * [Ron Pressler](https://openjdk.org/census#rpressler) (@pron - Committer)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10233/head:pull/10233` \
`$ git checkout pull/10233`

Update a local copy of the PR: \
`$ git checkout pull/10233` \
`$ git pull https://git.openjdk.org/jdk pull/10233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10233`

View PR using the GUI difftool: \
`$ git pr show -t 10233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10233.diff">https://git.openjdk.org/jdk/pull/10233.diff</a>

</details>
