### PR TITLE
8293654: Improve SharedRuntime handling of continuation helper out-arguments

### DIFF
--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -1127,11 +1127,9 @@ static void gen_continuation_yield(MacroAssembler* masm,
                                    const methodHandle& method,
                                    const BasicType* sig_bt,
                                    const VMRegPair* regs,
-                                   int& exception_offset,
                                    OopMapSet* oop_maps,
                                    int& frame_complete,
                                    int& stack_slots,
-                                   int& interpreted_entry_offset,
                                    int& compiled_entry_offset) {
     enum layout {
       rfp_off1,
@@ -1264,12 +1262,12 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
                                                 VMRegPair* in_regs,
                                                 BasicType ret_type) {
   if (method->is_continuation_native_intrinsic()) {
-    int vep_offset = 0;
-    int exception_offset = 0;
-    int frame_complete = 0;
-    int stack_slots = 0;
-    OopMapSet* oop_maps =  new OopMapSet();
+    int exception_offset = -1;
+    OopMapSet* oop_maps = new OopMapSet();
+    int frame_complete = -1;
+    int stack_slots = -1;
     int interpreted_entry_offset = -1;
+    int vep_offset = -1;
     if (method->is_continuation_enter_intrinsic()) {
       gen_continuation_enter(masm,
                              method,
@@ -1286,15 +1284,27 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
                              method,
                              in_sig_bt,
                              in_regs,
-                             exception_offset,
                              oop_maps,
                              frame_complete,
                              stack_slots,
-                             interpreted_entry_offset,
                              vep_offset);
     } else {
       guarantee(false, "Unknown Continuation native intrinsic");
     }
+
+#ifdef ASSERT
+    if (method->is_continuation_enter_intrinsic()) {
+      assert(interpreted_entry_offset != -1, "Must be set");
+      assert(exception_offset != -1,         "Must be set");
+    } else {
+      assert(interpreted_entry_offset == -1, "Must be unset");
+      assert(exception_offset == -1,         "Must be unset");
+    }
+    assert(frame_complete != -1,    "Must be set");
+    assert(stack_slots != -1,       "Must be set");
+    assert(vep_offset != -1,        "Must be set");
+#endif
+
     __ flush();
     nmethod* nm = nmethod::new_native_nmethod(method,
                                               compile_id,

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -1608,6 +1608,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       guarantee(false, "Unknown Continuation native intrinsic");
     }
 
+#ifdef ASSERT
     if (method->is_continuation_enter_intrinsic()) {
       assert(interpreted_entry_offset != -1, "Must be set");
       assert(exception_offset != -1,         "Must be set");
@@ -1618,6 +1619,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     assert(frame_complete != -1,    "Must be set");
     assert(stack_slots != -1,       "Must be set");
     assert(vep_offset != -1,        "Must be set");
+#endif
 
     __ flush();
     nmethod* nm = nmethod::new_native_nmethod(method,

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -1446,11 +1446,9 @@ static void gen_continuation_enter(MacroAssembler* masm,
 
 static void gen_continuation_yield(MacroAssembler* masm,
                                    const VMRegPair* regs,
-                                   int& exception_offset,
                                    OopMapSet* oop_maps,
                                    int& frame_complete,
                                    int& stack_slots,
-                                   int& interpreted_entry_offset,
                                    int& compiled_entry_offset) {
   enum layout {
     rbp_off,
@@ -1584,12 +1582,12 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
                                                 VMRegPair* in_regs,
                                                 BasicType ret_type) {
   if (method->is_continuation_native_intrinsic()) {
-    int vep_offset = 0;
-    int exception_offset = 0;
-    int frame_complete = 0;
-    int stack_slots = 0;
+    int exception_offset = -1;
     OopMapSet* oop_maps = new OopMapSet();
+    int frame_complete = -1;
+    int stack_slots = -1;
     int interpreted_entry_offset = -1;
+    int vep_offset = -1;
     if (method->is_continuation_enter_intrinsic()) {
       gen_continuation_enter(masm,
                              in_regs,
@@ -1602,15 +1600,25 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     } else if (method->is_continuation_yield_intrinsic()) {
       gen_continuation_yield(masm,
                              in_regs,
-                             exception_offset,
                              oop_maps,
                              frame_complete,
                              stack_slots,
-                             interpreted_entry_offset,
                              vep_offset);
     } else {
       guarantee(false, "Unknown Continuation native intrinsic");
     }
+
+    if (method->is_continuation_enter_intrinsic()) {
+      assert(interpreted_entry_offset != -1, "Must be set");
+      assert(exception_offset != -1,         "Must be set");
+    } else {
+      assert(interpreted_entry_offset == -1, "Must be unset");
+      assert(exception_offset == -1,         "Must be unset");
+    }
+    assert(frame_complete != -1,    "Must be set");
+    assert(stack_slots != -1,       "Must be set");
+    assert(vep_offset != -1,        "Must be set");
+
     __ flush();
     nmethod* nm = nmethod::new_native_nmethod(method,
                                               compile_id,


### PR DESCRIPTION
(Found this while adapting current mainline to x86_32 port)

After [JDK-8292584](https://bugs.openjdk.org/browse/JDK-8292584), we have `gen_continuation_yield()` that generates compiled entry, and implicitly uses the defaults for other ones (interpreter, exception). We should be more explicit about these, and verify the generators properly initialized all out-parameters.

I think we are only using interpreter/exception entry in `enterContinuation`, but not in `yield`. Notably, `exception_offset` should be `-1` for `nmethod::new_native_nmethod` to treat it as "no exception handlers". 

There a many ways to strengthen this, this PR is the one I like. I can do the symmetric change in aarch64, once we are agree on x86_64 version.

Additional testing:
 - [x] Linux x86_64 fastdebug, `hotspot_loom jdk_loom`
 - [x] Linux x86_64 fastdebug, `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293654](https://bugs.openjdk.org/browse/JDK-8293654): Improve SharedRuntime handling of continuation helper out-arguments


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [f9101ab7](https://git.openjdk.org/jdk/pull/10241/files/f9101ab7dd0c1674d4ad9f0f02e66fcc3f5acc91)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10241/head:pull/10241` \
`$ git checkout pull/10241`

Update a local copy of the PR: \
`$ git checkout pull/10241` \
`$ git pull https://git.openjdk.org/jdk pull/10241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10241`

View PR using the GUI difftool: \
`$ git pr show -t 10241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10241.diff">https://git.openjdk.org/jdk/pull/10241.diff</a>

</details>
