### PR TITLE
8293792: runtime/Dictionary/ProtectionDomainCacheTest.java fails with FileAlreadyExistsException: /tmp

### DIFF
--- a/test/lib/jdk/test/lib/util/JarUtils.java
+++ b/test/lib/jdk/test/lib/util/JarUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ public final class JarUtils {
     {
         // create the target directory
         Path parent = jarfile.getParent();
-        if (parent != null) {
+        if (parent != null && Files.notExists(parent)) {
             Files.createDirectories(parent);
         }
 


### PR DESCRIPTION
Hi all,

runtime/Dictionary/ProtectionDomainCacheTest.java fails on Linux if `/tmp` is a symbolic link directory.
The root cause is that `JarUtils.createJarFile` [1] will throw `FileAlreadyExistsException` if `parent` is a symbolic directory.
So it seems better to test the existance of `parent` before creation.

Testing:
- tier1~3 on Linux/x64 in progress, seems fine until now

Thanks.
Best regards,
Jie


[1] https://github.com/openjdk/jdk/blob/master/test/lib/jdk/test/lib/util/JarUtils.java#L72

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293792](https://bugs.openjdk.org/browse/JDK-8293792): runtime/Dictionary/ProtectionDomainCacheTest.java fails with FileAlreadyExistsException: /tmp


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10266/head:pull/10266` \
`$ git checkout pull/10266`

Update a local copy of the PR: \
`$ git checkout pull/10266` \
`$ git pull https://git.openjdk.org/jdk pull/10266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10266`

View PR using the GUI difftool: \
`$ git pr show -t 10266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10266.diff">https://git.openjdk.org/jdk/pull/10266.diff</a>

</details>
