### PR TITLE
8293502: (fc) FileChannel::transfer methods fail to copy /proc files on Linux

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -771,7 +771,7 @@ public class FileChannelImpl
 
         // Adjust count only if remaining > 0, i.e.,
         // sz > position which means sz > 0
-        if (remaining < count && remaining > 0)
+        if (remaining > 0 && remaining < count)
             count = remaining;
 
         // System calls supporting fast transfers might not work on files

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -761,23 +761,33 @@ public class FileChannelImpl
             throw new NonWritableChannelException();
         if ((position < 0) || (count < 0))
             throw new IllegalArgumentException();
-        long sz = size();
+        final long sz = size();
         if (position > sz)
             return 0;
 
-        if ((sz - position) < count)
-            count = sz - position;
+        // Now position <= sz so remaining >= 0 and
+        // remaining == 0 if and only if sz == 0
+        long remaining = sz - position;
 
-        // Attempt a direct transfer, if the kernel supports it, limiting
-        // the number of bytes according to which platform
-        int icount = (int)Math.min(count, MAX_DIRECT_TRANSFER_SIZE);
-        long n;
-        if ((n = transferToDirectly(position, icount, target)) >= 0)
-            return n;
+        // Adjust count only if remaining > 0, i.e.,
+        // sz > position which means sz > 0
+        if (remaining < count && remaining > 0)
+            count = remaining;
 
-        // Attempt a mapped transfer, but only to trusted channel types
-        if ((n = transferToTrustedChannel(position, count, target)) >= 0)
-            return n;
+        // System calls supporting fast transfers might not work on files
+        // which advertise zero size such as those in Linux /proc
+        if (sz > 0) {
+            // Attempt a direct transfer, if the kernel supports it, limiting
+            // the number of bytes according to which platform
+            int icount = (int)Math.min(count, MAX_DIRECT_TRANSFER_SIZE);
+            long n;
+            if ((n = transferToDirectly(position, icount, target)) >= 0)
+                return n;
+
+            // Attempt a mapped transfer, but only to trusted channel types
+            if ((n = transferToTrustedChannel(position, count, target)) >= 0)
+                return n;
+        }
 
         // Slow path for untrusted targets
         return transferToArbitraryChannel(position, count, target);
@@ -925,6 +935,8 @@ public class FileChannelImpl
         ensureOpen();
         if (!src.isOpen())
             throw new ClosedChannelException();
+        if (src instanceof FileChannelImpl fci && !fci.readable)
+            throw new NonReadableChannelException();
         if (!writable)
             throw new NonWritableChannelException();
         if ((position < 0) || (count < 0))
@@ -932,7 +944,9 @@ public class FileChannelImpl
         if (position > size())
             return 0;
 
