### PR TITLE
JDK-8293659: Improve UnsatisfiedLinkError error message to include dlopen error details

### DIFF
--- a/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
+++ b/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
@@ -328,7 +328,23 @@ public final class NativeLibraries {
                 throw new InternalError("Native library " + name + " has been loaded");
             }
 
-            return load(this, name, isBuiltin, loadLibraryOnlyIfPresent);
+            return load(this, name, isBuiltin, throwExceptionIfFail());
+        }
+
+        @SuppressWarnings("removal")
+        private boolean throwExceptionIfFail() {
+            if (loadLibraryOnlyIfPresent) return true;
+
+            boolean fileExists = AccessController.doPrivileged(new PrivilegedAction<>() {
+                public Boolean run() {
+                    File file = new File(name);
+                    return file.exists();
+                }
+            });
+
+            // If the file exists but fails to load, UnsatisfiedLinkException thrown by the VM
+            // will include the error message from dlopen to provide diagnostic information
+            return fileExists;
         }
 
         /*

--- a/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
+++ b/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
@@ -335,16 +335,14 @@ public final class NativeLibraries {
         private boolean throwExceptionIfFail() {
             if (loadLibraryOnlyIfPresent) return true;
 
-            boolean fileExists = AccessController.doPrivileged(new PrivilegedAction<>() {
+            // If the file exists but fails to load, UnsatisfiedLinkException thrown by the VM
+            // will include the error message from dlopen to provide diagnostic information
+            return AccessController.doPrivileged(new PrivilegedAction<>() {
                 public Boolean run() {
                     File file = new File(name);
                     return file.exists();
                 }
             });
-
-            // If the file exists but fails to load, UnsatisfiedLinkException thrown by the VM
-            // will include the error message from dlopen to provide diagnostic information
-            return fileExists;
         }
 
         /*


### PR DESCRIPTION
When trying to load a x64 lib on macOS aarch64 one got previously this detailed message before [JDK-8275703](https://bugs.openjdk.org/browse/JDK-8275703):

java.lang.UnsatisfiedLinkError: /testing/jco3/macOsx64/libsapjco3.dylib: dlopen(/testing/jco3/macOsx64/libsapjco3.dylib, 1): no suitable image found. Did find:
                /testing/jco3/macOsx64/libsapjco3.dylib: mach-o, but wrong architecture
                /testing/jco3/macOsx64/libsapjco3.dylib: mach-o, but wrong architecture [in thread "main"]

After [JDK-8275703](https://bugs.openjdk.org/browse/JDK-8275703), the error message does not include the details:
java.lang.UnsatisfiedLinkError: Can't load library: /testing/jco3/macOsx64/libsapjco3.dylib [in thread "main"]

The error details are useful to help diagnosing user's error like mismatched target architecture.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293659](https://bugs.openjdk.org/browse/JDK-8293659): Improve UnsatisfiedLinkError error message to include dlopen error details


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10286/head:pull/10286` \
`$ git checkout pull/10286`

Update a local copy of the PR: \
`$ git checkout pull/10286` \
`$ git pull https://git.openjdk.org/jdk pull/10286/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10286`

View PR using the GUI difftool: \
`$ git pr show -t 10286`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10286.diff">https://git.openjdk.org/jdk/pull/10286.diff</a>

</details>
