### PR TITLE
JDK-8293676: riscv: Trampoline not created for far runtime targets outside small CodeCache

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2816,8 +2816,23 @@ address MacroAssembler::trampoline_call(Address entry, CodeBuffer* cbuf) {
          entry.rspec().type() == relocInfo::static_call_type ||
          entry.rspec().type() == relocInfo::virtual_call_type, "wrong reloc type");
 
+  bool need_trampoline = far_branches();
+  if (!need_trampoline && entry.rspec().type() == relocInfo::runtime_call_type && !CodeCache::contains(entry.target())) {
+    // If it is a runtime call of an address outside small CodeCache,
+    // we need to check whether it is in range.
+    address target = entry.target();
+    assert(target < CodeCache::low_bound() || target >= CodeCache::high_bound(), "target is inside CodeCache");
+    // Case 1: -------T-------L====CodeCache====H-------
+    //                ^-------longest branch---|
+    // Case 2: -------L====CodeCache====H-------T-------
+    //                |-------longest branch ---^
+    address longest_branch_start = (target < CodeCache::low_bound()) ? CodeCache::high_bound() - NativeInstruction::instruction_size
+                                                                     : CodeCache::low_bound();
+    need_trampoline = !reachable_from_branch_at(longest_branch_start, target);
+  }
+
   // We need a trampoline if branches are far.
-  if (far_branches()) {
+  if (need_trampoline) {
     bool in_scratch_emit_size = false;
 #ifdef COMPILER2
     // We don't want to emit a trampoline if C2 is generating dummy
@@ -2838,7 +2853,7 @@ address MacroAssembler::trampoline_call(Address entry, CodeBuffer* cbuf) {
 
   if (cbuf != NULL) { cbuf->set_insts_mark(); }
   relocate(entry.rspec());
-  if (!far_branches()) {
+  if (!need_trampoline) {
     jal(entry.target());
   } else {
     jal(pc());


### PR DESCRIPTION
Follow up [JDK-8286314](https://bugs.openjdk.org/browse/JDK-8286314), this case also exists in riscv.

`relocInfo::runtime_call_type` calls can have targets inside or outside CodeCache. If offsets to the targets are not in range, trampoline calls must be used. Currently trampolines for calls are generated based on the size of CodeCache and the maximum possible branch range. If the size of CodeCache is smaller than the range, no trampoline is generated. This works well if a target is inside CodeCache. It does not work if a target is outside CodeCache and CodeCache size is smaller than the maximum possible branch range.

## Testing:

- hotspot/jdk tier1 on unmatched board

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293676](https://bugs.openjdk.org/browse/JDK-8293676): riscv: Trampoline not created for far runtime targets outside small CodeCache


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10246/head:pull/10246` \
`$ git checkout pull/10246`

Update a local copy of the PR: \
`$ git checkout pull/10246` \
`$ git pull https://git.openjdk.org/jdk pull/10246/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10246`

View PR using the GUI difftool: \
`$ git pr show -t 10246`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10246.diff">https://git.openjdk.org/jdk/pull/10246.diff</a>

</details>
