### PR TITLE
8293816: CI: ciBytecodeStream::get_klass() is not consistent

### DIFF
--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -330,7 +330,7 @@ void ciInstanceKlass::print_impl(outputStream* st) {
   ciKlass::print_impl(st);
   GUARDED_VM_ENTRY(st->print(" loader=" INTPTR_FORMAT, p2i(loader()));)
   if (is_loaded()) {
-    st->print(" loaded=true initialized=%s finalized=%s subklass=%s size=%d flags=",
+    st->print(" initialized=%s finalized=%s subklass=%s size=%d flags=",
               bool_to_str(is_initialized()),
               bool_to_str(has_finalizer()),
               bool_to_str(has_subklass()),
@@ -345,8 +345,6 @@ void ciInstanceKlass::print_impl(outputStream* st) {
     if (_java_mirror) {
       st->print(" mirror=PRESENT");
     }
-  } else {
-    st->print(" loaded=false");
   }
 }
 

--- a/src/hotspot/share/ci/ciKlass.cpp
+++ b/src/hotspot/share/ci/ciKlass.cpp
@@ -233,6 +233,7 @@ jint ciKlass::access_flags() {
 void ciKlass::print_impl(outputStream* st) {
   st->print(" name=");
   print_name_on(st);
+  st->print(" loaded=%s", (is_loaded() ? "true" : "false"));
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -201,12 +201,8 @@ ciKlass* ciBytecodeStream::get_klass() {
   bool will_link;
   ciKlass* klass = get_klass(will_link);
   if (!will_link && klass->is_loaded()) { // klass not accessible
-    if (klass->is_array_klass()) {
-      assert(!klass->is_type_array_klass(), "");
-      klass = ciEnv::unloaded_ciobjarrayklass();
-    } else {
-      klass = ciEnv::unloaded_ciinstance_klass();
-    }
+    VM_ENTRY_MARK;
+    klass = CURRENT_ENV->get_unloaded_klass(_holder, klass->name());
   }
   return klass;
 }


### PR DESCRIPTION
CI responses should be consistent during a single compilation.

[JDK-8293044](https://bugs.openjdk.org/browse/JDK-8293044) was fixed by turning inaccessible classes into unloaded ones when resolving them through CI.

But there's another case when `ciEnv::get_klass_by_index()` returns a loaded ciKlass while setting `will_link` to `false`: a not-yet-resolved klass revealed through a class loader constraint.

In such case, after a concurrent class loading CI will start reporting a loaded ciKlass instance. Such inconsistency may trigger some paradoxical situations during compilation.   

The fix is to instantiate a proper instance of an unloaded ciKlass, so further requests will return the unloaded instances as well.

Testing: hs-tier1 - hs-tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293816](https://bugs.openjdk.org/browse/JDK-8293816): CI: ciBytecodeStream::get_klass() is not consistent


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10294/head:pull/10294` \
`$ git checkout pull/10294`

Update a local copy of the PR: \
`$ git checkout pull/10294` \
`$ git pull https://git.openjdk.org/jdk pull/10294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10294`

View PR using the GUI difftool: \
`$ git pr show -t 10294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10294.diff">https://git.openjdk.org/jdk/pull/10294.diff</a>

</details>
