### PR TITLE
8295964: Move InstanceKlass::_misc_flags

### DIFF
--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -160,7 +160,7 @@
   nonstatic_field(InstanceKlass,               _constants,                                    ConstantPool*)                         \
   nonstatic_field(InstanceKlass,               _init_state,                                   InstanceKlass::ClassState)             \
   nonstatic_field(InstanceKlass,               _init_thread,                                  Thread*)                               \
-  nonstatic_field(InstanceKlass,               _misc_flags,                                   u2)                                    \
+  nonstatic_field(InstanceKlass,               _misc_status._flags,                           u2)                                    \
   nonstatic_field(InstanceKlass,               _annotations,                                  Annotations*)                          \
                                                                                                                                      \
   volatile_nonstatic_field(JavaFrameAnchor,    _last_Java_sp,                                 intptr_t*)                             \
@@ -651,8 +651,8 @@
   /* InstanceKlass _misc_flags */                                         \
   /*********************************/                                     \
                                                                           \
-  declare_constant(InstanceKlass::_misc_has_nonstatic_concrete_methods)   \
-  declare_constant(InstanceKlass::_misc_declares_nonstatic_concrete_methods) \
+  declare_constant(InstanceKlassMiscStatus::_misc_has_nonstatic_concrete_methods)   \
+  declare_constant(InstanceKlassMiscStatus::_misc_declares_nonstatic_concrete_methods) \
                                                                           \
   declare_constant(JumpData::taken_off_set)                               \
   declare_constant(JumpData::displacement_off_set)                        \

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2621,36 +2621,6 @@ bool InstanceKlass::can_be_verified_at_dumptime() const {
   }
   return true;
 }
-
-void InstanceKlass::set_shared_class_loader_type(s2 loader_type) {
-  switch (loader_type) {
-  case ClassLoader::BOOT_LOADER:
-    _misc_flags |= _misc_is_shared_boot_class;
-    break;
-  case ClassLoader::PLATFORM_LOADER:
-    _misc_flags |= _misc_is_shared_platform_class;
-    break;
-  case ClassLoader::APP_LOADER:
-    _misc_flags |= _misc_is_shared_app_class;
-    break;
-  default:
-    ShouldNotReachHere();
-    break;
-  }
-}
-
-void InstanceKlass::assign_class_loader_type() {
-  ClassLoaderData *cld = class_loader_data();
-  if (cld->is_boot_class_loader_data()) {
-    set_shared_class_loader_type(ClassLoader::BOOT_LOADER);
-  }
-  else if (cld->is_platform_class_loader_data()) {
-    set_shared_class_loader_type(ClassLoader::PLATFORM_LOADER);
-  }
-  else if (cld->is_system_class_loader_data()) {
-    set_shared_class_loader_type(ClassLoader::APP_LOADER);
-  }
-}
 #endif // INCLUDE_CDS
 
 #if INCLUDE_JVMTI

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -29,6 +29,7 @@
 #include "oops/annotations.hpp"
 #include "oops/constMethod.hpp"
 #include "oops/fieldInfo.hpp"
+#include "oops/instanceKlassMiscStatus.hpp"
 #include "oops/instanceOop.hpp"
 #include "runtime/handles.hpp"
 #include "utilities/accessFlags.hpp"
