### PR TITLE
JDK-8293767: AWT test TestSinhalaChar.java has old SCCS markings

### DIFF
--- a/test/jdk/java/awt/font/TextLayout/TestSinhalaChar.java
+++ b/test/jdk/java/awt/font/TextLayout/TestSinhalaChar.java
@@ -22,7 +22,7 @@
  */
 
 /**
- * @test @(#)TestSinhalaChar.java
+ * @test
  * @key headful
  * @summary verify lack of crash on U+0DDD.
  * @bug 6795060


### PR DESCRIPTION
Old SCCS markings removed from the jtreg tag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293767](https://bugs.openjdk.org/browse/JDK-8293767): AWT test TestSinhalaChar.java has old SCCS markings


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10285/head:pull/10285` \
`$ git checkout pull/10285`

Update a local copy of the PR: \
`$ git checkout pull/10285` \
`$ git pull https://git.openjdk.org/jdk pull/10285/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10285`

View PR using the GUI difftool: \
`$ git pr show -t 10285`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10285.diff">https://git.openjdk.org/jdk/pull/10285.diff</a>

</details>
