### PR TITLE
7172359: HTML parser StackOverflowError on invalid HTML: <li> tag inside an <option>

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/parser/Parser.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/parser/Parser.java
@@ -703,6 +703,12 @@ class Parser implements DTDConstants {
                 }
                 if (!s.terminate() || (strict && !s.elem.omitEnd())) {
                     break;
+                } else if (s.terminate()) {
+                    // Since the current tag is not valid in current context
+                    // as otherwise s.advance(elem) would have returned true
+                    // so check if the stack is to be terminated
+                    // in which case return false
+                    return false;
                 }
             }
         }
@@ -781,7 +787,7 @@ class Parser implements DTDConstants {
             }
 
             endTag(true);
-            return true;
+            return legalElementContext(elem);
         }
 
         // At this point we know that something is screwed up.

--- a/src/java.desktop/share/classes/javax/swing/text/html/parser/Parser.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/parser/Parser.java
@@ -781,7 +781,7 @@ class Parser implements DTDConstants {
             }
 
             endTag(true);
-            return legalElementContext(elem);
+            return true;
         }
 
         // At this point we know that something is screwed up.

--- a/test/jdk/javax/swing/text/html/parser/ParserCrash.java
+++ b/test/jdk/javax/swing/text/html/parser/ParserCrash.java
@@ -23,7 +23,7 @@
 /*
  * @test
  * @bug 7172359
- * @summary  Verifies HTML parser StackOverflowError on invalid HTML: <li> tag 
+ * @summary  Verifies HTML parser StackOverflowError on invalid HTML: <li> tag
  *           inside an <option>
  * @run main ParserCrash
  */
@@ -37,7 +37,7 @@ public class ParserCrash {
      * li element inside an option will crash javax.swing.text.html.parser.Parser
      */
     public static void main( String[] argv ) throws Exception {
-        String badHtml = 
+        String badHtml =
          "<html><body><form><select><option><li></option></select></form></body></html>";
 
         HTMLEditorKit kit = new HTMLEditorKit();

--- a/test/jdk/javax/swing/text/html/parser/ParserCrash.java
+++ b/test/jdk/javax/swing/text/html/parser/ParserCrash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/text/html/parser/ParserCrash.java
+++ b/test/jdk/javax/swing/text/html/parser/ParserCrash.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 7172359
+ * @summary  Verifies HTML parser StackOverflowError on invalid HTML: <li> tag 
+ *           inside an <option>
+ * @run main ParserCrash
+ */
+import javax.swing.text.html.HTMLDocument;
+import javax.swing.text.html.HTMLEditorKit;
+import java.io.StringReader;
+import java.io.Reader;
+
+public class ParserCrash {
+    /*
+     * li element inside an option will crash javax.swing.text.html.parser.Parser
+     */
+    public static void main( String[] argv ) throws Exception {
+        String badHtml = 
+         "<html><body><form><select><option><li></option></select></form></body></html>";
+
+        HTMLEditorKit kit = new HTMLEditorKit();
+        HTMLDocument doc = (HTMLDocument) kit.createDefaultDocument();
+        Reader reader = new StringReader(badHtml);
+        kit.read(reader, doc, 0); // StackOverflowError here
+
+        System.out.println("Succeeded! (expected StackOverflowError");
+    }
+}
+

--- a/test/jdk/javax/swing/text/html/parser/ParserStackOverflow.java
+++ b/test/jdk/javax/swing/text/html/parser/ParserStackOverflow.java
@@ -45,7 +45,7 @@ public class ParserStackOverflow {
         Reader reader = new StringReader(badHtml);
         kit.read(reader, doc, 0); // StackOverflowError here
 
-        System.out.println("Succeeded! (no StackOverflowError");
+        System.out.println("Succeeded! (no StackOverflowError)");
     }
 }
 

--- a/test/jdk/javax/swing/text/html/parser/ParserStackOverflow.java
+++ b/test/jdk/javax/swing/text/html/parser/ParserStackOverflow.java
@@ -25,14 +25,14 @@
  * @bug 7172359
  * @summary  Verifies HTML parser StackOverflowError on invalid HTML: <li> tag
  *           inside an <option>
- * @run main ParserCrash
+ * @run main ParserStackOverflow
  */
 import javax.swing.text.html.HTMLDocument;
 import javax.swing.text.html.HTMLEditorKit;
 import java.io.StringReader;
 import java.io.Reader;
 
-public class ParserCrash {
+public class ParserStackOverflow {
     /*
      * li element inside an option will crash javax.swing.text.html.parser.Parser
      */
@@ -45,7 +45,7 @@ public class ParserCrash {
         Reader reader = new StringReader(badHtml);
         kit.read(reader, doc, 0); // StackOverflowError here
 
-        System.out.println("Succeeded! (expected StackOverflowError");
+        System.out.println("Succeeded! (no StackOverflowError");
     }
 }
 


### PR DESCRIPTION
If there is invalid tag, stack terminates but it still tries to recurse through by calling legalElementContext() which results in StackOverflowError.
Fix is to return if stack is terminated after checking current tag is not valid in current context

All other test/html/parser as well as other jtreg suite tests are ok with the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7172359](https://bugs.openjdk.org/browse/JDK-7172359): HTML parser StackOverflowError on invalid HTML: <li> tag inside an <option>


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Author) ⚠️ Review applies to [4296729f](https://git.openjdk.org/jdk/pull/10279/files/4296729f7fd28f77b5a4a8a09244bbc221f7c744)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**) ⚠️ Review applies to [4296729f](https://git.openjdk.org/jdk/pull/10279/files/4296729f7fd28f77b5a4a8a09244bbc221f7c744)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**) ⚠️ Review applies to [46c477d8](https://git.openjdk.org/jdk/pull/10279/files/46c477d84f36454d4988a40da3ce77437bc16241)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10279/head:pull/10279` \
`$ git checkout pull/10279`

Update a local copy of the PR: \
`$ git checkout pull/10279` \
`$ git pull https://git.openjdk.org/jdk pull/10279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10279`

View PR using the GUI difftool: \
`$ git pr show -t 10279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10279.diff">https://git.openjdk.org/jdk/pull/10279.diff</a>

</details>
