### PR TITLE
8293844: C2: Verify Location::{oop,normal} types in PhaseOutput::FillLocArray

### DIFF
--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -930,8 +930,16 @@ void PhaseOutput::FillLocArray( int idx, MachSafePointNode* sfpt, Node *local,
                t->base() == Type::VectorD || t->base() == Type::VectorX ||
                t->base() == Type::VectorY || t->base() == Type::VectorZ) {
       array->append(new_loc_value( C->regalloc(), regnum, Location::vector ));
+    } else if (C->regalloc()->is_oop(local)) {
+      assert(t->base() == Type::OopPtr || t->base() == Type::InstPtr ||
+             t->base() == Type::AryPtr,
+             "Unexpected type: %s", t->msg());
+      array->append(new_loc_value( C->regalloc(), regnum, Location::oop ));
     } else {
-      array->append(new_loc_value( C->regalloc(), regnum, C->regalloc()->is_oop(local) ? Location::oop : Location::normal ));
+      assert(t->base() == Type::Int || t->base() == Type::Half ||
+             t->base() == Type::FloatCon || t->base() == Type::FloatBot,
+             "Unexpected type: %s", t->msg());
+      array->append(new_loc_value( C->regalloc(), regnum, Location::normal ));
     }
     return;
   }


### PR DESCRIPTION
I have been debugging a weird issue in C2/deopt, and wanted to have stronger asserts in critical paths. One such place is `PhaseOutput::FillLocArray`, which emits `Location::normal` on unconditional `else` branch. `Location::normal` is described as "Ints, floats, double halves". I think we would be better off verifying the types explicitly. Same goes for `Location::oop`, which we can also verify.

Aside: In fact, I suspect the whole `Regalloc::is_oop` business can go away, and we can rely on reg types to sense if we are dealing with oops here, but that looks like a change with some unexpected effects, so I would like to do that separately, see [JDK-8293845](https://bugs.openjdk.org/browse/JDK-8293845).

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1`
 - [x] Linux x86_64 fastdebug `tier2`
 - [x] Linux x86_32 fastdebug `tier1`
 - [x] Linux x86_32 fastdebug `tier2`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293844](https://bugs.openjdk.org/browse/JDK-8293844): C2: Verify Location::{oop,normal} types in PhaseOutput::FillLocArray


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10281/head:pull/10281` \
`$ git checkout pull/10281`

Update a local copy of the PR: \
`$ git checkout pull/10281` \
`$ git pull https://git.openjdk.org/jdk pull/10281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10281`

View PR using the GUI difftool: \
`$ git pr show -t 10281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10281.diff">https://git.openjdk.org/jdk/pull/10281.diff</a>

</details>
