### PR TITLE
8293849: PrintIdealPhase in compiler directives file is ignored when used with other compile commands

### DIFF
--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -583,6 +583,7 @@ DirectiveSet* DirectiveSet::clone(DirectiveSet const* src) {
     compilerdirectives_c1_flags(copy_members_definition)
 
   set->_intrinsic_control_words = src->_intrinsic_control_words;
+  set->_ideal_phase_name_mask = src->_ideal_phase_name_mask;
   return set;
 }
 


### PR DESCRIPTION
When using a compiler directives file with `PrintIdealPhase`:

```
[
  {
    match : "Test::*",
    log : true,
    PrintIdealPhase : "BEFORE_MATCHING"
  }
]
```

together with other compile commands specified in `compilerdirectives_common_flags` and/or `compilerdirectives_c2_flags`:
https://github.com/openjdk/jdk/blob/aff5ff14b208b3c2be93d7b4fab8b07c5be12f3e/src/hotspot/share/compiler/compilerDirectives.hpp#L38-L39
https://github.com/openjdk/jdk/blob/aff5ff14b208b3c2be93d7b4fab8b07c5be12f3e/src/hotspot/share/compiler/compilerDirectives.hpp#L63-L64

then the `PrintIdealPhase` option is ignored. 

The reason is that when cloning the `DirectiveSet` for the current compilation in `DirectiveSet::clone()`, we only set `PrintIdealPhaseOption` but forget to also set `_ideal_phase_name_mask` which is used when deciding if a compile phase should be dumped or not. As a result, the mask keeps its default value zero and nothing is dumped because `Compile::shoud_print_phase()` returns false:

https://github.com/openjdk/jdk/blob/aff5ff14b208b3c2be93d7b4fab8b07c5be12f3e/src/hotspot/share/opto/compile.cpp#L5060-L5067


The fix is to also clone the old value of `_ideal_phase_name_mask`. 

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293849](https://bugs.openjdk.org/browse/JDK-8293849): PrintIdealPhase in compiler directives file is ignored when used with other compile commands


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10283/head:pull/10283` \
`$ git checkout pull/10283`

Update a local copy of the PR: \
`$ git checkout pull/10283` \
`$ git pull https://git.openjdk.org/jdk pull/10283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10283`

View PR using the GUI difftool: \
`$ git pr show -t 10283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10283.diff">https://git.openjdk.org/jdk/pull/10283.diff</a>

</details>
