### PR TITLE
8293875: ProblemList sun/management/jmxremote/bootstrap/RmiBootstrapTest.java#id1 on linux-x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -524,6 +524,7 @@ java/lang/management/ThreadMXBean/ThreadMXBeanStateTest.java    8247426 generic-
 sun/management/jdp/JdpDefaultsTest.java                         8241865 linux-aarch64,macosx-all
 sun/management/jdp/JdpJmxRemoteDynamicPortTest.java             8241865 macosx-all
 sun/management/jdp/JdpSpecificAddressTest.java                  8241865 macosx-all
+sun/management/jmxremote/bootstrap/RmiBootstrapTest.java#id1    8293657 linux-x64
 
 ############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList sun/management/jmxremote/bootstrap/RmiBootstrapTest.java#id1 on linux-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293875](https://bugs.openjdk.org/browse/JDK-8293875): ProblemList sun/management/jmxremote/bootstrap/RmiBootstrapTest.java#id1 on linux-x64


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10293/head:pull/10293` \
`$ git checkout pull/10293`

Update a local copy of the PR: \
`$ git checkout pull/10293` \
`$ git pull https://git.openjdk.org/jdk pull/10293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10293`

View PR using the GUI difftool: \
`$ git pr show -t 10293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10293.diff">https://git.openjdk.org/jdk/pull/10293.diff</a>

</details>
