### PR TITLE
8287394: AArch64: Remove cbuf parameter from far_call/far_jump/trampoline_call

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3622,7 +3622,7 @@ encode %{
     address call;
     if (!_method) {
       // A call to a runtime wrapper, e.g. new, new_typeArray_Java, uncommon_trap.
-      call = __ trampoline_call(Address(addr, relocInfo::runtime_call_type), &cbuf);
+      call = __ trampoline_call(Address(addr, relocInfo::runtime_call_type));
       if (call == NULL) {
         ciEnv::current()->record_failure("CodeCache is full");
         return;
@@ -3631,7 +3631,7 @@ encode %{
       int method_index = resolved_method_index(cbuf);
       RelocationHolder rspec = _optimized_virtual ? opt_virtual_call_Relocation::spec(method_index)
                                                   : static_call_Relocation::spec(method_index);
-      call = __ trampoline_call(Address(addr, rspec), &cbuf);
+      call = __ trampoline_call(Address(addr, rspec));
       if (call == NULL) {
         ciEnv::current()->record_failure("CodeCache is full");
         return;
@@ -3639,10 +3639,10 @@ encode %{
       if (CodeBuffer::supports_shared_stubs() && _method->can_be_statically_bound()) {
         // Calls of the same statically bound method can share
         // a stub to the interpreter.
-        cbuf.shared_stub_to_interp_for(_method, cbuf.insts()->mark_off());
+        cbuf.shared_stub_to_interp_for(_method, call - cbuf.insts_begin());
       } else {
         // Emit stub for static call
-        address stub = CompiledStaticCall::emit_to_interp_stub(cbuf);
+        address stub = CompiledStaticCall::emit_to_interp_stub(cbuf, call);
         if (stub == NULL) {
           ciEnv::current()->record_failure("CodeCache is full");
           return;
@@ -3650,7 +3650,6 @@ encode %{
       }
     }
 
-    _masm.clear_inst_mark();
     __ post_call_nop();
 
     // Only non uncommon_trap calls need to reinitialize ptrue.
@@ -3697,7 +3696,6 @@ encode %{
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
-      _masm.clear_inst_mark();
       __ post_call_nop();
     } else {
       Label retaddr;

--- a/src/hotspot/cpu/aarch64/c1_CodeStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_CodeStubs_aarch64.cpp
@@ -308,7 +308,7 @@ void SimpleExceptionStub::emit_code(LIR_Assembler* ce) {
   if (_obj->is_cpu_register()) {
     __ mov(rscratch1, _obj->as_register());
   }
-  __ far_call(RuntimeAddress(Runtime1::entry_for(_stub)), NULL, rscratch2);
+  __ far_call(RuntimeAddress(Runtime1::entry_for(_stub)), rscratch2);
   ce->add_call_info_here(_info);
   debug_only(__ should_not_reach_here());
 }

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1178,8 +1178,8 @@ public:
   // - relocInfo::static_call_type
   // - relocInfo::virtual_call_type
   //
-  // Return: NULL if CodeCache is full.
-  address trampoline_call(Address entry, CodeBuffer* cbuf = NULL);
+  // Return: the call PC or NULL if CodeCache is full.
+  address trampoline_call(Address entry);
 
   static bool far_branches() {
     return ReservedCodeCacheSize > branch_range;
@@ -1201,8 +1201,8 @@ public:
   // The tmp register is invalidated.
   //
   // Far_jump returns the amount of the emitted code.
-  void far_call(Address entry, CodeBuffer *cbuf = NULL, Register tmp = rscratch1);
-  int far_jump(Address entry, CodeBuffer *cbuf = NULL, Register tmp = rscratch1);
+  void far_call(Address entry, Register tmp = rscratch1);
+  int far_jump(Address entry, Register tmp = rscratch1);
 
   static int far_codestub_branch_size() {
     if (codestub_branch_needs_far_jump()) {

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -1052,8 +1052,7 @@ static void gen_continuation_enter(MacroAssembler* masm,
 
     __ cbnz(c_rarg2, call_thaw);
 
-    address mark = __ pc();
-    __ trampoline_call(resolve);
+    const address tr_call = __ trampoline_call(resolve);
 
     oop_maps->add_gc_map(__ pc() - start, map);
     __ post_call_nop();
@@ -1061,7 +1060,7 @@ static void gen_continuation_enter(MacroAssembler* masm,
     __ b(exit);
 
     CodeBuffer* cbuf = masm->code_section()->outer();
-    CompiledStaticCall::emit_to_interp_stub(*cbuf, mark);
+    CompiledStaticCall::emit_to_interp_stub(*cbuf, tr_call);
   }
 
   // compiled entry
@@ -1077,8 +1076,7 @@ static void gen_continuation_enter(MacroAssembler* masm,
 
   __ cbnz(c_rarg2, call_thaw);
 
-  address mark = __ pc();
-  __ trampoline_call(resolve);
+  const address tr_call = __ trampoline_call(resolve);
 
   oop_maps->add_gc_map(__ pc() - start, map);
   __ post_call_nop();
@@ -1120,7 +1118,7 @@ static void gen_continuation_enter(MacroAssembler* masm,
   }
 
   CodeBuffer* cbuf = masm->code_section()->outer();
-  CompiledStaticCall::emit_to_interp_stub(*cbuf, mark);
+  CompiledStaticCall::emit_to_interp_stub(*cbuf, tr_call);
 }
 
 static void gen_continuation_yield(MacroAssembler* masm,


### PR DESCRIPTION
`far_call`/`far_jump`/`trampoline_call` have parameter `cbuf` with the default value `NULL`. We always call `far_call`/`far_jump` with `NULL`. We call  `trampoline_call` with either `NULL` or the `CodeBuffer` currently used by `MacroAssembler`. If not `NULL` we mark a trampoline call position.

Andrew Haley(@theRealAph) in https://github.com/openjdk/jdk/pull/8564#discussion_r871062342 suggests to remove it.

This PR removes the parameter. In the case of `trampoline_call` we explicitly return the position of the generated trampoline calls. All places using the position of the generated trampoline call are updated.

Tested with release and fastdebug builds:
- `gtest`: Passed.
- `tier1`/`tier2`: Passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287394](https://bugs.openjdk.org/browse/JDK-8287394): AArch64: Remove cbuf parameter from far_call/far_jump/trampoline_call


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10244/head:pull/10244` \
`$ git checkout pull/10244`

Update a local copy of the PR: \
`$ git checkout pull/10244` \
`$ git pull https://git.openjdk.org/jdk pull/10244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10244`

View PR using the GUI difftool: \
`$ git pr show -t 10244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10244.diff">https://git.openjdk.org/jdk/pull/10244.diff</a>

</details>
