### PR TITLE
8293774: Improve TraceOptoParse to dump the bytecode name

### DIFF
--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -1821,6 +1821,7 @@ void Parse::do_one_bytecode() {
   if (TraceOptoParse) {
     tty->print(" @");
     dump_bci(bci());
+    tty->print(" %s", Bytecodes::name(bc()));
     tty->cr();
   }
 #endif


### PR DESCRIPTION
Hi all,

Please review this one-line patch which prints the bytecode name for `TraceOptoParse`.

While I was debugging with `TraceOptoParse`, I found it only prints the bci without the bytecode name.
I had to map the bci to the bytecode manually again and again.
It would be better to also dump the bytecode name.

Before:
```
    568  503       4       jdk.internal.org.objectweb.asm.ByteVector::putUTF8 (144 bytes)
Merging state at block #0 bci:0 with empty state on path 1
Parsing block #0 at bci [0,11), successors:  1 2
 @ bci:0
 @ bci:1
Uncommon trap reason='null_check' action='maybe_recompile' debug_id='0' at bci:1
Merging state at block #0 bci:0 with empty state on path 1
Parsing block #0 at bci [0,11), successors:
 @ bci:0
 @ bci:1
 @ bci:4
Uncommon trap reason='null_check' action='maybe_recompile' debug_id='0' at bci:4
 @ bci:5
 @ bci:6
Merging state at block #0 bci:0 with empty state on path 1
```

After:
```
    571  507       4       jdk.internal.org.objectweb.asm.ByteVector::putUTF8 (144 bytes)
Merging state at block #0 bci:0 with empty state on path 1
Parsing block #0 at bci [0,11), successors:  1 2
 @ bci:0 aload_1
 @ bci:1 invokevirtual
Uncommon trap reason='null_check' action='maybe_recompile' debug_id='0' at bci:1
Merging state at block #0 bci:0 with empty state on path 1
Parsing block #0 at bci [0,11), successors:
 @ bci:0 aload_0
 @ bci:1 getfield
 @ bci:4 arraylength
Uncommon trap reason='null_check' action='maybe_recompile' debug_id='0' at bci:4
 @ bci:5 aload_0
 @ bci:6 invokevirtual
Merging state at block #0 bci:0 with empty state on path 1
```

Testing:
 - tier1~3 on Linux/x64 in progress, seems fine until now

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293774](https://bugs.openjdk.org/browse/JDK-8293774): Improve TraceOptoParse to dump the bytecode name


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10262/head:pull/10262` \
`$ git checkout pull/10262`

Update a local copy of the PR: \
`$ git checkout pull/10262` \
`$ git pull https://git.openjdk.org/jdk pull/10262/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10262`

View PR using the GUI difftool: \
`$ git pr show -t 10262`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10262.diff">https://git.openjdk.org/jdk/pull/10262.diff</a>

</details>
