### PR TITLE
JDK-8293787: Linux aarch64 build fails after 8292591

### DIFF
--- a/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
+++ b/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
@@ -37,6 +37,8 @@
   #define SYS_membarrier 324
   #elif defined(PPC64)
   #define SYS_membarrier 365
+  #elif defined(AARCH64)
+  #define SYS_membarrier 283
   #else
   #error define SYS_membarrier for the arch
   #endif


### PR DESCRIPTION
After 8292591 we run into the following build error on Linux aarch64  (this one uses a rather old devkit):

* For target hotspot_variant-server_libjvm_objs_systemMemoryBarrier_linux.o:
/nb/linuxaarch64/jdk/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp:41:4: error: #error define SYS_membarrier for the arch
   #error define SYS_membarrier for the arch
    ^~~~~
/nb/linuxaarch64/jdk/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp: In function 'int membarrier(int, unsigned int, int)':
/nb/linuxaarch64/jdk/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp:63:18: error: 'SYS_membarrier' was not declared in this scope
   return syscall(SYS_membarrier, cmd, flags, cpu_id); // cpu_id only on >= 5.10
                  ^~~~~~~~~~~~~~
/nb/linuxaarch64/jdk/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp:63:18: note: suggested alternative: 'membarrier'
   return syscall(SYS_membarrier, cmd, flags, cpu_id); // cpu_id only on >= 5.10
                  ^~~~~~~~~~~~~~
                  membarrier

This could most likely be solved by adding a definition for aarch64 to hotspot/os/linux/systemMemoryBarrier_linux.cpp .
On the mentioned linux aarch64 system (kernel 5.15) SYS_membarrier is :
aarch64-linux-gnu/bits/syscall.h:899:# define SYS_membarrier __NR_membarrier

asm-generic/unistd.h:755:#define __NR_membarrier 283

I find the 283 on Ubuntu 18, 22, SLES17 and RHEL 9 .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293787](https://bugs.openjdk.org/browse/JDK-8293787): Linux aarch64 build fails after 8292591


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10265/head:pull/10265` \
`$ git checkout pull/10265`

Update a local copy of the PR: \
`$ git checkout pull/10265` \
`$ git pull https://git.openjdk.org/jdk pull/10265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10265`

View PR using the GUI difftool: \
`$ git pr show -t 10265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10265.diff">https://git.openjdk.org/jdk/pull/10265.diff</a>

</details>
