### PR TITLE
8293647: Avoid unnecessary boxing in jdk.hotspot.agent

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -1226,7 +1226,7 @@ public class CommandProcessor {
                 if (t.countTokens() == 0) {
                     out.println("echo is " + doEcho);
                 } else if (t.countTokens() == 1) {
-                    doEcho = Boolean.valueOf(t.nextToken()).booleanValue();
+                    doEcho = Boolean.parseBoolean(t.nextToken());
                 } else {
                     usage();
                 }
@@ -1238,7 +1238,7 @@ public class CommandProcessor {
                     out.println("versioncheck is " +
                                 (System.getProperty("sun.jvm.hotspot.runtime.VM.disableVersionCheck") == null));
                 } else if (t.countTokens() == 1) {
-                    if (Boolean.valueOf(t.nextToken()).booleanValue()) {
+                    if (Boolean.parseBoolean(t.nextToken())) {
                         System.clearProperty("sun.jvm.hotspot.runtime.VM.disableVersionCheck");
                     } else {
                         System.setProperty("sun.jvm.hotspot.runtime.VM.disableVersionCheck", "true");
@@ -1302,7 +1302,7 @@ public class CommandProcessor {
                     }
                 } else if (t.countTokens() == 2) {
                     String name = t.nextToken();
-                    Integer value = Integer.valueOf(t.nextToken());
+                    int value = Integer.parseInt(t.nextToken());
                     db.addIntConstant(name, value);
                 }
             }
@@ -1325,7 +1325,7 @@ public class CommandProcessor {
                     }
                 } else if (t.countTokens() == 2) {
                     String name = t.nextToken();
-                    Long value = Long.valueOf(t.nextToken());
+                    long value = Long.parseLong(t.nextToken());
                     db.addLongConstant(name, value);
                 }
             }
@@ -1352,7 +1352,7 @@ public class CommandProcessor {
                     // The field's Type must already be in the database -- no exceptions
                     Type fieldType = agent.getTypeDataBase().lookupType(t.nextToken());
 
-                    boolean isStatic = Boolean.valueOf(t.nextToken()).booleanValue();
+                    boolean isStatic = Boolean.parseBoolean(t.nextToken());
                     long offset = Long.parseLong(t.nextToken());
                     Address staticAddress = parseAddress(t.nextToken());
                     if (isStatic && staticAddress == null) {
@@ -1414,9 +1414,9 @@ public class CommandProcessor {
                     if (superclassName.equals("null")) {
                         superclassName = null;
                     }
-                    boolean isOop = Boolean.valueOf(t.nextToken()).booleanValue();
-                    boolean isInteger = Boolean.valueOf(t.nextToken()).booleanValue();
-                    boolean isUnsigned = Boolean.valueOf(t.nextToken()).booleanValue();
+                    boolean isOop = Boolean.parseBoolean(t.nextToken());
+                    boolean isInteger = Boolean.parseBoolean(t.nextToken());
+                    boolean isUnsigned = Boolean.parseBoolean(t.nextToken());
                     long size = Long.parseLong(t.nextToken());
 
                     BasicType type = null;
@@ -1807,7 +1807,7 @@ public class CommandProcessor {
                 if (t.countTokens() != 1) {
                     usage();
                 } else {
-                    verboseExceptions = Boolean.valueOf(t.nextToken()).booleanValue();
+                    verboseExceptions = Boolean.parseBoolean(t.nextToken());
                 }
             }
         },
@@ -1816,7 +1816,7 @@ public class CommandProcessor {
                 if (t.countTokens() != 1) {
                     usage();
                 } else {
-                    Assert.ASSERTS_ENABLED = Boolean.valueOf(t.nextToken()).booleanValue();
+                    Assert.ASSERTS_ENABLED = Boolean.parseBoolean(t.nextToken());
                 }
             }
         },

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotTypeDataBase.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotTypeDataBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotTypeDataBase.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotTypeDataBase.java
@@ -267,7 +267,7 @@ public class HotSpotTypeDataBase extends BasicTypeDataBase {
             t.nextToken();
             Type fieldType = lookupType(t.sval);
             t.nextToken();
-            boolean isStatic = Boolean.valueOf(t.sval).booleanValue();
+            boolean isStatic = Boolean.parseBoolean(t.sval);
             t.nextToken();
             long offset = Long.parseLong(t.sval);
             t.nextToken();
@@ -321,11 +321,11 @@ public class HotSpotTypeDataBase extends BasicTypeDataBase {
               superclassName = null;
             }
             t.nextToken();
-            boolean isOop = Boolean.valueOf(t.sval).booleanValue();
+            boolean isOop = Boolean.parseBoolean(t.sval);
             t.nextToken();
-            boolean isInteger = Boolean.valueOf(t.sval).booleanValue();
+            boolean isInteger = Boolean.parseBoolean(t.sval);
             t.nextToken();
-            boolean isUnsigned = Boolean.valueOf(t.sval).booleanValue();
+            boolean isUnsigned = Boolean.parseBoolean(t.sval);
             t.nextToken();
             long size = Long.parseLong(t.sval);
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerFinder.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerFinder.java
@@ -73,7 +73,7 @@ public class PointerFinder {
         JavaThread t = threads.getJavaThreadAt(i);
         Address stackBase = t.getStackBase();
         if (stackBase != null) {
-            Long stackSize = t.getStackSize();
+            long stackSize = t.getStackSize();
             Address stackEnd = stackBase.addOffsetTo(-stackSize);
             if (a.lessThanOrEqual(stackBase) && a.greaterThan(stackEnd)) {
                 loc.stackThread = t;


### PR DESCRIPTION
Usages of methods `Integer.valueOf`, `Boolean.valueOf`, `Long.valueOf` often can be simplified by using their pair methods `parseInt`/`parseBoolean`/`parseLong`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293647](https://bugs.openjdk.org/browse/JDK-8293647): Avoid unnecessary boxing in jdk.hotspot.agent


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * @stsypanov (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10237/head:pull/10237` \
`$ git checkout pull/10237`

Update a local copy of the PR: \
`$ git checkout pull/10237` \
`$ git pull https://git.openjdk.org/jdk pull/10237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10237`

View PR using the GUI difftool: \
`$ git pr show -t 10237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10237.diff">https://git.openjdk.org/jdk/pull/10237.diff</a>

</details>
