### PR TITLE
8293771: runtime/handshake/SystemMembarHandshakeTransitionTest.java fails if MEMBARRIER_CMD_QUERY is unsupported

### DIFF
--- a/test/hotspot/jtreg/runtime/handshake/SystemMembarHandshakeTransitionTest.java
+++ b/test/hotspot/jtreg/runtime/handshake/SystemMembarHandshakeTransitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,6 +58,6 @@ public class SystemMembarHandshakeTransitionTest {
 
         OutputAnalyzer output = ProcessTools.executeProcess(pb);
         output.reportDiagnosticSummary();
-        output.shouldMatch("(JOINED|Failed to initialize request system memory barrier synchronization.)");
+        output.shouldMatch("(JOINED|Failed to initialize the requested system memory barrier synchronization.)");
     }
 }


### PR DESCRIPTION
Hi all,

Please review this trivial fix.
It fails due to the failing msg is incorrect in the test.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293771](https://bugs.openjdk.org/browse/JDK-8293771): runtime/handshake/SystemMembarHandshakeTransitionTest.java fails if MEMBARRIER_CMD_QUERY is unsupported


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10259/head:pull/10259` \
`$ git checkout pull/10259`

Update a local copy of the PR: \
`$ git checkout pull/10259` \
`$ git pull https://git.openjdk.org/jdk pull/10259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10259`

View PR using the GUI difftool: \
`$ git pr show -t 10259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10259.diff">https://git.openjdk.org/jdk/pull/10259.diff</a>

</details>
