### PR TITLE
8293779: redundant checking in AESCrypt.makeSessionKey() method

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/AESCrypt.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/AESCrypt.java
@@ -602,13 +602,6 @@ final class AESCrypt extends SymmetricCipher implements AESConstants
      * @exception InvalidKeyException  If the key is invalid.
      */
     private void makeSessionKey(byte[] k) throws InvalidKeyException {
-        if (k == null) {
-            throw new InvalidKeyException("Empty key");
-        }
-        if (!isKeySizeValid(k.length)) {
-             throw new InvalidKeyException("Invalid AES key length: " +
-                                           k.length + " bytes");
-        }
         int ROUNDS          = getRounds(k.length);
         int ROUND_KEY_COUNT = (ROUNDS + 1) * 4;
 


### PR DESCRIPTION
Hi,

Please review this simple code cleanup.

The following checking for key in the makeSessionKey() method is redundant as it the same checking has been performance before calling the method.

```
        if (k == null) {
            throw new InvalidKeyException("Empty key");
        }
        if (!isKeySizeValid(k.length)) {
             throw new InvalidKeyException("Invalid AES key length: " +
                                           k.length + " bytes");
        }
```

No new regression test, simple cleanup.