### PR TITLE
8293591: Remove use of Thread.stop from jshell tests

### DIFF
--- a/test/langtools/jdk/jshell/UITesting.java
+++ b/test/langtools/jdk/jshell/UITesting.java
@@ -120,12 +120,9 @@ public class UITesting {
             waitOutput(out, PROMPT);
             test.test(inputSink, out);
         } finally {
-            inputSink.write(INTERRUPT + INTERRUPT + "/exit");
+            inputSink.write(INTERRUPT + INTERRUPT + "/exit\n");
 
-            runner.join(1000);
-            if (runner.isAlive()) {
-                runner.stop();
-            }
+            runner.join();
         }
     }
 


### PR DESCRIPTION
Two changes here:
- confirming the '/exit` command, so that the JShell instance is actually stopped
- removing the call to `Thread.stop`, which is intended to stop the test if something goes wrong unexpectedly. As we cannot use `Thread.stop` anymore, we'll rely on jtreg to stop the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293591](https://bugs.openjdk.org/browse/JDK-8293591): Remove use of Thread.stop from jshell tests


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10271/head:pull/10271` \
`$ git checkout pull/10271`

Update a local copy of the PR: \
`$ git checkout pull/10271` \
`$ git pull https://git.openjdk.org/jdk pull/10271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10271`

View PR using the GUI difftool: \
`$ git pr show -t 10271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10271.diff">https://git.openjdk.org/jdk/pull/10271.diff</a>

</details>
