### PR TITLE
8293422: DWARF emitted by Clang cannot be parsed

### DIFF
--- a/src/hotspot/share/utilities/decoder_elf.cpp
+++ b/src/hotspot/share/utilities/decoder_elf.cpp
@@ -55,6 +55,10 @@ bool ElfDecoder::decode(address addr, char *buf, int buflen, int* offset, const 
 }
 
 bool ElfDecoder::get_source_info(address pc, char* filename, size_t filename_len, int* line, bool is_pc_after_call) {
+#ifdef __clang__
+  DWARF_LOG_ERROR("Parsing DWARF emitted by Clang is currently not supported due to an incomplete .debug_aranges section.");
+  return false;
+#else
   assert(filename != nullptr && filename_len > 0 && line != nullptr, "Argument error");
   filename[0] = '\0';
   *line = -1;
@@ -90,6 +94,7 @@ bool ElfDecoder::get_source_info(address pc, char* filename, size_t filename_len
                        p2i(pc), offset_in_library, filename, *line);
   DWARF_LOG_INFO("") // To structure the debug output better.
   return true;
+#endif // clang
 }
 
 

--- a/test/hotspot/gtest/runtime/test_os_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_os_linux.cpp
@@ -434,7 +434,7 @@ TEST(os_linux, addr_to_function_valid) {
   ASSERT_TRUE(offset >= 0);
 }
 
-#ifndef PRODUCT
+#ifndef __clang__ // Parsing DWARF emitted by Clang is currently unsupported
 // Test valid address of method JNI_CreateJavaVM in jni.cpp. We should get "jni.cpp" in the buffer and a valid line number.
 TEST_VM(os_linux, decoder_get_source_info_valid) {
   char buf[128] = "";
@@ -475,5 +475,5 @@ TEST_VM(os_linux, decoder_get_source_info_invalid) {
     ASSERT_TRUE(line == -1);
   }
 }
-#endif // NOT PRODUCT
+#endif // NOT clang
 #endif // LINUX


### PR DESCRIPTION
The DWARF debugging symbols emitted by Clang is different from what GCC is emitting. While GCC produces a complete `.debug_aranges` section (which is required in the DWARF parser), Clang does not. As a result, the DWARF parser cannot find the necessary information to proceed and create the line number information:

The `.debug_aranges` section contains address range to compilation unit offset mappings. The parsing algorithm can just walk through all these entries to find the correct address range that contains the library offset of the current pc. This gives us the compilation unit offset into the `.debug_info` section from where we can proceed to parse the line number information.

Without a complete `.debug_aranges` section, we fail with an assertion that we could not find the correct entry. Since [JDK-8293402](https://bugs.openjdk.org/browse/JDK-8293402), we will still get the complete stack trace at least. Nevertheless, we should still fix this assertion failure of course. But that would require a different parsing approach. We need to parse the entire `.debug_info` section instead to get to the correct compilation unit. This, however, would require a lot more work. 

I therefore suggest to disable DWARF parsing for Clang for now and file an RFE to support Clang in the future with a different parsing approach. I'm using the `__clang__` `ifdef` to bail out in `get_source_info()` and disable the `gtests`. I've noticed that we are currently running the `gtests` with `NOT PRODUCT` which I think is not necessary - the gtests should also work fine with product builds. I've corrected this as well but that could also be done separately.

Thanks,
Christian 