### PR TITLE
8293851: hs_err should print more stack in hex dump

### DIFF
--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -456,7 +456,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const ucontext_t* uc = (const ucontext_t*)context;
 
   address sp = (address)os::Aix::ucontext_get_sp(uc);
-  print_stack(st, sp);
+  print_tos(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -455,9 +455,8 @@ void os::print_tos_pc(outputStream *st, const void *context) {
 
   const ucontext_t* uc = (const ucontext_t*)context;
 
-  intptr_t *sp = (intptr_t *)os::Aix::ucontext_get_sp(uc);
-  st->print_cr("Top of Stack: (sp=" PTR_FORMAT ")", sp);
-  print_hex_dump(st, (address)sp, (address)(sp + 128), sizeof(intptr_t));
+  address sp = (address)os::Aix::ucontext_get_sp(uc);
+  print_stack(st, sp, sizeof(intptr_t));
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -456,7 +456,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const ucontext_t* uc = (const ucontext_t*)context;
 
   address sp = (address)os::Aix::ucontext_get_sp(uc);
-  print_stack(st, sp, sizeof(intptr_t));
+  print_stack(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
@@ -469,9 +469,8 @@ void os::print_tos_pc(outputStream *st, const void *context) {
 
   const ucontext_t* uc = (const ucontext_t*)context;
 
-  intptr_t *sp = (intptr_t *)os::Bsd::ucontext_get_sp(uc);
-  st->print_cr("Top of Stack: (sp=" INTPTR_FORMAT ")", (intptr_t)sp);
-  print_hex_dump(st, (address)sp, (address)(sp + 8*sizeof(intptr_t)), sizeof(intptr_t));
+  address sp = (address)os::Bsd::ucontext_get_sp(uc);
+  print_stack(st, sp, sizeof(intptr_t));
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
@@ -470,7 +470,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const ucontext_t* uc = (const ucontext_t*)context;
 
   address sp = (address)os::Bsd::ucontext_get_sp(uc);
-  print_stack(st, sp, sizeof(intptr_t));
+  print_stack(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
@@ -470,7 +470,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const ucontext_t* uc = (const ucontext_t*)context;
 
   address sp = (address)os::Bsd::ucontext_get_sp(uc);
-  print_stack(st, sp);
+  print_tos(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -854,7 +854,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const ucontext_t* uc = (const ucontext_t*)context;
 
   address sp = (address)os::Bsd::ucontext_get_sp(uc);
-  print_stack(st, sp);
+  print_tos(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -853,9 +853,8 @@ void os::print_tos_pc(outputStream *st, const void *context) {
 
   const ucontext_t* uc = (const ucontext_t*)context;
 
-  intptr_t *sp = (intptr_t *)os::Bsd::ucontext_get_sp(uc);
-  st->print_cr("Top of Stack: (sp=" INTPTR_FORMAT ")", (intptr_t)sp);
-  print_hex_dump(st, (address)sp, (address)(sp + 8*sizeof(intptr_t)), sizeof(intptr_t));
+  address sp = (address)os::Bsd::ucontext_get_sp(uc);
+  print_stack(st, sp, sizeof(intptr_t));
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -854,7 +854,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const ucontext_t* uc = (const ucontext_t*)context;
 
   address sp = (address)os::Bsd::ucontext_get_sp(uc);
-  print_stack(st, sp, sizeof(intptr_t));
+  print_stack(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
@@ -342,7 +342,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const ucontext_t* uc = (const ucontext_t*)context;
 
   address sp = (address)os::Linux::ucontext_get_sp(uc);
-  print_stack(st, sp, sizeof(intptr_t));
+  print_stack(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
@@ -342,7 +342,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const ucontext_t* uc = (const ucontext_t*)context;
 
   address sp = (address)os::Linux::ucontext_get_sp(uc);
-  print_stack(st, sp);
+  print_tos(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
@@ -341,9 +341,8 @@ void os::print_tos_pc(outputStream *st, const void *context) {
 
   const ucontext_t* uc = (const ucontext_t*)context;
 
-  intptr_t *sp = (intptr_t *)os::Linux::ucontext_get_sp(uc);
-  st->print_cr("Top of Stack: (sp=" PTR_FORMAT ")", p2i(sp));
-  print_hex_dump(st, (address)sp, (address)(sp + 8*sizeof(intptr_t)), sizeof(intptr_t));
+  address sp = (address)os::Linux::ucontext_get_sp(uc);
+  print_stack(st, sp, sizeof(intptr_t));
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
+++ b/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
@@ -476,7 +476,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const ucontext_t* uc = (const ucontext_t*)context;
 
   address sp = (address)os::Linux::ucontext_get_sp(uc);
-  print_stack(st, sp, sizeof(intptr_t));
+  print_stack(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
+++ b/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
@@ -475,9 +475,8 @@ void os::print_tos_pc(outputStream *st, const void *context) {
 
   const ucontext_t* uc = (const ucontext_t*)context;
 
-  intptr_t *sp = (intptr_t *)os::Linux::ucontext_get_sp(uc);
-  st->print_cr("Top of Stack: (sp=" INTPTR_FORMAT ")", p2i(sp));
-  print_hex_dump(st, (address)sp, (address)(sp + 8*sizeof(intptr_t)), sizeof(intptr_t));
+  address sp = (address)os::Linux::ucontext_get_sp(uc);
+  print_stack(st, sp, sizeof(intptr_t));
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
+++ b/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
@@ -476,7 +476,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const ucontext_t* uc = (const ucontext_t*)context;
 
   address sp = (address)os::Linux::ucontext_get_sp(uc);
-  print_stack(st, sp);
+  print_tos(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
@@ -470,7 +470,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const ucontext_t* uc = (const ucontext_t*)context;
 
   address sp = (address)os::Linux::ucontext_get_sp(uc);
-  print_stack(st, sp);
+  print_tos(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
@@ -469,9 +469,8 @@ void os::print_tos_pc(outputStream *st, const void *context) {
 
   const ucontext_t* uc = (const ucontext_t*)context;
 
-  intptr_t *sp = (intptr_t *)os::Linux::ucontext_get_sp(uc);
-  st->print_cr("Top of Stack: (sp=" PTR_FORMAT ")", p2i(sp));
-  print_hex_dump(st, (address)sp, (address)(sp + 128), sizeof(intptr_t));
+  address sp = (address)os::Linux::ucontext_get_sp(uc);
+  print_stack(st, sp, sizeof(intptr_t));
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
@@ -470,7 +470,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const ucontext_t* uc = (const ucontext_t*)context;
 
   address sp = (address)os::Linux::ucontext_get_sp(uc);
-  print_stack(st, sp, sizeof(intptr_t));
+  print_stack(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
@@ -351,7 +351,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const ucontext_t* uc = (const ucontext_t*)context;
 
   address sp = (address)os::Linux::ucontext_get_sp(uc);
-  print_stack(st, sp);
+  print_tos(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
@@ -351,7 +351,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const ucontext_t* uc = (const ucontext_t*)context;
 
   address sp = (address)os::Linux::ucontext_get_sp(uc);
-  print_stack(st, sp, sizeof(intptr_t));
+  print_stack(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
@@ -350,9 +350,8 @@ void os::print_tos_pc(outputStream *st, const void *context) {
 
   const ucontext_t* uc = (const ucontext_t*)context;
 
-  intptr_t *frame_sp = (intptr_t *)os::Linux::ucontext_get_sp(uc);
-  st->print_cr("Top of Stack: (sp=" PTR_FORMAT ")", p2i(frame_sp));
-  print_hex_dump(st, (address)frame_sp, (address)(frame_sp + 64), sizeof(intptr_t));
+  address sp = (address)os::Linux::ucontext_get_sp(uc);
+  print_stack(st, sp, sizeof(intptr_t));
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/linux_s390/os_linux_s390.cpp
+++ b/src/hotspot/os_cpu/linux_s390/os_linux_s390.cpp
@@ -442,7 +442,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const ucontext_t* uc = (const ucontext_t*)context;
 
   address sp = (address)os::Linux::ucontext_get_sp(uc);
-  print_stack(st, sp);
+  print_tos(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/linux_s390/os_linux_s390.cpp
+++ b/src/hotspot/os_cpu/linux_s390/os_linux_s390.cpp
@@ -441,9 +441,8 @@ void os::print_tos_pc(outputStream *st, const void *context) {
 
   const ucontext_t* uc = (const ucontext_t*)context;
 
-  intptr_t *sp = (intptr_t *)os::Linux::ucontext_get_sp(uc);
-  st->print_cr("Top of Stack: (sp=" PTR_FORMAT ")", p2i(sp));
-  print_hex_dump(st, (address)sp, (address)(sp + 128), sizeof(intptr_t));
+  address sp = (address)os::Linux::ucontext_get_sp(uc);
+  print_stack(st, sp, sizeof(intptr_t));
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/linux_s390/os_linux_s390.cpp
+++ b/src/hotspot/os_cpu/linux_s390/os_linux_s390.cpp
@@ -442,7 +442,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const ucontext_t* uc = (const ucontext_t*)context;
 
   address sp = (address)os::Linux::ucontext_get_sp(uc);
-  print_stack(st, sp, sizeof(intptr_t));
+  print_stack(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -579,9 +579,8 @@ void os::print_tos_pc(outputStream *st, const void *context) {
 
   const ucontext_t* uc = (const ucontext_t*)context;
 
-  intptr_t *sp = (intptr_t *)os::Linux::ucontext_get_sp(uc);
-  st->print_cr("Top of Stack: (sp=" PTR_FORMAT ")", p2i(sp));
-  print_hex_dump(st, (address)sp, (address)(sp + 8), sizeof(intptr_t));
+  address sp = (address)os::Linux::ucontext_get_sp(uc);
+  print_stack(st, sp, sizeof(intptr_t));
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -580,7 +580,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const ucontext_t* uc = (const ucontext_t*)context;
 
   address sp = (address)os::Linux::ucontext_get_sp(uc);
-  print_stack(st, sp, sizeof(intptr_t));
+  print_stack(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -580,7 +580,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const ucontext_t* uc = (const ucontext_t*)context;
 
   address sp = (address)os::Linux::ucontext_get_sp(uc);
-  print_stack(st, sp);
+  print_tos(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp
@@ -213,7 +213,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const CONTEXT* uc = (const CONTEXT*)context;
 
   address sp = (address)uc->Sp;
-  print_stack(st, sp, sizeof(intptr_t));
+  print_stack(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp
@@ -212,9 +212,8 @@ void os::print_tos_pc(outputStream *st, const void *context) {
 
   const CONTEXT* uc = (const CONTEXT*)context;
 
-  intptr_t *sp = (intptr_t *)uc->Sp;
-  st->print_cr("Top of Stack: (sp=" PTR_FORMAT ")", sp);
-  print_hex_dump(st, (address)sp, (address)(sp + 32), sizeof(intptr_t));
+  address sp = (address)uc->Sp;
+  print_stack(st, sp, sizeof(intptr_t));
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp
@@ -213,7 +213,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const CONTEXT* uc = (const CONTEXT*)context;
 
   address sp = (address)uc->Sp;
-  print_stack(st, sp);
+  print_tos(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
@@ -450,7 +450,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const CONTEXT* uc = (const CONTEXT*)context;
 
   address sp = (address)uc->REG_SP;
-  print_stack(st, sp);
+  print_tos(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
@@ -449,9 +449,8 @@ void os::print_tos_pc(outputStream *st, const void *context) {
 
   const CONTEXT* uc = (const CONTEXT*)context;
 
-  intptr_t *sp = (intptr_t *)uc->REG_SP;
-  st->print_cr("Top of Stack: (sp=" PTR_FORMAT ")", sp);
-  print_hex_dump(st, (address)sp, (address)(sp + 32), sizeof(intptr_t));
+  address sp = (address)uc->REG_SP;
+  print_stack(st, sp, sizeof(intptr_t));
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
@@ -450,7 +450,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   const CONTEXT* uc = (const CONTEXT*)context;
 
   address sp = (address)uc->REG_SP;
-  print_stack(st, sp, sizeof(intptr_t));
+  print_stack(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -935,6 +935,11 @@ void os::print_dhm(outputStream* st, const char* startStr, long sec) {
   st->print_cr("%s %ld days %ld:%02ld hours", startStr, days, hours, minutes);
 }
 
+void os::print_stack(outputStream* st, address sp, int unitsize) {
+  st->print_cr("Top of Stack: (sp=" PTR_FORMAT ")", p2i(sp));
+  print_hex_dump(st, sp, sp + 512, unitsize);
+}
+
 void os::print_instructions(outputStream* st, address pc, int unitsize) {
   st->print_cr("Instructions: (pc=" PTR_FORMAT ")", p2i(pc));
   print_hex_dump(st, pc - 256, pc + 256, unitsize);

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -935,7 +935,7 @@ void os::print_dhm(outputStream* st, const char* startStr, long sec) {
   st->print_cr("%s %ld days %ld:%02ld hours", startStr, days, hours, minutes);
 }
 
-void os::print_stack(outputStream* st, address sp) {
+void os::print_tos(outputStream* st, address sp) {
   st->print_cr("Top of Stack: (sp=" PTR_FORMAT ")", p2i(sp));
   print_hex_dump(st, sp, sp + 512, sizeof(intptr_t));
 }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -935,9 +935,9 @@ void os::print_dhm(outputStream* st, const char* startStr, long sec) {
   st->print_cr("%s %ld days %ld:%02ld hours", startStr, days, hours, minutes);
 }
 
-void os::print_stack(outputStream* st, address sp, int unitsize) {
+void os::print_stack(outputStream* st, address sp) {
   st->print_cr("Top of Stack: (sp=" PTR_FORMAT ")", p2i(sp));
-  print_hex_dump(st, sp, sp + 512, unitsize);
+  print_hex_dump(st, sp, sp + 512, sizeof(intptr_t));
 }
 
 void os::print_instructions(outputStream* st, address pc, int unitsize) {

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -763,6 +763,7 @@ class os: AllStatic {
   static void print_siginfo(outputStream* st, const void* siginfo);
   static void print_signal_handlers(outputStream* st, char* buf, size_t buflen);
   static void print_date_and_time(outputStream* st, char* buf, size_t buflen);
+  static void print_stack(outputStream* st, address sp, int unitsize);
   static void print_instructions(outputStream* st, address pc, int unitsize);
 
   static void print_user_info(outputStream* st);

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -758,13 +758,13 @@ class os: AllStatic {
   static void print_environment_variables(outputStream* st, const char** env_list);
   static void print_context(outputStream* st, const void* context);
   static void print_tos_pc(outputStream* st, const void* context);
+  static void print_tos(outputStream* st, address sp);
+  static void print_instructions(outputStream* st, address pc, int unitsize);
   static void print_register_info(outputStream* st, const void* context);
   static bool signal_sent_by_kill(const void* siginfo);
   static void print_siginfo(outputStream* st, const void* siginfo);
   static void print_signal_handlers(outputStream* st, char* buf, size_t buflen);
   static void print_date_and_time(outputStream* st, char* buf, size_t buflen);
-  static void print_stack(outputStream* st, address sp);
-  static void print_instructions(outputStream* st, address pc, int unitsize);
 
   static void print_user_info(outputStream* st);
   static void print_active_locale(outputStream* st);

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -763,7 +763,7 @@ class os: AllStatic {
   static void print_siginfo(outputStream* st, const void* siginfo);
   static void print_signal_handlers(outputStream* st, char* buf, size_t buflen);
   static void print_date_and_time(outputStream* st, char* buf, size_t buflen);
-  static void print_stack(outputStream* st, address sp, int unitsize);
+  static void print_stack(outputStream* st, address sp);
   static void print_instructions(outputStream* st, address pc, int unitsize);
 
   static void print_user_info(outputStream* st);


### PR DESCRIPTION
Similar to [JDK-8217879](https://bugs.openjdk.org/browse/JDK-8217879), the debugging would be easier if we dump more stack in the hex dump. This is especially convenient when debugging Loom and seeing more of the raw stack in the crash log. Reading farther from current SP is generally safe, since stack banging mechanism provides us with accessible stack at all times for normal SPs. In fact, many platforms already read significantly more stack than x86. 

We can homogenize the stack printing across all architectures. I believe the stack grows the same way on all supported arches (downwards), so we can read in one direction. Tell me if you still want to make that one selectable.

As the safeguard, [JDK-8217994](https://bugs.openjdk.org/browse/JDK-8217994) gives us the facility to read the memory much more safely, so we can dump more stack without elevated risk of secondary crash, in case the stack is not readable.

x86_64 hs_err before:
```
Top of Stack: (sp=0x00007fdab92650b0)
0x00007fdab92650b0:   00000000ffffffff 00007fdb0c2d5c50
0x00007fdab92650c0:   00007fdab9265460 00007fdb12e4a106
0x00007fdab92650d0:   0000000000000001 00007fdb0c20e980
0x00007fdab92650e0:   0000000000000000 00007fdb0c2ff4c0 
```

x86_64 hs_err after:
```
Top of Stack: (sp=0x00007f10ccb1d0b0)
0x00007f10ccb1d0b0:   00000000ffffffff 00007f11202d5c50
0x00007f10ccb1d0c0:   00007f10ccb1d460 00007f11266e4106
0x00007f10ccb1d0d0:   0000000000000001 00007f112020e980
0x00007f10ccb1d0e0:   0000000000000000 00007f11202ff4c0
0x00007f10ccb1d0f0:   00007f112020e980 00007f10ccb1d140
0x00007f10ccb1d100:   00007f11202fd4f0 00007f11202ffb80
0x00007f10ccb1d110:   00007f11202ffbc0 00007f11202fff68
0x00007f10ccb1d120:   00000000000003d8 00007f1000000002
0x00007f10ccb1d130:   00007f11202ff4c0 00007f10ccb1d550
0x00007f10ccb1d140:   00007f11202fd4f0 0000000300000007
0x00007f10ccb1d150:   00007f11202d5c50 00007f112020e980
0x00007f10ccb1d160:   00007f10ccb1d740 0000000000000000
0x00007f10ccb1d170:   00007f10a80668c0 00007f11ffffffff
0x00007f10ccb1d180:   00007f109c00d250 00007f1000000000
0x00007f10ccb1d190:   00007f109c00ecd8 00007f10a80404a0
0x00007f10ccb1d1a0:   0000000000000000 000000011d001001
0x00007f10ccb1d1b0:   0000000000000000 00007f11202ffc20
0x00007f10ccb1d1c0:   00007f11202ffbc0 0000000800000000
0x00007f10ccb1d1d0:   0000000100000003 0000000000000000
0x00007f10ccb1d1e0:   00007f11202ffc68 00007f1000000003
0x00007f10ccb1d1f0:   00007f10a803b1d0 0000002000000000
0x00007f10ccb1d200:   000000000000003b 0000004100000000
0x00007f10ccb1d210:   000000aaffffffff 00007f10ccb1d218
0x00007f10ccb1d220:   00000000000001e8 00007f1127d233e6
0x00007f10ccb1d230:   00007f110fee5f80 0000000000000000
0x00007f10ccb1d240:   00007f110fee5f80 00007f110fef2c50
0x00007f10ccb1d250:   00007f10a8040490 00007f10a8040490
0x00007f10ccb1d260:   00007f10a8040498 00007f110fee5f80
0x00007f10ccb1d270:   00007f1120000001 00007f10ccb1d218
0x00007f10ccb1d280:   00007f110fe65f80 0000000000000000
0x00007f10ccb1d290:   00007f110fe66051 00007f110fee5b18
0x00007f10ccb1d2a0:   00007f10a8040338 00007f10a804034c 
```

Testing:
  - [x] Eyeballing ad-hoc crash logs
  - [x] Build: linux-x86_64-server-fastdebug
  - [x] Build: linux-x86_64-zero-fastdebug
  - [x] Build: linux-x86-server-fastdebug
  - [x] Cross-build: linux-aarch64-server-fastdebug
  - [x] Cross-build: linux-arm-server-fastdebug
  - [x] Cross-build: linux-riscv64-server-fastdebug
  - [x] Cross-build: linux-s390x-server-fastdebug
  - [x] Cross-build: linux-ppc64le-server-fastdebug
  - [x] Cross-build: linux-ppc64-server-fastdebug

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293851](https://bugs.openjdk.org/browse/JDK-8293851): hs_err should print more stack in hex dump


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10282/head:pull/10282` \
`$ git checkout pull/10282`

Update a local copy of the PR: \
`$ git checkout pull/10282` \
`$ git pull https://git.openjdk.org/jdk pull/10282/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10282`

View PR using the GUI difftool: \
`$ git pr show -t 10282`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10282.diff">https://git.openjdk.org/jdk/pull/10282.diff</a>

</details>
