### PR TITLE
8293618: x86: Wrong code generation in class Assembler

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -348,6 +348,12 @@ void Assembler::emit_arith_operand(int op1, Register rm, Address adr, int32_t im
   }
 }
 
+void Assembler::emit_arith_operand_imm32(int op1, Register rm, Address adr, int32_t imm32) {
+  assert(op1 == 0x81, "unexpected opcode");
+  emit_int8(op1);
+  emit_operand(rm, adr, 4);
+  emit_int32(imm32);
+}
 
 void Assembler::emit_arith(int op1, int op2, Register dst, Register src) {
   assert(isByte(op1) && isByte(op2), "wrong opcode");
@@ -591,7 +597,7 @@ inline void Assembler::emit_modrm_sib_disp8(int mod, int dst_enc, int src_enc,
 void Assembler::emit_operand_helper(int reg_enc, int base_enc, int index_enc,
                                     Address::ScaleFactor scale, int disp,
                                     RelocationHolder const& rspec,
-                                    int rip_relative_correction) {
+                                    int post_addr_length) {
   bool no_relocation = (rspec.type() == relocInfo::none);
 
   if (is_valid_encoding(base_enc)) {
@@ -679,7 +685,7 @@ void Assembler::emit_operand_helper(int reg_enc, int base_enc, int index_enc,
       // at the start of the instruction. That needs more correction here.
       // intptr_t disp = target - next_ip;
       assert(inst_mark() != NULL, "must be inside InstructionMark");
-      address next_ip = pc() + sizeof(int32_t) + rip_relative_correction;
+      address next_ip = pc() + sizeof(int32_t) + post_addr_length;
       int64_t adjusted = disp;
       // Do rip-rel adjustment for 64bit
       LP64_ONLY(adjusted -=  (next_ip - inst_mark()));
@@ -702,44 +708,46 @@ void Assembler::emit_operand_helper(int reg_enc, int base_enc, int index_enc,
 void Assembler::emit_operand(Register reg, Register base, Register index,
                              Address::ScaleFactor scale, int disp,
                              RelocationHolder const& rspec,
-                             int rip_relative_correction) {
+                             int post_addr_length) {
   assert(!index->is_valid() || index != rsp, "illegal addressing mode");
   emit_operand_helper(raw_encode(reg), raw_encode(base), raw_encode(index),
-                      scale, disp, rspec, rip_relative_correction);
+                      scale, disp, rspec, post_addr_length);
 
 }
 void Assembler::emit_operand(XMMRegister xmmreg, Register base, Register index,
                              Address::ScaleFactor scale, int disp,
-                             RelocationHolder const& rspec) {
+                             RelocationHolder const& rspec,
+                             int post_addr_length) {
   assert(!index->is_valid() || index != rsp, "illegal addressing mode");
   assert(xmmreg->encoding() < 16 || UseAVX > 2, "not supported");
   emit_operand_helper(raw_encode(xmmreg), raw_encode(base), raw_encode(index),
-                      scale, disp, rspec);
+                      scale, disp, rspec, post_addr_length);
 }
 
 void Assembler::emit_operand(XMMRegister xmmreg, Register base, XMMRegister xmmindex,
                              Address::ScaleFactor scale, int disp,
-                             RelocationHolder const& rspec) {
+                             RelocationHolder const& rspec,
+                             int post_addr_length) {
   assert(xmmreg->encoding() < 16 || UseAVX > 2, "not supported");
   assert(xmmindex->encoding() < 16 || UseAVX > 2, "not supported");
   emit_operand_helper(raw_encode(xmmreg), raw_encode(base), raw_encode(xmmindex),
-                      scale, disp, rspec, /* rip_relative_correction */ 0);
+                      scale, disp, rspec, post_addr_length);
 }
 
 void Assembler::emit_operand(KRegister kreg, Address adr,
-                             int rip_relative_correction) {
+                             int post_addr_length) {
   emit_operand(kreg, adr._base, adr._index, adr._scale, adr._disp,
                adr._rspec,
-               rip_relative_correction);
+               post_addr_length);
 }
 
 void Assembler::emit_operand(KRegister kreg, Register base, Register index,
                              Address::ScaleFactor scale, int disp,
                              RelocationHolder const& rspec,
-                             int rip_relative_correction) {
+                             int post_addr_length) {
   assert(!index->is_valid() || index != rsp, "illegal addressing mode");
   emit_operand_helper(raw_encode(kreg), raw_encode(base), raw_encode(index),
-                      scale, disp, rspec, rip_relative_correction);
+                      scale, disp, rspec, post_addr_length);
 }
 
 // Secret local extension to Assembler::WhichOperand:
@@ -1247,19 +1255,15 @@ void Assembler::check_relocation(RelocationHolder const& rspec, int format) {
 }
 #endif // ASSERT
 
-void Assembler::emit_operand(Register reg, Address adr,
-                             int rip_relative_correction) {
-  emit_operand(reg, adr._base, adr._index, adr._scale, adr._disp,
-               adr._rspec,
-               rip_relative_correction);
+void Assembler::emit_operand(Register reg, Address adr, int post_addr_length) {
+  emit_operand(reg, adr._base, adr._index, adr._scale, adr._disp, adr._rspec, post_addr_length);
 }
 
-void Assembler::emit_operand(XMMRegister reg, Address adr) {
+void Assembler::emit_operand(XMMRegister reg, Address adr, int post_addr_length) {
   if (adr.isxmmindex()) {
-     emit_operand(reg, adr._base, adr._xmmindex, adr._scale, adr._disp, adr._rspec);
+     emit_operand(reg, adr._base, adr._xmmindex, adr._scale, adr._disp, adr._rspec, post_addr_length);
   } else {
-     emit_operand(reg, adr._base, adr._index, adr._scale, adr._disp,
-     adr._rspec);
+     emit_operand(reg, adr._base, adr._index, adr._scale, adr._disp, adr._rspec, post_addr_length);
   }
 }
 
@@ -1275,7 +1279,7 @@ void Assembler::adcl(Address dst, Register src) {
   InstructionMark im(this);
   prefix(dst, src);
   emit_int8(0x11);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::adcl(Register dst, int32_t imm32) {
@@ -1287,7 +1291,7 @@ void Assembler::adcl(Register dst, Address src) {
   InstructionMark im(this);
   prefix(src, dst);
   emit_int8(0x13);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::adcl(Register dst, Register src) {
@@ -1310,6 +1314,7 @@ void Assembler::addb(Address dst, int imm8) {
 }
 
 void Assembler::addw(Register dst, Register src) {
+  emit_int8(0x66);
   (void)prefix_and_encode(dst->encoding(), src->encoding());
   emit_arith(0x03, 0xC0, dst, src);
 }
@@ -1327,7 +1332,7 @@ void Assembler::addl(Address dst, Register src) {
   InstructionMark im(this);
   prefix(dst, src);
   emit_int8(0x01);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::addl(Register dst, int32_t imm32) {
@@ -1339,7 +1344,7 @@ void Assembler::addl(Register dst, Address src) {
   InstructionMark im(this);
   prefix(src, dst);
   emit_int8(0x03);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::addl(Register dst, Register src) {
@@ -1403,7 +1408,7 @@ void Assembler::addsd(XMMRegister dst, Address src) {
   attributes.set_rex_vex_w_reverted();
   simd_prefix(dst, dst, src, VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x58);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::addss(XMMRegister dst, XMMRegister src) {
@@ -1420,7 +1425,7 @@ void Assembler::addss(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(dst, dst, src, VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x58);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::aesdec(XMMRegister dst, Address src) {
@@ -1429,7 +1434,7 @@ void Assembler::aesdec(XMMRegister dst, Address src) {
   InstructionAttr attributes(AVX_128bit, /* rex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   simd_prefix(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xDE);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::aesdec(XMMRegister dst, XMMRegister src) {
@@ -1454,7 +1459,7 @@ void Assembler::aesdeclast(XMMRegister dst, Address src) {
   InstructionAttr attributes(AVX_128bit, /* rex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   simd_prefix(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xDF);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::aesdeclast(XMMRegister dst, XMMRegister src) {
@@ -1478,7 +1483,7 @@ void Assembler::aesenc(XMMRegister dst, Address src) {
   InstructionAttr attributes(AVX_128bit, /* rex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   simd_prefix(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xDC);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::aesenc(XMMRegister dst, XMMRegister src) {
@@ -1502,7 +1507,7 @@ void Assembler::aesenclast(XMMRegister dst, Address src) {
   InstructionAttr attributes(AVX_128bit, /* rex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   simd_prefix(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xDD);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::aesenclast(XMMRegister dst, XMMRegister src) {
@@ -1524,7 +1529,7 @@ void Assembler::andb(Address dst, Register src) {
   InstructionMark im(this);
   prefix(dst, src, true);
   emit_int8(0x20);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::andw(Register dst, Register src) {
@@ -1547,14 +1552,14 @@ void Assembler::andl(Address dst, Register src) {
   InstructionMark im(this);
   prefix(dst, src);
   emit_int8(0x21);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::andl(Register dst, Address src) {
   InstructionMark im(this);
   prefix(src, dst);
   emit_int8(0x23);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::andl(Register dst, Register src) {
@@ -1575,7 +1580,7 @@ void Assembler::andnl(Register dst, Register src1, Address src2) {
   InstructionAttr attributes(AVX_128bit, /* rex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(src2, src1->encoding(), dst->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xF2);
-  emit_operand(dst, src2);
+  emit_operand(dst, src2, 0);
 }
 
 void Assembler::bsfl(Register dst, Register src) {
@@ -1610,7 +1615,7 @@ void Assembler::blsil(Register dst, Address src) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(src, dst->encoding(), rbx->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xF3);
-  emit_operand(rbx, src);
+  emit_operand(rbx, src, 0);
 }
 
 void Assembler::blsmskl(Register dst, Register src) {
@@ -1627,7 +1632,7 @@ void Assembler::blsmskl(Register dst, Address src) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(src, dst->encoding(), rdx->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xF3);
-  emit_operand(rdx, src);
+  emit_operand(rdx, src, 0);
 }
 
 void Assembler::blsrl(Register dst, Register src) {
@@ -1643,7 +1648,7 @@ void Assembler::blsrl(Register dst, Address src) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(src, dst->encoding(), rcx->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xF3);
-  emit_operand(rcx, src);
+  emit_operand(rcx, src, 0);
 }
 
 void Assembler::call(Label& L, relocInfo::relocType rtype) {
@@ -1678,7 +1683,7 @@ void Assembler::call(Address adr) {
   InstructionMark im(this);
   prefix(adr);
   emit_int8((unsigned char)0xFF);
-  emit_operand(rdx, adr);
+  emit_operand(rdx, adr, 0);
 }
 
 void Assembler::call_literal(address entry, RelocationHolder const& rspec) {
@@ -1716,7 +1721,7 @@ void Assembler::cmovl(Condition cc, Register dst, Address src) {
   NOT_LP64(guarantee(VM_Version::supports_cmov(), "illegal instruction"));
   prefix(src, dst);
   emit_int16(0x0F, (0x40 | cc));
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::cmpb(Address dst, int imm8) {
@@ -1730,9 +1735,7 @@ void Assembler::cmpb(Address dst, int imm8) {
 void Assembler::cmpl(Address dst, int32_t imm32) {
   InstructionMark im(this);
   prefix(dst);
-  emit_int8((unsigned char)0x81);
-  emit_operand(rdi, dst, 4);
-  emit_int32(imm32);
+  emit_arith_operand(0x81, as_Register(7), dst, imm32);
 }
 
 void Assembler::cmpl(Register dst, int32_t imm32) {
@@ -1745,11 +1748,17 @@ void Assembler::cmpl(Register dst, Register src) {
   emit_arith(0x3B, 0xC0, dst, src);
 }
 
-void Assembler::cmpl(Register dst, Address  src) {
+void Assembler::cmpl(Register dst, Address src) {
   InstructionMark im(this);
   prefix(src, dst);
   emit_int8(0x3B);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
+}
+
+void Assembler::cmpl_imm32(Address dst, int32_t imm32) {
+  InstructionMark im(this);
+  prefix(dst);
+  emit_arith_operand_imm32(0x81, as_Register(7), dst, imm32);
 }
 
 void Assembler::cmpw(Address dst, int imm16) {
@@ -1767,7 +1776,7 @@ void Assembler::cmpxchgl(Register reg, Address adr) { // cmpxchg
   InstructionMark im(this);
   prefix(adr, reg);
   emit_int16(0x0F, (unsigned char)0xB1);
-  emit_operand(reg, adr);
+  emit_operand(reg, adr, 0);
 }
 
 void Assembler::cmpxchgw(Register reg, Address adr) { // cmpxchg
@@ -1775,7 +1784,7 @@ void Assembler::cmpxchgw(Register reg, Address adr) { // cmpxchg
   size_prefix();
   prefix(adr, reg);
   emit_int16(0x0F, (unsigned char)0xB1);
-  emit_operand(reg, adr);
+  emit_operand(reg, adr, 0);
 }
 
 // The 8-bit cmpxchg compares the value at adr with the contents of rax,
@@ -1785,7 +1794,7 @@ void Assembler::cmpxchgb(Register reg, Address adr) { // cmpxchg
   InstructionMark im(this);
   prefix(adr, reg, true);
   emit_int16(0x0F, (unsigned char)0xB0);
-  emit_operand(reg, adr);
+  emit_operand(reg, adr, 0);
 }
 
 void Assembler::comisd(XMMRegister dst, Address src) {
@@ -1798,7 +1807,7 @@ void Assembler::comisd(XMMRegister dst, Address src) {
   attributes.set_rex_vex_w_reverted();
   simd_prefix(dst, xnoreg, src, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x2F);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::comisd(XMMRegister dst, XMMRegister src) {
@@ -1816,7 +1825,7 @@ void Assembler::comiss(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(dst, xnoreg, src, VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8(0x2F);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::comiss(XMMRegister dst, XMMRegister src) {
@@ -1904,7 +1913,7 @@ void Assembler::crc32(Register crc, Address adr, int8_t sizeInBytes) {
   }
   LP64_ONLY(prefix(crc, adr, p);)
   emit_int24(0x0F, 0x38, (0xF0 | w));
-  emit_operand(crc, adr);
+  emit_operand(crc, adr, 0);
 }
 
 void Assembler::cvtdq2pd(XMMRegister dst, XMMRegister src) {
@@ -1951,7 +1960,7 @@ void Assembler::cvtsd2ss(XMMRegister dst, Address src) {
   attributes.set_rex_vex_w_reverted();
   simd_prefix(dst, dst, src, VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x5A);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::cvtsi2sdl(XMMRegister dst, Register src) {
@@ -1968,7 +1977,7 @@ void Assembler::cvtsi2sdl(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(dst, dst, src, VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x2A);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::cvtsi2ssl(XMMRegister dst, Register src) {
@@ -1985,7 +1994,7 @@ void Assembler::cvtsi2ssl(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(dst, dst, src, VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x2A);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::cvtsi2ssq(XMMRegister dst, Register src) {
@@ -2009,7 +2018,7 @@ void Assembler::cvtss2sd(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(dst, dst, src, VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x5A);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 
@@ -2228,7 +2237,7 @@ void Assembler::decl(Address dst) {
   InstructionMark im(this);
   prefix(dst);
   emit_int8((unsigned char)0xFF);
-  emit_operand(rcx, dst);
+  emit_operand(rcx, dst, 0);
 }
 
 void Assembler::divsd(XMMRegister dst, Address src) {
@@ -2239,7 +2248,7 @@ void Assembler::divsd(XMMRegister dst, Address src) {
   attributes.set_rex_vex_w_reverted();
   simd_prefix(dst, dst, src, VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x5E);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::divsd(XMMRegister dst, XMMRegister src) {
@@ -2257,7 +2266,7 @@ void Assembler::divss(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(dst, dst, src, VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x5E);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::divss(XMMRegister dst, XMMRegister src) {
@@ -2298,11 +2307,11 @@ void Assembler::imull(Register dst, Address src, int32_t value) {
   prefix(src, dst);
   if (is8bit(value)) {
     emit_int8((unsigned char)0x6B);
-    emit_operand(dst, src);
+    emit_operand(dst, src, 1);
     emit_int8(value);
   } else {
     emit_int8((unsigned char)0x69);
-    emit_operand(dst, src);
+    emit_operand(dst, src, 4);
     emit_int32(value);
   }
 }
@@ -2321,7 +2330,7 @@ void Assembler::imull(Register dst, Address src) {
   InstructionMark im(this);
   prefix(src, dst);
   emit_int16(0x0F, (unsigned char)0xAF);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 
@@ -2330,7 +2339,7 @@ void Assembler::incl(Address dst) {
   InstructionMark im(this);
   prefix(dst);
   emit_int8((unsigned char)0xFF);
-  emit_operand(rax, dst);
+  emit_operand(rax, dst, 0);
 }
 
 void Assembler::jcc(Condition cc, Label& L, bool maybe_short) {
@@ -2390,7 +2399,7 @@ void Assembler::jmp(Address adr) {
   InstructionMark im(this);
   prefix(adr);
   emit_int8((unsigned char)0xFF);
-  emit_operand(rsp, adr);
+  emit_operand(rsp, adr, 0);
 }
 
 void Assembler::jmp(Label& L, bool maybe_short) {
@@ -2461,13 +2470,13 @@ void Assembler::ldmxcsr( Address src) {
     InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
     vex_prefix(src, 0, 0, VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
     emit_int8((unsigned char)0xAE);
-    emit_operand(as_Register(2), src);
+    emit_operand(as_Register(2), src, 0);
   } else {
     NOT_LP64(assert(VM_Version::supports_sse(), ""));
     InstructionMark im(this);
     prefix(src);
     emit_int16(0x0F, (unsigned char)0xAE);
-    emit_operand(as_Register(2), src);
+    emit_operand(as_Register(2), src, 0);
   }
 }
 
@@ -2475,7 +2484,7 @@ void Assembler::leal(Register dst, Address src) {
   InstructionMark im(this);
   prefix(src, dst);
   emit_int8((unsigned char)0x8D);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::lfence() {
@@ -2503,7 +2512,7 @@ void Assembler::lzcntl(Register dst, Address src) {
   emit_int8((unsigned char)0xF3);
   prefix(src, dst);
   emit_int16(0x0F, (unsigned char)0xBD);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 // Emit mfence instruction
@@ -2551,7 +2560,7 @@ void Assembler::movb(Register dst, Address src) {
   InstructionMark im(this);
   prefix(src, dst, true);
   emit_int8((unsigned char)0x8A);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movddup(XMMRegister dst, XMMRegister src) {
@@ -2571,7 +2580,7 @@ void Assembler::movddup(XMMRegister dst, Address src) {
   attributes.set_rex_vex_w_reverted();
   simd_prefix(dst, xnoreg, src, VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x12);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vmovddup(XMMRegister dst, Address src, int vector_len) {
@@ -2582,7 +2591,7 @@ void Assembler::vmovddup(XMMRegister dst, Address src, int vector_len) {
   attributes.set_rex_vex_w_reverted();
   simd_prefix(dst, xnoreg, src, VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x12);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::kmovbl(KRegister dst, KRegister src) {
@@ -2626,7 +2635,7 @@ void Assembler::kmovwl(KRegister dst, Address src) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0x90);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::kmovwl(Address dst, KRegister src) {
@@ -2635,7 +2644,7 @@ void Assembler::kmovwl(Address dst, KRegister src) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0x91);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::kmovwl(KRegister dst, KRegister src) {
@@ -2672,7 +2681,7 @@ void Assembler::kmovql(KRegister dst, Address src) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0x90);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::kmovql(Address dst, KRegister src) {
@@ -2681,7 +2690,7 @@ void Assembler::kmovql(Address dst, KRegister src) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0x91);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::kmovql(KRegister dst, Register src) {
@@ -2961,7 +2970,7 @@ void Assembler::movb(Address dst, Register src) {
   InstructionMark im(this);
   prefix(dst, src, true);
   emit_int8((unsigned char)0x88);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::movdl(XMMRegister dst, Register src) {
@@ -2986,7 +2995,7 @@ void Assembler::movdl(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(dst, xnoreg, src, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x6E);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movdl(Address dst, XMMRegister src) {
@@ -2996,7 +3005,7 @@ void Assembler::movdl(Address dst, XMMRegister src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(src, xnoreg, dst, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x7E);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::movdqa(XMMRegister dst, XMMRegister src) {
@@ -3013,7 +3022,7 @@ void Assembler::movdqa(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_FVM, /* input_size_in_bits */ EVEX_NObit);
   simd_prefix(dst, xnoreg, src, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x6F);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movdqu(XMMRegister dst, Address src) {
@@ -3023,7 +3032,7 @@ void Assembler::movdqu(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_FVM, /* input_size_in_bits */ EVEX_NObit);
   simd_prefix(dst, xnoreg, src, VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x6F);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movdqu(XMMRegister dst, XMMRegister src) {
@@ -3041,7 +3050,7 @@ void Assembler::movdqu(Address dst, XMMRegister src) {
   attributes.reset_is_clear_context();
   simd_prefix(src, xnoreg, dst, VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x7F);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 // Move Unaligned 256bit Vector
@@ -3059,7 +3068,7 @@ void Assembler::vmovdqu(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_FVM, /* input_size_in_bits */ EVEX_NObit);
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x6F);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vmovdqu(Address dst, XMMRegister src) {
@@ -3072,7 +3081,7 @@ void Assembler::vmovdqu(Address dst, XMMRegister src) {
   assert(src != xnoreg, "sanity");
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x7F);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::vpmaskmovd(XMMRegister dst, XMMRegister mask, Address src, int vector_len) {
@@ -3081,7 +3090,7 @@ void Assembler::vpmaskmovd(XMMRegister dst, XMMRegister mask, Address src, int v
   InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ false, /* uses_vl */ false);
   vex_prefix(src, mask->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0x8C);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vpmaskmovq(XMMRegister dst, XMMRegister mask, Address src, int vector_len) {
@@ -3090,7 +3099,7 @@ void Assembler::vpmaskmovq(XMMRegister dst, XMMRegister mask, Address src, int v
   InstructionAttr attributes(vector_len, /* vex_w */ true, /* legacy_mode */ true, /* no_mask_reg */ false, /* uses_vl */ false);
   vex_prefix(src, mask->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0x8C);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vmaskmovps(XMMRegister dst, Address src, XMMRegister mask, int vector_len) {
@@ -3099,7 +3108,7 @@ void Assembler::vmaskmovps(XMMRegister dst, Address src, XMMRegister mask, int v
   InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(src, mask->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x2C);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vmaskmovpd(XMMRegister dst, Address src, XMMRegister mask, int vector_len) {
@@ -3108,7 +3117,7 @@ void Assembler::vmaskmovpd(XMMRegister dst, Address src, XMMRegister mask, int v
   InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(src, mask->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x2D);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vmaskmovps(Address dst, XMMRegister src, XMMRegister mask, int vector_len) {
@@ -3117,7 +3126,7 @@ void Assembler::vmaskmovps(Address dst, XMMRegister src, XMMRegister mask, int v
   InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(dst, mask->encoding(), src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x2E);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::vmaskmovpd(Address dst, XMMRegister src, XMMRegister mask, int vector_len) {
@@ -3126,7 +3135,7 @@ void Assembler::vmaskmovpd(Address dst, XMMRegister src, XMMRegister mask, int v
   InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(dst, mask->encoding(), src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x2F);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 // Move Unaligned EVEX enabled Vector (programmable : 8,16,32,64)
@@ -3159,7 +3168,7 @@ void Assembler::evmovdqub(XMMRegister dst, KRegister mask, Address src, bool mer
   }
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x6F);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evmovdqub(XMMRegister dst, Address src, int vector_len) {
@@ -3180,7 +3189,7 @@ void Assembler::evmovdqub(Address dst, KRegister mask, XMMRegister src, bool mer
   }
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x7F);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::evmovdquw(XMMRegister dst, Address src, int vector_len) {
@@ -3200,7 +3209,7 @@ void Assembler::evmovdquw(XMMRegister dst, KRegister mask, Address src, bool mer
   }
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x6F);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evmovdquw(Address dst, XMMRegister src, int vector_len) {
@@ -3221,7 +3230,7 @@ void Assembler::evmovdquw(Address dst, KRegister mask, XMMRegister src, bool mer
   }
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x7F);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::evmovdqul(XMMRegister dst, XMMRegister src, int vector_len) {
@@ -3258,7 +3267,7 @@ void Assembler::evmovdqul(XMMRegister dst, KRegister mask, Address src, bool mer
   }
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x6F);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evmovdqul(Address dst, XMMRegister src, int vector_len) {
@@ -3279,12 +3288,11 @@ void Assembler::evmovdqul(Address dst, KRegister mask, XMMRegister src, bool mer
   }
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x7F);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::evmovdquq(XMMRegister dst, XMMRegister src, int vector_len) {
   // Unmasked instruction
-  if (dst->encoding() == src->encoding()) return;
   evmovdquq(dst, k0, src, /*merge*/ false, vector_len);
 }
 
@@ -3317,7 +3325,7 @@ void Assembler::evmovdquq(XMMRegister dst, KRegister mask, Address src, bool mer
   }
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x6F);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evmovdquq(Address dst, XMMRegister src, int vector_len) {
@@ -3338,7 +3346,7 @@ void Assembler::evmovdquq(Address dst, KRegister mask, XMMRegister src, bool mer
   attributes.set_is_evex_instruction();
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x7F);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 // Uses zero extension on 64bit
@@ -3358,7 +3366,7 @@ void Assembler::movl(Register dst, Address src) {
   InstructionMark im(this);
   prefix(src, dst);
   emit_int8((unsigned char)0x8B);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movl(Address dst, int32_t imm32) {
@@ -3373,7 +3381,7 @@ void Assembler::movl(Address dst, Register src) {
   InstructionMark im(this);
   prefix(dst, src);
   emit_int8((unsigned char)0x89);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 // New cpus require to use movsd and movss to avoid partial register stall
@@ -3387,7 +3395,7 @@ void Assembler::movlpd(XMMRegister dst, Address src) {
   attributes.set_rex_vex_w_reverted();
   simd_prefix(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x12);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movq(XMMRegister dst, Address src) {
@@ -3398,7 +3406,7 @@ void Assembler::movq(XMMRegister dst, Address src) {
   attributes.set_rex_vex_w_reverted();
   simd_prefix(dst, xnoreg, src, VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x7E);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movq(Address dst, XMMRegister src) {
@@ -3409,7 +3417,7 @@ void Assembler::movq(Address dst, XMMRegister src) {
   attributes.set_rex_vex_w_reverted();
   simd_prefix(src, xnoreg, dst, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xD6);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::movq(XMMRegister dst, XMMRegister src) {
@@ -3439,7 +3447,7 @@ void Assembler::movsbl(Register dst, Address src) { // movsxb
   InstructionMark im(this);
   prefix(src, dst);
   emit_int16(0x0F, (unsigned char)0xBE);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movsbl(Register dst, Register src) { // movsxb
@@ -3464,7 +3472,7 @@ void Assembler::movsd(XMMRegister dst, Address src) {
   attributes.set_rex_vex_w_reverted();
   simd_prefix(dst, xnoreg, src, VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x10);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movsd(Address dst, XMMRegister src) {
@@ -3476,7 +3484,7 @@ void Assembler::movsd(Address dst, XMMRegister src) {
   attributes.set_rex_vex_w_reverted();
   simd_prefix(src, xnoreg, dst, VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x11);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::movss(XMMRegister dst, XMMRegister src) {
@@ -3493,7 +3501,7 @@ void Assembler::movss(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(dst, xnoreg, src, VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x10);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movss(Address dst, XMMRegister src) {
@@ -3504,14 +3512,14 @@ void Assembler::movss(Address dst, XMMRegister src) {
   attributes.reset_is_clear_context();
   simd_prefix(src, xnoreg, dst, VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x11);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::movswl(Register dst, Address src) { // movsxw
   InstructionMark im(this);
   prefix(src, dst);
   emit_int16(0x0F, (unsigned char)0xBF);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movswl(Register dst, Register src) { // movsxw
@@ -3526,7 +3534,7 @@ void Assembler::movups(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_FVM, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(dst, xnoreg, src, VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8(0x10);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vmovups(XMMRegister dst, Address src, int vector_len) {
@@ -3536,7 +3544,7 @@ void Assembler::vmovups(XMMRegister dst, Address src, int vector_len) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_FVM, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(dst, xnoreg, src, VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8(0x10);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movups(Address dst, XMMRegister src) {
@@ -3546,7 +3554,7 @@ void Assembler::movups(Address dst, XMMRegister src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_FVM, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(src, xnoreg, dst, VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8(0x11);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::vmovups(Address dst, XMMRegister src, int vector_len) {
@@ -3556,7 +3564,7 @@ void Assembler::vmovups(Address dst, XMMRegister src, int vector_len) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_FVM, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(src, xnoreg, dst, VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8(0x11);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::movw(Address dst, int imm16) {
@@ -3574,7 +3582,7 @@ void Assembler::movw(Register dst, Address src) {
   emit_int8(0x66);
   prefix(src, dst);
   emit_int8((unsigned char)0x8B);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movw(Address dst, Register src) {
@@ -3582,14 +3590,14 @@ void Assembler::movw(Address dst, Register src) {
   emit_int8(0x66);
   prefix(dst, src);
   emit_int8((unsigned char)0x89);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::movzbl(Register dst, Address src) { // movzxb
   InstructionMark im(this);
   prefix(src, dst);
   emit_int16(0x0F, (unsigned char)0xB6);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movzbl(Register dst, Register src) { // movzxb
@@ -3602,7 +3610,7 @@ void Assembler::movzwl(Register dst, Address src) { // movzxw
   InstructionMark im(this);
   prefix(src, dst);
   emit_int16(0x0F, (unsigned char)0xB7);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movzwl(Register dst, Register src) { // movzxw
@@ -3614,7 +3622,7 @@ void Assembler::mull(Address src) {
   InstructionMark im(this);
   prefix(src);
   emit_int8((unsigned char)0xF7);
-  emit_operand(rsp, src);
+  emit_operand(rsp, src, 0);
 }
 
 void Assembler::mull(Register src) {
@@ -3630,7 +3638,7 @@ void Assembler::mulsd(XMMRegister dst, Address src) {
   attributes.set_rex_vex_w_reverted();
   simd_prefix(dst, dst, src, VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x59);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::mulsd(XMMRegister dst, XMMRegister src) {
@@ -3648,7 +3656,7 @@ void Assembler::mulss(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(dst, dst, src, VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x59);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::mulss(XMMRegister dst, XMMRegister src) {
@@ -3667,7 +3675,7 @@ void Assembler::negl(Address dst) {
   InstructionMark im(this);
   prefix(dst);
   emit_int8((unsigned char)0xF7);
-  emit_operand(as_Register(3), dst);
+  emit_operand(as_Register(3), dst, 0);
 }
 
 void Assembler::nop(int i) {
@@ -4001,7 +4009,7 @@ void Assembler::orl(Register dst, Address src) {
   InstructionMark im(this);
   prefix(src, dst);
   emit_int8(0x0B);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::orl(Register dst, Register src) {
@@ -4013,7 +4021,7 @@ void Assembler::orl(Address dst, Register src) {
   InstructionMark im(this);
   prefix(dst, src);
   emit_int8(0x09);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::orb(Address dst, int imm8) {
@@ -4028,7 +4036,7 @@ void Assembler::orb(Address dst, Register src) {
   InstructionMark im(this);
   prefix(dst, src, true);
   emit_int8(0x08);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::packsswb(XMMRegister dst, XMMRegister src) {
@@ -4067,7 +4075,7 @@ void Assembler::packuswb(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x67);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::packuswb(XMMRegister dst, XMMRegister src) {
@@ -4130,7 +4138,7 @@ void Assembler::vpermb(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_is_evex_instruction();
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0x8D);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vpermw(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
@@ -4158,7 +4166,7 @@ void Assembler::vpermd(XMMRegister dst, XMMRegister nds, Address src, int vector
   InstructionAttr attributes(vector_len, /* rex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x36);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vperm2i128(XMMRegister dst,  XMMRegister nds, XMMRegister src, int imm8) {
@@ -4235,7 +4243,7 @@ void Assembler::pcmpestri(XMMRegister dst, Address src, int imm8) {
   InstructionAttr attributes(AVX_128bit, /* rex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   simd_prefix(dst, xnoreg, src, VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x61);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 1);
   emit_int8(imm8);
 }
 
@@ -4289,7 +4297,7 @@ void Assembler::evpcmpgtb(KRegister kdst, XMMRegister nds, Address src, int vect
   int dst_enc = kdst->encoding();
   vex_prefix(src, nds->encoding(), dst_enc, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x64);
-  emit_operand(as_Register(dst_enc), src);
+  emit_operand(as_Register(dst_enc), src, 0);
 }
 
 void Assembler::evpcmpgtb(KRegister kdst, KRegister mask, XMMRegister nds, Address src, int vector_len) {
@@ -4303,7 +4311,7 @@ void Assembler::evpcmpgtb(KRegister kdst, KRegister mask, XMMRegister nds, Addre
   int dst_enc = kdst->encoding();
   vex_prefix(src, nds->encoding(), dst_enc, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x64);
-  emit_operand(as_Register(dst_enc), src);
+  emit_operand(as_Register(dst_enc), src, 0);
 }
 
 void Assembler::evpcmpuw(KRegister kdst, XMMRegister nds, XMMRegister src, ComparisonPredicate vcc, int vector_len) {
@@ -4323,7 +4331,7 @@ void Assembler::evpcmpuw(KRegister kdst, XMMRegister nds, Address src, Compariso
   int dst_enc = kdst->encoding();
   vex_prefix(src, nds->encoding(), kdst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x3E);
-  emit_operand(as_Register(dst_enc), src);
+  emit_operand(as_Register(dst_enc), src, 1);
   emit_int8(vcc);
 }
 
@@ -4336,7 +4344,7 @@ void Assembler::evpcmpeqb(KRegister kdst, XMMRegister nds, Address src, int vect
   int dst_enc = kdst->encoding();
   vex_prefix(src, nds->encoding(), dst_enc, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x74);
-  emit_operand(as_Register(dst_enc), src);
+  emit_operand(as_Register(dst_enc), src, 0);
 }
 
 void Assembler::evpcmpeqb(KRegister kdst, KRegister mask, XMMRegister nds, Address src, int vector_len) {
@@ -4349,7 +4357,7 @@ void Assembler::evpcmpeqb(KRegister kdst, KRegister mask, XMMRegister nds, Addre
   attributes.set_is_evex_instruction();
   vex_prefix(src, nds->encoding(), kdst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x74);
-  emit_operand(as_Register(kdst->encoding()), src);
+  emit_operand(as_Register(kdst->encoding()), src, 0);
 }
 
 // In this context, the dst vector contains the components that are equal, non equal components are zeroed in dst
@@ -4387,7 +4395,7 @@ void Assembler::evpcmpeqw(KRegister kdst, XMMRegister nds, Address src, int vect
   int dst_enc = kdst->encoding();
   vex_prefix(src, nds->encoding(), dst_enc, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x75);
-  emit_operand(as_Register(dst_enc), src);
+  emit_operand(as_Register(dst_enc), src, 0);
 }
 
 // In this context, the dst vector contains the components that are equal, non equal components are zeroed in dst
@@ -4429,7 +4437,7 @@ void Assembler::evpcmpeqd(KRegister kdst, KRegister mask, XMMRegister nds, Addre
   int dst_enc = kdst->encoding();
   vex_prefix(src, nds->encoding(), dst_enc, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x76);
-  emit_operand(as_Register(dst_enc), src);
+  emit_operand(as_Register(dst_enc), src, 0);
 }
 
 // In this context, the dst vector contains the components that are equal, non equal components are zeroed in dst
@@ -4486,7 +4494,7 @@ void Assembler::evpcmpeqq(KRegister kdst, XMMRegister nds, Address src, int vect
   int dst_enc = kdst->encoding();
   vex_prefix(src, nds->encoding(), dst_enc, VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x29);
-  emit_operand(as_Register(dst_enc), src);
+  emit_operand(as_Register(dst_enc), src, 0);
 }
 
 void Assembler::pcmpgtq(XMMRegister dst, XMMRegister src) {
@@ -4539,7 +4547,7 @@ void Assembler::pextrd(Address dst, XMMRegister src, int imm8) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(src, xnoreg, dst, VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x16);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 1);
   emit_int8(imm8);
 }
 
@@ -4556,7 +4564,7 @@ void Assembler::pextrq(Address dst, XMMRegister src, int imm8) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_64bit);
   simd_prefix(src, xnoreg, dst, VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x16);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 1);
   emit_int8(imm8);
 }
 
@@ -4573,7 +4581,7 @@ void Assembler::pextrw(Address dst, XMMRegister src, int imm8) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_16bit);
   simd_prefix(src, xnoreg, dst, VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x15);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 1);
   emit_int8(imm8);
 }
 
@@ -4590,7 +4598,7 @@ void Assembler::pextrb(Address dst, XMMRegister src, int imm8) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_8bit);
   simd_prefix(src, xnoreg, dst, VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x14);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 1);
   emit_int8(imm8);
 }
 
@@ -4607,7 +4615,7 @@ void Assembler::pinsrd(XMMRegister dst, Address src, int imm8) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x22);
-  emit_operand(dst,src);
+  emit_operand(dst, src, 1);
   emit_int8(imm8);
 }
 
@@ -4631,7 +4639,7 @@ void Assembler::pinsrq(XMMRegister dst, Address src, int imm8) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_64bit);
   simd_prefix(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x22);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 1);
   emit_int8(imm8);
 }
 
@@ -4655,7 +4663,7 @@ void Assembler::pinsrw(XMMRegister dst, Address src, int imm8) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_16bit);
   simd_prefix(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xC4);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 1);
   emit_int8(imm8);
 }
 
@@ -4672,7 +4680,7 @@ void Assembler::pinsrb(XMMRegister dst, Address src, int imm8) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_8bit);
   simd_prefix(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x20);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 1);
   emit_int8(imm8);
 }
 
@@ -4711,7 +4719,7 @@ void Assembler::pmovzxbw(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_HVM, /* input_size_in_bits */ EVEX_NObit);
   simd_prefix(dst, xnoreg, src, VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x30);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::pmovzxbw(XMMRegister dst, XMMRegister src) {
@@ -4771,7 +4779,7 @@ void Assembler::vpmovzxbw(XMMRegister dst, Address src, int vector_len) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_HVM, /* input_size_in_bits */ EVEX_NObit);
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x30);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vpmovzxbw(XMMRegister dst, XMMRegister src, int vector_len) {
@@ -4802,7 +4810,7 @@ void Assembler::evpmovzxbw(XMMRegister dst, KRegister mask, Address src, int vec
   attributes.set_is_evex_instruction();
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x30);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpandd(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -4893,7 +4901,7 @@ void Assembler::evpmovwb(Address dst, XMMRegister src, int vector_len) {
   attributes.set_is_evex_instruction();
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x30);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::evpmovwb(Address dst, KRegister mask, XMMRegister src, int vector_len) {
@@ -4907,7 +4915,7 @@ void Assembler::evpmovwb(Address dst, KRegister mask, XMMRegister src, int vecto
   attributes.set_is_evex_instruction();
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x30);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::evpmovdb(Address dst, XMMRegister src, int vector_len) {
@@ -4919,7 +4927,7 @@ void Assembler::evpmovdb(Address dst, XMMRegister src, int vector_len) {
   attributes.set_is_evex_instruction();
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x31);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::vpmovzxwd(XMMRegister dst, XMMRegister src, int vector_len) {
@@ -4986,7 +4994,7 @@ void Assembler::popcntl(Register dst, Address src) {
   emit_int8((unsigned char)0xF3);
   prefix(src, dst);
   emit_int16(0x0F, (unsigned char)0xB8);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::popcntl(Register dst, Register src) {
@@ -5058,7 +5066,7 @@ void Assembler::popl(Address dst) {
   InstructionMark im(this);
   prefix(dst);
   emit_int8((unsigned char)0x8F);
-  emit_operand(rax, dst);
+  emit_operand(rax, dst, 0);
 }
 #endif
 
@@ -5067,7 +5075,7 @@ void Assembler::prefetchnta(Address src) {
   InstructionMark im(this);
   prefix(src);
   emit_int16(0x0F, 0x18);
-  emit_operand(rax, src); // 0, src
+  emit_operand(rax, src, 0); // 0, src
 }
 
 void Assembler::prefetchr(Address src) {
@@ -5075,7 +5083,7 @@ void Assembler::prefetchr(Address src) {
   InstructionMark im(this);
   prefix(src);
   emit_int16(0x0F, 0x0D);
-  emit_operand(rax, src); // 0, src
+  emit_operand(rax, src, 0); // 0, src
 }
 
 void Assembler::prefetcht0(Address src) {
@@ -5083,7 +5091,7 @@ void Assembler::prefetcht0(Address src) {
   InstructionMark im(this);
   prefix(src);
   emit_int16(0x0F, 0x18);
-  emit_operand(rcx, src); // 1, src
+  emit_operand(rcx, src, 0); // 1, src
 }
 
 void Assembler::prefetcht1(Address src) {
@@ -5091,7 +5099,7 @@ void Assembler::prefetcht1(Address src) {
   InstructionMark im(this);
   prefix(src);
   emit_int16(0x0F, 0x18);
-  emit_operand(rdx, src); // 2, src
+  emit_operand(rdx, src, 0); // 2, src
 }
 
 void Assembler::prefetcht2(Address src) {
@@ -5099,7 +5107,7 @@ void Assembler::prefetcht2(Address src) {
   InstructionMark im(this);
   prefix(src);
   emit_int16(0x0F, 0x18);
-  emit_operand(rbx, src); // 3, src
+  emit_operand(rbx, src, 0); // 3, src
 }
 
 void Assembler::prefetchw(Address src) {
@@ -5107,7 +5115,7 @@ void Assembler::prefetchw(Address src) {
   InstructionMark im(this);
   prefix(src);
   emit_int16(0x0F, 0x0D);
-  emit_operand(rcx, src); // 1, src
+  emit_operand(rcx, src, 0); // 1, src
 }
 
 void Assembler::prefix(Prefix p) {
@@ -5149,7 +5157,7 @@ void Assembler::pshufb(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_FVM, /* input_size_in_bits */ EVEX_NObit);
   simd_prefix(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x00);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::pshufd(XMMRegister dst, XMMRegister src, int mode) {
@@ -5180,7 +5188,7 @@ void Assembler::pshufd(XMMRegister dst, Address src, int mode) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(dst, xnoreg, src, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x70);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 1);
   emit_int8(mode & 0xFF);
 }
 
@@ -5209,7 +5217,7 @@ void Assembler::pshuflw(XMMRegister dst, Address src, int mode) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_FVM, /* input_size_in_bits */ EVEX_NObit);
   simd_prefix(dst, xnoreg, src, VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x70);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 1);
   emit_int8(mode & 0xFF);
 }
 
@@ -5293,7 +5301,7 @@ void Assembler::ptest(XMMRegister dst, Address src) {
   InstructionAttr attributes(AVX_128bit, /* rex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   simd_prefix(dst, xnoreg, src, VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x17);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::ptest(XMMRegister dst, XMMRegister src) {
@@ -5312,7 +5320,7 @@ void Assembler::vptest(XMMRegister dst, Address src) {
   // swap src<->dst for encoding
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x17);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vptest(XMMRegister dst, XMMRegister src) {
@@ -5346,7 +5354,7 @@ void Assembler::punpcklbw(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_FVM, /* input_size_in_bits */ EVEX_NObit);
   simd_prefix(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x60);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::punpcklbw(XMMRegister dst, XMMRegister src) {
@@ -5364,7 +5372,7 @@ void Assembler::punpckldq(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x62);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::punpckldq(XMMRegister dst, XMMRegister src) {
@@ -5404,7 +5412,7 @@ void Assembler::pushl(Address src) {
   InstructionMark im(this);
   prefix(src);
   emit_int8((unsigned char)0xFF);
-  emit_operand(rsi, src);
+  emit_operand(rsi, src, 0);
 }
 #endif
 
@@ -5564,11 +5572,11 @@ void Assembler::sall(Address dst, int imm8) {
   prefix(dst);
   if (imm8 == 1) {
     emit_int8((unsigned char)0xD1);
-    emit_operand(as_Register(4), dst);
+    emit_operand(as_Register(4), dst, 0);
   }
   else {
     emit_int8((unsigned char)0xC1);
-    emit_operand(as_Register(4), dst);
+    emit_operand(as_Register(4), dst, 1);
     emit_int8(imm8);
   }
 }
@@ -5577,7 +5585,7 @@ void Assembler::sall(Address dst) {
   InstructionMark im(this);
   prefix(dst);
   emit_int8((unsigned char)0xD3);
-  emit_operand(as_Register(4), dst);
+  emit_operand(as_Register(4), dst, 0);
 }
 
 void Assembler::sall(Register dst, int imm8) {
@@ -5601,11 +5609,11 @@ void Assembler::sarl(Address dst, int imm8) {
   prefix(dst);
   if (imm8 == 1) {
     emit_int8((unsigned char)0xD1);
-    emit_operand(as_Register(7), dst);
+    emit_operand(as_Register(7), dst, 0);
   }
   else {
     emit_int8((unsigned char)0xC1);
-    emit_operand(as_Register(7), dst);
+    emit_operand(as_Register(7), dst, 1);
     emit_int8(imm8);
   }
 }
@@ -5614,7 +5622,7 @@ void Assembler::sarl(Address dst) {
   InstructionMark im(this);
   prefix(dst);
   emit_int8((unsigned char)0xD3);
-  emit_operand(as_Register(7), dst);
+  emit_operand(as_Register(7), dst, 0);
 }
 
 void Assembler::sarl(Register dst, int imm8) {
@@ -5648,7 +5656,7 @@ void Assembler::sbbl(Register dst, Address src) {
   InstructionMark im(this);
   prefix(src, dst);
   emit_int8(0x1B);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::sbbl(Register dst, Register src) {
@@ -5787,7 +5795,7 @@ void Assembler::shrl(Address dst) {
   InstructionMark im(this);
   prefix(dst);
   emit_int8((unsigned char)0xD3);
-  emit_operand(as_Register(5), dst);
+  emit_operand(as_Register(5), dst, 0);
 }
 
 void Assembler::shrl(Address dst, int imm8) {
@@ -5796,11 +5804,11 @@ void Assembler::shrl(Address dst, int imm8) {
   prefix(dst);
   if (imm8 == 1) {
     emit_int8((unsigned char)0xD1);
-    emit_operand(as_Register(5), dst);
+    emit_operand(as_Register(5), dst, 0);
   }
   else {
     emit_int8((unsigned char)0xC1);
-    emit_operand(as_Register(5), dst);
+    emit_operand(as_Register(5), dst, 1);
     emit_int8(imm8);
   }
 }
@@ -5844,7 +5852,7 @@ void Assembler::roundsd(XMMRegister dst, Address src, int32_t rmode) {
   InstructionAttr attributes(AVX_128bit, /* rex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   simd_prefix(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x0B);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 1);
   emit_int8((unsigned char)rmode);
 }
 
@@ -5864,7 +5872,7 @@ void Assembler::sqrtsd(XMMRegister dst, Address src) {
   attributes.set_rex_vex_w_reverted();
   simd_prefix(dst, dst, src, VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x51);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::sqrtss(XMMRegister dst, XMMRegister src) {
@@ -5885,7 +5893,7 @@ void Assembler::sqrtss(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(dst, dst, src, VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x51);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::stmxcsr( Address dst) {
@@ -5895,13 +5903,13 @@ void Assembler::stmxcsr( Address dst) {
     InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
     vex_prefix(dst, 0, 0, VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
     emit_int8((unsigned char)0xAE);
-    emit_operand(as_Register(3), dst);
+    emit_operand(as_Register(3), dst, 0);
   } else {
     NOT_LP64(assert(VM_Version::supports_sse(), ""));
     InstructionMark im(this);
     prefix(dst);
     emit_int16(0x0F, (unsigned char)0xAE);
-    emit_operand(as_Register(3), dst);
+    emit_operand(as_Register(3), dst, 0);
   }
 }
 
@@ -5915,7 +5923,7 @@ void Assembler::subl(Address dst, Register src) {
   InstructionMark im(this);
   prefix(dst, src);
   emit_int8(0x29);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::subl(Register dst, int32_t imm32) {
@@ -5933,7 +5941,7 @@ void Assembler::subl(Register dst, Address src) {
   InstructionMark im(this);
   prefix(src, dst);
   emit_int8(0x2B);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::subl(Register dst, Register src) {
@@ -5957,7 +5965,7 @@ void Assembler::subsd(XMMRegister dst, Address src) {
   attributes.set_rex_vex_w_reverted();
   simd_prefix(dst, dst, src, VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x5C);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::subss(XMMRegister dst, XMMRegister src) {
@@ -5974,7 +5982,7 @@ void Assembler::subss(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(dst, dst, src, VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x5C);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::testb(Register dst, int imm8) {
@@ -5997,21 +6005,14 @@ void Assembler::testb(Address dst, int imm8) {
 }
 
 void Assembler::testl(Address dst, int32_t imm32) {
-  if (imm32 >= 0 && is8bit(imm32)) {
-    testb(dst, imm32);
-    return;
-  }
   InstructionMark im(this);
+  prefix(dst);
   emit_int8((unsigned char)0xF7);
-  emit_operand(as_Register(0), dst);
+  emit_operand(as_Register(0), dst, 4);
   emit_int32(imm32);
 }
 
 void Assembler::testl(Register dst, int32_t imm32) {
-  if (imm32 >= 0 && is8bit(imm32) && dst->has_byte_register()) {
-    testb(dst, imm32);
-    return;
-  }
   // not using emit_arith because test
   // doesn't support sign-extension of
   // 8bit operands
@@ -6035,7 +6036,7 @@ void Assembler::testl(Register dst, Address src) {
   InstructionMark im(this);
   prefix(src, dst);
   emit_int8((unsigned char)0x85);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::tzcntl(Register dst, Register src) {
@@ -6053,7 +6054,7 @@ void Assembler::tzcntl(Register dst, Address src) {
   emit_int8((unsigned char)0xF3);
   prefix(src, dst);
   emit_int16(0x0F, (unsigned char)0xBC);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::tzcntq(Register dst, Register src) {
@@ -6069,7 +6070,7 @@ void Assembler::tzcntq(Register dst, Address src) {
   emit_int8((unsigned char)0xF3);
   prefixq(src, dst);
   emit_int16(0x0F, (unsigned char)0xBC);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::ucomisd(XMMRegister dst, Address src) {
@@ -6080,7 +6081,7 @@ void Assembler::ucomisd(XMMRegister dst, Address src) {
   attributes.set_rex_vex_w_reverted();
   simd_prefix(dst, xnoreg, src, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x2E);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::ucomisd(XMMRegister dst, XMMRegister src) {
@@ -6098,7 +6099,7 @@ void Assembler::ucomiss(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(dst, xnoreg, src, VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8(0x2E);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::ucomiss(XMMRegister dst, XMMRegister src) {
@@ -6116,7 +6117,7 @@ void Assembler::xaddb(Address dst, Register src) {
   InstructionMark im(this);
   prefix(dst, src, true);
   emit_int16(0x0F, (unsigned char)0xC0);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::xaddw(Address dst, Register src) {
@@ -6124,14 +6125,14 @@ void Assembler::xaddw(Address dst, Register src) {
   emit_int8(0x66);
   prefix(dst, src);
   emit_int16(0x0F, (unsigned char)0xC1);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::xaddl(Address dst, Register src) {
   InstructionMark im(this);
   prefix(dst, src);
   emit_int16(0x0F, (unsigned char)0xC1);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::xbegin(Label& abort, relocInfo::relocType rtype) {
@@ -6154,7 +6155,7 @@ void Assembler::xchgb(Register dst, Address src) { // xchg
   InstructionMark im(this);
   prefix(src, dst, true);
   emit_int8((unsigned char)0x86);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::xchgw(Register dst, Address src) { // xchg
@@ -6162,14 +6163,14 @@ void Assembler::xchgw(Register dst, Address src) { // xchg
   emit_int8(0x66);
   prefix(src, dst);
   emit_int8((unsigned char)0x87);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::xchgl(Register dst, Address src) { // xchg
   InstructionMark im(this);
   prefix(src, dst);
   emit_int8((unsigned char)0x87);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::xchgl(Register dst, Register src) {
@@ -6200,7 +6201,7 @@ void Assembler::xorl(Register dst, Address src) {
   InstructionMark im(this);
   prefix(src, dst);
   emit_int8(0x33);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::xorl(Register dst, Register src) {
@@ -6212,21 +6213,21 @@ void Assembler::xorl(Address dst, Register src) {
   InstructionMark im(this);
   prefix(dst, src);
   emit_int8(0x31);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::xorb(Register dst, Address src) {
   InstructionMark im(this);
   prefix(src, dst);
   emit_int8(0x32);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::xorb(Address dst, Register src) {
   InstructionMark im(this);
   prefix(dst, src, true);
   emit_int8(0x30);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::xorw(Register dst, Register src) {
@@ -6244,7 +6245,7 @@ void Assembler::vaddsd(XMMRegister dst, XMMRegister nds, Address src) {
   attributes.set_rex_vex_w_reverted();
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x58);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vaddsd(XMMRegister dst, XMMRegister nds, XMMRegister src) {
@@ -6262,7 +6263,7 @@ void Assembler::vaddss(XMMRegister dst, XMMRegister nds, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_32bit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x58);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vaddss(XMMRegister dst, XMMRegister nds, XMMRegister src) {
@@ -6280,7 +6281,7 @@ void Assembler::vdivsd(XMMRegister dst, XMMRegister nds, Address src) {
   attributes.set_rex_vex_w_reverted();
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x5E);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vdivsd(XMMRegister dst, XMMRegister nds, XMMRegister src) {
@@ -6298,7 +6299,7 @@ void Assembler::vdivss(XMMRegister dst, XMMRegister nds, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_32bit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x5E);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vdivss(XMMRegister dst, XMMRegister nds, XMMRegister src) {
@@ -6330,7 +6331,7 @@ void Assembler::vmulsd(XMMRegister dst, XMMRegister nds, Address src) {
   attributes.set_rex_vex_w_reverted();
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x59);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vmulsd(XMMRegister dst, XMMRegister nds, XMMRegister src) {
@@ -6348,7 +6349,7 @@ void Assembler::vmulss(XMMRegister dst, XMMRegister nds, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_32bit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x59);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vmulss(XMMRegister dst, XMMRegister nds, XMMRegister src) {
@@ -6366,7 +6367,7 @@ void Assembler::vsubsd(XMMRegister dst, XMMRegister nds, Address src) {
   attributes.set_rex_vex_w_reverted();
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x5C);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vsubsd(XMMRegister dst, XMMRegister nds, XMMRegister src) {
@@ -6384,7 +6385,7 @@ void Assembler::vsubss(XMMRegister dst, XMMRegister nds, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_32bit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x5C);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vsubss(XMMRegister dst, XMMRegister nds, XMMRegister src) {
@@ -6414,7 +6415,7 @@ void Assembler::addpd(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_64bit);
   simd_prefix(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x58);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 
@@ -6448,7 +6449,7 @@ void Assembler::vaddpd(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_rex_vex_w_reverted();
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x58);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vaddps(XMMRegister dst, XMMRegister nds, Address src, int vector_len) {
@@ -6458,7 +6459,7 @@ void Assembler::vaddps(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_32bit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8(0x58);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::subpd(XMMRegister dst, XMMRegister src) {
@@ -6499,7 +6500,7 @@ void Assembler::vsubpd(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_rex_vex_w_reverted();
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x5C);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vsubps(XMMRegister dst, XMMRegister nds, Address src, int vector_len) {
@@ -6509,7 +6510,7 @@ void Assembler::vsubps(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_32bit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8(0x5C);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::mulpd(XMMRegister dst, XMMRegister src) {
@@ -6528,7 +6529,7 @@ void Assembler::mulpd(XMMRegister dst, Address src) {
   attributes.set_rex_vex_w_reverted();
   simd_prefix(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x59);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::mulps(XMMRegister dst, XMMRegister src) {
@@ -6561,7 +6562,7 @@ void Assembler::vmulpd(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_rex_vex_w_reverted();
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x59);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vmulps(XMMRegister dst, XMMRegister nds, Address src, int vector_len) {
@@ -6571,7 +6572,7 @@ void Assembler::vmulps(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_32bit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8(0x59);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vfmadd231pd(XMMRegister dst, XMMRegister src1, XMMRegister src2, int vector_len) {
@@ -6595,7 +6596,7 @@ void Assembler::vfmadd231pd(XMMRegister dst, XMMRegister src1, Address src2, int
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_64bit);
   vex_prefix(src2, src1->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xB8);
-  emit_operand(dst, src2);
+  emit_operand(dst, src2, 0);
 }
 
 void Assembler::vfmadd231ps(XMMRegister dst, XMMRegister src1, Address src2, int vector_len) {
@@ -6605,7 +6606,7 @@ void Assembler::vfmadd231ps(XMMRegister dst, XMMRegister src1, Address src2, int
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_32bit);
   vex_prefix(src2, src1->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xB8);
-  emit_operand(dst, src2);
+  emit_operand(dst, src2, 0);
 }
 
 void Assembler::divpd(XMMRegister dst, XMMRegister src) {
@@ -6646,7 +6647,7 @@ void Assembler::vdivpd(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_rex_vex_w_reverted();
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x5E);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vdivps(XMMRegister dst, XMMRegister nds, Address src, int vector_len) {
@@ -6656,7 +6657,7 @@ void Assembler::vdivps(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_32bit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8(0x5E);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vroundpd(XMMRegister dst, XMMRegister src, int32_t rmode, int vector_len) {
@@ -6672,7 +6673,7 @@ void Assembler::vroundpd(XMMRegister dst, Address src, int32_t rmode,  int vecto
   InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x09);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 1);
   emit_int8((rmode));
 }
 
@@ -6693,7 +6694,7 @@ void Assembler::vrndscalepd(XMMRegister dst, Address src, int32_t rmode, int vec
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_64bit);
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x09);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 1);
   emit_int8((rmode));
 }
 
@@ -6713,7 +6714,7 @@ void Assembler::vsqrtpd(XMMRegister dst, Address src, int vector_len) {
   attributes.set_rex_vex_w_reverted();
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x51);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vsqrtps(XMMRegister dst, XMMRegister src, int vector_len) {
@@ -6730,7 +6731,7 @@ void Assembler::vsqrtps(XMMRegister dst, Address src, int vector_len) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_64bit);
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8(0x51);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::andpd(XMMRegister dst, XMMRegister src) {
@@ -6755,7 +6756,7 @@ void Assembler::andps(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(dst, dst, src, VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8(0x54);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::andpd(XMMRegister dst, Address src) {
@@ -6766,7 +6767,7 @@ void Assembler::andpd(XMMRegister dst, Address src) {
   attributes.set_rex_vex_w_reverted();
   simd_prefix(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x54);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vandpd(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
@@ -6792,7 +6793,7 @@ void Assembler::vandpd(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_rex_vex_w_reverted();
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x54);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vandps(XMMRegister dst, XMMRegister nds, Address src, int vector_len) {
@@ -6802,7 +6803,7 @@ void Assembler::vandps(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_32bit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8(0x54);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::unpckhpd(XMMRegister dst, XMMRegister src) {
@@ -6845,7 +6846,7 @@ void Assembler::xorpd(XMMRegister dst, Address src) {
   attributes.set_rex_vex_w_reverted();
   simd_prefix(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x57);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::xorps(XMMRegister dst, Address src) {
@@ -6855,7 +6856,7 @@ void Assembler::xorps(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_32bit);
   simd_prefix(dst, dst, src, VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8(0x57);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vxorpd(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
@@ -6881,7 +6882,7 @@ void Assembler::vxorpd(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_rex_vex_w_reverted();
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x57);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vxorps(XMMRegister dst, XMMRegister nds, Address src, int vector_len) {
@@ -6891,7 +6892,7 @@ void Assembler::vxorps(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_32bit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8(0x57);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 // Integer vector arithmetic
@@ -6938,7 +6939,7 @@ void Assembler::paddd(XMMRegister dst, Address src) {
   InstructionAttr attributes(AVX_128bit, /* rex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
   simd_prefix(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xFE);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::paddq(XMMRegister dst, XMMRegister src) {
@@ -6999,7 +7000,7 @@ void Assembler::vpaddb(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_address_attributes(/* tuple_type */ EVEX_FVM, /* input_size_in_bits */ EVEX_NObit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xFC);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vpaddw(XMMRegister dst, XMMRegister nds, Address src, int vector_len) {
@@ -7009,7 +7010,7 @@ void Assembler::vpaddw(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_address_attributes(/* tuple_type */ EVEX_FVM, /* input_size_in_bits */ EVEX_NObit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xFD);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vpaddd(XMMRegister dst, XMMRegister nds, Address src, int vector_len) {
@@ -7019,7 +7020,7 @@ void Assembler::vpaddd(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_32bit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xFE);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vpaddq(XMMRegister dst, XMMRegister nds, Address src, int vector_len) {
@@ -7030,7 +7031,7 @@ void Assembler::vpaddq(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_rex_vex_w_reverted();
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xD4);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::psubb(XMMRegister dst, XMMRegister src) {
@@ -7105,7 +7106,7 @@ void Assembler::vpsubb(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_address_attributes(/* tuple_type */ EVEX_FVM, /* input_size_in_bits */ EVEX_NObit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xF8);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vpsubw(XMMRegister dst, XMMRegister nds, Address src, int vector_len) {
@@ -7115,7 +7116,7 @@ void Assembler::vpsubw(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_address_attributes(/* tuple_type */ EVEX_FVM, /* input_size_in_bits */ EVEX_NObit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xF9);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vpsubd(XMMRegister dst, XMMRegister nds, Address src, int vector_len) {
@@ -7125,7 +7126,7 @@ void Assembler::vpsubd(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_32bit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xFA);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vpsubq(XMMRegister dst, XMMRegister nds, Address src, int vector_len) {
@@ -7136,7 +7137,7 @@ void Assembler::vpsubq(XMMRegister dst, XMMRegister nds, Address src, int vector
   attributes.set_rex_vex_w_reverted();
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xFB);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::pmullw(XMMRegister dst, XMMRegister src) {
@@ -7205,7 +7206,7 @@ void Assembler::vpmullw(XMMRegister dst, XMMRegister nds, Address src, int vecto
   attributes.set_address_attributes(/* tuple_type */ EVEX_FVM, /* input_size_in_bits */ EVEX_NObit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xD5);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vpmulld(XMMRegister dst, XMMRegister nds, Address src, int vector_len) {
@@ -7215,7 +7216,7 @@ void Assembler::vpmulld(XMMRegister dst, XMMRegister nds, Address src, int vecto
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_32bit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x40);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vpmullq(XMMRegister dst, XMMRegister nds, Address src, int vector_len) {
@@ -7226,7 +7227,7 @@ void Assembler::vpmullq(XMMRegister dst, XMMRegister nds, Address src, int vecto
   attributes.set_is_evex_instruction();
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x40);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 // Min, max
@@ -7701,7 +7702,7 @@ void Assembler::vpand(XMMRegister dst, XMMRegister nds, Address src, int vector_
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_32bit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xDB);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vpandq(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
@@ -7818,7 +7819,7 @@ void Assembler::vpor(XMMRegister dst, XMMRegister nds, Address src, int vector_l
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_32bit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xEB);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vporq(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
@@ -7855,7 +7856,7 @@ void Assembler::evpord(XMMRegister dst, KRegister mask, XMMRegister nds, Address
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xEB);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::pxor(XMMRegister dst, XMMRegister src) {
@@ -7885,7 +7886,7 @@ void Assembler::vpxor(XMMRegister dst, XMMRegister nds, Address src, int vector_
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_32bit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xEF);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vpxorq(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
@@ -7921,7 +7922,7 @@ void Assembler::evpxord(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xEF);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpxorq(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -7949,7 +7950,7 @@ void Assembler::evpxorq(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xEF);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpandd(XMMRegister dst, KRegister mask, XMMRegister nds, Address src, bool merge, int vector_len) {
@@ -7964,7 +7965,7 @@ void Assembler::evpandd(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xDB);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpandq(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -7991,7 +7992,7 @@ void Assembler::evpandq(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xDB);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evporq(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -8018,7 +8019,7 @@ void Assembler::evporq(XMMRegister dst, KRegister mask, XMMRegister nds, Address
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xEB);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpxorq(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
@@ -8038,7 +8039,7 @@ void Assembler::evpxorq(XMMRegister dst, XMMRegister nds, Address src, int vecto
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_64bit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xEF);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evprold(XMMRegister dst, XMMRegister src, int shift, int vector_len) {
@@ -8160,7 +8161,7 @@ void Assembler::vpternlogd(XMMRegister dst, int imm8, XMMRegister src2, Address 
   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_64bit);
   vex_prefix(src3, src2->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x25);
-  emit_operand(dst, src3);
+  emit_operand(dst, src3, 1);
   emit_int8(imm8);
 }
 
@@ -8275,7 +8276,7 @@ void Assembler::vinserti128(XMMRegister dst, XMMRegister nds, Address src, uint8
   attributes.set_address_attributes(/* tuple_type */ EVEX_T4, /* input_size_in_bits */ EVEX_32bit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x38);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 1);
   // 0x00 - insert into lower 128 bits
   // 0x01 - insert into upper 128 bits
   emit_int8(imm8 & 0x01);
@@ -8305,7 +8306,7 @@ void Assembler::vinserti32x4(XMMRegister dst, XMMRegister nds, Address src, uint
   attributes.set_is_evex_instruction();
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x18);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 1);
   // 0x00 - insert into q0 128 bits (0..127)
   // 0x01 - insert into q1 128 bits (128..255)
   // 0x02 - insert into q2 128 bits (256..383)
@@ -8348,7 +8349,7 @@ void Assembler::vinsertf128(XMMRegister dst, XMMRegister nds, Address src, uint8
   attributes.set_address_attributes(/* tuple_type */ EVEX_T4, /* input_size_in_bits */ EVEX_32bit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x18);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 1);
   // 0x00 - insert into lower 128 bits
   // 0x01 - insert into upper 128 bits
   emit_int8(imm8 & 0x01);
@@ -8376,7 +8377,7 @@ void Assembler::vinsertf32x4(XMMRegister dst, XMMRegister nds, Address src, uint
   attributes.set_address_attributes(/* tuple_type */ EVEX_T4, /* input_size_in_bits */ EVEX_32bit);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x18);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 1);
   // 0x00 - insert into q0 128 bits (0..127)
   // 0x01 - insert into q1 128 bits (128..255)
   // 0x02 - insert into q0 128 bits (256..383)
@@ -8406,7 +8407,7 @@ void Assembler::vinsertf64x4(XMMRegister dst, XMMRegister nds, Address src, uint
   attributes.set_is_evex_instruction();
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x1A);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 1);
   // 0x00 - insert into lower 256 bits
   // 0x01 - insert into upper 256 bits
   emit_int8(imm8 & 0x01);
@@ -8436,7 +8437,7 @@ void Assembler::vextracti128(Address dst, XMMRegister src, uint8_t imm8) {
   attributes.reset_is_clear_context();
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x39);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 1);
   // 0x00 - extract from lower 128 bits
   // 0x01 - extract from upper 128 bits
   emit_int8(imm8 & 0x01);
@@ -8467,7 +8468,7 @@ void Assembler::vextracti32x4(Address dst, XMMRegister src, uint8_t imm8) {
   attributes.set_is_evex_instruction();
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x39);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 1);
   // 0x00 - extract from bits 127:0
   // 0x01 - extract from bits 255:128
   // 0x02 - extract from bits 383:256
@@ -8512,7 +8513,7 @@ void Assembler::vextracti64x4(Address dst, XMMRegister src, uint8_t imm8) {
   attributes.set_is_evex_instruction();
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x38);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 1);
   // 0x00 - extract from lower 256 bits
   // 0x01 - extract from upper 256 bits
   emit_int8(imm8 & 0x01);
@@ -8540,7 +8541,7 @@ void Assembler::vextractf128(Address dst, XMMRegister src, uint8_t imm8) {
   attributes.reset_is_clear_context();
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x19);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 1);
   // 0x00 - extract from lower 128 bits
   // 0x01 - extract from upper 128 bits
   emit_int8(imm8 & 0x01);
@@ -8571,7 +8572,7 @@ void Assembler::vextractf32x4(Address dst, XMMRegister src, uint8_t imm8) {
   attributes.set_is_evex_instruction();
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x19);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 1);
   // 0x00 - extract from bits 127:0
   // 0x01 - extract from bits 255:128
   // 0x02 - extract from bits 383:256
@@ -8616,7 +8617,7 @@ void Assembler::vextractf64x4(Address dst, XMMRegister src, uint8_t imm8) {
   attributes.set_is_evex_instruction();
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x1B);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 1);
   // 0x00 - extract from lower 256 bits
   // 0x01 - extract from upper 256 bits
   emit_int8(imm8 & 0x01);
@@ -8639,7 +8640,7 @@ void Assembler::vpbroadcastb(XMMRegister dst, Address src, int vector_len) {
   // swap src<->dst for encoding
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x78);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 // duplicate 2-byte integer data from src into programmed locations in dest : requires AVX512BW and AVX512VL
@@ -8659,7 +8660,7 @@ void Assembler::vpbroadcastw(XMMRegister dst, Address src, int vector_len) {
   // swap src<->dst for encoding
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x79);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vpsadbw(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
@@ -8722,7 +8723,7 @@ void Assembler::evpaddb(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xFC);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpaddw(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -8749,7 +8750,7 @@ void Assembler::evpaddw(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xFD);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpaddd(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -8778,7 +8779,7 @@ void Assembler::evpaddd(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xFE);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpaddq(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -8807,7 +8808,7 @@ void Assembler::evpaddq(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xD4);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evaddps(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -8836,7 +8837,7 @@ void Assembler::evaddps(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8(0x58);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evaddpd(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -8865,7 +8866,7 @@ void Assembler::evaddpd(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x58);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpsubb(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -8892,7 +8893,7 @@ void Assembler::evpsubb(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xF8);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpsubw(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -8919,7 +8920,7 @@ void Assembler::evpsubw(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xF9);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpsubd(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -8948,7 +8949,7 @@ void Assembler::evpsubd(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xFA);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpsubq(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -8977,7 +8978,7 @@ void Assembler::evpsubq(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xFB);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evsubps(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -9006,7 +9007,7 @@ void Assembler::evsubps(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8(0x5C);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evsubpd(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -9035,7 +9036,7 @@ void Assembler::evsubpd(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x5C);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpmullw(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -9062,7 +9063,7 @@ void Assembler::evpmullw(XMMRegister dst, KRegister mask, XMMRegister nds, Addre
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xD5);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpmulld(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -9091,7 +9092,7 @@ void Assembler::evpmulld(XMMRegister dst, KRegister mask, XMMRegister nds, Addre
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x40);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpmullq(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -9118,7 +9119,7 @@ void Assembler::evpmullq(XMMRegister dst, KRegister mask, XMMRegister nds, Addre
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x40);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evmulps(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -9147,7 +9148,7 @@ void Assembler::evmulps(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8(0x59);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evmulpd(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -9176,7 +9177,7 @@ void Assembler::evmulpd(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x59);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evsqrtps(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -9205,7 +9206,7 @@ void Assembler::evsqrtps(XMMRegister dst, KRegister mask, XMMRegister nds, Addre
   }
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8(0x51);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evsqrtpd(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -9234,7 +9235,7 @@ void Assembler::evsqrtpd(XMMRegister dst, KRegister mask, XMMRegister nds, Addre
   }
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x51);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 
@@ -9264,7 +9265,7 @@ void Assembler::evdivps(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int8(0x5E);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evdivpd(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -9293,7 +9294,7 @@ void Assembler::evdivpd(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8(0x5E);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpabsb(XMMRegister dst, KRegister mask, XMMRegister src, bool merge, int vector_len) {
@@ -9322,7 +9323,7 @@ void Assembler::evpabsb(XMMRegister dst, KRegister mask, Address src, bool merge
   }
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x1C);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpabsw(XMMRegister dst, KRegister mask, XMMRegister src, bool merge, int vector_len) {
@@ -9351,7 +9352,7 @@ void Assembler::evpabsw(XMMRegister dst, KRegister mask, Address src, bool merge
   }
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x1D);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpabsd(XMMRegister dst, KRegister mask, XMMRegister src, bool merge, int vector_len) {
@@ -9382,7 +9383,7 @@ void Assembler::evpabsd(XMMRegister dst, KRegister mask, Address src, bool merge
   }
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x1E);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpabsq(XMMRegister dst, KRegister mask, XMMRegister src, bool merge, int vector_len) {
@@ -9413,7 +9414,7 @@ void Assembler::evpabsq(XMMRegister dst, KRegister mask, Address src, bool merge
   }
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x1F);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpfma213ps(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -9442,7 +9443,7 @@ void Assembler::evpfma213ps(XMMRegister dst, KRegister mask, XMMRegister nds, Ad
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xA8);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpfma213pd(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -9471,7 +9472,7 @@ void Assembler::evpfma213pd(XMMRegister dst, KRegister mask, XMMRegister nds, Ad
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xA8);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpermb(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -9497,7 +9498,7 @@ void Assembler::evpermb(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0x8D);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpermw(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -9523,7 +9524,7 @@ void Assembler::evpermw(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0x8D);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpermd(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -9549,7 +9550,7 @@ void Assembler::evpermd(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x36);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpermq(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -9575,7 +9576,7 @@ void Assembler::evpermq(XMMRegister dst, KRegister mask, XMMRegister nds, Addres
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x36);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpsllw(XMMRegister dst, KRegister mask, XMMRegister src, int shift, bool merge, int vector_len) {
@@ -9943,7 +9944,7 @@ void Assembler::evpminsb(XMMRegister dst, KRegister mask, XMMRegister nds, Addre
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x38);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpminsw(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -9969,7 +9970,7 @@ void Assembler::evpminsw(XMMRegister dst, KRegister mask, XMMRegister nds, Addre
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xEA);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpminsd(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -9997,7 +9998,7 @@ void Assembler::evpminsd(XMMRegister dst, KRegister mask, XMMRegister nds, Addre
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x39);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpminsq(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -10025,7 +10026,7 @@ void Assembler::evpminsq(XMMRegister dst, KRegister mask, XMMRegister nds, Addre
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x39);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 
@@ -10052,7 +10053,7 @@ void Assembler::evpmaxsb(XMMRegister dst, KRegister mask, XMMRegister nds, Addre
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x3C);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpmaxsw(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -10078,7 +10079,7 @@ void Assembler::evpmaxsw(XMMRegister dst, KRegister mask, XMMRegister nds, Addre
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int8((unsigned char)0xEE);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpmaxsd(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -10106,7 +10107,7 @@ void Assembler::evpmaxsd(XMMRegister dst, KRegister mask, XMMRegister nds, Addre
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x3D);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpmaxsq(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
@@ -10134,7 +10135,7 @@ void Assembler::evpmaxsq(XMMRegister dst, KRegister mask, XMMRegister nds, Addre
   }
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x3D);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpternlogd(XMMRegister dst, int imm8, KRegister mask, XMMRegister src2, XMMRegister src3, bool merge, int vector_len) {
@@ -10164,7 +10165,7 @@ void Assembler::evpternlogd(XMMRegister dst, int imm8, KRegister mask, XMMRegist
   }
   vex_prefix(src3, src2->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x25);
-  emit_operand(dst, src3);
+  emit_operand(dst, src3, 1);
   emit_int8(imm8);
 }
 
@@ -10195,7 +10196,7 @@ void Assembler::evpternlogq(XMMRegister dst, int imm8, KRegister mask, XMMRegist
   }
   vex_prefix(src3, src2->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int8(0x25);
-  emit_operand(dst, src3);
+  emit_operand(dst, src3, 1);
   emit_int8(imm8);
 }
 
@@ -10232,7 +10233,7 @@ void Assembler::vpbroadcastd(XMMRegister dst, Address src, int vector_len) {
   // swap src<->dst for encoding
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x58);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 // duplicate 8-byte integer data from src into programmed locations in dest : requires AVX512VL
@@ -10254,7 +10255,7 @@ void Assembler::vpbroadcastq(XMMRegister dst, Address src, int vector_len) {
   // swap src<->dst for encoding
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x59);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evbroadcasti32x4(XMMRegister dst, Address src, int vector_len) {
@@ -10268,7 +10269,7 @@ void Assembler::evbroadcasti32x4(XMMRegister dst, Address src, int vector_len) {
   // swap src<->dst for encoding
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x5A);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evbroadcasti64x2(XMMRegister dst, XMMRegister src, int vector_len) {
@@ -10291,7 +10292,7 @@ void Assembler::evbroadcasti64x2(XMMRegister dst, Address src, int vector_len) {
   // swap src<->dst for encoding
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x5A);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 // scalar single/double precision replicate
@@ -10313,7 +10314,7 @@ void Assembler::vbroadcastss(XMMRegister dst, Address src, int vector_len) {
   // swap src<->dst for encoding
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x18);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 // duplicate double precision data from src into programmed locations in dest : requires AVX512VL
@@ -10337,7 +10338,7 @@ void Assembler::vbroadcastsd(XMMRegister dst, Address src, int vector_len) {
   // swap src<->dst for encoding
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x19);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vbroadcastf128(XMMRegister dst, Address src, int vector_len) {
@@ -10350,7 +10351,7 @@ void Assembler::vbroadcastf128(XMMRegister dst, Address src, int vector_len) {
   // swap src<->dst for encoding
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x1A);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 // gpr source broadcast forms
@@ -10401,7 +10402,7 @@ void Assembler::vpgatherdd(XMMRegister dst, Address src, XMMRegister mask, int v
   InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ true);
   vex_prefix(src, mask->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0x90);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vpgatherdq(XMMRegister dst, Address src, XMMRegister mask, int vector_len) {
@@ -10414,7 +10415,7 @@ void Assembler::vpgatherdq(XMMRegister dst, Address src, XMMRegister mask, int v
   InstructionAttr attributes(vector_len, /* vex_w */ true, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ true);
   vex_prefix(src, mask->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0x90);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vgatherdpd(XMMRegister dst, Address src, XMMRegister mask, int vector_len) {
@@ -10427,7 +10428,7 @@ void Assembler::vgatherdpd(XMMRegister dst, Address src, XMMRegister mask, int v
   InstructionAttr attributes(vector_len, /* vex_w */ true, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ true);
   vex_prefix(src, mask->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0x92);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::vgatherdps(XMMRegister dst, Address src, XMMRegister mask, int vector_len) {
@@ -10440,7 +10441,7 @@ void Assembler::vgatherdps(XMMRegister dst, Address src, XMMRegister mask, int v
   InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ false, /* uses_vl */ true);
   vex_prefix(src, mask->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0x92);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 void Assembler::evpgatherdd(XMMRegister dst, KRegister mask, Address src, int vector_len) {
   assert(VM_Version::supports_evex(), "");
@@ -10457,7 +10458,7 @@ void Assembler::evpgatherdd(XMMRegister dst, KRegister mask, Address src, int ve
   // swap src<->dst for encoding
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0x90);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpgatherdq(XMMRegister dst, KRegister mask, Address src, int vector_len) {
@@ -10475,7 +10476,7 @@ void Assembler::evpgatherdq(XMMRegister dst, KRegister mask, Address src, int ve
   // swap src<->dst for encoding
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0x90);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evgatherdpd(XMMRegister dst, KRegister mask, Address src, int vector_len) {
@@ -10493,7 +10494,7 @@ void Assembler::evgatherdpd(XMMRegister dst, KRegister mask, Address src, int ve
   // swap src<->dst for encoding
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0x92);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evgatherdps(XMMRegister dst, KRegister mask, Address src, int vector_len) {
@@ -10511,7 +10512,7 @@ void Assembler::evgatherdps(XMMRegister dst, KRegister mask, Address src, int ve
   // swap src<->dst for encoding
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0x92);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::evpscatterdd(Address dst, KRegister mask, XMMRegister src, int vector_len) {
@@ -10525,7 +10526,7 @@ void Assembler::evpscatterdd(Address dst, KRegister mask, XMMRegister src, int v
   attributes.set_is_evex_instruction();
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xA0);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::evpscatterdq(Address dst, KRegister mask, XMMRegister src, int vector_len) {
@@ -10539,7 +10540,7 @@ void Assembler::evpscatterdq(Address dst, KRegister mask, XMMRegister src, int v
   attributes.set_is_evex_instruction();
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xA0);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::evscatterdps(Address dst, KRegister mask, XMMRegister src, int vector_len) {
@@ -10553,7 +10554,7 @@ void Assembler::evscatterdps(Address dst, KRegister mask, XMMRegister src, int v
   attributes.set_is_evex_instruction();
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xA2);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::evscatterdpd(Address dst, KRegister mask, XMMRegister src, int vector_len) {
@@ -10567,7 +10568,7 @@ void Assembler::evscatterdpd(Address dst, KRegister mask, XMMRegister src, int v
   attributes.set_is_evex_instruction();
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xA2);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 // Carry-Less Multiplication Quadword
 void Assembler::pclmulqdq(XMMRegister dst, XMMRegister src, int mask) {
@@ -10624,20 +10625,19 @@ void Assembler::vfpclasssd(KRegister kdst, XMMRegister src, uint8_t imm8) {
 void Assembler::fld_x(Address adr) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xDB);
-  emit_operand32(rbp, adr);
+  emit_operand32(rbp, adr, 0);
 }
 
 void Assembler::fstp_x(Address adr) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xDB);
-  emit_operand32(rdi, adr);
+  emit_operand32(rdi, adr, 0);
 }
 
-void Assembler::emit_operand32(Register reg, Address adr) {
+void Assembler::emit_operand32(Register reg, Address adr, int post_addr_length) {
   assert(reg->encoding() < 8, "no extended registers");
   assert(!adr.base_needs_rex() && !adr.index_needs_rex(), "no extended registers");
-  emit_operand(reg, adr._base, adr._index, adr._scale, adr._disp,
-               adr._rspec);
+  emit_operand(reg, adr._base, adr._index, adr._scale, adr._disp, adr._rspec, post_addr_length);
 }
 
 #ifndef _LP64
@@ -10663,7 +10663,7 @@ void Assembler::cmp_literal32(Address src1, int32_t imm32, RelocationHolder cons
   // NO PREFIX AS NEVER 64BIT (not even 32bit versions of 64bit regs
   InstructionMark im(this);
   emit_int8((unsigned char)0x81);
-  emit_operand(rdi, src1);
+  emit_operand(rdi, src1, 4);
   emit_data(imm32, rspec, 0);
 }
 
@@ -10673,7 +10673,7 @@ void Assembler::cmp_literal32(Address src1, int32_t imm32, RelocationHolder cons
 void Assembler::cmpxchg8(Address adr) {
   InstructionMark im(this);
   emit_int16(0x0F, (unsigned char)0xC7);
-  emit_operand(rcx, adr);
+  emit_operand(rcx, adr, 0);
 }
 
 void Assembler::decl(Register dst) {
@@ -10700,13 +10700,13 @@ void Assembler::fadd(int i) {
 void Assembler::fadd_d(Address src) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xDC);
-  emit_operand32(rax, src);
+  emit_operand32(rax, src, 0);
 }
 
 void Assembler::fadd_s(Address src) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xD8);
-  emit_operand32(rax, src);
+  emit_operand32(rax, src, 0);
 }
 
 void Assembler::fadda(int i) {
@@ -10732,13 +10732,13 @@ void Assembler::fcomp(int i) {
 void Assembler::fcomp_d(Address src) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xDC);
-  emit_operand32(rbx, src);
+  emit_operand32(rbx, src, 0);
 }
 
 void Assembler::fcomp_s(Address src) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xD8);
-  emit_operand32(rbx, src);
+  emit_operand32(rbx, src, 0);
 }
 
 void Assembler::fcompp() {
@@ -10760,13 +10760,13 @@ void Assembler::fdiv(int i) {
 void Assembler::fdiv_d(Address src) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xDC);
-  emit_operand32(rsi, src);
+  emit_operand32(rsi, src, 0);
 }
 
 void Assembler::fdiv_s(Address src) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xD8);
-  emit_operand32(rsi, src);
+  emit_operand32(rsi, src, 0);
 }
 
 void Assembler::fdiva(int i) {
@@ -10787,13 +10787,13 @@ void Assembler::fdivr(int i) {
 void Assembler::fdivr_d(Address src) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xDC);
-  emit_operand32(rdi, src);
+  emit_operand32(rdi, src, 0);
 }
 
 void Assembler::fdivr_s(Address src) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xD8);
-  emit_operand32(rdi, src);
+  emit_operand32(rdi, src, 0);
 }
 
 void Assembler::fdivra(int i) {
@@ -10811,13 +10811,13 @@ void Assembler::ffree(int i) {
 void Assembler::fild_d(Address adr) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xDF);
-  emit_operand32(rbp, adr);
+  emit_operand32(rbp, adr, 0);
 }
 
 void Assembler::fild_s(Address adr) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xDB);
-  emit_operand32(rax, adr);
+  emit_operand32(rax, adr, 0);
 }
 
 void Assembler::fincstp() {
@@ -10831,19 +10831,19 @@ void Assembler::finit() {
 void Assembler::fist_s(Address adr) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xDB);
-  emit_operand32(rdx, adr);
+  emit_operand32(rdx, adr, 0);
 }
 
 void Assembler::fistp_d(Address adr) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xDF);
-  emit_operand32(rdi, adr);
+  emit_operand32(rdi, adr, 0);
 }
 
 void Assembler::fistp_s(Address adr) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xDB);
-  emit_operand32(rbx, adr);
+  emit_operand32(rbx, adr, 0);
 }
 
 void Assembler::fld1() {
@@ -10853,13 +10853,13 @@ void Assembler::fld1() {
 void Assembler::fld_d(Address adr) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xDD);
-  emit_operand32(rax, adr);
+  emit_operand32(rax, adr, 0);
 }
 
 void Assembler::fld_s(Address adr) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xD9);
-  emit_operand32(rax, adr);
+  emit_operand32(rax, adr, 0);
 }
 
 
@@ -10870,13 +10870,13 @@ void Assembler::fld_s(int index) {
 void Assembler::fldcw(Address src) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xD9);
-  emit_operand32(rbp, src);
+  emit_operand32(rbp, src, 0);
 }
 
 void Assembler::fldenv(Address src) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xD9);
-  emit_operand32(rsp, src);
+  emit_operand32(rsp, src, 0);
 }
 
 void Assembler::fldlg2() {
@@ -10910,13 +10910,13 @@ void Assembler::fmul(int i) {
 void Assembler::fmul_d(Address src) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xDC);
-  emit_operand32(rcx, src);
+  emit_operand32(rcx, src, 0);
 }
 
 void Assembler::fmul_s(Address src) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xD8);
-  emit_operand32(rcx, src);
+  emit_operand32(rcx, src, 0);
 }
 
 void Assembler::fmula(int i) {
@@ -10930,13 +10930,13 @@ void Assembler::fmulp(int i) {
 void Assembler::fnsave(Address dst) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xDD);
-  emit_operand32(rsi, dst);
+  emit_operand32(rsi, dst, 0);
 }
 
 void Assembler::fnstcw(Address src) {
   InstructionMark im(this);
   emit_int16((unsigned char)0x9B, (unsigned char)0xD9);
-  emit_operand32(rdi, src);
+  emit_operand32(rdi, src, 0);
 }
 
 void Assembler::fnstsw_ax() {
@@ -10954,7 +10954,7 @@ void Assembler::fprem1() {
 void Assembler::frstor(Address src) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xDD);
-  emit_operand32(rsp, src);
+  emit_operand32(rsp, src, 0);
 }
 
 void Assembler::fsin() {
@@ -10968,19 +10968,19 @@ void Assembler::fsqrt() {
 void Assembler::fst_d(Address adr) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xDD);
-  emit_operand32(rdx, adr);
+  emit_operand32(rdx, adr, 0);
 }
 
 void Assembler::fst_s(Address adr) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xD9);
-  emit_operand32(rdx, adr);
+  emit_operand32(rdx, adr, 0);
 }
 
 void Assembler::fstp_d(Address adr) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xDD);
-  emit_operand32(rbx, adr);
+  emit_operand32(rbx, adr, 0);
 }
 
 void Assembler::fstp_d(int index) {
@@ -10990,7 +10990,7 @@ void Assembler::fstp_d(int index) {
 void Assembler::fstp_s(Address adr) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xD9);
-  emit_operand32(rbx, adr);
+  emit_operand32(rbx, adr, 0);
 }
 
 void Assembler::fsub(int i) {
@@ -11000,13 +11000,13 @@ void Assembler::fsub(int i) {
 void Assembler::fsub_d(Address src) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xDC);
-  emit_operand32(rsp, src);
+  emit_operand32(rsp, src, 0);
 }
 
 void Assembler::fsub_s(Address src) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xD8);
-  emit_operand32(rsp, src);
+  emit_operand32(rsp, src, 0);
 }
 
 void Assembler::fsuba(int i) {
@@ -11024,13 +11024,13 @@ void Assembler::fsubr(int i) {
 void Assembler::fsubr_d(Address src) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xDC);
-  emit_operand32(rbp, src);
+  emit_operand32(rbp, src, 0);
 }
 
 void Assembler::fsubr_s(Address src) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xD8);
-  emit_operand32(rbp, src);
+  emit_operand32(rbp, src, 0);
 }
 
 void Assembler::fsubra(int i) {
@@ -11520,7 +11520,7 @@ void Assembler::evpcmpd(KRegister kdst, KRegister mask, XMMRegister nds, Address
   vex_prefix(src, nds->encoding(), dst_enc, VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   int opcode = is_signed ? 0x1F : 0x1E;
   emit_int8((unsigned char)opcode);
-  emit_operand(as_Register(dst_enc), src);
+  emit_operand(as_Register(dst_enc), src, 1);
   emit_int8((unsigned char)comparison);
 }
 
@@ -11553,7 +11553,7 @@ void Assembler::evpcmpq(KRegister kdst, KRegister mask, XMMRegister nds, Address
   vex_prefix(src, nds->encoding(), dst_enc, VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   int opcode = is_signed ? 0x1F : 0x1E;
   emit_int8((unsigned char)opcode);
-  emit_operand(as_Register(dst_enc), src);
+  emit_operand(as_Register(dst_enc), src, 1);
   emit_int8((unsigned char)comparison);
 }
 
@@ -11588,7 +11588,7 @@ void Assembler::evpcmpb(KRegister kdst, KRegister mask, XMMRegister nds, Address
   vex_prefix(src, nds->encoding(), dst_enc, VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   int opcode = is_signed ? 0x3F : 0x3E;
   emit_int8((unsigned char)opcode);
-  emit_operand(as_Register(dst_enc), src);
+  emit_operand(as_Register(dst_enc), src, 1);
   emit_int8((unsigned char)comparison);
 }
 
@@ -11623,7 +11623,7 @@ void Assembler::evpcmpw(KRegister kdst, KRegister mask, XMMRegister nds, Address
   vex_prefix(src, nds->encoding(), dst_enc, VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   int opcode = is_signed ? 0x3F : 0x3E;
   emit_int8((unsigned char)opcode);
-  emit_operand(as_Register(dst_enc), src);
+  emit_operand(as_Register(dst_enc), src, 1);
   emit_int8((unsigned char)comparison);
 }
 
@@ -11852,7 +11852,7 @@ void Assembler::pextl(Register dst, Register src1, Address src2) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(src2, src1->encoding(), dst->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xF5);
-  emit_operand(dst, src2);
+  emit_operand(dst, src2, 0);
 }
 
 void Assembler::pdepl(Register dst, Register src1, Address src2) {
@@ -11861,7 +11861,7 @@ void Assembler::pdepl(Register dst, Register src1, Address src2) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(src2, src1->encoding(), dst->encoding(), VEX_SIMD_F2, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xF5);
-  emit_operand(dst, src2);
+  emit_operand(dst, src2, 0);
 }
 
 void Assembler::pextq(Register dst, Register src1, Address src2) {
@@ -11870,7 +11870,7 @@ void Assembler::pextq(Register dst, Register src1, Address src2) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(src2, src1->encoding(), dst->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xF5);
-  emit_operand(dst, src2);
+  emit_operand(dst, src2, 0);
 }
 
 void Assembler::pdepq(Register dst, Register src1, Address src2) {
@@ -11879,7 +11879,7 @@ void Assembler::pdepq(Register dst, Register src1, Address src2) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(src2, src1->encoding(), dst->encoding(), VEX_SIMD_F2, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xF5);
-  emit_operand(dst, src2);
+  emit_operand(dst, src2, 0);
 }
 
 void Assembler::sarxl(Register dst, Register src1, Register src2) {
@@ -11895,7 +11895,7 @@ void Assembler::sarxl(Register dst, Address src1, Register src2) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ true);
   vex_prefix(src1, src2->encoding(), dst->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xF7);
-  emit_operand(dst, src1);
+  emit_operand(dst, src1, 0);
 }
 
 void Assembler::sarxq(Register dst, Register src1, Register src2) {
@@ -11911,7 +11911,7 @@ void Assembler::sarxq(Register dst, Address src1, Register src2) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ true);
   vex_prefix(src1, src2->encoding(), dst->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xF7);
-  emit_operand(dst, src1);
+  emit_operand(dst, src1, 0);
 }
 
 void Assembler::shlxl(Register dst, Register src1, Register src2) {
@@ -11927,7 +11927,7 @@ void Assembler::shlxl(Register dst, Address src1, Register src2) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ true);
   vex_prefix(src1, src2->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xF7);
-  emit_operand(dst, src1);
+  emit_operand(dst, src1, 0);
 }
 
 void Assembler::shlxq(Register dst, Register src1, Register src2) {
@@ -11943,7 +11943,7 @@ void Assembler::shlxq(Register dst, Address src1, Register src2) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ true);
   vex_prefix(src1, src2->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xF7);
-  emit_operand(dst, src1);
+  emit_operand(dst, src1, 0);
 }
 
 void Assembler::shrxl(Register dst, Register src1, Register src2) {
@@ -11959,7 +11959,7 @@ void Assembler::shrxl(Register dst, Address src1, Register src2) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ true);
   vex_prefix(src1, src2->encoding(), dst->encoding(), VEX_SIMD_F2, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xF7);
-  emit_operand(dst, src1);
+  emit_operand(dst, src1, 0);
 }
 
 void Assembler::shrxq(Register dst, Register src1, Register src2) {
@@ -11975,7 +11975,7 @@ void Assembler::shrxq(Register dst, Address src1, Register src2) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ true);
   vex_prefix(src1, src2->encoding(), dst->encoding(), VEX_SIMD_F2, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xF7);
-  emit_operand(dst, src1);
+  emit_operand(dst, src1, 0);
 }
 
 void Assembler::evpmovq2m(KRegister dst, XMMRegister src, int vector_len) {
@@ -12134,7 +12134,7 @@ void Assembler::lea(Register dst, Address src) {
 void Assembler::mov_literal32(Address dst, int32_t imm32, RelocationHolder const& rspec) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xC7);
-  emit_operand(rax, dst);
+  emit_operand(rax, dst, 4);
   emit_data((int)imm32, rspec, 0);
 }
 
@@ -12554,7 +12554,7 @@ void Assembler::adcq(Register dst, int32_t imm32) {
 void Assembler::adcq(Register dst, Address src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(src, dst), 0x13);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::adcq(Register dst, Register src) {
@@ -12571,7 +12571,7 @@ void Assembler::addq(Address dst, int32_t imm32) {
 void Assembler::addq(Address dst, Register src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(dst, src), 0x01);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::addq(Register dst, int32_t imm32) {
@@ -12582,7 +12582,7 @@ void Assembler::addq(Register dst, int32_t imm32) {
 void Assembler::addq(Register dst, Address src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(src, dst), 0x03);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::addq(Register dst, Register src) {
@@ -12624,7 +12624,7 @@ void Assembler::andq(Register dst, int32_t imm32) {
 void Assembler::andq(Register dst, Address src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(src, dst), 0x23);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::andq(Register dst, Register src) {
@@ -12635,7 +12635,7 @@ void Assembler::andq(Register dst, Register src) {
 void Assembler::andq(Address dst, Register src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(dst, src), 0x21);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::andnq(Register dst, Register src1, Register src2) {
@@ -12651,7 +12651,7 @@ void Assembler::andnq(Register dst, Register src1, Address src2) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(src2, src1->encoding(), dst->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xF2);
-  emit_operand(dst, src2);
+  emit_operand(dst, src2, 0);
 }
 
 void Assembler::bsfq(Register dst, Register src) {
@@ -12682,7 +12682,7 @@ void Assembler::blsiq(Register dst, Address src) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(src, dst->encoding(), rbx->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xF3);
-  emit_operand(rbx, src);
+  emit_operand(rbx, src, 0);
 }
 
 void Assembler::blsmskq(Register dst, Register src) {
@@ -12698,7 +12698,7 @@ void Assembler::blsmskq(Register dst, Address src) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(src, dst->encoding(), rdx->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xF3);
-  emit_operand(rdx, src);
+  emit_operand(rdx, src, 0);
 }
 
 void Assembler::blsrq(Register dst, Register src) {
@@ -12714,7 +12714,7 @@ void Assembler::blsrq(Register dst, Address src) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(src, dst->encoding(), rcx->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0xF3);
-  emit_operand(rcx, src);
+  emit_operand(rcx, src, 0);
 }
 
 void Assembler::cdqq() {
@@ -12725,7 +12725,7 @@ void Assembler::clflush(Address adr) {
   assert(VM_Version::supports_clflush(), "should do");
   prefix(adr);
   emit_int16(0x0F, (unsigned char)0xAE);
-  emit_operand(rdi, adr);
+  emit_operand(rdi, adr, 0);
 }
 
 void Assembler::clflushopt(Address adr) {
@@ -12740,7 +12740,7 @@ void Assembler::clflushopt(Address adr) {
   // opcode family is 0x0F 0xAE
   emit_int16(0x0F, (unsigned char)0xAE);
   // extended opcode byte is 7 == rdi
-  emit_operand(rdi, adr);
+  emit_operand(rdi, adr, 0);
 }
 
 void Assembler::clwb(Address adr) {
@@ -12755,7 +12755,7 @@ void Assembler::clwb(Address adr) {
   // opcode family is 0x0f 0xAE
   emit_int16(0x0F, (unsigned char)0xAE);
   // extended opcode byte is 6 == rsi
-  emit_operand(rsi, adr);
+  emit_operand(rsi, adr, 0);
 }
 
 void Assembler::cmovq(Condition cc, Register dst, Register src) {
@@ -12766,14 +12766,13 @@ void Assembler::cmovq(Condition cc, Register dst, Register src) {
 void Assembler::cmovq(Condition cc, Register dst, Address src) {
   InstructionMark im(this);
   emit_int24(get_prefixq(src, dst), 0x0F, (0x40 | cc));
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::cmpq(Address dst, int32_t imm32) {
   InstructionMark im(this);
-  emit_int16(get_prefixq(dst), (unsigned char)0x81);
-  emit_operand(rdi, dst, 4);
-  emit_int32(imm32);
+  prefixq(dst);
+  emit_arith_operand(0x81, as_Register(7), dst, imm32);
 }
 
 void Assembler::cmpq(Register dst, int32_t imm32) {
@@ -12784,7 +12783,7 @@ void Assembler::cmpq(Register dst, int32_t imm32) {
 void Assembler::cmpq(Address dst, Register src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(dst, src), 0x39);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::cmpq(Register dst, Register src) {
@@ -12795,13 +12794,13 @@ void Assembler::cmpq(Register dst, Register src) {
 void Assembler::cmpq(Register dst, Address src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(src, dst), 0x3B);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::cmpxchgq(Register reg, Address adr) {
   InstructionMark im(this);
   emit_int24(get_prefixq(adr, reg), 0x0F, (unsigned char)0xB1);
-  emit_operand(reg, adr);
+  emit_operand(reg, adr, 0);
 }
 
 void Assembler::cvtsi2sdq(XMMRegister dst, Register src) {
@@ -12818,7 +12817,7 @@ void Assembler::cvtsi2sdq(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_64bit);
   simd_prefix(dst, dst, src, VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
   emit_int8(0x2A);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::cvtsi2ssq(XMMRegister dst, Address src) {
@@ -12828,7 +12827,7 @@ void Assembler::cvtsi2ssq(XMMRegister dst, Address src) {
   attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_64bit);
   simd_prefix(dst, dst, src, VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
   emit_int8(0x2A);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::cvttsd2siq(Register dst, Address src) {
@@ -12837,7 +12836,7 @@ void Assembler::cvttsd2siq(Register dst, Address src) {
   // CVTTSD2SI r64, xmm1/m64
   InstructionMark im(this);
   emit_int32((unsigned char)0xF2, REX_W, 0x0F, 0x2C);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::cvttsd2siq(Register dst, XMMRegister src) {
@@ -12879,27 +12878,27 @@ void Assembler::decq(Address dst) {
   // Don't use it directly. Use MacroAssembler::decrementq() instead.
   InstructionMark im(this);
   emit_int16(get_prefixq(dst), (unsigned char)0xFF);
-  emit_operand(rcx, dst);
+  emit_operand(rcx, dst, 0);
 }
 
 void Assembler::fxrstor(Address src) {
   emit_int24(get_prefixq(src), 0x0F, (unsigned char)0xAE);
-  emit_operand(as_Register(1), src);
+  emit_operand(as_Register(1), src, 0);
 }
 
 void Assembler::xrstor(Address src) {
   emit_int24(get_prefixq(src), 0x0F, (unsigned char)0xAE);
-  emit_operand(as_Register(5), src);
+  emit_operand(as_Register(5), src, 0);
 }
 
 void Assembler::fxsave(Address dst) {
   emit_int24(get_prefixq(dst), 0x0F, (unsigned char)0xAE);
-  emit_operand(as_Register(0), dst);
+  emit_operand(as_Register(0), dst, 0);
 }
 
 void Assembler::xsave(Address dst) {
   emit_int24(get_prefixq(dst), 0x0F, (unsigned char)0xAE);
-  emit_operand(as_Register(4), dst);
+  emit_operand(as_Register(4), dst, 0);
 }
 
 void Assembler::idivq(Register src) {
@@ -12927,11 +12926,11 @@ void Assembler::imulq(Register dst, Address src, int32_t value) {
   prefixq(src, dst);
   if (is8bit(value)) {
     emit_int8((unsigned char)0x6B);
-    emit_operand(dst, src);
+    emit_operand(dst, src, 1);
     emit_int8(value);
   } else {
     emit_int8((unsigned char)0x69);
-    emit_operand(dst, src);
+    emit_operand(dst, src, 4);
     emit_int32(value);
   }
 }
@@ -12949,7 +12948,7 @@ void Assembler::imulq(Register dst, Register src, int value) {
 void Assembler::imulq(Register dst, Address src) {
   InstructionMark im(this);
   emit_int24(get_prefixq(src, dst), 0x0F, (unsigned char)0xAF);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::incl(Register dst) {
@@ -12970,7 +12969,7 @@ void Assembler::incq(Address dst) {
   // Don't use it directly. Use MacroAssembler::incrementq() instead.
   InstructionMark im(this);
   emit_int16(get_prefixq(dst), (unsigned char)0xFF);
-  emit_operand(rax, dst);
+  emit_operand(rax, dst, 0);
 }
 
 void Assembler::lea(Register dst, Address src) {
@@ -12980,7 +12979,7 @@ void Assembler::lea(Register dst, Address src) {
 void Assembler::leaq(Register dst, Address src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(src, dst), (unsigned char)0x8D);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::mov64(Register dst, int64_t imm64) {
@@ -13047,7 +13046,7 @@ void Assembler::lzcntq(Register dst, Address src) {
   emit_int8((unsigned char)0xF3);
   prefixq(src, dst);
   emit_int16(0x0F, (unsigned char)0xBD);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movdq(XMMRegister dst, Register src) {
@@ -13077,19 +13076,19 @@ void Assembler::movq(Register dst, Register src) {
 void Assembler::movq(Register dst, Address src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(src, dst), (unsigned char)0x8B);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movq(Address dst, Register src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(dst, src), (unsigned char)0x89);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::movq(Address dst, int32_t imm32) {
   InstructionMark im(this);
   emit_int16(get_prefixq(dst), (unsigned char)0xC7);
-  emit_operand(as_Register(0), dst);
+  emit_operand(as_Register(0), dst, 4);
   emit_int32(imm32);
 }
 
@@ -13104,7 +13103,7 @@ void Assembler::movsbq(Register dst, Address src) {
   emit_int24(get_prefixq(src, dst),
              0x0F,
              (unsigned char)0xBE);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movsbq(Register dst, Register src) {
@@ -13134,7 +13133,7 @@ void Assembler::movslq(Address dst, int32_t imm32) {
 void Assembler::movslq(Register dst, Address src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(src, dst), 0x63);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movslq(Register dst, Register src) {
@@ -13147,7 +13146,7 @@ void Assembler::movswq(Register dst, Address src) {
   emit_int24(get_prefixq(src, dst),
              0x0F,
              (unsigned char)0xBF);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movswq(Register dst, Register src) {
@@ -13160,7 +13159,7 @@ void Assembler::movzbq(Register dst, Address src) {
   emit_int24(get_prefixq(src, dst),
              0x0F,
              (unsigned char)0xB6);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movzbq(Register dst, Register src) {
@@ -13173,7 +13172,7 @@ void Assembler::movzwq(Register dst, Address src) {
   emit_int24(get_prefixq(src, dst),
              0x0F,
              (unsigned char)0xB7);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::movzwq(Register dst, Register src) {
@@ -13184,7 +13183,7 @@ void Assembler::movzwq(Register dst, Register src) {
 void Assembler::mulq(Address src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(src), (unsigned char)0xF7);
-  emit_operand(rsp, src);
+  emit_operand(rsp, src, 0);
 }
 
 void Assembler::mulq(Register src) {
@@ -13207,7 +13206,7 @@ void Assembler::negq(Register dst) {
 void Assembler::negq(Address dst) {
   InstructionMark im(this);
   emit_int16(get_prefixq(dst), (unsigned char)0xF7);
-  emit_operand(as_Register(3), dst);
+  emit_operand(as_Register(3), dst, 0);
 }
 
 void Assembler::notq(Register dst) {
@@ -13244,7 +13243,7 @@ void Assembler::orq(Address dst, int32_t imm32) {
 void Assembler::orq(Address dst, Register src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(dst, src), (unsigned char)0x09);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::orq(Register dst, int32_t imm32) {
@@ -13255,7 +13254,7 @@ void Assembler::orq(Register dst, int32_t imm32) {
 void Assembler::orq(Register dst, Address src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(src, dst), 0x0B);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::orq(Register dst, Register src) {
@@ -13270,7 +13269,7 @@ void Assembler::popcntq(Register dst, Address src) {
              get_prefixq(src, dst),
              0x0F,
              (unsigned char)0xB8);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::popcntq(Register dst, Register src) {
@@ -13283,7 +13282,7 @@ void Assembler::popcntq(Register dst, Register src) {
 void Assembler::popq(Address dst) {
   InstructionMark im(this);
   emit_int16(get_prefixq(dst), (unsigned char)0x8F);
-  emit_operand(rax, dst);
+  emit_operand(rax, dst, 0);
 }
 
 void Assembler::popq(Register dst) {
@@ -13421,7 +13420,7 @@ void Assembler::vzeroupper() {
 void Assembler::pushq(Address src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(src), (unsigned char)0xFF);
-  emit_operand(rsi, src);
+  emit_operand(rsi, src, 0);
 }
 
 void Assembler::rclq(Register dst, int imm8) {
@@ -13457,7 +13456,7 @@ void Assembler::rorxl(Register dst, Address src, int imm8) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_F2, VEX_OPCODE_0F_3A, &attributes);
   emit_int8((unsigned char)0xF0);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 1);
   emit_int8(imm8);
 }
 
@@ -13474,7 +13473,7 @@ void Assembler::rorxq(Register dst, Address src, int imm8) {
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_F2, VEX_OPCODE_0F_3A, &attributes);
   emit_int8((unsigned char)0xF0);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 1);
   emit_int8(imm8);
 }
 
@@ -13484,11 +13483,11 @@ void Assembler::salq(Address dst, int imm8) {
   assert(isShiftCount(imm8 >> 1), "illegal shift count");
   if (imm8 == 1) {
     emit_int16(get_prefixq(dst), (unsigned char)0xD1);
-    emit_operand(as_Register(4), dst);
+    emit_operand(as_Register(4), dst, 0);
   }
   else {
     emit_int16(get_prefixq(dst), (unsigned char)0xC1);
-    emit_operand(as_Register(4), dst);
+    emit_operand(as_Register(4), dst, 1);
     emit_int8(imm8);
   }
 }
@@ -13496,7 +13495,7 @@ void Assembler::salq(Address dst, int imm8) {
 void Assembler::salq(Address dst) {
   InstructionMark im(this);
   emit_int16(get_prefixq(dst), (unsigned char)0xD3);
-  emit_operand(as_Register(4), dst);
+  emit_operand(as_Register(4), dst, 0);
 }
 
 void Assembler::salq(Register dst, int imm8) {
@@ -13519,11 +13518,11 @@ void Assembler::sarq(Address dst, int imm8) {
   assert(isShiftCount(imm8 >> 1), "illegal shift count");
   if (imm8 == 1) {
     emit_int16(get_prefixq(dst), (unsigned char)0xD1);
-    emit_operand(as_Register(7), dst);
+    emit_operand(as_Register(7), dst, 0);
   }
   else {
     emit_int16(get_prefixq(dst), (unsigned char)0xC1);
-    emit_operand(as_Register(7), dst);
+    emit_operand(as_Register(7), dst, 1);
     emit_int8(imm8);
   }
 }
@@ -13531,7 +13530,7 @@ void Assembler::sarq(Address dst, int imm8) {
 void Assembler::sarq(Address dst) {
   InstructionMark im(this);
   emit_int16(get_prefixq(dst), (unsigned char)0xD3);
-  emit_operand(as_Register(7), dst);
+  emit_operand(as_Register(7), dst, 0);
 }
 
 void Assembler::sarq(Register dst, int imm8) {
@@ -13564,7 +13563,7 @@ void Assembler::sbbq(Register dst, int32_t imm32) {
 void Assembler::sbbq(Register dst, Address src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(src, dst), 0x1B);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::sbbq(Register dst, Register src) {
@@ -13606,7 +13605,7 @@ void Assembler::shrq(Register dst) {
 void Assembler::shrq(Address dst) {
   InstructionMark im(this);
   emit_int16(get_prefixq(dst), (unsigned char)0xD3);
-  emit_operand(as_Register(5), dst);
+  emit_operand(as_Register(5), dst, 0);
 }
 
 void Assembler::shrq(Address dst, int imm8) {
@@ -13614,11 +13613,11 @@ void Assembler::shrq(Address dst, int imm8) {
   assert(isShiftCount(imm8 >> 1), "illegal shift count");
   if (imm8 == 1) {
     emit_int16(get_prefixq(dst), (unsigned char)0xD1);
-    emit_operand(as_Register(5), dst);
+    emit_operand(as_Register(5), dst, 0);
   }
   else {
     emit_int16(get_prefixq(dst), (unsigned char)0xC1);
-    emit_operand(as_Register(5), dst);
+    emit_operand(as_Register(5), dst, 1);
     emit_int8(imm8);
   }
 }
@@ -13632,7 +13631,7 @@ void Assembler::subq(Address dst, int32_t imm32) {
 void Assembler::subq(Address dst, Register src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(dst, src), 0x29);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::subq(Register dst, int32_t imm32) {
@@ -13649,7 +13648,7 @@ void Assembler::subq_imm32(Register dst, int32_t imm32) {
 void Assembler::subq(Register dst, Address src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(src, dst), 0x2B);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::subq(Register dst, Register src) {
@@ -13658,21 +13657,13 @@ void Assembler::subq(Register dst, Register src) {
 }
 
 void Assembler::testq(Address dst, int32_t imm32) {
-  if (imm32 >= 0) {
-    testl(dst, imm32);
-    return;
-  }
   InstructionMark im(this);
   emit_int16(get_prefixq(dst), (unsigned char)0xF7);
-  emit_operand(as_Register(0), dst);
+  emit_operand(as_Register(0), dst, 4);
   emit_int32(imm32);
 }
 
 void Assembler::testq(Register dst, int32_t imm32) {
-  if (imm32 >= 0) {
-    testl(dst, imm32);
-    return;
-  }
   // not using emit_arith because test
   // doesn't support sign-extension of
   // 8bit operands
@@ -13696,19 +13687,19 @@ void Assembler::testq(Register dst, Register src) {
 void Assembler::testq(Register dst, Address src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(src, dst), (unsigned char)0x85);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::xaddq(Address dst, Register src) {
   InstructionMark im(this);
   emit_int24(get_prefixq(dst, src), 0x0F, (unsigned char)0xC1);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 void Assembler::xchgq(Register dst, Address src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(src, dst), (unsigned char)0x87);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::xchgq(Register dst, Register src) {
@@ -13724,7 +13715,7 @@ void Assembler::xorq(Register dst, Register src) {
 void Assembler::xorq(Register dst, Address src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(src, dst), 0x33);
-  emit_operand(dst, src);
+  emit_operand(dst, src, 0);
 }
 
 void Assembler::xorq(Register dst, int32_t imm32) {
@@ -13741,7 +13732,7 @@ void Assembler::xorq(Address dst, int32_t imm32) {
 void Assembler::xorq(Address dst, Register src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(dst, src), 0x31);
-  emit_operand(src, dst);
+  emit_operand(src, dst, 0);
 }
 
 #endif // !LP64

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -755,51 +755,55 @@ private:
                            int base_enc, int index_enc, Address::ScaleFactor scale,
                            int disp,
                            RelocationHolder const& rspec,
-                           int rip_relative_correction = 0);
+                           int post_addr_length);
 
   void emit_operand(Register reg,
                     Register base, Register index, Address::ScaleFactor scale,
                     int disp,
                     RelocationHolder const& rspec,
-                    int rip_relative_correction = 0);
+                    int post_addr_length);
 
   void emit_operand(Register reg,
                     Register base, XMMRegister index, Address::ScaleFactor scale,
                     int disp,
-                    RelocationHolder const& rspec);
+                    RelocationHolder const& rspec,
+                    int post_addr_length);
 
   void emit_operand(XMMRegister xreg,
                     Register base, XMMRegister xindex, Address::ScaleFactor scale,
                     int disp,
-                    RelocationHolder const& rspec);
+                    RelocationHolder const& rspec,
+                    int post_addr_length);
 
   void emit_operand(Register reg, Address adr,
-                    int rip_relative_correction = 0);
+                    int post_addr_length);
 
   void emit_operand(XMMRegister reg,
                     Register base, Register index, Address::ScaleFactor scale,
                     int disp,
-                    RelocationHolder const& rspec);
+                    RelocationHolder const& rspec,
+                    int post_addr_length);
 
   void emit_operand_helper(KRegister kreg,
                            int base_enc, int index_enc, Address::ScaleFactor scale,
                            int disp,
                            RelocationHolder const& rspec,
-                           int rip_relative_correction = 0);
+                           int post_addr_length);
 
   void emit_operand(KRegister kreg, Address adr,
-                    int rip_relative_correction = 0);
+                    int post_addr_length);
 
   void emit_operand(KRegister kreg,
                     Register base, Register index, Address::ScaleFactor scale,
                     int disp,
                     RelocationHolder const& rspec,
-                    int rip_relative_correction = 0);
+                    int post_addr_length);
 
-  void emit_operand(XMMRegister reg, Address adr);
+  void emit_operand(XMMRegister reg, Address adr, int post_addr_length);
 
   // Immediate-to-memory forms
   void emit_arith_operand(int op1, Register rm, Address adr, int32_t imm32);
+  void emit_arith_operand_imm32(int op1, Register rm, Address adr, int32_t imm32);
 
  protected:
 #ifdef ASSERT
@@ -1099,6 +1103,7 @@ private:
   void cmpl(Register dst, int32_t imm32);
   void cmpl(Register dst, Register src);
   void cmpl(Register dst, Address src);
+  void cmpl_imm32(Address dst, int32_t imm32);
 
   void cmpq(Address dst, int32_t imm32);
   void cmpq(Address dst, Register src);
@@ -1366,7 +1371,7 @@ private:
 #endif // !_LP64
 
   // operands that only take the original 32bit registers
-  void emit_operand32(Register reg, Address adr);
+  void emit_operand32(Register reg, Address adr, int post_addr_length);
 
   void fld_x(Address adr);  // extended-precision (80-bit) format
   void fstp_x(Address adr); // extended-precision (80-bit) format

--- a/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
@@ -285,7 +285,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
   // byte aligned, which means that the immediate will not cross a cache line
   __ align(4);
   uintptr_t before_cmp = (uintptr_t)__ pc();
-  __ cmpl(disarmed_addr, 0);
+  __ cmpl_imm32(disarmed_addr, 0);
   uintptr_t after_cmp = (uintptr_t)__ pc();
   guarantee(after_cmp - before_cmp == 8, "Wrong assumed instruction length");
 
@@ -313,7 +313,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label*, La
   __ movptr(tmp, (intptr_t)bs_nm->disarmed_value_address());
   Address disarmed_addr(tmp, 0);
   __ align(4);
-  __ cmpl(disarmed_addr, 0);
+  __ cmpl_imm32(disarmed_addr, 0);
   __ pop(tmp);
   __ jcc(Assembler::equal, continuation);
   __ call(RuntimeAddress(StubRoutines::x86::method_entry_barrier()));

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -3125,10 +3125,46 @@ void MacroAssembler::sign_extend_short(Register reg) {
   }
 }
 
+void MacroAssembler::testl(Address dst, int32_t imm32) {
+  if (imm32 >= 0 && is8bit(imm32)) {
+    testb(dst, imm32);
+  } else {
+    Assembler::testl(dst, imm32);
+  }
+}
+
+void MacroAssembler::testl(Register dst, int32_t imm32) {
+  if (imm32 >= 0 && is8bit(imm32) && dst->has_byte_register()) {
+    testb(dst, imm32);
+  } else {
+    Assembler::testl(dst, imm32);
+  }
+}
+
 void MacroAssembler::testl(Register dst, AddressLiteral src) {
-  assert(reachable(src), "Address should be reachable");
+  assert(always_reachable(src), "Address should be reachable");
   testl(dst, as_Address(src));
 }
+
+#ifdef _LP64
+
+void MacroAssembler::testq(Address dst, int32_t imm32) {
+  if (imm32 >= 0) {
+    testl(dst, imm32);
+  } else {
+    Assembler::testq(dst, imm32);
+  }
+}
+
+void MacroAssembler::testq(Register dst, int32_t imm32) {
+  if (imm32 >= 0) {
+    testl(dst, imm32);
+  } else {
+    Assembler::testq(dst, imm32);
+  }
+}
+
+#endif
 
 void MacroAssembler::pcmpeqb(XMMRegister dst, XMMRegister src) {
   assert(((dst->encoding() < 16 && src->encoding() < 16) || VM_Version::supports_avx512vlbw()),"XMM register should be 0-15");

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -831,7 +831,12 @@ public:
   // Import other testl() methods from the parent class or else
   // they will be hidden by the following overriding declaration.
   using Assembler::testl;
+  void testl(Address dst, int32_t imm32);
+  void testl(Register dst, int32_t imm32);
   void testl(Register dst, AddressLiteral src); // requires reachable address
+  using Assembler::testq;
+  void testq(Address dst, int32_t imm32);
+  void testq(Register dst, int32_t imm32);
 
   void orptr(Register dst, Address src) { LP64_ONLY(orq(dst, src)) NOT_LP64(orl(dst, src)); }
   void orptr(Register dst, Register src) { LP64_ONLY(orq(dst, src)) NOT_LP64(orl(dst, src)); }


### PR DESCRIPTION
Hi,

This patch fixes some issues in the code generation of x86 assembler:

- `Assembler::testl` misses `prefix(dst)`
- `Assembler::addw` misses the 0x66 prefix
- `Assembler::emit_operand` needs the length of the instruction from the address operand, this is often forgotten, making this parameter explicit to prevent potential issues
- The assembler should not do optimisations that change the actual emitted instructions, these should be moved to `MacroAssembler` instead

AFAICT there is no failure due to these mistakes. Please take a look and give reviews.
Thanks you very much.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293618](https://bugs.openjdk.org/browse/JDK-8293618): x86: Wrong code generation in class Assembler


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10240/head:pull/10240` \
`$ git checkout pull/10240`

Update a local copy of the PR: \
`$ git checkout pull/10240` \
`$ git pull https://git.openjdk.org/jdk pull/10240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10240`

View PR using the GUI difftool: \
`$ git pr show -t 10240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10240.diff">https://git.openjdk.org/jdk/pull/10240.diff</a>

</details>
