### PR TITLE
8293339: vm/jvmti/StopThread/stop001/stop00103 crashes with SIGSEGV in Continuation::is_continuation_mounted

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -1182,6 +1182,8 @@ JvmtiEnv::ResumeAllVirtualThreads(jint except_count, const jthread* except_list)
 jvmtiError
 JvmtiEnv::StopThread(jthread thread, jobject exception) {
   JavaThread* current_thread = JavaThread::current();
+
+  JvmtiVTMSTransitionDisabler disabler;
   ThreadsListHandle tlh(current_thread);
   JavaThread* java_thread = NULL;
   oop thread_oop = NULL;


### PR DESCRIPTION
I was not able to reproduce this issue in thousands of mach5 runs on multiple platforms. However, the root cause seems to be pretty simple. A JvmtiVTMSTransitionDisabler needs to be added to make the JVM TI StopThread function to be VTMS (Virtual Thread Mount state) transition safe.

So the fix is a one-liner:
```
diff --git a/src/hotspot/share/prims/jvmtiEnv.cpp b/src/hotspot/share/prims/jvmtiEnv.cpp
index a9efe01c92e..f5e9176230a 100644
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -1182,6 +1182,8 @@ JvmtiEnv::ResumeAllVirtualThreads(jint except_count, const jthread* except_list)
 jvmtiError
 JvmtiEnv::StopThread(jthread thread, jobject exception) {
   JavaThread* current_thread = JavaThread::current();
+
+  JvmtiVTMSTransitionDisabler disabler;
   ThreadsListHandle tlh(current_thread);
   JavaThread* java_thread = NULL;
   oop thread_oop = NULL;
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293339](https://bugs.openjdk.org/browse/JDK-8293339): vm/jvmti/StopThread/stop001/stop00103 crashes with SIGSEGV in Continuation::is_continuation_mounted


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10235/head:pull/10235` \
`$ git checkout pull/10235`

Update a local copy of the PR: \
`$ git checkout pull/10235` \
`$ git pull https://git.openjdk.org/jdk pull/10235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10235`

View PR using the GUI difftool: \
`$ git pr show -t 10235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10235.diff">https://git.openjdk.org/jdk/pull/10235.diff</a>

</details>
