### PR TITLE
8293879: Remove unnecessary castings in jdk.hotspot.agent

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/com/sun/java/swing/action/ActionManager.java
+++ b/src/jdk.hotspot.agent/share/classes/com/sun/java/swing/action/ActionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public abstract class ActionManager
 
     public Action getAction(String key)
     {
-        return (Action)actions.get(key);
+        return actions.get(key);
     }
 
     public DelegateAction getDelegateAction(String name)

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -197,7 +197,7 @@ public class CommandProcessor {
                     add(w[i], t);
                 }
             }
-            tokens = (String[])t.toArray(new String[0]);
+            tokens = t.toArray(new String[0]);
             i = 0;
             length = tokens.length;
 
@@ -768,7 +768,7 @@ public class CommandProcessor {
                           });
                     for (int i = 0; i < keys.length; i++) {
                         out.print("  ");
-                        out.println(((Command)commands.get(keys[i])).usage);
+                        out.println(commands.get(keys[i]).usage);
                     }
                 }
             }
@@ -1085,7 +1085,7 @@ public class CommandProcessor {
                         n = n.getSuperclass();
                     }
                     while (!pending.isEmpty()) {
-                        n = (Type)pending.pop();
+                        n = pending.pop();
                         dumpType(n);
                         emitted.add(n.getName());
                     }
@@ -1481,7 +1481,7 @@ public class CommandProcessor {
                             n = n.getSuperclass();
                         }
                         while (!pending.isEmpty()) {
-                            n = (Type)pending.pop();
+                            n = pending.pop();
                             dumpType(n);
                             emitted.add(n.getName());
                         }
