### PR TITLE
8293770: RISC-V: Reuse runtime call trampolines

### DIFF
--- a/src/hotspot/cpu/riscv/codeBuffer_riscv.cpp
+++ b/src/hotspot/cpu/riscv/codeBuffer_riscv.cpp
@@ -27,6 +27,56 @@
 #include "asm/codeBuffer.inline.hpp"
 #include "asm/macroAssembler.hpp"
 
+void CodeBuffer::share_trampoline_for(address dest, int caller_offset) {
+  if (_shared_trampoline_requests == nullptr) {
+    constexpr unsigned init_size = 8;
+    constexpr unsigned max_size  = 256;
+    _shared_trampoline_requests = new SharedTrampolineRequests(init_size, max_size);
+  }
+
+  bool created;
+  Offsets* offsets = _shared_trampoline_requests->put_if_absent(dest, &created);
+  if (created) {
+    _shared_trampoline_requests->maybe_grow();
+  }
+  offsets->add(caller_offset);
+  _finalize_stubs = true;
+}
+
+static bool emit_shared_trampolines(CodeBuffer* cb, CodeBuffer::SharedTrampolineRequests* requests) {
+  if (requests == nullptr) {
+    return true;
+  }
+
+  MacroAssembler masm(cb);
+
+  bool p_succeeded = true;
+  auto emit = [&](address dest, const CodeBuffer::Offsets &offsets) {
+    masm.set_code_section(cb->stubs());
+    masm.align(wordSize, NativeCallTrampolineStub::data_offset);
+
+    LinkedListIterator<int> it(offsets.head());
+    int offset = *it.next();
+    for (; !it.is_empty(); offset = *it.next()) {
+      masm.relocate(trampoline_stub_Relocation::spec(cb->insts()->start() + offset));
+    }
+    masm.set_code_section(cb->insts());
+
+    address stub = masm.emit_trampoline_stub(offset, dest);
+    if (stub == nullptr) {
+      ciEnv::current()->record_failure("CodeCache is full");
+      p_succeeded = false;
+    }
+
+    return p_succeeded;
+  };
+
+  requests->iterate(emit);
+
+  return p_succeeded;
+}
+
 bool CodeBuffer::pd_finalize_stubs() {
-  return emit_shared_stubs_to_interp<MacroAssembler>(this, _shared_stub_to_interp_requests);
+  return emit_shared_stubs_to_interp<MacroAssembler>(this, _shared_stub_to_interp_requests)
+      && emit_shared_trampolines(this, _shared_trampoline_requests);
 }

--- a/src/hotspot/cpu/riscv/codeBuffer_riscv.cpp
+++ b/src/hotspot/cpu/riscv/codeBuffer_riscv.cpp
@@ -78,5 +78,5 @@ static bool emit_shared_trampolines(CodeBuffer* cb, CodeBuffer::SharedTrampoline
 
 bool CodeBuffer::pd_finalize_stubs() {
   return emit_shared_stubs_to_interp<MacroAssembler>(this, _shared_stub_to_interp_requests)
-      && emit_shared_trampolines(this, _shared_trampoline_requests);
+         && emit_shared_trampolines(this, _shared_trampoline_requests);
 }

--- a/src/hotspot/cpu/riscv/codeBuffer_riscv.hpp
+++ b/src/hotspot/cpu/riscv/codeBuffer_riscv.hpp
@@ -35,4 +35,6 @@ public:
   void flush_bundle(bool start_new_bundle) {}
   static constexpr bool supports_shared_stubs() { return true; }
 
+  void share_trampoline_for(address dest, int caller_offset);
+
 #endif // CPU_RISCV_CODEBUFFER_RISCV_HPP

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2804,6 +2804,8 @@ address MacroAssembler::trampoline_call(Address entry) {
          entry.rspec().type() == relocInfo::static_call_type ||
          entry.rspec().type() == relocInfo::virtual_call_type, "wrong reloc type");
 
+  address target = entry.target();
+
   // We need a trampoline if branches are far.
   if (far_branches()) {
     bool in_scratch_emit_size = false;
@@ -2816,10 +2818,15 @@ address MacroAssembler::trampoline_call(Address entry) {
        Compile::current()->output()->in_scratch_emit_size());
 #endif
     if (!in_scratch_emit_size) {
-      address stub = emit_trampoline_stub(offset(), entry.target());
-      if (stub == NULL) {
-        postcond(pc() == badAddress);
-        return NULL; // CodeCache is full
+      if (entry.rspec().type() == relocInfo::runtime_call_type) {
+        assert(CodeBuffer::supports_shared_stubs(), "must support shared stubs");
+        code()->share_trampoline_for(entry.target(), offset());
+      } else {
+        address stub = emit_trampoline_stub(offset(), target);
+        if (stub == NULL) {
+          postcond(pc() == badAddress);
+          return NULL; // CodeCache is full
+        }
       }
     }
   }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2829,6 +2829,7 @@ address MacroAssembler::trampoline_call(Address entry) {
         }
       }
     }
