### PR TITLE
Add an additional -v cli flag for displaying version information

### DIFF
--- a/src/java.base/share/native/libjli/args.c
+++ b/src/java.base/share/native/libjli/args.c
@@ -459,6 +459,7 @@ int isTerminalOpt(char *arg) {
            JLI_StrCmp(arg, "--help-extra") == 0 ||
            JLI_StrCmp(arg, "-version") == 0 ||
            JLI_StrCmp(arg, "--version") == 0 ||
+           JLI_StrCmp(arg, "-v") == 0 ||
            JLI_StrCmp(arg, "-fullversion") == 0 ||
            JLI_StrCmp(arg, "--full-version") == 0;
 }

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1295,7 +1295,8 @@ ParseArguments(int *pargc, char ***pargv,
             printUsage = JNI_TRUE;
             printTo = USE_STDOUT;
             return JNI_TRUE;
-        } else if (JLI_StrCmp(arg, "-version") == 0) {
+        } else if (JLI_StrCmp(arg, "-version") == 0 ||
+                   JLI_StrCmp(arg, "-v") == 0) {
             printVersion = JNI_TRUE;
             return JNI_TRUE;
         } else if (JLI_StrCmp(arg, "--version") == 0) {


### PR DESCRIPTION
I'm still reading contribution guidelines, and am still working on building this codebase locally to do initial testing, but willing to hopefully engage anyone on this proposed change.

That being said, version information displayed from different popular development frameworks and toolkits *mostly* adhere to using a convention of `-v`.

I don't know if this has ever been proposed previously, so many apologies in advance.

![Screenshot 2022-09-13 202557](https://user-images.githubusercontent.com/962434/190044722-1c097c17-b0ff-4613-8f37-d5ca4de74f67.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10258/head:pull/10258` \
`$ git checkout pull/10258`

Update a local copy of the PR: \
`$ git checkout pull/10258` \
`$ git pull https://git.openjdk.org/jdk pull/10258/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10258`

View PR using the GUI difftool: \
`$ git pr show -t 10258`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10258.diff">https://git.openjdk.org/jdk/pull/10258.diff</a>

</details>
