### PR TITLE
8293503: gc/metaspace/TestMetaspacePerfCounters.java#Epsilon-64 failed assertGreaterThanOrEqual: expected MMM >= NNN

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -83,7 +83,6 @@ gc/stress/gclocker/TestGCLockerWithG1.java 8180622 generic-all
 gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java 8192647 generic-all
 gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8241293 macosx-x64
 gc/stress/TestStressG1Humongous.java 8286554 windows-x64
-gc/metaspace/TestMetaspacePerfCounters.java#Epsilon-64 8293503 generic-all
 
 #############################################################################
 

--- a/test/hotspot/jtreg/gc/metaspace/TestMetaspacePerfCounters.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestMetaspacePerfCounters.java
@@ -211,16 +211,20 @@ public class TestMetaspacePerfCounters {
         long capacity;
         long used;
 
-        // The perf counter values are updated during GC and to be able to
-        // do the assertions below we need to ensure that the values are from
-        // the same GC cycle.
+        // The perf counter values are updated during GC for all but Epsilon
+        // GC. To be able to do the assertions below we need to ensure that
+        // the values are at least from the same GC cycle.
+        // For Epsilon we assume that current "capacity" always increases
+        // without a metaspace GC which will cause another loop iteration, so
+        // reading "capacity" after "used" will at least return a consistent
+        // result.
         do {
             gcCountBefore = currentGCCount();
 
             minCapacity = getMinCapacity(ns);
             maxCapacity = getMaxCapacity(ns);
-            capacity = getCapacity(ns);
             used = getUsed(ns);
+            capacity = getCapacity(ns);
 
             gcCountAfter = currentGCCount();
             assertGTE(gcCountAfter, gcCountBefore);

--- a/test/hotspot/jtreg/gc/metaspace/TestMetaspacePerfCounters.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestMetaspacePerfCounters.java
@@ -243,6 +243,7 @@ public class TestMetaspacePerfCounters {
         PerfCounterSnapshot snap2 = new PerfCounterSnapshot();
 
         final int MaxAttempts = 10;
+
         int attempts = 0;
         do {
             snap1.get(ns);
@@ -250,7 +251,7 @@ public class TestMetaspacePerfCounters {
             snap2.get(ns);
         } while ((!snap1.equals(snap2)) && (++attempts < MaxAttempts));
 
-        if (attempts == 10) {
+        if (attempts == MaxAttempts) {
             throw new Exception("Failed to get stable reading of metaspace performance counters after " + MaxAttempts + " tries");
         }
 

--- a/test/hotspot/jtreg/gc/metaspace/TestMetaspacePerfCounters.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestMetaspacePerfCounters.java
@@ -244,15 +244,17 @@ public class TestMetaspacePerfCounters {
 
         final int MaxAttempts = 10;
 
-        int attempts = 0;
-        do {
+        for (int attempts = 0; ; attempts++) {
             snap1.get(ns);
             VarHandle.fullFence();
             snap2.get(ns);
-        } while ((!snap1.equals(snap2)) && (++attempts < MaxAttempts));
 
-        if (attempts == MaxAttempts) {
-            throw new Exception("Failed to get stable reading of metaspace performance counters after " + MaxAttempts + " tries");
+            if (snap1.equals(snap2)) {
+              // Got a consistent snapshot for examination.
+              break;
+            } else if (attempts == MaxAttempts) {
+              throw new Exception("Failed to get stable reading of metaspace performance counters after " + attempts + " tries");
+            }
         }
 
         assertGTE(snap1.minCapacity, 0L);

--- a/test/hotspot/jtreg/gc/metaspace/TestMetaspacePerfCounters.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestMetaspacePerfCounters.java
@@ -23,7 +23,7 @@
 
 package gc.metaspace;
 
-import java.lang.management.GarbageCollectorMXBean;
+import java.lang.invoke.VarHandle;
 import java.util.List;
 import java.util.ArrayList;
 
@@ -183,10 +183,45 @@ import gc.testlibrary.PerfCounters;
  * @run main/othervm -XX:+UsePerfData -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.metaspace.TestMetaspacePerfCounters
  */
 
+class PerfCounterSnapshot {
+    private static long getMinCapacity(String ns) throws Exception {
+        return PerfCounters.findByName(ns + ".minCapacity").longValue();
+    }
+
+    private static long getCapacity(String ns) throws Exception {
+        return PerfCounters.findByName(ns + ".capacity").longValue();
+    }
+
+    private static long getMaxCapacity(String ns) throws Exception {
+        return PerfCounters.findByName(ns + ".maxCapacity").longValue();
+    }
+
+    private static long getUsed(String ns) throws Exception {
+        return PerfCounters.findByName(ns + ".used").longValue();
+    }
+
+    public long minCapacity;
+    public long maxCapacity;
+    public long capacity;
+    public long used;
+
+    public void get(String ns) throws Exception {
+        minCapacity = getMinCapacity(ns);
+        maxCapacity = getMaxCapacity(ns);
+        used = getUsed(ns);
+        capacity = getCapacity(ns);
+    }
+
+    public boolean equals(Object object) {
+        PerfCounterSnapshot other = (PerfCounterSnapshot)object;
+        return (minCapacity == other.minCapacity) && (maxCapacity == other.maxCapacity) &&
+            (used == other.used) && (capacity == other.capacity);
+    }
+}
+
 public class TestMetaspacePerfCounters {
     public static Class<?> fooClass = null;
     private static final String[] counterNames = {"minCapacity", "maxCapacity", "capacity", "used"};
-    private static final List<GarbageCollectorMXBean> gcBeans = ManagementFactoryHelper.getGarbageCollectorMXBeans();
 
     public static void main(String[] args) throws Exception {
         String metaspace = "sun.gc.metaspace";
@@ -204,36 +239,25 @@ public class TestMetaspacePerfCounters {
     }
 
     private static void checkPerfCounters(String ns) throws Exception {
-        long gcCountBefore;
-        long gcCountAfter;
-        long minCapacity;
-        long maxCapacity;
-        long capacity;
-        long used;
+        PerfCounterSnapshot snap1 = new PerfCounterSnapshot();
+        PerfCounterSnapshot snap2 = new PerfCounterSnapshot();
 
-        // The perf counter values are updated during GC for all but Epsilon
-        // GC. To be able to do the assertions below we need to ensure that
-        // the values are at least from the same GC cycle.
-        // For Epsilon we assume that current "capacity" always increases
-        // without a metaspace GC which will cause another loop iteration, so
-        // reading "capacity" after "used" will at least return a consistent
-        // result.
+        final int MaxAttempts = 10;
+        int attempts = 0;
         do {
-            gcCountBefore = currentGCCount();
+            snap1.get(ns);
+            VarHandle.fullFence();
+            snap2.get(ns);
+        } while ((!snap1.equals(snap2)) && (++attempts < MaxAttempts));
 
-            minCapacity = getMinCapacity(ns);
-            maxCapacity = getMaxCapacity(ns);
-            used = getUsed(ns);
-            capacity = getCapacity(ns);
+        if (attempts == 10) {
+            throw new Exception("Failed to get stable reading of metaspace performance counters after " + MaxAttempts + " tries");
+        }
 
-            gcCountAfter = currentGCCount();
-            assertGTE(gcCountAfter, gcCountBefore);
-        } while(gcCountAfter > gcCountBefore);
-
-        assertGTE(minCapacity, 0L);
-        assertGTE(used, minCapacity);
-        assertGTE(capacity, used);
-        assertGTE(maxCapacity, capacity);
+        assertGTE(snap1.minCapacity, 0L);
+        assertGTE(snap1.used, snap1.minCapacity);
+        assertGTE(snap1.capacity, snap1.used);
+        assertGTE(snap1.maxCapacity, snap1.capacity);
     }
 
     private static void checkEmptyPerfCounters(String ns) throws Exception {
@@ -247,12 +271,14 @@ public class TestMetaspacePerfCounters {
         // Need to ensure that used is up to date and that all unreachable
         // classes are unloaded before doing this check.
         System.gc();
-        long before = getUsed(ns);
+        PerfCounterSnapshot before = new PerfCounterSnapshot();
+        before.get(ns);
         fooClass = compileAndLoad("Foo", "public class Foo { }");
         System.gc();
-        long after = getUsed(ns);
+        PerfCounterSnapshot after = new PerfCounterSnapshot();
+        after.get(ns);
 
-        assertGT(after, before);
+        assertGT(after.used, before.used);
     }
 
     private static List<PerfCounter> countersInNamespace(String ns) throws Exception {
@@ -270,29 +296,5 @@ public class TestMetaspacePerfCounters {
 
     private static boolean isUsingCompressedClassPointers() {
         return Platform.is64bit() && InputArguments.contains("-XX:+UseCompressedClassPointers");
-    }
-
-    private static long getMinCapacity(String ns) throws Exception {
-        return PerfCounters.findByName(ns + ".minCapacity").longValue();
-    }
-
-    private static long getCapacity(String ns) throws Exception {
-        return PerfCounters.findByName(ns + ".capacity").longValue();
-    }
-
-    private static long getMaxCapacity(String ns) throws Exception {
-        return PerfCounters.findByName(ns + ".maxCapacity").longValue();
-    }
-
-    private static long getUsed(String ns) throws Exception {
-        return PerfCounters.findByName(ns + ".used").longValue();
-    }
-
-    private static long currentGCCount() {
-        long gcCount = 0;
-        for (GarbageCollectorMXBean bean : gcBeans) {
-            gcCount += bean.getCollectionCount();
-        }
-        return gcCount;
     }
 }

--- a/test/hotspot/jtreg/gc/metaspace/TestMetaspacePerfCounters.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestMetaspacePerfCounters.java
@@ -212,8 +212,7 @@ class PerfCounterSnapshot {
         capacity = getCapacity(ns);
     }
 
-    public boolean equals(Object object) {
-        PerfCounterSnapshot other = (PerfCounterSnapshot)object;
+    public boolean consistentWith(PerfCounterSnapshot other) {
         return (minCapacity == other.minCapacity) && (maxCapacity == other.maxCapacity) &&
             (used == other.used) && (capacity == other.capacity);
     }
@@ -249,7 +248,7 @@ public class TestMetaspacePerfCounters {
             VarHandle.fullFence();
             snap2.get(ns);
 
-            if (snap1.equals(snap2)) {
+            if (snap1.consistentWith(snap2)) {
               // Got a consistent snapshot for examination.
               break;
             } else if (attempts == MaxAttempts) {


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that workarounds some epsilon gc specific behavior in the gc/metaspace/TestMetaspacePerfCounters test?

The test gathers statistics about metaspace to check one by one:

        // The perf counter values are updated during GC and to be able to
        // do the assertions below we need to ensure that the values are from
        // the same GC cycle.
        do {
            gcCountBefore = currentGCCount();

            minCapacity = getMinCapacity(ns);
            maxCapacity = getMaxCapacity(ns);
            capacity = getCapacity(ns);
            used = getUsed(ns);
    
[...]

For Epsilon GC the assumption stated in the comment in the code does not hold (and in general, it seems more because of knowledge about Hotspot than actual specification) - Epsilon also updates the statistics every X TLAB refills without a pause. Without these updates at TLAB refill, Epsilon would mostly always never update these (it does not do any GC by itself, only out-of-metaspace GC actually performs one).

The problem then is that if there is such an update between getCapacity() and getUsed(), used can be larger than capacity gathered before as both may have changed at the second call. It also assumes that there is sufficient memory visibility related synchronization between these calls.

There is no way to get multiple performance counter values atomically as e.g. in the MemoryMXBean API, so some inconsistency is probably expected.

So the suggested fix here is to get two snapshots of the values, separated by a memory barrier and only continue if both snapshots are equal.

Testing: running the test for 1000 times without issue, fails 10 times or so without this patch

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293503](https://bugs.openjdk.org/browse/JDK-8293503): gc/metaspace/TestMetaspacePerfCounters.java#Epsilon-64 failed assertGreaterThanOrEqual: expected MMM >= NNN


### Reviewers
 * [Leo Korinth](https://openjdk.org/census#lkorinth) (@lkorinth - **Reviewer**) ⚠️ Review applies to [4714b548](https://git.openjdk.org/jdk/pull/10239/files/4714b5487ef64d518babe908fb2181b7c0b1492e)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to [e22cdd54](https://git.openjdk.org/jdk/pull/10239/files/e22cdd5495eb273d0721fe971f6791827ec6e037)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10239/head:pull/10239` \
`$ git checkout pull/10239`

Update a local copy of the PR: \
`$ git checkout pull/10239` \
`$ git pull https://git.openjdk.org/jdk pull/10239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10239`

View PR using the GUI difftool: \
`$ git pr show -t 10239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10239.diff">https://git.openjdk.org/jdk/pull/10239.diff</a>

</details>