+    target = pc();
   }
 
   address call_pc = pc();
@@ -2838,11 +2839,7 @@ address MacroAssembler::trampoline_call(Address entry) {
   }
 #endif
   relocate(entry.rspec());
-  if (!far_branches()) {
-    jal(entry.target());
-  } else {
-    jal(pc());
-  }
+  jal(target);
 
   postcond(pc() != badAddress);
   return call_pc;

--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedTrampolineTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedTrampolineTest.java
@@ -28,7 +28,8 @@
  * @bug 8280152
  * @library /test/lib
  *
- * @requires vm.debug & os.arch=="aarch64"
+ * @requires os.arch=="aarch64" | os.arch=="riscv64"
+ * @requires vm.debug
  *
  * @run driver compiler.sharedstubs.SharedTrampolineTest
  */


### PR DESCRIPTION
Follow up [JDK-8280152](https://bugs.openjdk.org/browse/JDK-8280152), this case also exists in riscv.

Benchmark als, chi-square, dec-tree, log-regression, naive-bayes, page-rank, fj-kmeans, reactors, future-genetic, mnemonics, dotty, scala-kmeans, and finagle-http in Renaissance (0.14.1) are tested. The sum of the used size of CodeHeap 'non-profiled nmethods' and CodeHeap 'profiled nmethods' shows ~2.1% reduction on average.

## Testing:

- hotspot and jdk tier1 on unmatched board without new failures
- hotspot/jtreg/compiler/sharedstubs/SharedTrampolineTest.java with fastdebug on qemu


## Results
#### Results from [Renaissance 0.14.1](https://github.com/renaissance-benchmarks/renaissance/releases/tag/v0.14.1)

- riscv64
```
+--------------------------------------------------------------------------------------------------------+
|                |                     Before                |                    After                  |
|    Benchmark   |---------------------------------------------------------------------------------------| 
|                | non-profiled nmethods | profiled nmethods | non-profiled nmethods | profiled nmethods |
+----------------+-----------------------+-------------------+-----------------------+-------------------| 
| als            |                 15628 |             39421 |                 12341 |             26681 |
| chi-square     |                  6349 |             20268 |                  6033 |             20252 |
| dec-tree       |                 11058 |             42443 |                 10774 |             43880 |
| log-regression |                 10939 |             38237 |                 12071 |             44199 |
| naive-bayes    |                  9023 |             29563 |                  9294 |             30948 |
| page-rank      |                  6054 |             17041 |                  5812 |             17353 |
| fj-kmeans      |                   692 |              2893 |                   651 |              3354 |
| reactors       |                  2126 |              4073 |                  1876 |              4106 |
| future-genetic |                  1306 |              4118 |                  1226 |              4142 |
| mnemonics      |                   726 |              2659 |                   706 |              2684 |
| dotty          |                 26059 |             24417 |                 24585 |             25379 |
| scala-kmeans   |                   564 |              3122 |                   543 |              3132 |
| finagle-http   |                  6188 |             12455 |                  6102 |             12295 |
| sum            |                 96712 |            240710 |                 92014 |            238405 |
+--------------------------------------------------------------------------------------------------------+
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293770](https://bugs.openjdk.org/browse/JDK-8293770): RISC-V: Reuse runtime call trampolines


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Contributors
 * zifeihan `<caogui@iscas.ac.cn>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10260/head:pull/10260` \
`$ git checkout pull/10260`

Update a local copy of the PR: \
`$ git checkout pull/10260` \
`$ git pull https://git.openjdk.org/jdk pull/10260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10260`

View PR using the GUI difftool: \
`$ git pr show -t 10260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10260.diff">https://git.openjdk.org/jdk/pull/10260.diff</a>

</details>
