### PR TITLE
8293680: PPC64BE build failure after JDK-8293344

### DIFF
--- a/src/hotspot/share/utilities/elfFile.cpp
+++ b/src/hotspot/share/utilities/elfFile.cpp
@@ -34,7 +34,6 @@
 #include "jvm_io.h"
 #include "logging/log.hpp"
 #include "memory/allocation.inline.hpp"
-#include "memory/resourceArea.hpp"
 #include "utilities/decoder.hpp"
 #include "utilities/elfFile.hpp"
 #include "utilities/elfFuncDescTable.hpp"
@@ -259,7 +258,6 @@ NullDecoder::decoder_status ElfFile::load_tables() {
 int ElfFile::section_by_name(const char* name, Elf_Shdr& hdr) {
   assert(name != NULL, "No section name");
   size_t len = strlen(name) + 1;
-  ResourceMark rm;
   char* buf = (char*)os::malloc(len, mtInternal);
   if (buf == NULL) {
     return -1;

--- a/src/hotspot/share/utilities/elfFile.cpp
+++ b/src/hotspot/share/utilities/elfFile.cpp
@@ -34,6 +34,7 @@
 #include "jvm_io.h"
 #include "logging/log.hpp"
 #include "memory/allocation.inline.hpp"
+#include "memory/resourceArea.hpp"
 #include "utilities/decoder.hpp"
 #include "utilities/elfFile.hpp"
 #include "utilities/elfFuncDescTable.hpp"


### PR DESCRIPTION
The bug manifests on PPC64, since `section_by_name` is protected by `#if defined(PPC64) && !defined(ABI_ELFv2)`:

```
* For target hotspot_variant-server_libjvm_objs_elfFile.o:
/home/shade/trunks/jdk/src/hotspot/share/utilities/elfFile.cpp: In member function 'int ElfFile::section_by_name(const char*, Elf_Shdr&)':
/home/shade/trunks/jdk/src/hotspot/share/utilities/elfFile.cpp:261:16: error: aggregate 'ResourceMark rm' has incomplete type and cannot be defined
  261 | ResourceMark rm;
      | ^~
``` 

This restores the include that previous commit removed: https://github.com/openjdk/jdk/commit/d4e3e69505db1b114afec2f6a61acf1261a8e69c

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293680](https://bugs.openjdk.org/browse/JDK-8293680): PPC64BE build failure after JDK-8293344


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10247/head:pull/10247` \
`$ git checkout pull/10247`

Update a local copy of the PR: \
`$ git checkout pull/10247` \
`$ git pull https://git.openjdk.org/jdk pull/10247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10247`

View PR using the GUI difftool: \
`$ git pr show -t 10247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10247.diff">https://git.openjdk.org/jdk/pull/10247.diff</a>

</details>
