### PR TITLE
JDK-8293768: Add links to JLS 19 and 20 from SourceVersion enum constants

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
+++ b/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
@@ -351,6 +351,10 @@ public enum SourceVersion {
      * No major changes from the prior release.
      *
      * @since 19
+     *
+     * @see <a
+     * href="https://docs.oracle.com/javase/specs/jls/se19/html/index.html">
+     * <cite>The Java Language Specification, Java SE 19 Edition</cite></a>
      */
     RELEASE_19,
 
@@ -359,6 +363,10 @@ public enum SourceVersion {
      * 20.
      *
      * @since 20
+     *
+     * @see <a
+     * href="https://docs.oracle.com/javase/specs/jls/se20/html/index.html">
+     * <cite>The Java Language Specification, Java SE 20 Edition</cite></a>
      */
     RELEASE_20;
 


### PR DESCRIPTION
Originally, I was only going to add a link to JLS 19 for when the docs for Java SE 19 went live, but at time of writing the JLS 19 link goes to the specifications landing page rather than giving a 404. Therefore, adding links to both JLS 19 and 20 know aren't dead links per se and will become better links as the JLS 19 and 20 pages are published in the future.

When the resolved JLS-version-specific links resolving the specification home page, the future I'll add the link to the specific JLS version when I add a new SourceVersion constant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293768](https://bugs.openjdk.org/browse/JDK-8293768): Add links to JLS 19 and 20 from SourceVersion enum constants


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10257/head:pull/10257` \
`$ git checkout pull/10257`

Update a local copy of the PR: \
`$ git checkout pull/10257` \
`$ git pull https://git.openjdk.org/jdk pull/10257/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10257`

View PR using the GUI difftool: \
`$ git pr show -t 10257`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10257.diff">https://git.openjdk.org/jdk/pull/10257.diff</a>

</details>
