### PR TITLE
8293811: Provide a reason for PassFailJFrame.forceFail

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -56,6 +56,11 @@ public class PassFailJFrame {
     private static final int ROWS = 10;
     private static final int COLUMNS = 40;
 
+    /**
+     * Prefix for the user-provided failure reason.
+     */
+    private static final String FAILURE_REASON = "Failure Reason:\n";
+
     private static final List<Window> windowList = new ArrayList<>();
     private static final Timer timer = new Timer(0, null);
     private static final CountDownLatch latch = new CountDownLatch(1);
@@ -135,8 +140,8 @@ public class PassFailJFrame {
             long leftTime = tTimeout - (System.currentTimeMillis() - startTime);
             if ((leftTime < 0) || failed) {
                 timer.stop();
-                testFailedReason = "Failure Reason:\n"
-                        + "Timeout User did not perform testing.";
+                testFailedReason = FAILURE_REASON
+                                   + "Timeout User did not perform testing.";
                 timeout = true;
                 latch.countDown();
             }
@@ -166,8 +171,8 @@ public class PassFailJFrame {
             @Override
             public void windowClosing(WindowEvent e) {
                 super.windowClosing(e);
-                testFailedReason = "Failure Reason:\n"
-                        + "User closed the instruction Frame";
+                testFailedReason = FAILURE_REASON
+                                   + "User closed the instruction Frame";
                 failed = true;
                 latch.countDown();
             }
@@ -240,7 +245,7 @@ public class PassFailJFrame {
 
         JButton okButton = new JButton("OK");
         okButton.addActionListener((ae) -> {
-            testFailedReason = "Failure Reason:\n" + jTextArea.getText();
+            testFailedReason = FAILURE_REASON + jTextArea.getText();
             dialog.setVisible(false);
         });
 
@@ -403,9 +408,17 @@ public class PassFailJFrame {
      *  Forcibly fail the test.
      */
     public static void forceFail() {
+        forceFail("forceFail called");
+    }
+
+    /**
+     *  Forcibly fail the test and provide a reason.
+     *
+     * @param reason the reason why the test is failed
+     */
+    public static void forceFail(String reason) {
         failed = true;
-        testFailedReason = "Failure Reason:\n" +
-                           "forceFail called";
+        testFailedReason = FAILURE_REASON + reason;
         latch.countDown();
     }
 }

--- a/test/jdk/javax/swing/JTable/PrintAllPagesTest.java
+++ b/test/jdk/javax/swing/JTable/PrintAllPagesTest.java
@@ -109,6 +109,6 @@ public class PrintAllPagesTest {
 
         f = new JFrame("Table test");
         f.add(scrollpane);
-        f.setSize(1000, 800);
+        f.setSize(500, 400);
     }
 }

--- a/test/jdk/javax/swing/JTable/PrintAllPagesTest.java
+++ b/test/jdk/javax/swing/JTable/PrintAllPagesTest.java
@@ -41,7 +41,6 @@ import javax.swing.WindowConstants;
 public class PrintAllPagesTest {
     static JFrame f;
     static JTable table;
-    static volatile boolean ret = false;
 
     static final String INSTRUCTIONS = """
          Note: You must have a printer installed for this test.
@@ -71,13 +70,15 @@ public class PrintAllPagesTest {
             // Arrange the test instruction frame and test frame side by side
             PassFailJFrame.positionTestWindow(f, PassFailJFrame.Position.HORIZONTAL);
             f.setVisible(true);
+
+            boolean ret;
             try {
                 ret = table.print();
             } catch (PrinterException ex) {
                 ret = false;
             }
             if (!ret) {
-                throw new RuntimeException("Printing cancelled/failed");
+                PassFailJFrame.forceFail("Printing cancelled/failed");
             }
         });
         passFailJFrame.awaitAndCheck();


### PR DESCRIPTION
Add `forceFail` implementation which allows passing the reason why the test is failed.

I used the newly added method `forceFail(reason)` instead of throwing an exception in `PrintAllPagesTest`. When the test is run outside of jtreg and printing is cancelled, the the test UI becomes “hung”: clicking Pass or Fail or closing windows does not stop the test.

I also converted the `ret` field to local variable.

In addition to this, I reduced the size of the test frame, its size of 1000×800 doesn't fit even full HD screens when positioned close to the instruction frame.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293811](https://bugs.openjdk.org/browse/JDK-8293811): Provide a reason for PassFailJFrame.forceFail


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Author)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10269/head:pull/10269` \
`$ git checkout pull/10269`

Update a local copy of the PR: \
`$ git checkout pull/10269` \
`$ git pull https://git.openjdk.org/jdk pull/10269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10269`

View PR using the GUI difftool: \
`$ git pr show -t 10269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10269.diff">https://git.openjdk.org/jdk/pull/10269.diff</a>

</details>
