### PR TITLE
8287217: C2: PhaseCCP: remove not visited nodes, prevent type inconsistency

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -406,7 +406,7 @@ void Compile::remove_useless_node(Node* dead) {
 }
 
 // Disconnect all useless nodes by disconnecting those at the boundary.
-void Compile::remove_useless_nodes(Unique_Node_List &useful) {
+void Compile::disconnect_useless_nodes(Unique_Node_List &useful, Unique_Node_List* worklist) {
   uint next = 0;
   while (next < useful.size()) {
     Node *n = useful.at(next++);
@@ -429,7 +429,7 @@ void Compile::remove_useless_nodes(Unique_Node_List &useful) {
       }
     }
     if (n->outcnt() == 1 && n->has_special_unique_user()) {
-      record_for_igvn(n->unique_out());
+      worklist->push(n->unique_out());
     }
   }
 

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -440,6 +440,11 @@ void Compile::disconnect_useless_nodes(Unique_Node_List &useful, Unique_Node_Lis
   remove_useless_nodes(_for_post_loop_igvn, useful); // remove useless node recorded for post loop opts IGVN pass
   remove_useless_unstable_if_traps(useful);          // remove useless unstable_if traps
   remove_useless_coarsened_locks(useful);            // remove useless coarsened locks nodes
+#ifdef ASSERT
+  if (_modified_nodes != NULL) {
+    _modified_nodes->remove_useless_nodes(useful.member_set());
+  }
+#endif
 
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
   bs->eliminate_useless_gc_barriers(useful, this);

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -951,7 +951,7 @@ class Compile : public Phase {
 
   void              identify_useful_nodes(Unique_Node_List &useful);
   void              update_dead_node_list(Unique_Node_List &useful);
-  void              remove_useless_nodes (Unique_Node_List &useful);
+  void              disconnect_useless_nodes(Unique_Node_List &useful, Unique_Node_List* worklist);
 
   void              remove_useless_node(Node* dead);
 

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1982,8 +1982,8 @@ Node *PhaseCCP::transform( Node *n ) {
     useful.push(new_node);
   }
 
-  while ( transform_stack.is_nonempty() ) {
-    Node *clone = transform_stack.pop();
+  while (transform_stack.is_nonempty()) {
+    Node* clone = transform_stack.pop();
     uint cnt = clone->req();
     for( uint i = 0; i < cnt; i++ ) {          // For all inputs do
       Node *input = clone->in(i);

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1778,7 +1778,7 @@ void PhaseCCP::analyze() {
     if (n->is_SafePoint()) {
       // Make sure safepoints are processed by PhaseCCP::transform even if they are
       // not reachable from the bottom. Otherwise, infinite loops would be removed.
-      //_root_and_safepoints.push(n);
+      _root_and_safepoints.push(n);
     }
     const Type* new_type = n->Value(this);
     if (new_type != type(n)) {

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -423,7 +423,7 @@ PhaseRemoveUseless::PhaseRemoveUseless(PhaseGVN* gvn, Unique_Node_List* worklist
   worklist->remove_useless_nodes(_useful.member_set());
 
   // Disconnect 'useless' nodes that are adjacent to useful nodes
-  C->remove_useless_nodes(_useful);
+  C->disconnect_useless_nodes(_useful, worklist);
 }
 
 //=============================================================================
@@ -1768,13 +1768,17 @@ void PhaseCCP::analyze() {
   Unique_Node_List worklist;
   worklist.push(C->root());
 
+  assert(_root_and_safepoints.size() == 0, "must be empty (unused)");
+  _root_and_safepoints.push(C->root());
+
   // Pull from worklist; compute new value; push changes out.
   // This loop is the meat of CCP.
   while (worklist.size() != 0) {
     Node* n = fetch_next_node(worklist);
     if (n->is_SafePoint()) {
-      // Keep track of SafePoint nodes for PhaseCCP::transform()
-      _safepoints.push(n);
+      // Make sure safepoints are processed by PhaseCCP::transform even if they are
+      // not reachable from the bottom. Otherwise, infinite loops would be removed.
+      //_root_and_safepoints.push(n);
     }
     const Type* new_type = n->Value(this);
     if (new_type != type(n)) {
@@ -1952,14 +1956,15 @@ Node *PhaseCCP::transform( Node *n ) {
   Node *new_node = _nodes[n->_idx]; // Check for transformed node
   if( new_node != NULL )
     return new_node;                // Been there, done that, return old answer
-  new_node = transform_once(n);     // Check for constant
-  _nodes.map( n->_idx, new_node );  // Flag as having been cloned
+
+  assert(n->is_Root(), "traversal must start at root");
+  assert(_root_and_safepoints.member(n), "root (n) must be in list");
 
   // Allocate stack of size _nodes.Size()/2 to avoid frequent realloc
-  GrowableArray <Node *> trstack(C->live_nodes() >> 1);
+  GrowableArray <Node *> transform_stack(C->live_nodes() >> 1);
+  Unique_Node_List useful; // track all visited nodes, so that we can remove the complement
 
-  trstack.push(new_node);           // Process children of cloned node
-
+  // Initialize the traversal.
   // This CCP pass may prove that no exit test for a loop ever succeeds (i.e. the loop is infinite). In that case,
   // the logic below doesn't follow any path from Root to the loop body: there's at least one such path but it's proven
   // never taken (its type is TOP). As a consequence the node on the exit path that's input to Root (let's call it n) is
@@ -1967,17 +1972,18 @@ Node *PhaseCCP::transform( Node *n ) {
   // through the graph from Root, this causes the loop body to never be processed here even when it's not dead (that
   // is reachable from Root following its uses). To prevent that issue, transform() starts walking the graph from Root
   // and all safepoints.
-  for (uint i = 0; i < _safepoints.size(); ++i) {
-    Node* nn = _safepoints.at(i);
+  for (uint i = 0; i < _root_and_safepoints.size(); ++i) {
+    Node* nn = _root_and_safepoints.at(i);
     Node* new_node = _nodes[nn->_idx];
     assert(new_node == NULL, "");
-    new_node = transform_once(nn);
-    _nodes.map(nn->_idx, new_node);
-    trstack.push(new_node);
+    new_node = transform_once(nn);  // Check for constant
+    _nodes.map(nn->_idx, new_node); // Flag as having been cloned
+    transform_stack.push(new_node); // Process children of cloned node
+    useful.push(new_node);
   }
 
-  while ( trstack.is_nonempty() ) {
-    Node *clone = trstack.pop();
+  while ( transform_stack.is_nonempty() ) {
+    Node *clone = transform_stack.pop();
     uint cnt = clone->req();
     for( uint i = 0; i < cnt; i++ ) {          // For all inputs do
       Node *input = clone->in(i);
@@ -1986,13 +1992,33 @@ Node *PhaseCCP::transform( Node *n ) {
         if( new_input == NULL ) {
           new_input = transform_once(input);   // Check for constant
           _nodes.map( input->_idx, new_input );// Flag as having been cloned
-          trstack.push(new_input);
+          transform_stack.push(new_input);     // Process children of cloned node
+          useful.push(new_input);
         }
         assert( new_input == clone->in(i), "insanity check");
       }
     }
   }
-  return new_node;
+
+  // The above transformation might lead to subgraphs becoming unreachable from the
+  // bottom while still being reachable from the top. As a result, nodes in that
+  // subgraph are not transformed and their bottom types are not updated, leading to
+  // an inconsistency between bottom_type() and type(). In rare cases, LoadNodes in
+  // such a subgraph, might be re-enqueued for IGVN indefinitely by MemNode::Ideal_common
+  // because their address type is inconsistent. Therefore, we aggressively remove
+  // all useless nodes here even before PhaseIdealLoop::build_loop_late gets a chance
+  // to remove them anyway.
+  if (C->cached_top_node()) {
+    useful.push(C->cached_top_node());
+  }
+  C->update_dead_node_list(useful);
+  remove_useless_nodes(useful.member_set());
+  _worklist.remove_useless_nodes(useful.member_set());
+  C->disconnect_useless_nodes(useful, &_worklist);
+
+  Node* new_root = _nodes[n->_idx];
+  assert(new_root->is_Root(), "transformed root node must be a root node");
+  return new_root;
 }
 
 

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -566,7 +566,7 @@ protected:
 // Phase for performing global Conditional Constant Propagation.
 // Should be replaced with combined CCP & GVN someday.
 class PhaseCCP : public PhaseIterGVN {
-  Unique_Node_List _safepoints;
+  Unique_Node_List _root_and_safepoints;
   // Non-recursive.  Use analysis to transform single Node.
   virtual Node* transform_once(Node* n);
 

--- a/test/hotspot/jtreg/compiler/ccp/TestRemoveUnreachableCCP.java
+++ b/test/hotspot/jtreg/compiler/ccp/TestRemoveUnreachableCCP.java
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
- *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +25,7 @@
  * @test
  * @bug 8287217
  * @summary CCP must remove nodes that are not traversed, else their type can be inconsistent
- * @run main/othervm -Xcomp -Xbatch -XX:CompileCommand=compileOnly,TestRemoveUnreachableCCP::test
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,TestRemoveUnreachableCCP::test
  *                   TestRemoveUnreachableCCP
  */
 
@@ -42,7 +41,6 @@ public class TestRemoveUnreachableCCP {
     }
 
     public static void main(String[] strArr) {
-        TestRemoveUnreachableCCP _instance = new TestRemoveUnreachableCCP();
         for (int i = 0; i < 11; i++) {
             test();
         }

--- a/test/hotspot/jtreg/compiler/ccp/TestRemoveUnreachableCCP.java
+++ b/test/hotspot/jtreg/compiler/ccp/TestRemoveUnreachableCCP.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8287217
+ * @summary CCP must remove nodes that are not traversed, else their type can be inconsistent
+ * @run main/othervm -Xcomp -Xbatch -XX:CompileCommand=compileOnly,TestRemoveUnreachableCCP::test
+ *                   TestRemoveUnreachableCCP
+ */
+
+public class TestRemoveUnreachableCCP {
+  
+  static void test() {
+    Byte x = 1;
+    for (int i = 0; i < 10000; i++) {
+      if ((i & 1) == 0) {
+        x = (byte)x;
+      }
+    }
+  }
+  
+  public static void main(String[] strArr) {
+    TestRemoveUnreachableCCP _instance = new TestRemoveUnreachableCCP();
+    for (int i = 0; i < 11; i++) {
+        test();
+    }
+  }
+}

--- a/test/hotspot/jtreg/compiler/ccp/TestRemoveUnreachableCCP.java
+++ b/test/hotspot/jtreg/compiler/ccp/TestRemoveUnreachableCCP.java
@@ -31,20 +31,20 @@
  */
 
 public class TestRemoveUnreachableCCP {
-  
-  static void test() {
-    Byte x = 1;
-    for (int i = 0; i < 10000; i++) {
-      if ((i & 1) == 0) {
-        x = (byte)x;
-      }
+
+    static void test() {
+        Byte x = 1;
+        for (int i = 0; i < 10000; i++) {
+            if ((i & 1) == 0) {
+                x = (byte)x;
+            }
+        }
     }
-  }
-  
-  public static void main(String[] strArr) {
-    TestRemoveUnreachableCCP _instance = new TestRemoveUnreachableCCP();
-    for (int i = 0; i < 11; i++) {
-        test();
+
+    public static void main(String[] strArr) {
+        TestRemoveUnreachableCCP _instance = new TestRemoveUnreachableCCP();
+        for (int i = 0; i < 11; i++) {
+            test();
+        }
     }
-  }
 }


### PR DESCRIPTION
**Context:**
[JDK-8265973](https://bugs.openjdk.org/browse/JDK-8265973) Fix in Valhalla repository (Tobias @TobiHartmann  ).
[JDK-8290711](https://bugs.openjdk.org/browse/JDK-8290711) Fix in mainline (Roland @rwestrel ).
Tobias' fix is a superset of Rolands. Unfortunately, Tobias gave up his fix once Rolands came up, because they did not have tests that required the superset fix.

We now have such a test, where Rolands fix is not sufficient. But Tobias' fix is the solution. So I ported Tobias' fix to mainline.

**Analysis:**
In this bug, we have two `LoadB` nodes re-pushing themselves to the `igvn.worklist`, without end. This leads to an assert after too many iterations.

`PhaseCCP::analyze` is looking at a post-loop. The loop has a memory access, so there is a `null_check`. The data-part of the loop is connected down to Root via this `null_check`
(`Phi-> CmpP -> Bool -> If -> IfFalse -> Region -> CallStaticJava uncommon_trap -> ... -> Root`).
During `CCP::analyze`, we discover that the memory address is NonNull. So we update the `phase->type(n)` for many of the data-nodes of the loop.

During `PhaseCCP::do_transform`, we now traverse recursively up from the root, visiting all reachable nodes.
When we visit a node, we store the cached `phase->type(n)` into the node, making the node's type consistent.
We traverse up through the `null_check`, through the `uncommon_trap`, and the `If`, to the `Bool` node.
`BoolNode::Value` realizes that we can never have Null, and is subsumed by constant `#int:1` (true).
This means that the data-part of the loop just lost its connection down to Root.
The traversal now also does not reach further than the Bool node which was just subsumed, and hence does not reach the data-part of the loop.
This means we have nodes with inconsistent type.

Summary: CCP disconnects the last path down to root for a data-loop, because it realizes that a `null_check` will never trap. The disconnected state means the types of the data-loop may be left inconsistent.

Right after PhaseCCP, we continue with IGVN.
The `LoadB` from that data-part of the loop has `MemNode::Ideal_common` called, which defers its transformation until the type of the address is consistent. However, this is never made consistent, as it is already left inconsistent after PhaseCCP.
https://github.com/openjdk/jdk/blob/aa7ccdf44549a52cce9e99f6569097d3343d9ee4/src/hotspot/share/opto/memnode.cpp#L351-L358
Note that we only re-push if there is another node in the worklist - a node that hopefully has something to do with the address.
But in our case it is just the two LoadB nodes, which were generated from the same `split_through_phi`.

**Solution:**
At the end of PhaseCCP, we remove all nodes that were not visited (and may have an inconsistent state). We can do this because we visited all nodes that are still relevant. Rolands fix already made sure that SafePointNodes are visited, such that infinite loops are covered as well.

Regression test added.
Test suite passed.
Tests rerunning for review suggestion (commit 3)...

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287217](https://bugs.openjdk.org/browse/JDK-8287217): C2: PhaseCCP: remove not visited nodes, prevent type inconsistency


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**) ⚠️ Review applies to [7dc29ae8](https://git.openjdk.org/jdk/pull/10250/files/7dc29ae84af12e4418a08a9d8b7b4a9bcc107f15)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10250/head:pull/10250` \
`$ git checkout pull/10250`

Update a local copy of the PR: \
`$ git checkout pull/10250` \
`$ git pull https://git.openjdk.org/jdk pull/10250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10250`

View PR using the GUI difftool: \
`$ git pr show -t 10250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10250.diff">https://git.openjdk.org/jdk/pull/10250.diff</a>

</details>
