### PR TITLE
JDK-8293808: mscapi destroyKeyContainer enhance KeyStoreException: Access is denied exception

### DIFF
--- a/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
+++ b/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
@@ -128,6 +128,24 @@ void ThrowExceptionWithMessage(JNIEnv *env, const char *exceptionName,
     }
 }
 
+void ThrowExceptionWithMessageAndErrcode(JNIEnv *env, const char *exceptionName,
+                                         const char *msg, DWORD dwError) {
+    char szMessage[500];
+    szMessage[0] = '\0';
+    char szMessage2[1024];
+    szMessage2[0] = '\0';
+
+    DWORD res = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, NULL, dwError,
+        NULL, szMessage, sizeof(szMessage), NULL);
+    if (res == 0) {
+        strcpy(szMessage, "Unknown error");
+    }
+    snprintf(szMessage2, sizeof(szMessage2), "%s: error %lu, %s", msg, dwError, szMessage);
+
+    ThrowExceptionWithMessage(env, exceptionName, szMessage2);
+}
+
+
 /*
  * Throws an arbitrary Java exception.
  * The exception message is a Windows system error message.
@@ -1845,8 +1863,7 @@ JNIEXPORT void JNICALL Java_sun_security_mscapi_CKeyStore_destroyKeyContainer
         // Destroying the default key container is not permitted
         // (because it may contain more one keypair).
         if (pszKeyContainerName == NULL) {
-
-            ThrowException(env, KEYSTORE_EXCEPTION, NTE_BAD_KEYSET_PARAM);
+            ThrowExceptionWithMessage(env, KEYSTORE_EXCEPTION, "key container name was NULL, NTE_BAD_KEYSET_PARAM");
             __leave;
         }
 
@@ -1858,7 +1875,7 @@ JNIEXPORT void JNICALL Java_sun_security_mscapi_CKeyStore_destroyKeyContainer
             PROV_RSA_FULL,
             CRYPT_DELETEKEYSET) == FALSE)
         {
-            ThrowException(env, KEYSTORE_EXCEPTION, GetLastError());
+            ThrowExceptionWithMessageAndErrcode(env, KEYSTORE_EXCEPTION, "CryptAcquireContext failure", GetLastError());
             __leave;
         }
 

--- a/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
+++ b/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
@@ -162,7 +162,7 @@ void ThrowException(JNIEnv *env, const char *exceptionName, DWORD dwError)
     if (res == 0) {
         strcpy(szMessage, "Unknown error");
     }
-    snprintf(szMessage2, sizeof(szMessage2), "error %lu, %s", msg, dwError, szMessage);
+    snprintf(szMessage2, sizeof(szMessage2), "error %lu, %s", dwError, szMessage);
 
     ThrowExceptionWithMessage(env, exceptionName, szMessage2);
 }

--- a/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
+++ b/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
@@ -152,16 +152,19 @@ void ThrowExceptionWithMessageAndErrcode(JNIEnv *env, const char *exceptionName,
  */
 void ThrowException(JNIEnv *env, const char *exceptionName, DWORD dwError)
 {
-    char szMessage[1024];
+    char szMessage[500];
     szMessage[0] = '\0';
+    char szMessage2[1024];
+    szMessage2[0] = '\0';
 
     DWORD res = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, NULL, dwError,
         NULL, szMessage, sizeof(szMessage), NULL);
     if (res == 0) {
         strcpy(szMessage, "Unknown error");
     }
+    snprintf(szMessage2, sizeof(szMessage2), "error %lu, %s", msg, dwError, szMessage);
 
-    ThrowExceptionWithMessage(env, exceptionName, szMessage);
+    ThrowExceptionWithMessage(env, exceptionName, szMessage2);
 }
 
 /*


### PR DESCRIPTION
Currently we see on various Windows machines the following exception :
https://bugs.openjdk.org/browse/JDK-8293097

java.security.KeyStoreException: Access is denied.

This should probably be enhanced a bit so that the exception tell us more about what went wrong exactly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293808](https://bugs.openjdk.org/browse/JDK-8293808): mscapi destroyKeyContainer enhance KeyStoreException: Access is denied exception


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10280/head:pull/10280` \
`$ git checkout pull/10280`

Update a local copy of the PR: \
`$ git checkout pull/10280` \
`$ git pull https://git.openjdk.org/jdk pull/10280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10280`

View PR using the GUI difftool: \
`$ git pr show -t 10280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10280.diff">https://git.openjdk.org/jdk/pull/10280.diff</a>

</details>
