### PR TITLE
8262901: [macos_aarch64] NativeCallTest expected:<-3.8194101E18> but was:<3.02668882E10>

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.code/src/jdk/vm/ci/code/TargetDescription.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.code/src/jdk/vm/ci/code/TargetDescription.java
@@ -25,12 +25,16 @@ package jdk.vm.ci.code;
 import static jdk.vm.ci.meta.MetaUtil.identityHashCodeString;
 
 import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.services.Services;
 
 /**
  * Represents the target machine for a compiler, including the CPU architecture, the size of
  * pointers and references, alignment of stacks, caches, etc.
  */
 public class TargetDescription {
+
+    public final boolean linuxOs = Services.getSavedProperty("os.name", "").startsWith("Linux");
+    public final boolean macOs = Services.getSavedProperty("os.name", "").startsWith("Mac");
 
     public final Architecture arch;
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.aarch64/src/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotJVMCIBackendFactory.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.aarch64/src/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotJVMCIBackendFactory.java
@@ -94,7 +94,7 @@ public class AArch64HotSpotJVMCIBackendFactory implements HotSpotJVMCIBackendFac
         // and Darwin use it for such. Linux doesn't assign it and thus r18 can
         // be used as an additional register.
         boolean canUsePlatformRegister = config.linuxOs;
-        return new AArch64HotSpotRegisterConfig(target, config.useCompressedOops, canUsePlatformRegister);
+        return new AArch64HotSpotRegisterConfig(target, config.useCompressedOops, canUsePlatformRegister, config.macOs);
     }
 
     protected HotSpotCodeCacheProvider createCodeCache(HotSpotJVMCIRuntime runtime, TargetDescription target, RegisterConfig regConfig) {

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.aarch64/src/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotJVMCIBackendFactory.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.aarch64/src/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotJVMCIBackendFactory.java
@@ -93,8 +93,8 @@ public class AArch64HotSpotJVMCIBackendFactory implements HotSpotJVMCIBackendFac
         // ARMv8 defines r18 as being available to the platform ABI. Windows
         // and Darwin use it for such. Linux doesn't assign it and thus r18 can
         // be used as an additional register.
-        boolean canUsePlatformRegister = config.linuxOs;
-        return new AArch64HotSpotRegisterConfig(target, config.useCompressedOops, canUsePlatformRegister, config.macOs);
+        boolean canUsePlatformRegister = target.linuxOs;
+        return new AArch64HotSpotRegisterConfig(target, config.useCompressedOops, canUsePlatformRegister);
     }
 
     protected HotSpotCodeCacheProvider createCodeCache(HotSpotJVMCIRuntime runtime, TargetDescription target, RegisterConfig regConfig) {

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.aarch64/src/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotRegisterConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.aarch64/src/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotRegisterConfig.java
@@ -116,8 +116,6 @@ public class AArch64HotSpotRegisterConfig implements RegisterConfig {
     private final RegisterArray nativeGeneralParameterRegisters = new RegisterArray(r0, r1, r2, r3, r4, r5, r6, r7);
     private final RegisterArray simdParameterRegisters = new RegisterArray(v0, v1, v2, v3, v4, v5, v6, v7);
 
-    private final boolean macOS;
-
     public static final Register inlineCacheRegister = rscratch2;
 
     /**
@@ -164,14 +162,13 @@ public class AArch64HotSpotRegisterConfig implements RegisterConfig {
         return new RegisterArray(registers);
     }
 
-    public AArch64HotSpotRegisterConfig(TargetDescription target, boolean useCompressedOops, boolean canUsePlatformRegister, boolean macOs) {
-        this(target, initAllocatable(target.arch, useCompressedOops, canUsePlatformRegister), macOs);
+    public AArch64HotSpotRegisterConfig(TargetDescription target, boolean useCompressedOops, boolean canUsePlatformRegister) {
+        this(target, initAllocatable(target.arch, useCompressedOops, canUsePlatformRegister));
         assert callerSaved.size() >= allocatable.size();
     }
 
-    public AArch64HotSpotRegisterConfig(TargetDescription target, RegisterArray allocatable, boolean macOs) {
+    public AArch64HotSpotRegisterConfig(TargetDescription target, RegisterArray allocatable) {
         this.target = target;
-        this.macOS = macOs;
 
         this.allocatable = allocatable;
         Set<Register> callerSaveSet = new HashSet<>();
@@ -288,7 +285,7 @@ public class AArch64HotSpotRegisterConfig implements RegisterConfig {
             }
 
             if (locations[i] == null) {
-                if (macOS && type == HotSpotCallingConventionType.NativeCall) {
+                if (target.macOs && type == HotSpotCallingConventionType.NativeCall) {
                     currentStackOffset = parseDarwinNativeStackArg(valueKindFactory.getValueKind(kind), locations, i, currentStackOffset, type);
                 } else {
                     currentStackOffset = parseStackArg(valueKindFactory.getValueKind(kind), locations, i, currentStackOffset, type);

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.aarch64/src/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotRegisterConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.aarch64/src/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotRegisterConfig.java
@@ -116,6 +116,8 @@ public class AArch64HotSpotRegisterConfig implements RegisterConfig {
     private final RegisterArray nativeGeneralParameterRegisters = new RegisterArray(r0, r1, r2, r3, r4, r5, r6, r7);
     private final RegisterArray simdParameterRegisters = new RegisterArray(v0, v1, v2, v3, v4, v5, v6, v7);
 
+    private final boolean macOS;
+
     public static final Register inlineCacheRegister = rscratch2;
 
     /**
@@ -162,13 +164,14 @@ public class AArch64HotSpotRegisterConfig implements RegisterConfig {
         return new RegisterArray(registers);
     }
 
-    public AArch64HotSpotRegisterConfig(TargetDescription target, boolean useCompressedOops, boolean canUsePlatformRegister) {
-        this(target, initAllocatable(target.arch, useCompressedOops, canUsePlatformRegister));
+    public AArch64HotSpotRegisterConfig(TargetDescription target, boolean useCompressedOops, boolean canUsePlatformRegister, boolean macOs) {
+        this(target, initAllocatable(target.arch, useCompressedOops, canUsePlatformRegister), macOs);
         assert callerSaved.size() >= allocatable.size();
     }
 
-    public AArch64HotSpotRegisterConfig(TargetDescription target, RegisterArray allocatable) {
+    public AArch64HotSpotRegisterConfig(TargetDescription target, RegisterArray allocatable, boolean macOs) {
         this.target = target;
+        this.macOS = macOs;
 
         this.allocatable = allocatable;
         Set<Register> callerSaveSet = new HashSet<>();
@@ -264,12 +267,29 @@ public class AArch64HotSpotRegisterConfig implements RegisterConfig {
             }
 
             if (locations[i] == null) {
-                ValueKind<?> valueKind = valueKindFactory.getValueKind(kind);
-                locations[i] = StackSlot.get(valueKind, currentStackOffset, !type.out);
-                currentStackOffset += Math.max(valueKind.getPlatformKind().getSizeInBytes(), target.wordSize);
+                if (type == HotSpotCallingConventionType.NativeCall) {
+                    ValueKind<?> valueKind = valueKindFactory.getValueKind(kind);
+                    int kindSize = valueKind.getPlatformKind().getSizeInBytes();
+                    if (macOS && currentStackOffset % kindSize != 0) {
+                        // In MacOS natural alignment is used
+                        // See https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms
+                        currentStackOffset += kindSize - currentStackOffset % kindSize;
+                    }
+                    locations[i] = StackSlot.get(valueKind, currentStackOffset, !type.out);
+                    if (macOS) {
+                        // In MacOS "Function arguments may consume slots on the stack that are not multiples of 8 bytes"
+                        // See https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms
+                        currentStackOffset += kindSize;
+                    } else {
+                        currentStackOffset += Math.max(kindSize, target.wordSize);
+                    }
+                } else {
+                    ValueKind<?> valueKind = valueKindFactory.getValueKind(kind);
+                    locations[i] = StackSlot.get(valueKind, currentStackOffset, !type.out);
+                    currentStackOffset += Math.max(valueKind.getPlatformKind().getSizeInBytes(), target.wordSize);
+                }
             }
         }
-
         JavaKind returnKind = returnType == null ? JavaKind.Void : returnType.getJavaKind();
         AllocatableValue returnLocation = returnKind == JavaKind.Void ? Value.ILLEGAL : getReturnRegister(returnKind).asValue(valueKindFactory.getValueKind(returnKind.getStackKind()));
         return new CallingConvention(currentStackOffset, returnLocation, locations);

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.aarch64/src/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.aarch64/src/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotVMConfig.java
@@ -38,6 +38,7 @@ class AArch64HotSpotVMConfig extends HotSpotVMConfigAccess {
     }
 
     final boolean linuxOs = Services.getSavedProperty("os.name", "").startsWith("Linux");
+    final boolean macOs = Services.getSavedProperty("os.name", "").startsWith("Mac");
 
     final boolean useCompressedOops = getFlag("UseCompressedOops", Boolean.class);
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.aarch64/src/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.aarch64/src/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotVMConfig.java
@@ -24,7 +24,6 @@ package jdk.vm.ci.hotspot.aarch64;
 
 import jdk.vm.ci.hotspot.HotSpotVMConfigAccess;
 import jdk.vm.ci.hotspot.HotSpotVMConfigStore;
-import jdk.vm.ci.services.Services;
 
 /**
  * Used to access native configuration details.
@@ -36,9 +35,6 @@ class AArch64HotSpotVMConfig extends HotSpotVMConfigAccess {
     AArch64HotSpotVMConfig(HotSpotVMConfigStore config) {
         super(config);
     }
-
-    final boolean linuxOs = Services.getSavedProperty("os.name", "").startsWith("Linux");
-    final boolean macOs = Services.getSavedProperty("os.name", "").startsWith("Mac");
 
     final boolean useCompressedOops = getFlag("UseCompressedOops", Boolean.class);
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -46,7 +46,6 @@
 compiler/ciReplay/TestSAServer.java 8029528 generic-all
 compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java 8225370 generic-all
 compiler/jvmci/compilerToVM/GetFlagValueTest.java 8204459 generic-all
-compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java 8262901 macosx-aarch64
 compiler/tiered/LevelTransitionTest.java 8067651 generic-all
 
 compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java 8190680 generic-all

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/libNativeCallTest.c
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/libNativeCallTest.c
@@ -189,6 +189,39 @@ JNIEXPORT jfloat JNICALL Java_jdk_vm_ci_code_test_NativeCallTest__1L32SDILDS(JNI
                    a,   b,   c,   d,   e,   f);
 }
 
+jint JNICALL I32I(jint i00, jint i01, jint i02, jint i03, jint i04, jint i05, jint i06, jint i07,
+                  jint i08, jint i09, jint i0a, jint i0b, jint i0c, jint i0d, jint i0e, jint i0f,
+                  jint i10, jint i11, jint i12, jint i13, jint i14, jint i15, jint i16, jint i17,
+                  jint i18, jint i19, jint i1a, jint i1b, jint i1c, jint i1d, jint i1e, jint i1f,
+                  jint a) {
+  return i00 + i01 + i02 + i03 + i04 + i05 + i06 + i07 +
+         i08 + i09 + i0a + i0b + i0c + i0d + i0e + i0f +
+         i10 + i11 + i12 + i13 + i14 + i15 + i16 + i17 +
+         i18 + i19 + i1a + i1b + i1c + i1d + i1e + i1f +
+         a;
+}
+
+JNIEXPORT jlong JNICALL Java_jdk_vm_ci_code_test_NativeCallTest_getI32I(JNIEnv *env, jclass clazz) {
+  return (jlong) (intptr_t) I32I;
+}
+
+JNIEXPORT jint JNICALL Java_jdk_vm_ci_code_test_NativeCallTest__1I32I(JNIEnv *env, jclass clazz,
+                                                                      jint i00, jint i01, jint i02, jint i03,
+                                                                      jint i04, jint i05, jint i06, jint i07,
+                                                                      jint i08, jint i09, jint i0a, jint i0b,
+                                                                      jint i0c, jint i0d, jint i0e, jint i0f,
+                                                                      jint i10, jint i11, jint i12, jint i13,
+                                                                      jint i14, jint i15, jint i16, jint i17,
+                                                                      jint i18, jint i19, jint i1a, jint i1b,
+                                                                      jint i1c, jint i1d, jint i1e, jint i1f,
+                                                                      jint a) {
+  return I32I(i00, i01, i02, i03, i04, i05, i06, i07,
+              i08, i09, i0a, i0b, i0c, i0d, i0e, i0f,
+              i10, i11, i12, i13, i14, i15, i16, i17,
+              i18, i19, i1a, i1b, i1c, i1d, i1e, i1f,
+              a);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java
@@ -125,6 +125,26 @@ public class NativeCallTest extends CodeInstallationTest {
         test("I32SDILDS", getI32SDILDS(), float.class, argClazz, argValues);
     }
 
+    @Test
+    public void testI32I() {
+        int sCount = 32;
+        // Pairs of <Object>, <Class>
+        Object[] remainingArgs = new Object[]{
+                        12, int.class
+        };
+        Class<?>[] argClazz = new Class[sCount + remainingArgs.length / 2];
+        Object[] argValues = new Object[sCount + remainingArgs.length / 2];
+        for (int i = 0; i < sCount; i++) {
+            argValues[i] = i;
+            argClazz[i] = int.class;
+        }
+        for (int i = 0; i < remainingArgs.length; i += 2) {
+            argValues[sCount + i / 2] = remainingArgs[i + 0];
+            argClazz[sCount + i / 2] = (Class<?>) remainingArgs[i + 1];
+        }
+        test("I32I", getI32I(), int.class, argClazz, argValues);
+    }
+
     public void test(String name, long addr, Class<?> returnClazz, Class<?>[] types, Object[] values) {
         try {
             test(asm -> {
@@ -243,5 +263,25 @@ public class NativeCallTest extends CodeInstallationTest {
                         l10, l11, l12, l13, l14, l15, l16, l17,
                         l18, l19, l1a, l1b, l1c, l1d, l1e, l1f,
                         a, b, c, d, e, f);
+    }
+
+    public static native long getI32I();
+
+    public static native int _I32I(int i00, int i01, int i02, int i03, int i04, int i05, int i06, int i07,
+                    int i08, int i09, int i0a, int i0b, int i0c, int i0d, int i0e, int i0f,
+                    int i10, int i11, int i12, int i13, int i14, int i15, int i16, int i17,
+                    int i18, int i19, int i1a, int i1b, int i1c, int i1d, int i1e, int i1f,
+                    int a);
+
+    public static int I32I(int i00, int i01, int i02, int i03, int i04, int i05, int i06, int i07,
+                    int i08, int i09, int i0a, int i0b, int i0c, int i0d, int i0e, int i0f,
+                    int i10, int i11, int i12, int i13, int i14, int i15, int i16, int i17,
+                    int i18, int i19, int i1a, int i1b, int i1c, int i1d, int i1e, int i1f,
+                    int a) {
+        return _I32I(i00, i01, i02, i03, i04, i05, i06, i07,
+                    i08, i09, i0a, i0b, i0c, i0d, i0e, i0f,
+                    i10, i11, i12, i13, i14, i15, i16, i17,
+                    i18, i19, i1a, i1b, i1c, i1d, i1e, i1f,
+                    a);
     }
 }

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/aarch64/AArch64TestAssembler.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/aarch64/AArch64TestAssembler.java
@@ -272,8 +272,7 @@ public class AArch64TestAssembler extends TestAssembler {
 
     @Override
     public void emitCallPrologue(CallingConvention cc, Object... prim) {
-        emitGrowStack(cc.getStackSize());
-        frameSize += cc.getStackSize();
+        growFrame(cc.getStackSize());
         AllocatableValue[] args = cc.getArguments();
         for (int i = 0; i < args.length; i++) {
             emitLoad(args[i], prim[i]);
@@ -282,8 +281,7 @@ public class AArch64TestAssembler extends TestAssembler {
 
     @Override
     public void emitCallEpilogue(CallingConvention cc) {
-        emitGrowStack(-cc.getStackSize());
-        frameSize -= cc.getStackSize();
+        growFrame(-cc.getStackSize());
     }
 
     @Override


### PR DESCRIPTION
This PR is opened as a follow-up for [1] and included the "must-done" fixes pointed by @teshull.

This patch for JVMCI includes the following fixes related to the macOS AArch64 calling convention:
1. arguments may consume slots on the stack that are not multiples of 8 bytes [2]
2. natural alignment of stack arguments [2]
3. stack must remain 16-byte aligned [3][4]

Tested with tier1 on macOS AArch64 and Linux AArch64.

[1] https://github.com/openjdk/jdk/pull/6641
[2] https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms
[3] https://docs.microsoft.com/en-us/cpp/build/arm64-windows-abi-conventions?view=msvc-160#stack
[4] https://docs.microsoft.com/en-us/cpp/build/stack-usage?view=msvc-170

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8262901](https://bugs.openjdk.org/browse/JDK-8262901): [macos_aarch64] NativeCallTest expected:<-3.8194101E18> but was:<3.02668882E10>


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10238/head:pull/10238` \
`$ git checkout pull/10238`

Update a local copy of the PR: \
`$ git checkout pull/10238` \
`$ git pull https://git.openjdk.org/jdk pull/10238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10238`

View PR using the GUI difftool: \
`$ git pr show -t 10238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10238.diff">https://git.openjdk.org/jdk/pull/10238.diff</a>

</details>