@@ -222,33 +223,15 @@ class InstanceKlass: public Klass {
   volatile u2     _idnum_allocated_count;   // JNI/JVMTI: increments with the addition of methods, old ids don't change
 
   // _is_marked_dependent can be set concurrently, thus cannot be part of the
-  // _misc_flags.
+  // _misc_status right now.
   bool            _is_marked_dependent;     // used for marking during flushing and deoptimization
 
   ClassState      _init_state;              // state of class
 
   u1              _reference_type;          // reference type
 
-  enum {
-    _misc_rewritten                           = 1 << 0,  // methods rewritten.
-    _misc_has_nonstatic_fields                = 1 << 1,  // for sizing with UseCompressedOops
-    _misc_should_verify_class                 = 1 << 2,  // allow caching of preverification
-    _misc_unused                              = 1 << 3,  // not currently used
-    _misc_is_contended                        = 1 << 4,  // marked with contended annotation
-    _misc_has_nonstatic_concrete_methods      = 1 << 5,  // class/superclass/implemented interfaces has non-static, concrete methods
-    _misc_declares_nonstatic_concrete_methods = 1 << 6,  // directly declares non-static, concrete methods
-    _misc_has_been_redefined                  = 1 << 7,  // class has been redefined
-    _misc_shared_loading_failed               = 1 << 8,  // class has been loaded from shared archive
-    _misc_is_scratch_class                    = 1 << 9,  // class is the redefined scratch class
-    _misc_is_shared_boot_class                = 1 << 10, // defining class loader is boot class loader
-    _misc_is_shared_platform_class            = 1 << 11, // defining class loader is platform class loader
-    _misc_is_shared_app_class                 = 1 << 12, // defining class loader is app class loader
-    _misc_has_contended_annotations           = 1 << 13  // has @Contended annotation
-  };
-  u2 shared_loader_type_bits() const {
-    return _misc_is_shared_boot_class|_misc_is_shared_platform_class|_misc_is_shared_app_class;
-  }
-  u2              _misc_flags;           // There is more space in access_flags for more flags.
+  // State is set while executing, eventually atomically to not disturb other state
+  InstanceKlassMiscStatus _misc_status;
 
   Monitor*        _init_monitor;         // mutual exclusion to _init_state and _init_thread.
   Thread*         _init_thread;          // Pointer to current thread doing initialization (to handle recursive initialization)
@@ -332,44 +315,26 @@ class InstanceKlass: public Klass {
   static void set_finalization_enabled(bool val) { _finalization_enabled = val; }
 
   // The three BUILTIN class loader types
-  bool is_shared_boot_class() const {
-    return (_misc_flags & _misc_is_shared_boot_class) != 0;
-  }
-  bool is_shared_platform_class() const {
-    return (_misc_flags & _misc_is_shared_platform_class) != 0;
-  }
-  bool is_shared_app_class() const {
-    return (_misc_flags & _misc_is_shared_app_class) != 0;
-  }
+  bool is_shared_boot_class() const { return _misc_status.is_shared_boot_class(); }
+  bool is_shared_platform_class() const { return _misc_status.is_shared_platform_class(); }
+  bool is_shared_app_class() const {  return _misc_status.is_shared_app_class(); }
   // The UNREGISTERED class loader type
-  bool is_shared_unregistered_class() const {
-    return (_misc_flags & shared_loader_type_bits()) == 0;
-  }
+  bool is_shared_unregistered_class() const { return _misc_status.is_shared_unregistered_class(); }
 
   // Check if the class can be shared in CDS
   bool is_shareable() const;
 
-  bool shared_loading_failed() const {
-    return (_misc_flags & _misc_shared_loading_failed) != 0;
-  }
+  bool shared_loading_failed() const { return _misc_status.shared_loading_failed(); }
 
-  void set_shared_loading_failed() {
-    _misc_flags |= _misc_shared_loading_failed;
-  }
+  void set_shared_loading_failed() { _misc_status.set_shared_loading_failed(true); }
 
-  void set_shared_class_loader_type(s2 loader_type);
+#if INCLUDE_CDS
+  void set_shared_class_loader_type(s2 loader_type) { _misc_status.set_shared_class_loader_type(loader_type); }
+  void assign_class_loader_type() { _misc_status.assign_class_loader_type(_class_loader_data); }
+#endif
 
-  void assign_class_loader_type();
-
-  bool has_nonstatic_fields() const        {
-    return (_misc_flags & _misc_has_nonstatic_fields) != 0;
-  }
-  void set_has_nonstatic_fields(bool b)    {
-    assert(!has_nonstatic_fields(), "set once");
-    if (b) {
-      _misc_flags |= _misc_has_nonstatic_fields;
-    }
-  }
+  bool has_nonstatic_fields() const        { return _misc_status.has_nonstatic_fields(); }
+  void set_has_nonstatic_fields(bool b)    { _misc_status.set_has_nonstatic_fields(b); }
 
   // field sizes
   int nonstatic_field_size() const         { return _nonstatic_field_size; }
@@ -546,7 +511,7 @@ public:
   bool is_init_thread(Thread *thread)      { return thread == _init_thread; }
   ClassState  init_state() const           { return Atomic::load(&_init_state); }
   const char* init_state_name() const;
-  bool is_rewritten() const                { return (_misc_flags & _misc_rewritten) != 0; }
+  bool is_rewritten() const                { return _misc_status.rewritten(); }
 
   class LockLinkState : public StackObj {
     InstanceKlass* _ik;
@@ -567,15 +532,8 @@ public:
   bool is_sealed() const;
 
   // defineClass specified verification
-  bool should_verify_class() const         {
-    return (_misc_flags & _misc_should_verify_class) != 0;
-  }
-  void set_should_verify_class(bool value) {
-    assert(!should_verify_class(), "set once");
-    if (value) {
-      _misc_flags |= _misc_should_verify_class;
-    }
-  }
+  bool should_verify_class() const         { return _misc_status.should_verify_class(); }
+  void set_should_verify_class(bool value) { _misc_status.set_should_verify_class(value); }
 
   // marking
   bool is_marked_dependent() const         { return _is_marked_dependent; }
@@ -691,15 +649,8 @@ public:
   // signers
   objArrayOop signers() const;
 
-  bool is_contended() const                {
-    return (_misc_flags & _misc_is_contended) != 0;
-  }
-  void set_is_contended(bool value)        {
-    assert(!is_contended(), "set once");
-    if (value) {
-      _misc_flags |= _misc_is_contended;
-    }
-  }
+  bool is_contended() const                { return _misc_status.is_contended(); }
+  void set_is_contended(bool value)        { _misc_status.set_is_contended(value); }
 
   // source file name
   Symbol* source_file_name() const               { return _constants->source_file_name(); }
@@ -728,15 +679,8 @@ public:
     _nonstatic_oop_map_size = words;
   }
 
-  bool has_contended_annotations() const {
-    return ((_misc_flags & _misc_has_contended_annotations) != 0);
-  }
-  void set_has_contended_annotations(bool value)  {
-    assert(!has_contended_annotations(), "set once");
-    if (value) {
-      _misc_flags |= _misc_has_contended_annotations;
-    }
-  }
+  bool has_contended_annotations() const { return _misc_status.has_contended_annotations(); }
+  void set_has_contended_annotations(bool value)  { _misc_status.set_has_contended_annotations(value); }
 
 #if INCLUDE_JVMTI
   // Redefinition locking.  Class can only be redefined by one thread at a time.
@@ -771,20 +715,11 @@ public:
     return NULL;
   }
 
-  bool has_been_redefined() const {
-    return (_misc_flags & _misc_has_been_redefined) != 0;
-  }
-  void set_has_been_redefined() {
-    _misc_flags |= _misc_has_been_redefined;
-  }
+  bool has_been_redefined() const { return _misc_status.has_been_redefined(); }
+  void set_has_been_redefined() { _misc_status.set_has_been_redefined(true); }
 
-  bool is_scratch_class() const {
-    return (_misc_flags & _misc_is_scratch_class) != 0;
-  }
-
-  void set_is_scratch_class() {
-    _misc_flags |= _misc_is_scratch_class;
-  }
+  bool is_scratch_class() const { return _misc_status.is_scratch_class(); }
+  void set_is_scratch_class() { _misc_status.set_is_scratch_class(true); }
 
   bool has_resolved_methods() const {
     return _access_flags.has_resolved_methods();
@@ -840,25 +775,11 @@ public:
 
 #endif // INCLUDE_JVMTI
 
-  bool has_nonstatic_concrete_methods() const {
-    return (_misc_flags & _misc_has_nonstatic_concrete_methods) != 0;
-  }
-  void set_has_nonstatic_concrete_methods(bool b) {
-    assert(!has_nonstatic_concrete_methods(), "set once");
-    if (b) {
-      _misc_flags |= _misc_has_nonstatic_concrete_methods;
-    }
-  }
+  bool has_nonstatic_concrete_methods() const { return _misc_status.has_nonstatic_concrete_methods(); }
+  void set_has_nonstatic_concrete_methods(bool b) { _misc_status.set_has_nonstatic_concrete_methods(b); }
 
-  bool declares_nonstatic_concrete_methods() const {
-    return (_misc_flags & _misc_declares_nonstatic_concrete_methods) != 0;
-  }
-  void set_declares_nonstatic_concrete_methods(bool b) {
-    assert(!declares_nonstatic_concrete_methods(), "set once");
-    if (b) {
-      _misc_flags |= _misc_declares_nonstatic_concrete_methods;
-    }
-  }
+  bool declares_nonstatic_concrete_methods() const { return _misc_status.declares_nonstatic_concrete_methods(); }
+  void set_declares_nonstatic_concrete_methods(bool b) { _misc_status.set_declares_nonstatic_concrete_methods(b); }
 
   // for adding methods, ConstMethod::UNSET_IDNUM means no more ids available
   inline u2 next_method_idnum();
@@ -1152,7 +1073,7 @@ public:
  private:
   // initialization state
   void set_init_state(ClassState state);
-  void set_rewritten()                  { _misc_flags |= _misc_rewritten; }
+  void set_rewritten()                  { _misc_status.set_rewritten(true); }
   void set_init_thread(Thread *thread)  {
     assert(thread == nullptr || _init_thread == nullptr, "Only one thread is allowed to own initialization");
     _init_thread = thread;

--- a/src/hotspot/share/oops/instanceKlassMiscStatus.cpp
+++ b/src/hotspot/share/oops/instanceKlassMiscStatus.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "classfile/classLoader.hpp"
+#include "classfile/classLoaderData.inline.hpp"
+#include "oops/instanceKlassMiscStatus.hpp"
+#include "utilities/macros.hpp"
+
+#if INCLUDE_CDS
+void InstanceKlassMiscStatus::set_shared_class_loader_type(s2 loader_type) {
+  switch (loader_type) {
+  case ClassLoader::BOOT_LOADER:
+    _flags |= _misc_is_shared_boot_class;
+    break;
+  case ClassLoader::PLATFORM_LOADER:
+    _flags |= _misc_is_shared_platform_class;
+    break;
+  case ClassLoader::APP_LOADER:
+    _flags |= _misc_is_shared_app_class;
+    break;
+  default:
+    ShouldNotReachHere();
+    break;
+  }
+}
+
+void InstanceKlassMiscStatus::assign_class_loader_type(const ClassLoaderData* cld) {
+  if (cld->is_boot_class_loader_data()) {
+    set_shared_class_loader_type(ClassLoader::BOOT_LOADER);
+  }
+  else if (cld->is_platform_class_loader_data()) {
+    set_shared_class_loader_type(ClassLoader::PLATFORM_LOADER);
+  }
+  else if (cld->is_system_class_loader_data()) {
+    set_shared_class_loader_type(ClassLoader::APP_LOADER);
+  }
+}
+#endif // INCLUDE_CDS

--- a/src/hotspot/share/oops/instanceKlassMiscStatus.hpp
+++ b/src/hotspot/share/oops/instanceKlassMiscStatus.hpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_OOPS_INSTANCEKLASSMISCSTATUS_HPP
+#define SHARE_OOPS_INSTANCEKLASSMISCSTATUS_HPP
+
+class ClassLoaderData;
+
+class InstanceKlassMiscStatus {
+  friend class VMStructs;
+  friend class JVMCIVMStructs;
+
+#define IK_FLAGS_DO(flag)  \
+    flag(rewritten                          , 1 << 0) /* methods rewritten. */ \
+    flag(has_nonstatic_fields               , 1 << 1) /* for sizing with UseCompressedOops */ \
+    flag(should_verify_class                , 1 << 2) /* allow caching of preverification */ \
+    flag(unused                             , 1 << 3) /* not currently used */ \
+    flag(is_contended                       , 1 << 4) /* marked with contended annotation */ \
+    flag(has_nonstatic_concrete_methods     , 1 << 5) /* class/superclass/implemented interfaces has non-static, concrete methods */ \
+    flag(declares_nonstatic_concrete_methods, 1 << 6) /* directly declares non-static, concrete methods */ \
+    flag(has_been_redefined                 , 1 << 7) /* class has been redefined */ \
+    flag(shared_loading_failed              , 1 << 8) /* class has been loaded from shared archive */ \
+    flag(is_scratch_class                   , 1 << 9) /* class is the redefined scratch class */ \
+    flag(is_shared_boot_class               , 1 << 10) /* defining class loader is boot class loader */ \
+    flag(is_shared_platform_class           , 1 << 11) /* defining class loader is platform class loader */ \
+    flag(is_shared_app_class                , 1 << 12) /* defining class loader is app class loader */ \
+    flag(has_contended_annotations          , 1 << 13) /* has @Contended annotation */
+
+#define IK_FLAGS_ENUM_NAME(name, value)    _misc_##name = value,
+  enum {
+    IK_FLAGS_DO(IK_FLAGS_ENUM_NAME)
+  };
+#undef IK_FLAGS_ENUM_NAME
+
+  u2 shared_loader_type_bits() const {
+    return _misc_is_shared_boot_class|_misc_is_shared_platform_class|_misc_is_shared_app_class;
+  }
+
+  // These flags are write-once before the class is published and then read-only so don't require atomic updates.
+  u2 _flags;
+
+ public:
+
+  InstanceKlassMiscStatus() : _flags(0) {}
+
+  // Create getters and setters for the flag values.
+#define IK_FLAGS_GET(name, ignore)          \
+  bool name() const { return (_flags & _misc_##name) != 0; }
+  IK_FLAGS_DO(IK_FLAGS_GET)
+#undef IK_FLAGS_GET
+
+#define IK_FLAGS_SET(name, ignore)   \
+  void set_##name(bool b) {         \
+    assert(!name(), "set once");    \
+    if (b) _flags |= _misc_##name; \
+  }
+  IK_FLAGS_DO(IK_FLAGS_SET)
+#undef IK_FLAGS_SET
+
+  bool is_shared_unregistered_class() const {
+    return (_flags & shared_loader_type_bits()) == 0;
+  }
+
+  void set_shared_class_loader_type(s2 loader_type);
+
+  void assign_class_loader_type(const ClassLoaderData* cld);
+};
+
+#endif // SHARE_OOPS_INSTANCEKLASSMISCSTATUS_HPP

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -4403,7 +4403,9 @@ void VM_RedefineClasses::redefine_single_class(Thread* current, jclass the_jclas
     scratch_class->enclosing_method_method_index());
   scratch_class->set_enclosing_method_indices(old_class_idx, old_method_idx);
 
-  the_class->set_has_been_redefined();
+  if (!the_class->has_been_redefined()) {
+    the_class->set_has_been_redefined();
+  }
 
   // Scratch class is unloaded but still needs cleaning, and skipping for CDS.
   scratch_class->set_is_scratch_class();

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -236,7 +236,6 @@
   nonstatic_field(InstanceKlass,               _static_oop_field_count,                       u2)                                    \
   nonstatic_field(InstanceKlass,               _nonstatic_oop_map_size,                       int)                                   \
   nonstatic_field(InstanceKlass,               _is_marked_dependent,                          bool)                                  \
-  nonstatic_field(InstanceKlass,               _misc_flags,                                   u2)                                    \
   nonstatic_field(InstanceKlass,               _init_state,                                   InstanceKlass::ClassState)             \
   nonstatic_field(InstanceKlass,               _init_thread,                                  Thread*)                               \
   nonstatic_field(InstanceKlass,               _itable_len,                                   int)                                   \
@@ -2283,22 +2282,6 @@
   declare_constant(InstanceKlass::being_initialized)                      \
   declare_constant(InstanceKlass::fully_initialized)                      \
   declare_constant(InstanceKlass::initialization_error)                   \
-                                                                          \
-  /***************************************/                               \
-  /* InstanceKlass enums for _misc_flags */                               \
-  /***************************************/                               \
-                                                                          \
-  declare_constant(InstanceKlass::_misc_rewritten)                        \
-  declare_constant(InstanceKlass::_misc_has_nonstatic_fields)             \
-  declare_constant(InstanceKlass::_misc_should_verify_class)              \
-  declare_constant(InstanceKlass::_misc_is_contended)                     \
-  declare_constant(InstanceKlass::_misc_has_nonstatic_concrete_methods)   \
-  declare_constant(InstanceKlass::_misc_declares_nonstatic_concrete_methods)\
-  declare_constant(InstanceKlass::_misc_has_been_redefined)               \
-  declare_constant(InstanceKlass::_misc_is_scratch_class)                 \
-  declare_constant(InstanceKlass::_misc_is_shared_boot_class)             \
-  declare_constant(InstanceKlass::_misc_is_shared_platform_class)         \
-  declare_constant(InstanceKlass::_misc_is_shared_app_class)              \
                                                                           \
   /*********************************/                                     \
   /* Symbol* - symbol max length */                                       \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
@@ -66,18 +66,6 @@ public class InstanceKlass extends Klass {
   private static int CLASS_STATE_FULLY_INITIALIZED;
   private static int CLASS_STATE_INITIALIZATION_ERROR;
 
-  // _misc_flags constants
-  private static int MISC_REWRITTEN;
-  private static int MISC_HAS_NONSTATIC_FIELDS;
-  private static int MISC_SHOULD_VERIFY_CLASS;
-  private static int MISC_IS_CONTENDED;
-  private static int MISC_HAS_NONSTATIC_CONCRETE_METHODS;
-  private static int MISC_DECLARES_NONSTATIC_CONCRETE_METHODS;
-  private static int MISC_HAS_BEEN_REDEFINED;
-  private static int MISC_IS_SCRATCH_CLASS;
-  private static int MISC_IS_SHARED_BOOT_CLASS;
-  private static int MISC_IS_SHARED_PLATFORM_CLASS;
-  private static int MISC_IS_SHARED_APP_CLASS;
 
   private static synchronized void initialize(TypeDataBase db) throws WrongTypeException {
     Type type            = db.lookupType("InstanceKlass");
@@ -102,7 +90,6 @@ public class InstanceKlass extends Klass {
     if (VM.getVM().isJvmtiSupported()) {
       breakpoints        = type.getAddressField("_breakpoints");
     }
-    miscFlags            = new CIntField(type.getCIntegerField("_misc_flags"), 0);
     headerSize           = type.getSize();
 
     // read field offset constants
@@ -124,18 +111,6 @@ public class InstanceKlass extends Klass {
     CLASS_STATE_BEING_INITIALIZED = db.lookupIntConstant("InstanceKlass::being_initialized").intValue();
     CLASS_STATE_FULLY_INITIALIZED = db.lookupIntConstant("InstanceKlass::fully_initialized").intValue();
     CLASS_STATE_INITIALIZATION_ERROR = db.lookupIntConstant("InstanceKlass::initialization_error").intValue();
-
-    MISC_REWRITTEN                    = db.lookupIntConstant("InstanceKlass::_misc_rewritten").intValue();
-    MISC_HAS_NONSTATIC_FIELDS         = db.lookupIntConstant("InstanceKlass::_misc_has_nonstatic_fields").intValue();
-    MISC_SHOULD_VERIFY_CLASS          = db.lookupIntConstant("InstanceKlass::_misc_should_verify_class").intValue();
-    MISC_IS_CONTENDED                 = db.lookupIntConstant("InstanceKlass::_misc_is_contended").intValue();
-    MISC_HAS_NONSTATIC_CONCRETE_METHODS      = db.lookupIntConstant("InstanceKlass::_misc_has_nonstatic_concrete_methods").intValue();
-    MISC_DECLARES_NONSTATIC_CONCRETE_METHODS = db.lookupIntConstant("InstanceKlass::_misc_declares_nonstatic_concrete_methods").intValue();
-    MISC_HAS_BEEN_REDEFINED           = db.lookupIntConstant("InstanceKlass::_misc_has_been_redefined").intValue();
-    MISC_IS_SCRATCH_CLASS             = db.lookupIntConstant("InstanceKlass::_misc_is_scratch_class").intValue();
-    MISC_IS_SHARED_BOOT_CLASS         = db.lookupIntConstant("InstanceKlass::_misc_is_shared_boot_class").intValue();
-    MISC_IS_SHARED_PLATFORM_CLASS     = db.lookupIntConstant("InstanceKlass::_misc_is_shared_platform_class").intValue();
-    MISC_IS_SHARED_APP_CLASS          = db.lookupIntConstant("InstanceKlass::_misc_is_shared_app_class").intValue();
   }
 
   public InstanceKlass(Address addr) {
@@ -180,7 +155,6 @@ public class InstanceKlass extends Klass {
   private static CIntField initState;
   private static CIntField itableLen;
   private static AddressField breakpoints;
-  private static CIntField miscFlags;
 
   // type safe enum for ClassState from instanceKlass.hpp
   public static class ClassState {
@@ -286,10 +260,6 @@ public class InstanceKlass extends Klass {
       size += wordLength;
     }
     return alignSize(size);
-  }
-
-  private int getMiscFlags() {
-    return (int) miscFlags.getValue(this);
   }
 
   public static long getHeaderSize() { return headerSize; }

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotVMConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,7 +101,7 @@ class HotSpotVMConfig extends HotSpotVMConfigAccess {
     final int instanceKlassConstantsOffset = getFieldOffset("InstanceKlass::_constants", Integer.class, "ConstantPool*");
     final int instanceKlassFieldsOffset = getFieldOffset("InstanceKlass::_fields", Integer.class, "Array<u2>*");
     final int instanceKlassAnnotationsOffset = getFieldOffset("InstanceKlass::_annotations", Integer.class, "Annotations*");
-    final int instanceKlassMiscFlagsOffset = getFieldOffset("InstanceKlass::_misc_flags", Integer.class, "u2");
+    final int instanceKlassMiscFlagsOffset = getFieldOffset("InstanceKlass::_misc_status._flags", Integer.class, "u2");
     final int klassVtableStartOffset = getFieldValue("CompilerToVM::Data::Klass_vtable_start_offset", Integer.class, "int");
     final int klassVtableLengthOffset = getFieldValue("CompilerToVM::Data::Klass_vtable_length_offset", Integer.class, "int");
 
@@ -139,8 +139,8 @@ class HotSpotVMConfig extends HotSpotVMConfigAccess {
     final int jvmAccEnum = getConstant("JVM_ACC_ENUM", Integer.class);
     final int jvmAccInterface = getConstant("JVM_ACC_INTERFACE", Integer.class);
 
-    final int jvmMiscFlagsHasDefaultMethods = getConstant("InstanceKlass::_misc_has_nonstatic_concrete_methods", Integer.class);
-    final int jvmMiscFlagsDeclaresDefaultMethods = getConstant("InstanceKlass::_misc_declares_nonstatic_concrete_methods", Integer.class);
+    final int jvmMiscFlagsHasDefaultMethods = getConstant("InstanceKlassMiscStatus::_misc_has_nonstatic_concrete_methods", Integer.class);
+    final int jvmMiscFlagsDeclaresDefaultMethods = getConstant("InstanceKlassMiscStatus::_misc_declares_nonstatic_concrete_methods", Integer.class);
 
     // This is only valid on AMD64.
     final int runtimeCallStackSize = getConstant("frame::arg_reg_save_area_bytes", Integer.class, osArch.equals("amd64") ? null : 0);


### PR DESCRIPTION
I moved misc_flags out to their own misc flags class so that we can put the writeable accessFlags there too with atomic access.

Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295964](https://bugs.openjdk.org/browse/JDK-8295964): Move InstanceKlass::_misc_flags


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10249/head:pull/10249` \
`$ git checkout pull/10249`

Update a local copy of the PR: \
`$ git checkout pull/10249` \
`$ git pull https://git.openjdk.org/jdk pull/10249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10249`

View PR using the GUI difftool: \
`$ git pr show -t 10249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10249.diff">https://git.openjdk.org/jdk/pull/10249.diff</a>

</details>
