### PR TITLE
8293845: C2: Clean up Regalloc::{set|is}_oop

### DIFF
--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -1315,7 +1315,6 @@ static void generate_peepreplace( FILE *fp, FormDict &globals, int peephole_numb
           fprintf(fp, "        root->_bottom_type = inst%d->bottom_type();\n", inst_num);
         }
         // Define result register and result operand
-        fprintf(fp, "        ra_->add_reference(root, inst%d);\n", inst_num);
         fprintf(fp, "        ra_->set_pair(root->_idx, ra_->get_reg_second(inst%d), ra_->get_reg_first(inst%d));\n", inst_num, inst_num);
         fprintf(fp, "        root->_opnds[0] = inst%d->_opnds[0]->clone(); // result\n", inst_num);
         fprintf(fp, "        // ----- Done with initial setup -----\n");

--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -1315,7 +1315,7 @@ static void generate_peepreplace( FILE *fp, FormDict &globals, int peephole_numb
           fprintf(fp, "        root->_bottom_type = inst%d->bottom_type();\n", inst_num);
         }
         // Define result register and result operand
-        fprintf(fp, "        ra_->set_oop (root, ra_->is_oop(inst%d));\n", inst_num);
+        fprintf(fp, "        ra_->add_reference(root, inst%d);\n", inst_num);
         fprintf(fp, "        ra_->set_pair(root->_idx, ra_->get_reg_second(inst%d), ra_->get_reg_first(inst%d));\n", inst_num, inst_num);
         fprintf(fp, "        root->_opnds[0] = inst%d->_opnds[0]->clone(); // result\n", inst_num);
         fprintf(fp, "        // ----- Done with initial setup -----\n");

--- a/src/hotspot/share/opto/chaitin.cpp
+++ b/src/hotspot/share/opto/chaitin.cpp
@@ -675,7 +675,6 @@ void PhaseChaitin::Register_Allocate() {
           set_pair(i, hi, lo);
         }
       }
-      if( lrg._is_oop ) _node_oops.set(i);
     } else {
       set_bad(i);
     }

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -930,10 +930,8 @@ void PhaseOutput::FillLocArray( int idx, MachSafePointNode* sfpt, Node *local,
                t->base() == Type::VectorD || t->base() == Type::VectorX ||
                t->base() == Type::VectorY || t->base() == Type::VectorZ) {
       array->append(new_loc_value( C->regalloc(), regnum, Location::vector ));
-    } else if (C->regalloc()->is_oop(local)) {
-      assert(t->base() == Type::OopPtr || t->base() == Type::InstPtr ||
-             t->base() == Type::AryPtr,
-             "Unexpected type: %s", t->msg());
+    } else if (t->base() == Type::OopPtr || t->base() == Type::InstPtr ||
+               t->base() == Type::AryPtr) {
       array->append(new_loc_value( C->regalloc(), regnum, Location::oop ));
     } else {
       assert(t->base() == Type::Int || t->base() == Type::Half ||

--- a/src/hotspot/share/opto/regalloc.cpp
+++ b/src/hotspot/share/opto/regalloc.cpp
@@ -96,18 +96,6 @@ OptoReg::Name PhaseRegAlloc::offset2reg(int stk_offset) const {
   return (OptoReg::Name) reg;
 }
 
-//------------------------------set_oop----------------------------------------
-void PhaseRegAlloc::set_oop( const Node *n, bool is_an_oop ) {
-  if( is_an_oop ) {
-    _node_oops.set(n->_idx);
-  }
-}
-
-//------------------------------is_oop-----------------------------------------
-bool PhaseRegAlloc::is_oop( const Node *n ) const {
-  return _node_oops.test(n->_idx) != 0;
-}
-
 // Allocate _node_regs table with at least "size" elements
 void PhaseRegAlloc::alloc_node_regs(int size) {
   _node_regs_max_index = size + (size >> 1) + NodeRegsOverflowSize;

--- a/src/hotspot/share/opto/regalloc.hpp
+++ b/src/hotspot/share/opto/regalloc.hpp
@@ -46,7 +46,6 @@ class PhaseRegAlloc : public Phase {
 protected:
   OptoRegPair  *_node_regs;
   uint         _node_regs_max_index;
-  VectorSet    _node_oops;         // Mapping from node indices to oopiness
 
   void alloc_node_regs(int size);  // allocate _node_regs table with at least "size" elements
 
@@ -101,9 +100,6 @@ public:
     assert( idx < _node_regs_max_index, "Exceeded _node_regs array");
     _node_regs[idx].set_ptr(reg);
   }
-  // Set and query if a node produces an oop
-  void set_oop( const Node *n, bool );
-  bool is_oop( const Node *n ) const;
 
   // Convert a register number to a stack offset
   int reg2offset          ( OptoReg::Name reg ) const;


### PR DESCRIPTION
WIP, includes parts of JDK-8293844.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293845](https://bugs.openjdk.org/browse/JDK-8293845): C2: Clean up Regalloc::{set|is}_oop


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10292/head:pull/10292` \
`$ git checkout pull/10292`

Update a local copy of the PR: \
`$ git checkout pull/10292` \
`$ git pull https://git.openjdk.org/jdk pull/10292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10292`

View PR using the GUI difftool: \
`$ git pr show -t 10292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10292.diff">https://git.openjdk.org/jdk/pull/10292.diff</a>

</details>