@@ -1986,7 +1986,7 @@ public class CommandProcessor {
     private boolean doEcho = false;
 
     private Command findCommand(String key) {
-        return (Command)commands.get(key);
+        return commands.get(key);
     }
 
     public void printPrompt() {
@@ -2082,17 +2082,17 @@ public class CommandProcessor {
 
                     String cmd = m.group(2);
                     if (cmd.equals("!!")) {
-                        result.append((String)history.get(history.size() - 1));
+                        result.append(history.get(history.size() - 1));
                     } else if (cmd.equals("!!-")) {
-                        Tokens item = new Tokens((String)history.get(history.size() - 1));
+                        Tokens item = new Tokens(history.get(history.size() - 1));
                         item.trim(1);
                         result.append(item.join(" "));
                     } else if (cmd.equals("!*")) {
-                        Tokens item = new Tokens((String)history.get(history.size() - 1));
+                        Tokens item = new Tokens(history.get(history.size() - 1));
                         item.nextToken();
                         result.append(item.join(" "));
                     } else if (cmd.equals("!$")) {
-                        Tokens item = new Tokens((String)history.get(history.size() - 1));
+                        Tokens item = new Tokens(history.get(history.size() - 1));
                         result.append(item.at(item.countTokens() - 1));
                     } else {
                         String tail = cmd.substring(1);
@@ -2115,13 +2115,13 @@ public class CommandProcessor {
                             if (index > size) {
                                 err.println("No such history item");
                             } else {
-                                result.append((String)history.get(index));
+                                result.append(history.get(index));
                             }
                             break;
                         }
                         default: {
                             for (int i = history.size() - 1; i >= 0; i--) {
-                                String s = (String)history.get(i);
+                                String s = history.get(i);
                                 if (s.startsWith(tail)) {
                                     result.append(s);
                                     break; // only capture the most recent match in the history

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
@@ -956,7 +956,7 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
             }
 
             // Add signal information to annotation if necessary
-            SignalInfo sigInfo = (SignalInfo) interruptedFrameMap.get(curFrame);
+            SignalInfo sigInfo = interruptedFrameMap.get(curFrame);
             if (sigInfo != null) {
               // This frame took a signal and we need to report it.
               anno = anno + "\n*** INTERRUPTED BY SIGNAL " + sigInfo.sigNum +
@@ -1778,7 +1778,7 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
     if (vf.isJavaFrame()) {
       return (JavaVFrame) vf;
     }
-    return (JavaVFrame) vf.javaSender();
+    return vf.javaSender();
   }
 
   // Internal routine for debugging

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
@@ -488,7 +488,7 @@ public class HotSpotAgent {
         RemoteDebugger remote =
         (RemoteDebugger) RMIHelper.lookup(debugServerID);
         debugger = new RemoteDebuggerClient(remote);
-        machDesc = ((RemoteDebuggerClient) debugger).getMachineDescription();
+        machDesc = debugger.getMachineDescription();
         os = debugger.getOS();
         setupJVMLibNames(os);
         cpu = debugger.getCPU();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ci/ciInstanceKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ci/ciInstanceKlass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,7 +96,7 @@ public class ciInstanceKlass extends ciKlass {
       sub = sub.getNextSiblingKlass();
     }
 
-    final int length = (int) cp.getLength();
+    final int length = cp.getLength();
     out.print("ciInstanceKlass " + name() + " " + (isLinked() ? 1 : 0) + " " + (isInitialized() ? 1 : 0) + " " + length);
     for (int index = 1; index < length; index++) {
       out.print(" " + cp.getTags().at(index));

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/NMethod.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/NMethod.java
@@ -229,7 +229,7 @@ public class NMethod extends CompiledMethod {
   }
 
   public NMethod getOSRLink() {
-    return (NMethod) VMObjectFactory.newObject(NMethod.class, osrLinkField.getValue(addr));
+    return VMObjectFactory.newObject(NMethod.class, osrLinkField.getValue(addr));
   }
 
   // MethodHandle
@@ -463,9 +463,9 @@ public class NMethod extends CompiledMethod {
       if (h.get(meta) != null) continue;
       h.put(meta, meta);
       if (meta instanceof InstanceKlass) {
-        ((InstanceKlass)meta).dumpReplayData(out);
+        meta.dumpReplayData(out);
       } else if (meta instanceof Method) {
-        ((Method)meta).dumpReplayData(out);
+        meta.dumpReplayData(out);
         MethodData mdo = ((Method)meta).getMethodData();
         if (mdo != null) {
           mdo.dumpReplayData(out);
@@ -481,7 +481,7 @@ public class NMethod extends CompiledMethod {
       }
     }
     if (h.get(method.getMethodHolder()) == null) {
-      ((InstanceKlass)method.getMethodHolder()).dumpReplayData(out);
+      method.getMethodHolder().dumpReplayData(out);
     }
     Klass holder = method.getMethodHolder();
     out.println("compile " + holder.getName().asString() + " " +

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/ObjectValue.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/ObjectValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public class ObjectValue extends ScopeValue {
   public int id() { return id; }
   public ScopeValue getKlass() { return klass; }
   public List<ScopeValue> getFieldsValue() { return fieldsValue; }
-  public ScopeValue getFieldAt(int i) { return (ScopeValue)fieldsValue.get(i); }
+  public ScopeValue getFieldAt(int i) { return fieldsValue.get(i); }
   public int fieldsSize() { return fieldsValue.size(); }
 
   // Field "value" is always NULL here since it is used
@@ -82,11 +82,11 @@ public class ObjectValue extends ScopeValue {
 
   void printFieldsOn(PrintStream tty) {
     if (fieldsValue.size() > 0) {
-      ((ScopeValue)fieldsValue.get(0)).printOn(tty);
+      fieldsValue.get(0).printOn(tty);
     }
     for (int i = 1; i < fieldsValue.size(); i++) {
       tty.print(", ");
-      ((ScopeValue)fieldsValue.get(i)).printOn(tty);
+      fieldsValue.get(i).printOn(tty);
     }
   }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/VMRegImpl.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/VMRegImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ public class VMRegImpl {
     Type type = db.lookupType("VMRegImpl");
     AddressField stack0Field = type.getAddressField("stack0");
     stack0Addr = stack0Field.getValue();
-    stack0Val = (int) stack0Addr.hashCode();
+    stack0Val = stack0Addr.hashCode();
     stack0 = new VMReg(stack0Val);
     regNameField = type.getAddressField("regName[0]");
     stackSlotSize = db.lookupIntConstant("VMRegImpl::stack_slot_size");

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/compiler/ImmutableOopMapSet.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/compiler/ImmutableOopMapSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,8 +92,8 @@ public class ImmutableOopMapSet extends VMObject {
     if (!VM.getVM().isCore()) {
       REG_COUNT = db.lookupIntConstant("REG_COUNT").intValue();
       if (VM.getVM().isServerCompiler()) {
-        SAVED_ON_ENTRY_REG_COUNT = (int) db.lookupIntConstant("SAVED_ON_ENTRY_REG_COUNT").intValue();
-        C_SAVED_ON_ENTRY_REG_COUNT = (int) db.lookupIntConstant("C_SAVED_ON_ENTRY_REG_COUNT").intValue();
+        SAVED_ON_ENTRY_REG_COUNT = db.lookupIntConstant("SAVED_ON_ENTRY_REG_COUNT").intValue();
+        C_SAVED_ON_ENTRY_REG_COUNT = db.lookupIntConstant("C_SAVED_ON_ENTRY_REG_COUNT").intValue();
       }
     }
   }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicBlockSym.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicBlockSym.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ public class BasicBlockSym extends BasicSym implements BlockSym {
   }
 
   public LocalSym getLocal(int i) {
-    return (LocalSym) locals.get(i);
+    return locals.get(i);
   }
 
   public void addLocal(LocalSym local) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicCDebugInfoDataBase.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicCDebugInfoDataBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -230,7 +230,7 @@ public class BasicCDebugInfoDataBase implements CDebugInfoDataBase {
   }
 
   public GlobalSym lookupSym(String name) {
-    return (GlobalSym) nameToSymMap.get(name);
+    return nameToSymMap.get(name);
   }
 
   public void addLineNumberInfo(BasicLineNumberInfo info) {
@@ -356,7 +356,7 @@ public class BasicCDebugInfoDataBase implements CDebugInfoDataBase {
       Address lastAddr = null;
       BlockSym ret = null;
       for (int i = highIdx; i >= 0; --i) {
-        BlockSym block = (BlockSym) blocks.get(i);
+        BlockSym block = blocks.get(i);
         if (AddressOps.lte(block.getAddress(), addr)) {
           if ((lastAddr == null) || (AddressOps.equal(block.getAddress(), lastAddr))) {
             lastAddr = block.getAddress();
@@ -369,7 +369,7 @@ public class BasicCDebugInfoDataBase implements CDebugInfoDataBase {
       return ret;
     }
     int midIdx = (lowIdx + highIdx) >> 1;
-    BlockSym block = (BlockSym) blocks.get(midIdx);
+    BlockSym block = blocks.get(midIdx);
     // See address relationship
     if (AddressOps.lte(block.getAddress(), addr)) {
       // Always move search up

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicCompoundType.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicCompoundType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ public class BasicCompoundType extends BasicType implements CompoundType {
     return ((baseClasses == null) ? 0 : baseClasses.size());
   }
   public BaseClass getBaseClass(int i) {
-    return (BaseClass) baseClasses.get(i);
+    return baseClasses.get(i);
   }
 
   public void addBaseClass(BaseClass b) {
@@ -66,7 +66,7 @@ public class BasicCompoundType extends BasicType implements CompoundType {
     return ((fields == null) ? 0 : fields.size());
   }
   public Field getField(int i) {
-    return (Field) fields.get(i);
+    return fields.get(i);
   }
 
   public void addField(Field f) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicEnumType.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicEnumType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,8 +76,8 @@ public class BasicEnumType extends BasicIntType implements EnumType {
   }
 
   public int    getNumEnumerates()  { return enums.size(); }
-  public String getEnumName(int i)  { return ((Enum) enums.get(i)).getName();  }
-  public long   getEnumValue(int i) { return ((Enum) enums.get(i)).getValue(); }
+  public String getEnumName(int i)  { return enums.get(i).getName();  }
+  public long   getEnumValue(int i) { return enums.get(i).getValue(); }
 
   public String enumNameForValue(long val) {
     if (enums == null) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicFunctionType.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicFunctionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public class BasicFunctionType extends BasicType implements FunctionType {
 
   public int  getNumArguments()      { return ((argumentTypes == null) ? 0 : argumentTypes.size()); }
   public Type getArgumentType(int i) {
-    return (Type) argumentTypes.get(i);
+    return argumentTypes.get(i);
   }
   public void addArgumentType(Type t) {
     if (argumentTypes == null) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicLineNumberMapping.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicLineNumberMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,7 +90,7 @@ public class BasicLineNumberMapping {
   //
 
   private BasicLineNumberInfo get(int i) {
-    return (BasicLineNumberInfo) infoList.get(i);
+    return infoList.get(i);
   }
 
   private BasicLineNumberInfo searchLineNumbers(Address addr, int lowIdx, int highIdx) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxCDebugger.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxCDebugger.java
@@ -68,7 +68,7 @@ class LinuxCDebugger implements CDebugger {
     List<LoadObject> objs = getLoadObjectList();
 
     for (int i = 0; i < objs.size(); i++) {
-      LoadObject ob = (LoadObject) objs.get(i);
+      LoadObject ob = objs.get(i);
       Address base = ob.getBase();
       long size = ob.getSize();
       if (pc.greaterThanOrEqual(base) && pc.lessThan(base.addOffsetTo(size))) {
@@ -116,7 +116,7 @@ class LinuxCDebugger implements CDebugger {
        return new LinuxRISCV64CFrame(dbg, fp, pc);
     } else {
        // Runtime exception thrown by LinuxThreadContextFactory if unknown cpu
-       ThreadContext context = (ThreadContext) thread.getContext();
+       ThreadContext context = thread.getContext();
        return context.getTopFrame(dbg);
     }
   }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/WindbgCDebugInfoBuilder.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/WindbgCDebugInfoBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -685,7 +685,7 @@ class WindbgCDebugInfoBuilder
 
     // Handle primitive types here.
     if (intIndex <= 0x0FFF) {
-      BasicType type = (BasicType) primIndexToTypeMap.get(index);
+      BasicType type = primIndexToTypeMap.get(index);
       if (type != null) {
         return type;
       }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/WindbgDebuggerLocal.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/WindbgDebuggerLocal.java
@@ -316,7 +316,7 @@ public class WindbgDebuggerLocal extends DebuggerBase implements WindbgDebugger 
   public synchronized long[] getThreadIntegerRegisterSet(long threadId)
     throws DebuggerException {
     requireAttach();
-    return (long[]) threadIntegerRegisterSet.get(threadId);
+    return threadIntegerRegisterSet.get(threadId);
   }
 
   public synchronized List<ThreadProxy> getThreadList() throws DebuggerException {
@@ -428,7 +428,7 @@ public class WindbgDebuggerLocal extends DebuggerBase implements WindbgDebugger 
       } // else fallthru...
     }
 
-    DLL dll = (DLL) nameToDllMap.get(objectName);
+    DLL dll = nameToDllMap.get(objectName);
     // The DLL can be null because we use this to search through known
     // DLLs in HotSpotTypeDataBase (for example)
     if (dll != null) {
@@ -507,7 +507,7 @@ public class WindbgDebuggerLocal extends DebuggerBase implements WindbgDebugger 
       // First place to search is co-located with saproc.dll in
       // $JAVA_HOME/jre/bin (java.home property is set to $JAVA_HOME/jre):
       searchList.add(System.getProperty("java.home") + File.separator + "bin");
-      saprocPath = (String) searchList.get(0) + File.separator +
+      saprocPath = searchList.get(0) + File.separator +
           "saproc.dll";
 
       // second place to search is specified by an environment variable:
@@ -536,7 +536,7 @@ public class WindbgDebuggerLocal extends DebuggerBase implements WindbgDebugger 
     }
 
     for (int i = 0; i < searchList.size(); i++) {
-      File dir = new File((String) searchList.get(i));
+      File dir = new File(searchList.get(i));
       if (!dir.exists()) {
         if (loadLibraryDEBUG) {
           System.err.println("DEBUG: '" + searchList.get(i) +
@@ -546,8 +546,8 @@ public class WindbgDebuggerLocal extends DebuggerBase implements WindbgDebugger 
         continue;
       }
 
-      dbgengPath = (String) searchList.get(i) + File.separator + "dbgeng.dll";
-      dbghelpPath = (String) searchList.get(i) + File.separator + "dbghelp.dll";
+      dbgengPath = searchList.get(i) + File.separator + "dbgeng.dll";
+      dbghelpPath = searchList.get(i) + File.separator + "dbghelp.dll";
 
       File feng = new File(dbgengPath);
       File fhelp = new File(dbghelpPath);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/aarch64/WindbgAARCH64Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/aarch64/WindbgAARCH64Thread.java
@@ -37,7 +37,7 @@ class WindbgAARCH64Thread implements ThreadProxy {
   // The address argument must be the address of the OSThread::_thread_id
   WindbgAARCH64Thread(WindbgDebugger debugger, Address addr) {
     this.debugger = debugger;
-    this.sysId    = (long)addr.getCIntegerAt(0, 4, true);
+    this.sysId    = addr.getCIntegerAt(0, 4, true);
     gotID         = false;
   }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/amd64/WindbgAMD64Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/amd64/WindbgAMD64Thread.java
@@ -36,7 +36,7 @@ class WindbgAMD64Thread implements ThreadProxy {
   // The address argument must be the address of the OSThread::_thread_id
   WindbgAMD64Thread(WindbgDebugger debugger, Address addr) {
     this.debugger = debugger;
-    this.sysId    = (long)addr.getCIntegerAt(0, 4, true);
+    this.sysId    = addr.getCIntegerAt(0, 4, true);
     gotID         = false;
   }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/x86/WindbgX86Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/x86/WindbgX86Thread.java
@@ -36,7 +36,7 @@ class WindbgX86Thread implements ThreadProxy {
   // The address argument must be the address of OSThread::_thread_id
   WindbgX86Thread(WindbgDebugger debugger, Address addr) {
     this.debugger = debugger;
-    this.sysId    = (long)addr.getCIntegerAt(0, 4, true);
+    this.sysId    = addr.getCIntegerAt(0, 4, true);
     gotID         = false;
   }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/g1/G1CollectedHeap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/g1/G1CollectedHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,31 +95,27 @@ public class G1CollectedHeap extends CollectedHeap {
 
     public HeapRegionManager hrm() {
         Address hrmAddr = addr.addOffsetTo(hrmFieldOffset);
-        return (HeapRegionManager) VMObjectFactory.newObject(HeapRegionManager.class,
-                                                             hrmAddr);
+        return VMObjectFactory.newObject(HeapRegionManager.class, hrmAddr);
     }
 
     public G1MonitoringSupport monitoringSupport() {
         Address monitoringSupportAddr = monitoringSupportField.getValue(addr);
-        return (G1MonitoringSupport) VMObjectFactory.newObject(G1MonitoringSupport.class, monitoringSupportAddr);
+        return VMObjectFactory.newObject(G1MonitoringSupport.class, monitoringSupportAddr);
     }
 
     public HeapRegionSetBase oldSet() {
         Address oldSetAddr = addr.addOffsetTo(oldSetFieldOffset);
-        return (HeapRegionSetBase) VMObjectFactory.newObject(HeapRegionSetBase.class,
-                                                             oldSetAddr);
+        return VMObjectFactory.newObject(HeapRegionSetBase.class, oldSetAddr);
     }
 
     public HeapRegionSetBase archiveSet() {
         Address archiveSetAddr = addr.addOffsetTo(archiveSetFieldOffset);
-        return (HeapRegionSetBase) VMObjectFactory.newObject(HeapRegionSetBase.class,
-                                                             archiveSetAddr);
+        return VMObjectFactory.newObject(HeapRegionSetBase.class, archiveSetAddr);
     }
 
     public HeapRegionSetBase humongousSet() {
         Address humongousSetAddr = addr.addOffsetTo(humongousSetFieldOffset);
-        return (HeapRegionSetBase) VMObjectFactory.newObject(HeapRegionSetBase.class,
-                                                             humongousSetAddr);
+        return VMObjectFactory.newObject(HeapRegionSetBase.class, humongousSetAddr);
     }
 
     private Iterator<HeapRegion> heapRegionIterator() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/g1/G1HeapRegionTable.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/g1/G1HeapRegionTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,8 +75,7 @@ public class G1HeapRegionTable extends VMObject {
         // Offset of &_base[index]
         long offset = index * VM.getVM().getAddressSize();
         Address regionAddr = arrayAddr.getAddressAt(offset);
-        return (HeapRegion) VMObjectFactory.newObject(HeapRegion.class,
-                                                      regionAddr);
+        return VMObjectFactory.newObject(HeapRegion.class, regionAddr);
     }
 
     public long length() {
@@ -139,6 +138,6 @@ public class G1HeapRegionTable extends VMObject {
         long biasedIndex = target.asLongValue() >>> shiftBy();
         long offset = biasedIndex * HeapRegion.getPointerSize();
         Address regionAddr = arrayAddr.getAddressAt(offset);
-        return (HeapRegion)VMObjectFactory.newObject(HeapRegion.class, regionAddr);
+        return VMObjectFactory.newObject(HeapRegion.class, regionAddr);
     }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/g1/HeapRegion.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/g1/HeapRegion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,7 +84,7 @@ public class HeapRegion extends CompactibleSpace implements LiveRegionsProvider 
         super(addr);
         Address typeAddr = (addr instanceof OopHandle) ? addr.addOffsetToAsOopHandle(typeFieldOffset)
                                                        : addr.addOffsetTo(typeFieldOffset);
-        type = (HeapRegionType)VMObjectFactory.newObject(HeapRegionType.class, typeAddr);
+        type = VMObjectFactory.newObject(HeapRegionType.class, typeAddr);
     }
 
     public Address bottom()        { return bottomField.getValue(addr); }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/g1/HeapRegionManager.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/g1/HeapRegionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,8 +59,7 @@ public class HeapRegionManager extends VMObject {
 
     private G1HeapRegionTable regions() {
         Address regionsAddr = addr.addOffsetTo(regionsFieldOffset);
-        return (G1HeapRegionTable) VMObjectFactory.newObject(G1HeapRegionTable.class,
-                                                             regionsAddr);
+        return VMObjectFactory.newObject(G1HeapRegionTable.class, regionsAddr);
     }
 
     public long capacity() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/parallel/PSOldGen.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/parallel/PSOldGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ public class PSOldGen extends VMObject {
 
    // Accessors
    public MutableSpace objectSpace() {
-      return (MutableSpace) VMObjectFactory.newObject(MutableSpace.class, objectSpaceField.getValue(addr));
+      return VMObjectFactory.newObject(MutableSpace.class, objectSpaceField.getValue(addr));
    }
 
    public long capacity() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/parallel/PSYoungGen.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/parallel/PSYoungGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,15 +61,15 @@ public class PSYoungGen extends VMObject {
 
    // Accessors
    public MutableSpace edenSpace() {
-      return (MutableSpace) VMObjectFactory.newObject(MutableSpace.class, edenSpaceField.getValue(addr));
+      return VMObjectFactory.newObject(MutableSpace.class, edenSpaceField.getValue(addr));
    }
 
    public MutableSpace fromSpace() {
-      return (MutableSpace) VMObjectFactory.newObject(MutableSpace.class, fromSpaceField.getValue(addr));
+      return VMObjectFactory.newObject(MutableSpace.class, fromSpaceField.getValue(addr));
    }
 
    public MutableSpace toSpace() {
-      return (MutableSpace) VMObjectFactory.newObject(MutableSpace.class, toSpaceField.getValue(addr));
+      return VMObjectFactory.newObject(MutableSpace.class, toSpaceField.getValue(addr));
    }
 
    public long capacity() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/parallel/ParallelScavengeHeap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/parallel/ParallelScavengeHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,11 +60,11 @@ public class ParallelScavengeHeap extends CollectedHeap {
 
    // Accessors
    public PSYoungGen youngGen() {
-      return (PSYoungGen) VMObjectFactory.newObject(PSYoungGen.class, youngGenField.getValue());
+      return VMObjectFactory.newObject(PSYoungGen.class, youngGenField.getValue());
    }
 
    public PSOldGen oldGen() {
-      return (PSOldGen) VMObjectFactory.newObject(PSOldGen.class, oldGenField.getValue());
+      return VMObjectFactory.newObject(PSOldGen.class, oldGenField.getValue());
    }
 
    public long capacity() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/serial/DefNewGeneration.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/serial/DefNewGeneration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,15 +68,15 @@ public class DefNewGeneration extends Generation {
 
   // Accessing spaces
   public ContiguousSpace eden() {
-    return (ContiguousSpace) VMObjectFactory.newObject(ContiguousSpace.class, edenSpaceField.getValue(addr));
+    return VMObjectFactory.newObject(ContiguousSpace.class, edenSpaceField.getValue(addr));
   }
 
   public ContiguousSpace from() {
-    return (ContiguousSpace) VMObjectFactory.newObject(ContiguousSpace.class, fromSpaceField.getValue(addr));
+    return VMObjectFactory.newObject(ContiguousSpace.class, fromSpaceField.getValue(addr));
   }
 
   public ContiguousSpace to() {
-    return (ContiguousSpace) VMObjectFactory.newObject(ContiguousSpace.class, toSpaceField.getValue(addr));
+    return VMObjectFactory.newObject(ContiguousSpace.class, toSpaceField.getValue(addr));
   }
 
   public long capacity()            { return eden().capacity() + from().capacity(); /* to() is only used during scavenge */ }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/serial/TenuredGeneration.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/serial/TenuredGeneration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ public class TenuredGeneration extends Generation {
   }
 
   public ContiguousSpace theSpace() {
-    return (ContiguousSpace) VMObjectFactory.newObject(ContiguousSpace.class, theSpaceField.getValue(addr));
+    return VMObjectFactory.newObject(ContiguousSpace.class, theSpaceField.getValue(addr));
   }
 
   public boolean isIn(Address p) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/shared/GenCollectedHeap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/shared/GenCollectedHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -127,13 +127,11 @@ public abstract class GenCollectedHeap extends CollectedHeap {
     }
 
     if (level == 0) {
-      return (GenerationSpec)
-              VMObjectFactory.newObject(GenerationSpec.class,
-                      youngGenSpecField.getAddress());
+      return VMObjectFactory.newObject(GenerationSpec.class,
+              youngGenSpecField.getAddress());
     } else {
-      return (GenerationSpec)
-              VMObjectFactory.newObject(GenerationSpec.class,
-                      oldGenSpecField.getAddress());
+      return VMObjectFactory.newObject(GenerationSpec.class,
+              oldGenSpecField.getAddress());
     }
   }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/shared/Generation.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/shared/Generation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -163,7 +163,7 @@ public abstract class Generation extends VMObject {
   }
 
   protected VirtualSpace virtualSpace() {
-    return (VirtualSpace) VMObjectFactory.newObject(VirtualSpace.class, addr.addOffsetTo(virtualSpaceFieldOffset));
+    return VMObjectFactory.newObject(VirtualSpace.class, addr.addOffsetTo(virtualSpaceFieldOffset));
   }
 
   public abstract String name();
@@ -192,6 +192,6 @@ public abstract class Generation extends VMObject {
   }
 
   private StatRecord getStatRecord() {
-    return (StatRecord) VMObjectFactory.newObject(Generation.StatRecord.class, addr.addOffsetTo(statRecordField.getOffset()));
+    return VMObjectFactory.newObject(StatRecord.class, addr.addOffsetTo(statRecordField.getOffset()));
   }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/z/ZCollectedHeap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/z/ZCollectedHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ public class ZCollectedHeap extends CollectedHeap {
 
     public ZHeap heap() {
         Address heapAddr = addr.addOffsetTo(zHeapFieldOffset);
-        return (ZHeap)VMObjectFactory.newObject(ZHeap.class, heapAddr);
+        return VMObjectFactory.newObject(ZHeap.class, heapAddr);
     }
 
     @Override

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/z/ZHeap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/z/ZHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,11 +61,11 @@ public class ZHeap extends VMObject {
 
     private ZPageAllocator pageAllocator() {
         Address pageAllocatorAddr = addr.addOffsetTo(pageAllocatorFieldOffset);
-        return (ZPageAllocator)VMObjectFactory.newObject(ZPageAllocator.class, pageAllocatorAddr);
+        return VMObjectFactory.newObject(ZPageAllocator.class, pageAllocatorAddr);
     }
 
     ZPageTable pageTable() {
-        return (ZPageTable)VMObjectFactory.newObject(ZPageTable.class, addr.addOffsetTo(pageTableFieldOffset));
+        return VMObjectFactory.newObject(ZPageTable.class, addr.addOffsetTo(pageTableFieldOffset));
     }
 
     ZForwardingTable forwardingTable() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/z/ZPageTable.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/z/ZPageTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ public class ZPageTable extends VMObject {
     }
 
     private ZGranuleMapForPageTable map() {
-        return (ZGranuleMapForPageTable)VMObjectFactory.newObject(ZGranuleMapForPageTable.class, addr.addOffsetTo(mapFieldOffset));
+        return VMObjectFactory.newObject(ZGranuleMapForPageTable.class, addr.addOffsetTo(mapFieldOffset));
     }
 
     private ZPageTableEntry getEntry(Address o) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/z/ZPageTableEntry.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/z/ZPageTableEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ class ZPageTableEntry {
     }
 
     ZPage page() {
-        return (ZPage)VMObjectFactory.newObject(ZPage.class, zPageBits());
+        return VMObjectFactory.newObject(ZPage.class, zPageBits());
     }
 
     private Address zPageBits() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeDisassembler.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeDisassembler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ public class BytecodeDisassembler {
    }
 
    private static Class getBytecodeClass(int bytecode) {
-      return (Class) bytecode2Class.get(bytecode);
+      return bytecode2Class.get(bytecode);
    }
 
    static {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/CodeHeap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/CodeHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,7 +148,7 @@ public class CodeHeap extends VMObject {
   }
 
   private HeapBlock getBlockAt(Address addr) {
-    return (HeapBlock) VMObjectFactory.newObject(HeapBlock.class, addr);
+    return VMObjectFactory.newObject(HeapBlock.class, addr);
   }
 
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/FileMapInfo.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/FileMapInfo.java
@@ -91,7 +91,7 @@ public class FileMapInfo {
     // FileMapHeader* header = info->_header
     Address info = getStatic_AddressField(FileMapInfo_type, "_current_info");
     Address header = get_AddressField(FileMapInfo_type, info, "_header");
-    headerObj = (FileMapHeader) VMObjectFactory.newObject(FileMapInfo.FileMapHeader.class, header);
+    headerObj = VMObjectFactory.newObject(FileMapHeader.class, header);
 
     // char* mapped_base_address = header->_mapped_base_address
     // size_t cloned_vtable_offset = header->_cloned_vtable_offset

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/HeapBlock.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/HeapBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,6 +93,6 @@ public class HeapBlock extends VMObject {
   }
 
   private Header getHeader() {
-    return (Header) VMObjectFactory.newObject(HeapBlock.Header.class, addr.addOffsetTo(headerField.getOffset()));
+    return VMObjectFactory.newObject(Header.class, addr.addOffsetTo(headerField.getOffset()));
   }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/BreakpointInfo.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/BreakpointInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ public class BreakpointInfo extends VMObject {
   public long getNameIndex()      { return nameIndexField.getValue(addr);            }
   public long getSignatureIndex() { return signatureIndexField.getValue(addr);       }
   public BreakpointInfo getNext() {
-    return (BreakpointInfo) VMObjectFactory.newObject(BreakpointInfo.class, nextField.getValue(addr));
+    return VMObjectFactory.newObject(BreakpointInfo.class, nextField.getValue(addr));
   }
 
   public boolean match(Method m, int bci) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/CompiledICHolder.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/CompiledICHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ public class CompiledICHolder extends VMObject {
   private static MetadataField holderKlass;
 
   // Accessors for declared fields
-  public Metadata getHolderMetadata() { return (Metadata) holderMetadata.getValue(this); }
+  public Metadata getHolderMetadata() { return holderMetadata.getValue(this); }
   public Klass    getHolderKlass()    { return (Klass)    holderKlass.getValue(this); }
 
   public void printValueOn(PrintStream tty) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstMethod.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,7 +126,7 @@ public class ConstMethod extends Metadata {
   private static long exceptionTableElementSize;
 
   public Method getMethod() {
-    InstanceKlass ik = (InstanceKlass)getConstants().getPoolHolder();
+    InstanceKlass ik = getConstants().getPoolHolder();
     MethodArray methods = ik.getMethods();
     return methods.at((int)getIdNum());
   }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstantPool.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstantPool.java
@@ -132,7 +132,7 @@ public class ConstantPool extends Metadata implements ClassConstants {
   public U2Array           getOperands()   { return new U2Array(operands.getValue(getAddress())); }
   public ConstantPoolCache getCache()      {
     Address addr = cache.getValue(getAddress());
-    return (ConstantPoolCache) VMObjectFactory.newObject(ConstantPoolCache.class, addr);
+    return VMObjectFactory.newObject(ConstantPoolCache.class, addr);
   }
   public InstanceKlass     getPoolHolder() { return (InstanceKlass)poolHolder.getValue(this); }
   public int               getLength()     { return (int)length.getValue(getAddress()); }
@@ -182,7 +182,7 @@ public class ConstantPool extends Metadata implements ClassConstants {
   }
 
   public ConstantTag getTagAt(long index) {
-    return new ConstantTag((byte)getTags().at((int) index));
+    return new ConstantTag(getTags().at((int) index));
   }
 
   public CPSlot getSlotAt(long index) {
@@ -513,10 +513,10 @@ public class ConstantPool extends Metadata implements ClassConstants {
     super.iterateFields(visitor);
     visitor.doMetadata(poolHolder, true);
 
-      final int length = (int) getLength();
+      final int length = getLength();
       // zero'th pool entry is always invalid. ignore it.
       for (int index = 1; index < length; index++) {
-      int ctag = (int) getTags().at((int) index);
+      int ctag = getTags().at(index);
         switch (ctag) {
         case JVM_CONSTANT_ClassIndex:
         case JVM_CONSTANT_StringIndex:
@@ -566,7 +566,7 @@ public class ConstantPool extends Metadata implements ClassConstants {
           Map<String, Short> utf8ToIndex = new HashMap<>();
       DataOutputStream dos = new DataOutputStream(os);
       U1Array tags = getTags();
-      int len = (int)getLength();
+      int len = getLength();
       int ci = 0; // constant pool index
 
       // collect all modified UTF-8 Strings from Constant Pool
@@ -634,7 +634,7 @@ public class ConstantPool extends Metadata implements ClassConstants {
                   // Klass already resolved. ConstantPool contains Klass*.
                   Klass refKls = (Klass)Metadata.instantiateWrapperFor(getAddressAtRaw(ci));
                   String klassName = refKls.getName().asString();
-                  Short s = (Short) utf8ToIndex.get(klassName);
+                  Short s = utf8ToIndex.get(klassName);
                   dos.writeShort(s.shortValue());
                   if (DEBUG) debugMessage("CP[" + ci  + "] = class " + s);
                   break;
@@ -645,7 +645,7 @@ public class ConstantPool extends Metadata implements ClassConstants {
               case JVM_CONSTANT_UnresolvedClass: {
                   dos.writeByte(JVM_CONSTANT_Class);
                   String klassName = getSymbolAt(ci).asString();
-                  Short s = (Short) utf8ToIndex.get(klassName);
+                  Short s = utf8ToIndex.get(klassName);
                   dos.writeShort(s.shortValue());
                   if (DEBUG) debugMessage("CP[" + ci + "] = class " + s);
                   break;
@@ -654,7 +654,7 @@ public class ConstantPool extends Metadata implements ClassConstants {
               case JVM_CONSTANT_String: {
                   dos.writeByte(cpConstType);
                   String str = getUnresolvedStringAt(ci).asString();
-                  Short s = (Short) utf8ToIndex.get(str);
+                  Short s = utf8ToIndex.get(str);
                   dos.writeShort(s.shortValue());
                   if (DEBUG) debugMessage("CP[" + ci + "] = string " + s);
                   break;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -473,7 +473,7 @@ public class InstanceKlass extends Klass {
     long access = getAccessFlags();
     // But check if it happens to be member class.
     U2Array innerClassList = getInnerClasses();
-    int length = (innerClassList == null)? 0 : (int) innerClassList.length();
+    int length = (innerClassList == null)? 0 : innerClassList.length();
     if (length > 0) {
        if (Assert.ASSERTS_ENABLED) {
           Assert.that(length % InnerClassAttributeOffset.innerClassNextOffset == 0 ||
@@ -522,7 +522,7 @@ public class InstanceKlass extends Klass {
 
   private boolean isInInnerClasses(Symbol sym, boolean includeLocals) {
     U2Array innerClassList = getInnerClasses();
-    int length = ( innerClassList == null)? 0 : (int) innerClassList.length();
+    int length = ( innerClassList == null)? 0 : innerClassList.length();
     if (length > 0) {
        if (Assert.ASSERTS_ENABLED) {
          Assert.that(length % InnerClassAttributeOffset.innerClassNextOffset == 0 ||
@@ -882,22 +882,22 @@ public class InstanceKlass extends Klass {
       return null;
     }
     Address addr = getAddress().getAddressAt(breakpoints.getOffset());
-    return (BreakpointInfo) VMObjectFactory.newObject(BreakpointInfo.class, addr);
+    return VMObjectFactory.newObject(BreakpointInfo.class, addr);
   }
 
   public IntArray  getMethodOrdering() {
     Address addr = getAddress().getAddressAt(methodOrdering.getOffset());
-    return (IntArray) VMObjectFactory.newObject(IntArray.class, addr);
+    return VMObjectFactory.newObject(IntArray.class, addr);
   }
 
   public U2Array getFields() {
     Address addr = getAddress().getAddressAt(fields.getOffset());
-    return (U2Array) VMObjectFactory.newObject(U2Array.class, addr);
+    return VMObjectFactory.newObject(U2Array.class, addr);
   }
 
   public U2Array getInnerClasses() {
     Address addr = getAddress().getAddressAt(innerClasses.getOffset());
-    return (U2Array) VMObjectFactory.newObject(U2Array.class, addr);
+    return VMObjectFactory.newObject(U2Array.class, addr);
   }
 
 
@@ -992,7 +992,7 @@ public class InstanceKlass extends Klass {
   }
 
   private static int linearSearch(MethodArray methods, String name, String signature) {
-    int len = (int) methods.length();
+    int len = methods.length();
     for (int index = 0; index < len; index++) {
       Method m = methods.at(index);
       if (m.getSignature().equals(signature) && m.getName().equals(name)) {
@@ -1014,7 +1014,7 @@ public class InstanceKlass extends Klass {
         sub = sub.getNextSiblingKlass();
     }
 
-    final int length = (int) cp.getLength();
+    final int length = cp.getLength();
     out.print("ciInstanceKlass " + getName().asString() + " " + (isLinked() ? 1 : 0) + " " + (isInitialized() ? 1 : 0) + " " + length);
     for (int index = 1; index < length; index++) {
       out.print(" " + cp.getTags().at(index));

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Klass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Klass.java
@@ -115,7 +115,7 @@ public class Klass extends Metadata implements ClassConstants {
   }
   public Klass    getSuper()            { return (Klass)    superField.getValue(this);   }
   public Klass    getJavaSuper()        { return null;  }
-  public int      getLayoutHelper()     { return (int)           layoutHelper.getValue(this); }
+  public int      getLayoutHelper()     { return            layoutHelper.getValue(this); }
   public Symbol   getName()             { return            getSymbol(name); }
   public long     getAccessFlags()      { return            accessFlags.getValue(this);  }
   // Convenience routine

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Method.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Method.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,18 +113,18 @@ public class Method extends Metadata {
   // Accessors for declared fields
   public ConstMethod  getConstMethod()                {
     Address addr = constMethod.getValue(getAddress());
-    return (ConstMethod) VMObjectFactory.newObject(ConstMethod.class, addr);
+    return VMObjectFactory.newObject(ConstMethod.class, addr);
   }
   public ConstantPool getConstants()                  {
     return getConstMethod().getConstants();
   }
   public MethodData   getMethodData()                 {
     Address addr = methodData.getValue(getAddress());
-    return (MethodData) VMObjectFactory.newObject(MethodData.class, addr);
+    return VMObjectFactory.newObject(MethodData.class, addr);
   }
   public MethodCounters getMethodCounters()           {
     Address addr = methodCounters.getValue(getAddress());
-    return (MethodCounters) VMObjectFactory.newObject(MethodCounters.class, addr);
+    return VMObjectFactory.newObject(MethodCounters.class, addr);
   }
   /** WARNING: this is in words, not useful in this system; use getObjectSize() instead */
   public long         getMaxStack()                   { return                getConstMethod().getMaxStack();   }
@@ -148,7 +148,7 @@ public class Method extends Metadata {
   // get associated compiled native method, if available, else return null.
   public NMethod getNativeMethod() {
     Address addr = code.getValue(getAddress());
-    return (NMethod) VMObjectFactory.newObject(NMethod.class, addr);
+    return VMObjectFactory.newObject(NMethod.class, addr);
   }
 
   // Convenience routine

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHeap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHeap.java
@@ -138,15 +138,15 @@ public class ObjectHeap {
     // Summarize size
     long totalSize = 0;
     for (int i = 0; i < liveRegions.size(); i += 2) {
-      Address bottom = (Address) liveRegions.get(i);
-      Address top    = (Address) liveRegions.get(i+1);
+      Address bottom = liveRegions.get(i);
+      Address top    = liveRegions.get(i+1);
       totalSize += top.minus(bottom);
     }
     visitor.prologue(totalSize);
 
     for (int i = 0; i < liveRegions.size(); i += 2) {
-      Address bottom = (Address) liveRegions.get(i);
-      Address top    = (Address) liveRegions.get(i+1);
+      Address bottom = liveRegions.get(i);
+      Address top    = liveRegions.get(i+1);
 
       // Traverses the space from bottom to top
       while (bottom.lessThan(top)) {
@@ -227,15 +227,15 @@ public class ObjectHeap {
     // Summarize size
     long totalSize = 0;
     for (int i = 0; i < liveRegions.size(); i += 2) {
-      Address bottom = (Address) liveRegions.get(i);
-      Address top    = (Address) liveRegions.get(i+1);
+      Address bottom = liveRegions.get(i);
+      Address top    = liveRegions.get(i+1);
       totalSize += top.minus(bottom);
     }
     visitor.prologue(totalSize);
 
     for (int i = 0; i < liveRegions.size(); i += 2) {
-      Address bottom = (Address) liveRegions.get(i);
-      Address top    = (Address) liveRegions.get(i+1);
+      Address bottom = liveRegions.get(i);
+      Address top    = liveRegions.get(i+1);
 
       try {
         // Traverses the space from bottom to top
@@ -355,8 +355,8 @@ public class ObjectHeap {
     if (DEBUG) {
       System.err.println("liveRegions:");
       for (int i = 0; i < liveRegions.size(); i += 2) {
-          Address bottom = (Address) liveRegions.get(i);
-          Address top    = (Address) liveRegions.get(i+1);
+          Address bottom = liveRegions.get(i);
+          Address top    = liveRegions.get(i+1);
           System.err.println(" " + bottom + " - " + top);
       }
     }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/OopUtilities.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/OopUtilities.java
@@ -224,7 +224,7 @@ public class OopUtilities {
     // The threadStatus is only present starting in 1.5
     if (threadStatusField != null) {
       Oop holderOop = threadHolderField.getValue(threadOop);
-      return (int) threadStatusField.getValue(holderOop);
+      return threadStatusField.getValue(holderOop);
     } else {
       // All we can easily figure out is if it is alive, but that is
       // enough info for a valid unknown status.

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/TypeArray.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/TypeArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,7 @@ public class TypeArray extends Array {
     super.iterateFields(visitor, doVMFields);
     TypeArrayKlass klass = (TypeArrayKlass) getKlass();
     int length = (int) getLength();
-    int type   = (int) klass.getElementType();
+    int type   = klass.getElementType();
     for (int index = 0; index < length; index++) {
       FieldIdentifier id = new IndexableFieldIdentifier(index);
       switch (type) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/TypeArrayKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/TypeArrayKlass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ public class TypeArrayKlass extends ArrayKlass {
   public static final int T_LONG    = 11;
 
   public String getTypeName() {
-    switch ((int) getElementType()) {
+    switch (getElementType()) {
       case T_BOOLEAN: return "[Z";
       case T_CHAR:    return "[C";
       case T_FLOAT:   return "[F";
@@ -81,7 +81,7 @@ public class TypeArrayKlass extends ArrayKlass {
   }
 
   public String getElementTypeName() {
-    switch ((int) getElementType()) {
+    switch (getElementType()) {
       case T_BOOLEAN: return "boolean";
       case T_CHAR:    return "char";
       case T_FLOAT:   return "float";

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/opto/Block.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/opto/Block.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,7 +70,7 @@ public class Block extends VMObject {
   }
 
   public double freq() {
-    return (double)freqField.getValue(getAddress());
+    return freqField.getValue(getAddress());
   }
 
   public Node_List nodes() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/opto/Node.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/opto/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,7 +82,7 @@ public class Node extends VMObject {
     if (addr == null) return null;
     Node result = nodes.get(addr);
     if (result == null) {
-      result = (Node)virtualConstructor.instantiateWrapperFor(addr);
+      result = virtualConstructor.instantiateWrapperFor(addr);
       nodes.put(addr, result);
     }
     return result;
@@ -147,7 +147,7 @@ public class Node extends VMObject {
     for (int i = 0; i < depth; i++) {
       end = nstack.size();
       for(int j = begin; j < end; j++) {
-        Node tp  = (Node)nstack.get(j);
+        Node tp  = nstack.get(j);
         int limit = d > 0 ? tp.len() : tp.outcnt();
         for(int k = 0; k < limit; k++) {
           Node n = d > 0 ? tp.in(k) : tp.rawOut(k);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/CompiledVFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/CompiledVFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -200,7 +200,7 @@ public class CompiledVFrame extends JavaVFrame {
         ? getRegisterMap().getLocation(new VMReg(loc.getRegisterNumber()))
         // Else value was directly saved on the stack. The frame's original stack pointer,
         // before any extension by its callee (due to Compiler1 linkage on SPARC), must be used.
-        : ((Address)fr.getUnextendedSP()).addOffsetTo(loc.getStackOffset());
+        : fr.getUnextendedSP().addOffsetTo(loc.getStackOffset());
 
       // Then package it right depending on type
       if (loc.holdsFloat()) {    // Holds a float in a double register?

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaThread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaThread.java
@@ -327,7 +327,7 @@ public class JavaThread extends Thread {
   //
 
   public OSThread getOSThread() {
-    return (OSThread) VMObjectFactory.newObject(OSThread.class, osThreadField.getValue(addr));
+    return VMObjectFactory.newObject(OSThread.class, osThreadField.getValue(addr));
   }
 
   public Address getStackBase() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/PerfMemory.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/PerfMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,7 +79,7 @@ public class PerfMemory {
     }
 
     public static PerfDataPrologue prologue() {
-        return (PerfDataPrologue) VMObjectFactory.newObject(
+        return VMObjectFactory.newObject(
                    PerfDataPrologue.class, prologueField.getValue());
     }
 
@@ -102,7 +102,7 @@ public class PerfMemory {
         Address addr = header.getAddress();
 
         for (int i = 0; i < num; i++) {
-            PerfDataEntry pde = (PerfDataEntry) VMObjectFactory.newObject(
+            PerfDataEntry pde = VMObjectFactory.newObject(
                                PerfDataEntry.class, addr.addOffsetTo(off));
             off += pde.entryLength();
             if (visitor.visit(pde) == false) return;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/StackValueCollection.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/StackValueCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ public class StackValueCollection {
   public void add(StackValue val) { list.add(val); }
   public int  size()              { return list.size(); }
   public boolean isEmpty()        { return (size() == 0); }
-  public StackValue get(int i)    { return (StackValue) list.get(i); }
+  public StackValue get(int i)    { return list.get(i); }
 
   // Get typed locals/expressions
   // FIXME: must figure out whether word swapping is necessary on x86

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
@@ -1009,7 +1009,7 @@ public class VM {
         flagsMap.put(flags[i].getName(), flags[i]);
       }
     }
-    return (Flag) flagsMap.get(name);
+    return flagsMap.get(name);
   }
 
   private static final String cmdFlagTypes[] = {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/ClassLoaderStats.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/ClassLoaderStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,8 +113,8 @@ public class ClassLoaderStats extends Tool {
                            if (! (k instanceof InstanceKlass)) {
                               return;
                            }
-                           Oop loader = ((InstanceKlass) k).getClassLoader();
-                           LoaderData ld = (loader != null) ? (LoaderData)loaderMap.get(loader)
+                           Oop loader = k.getClassLoader();
+                           LoaderData ld = (loader != null) ? loaderMap.get(loader)
                                                             : bootstrapLoaderData;
                            if (ld != null) {
                               ld.numClasses++;
@@ -179,7 +179,7 @@ public class ClassLoaderStats extends Tool {
 
       for (Iterator keyItr = loaderMap.keySet().iterator(); keyItr.hasNext();) {
          Oop loader = (Oop) keyItr.next();
-         LoaderData data = (LoaderData) loaderMap.get(loader);
+         LoaderData data = loaderMap.get(loader);
          numClassLoaders ++;
          totalNumClasses += data.numClasses;
          totalClassSize  += data.classSize;
@@ -275,7 +275,7 @@ public class ClassLoaderStats extends Tool {
 
       // Methods
       MethodArray methods = k.getMethods();
-      int nmethods = (int) methods.getLength();
+      int nmethods = methods.getLength();
       if (nmethods != 0L) {
          size += methods.getSize();
          for (int i = 0; i < nmethods; ++i) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/FinalizerInfo.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/FinalizerInfo.java
@@ -134,7 +134,7 @@ public class FinalizerInfo extends Tool {
             System.out.println("Count" + "\t" + "Class description");
             System.out.println("-------------------------------------------------------");
             for (int i=0; i<list.size(); i++) {
-                ObjectHistogramElement e = (ObjectHistogramElement)list.get(i);
+                ObjectHistogramElement e = list.get(i);
                 System.out.println(e.getCount() + "\t" + e.getDescription());
             }
        }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
@@ -97,7 +97,7 @@ public class PStack extends Tool {
                out.print("----------------- ");
                out.print(th);
                out.println(" -----------------");
-               JavaThread jthread = (JavaThread) proxyToThread.get(th);
+               JavaThread jthread = proxyToThread.get(th);
                if (jthread != null) {
                   jthread.printThreadInfoOn(out);
                }
@@ -190,7 +190,7 @@ public class PStack extends Tool {
                // continue, may be we can do a better job for other threads
             }
             if (concurrentLocks) {
-               JavaThread jthread = (JavaThread) proxyToThread.get(th);
+               JavaThread jthread = proxyToThread.get(th);
                if (jthread != null) {
                    concLocksPrinter.print(jthread, out);
                }
@@ -248,7 +248,7 @@ public class PStack extends Tool {
       if (fp == null) {
          return null;
       }
-      JavaVFrame[] jvframes = (JavaVFrame[]) jframeCache.get(th);
+      JavaVFrame[] jvframes = jframeCache.get(th);
       if (jvframes == null) return null; // not a java thread
       List<String> names = new ArrayList<>(10);
       for (int fCount = 0; fCount < jvframes.length; fCount++) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ClassWriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ClassWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,34 +133,34 @@ public class ClassWriter implements /* imports */ ClassConstants
         // remember index of attribute name modified UTF-8 strings
 
         // class attributes
-        Short sourceFileIndex = (Short) utf8ToIndex.get("SourceFile");
+        Short sourceFileIndex = utf8ToIndex.get("SourceFile");
         _sourceFileIndex = (sourceFileIndex != null)? sourceFileIndex.shortValue() : 0;
         if (DEBUG) debugMessage("SourceFile index = " + _sourceFileIndex);
 
-        Short innerClassesIndex = (Short) utf8ToIndex.get("InnerClasses");
+        Short innerClassesIndex = utf8ToIndex.get("InnerClasses");
         _innerClassesIndex = (innerClassesIndex != null)? innerClassesIndex.shortValue() : 0;
         if (DEBUG) debugMessage("InnerClasses index = " + _innerClassesIndex);
 
         // field attributes
-        Short constantValueIndex = (Short) utf8ToIndex.get("ConstantValue");
+        Short constantValueIndex = utf8ToIndex.get("ConstantValue");
         _constantValueIndex = (constantValueIndex != null)?
                                           constantValueIndex.shortValue() : 0;
         if (DEBUG) debugMessage("ConstantValue index = " + _constantValueIndex);
 
-        Short syntheticIndex = (Short) utf8ToIndex.get("Synthetic");
+        Short syntheticIndex = utf8ToIndex.get("Synthetic");
         _syntheticIndex = (syntheticIndex != null)? syntheticIndex.shortValue() : 0;
         if (DEBUG) debugMessage("Synthetic index = " + _syntheticIndex);
 
-        Short deprecatedIndex = (Short) utf8ToIndex.get("Deprecated");
+        Short deprecatedIndex = utf8ToIndex.get("Deprecated");
         _deprecatedIndex = (deprecatedIndex != null)? deprecatedIndex.shortValue() : 0;
         if (DEBUG) debugMessage("Deprecated index = " + _deprecatedIndex);
 
         // method attributes
-        Short codeIndex = (Short) utf8ToIndex.get("Code");
+        Short codeIndex = utf8ToIndex.get("Code");
         _codeIndex = (codeIndex != null)? codeIndex.shortValue() : 0;
         if (DEBUG) debugMessage("Code index = " + _codeIndex);
 
-        Short exceptionsIndex = (Short) utf8ToIndex.get("Exceptions");
+        Short exceptionsIndex = utf8ToIndex.get("Exceptions");
         _exceptionsIndex = (exceptionsIndex != null)? exceptionsIndex.shortValue() : 0;
         if (DEBUG) debugMessage("Exceptions index = " + _exceptionsIndex);
 
@@ -168,17 +168,17 @@ public class ClassWriter implements /* imports */ ClassConstants
         // Short deprecatedIndex = (Short) utf8ToIndex.get("Deprecated");
 
         // Code attributes
-        Short lineNumberTableIndex = (Short) utf8ToIndex.get("LineNumberTable");
+        Short lineNumberTableIndex = utf8ToIndex.get("LineNumberTable");
         _lineNumberTableIndex = (lineNumberTableIndex != null)?
                                        lineNumberTableIndex.shortValue() : 0;
         if (DEBUG) debugMessage("LineNumberTable index = " + _lineNumberTableIndex);
 
-        Short localVariableTableIndex = (Short) utf8ToIndex.get("LocalVariableTable");
+        Short localVariableTableIndex = utf8ToIndex.get("LocalVariableTable");
         _localVariableTableIndex = (localVariableTableIndex != null)?
                                        localVariableTableIndex.shortValue() : 0;
         if (DEBUG) debugMessage("LocalVariableTable index = " + _localVariableTableIndex);
 
-        Short signatureIdx = (Short) utf8ToIndex.get("Signature");
+        Short signatureIdx = utf8ToIndex.get("Signature");
         _signatureIndex = (signatureIdx != null)? signatureIdx.shortValue() : 0;
         if (DEBUG) debugMessage("Signature index = " + _signatureIndex);
 
@@ -232,7 +232,7 @@ public class ClassWriter implements /* imports */ ClassConstants
                 case JVM_CONSTANT_UnresolvedClassInError: {
                      dos.writeByte(JVM_CONSTANT_Class);
                      String klassName = cpool.getKlassNameAt(ci).asString();
-                     Short s = (Short) utf8ToIndex.get(klassName);
+                     Short s = utf8ToIndex.get(klassName);
                      classToIndex.put(klassName, (short) ci);
                      dos.writeShort(s.shortValue());
                      if (DEBUG) debugMessage("CP[" + ci  + "] = class " + s);
@@ -242,7 +242,7 @@ public class ClassWriter implements /* imports */ ClassConstants
                 case JVM_CONSTANT_String: {
                      dos.writeByte(cpConstType);
                      String str = cpool.getUnresolvedStringAt(ci).asString();
-                     Short s = (Short) utf8ToIndex.get(str);
+                     Short s = utf8ToIndex.get(str);
                      dos.writeShort(s.shortValue());
                      if (DEBUG) debugMessage("CP[" + ci + "] = string " + s);
                      break;
@@ -333,7 +333,7 @@ public class ClassWriter implements /* imports */ ClassConstants
 
     protected void writeThisClass() throws IOException {
         String klassName = klass.getName().asString();
-        Short index = (Short) classToIndex.get(klassName);
+        Short index = classToIndex.get(klassName);
         dos.writeShort(index.shortValue());
         if (DEBUG) debugMessage("this class = " + index);
     }
@@ -342,7 +342,7 @@ public class ClassWriter implements /* imports */ ClassConstants
         Klass superKlass = klass.getSuper();
         if (superKlass != null) { // is not java.lang.Object
             String superName = superKlass.getName().asString();
-            Short index = (Short) classToIndex.get(superName);
+            Short index = classToIndex.get(superName);
             if (DEBUG) debugMessage("super class = " + index);
             dos.writeShort(index.shortValue());
         } else {
@@ -359,7 +359,7 @@ public class ClassWriter implements /* imports */ ClassConstants
         dos.writeShort((short) len);
         for (int i = 0; i < len; i++) {
            Klass k = interfaces.getAt(i);
-           Short index = (Short) classToIndex.get(k.getName().asString());
+           Short index = classToIndex.get(k.getName().asString());
            dos.writeShort(index.shortValue());
            if (DEBUG) debugMessage("\t" + index);
         }
@@ -598,7 +598,7 @@ public class ClassWriter implements /* imports */ ClassConstants
                 }
             }
 
-            dos.writeShort((short)codeAttrCount);
+            dos.writeShort(codeAttrCount);
             if (DEBUG) debugMessage("\tcode attribute count = " + codeAttrCount);
 
             // write LineNumberTable, if available.
@@ -614,7 +614,7 @@ public class ClassWriter implements /* imports */ ClassConstants
 
             // write LocalVariableTable, if available.
             if (hasLocalVariableTable) {
-                writeIndex((short) _localVariableTableIndex);
+                writeIndex(_localVariableTableIndex);
                 dos.writeInt(localVarAttrLen);
                 dos.writeShort((short) localVariableTable.length);
                 for (int l = 0; l < localVariableTable.length; l++) {
@@ -657,7 +657,7 @@ public class ClassWriter implements /* imports */ ClassConstants
         writeIndex(_signatureIndex);
         if (DEBUG) debugMessage("signature attribute = " + _signatureIndex);
         dos.writeInt(2);
-        Short index = (Short) utf8ToIndex.get(signature);
+        Short index = utf8ToIndex.get(signature);
         dos.writeShort(index.shortValue());
         if (DEBUG) debugMessage("generic signature = " + index);
     }
@@ -681,7 +681,7 @@ public class ClassWriter implements /* imports */ ClassConstants
             classAttributeCount++;
 
         U2Array innerClasses = klass.getInnerClasses();
-        final int numInnerClasses = (int) (innerClasses.length() / 4);
+        final int numInnerClasses = innerClasses.length() / 4;
         if (numInnerClasses != 0)
             classAttributeCount++;
 
@@ -696,7 +696,7 @@ public class ClassWriter implements /* imports */ ClassConstants
             writeIndex(_sourceFileIndex);
             if (DEBUG) debugMessage("source file attribute = " + _sourceFileIndex);
             dos.writeInt(2);
-            Short index = (Short) utf8ToIndex.get(sourceFileName.asString());
+            Short index = utf8ToIndex.get(sourceFileName.asString());
             dos.writeShort(index.shortValue());
             if (DEBUG) debugMessage("source file name = " + index);
         }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/types/basic/BasicType.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/types/basic/BasicType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -166,7 +166,7 @@ public class BasicType implements Type {
                         boolean throwExceptionIfNotFound) {
     Field field = null;
     if (nameToFieldMap != null) {
-      field = (Field) nameToFieldMap.get(fieldName);
+      field = nameToFieldMap.get(fieldName);
 
       if (field != null) {
         return field;
@@ -274,7 +274,7 @@ public class BasicType implements Type {
   }
 
   public NarrowOopField getNarrowOopField(String fieldName) throws WrongTypeException {
-    return (NarrowOopField) new BasicNarrowOopField(getOopField(fieldName));
+    return new BasicNarrowOopField(getOopField(fieldName));
   }
 
   public AddressField getAddressField(String fieldName) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/types/basic/BasicTypeDataBase.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/types/basic/BasicTypeDataBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,7 @@ public class BasicTypeDataBase implements TypeDataBase {
   }
 
   public Type lookupType(String cTypeName, boolean throwException) {
-    Type type = (Type) nameToTypeMap.get(cTypeName);
+    Type type = nameToTypeMap.get(cTypeName);
     if (type == null && throwException) {
       throw new RuntimeException("No type named \"" + cTypeName + "\" in database");
     }
@@ -93,7 +93,7 @@ public class BasicTypeDataBase implements TypeDataBase {
   }
 
   public Integer lookupIntConstant(String constantName, boolean throwException) {
-    Integer i = (Integer) nameToIntConstantMap.get(constantName);
+    Integer i = nameToIntConstantMap.get(constantName);
     if (i == null) {
       if (throwException) {
         throw new RuntimeException("No integer constant named \"" + constantName + "\" present in type database");
@@ -107,7 +107,7 @@ public class BasicTypeDataBase implements TypeDataBase {
   }
 
   public Long lookupLongConstant(String constantName, boolean throwException) {
-    Long i = (Long) nameToLongConstantMap.get(constantName);
+    Long i = nameToLongConstantMap.get(constantName);
     if (i == null) {
       if (throwException) {
         throw new RuntimeException("No long constant named \"" + constantName + "\" present in type database");
@@ -364,7 +364,7 @@ public class BasicTypeDataBase implements TypeDataBase {
       TypeDataBase. Throws a RuntimeException if this class was not
       present. */
   public void removeType(Type type) {
-    Type curType = (Type) nameToTypeMap.get(type.getName());
+    Type curType = nameToTypeMap.get(type.getName());
     if (curType == null) {
       throw new RuntimeException("type of name \"" + type.getName() + "\" not present");
     }
@@ -391,7 +391,7 @@ public class BasicTypeDataBase implements TypeDataBase {
       TypeDataBase. Throws a RuntimeException if an integer constant
       with this name was not present. */
   public void removeIntConstant(String name) {
-    Integer curConstant = (Integer) nameToIntConstantMap.get(name);
+    Integer curConstant = nameToIntConstantMap.get(name);
     if (curConstant == null) {
       throw new RuntimeException("int constant of name \"" + name + "\" not present");
     }
@@ -414,7 +414,7 @@ public class BasicTypeDataBase implements TypeDataBase {
       TypeDataBase. Throws a RuntimeException if a long constant with
       this name was not present. */
   public void removeLongConstant(String name) {
-    Long curConstant = (Long) nameToLongConstantMap.get(name);
+    Long curConstant = nameToLongConstantMap.get(name);
     if (curConstant == null) {
       throw new RuntimeException("long constant of name \"" + name + "\" not present");
     }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/AnnotatedMemoryPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/AnnotatedMemoryPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,7 +148,7 @@ public class AnnotatedMemoryPanel extends JPanel {
     BigInteger startVal  = scrollBar.getValueHP();
     BigInteger perLine = new BigInteger(Integer.toString((int) addressSize));
     // lineCount and maxLines are both 1 less than expected
-    BigInteger lineCount = new BigInteger(Integer.toString((int) (numLines - 1)));
+    BigInteger lineCount = new BigInteger(Integer.toString(numLines - 1));
     BigInteger maxLines = scrollBar.getMaximumHP().subtract(scrollBar.getMinimumHP()).divide(perLine);
     if (lineCount.compareTo(maxLines) > 0) {
       lineCount = maxLines;
@@ -226,7 +226,7 @@ public class AnnotatedMemoryPanel extends JPanel {
         // See whether we can pop any items off the stack
         boolean shouldContinue = true;
         do {
-          AnnoX annoX = (AnnoX) drawStack.peek();
+          AnnoX annoX = drawStack.peek();
           if (annoX.highBound.lessThanOrEqual((Address) interval.getLowEndpoint())) {
             curLineX = annoX.lineX;
             drawStack.pop();
@@ -493,7 +493,7 @@ public class AnnotatedMemoryPanel extends JPanel {
     java.util.List<Annotation> newAnnos = new ArrayList<>();
 
     for (Iterator<IntervalNode> iter = va.iterator(); iter.hasNext(); ) {
-      Annotation anno = (Annotation) ((IntervalNode) iter.next()).getData();
+      Annotation anno = (Annotation) iter.next().getData();
 
       // Search forward for this one
       boolean found = false;
@@ -532,7 +532,7 @@ public class AnnotatedMemoryPanel extends JPanel {
     if (firstConstraintAnnotation != null) {
       // Go back and lay out deferred annotations
       for (int i = deferredIndex; i >= 0; i--) {
-        Annotation anno = (Annotation) newAnnos.get(i);
+        Annotation anno = newAnnos.get(i);
         layoutBefore(anno, firstConstraintAnnotation, g, x, startAddr, lineHeight);
         firstConstraintAnnotation = anno;
       }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/Annotation.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/Annotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,8 +82,8 @@ public class Annotation {
     g.setColor(baseColor);
     int tmpY = y;
     for (int i = 0; i < strings.size(); i++) {
-      String s = (String) strings.get(i);
-      Integer h = (Integer) heights.get(i);
+      String s = strings.get(i);
+      Integer h = heights.get(i);
       g.drawString(s, x, tmpY);
       tmpY += h.intValue();
     }
@@ -152,7 +152,7 @@ public class Annotation {
   public String toString() {
     String result = "Annotation: lowAddr: " + getLowAddress() + " highAddr: " + getHighAddress() + " strings: "  + strings.size();
     for (int i = 0; i < strings.size(); i++) {
-      result += "\n" + (String) strings.get(i);
+      result += "\n" + strings.get(i);
     }
     return result;
   }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/ObjectListPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/ObjectListPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -175,7 +175,7 @@ public class ObjectListPanel extends SAPanel {
     }
 
     public Object getValueAt(int row, int col) {
-      Oop oop = (Oop) elements.get(row);
+      Oop oop = elements.get(row);
       return getValueForColumn(oop, col);
     }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/ProcessListPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/ProcessListPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ public class ProcessListPanel extends JPanel {
         }
 
         public Object getValueAt(int row, int col) {
-          ProcessInfo info = (ProcessInfo) els.get(row);
+          ProcessInfo info = els.get(row);
 
           switch (col) {
           case 0:

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/classbrowser/HTMLGenerator.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/classbrowser/HTMLGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -382,7 +382,7 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
       Formatter buf = new Formatter(genHTML);
       buf.append(genMethodLink(m));
       buf.append(" of ");
-      buf.append(genKlassLink((InstanceKlass) m.getMethodHolder()));
+      buf.append(genKlassLink(m.getMethodHolder()));
       return buf.toString();
    }
 
@@ -453,13 +453,13 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
       buf.headerCell("Constant Value");
       buf.endTag("tr");
 
-      final int length = (int) cpool.getLength();
+      final int length = cpool.getLength();
       // zero'th pool entry is always invalid. ignore it.
       for (int index = 1; index < length; index++) {
          buf.beginTag("tr");
          buf.cell(Integer.toString(index));
 
-         int ctag = (int) cpool.getTags().at((int) index);
+         int ctag = cpool.getTags().at(index);
          switch (ctag) {
             case JVM_CONSTANT_Integer:
                buf.cell("JVM_CONSTANT_Integer");
@@ -497,7 +497,7 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
 
             case JVM_CONSTANT_Class:
                buf.cell("JVM_CONSTANT_Class");
-               Klass klass = (Klass) cpool.getKlassAt(index);
+               Klass klass = cpool.getKlassAt(index);
                if (klass instanceof InstanceKlass) {
                   buf.cell(genKlassLink((InstanceKlass) klass));
                } else {
@@ -586,7 +586,7 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
          Formatter buf = new Formatter(genHTML);
          buf.genHTMLPrologue(genConstantPoolTitle(cpool));
          buf.h3("Holder Class");
-         buf.append(genKlassLink((InstanceKlass) cpool.getPoolHolder()));
+         buf.append(genKlassLink(cpool.getPoolHolder()));
          buf.h3("Constants");
          buf.append(genHTMLTableForConstantPool(cpool));
          buf.genHTMLEpilogue();
@@ -603,7 +603,7 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
    protected String genConstantPoolTitle(ConstantPool cpool) {
       Formatter buf = new Formatter(genHTML);
       buf.append("Constant Pool of [");
-      buf.append(genKlassTitle((InstanceKlass) cpool.getPoolHolder()));
+      buf.append(genKlassTitle(cpool.getPoolHolder()));
       buf.append("] @");
       buf.append(cpool.getAddress().toString());
       return buf.toString();
@@ -621,7 +621,7 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
          buf.genHTMLPrologue(genMethodTitle(method));
 
          buf.h3("Holder Class");
-         buf.append(genKlassLink((InstanceKlass) method.getMethodHolder()));
+         buf.append(genKlassLink(method.getMethodHolder()));
 
          NMethod nmethod = method.getNativeMethod();
          if (nmethod != null) {
@@ -630,7 +630,7 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
          }
 
          boolean hasThrows = method.hasCheckedExceptions();
-         ConstantPool cpool = ((InstanceKlass) method.getMethodHolder()).getConstants();
+         ConstantPool cpool = method.getMethodHolder().getConstants();
          if (hasThrows) {
             buf.h3("Checked Exception(s)");
             CheckedExceptionElement[] exceptions = method.getCheckedExceptions();
@@ -708,7 +708,7 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
                                   if (m != null) {
                                     buf.link(genMethodHref(m), instrStr);
                                     buf.append(" of ");
-                                    InstanceKlass klass = (InstanceKlass) m.getMethodHolder();
+                                    InstanceKlass klass = m.getMethodHolder();
                                     buf.link(genKlassHref(klass), genKlassTitle(klass));
                                   } else {
                                     buf.append(instrStr);
@@ -815,7 +815,7 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
       CodeBlob blob = null;
 
       try {
-         blob = (CodeBlob)VM.getVM().getCodeCache().findBlobUnsafe(pc);
+         blob = VM.getVM().getCodeCache().findBlobUnsafe(pc);
       } catch (Exception exp) {
          // ignore
       }
@@ -1121,7 +1121,7 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
                 int flen = ov.fieldsSize();
 
                 U2Array klfields = kls.getFields();
-                int klen = (int) klfields.length();
+                int klen = klfields.length();
                 int findex = 0;
                 for (int index = 0; index < klen; index++) {
                     int accsFlags = kls.getFieldAccessFlags(index);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/tree/SimpleTreeGroupNode.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/tree/SimpleTreeGroupNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,13 +38,13 @@ public class SimpleTreeGroupNode implements SimpleTreeNode {
 
   public int getChildCount() { return children.size(); }
   public SimpleTreeNode getChild(int index) {
-    return (SimpleTreeNode) children.get(index);
+    return children.get(index);
   }
   public void addChild(SimpleTreeNode child) {
     children.add(child);
   }
   public SimpleTreeNode removeChild(int index) {
-    return (SimpleTreeNode) children.remove(index);
+    return children.remove(index);
   }
   public void removeAllChildren() {
     children.clear();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapHprofBinWriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapHprofBinWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -519,7 +519,7 @@ public class HeapHprofBinWriter extends AbstractHeapGraphWriter {
             return 0;
         }
 
-        ClassData cd = (ClassData) classDataCache.get(klass);
+        ClassData cd = classDataCache.get(klass);
         if (Assert.ASSERTS_ENABLED) {
             Assert.that(cd != null, "can not get class data for " + klass.getName().asString() + klass.getAddress());
         }
@@ -1073,7 +1073,7 @@ public class HeapHprofBinWriter extends AbstractHeapGraphWriter {
         out.writeInt(DUMMY_STACK_TRACE_ID);
         writeObjectID(klass.getJavaMirror());
 
-        ClassData cd = (ClassData) classDataCache.get(klass);
+        ClassData cd = classDataCache.get(klass);
 
         if (Assert.ASSERTS_ENABLED) {
             Assert.that(cd != null, "can not get class data for " + klass.getName().asString() + klass.getAddress());

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/LivenessPath.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/LivenessPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class LivenessPath {
 
   /** Fetch the element at the given index; 0-based */
   public LivenessPathElement get(int index) throws ArrayIndexOutOfBoundsException {
-    return (LivenessPathElement) stack.get(index);
+    return stack.get(index);
   }
 
   public void printOn(PrintStream tty) {
@@ -78,7 +78,7 @@ public class LivenessPath {
 
   // Convenience routine for LivenessAnalysis
   LivenessPathElement peek() {
-    return (LivenessPathElement) stack.peek();
+    return stack.peek();
   }
 
   // Convenience routine for LivenessAnalysis

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/LivenessPathList.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/LivenessPathList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ public class LivenessPathList {
   }
 
   public LivenessPath get(int i) {
-    return (LivenessPath) list.get(i);
+    return list.get(i);
   }
 
   void add(LivenessPath path) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/ObjectReader.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/ObjectReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -186,7 +186,7 @@ public class ObjectReader {
       try {
          key = readObject(keyField.getValue(oop));
          value = readObject(valueField.getValue(oop));
-         next =  (Oop)nextField.getValue(oop);
+         next = nextField.getValue(oop);
          // For Properties, should use setProperty(k, v). Since it only runs in SA
          // using put(k, v) should be OK.
          p.put(key, value);
@@ -343,7 +343,7 @@ public class ObjectReader {
       if (result == null) {
          int length = (int) array.getLength();
          TypeArrayKlass klass = (TypeArrayKlass) array.getKlass();
-         int type = (int) klass.getElementType();
+         int type = klass.getElementType();
          switch (type) {
             case TypeArrayKlass.T_BOOLEAN: {
                final boolean[] arrayObj = new boolean[length];
@@ -677,10 +677,10 @@ public class ObjectReader {
 
    public java.lang.reflect.Field readField(sun.jvm.hotspot.oops.Field f)
             throws NoSuchFieldException, ClassNotFoundException {
-      java.lang.reflect.Field result = (java.lang.reflect.Field) fieldMap.get(f);
+      java.lang.reflect.Field result = fieldMap.get(f);
       if (result == null) {
          FieldIdentifier fieldId = f.getID();
-         Class clz = readClass((InstanceKlass) f.getFieldHolder());
+         Class clz = readClass(f.getFieldHolder());
          String name = fieldId.getName();
          try {
             result = clz.getField(name);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/ReversePtrsAnalysis.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/ReversePtrsAnalysis.java
@@ -254,7 +254,7 @@ public class ReversePtrsAnalysis {
         }
 
         // Get the next object to visit.
-        next = (Oop) workList.pop();
+        next = workList.pop();
       }
     } catch (EmptyStackException e) {
       // Done


### PR DESCRIPTION
Redundant castings make code harder to read.
Found them by IntelliJ IDEA.
I tried to choose only casts which are definitely safe to remove.
Most generification was done in [JDK-8241618](https://bugs.openjdk.org/browse/JDK-8241618), but casts weren't removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293879](https://bugs.openjdk.org/browse/JDK-8293879): Remove unnecessary castings in jdk.hotspot.agent


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10295/head:pull/10295` \
`$ git checkout pull/10295`

Update a local copy of the PR: \
`$ git checkout pull/10295` \
`$ git pull https://git.openjdk.org/jdk pull/10295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10295`

View PR using the GUI difftool: \
`$ git pr show -t 10295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10295.diff">https://git.openjdk.org/jdk/pull/10295.diff</a>

</details>
