### PR TITLE
8293669: SA: Remove unnecssary "InstanceStackChunkKlass: InstanceStackChunkKlass" output when scanning heap

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceStackChunkKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceStackChunkKlass.java
@@ -46,7 +46,6 @@ public class InstanceStackChunkKlass extends InstanceKlass {
   private static synchronized void initialize(TypeDataBase db) throws WrongTypeException {
     // Just make sure it's there for now
     Type type = db.lookupType("InstanceStackChunkKlass");
-    System.out.println("InstanceStackChunkKlass: " + type);
   }
 
   public InstanceStackChunkKlass(Address addr) {


### PR DESCRIPTION
Get rid of the following "debugging" output that was introduced in the loom repo:

` InstanceStackChunkKlass: InstanceStackChunkKlass `

I'd like to push this as a trivial change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293669](https://bugs.openjdk.org/browse/JDK-8293669): SA: Remove unnecssary "InstanceStackChunkKlass: InstanceStackChunkKlass" output when scanning heap


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10245/head:pull/10245` \
`$ git checkout pull/10245`

Update a local copy of the PR: \
`$ git checkout pull/10245` \
`$ git pull https://git.openjdk.org/jdk pull/10245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10245`

View PR using the GUI difftool: \
`$ git pr show -t 10245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10245.diff">https://git.openjdk.org/jdk/pull/10245.diff</a>

</details>
