### PR TITLE
8271328: User is able to choose the color after disabling the color chooser.

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKColorChooserPanel.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKColorChooserPanel.java
@@ -104,6 +104,20 @@ class GTKColorChooserPanel extends AbstractColorChooserPanel implements
         component.requestFocus();
     }
 
+    @Override
+    public void setEnabled(boolean enabled) {
+        super.setEnabled(enabled);
+        setEnabled(this, enabled);
+    }
+
+    private static void setEnabled(Container container, boolean enabled) {
+        for (Component component : container.getComponents()) {
+            component.setEnabled(enabled);
+            if (component instanceof Container) {
+                setEnabled((Container) component, enabled);
+            }
+        }
+    }
 
     /**
      * Returns a user presentable description of this GTKColorChooserPane.
@@ -674,6 +688,11 @@ class GTKColorChooserPanel extends AbstractColorChooserPanel implements
         }
 
         protected void processEvent(AWTEvent e) {
+
+            if (!(getGTKColorChooserPanel().isEnabled())) {
+                return;
+            }
+
             if (e.getID() == MouseEvent.MOUSE_PRESSED ||
                    ((isSet(FLAGS_DRAGGING) ||isSet(FLAGS_DRAGGING_TRIANGLE)) &&
                    e.getID() == MouseEvent.MOUSE_DRAGGED)) {

--- a/test/jdk/javax/swing/JColorChooser/TestDisabledColorChooser.java
+++ b/test/jdk/javax/swing/JColorChooser/TestDisabledColorChooser.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8271328
+ * @key headful
+ * @requires (os.family == "linux")
+ * @summary Verifies if user is not able to select color from disabled ColorChooser
+ * @run main TestDisabledColorChooser
+ */
+
+import java.awt.Color;
+import java.awt.event.InputEvent;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.awt.Point;
+import java.awt.Robot;
+import javax.swing.*;
+
+public class TestDisabledColorChooser  {
+    private static JFrame frame;
+    private static JColorChooser Colorchooser;
+
+    public TestDisabledColorChooser() {
+        createAndShowUI();
+    }
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                new TestDisabledColorChooser();
+            });
+		
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            Point pt = frame.getLocationOnScreen();
+            robot.mouseMove(pt.x+75, pt.y+frame.getHeight()/2);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            Color c1 = Colorchooser.getColor();
+
+            Colorchooser.setEnabled(false);
+            robot.mouseMove(pt.x+85, pt.y+frame.getHeight()/2);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            Color c2 = Colorchooser.getColor();
+            robot.delay(1000);
+
+            if (c1.getRGB() != c2.getRGB())
+                throw new RuntimeException("User is able to select color after disabling ColorChooser");
+            else
+                System.out.println("passed");
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private void createAndShowUI() {
+        frame = new JFrame("Test Disabled ColorChooser Color Selection");
+        Colorchooser = new JColorChooser();
+        frame.add(Colorchooser);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);  
+        frame.setVisible(true);
+    }
+}

--- a/test/jdk/javax/swing/JColorChooser/TestDisabledColorChooser.java
+++ b/test/jdk/javax/swing/JColorChooser/TestDisabledColorChooser.java
@@ -36,7 +36,10 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.Point;
 import java.awt.Robot;
-import javax.swing.*;
+import javax.swing.JColorChooser;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 
 public class TestDisabledColorChooser  {
     private static JFrame frame;

--- a/test/jdk/javax/swing/JColorChooser/TestDisabledColorChooser.java
+++ b/test/jdk/javax/swing/JColorChooser/TestDisabledColorChooser.java
@@ -54,7 +54,7 @@ public class TestDisabledColorChooser  {
             SwingUtilities.invokeAndWait(() -> {
                 new TestDisabledColorChooser();
             });
-		
+
             robot.waitForIdle();
             robot.delay(1000);
 
@@ -90,7 +90,7 @@ public class TestDisabledColorChooser  {
         frame.add(Colorchooser);
         frame.pack();
         frame.setLocationRelativeTo(null);
-        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);  
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.setVisible(true);
     }
 }


### PR DESCRIPTION
The proposed solution for this defect is to check the color chooser enabled state. If it is disabled then disable all the components (spinner, textfield etc.) in panel and don't process the mouse event when user click on a color triangle or color wheel.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271328](https://bugs.openjdk.org/browse/JDK-8271328): User is able to choose the color after disabling the color chooser.


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10276/head:pull/10276` \
`$ git checkout pull/10276`

Update a local copy of the PR: \
`$ git checkout pull/10276` \
`$ git pull https://git.openjdk.org/jdk pull/10276/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10276`

View PR using the GUI difftool: \
`$ git pr show -t 10276`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10276.diff">https://git.openjdk.org/jdk/pull/10276.diff</a>

</details>
