### PR TITLE
8293813: ProblemList com/sun/jdi/JdbLastErrorTest.java on windows-x64 in Xcomp mode

### DIFF
--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -30,5 +30,5 @@
 java/lang/invoke/MethodHandles/CatchExceptionTest.java 8146623 generic-all
 java/lang/ref/ReferenceEnqueue.java 8284236 generic-all
 
-com/sun/jdi/JdbLastErrorTest.java 8293829 generic-all
+com/sun/jdi/JdbLastErrorTest.java 8293829 windows-x64
 

--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -29,3 +29,6 @@
 
 java/lang/invoke/MethodHandles/CatchExceptionTest.java 8146623 generic-all
 java/lang/ref/ReferenceEnqueue.java 8284236 generic-all
+
+com/sun/jdi/JdbLastErrorTest.java 8293829 generic-all
+


### PR DESCRIPTION
Add com/sun/jdi/JdbLastErrorTest.java  to test/jdk/ProblemList-Xcomp.txt

The test fails immediately with -Xcomp, logged JDK-8293829 to look at that further.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293813](https://bugs.openjdk.org/browse/JDK-8293813): ProblemList com/sun/jdi/JdbLastErrorTest.java on windows-x64 in Xcomp mode


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10288/head:pull/10288` \
`$ git checkout pull/10288`

Update a local copy of the PR: \
`$ git checkout pull/10288` \
`$ git pull https://git.openjdk.org/jdk pull/10288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10288`

View PR using the GUI difftool: \
`$ git pr show -t 10288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10288.diff">https://git.openjdk.org/jdk/pull/10288.diff</a>

</details>