-        if (src instanceof FileChannelImpl fci) {
+        // System calls supporting fast transfers might not work on files
+        // which advertise zero size such as those in Linux /proc
+        if (src instanceof FileChannelImpl fci && fci.size() > 0) {
             long n;
             if ((n = transferFromDirectly(fci, position, count)) >= 0)
                 return n;

--- a/test/jdk/java/nio/file/Files/CopyProcFile.java
+++ b/test/jdk/java/nio/file/Files/CopyProcFile.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.ToLongBiFunction;
+import static java.nio.file.StandardOpenOption.*;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/*
+ * @test
+ * @bug 8293502
+ * @requires (os.family == "linux")
+ * @summary Ensure that copying from /proc/mounts works
+ * @run testng/othervm CopyProcFile
+ */
+public class CopyProcFile {
+    static final String SOURCE = "/proc/mounts";
+    static final String BUFFERED_COPY = "bufferedCopy";
+    static final String TARGET = "target";
+
+    static final int BUF_SIZE = 8192;
+
+    static long theSize;
+
+    // copy src to dst via Java buffers
+    static long bufferedCopy(String src, String dst) {
+        try (InputStream in = new FileInputStream(src);
+             OutputStream out = new FileOutputStream(dst)) {
+            byte[] b = new byte[BUF_SIZE];
+            long total = 0;
+            int n;
+            while ((n = in.read(b)) > 0) {
+                out.write(b, 0, n);
+                total += n;
+            }
+            return total;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    // copy src to dst using Files::copy
+    static long copy(String src, String dst) {
+        try {
+            return Files.size(Files.copy(Path.of(src), Path.of(dst)));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    // copy src to dst using InputStream::transferTo
+    static long transferToIO(String src, String dst) {
+        try (InputStream in = new FileInputStream(src);
+             OutputStream out = new FileOutputStream(dst)) {
+            return in.transferTo(out);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    // copy src to dst using FileChannel::transferTo
+    static long transferToNIO(String src, String dst) {
+        try (FileChannel fci = FileChannel.open(Path.of(src), READ);
+             FileChannel fco = FileChannel.open(Path.of(dst), CREATE_NEW,
+                                                WRITE);) {
+            return fci.transferTo(0, Long.MAX_VALUE, fco);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    // copy src to dst using FileChannel::transferFrom
+    static long transferFrom(String src, String dst) {
+        try (FileChannel fci = FileChannel.open(Path.of(src), READ);
+             FileChannel fco = FileChannel.open(Path.of(dst), CREATE_NEW,
+                                                WRITE);) {
+            return fco.transferFrom(fci, 0, Long.MAX_VALUE);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @BeforeTest(alwaysRun=true)
+    public void createBufferedCopy() {
+        try {
+            theSize = bufferedCopy(SOURCE, BUFFERED_COPY);
+            if (Files.mismatch(Path.of(BUFFERED_COPY), Path.of(SOURCE)) != -1)
+                throw new RuntimeException("Copy does not match source");
+        } catch (Exception e) {
+            try {
+                Files.delete(Path.of(BUFFERED_COPY));
+            } catch (IOException ignore) {}
+        }
+    }
+
+    @AfterTest(alwaysRun=true)
+    public void deleteBufferedCopy() {
+        try {
+            Files.delete(Path.of(BUFFERED_COPY));
+        } catch (IOException ignore) {}
+    }
+
+    static class FHolder {
+        ToLongBiFunction<String,String> f;
+
+        FHolder(ToLongBiFunction<String,String> f) {
+            this.f = f;
+        }
+
+        long apply(String src, String dst) {
+            return f.applyAsLong(src, dst);
+        }
+    }
+
+    @DataProvider
+    static Object[][] functions() throws IOException {
+        List<Object[]> funcs = new ArrayList<>();
+        funcs.add(new Object[] {new FHolder((s, d) -> copy(s, d))});
+        funcs.add(new Object[] {new FHolder((s, d) -> transferToIO(s, d))});
+        funcs.add(new Object[] {new FHolder((s, d) -> transferToNIO(s, d))});
+        funcs.add(new Object[] {new FHolder((s, d) -> transferFrom(s, d))});
+        return funcs.toArray(Object[][]::new);
+    }
+
+    @Test(dataProvider = "functions")
+    public static void testCopyAndTransfer(FHolder f) throws IOException {
+        try {
+            long size = f.apply(SOURCE, TARGET);
+            if (size != theSize)
+                throw new RuntimeException("Size: expected " + theSize +
+                                           "; actual: " + size);
+            long mismatch = Files.mismatch(Path.of(BUFFERED_COPY),
+                                           Path.of(TARGET));
+            if (mismatch != -1)
+                throw new RuntimeException("Target does not match copy");
+        } finally {
+            try {
+                Files.delete(Path.of(TARGET));
+            } catch (IOException ignore) {}
+        }
+    }
+}


### PR DESCRIPTION
Files in `/proc` advertise a size of zero for which direct and mapped transfers do not work. For this case, fall back to arbitrary channel transfer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293502](https://bugs.openjdk.org/browse/JDK-8293502): (fc) FileChannel::transfer methods fail to copy /proc files on Linux


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10267/head:pull/10267` \
`$ git checkout pull/10267`

Update a local copy of the PR: \
`$ git checkout pull/10267` \
`$ git pull https://git.openjdk.org/jdk pull/10267/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10267`

View PR using the GUI difftool: \
`$ git pr show -t 10267`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10267.diff">https://git.openjdk.org/jdk/pull/10267.diff</a>

</details>
