### PR TITLE
8293842: IPv6-only systems throws UnsupportedOperationException for several socket/TCP options

### DIFF
--- a/src/java.base/share/native/libnet/net_util.c
+++ b/src/java.base/share/native/libnet/net_util.c
@@ -79,7 +79,10 @@ DEF_JNI_OnLoad(JavaVM *vm, void *reserved)
     IPv4_available = IPv4_supported();
     IPv6_available = IPv6_supported() & (!preferIPv4Stack);
 
-    /* check if SO_REUSEPORT is supported on this platform */
+    /*
+     * Check if SO_REUSEPORT is supported on this platform.
+     * Must be called after IPv6_available is initialized.
+     */
     REUSEPORT_available = reuseport_supported();
     platformInit();
 

--- a/src/java.base/share/native/libnet/net_util.c
+++ b/src/java.base/share/native/libnet/net_util.c
@@ -30,7 +30,7 @@
 
 int IPv4_supported();
 int IPv6_supported();
-int reuseport_supported();
+int reuseport_supported(int ipv6_available);
 
 static int IPv4_available;
 static int IPv6_available;
@@ -79,11 +79,8 @@ DEF_JNI_OnLoad(JavaVM *vm, void *reserved)
     IPv4_available = IPv4_supported();
     IPv6_available = IPv6_supported() & (!preferIPv4Stack);
 
-    /*
-     * Check if SO_REUSEPORT is supported on this platform.
-     * Must be called after IPv6_available is initialized.
-     */
-    REUSEPORT_available = reuseport_supported();
+    /* check if SO_REUSEPORT is supported on this platform */
+    REUSEPORT_available = reuseport_supported(IPv6_available);
     platformInit();
 
     return JNI_VERSION_1_2;

--- a/src/java.base/unix/native/libnet/net_util_md.c
+++ b/src/java.base/unix/native/libnet/net_util_md.c
@@ -192,7 +192,11 @@ jint reuseport_supported()
     /* Do a simple dummy call, and try to figure out from that */
     int one = 1;
     int rv, s;
-    s = socket(PF_INET, SOCK_STREAM, 0);
+    if (ipv6_available()) {
+      s = socket(PF_INET6, SOCK_STREAM, 0);
+    } else {
+      s = socket(PF_INET, SOCK_STREAM, 0);
+    }
     if (s < 0) {
         return JNI_FALSE;
     }

--- a/src/java.base/unix/native/libnet/net_util_md.c
+++ b/src/java.base/unix/native/libnet/net_util_md.c
@@ -187,15 +187,15 @@ jint  IPv6_supported()
 }
 #endif /* DONT_ENABLE_IPV6 */
 
-jint reuseport_supported()
+jint reuseport_supported(int ipv6_available)
 {
     /* Do a simple dummy call, and try to figure out from that */
     int one = 1;
     int rv, s;
-    if (ipv6_available()) {
-      s = socket(PF_INET6, SOCK_STREAM, 0);
+    if (ipv6_available) {
+        s = socket(PF_INET6, SOCK_STREAM, 0);
     } else {
-      s = socket(PF_INET, SOCK_STREAM, 0);
+        s = socket(PF_INET, SOCK_STREAM, 0);
     }
     if (s < 0) {
         return JNI_FALSE;

--- a/src/java.base/windows/native/libnet/net_util_md.c
+++ b/src/java.base/windows/native/libnet/net_util_md.c
@@ -235,7 +235,7 @@ jint  IPv6_supported()
     return JNI_TRUE;
 }
 
-jint reuseport_supported()
+jint reuseport_supported(int ipv6_available)
 {
     /* SO_REUSEPORT is not supported on Windows */
     return JNI_FALSE;

--- a/src/jdk.net/linux/native/libextnet/LinuxSocketOptions.c
+++ b/src/jdk.net/linux/native/libextnet/LinuxSocketOptions.c
@@ -54,9 +54,15 @@ static jint socketOptionSupported(jint level, jint optname) {
     jint one = 1;
     jint rv, s;
     socklen_t sz = sizeof (one);
-    s = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+    /* First try IPv6; fall back to IPv4. */
+    s = socket(PF_INET6, SOCK_STREAM, IPPROTO_TCP);
     if (s < 0) {
-        return 0;
+        if (errno == EPFNOSUPPORT || errno == EAFNOSUPPORT) {
+            s = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+        }
+        if (s < 0) {
+            return 0;
+        }
     }
     rv = getsockopt(s, level, optname, (void *) &one, &sz);
     if (rv != 0 && errno == ENOPROTOOPT) {

--- a/src/jdk.net/macosx/native/libextnet/MacOSXSocketOptions.c
+++ b/src/jdk.net/macosx/native/libextnet/MacOSXSocketOptions.c
@@ -48,9 +48,15 @@ DEF_STATIC_JNI_OnLoad
 static jint socketOptionSupported(jint sockopt) {
     jint one = 1;
     jint rv, s;
-    s = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+    /* First try IPv6; fall back to IPv4. */
+    s = socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
     if (s < 0) {
-        return 0;
+        if (errno == EPFNOSUPPORT || errno == EAFNOSUPPORT) {
+            s = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+        }
+        if (s < 0) {
+            return 0;
+        }
     }
     rv = setsockopt(s, IPPROTO_TCP, sockopt, (void *) &one, sizeof (one));
     if (rv != 0 && errno == ENOPROTOOPT) {


### PR DESCRIPTION
Hi all,

Could anyone review this bug fix for ipv6-only system? See https://bugs.openjdk.org/browse/JDK-8293842 for detailed description of this bug.

Ideally, the `socket(PF_INET6, ...)` or `socket(PF_INET, ...)` call should depend on the value of `ipv6_available()`. However, this is only easy to do in net_util_md.c. Without checking `ipv6_available()` in <Linux|MacOSX>SocketOptions.c, I'm not sure if it is possible for ipv6 and ipv4 sockets to differ in the options they support.

For example, for a system with both ipv6 and ipv4, if ipv6 supports TCP_KEEPIDLE but ipv4 does not, then there might be a problem to always report TCP_KEEPIDLE as supported. 

I noticed https://bugs.openjdk.org/browse/JDK-8290349 added "isIPv6" parameter to a few functions in <Linux|MacOSX>SocketOptions.c. However, it is not applicable to the `socketOptionSupported()` function. This change is more similar to the `Java_jdk_net_MacOSXSocketOptions_ipDontFragmentSupported0()` function.

-Man

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293842](https://bugs.openjdk.org/browse/JDK-8293842): IPv6-only systems throws UnsupportedOperationException for several socket/TCP options


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - Committer) ⚠️ Review applies to [6a2c295b](https://git.openjdk.org/jdk/pull/10278/files/6a2c295b3ab862b656a5972d9966bc775f2075e8)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to [6a2c295b](https://git.openjdk.org/jdk/pull/10278/files/6a2c295b3ab862b656a5972d9966bc775f2075e8)


### Contributors
 * Martin Buchholz `<martin@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10278/head:pull/10278` \
`$ git checkout pull/10278`

Update a local copy of the PR: \
`$ git checkout pull/10278` \
`$ git pull https://git.openjdk.org/jdk pull/10278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10278`

View PR using the GUI difftool: \
`$ git pr show -t 10278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10278.diff">https://git.openjdk.org/jdk/pull/10278.diff</a>

</details>
