### PR TITLE
8293695: Implement isInfinite intrinsic for RISC-V

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -7230,6 +7230,32 @@ instruct minD_reg_reg(fRegD dst, fRegD src1, fRegD src2) %{
   ins_pipe(fp_dop_reg_reg_d);
 %}
 
+// Float.isInfinite
+instruct isIniniteF_reg_reg(iRegINoSp dst, fRegF src)
+%{
+  match(Set dst (IsInfiniteF src));
+  format %{ "isInfinite $dst, $src" %}
+  ins_encode %{
+    __ fclass_s(as_Register($dst$$reg), as_FloatRegister($src$$reg));
+    __ andi(as_Register($dst$$reg), as_Register($dst$$reg), 0b10000001);
+    __ slt(as_Register($dst$$reg), zr, as_Register($dst$$reg));
+  %}
+  ins_pipe(fp_dop_reg_reg_s);
+%}
+
+// Double.isInfinite
+instruct isInfiniteD_reg_reg(iRegINoSp dst, fRegD src)
+%{
+  match(Set dst (IsInfiniteD src));
+  format %{ "isInfinite $dst, $src" %}
+  ins_encode %{
+    __ fclass_d(as_Register($dst$$reg), as_FloatRegister($src$$reg));
+    __ andi(as_Register($dst$$reg), as_Register($dst$$reg), 0b10000001);
+    __ slt(as_Register($dst$$reg), zr, as_Register($dst$$reg));
+  %}
+  ins_pipe(fp_dop_reg_reg_d);
+%}
+
 instruct divF_reg_reg(fRegF dst, fRegF src1, fRegF src2) %{
   match(Set dst (DivF src1  src2));
 

--- a/test/hotspot/jtreg/compiler/intrinsics/TestDoubleClassCheck.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestDoubleClassCheck.java
@@ -23,8 +23,8 @@
 
 /**
 * @test
-* @summary Test x86_64 intrinsics for Double methods isNaN, isFinite, isInfinite.
-* @requires vm.cpu.features ~= ".*avx512dq.*"
+* @summary Test intrinsics for Double methods isNaN, isFinite, isInfinite.
+* @requires vm.cpu.features ~= ".*avx512dq.*" | os.arch == "riscv64"
 * @library /test/lib /
 * @run driver compiler.intrinsics.TestDoubleClassCheck
 */

--- a/test/hotspot/jtreg/compiler/intrinsics/TestFloatClassCheck.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestFloatClassCheck.java
@@ -23,8 +23,8 @@
 
 /**
 * @test
-* @summary Test x86_64 intrinsics for Float methods isNaN, isFinite, isInfinite.
-* @requires vm.cpu.features ~= ".*avx512dq.*"
+* @summary Test intrinsics for Float methods isNaN, isFinite, isInfinite.
+* @requires vm.cpu.features ~= ".*avx512dq.*" | os.arch == "riscv64"
 * @library /test/lib /
 * @run driver compiler.intrinsics.TestFloatClassCheck
 */


### PR DESCRIPTION
RISC-V 64 intrinsic for isInfinite follows the logic of x86 intrinsic (introduced by 8285868). This patch adds C2 match for IsInfinite nodes. Existing test is modified to run on RISC-V and passes on both release and fastdebug builds. Benchmark results are below:

before:
Benchmark                              Mode  Cnt   Score   Error Units
DoubleClassCheck.testIsInfiniteBranch  avgt   15  43.547 ± 6.843 ns/op
DoubleClassCheck.testIsInfiniteCMov    avgt   15  16.301 ± 1.386 ns/op
DoubleClassCheck.testIsInfiniteStore   avgt   15  16.230 ± 1.477 ns/op
FloatClassCheck.testIsInfiniteBranch   avgt   15  38.774 ± 3.572 ns/op
FloatClassCheck.testIsInfiniteCMov     avgt   15  15.064 ± 1.310 ns/op
FloatClassCheck.testIsInfiniteStore    avgt   15  14.967 ± 1.298 ns/op

after:
Benchmark                              Mode  Cnt   Score    Error Units
DoubleClassCheck.testIsInfiniteBranch  avgt   15  39.987 ±  6.179 ns/op
DoubleClassCheck.testIsInfiniteCMov    avgt   15  13.477 ±  1.159 ns/op
DoubleClassCheck.testIsInfiniteStore   avgt   15   9.607 ±  0.834 ns/op
FloatClassCheck.testIsInfiniteBranch   avgt   15  36.265 ±  3.168 ns/op
FloatClassCheck.testIsInfiniteCMov     avgt   15  13.230 ±  1.100 ns/op
FloatClassCheck.testIsInfiniteStore    avgt   15   9.492 ±  0.807 ns/op

According to 8285868 discussion, isNaN and isFinite methods intrinsification using the same approach might be not beneficial. I'm going to investigate it for RISC-V and propose methods intrinsification as part of further work in case it's profitable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293695](https://bugs.openjdk.org/browse/JDK-8293695): Implement isInfinite intrinsic for RISC-V


### Reviewers
 * [Yadong Wang](https://openjdk.org/census#yadongwang) (@yadongw - Author)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * @bell-sw (no known github.com user name / role)
 * [Dmitry Samersoff](https://openjdk.org/census#dsamersoff) (@dsamersoff - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10253/head:pull/10253` \
`$ git checkout pull/10253`

Update a local copy of the PR: \
`$ git checkout pull/10253` \
`$ git pull https://git.openjdk.org/jdk pull/10253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10253`

View PR using the GUI difftool: \
`$ git pr show -t 10253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10253.diff">https://git.openjdk.org/jdk/pull/10253.diff</a>

</details>
