### PR TITLE
JDK-8293626: AccessFlag::locations(ClassFileFormatVersion cffv) does not throw NPEx when parameter is null

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -26,6 +26,7 @@
 package java.lang.reflect;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -324,7 +325,7 @@ public enum AccessFlag {
      * major versions 46 through 60, inclusive (JVMS {@jvms 4.6}),
      * corresponding to Java SE 1.2 through 16.
      */
-    STRICT(Modifier.STRICT, true, Location.SET_METHOD,
+    STRICT(Modifier.STRICT, true, Location.EMPTY_SET,
              new Function<ClassFileFormatVersion, Set<Location>>() {
                @Override
                public Set<Location> apply(ClassFileFormatVersion cffv) {
@@ -470,6 +471,7 @@ public enum AccessFlag {
      * @throws NullPointerException if the parameter is {@code null}
      */
     public Set<Location> locations(ClassFileFormatVersion cffv) {
+        Objects.requireNonNull(cffv);
         if (cffvToLocations == null) {
             return locations;
         } else {

--- a/test/jdk/java/lang/reflect/AccessFlag/BasicAccessFlagTest.java
+++ b/test/jdk/java/lang/reflect/AccessFlag/BasicAccessFlagTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8266670
+ * @bug 8266670 8293626
  * @summary Basic tests of AccessFlag
  */
 
@@ -42,6 +42,7 @@ public class BasicAccessFlagTest {
         testMaskOrdering();
         testDisjoint();
         testMaskToAccessFlagsPositive();
+        testLocationsNullHandling();
     }
 
     /*
@@ -144,6 +145,17 @@ public class BasicAccessFlagTest {
                     throw new RuntimeException("Bad set computation on " +
                                                accessFlag + ", " + location);
                 }
+            }
+        }
+    }
+
+    private static void testLocationsNullHandling() {
+        for (var flag : AccessFlag.values() ) {
+            try {
+                flag.locations(null);
+                throw new RuntimeException("Did not get NPE on " + flag + ".location(null)");
+            } catch (NullPointerException npe ) {
+                ; // Expected
             }
         }
     }

--- a/test/jdk/java/lang/reflect/AccessFlag/VersionedLocationsTest.java
+++ b/test/jdk/java/lang/reflect/AccessFlag/VersionedLocationsTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8289106
+ * @bug 8289106 8293627
  * @summary Tests of AccessFlag.locations(ClassFileFormatVersion)
  */
 
@@ -78,6 +78,7 @@ public class VersionedLocationsTest {
         testTwoStepAccessFlags();
         testSynthetic();
         testStrict();
+        testLatestMatch();
     }
 
     /**
@@ -269,4 +270,19 @@ public class VersionedLocationsTest {
             compareLocations(expected, STRICT, cffv);
         }
     }
+
+    private static void testLatestMatch() {
+        // Verify accessFlag.locations() and
+        // accessFlag.locations(ClassFileFormatVersion.latest()) are
+        // consistent
+        var LATEST = ClassFileFormatVersion.latest();
+        for (var accessFlag : AccessFlag.values()) {
+            var locationSet = accessFlag.locations();
+            var locationLatestSet = accessFlag.locations(LATEST);
+            if (!locationSet.equals(locationLatestSet)) {
+                throw new RuntimeException("Unequal location sets for " + accessFlag);
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Small fixes to AccessFlag implementation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8293626](https://bugs.openjdk.org/browse/JDK-8293626): AccessFlag::locations(ClassFileFormatVersion cffv) does not throw NPEx when parameter is null
 * [JDK-8293627](https://bugs.openjdk.org/browse/JDK-8293627): AccessFlag::locations(ClassFileFormatVersion cffv) and locations() results are inconsistent


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10243/head:pull/10243` \
`$ git checkout pull/10243`

Update a local copy of the PR: \
`$ git checkout pull/10243` \
`$ git pull https://git.openjdk.org/jdk pull/10243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10243`

View PR using the GUI difftool: \
`$ git pr show -t 10243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10243.diff">https://git.openjdk.org/jdk/pull/10243.diff</a>

</details>
