### PR TITLE
JDK-8293892: Add links to JVMS 19 and 20 from ClassFileFormatVersion enum constants

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/ClassFileFormatVersion.java
+++ b/src/java.base/share/classes/java/lang/reflect/ClassFileFormatVersion.java
@@ -247,12 +247,20 @@ public enum ClassFileFormatVersion {
     /**
      * The version recognized by the Java Platform, Standard Edition
      * 19.
+     *
+     * @see <a
+     * href="https://docs.oracle.com/javase/specs/jvms/se19/html/index.html">
+     * <cite>The Java Virtual Machine Specification, Java SE 19 Edition</cite></a>
      */
     RELEASE_19(63),
 
     /**
      * The version recognized by the Java Platform, Standard Edition
      * 20.
+     *
+     * @see <a
+     * href="https://docs.oracle.com/javase/specs/jvms/se20/html/index.html">
+     * <cite>The Java Virtual Machine Specification, Java SE 20 Edition</cite></a>
      */
     RELEASE_20(64);
 


### PR DESCRIPTION
Analogous fix to one already done for javax.lang.model.SourceVersion (JDK-8293768), the links to JVMS 19 and 20 are not currently valid, but redirect to the spec language page

https://docs.oracle.com/javase/specs/index.html

The URLs will become valid when 19 and 20, respectively, ship.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293892](https://bugs.openjdk.org/browse/JDK-8293892): Add links to JVMS 19 and 20 from ClassFileFormatVersion enum constants


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10298/head:pull/10298` \
`$ git checkout pull/10298`

Update a local copy of the PR: \
`$ git checkout pull/10298` \
`$ git pull https://git.openjdk.org/jdk pull/10298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10298`

View PR using the GUI difftool: \
`$ git pr show -t 10298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10298.diff">https://git.openjdk.org/jdk/pull/10298.diff</a>

</details>
