### PR TITLE
8293910: tools/launcher/FXLauncherTest.java fail with jfx

### DIFF
--- a/test/jdk/tools/launcher/FXLauncherTest.java
+++ b/test/jdk/tools/launcher/FXLauncherTest.java
@@ -448,7 +448,8 @@ public class FXLauncherTest extends TestHelper {
             // do nothing
         }
         if (fxClass != null) {
-            throw new RuntimeException("JavaFX modules erroneously included in the JDK");
+            System.out.println("JavaFX modules erroneously included in the JDK. Skip the test.");
+            return;
         }
 
         FXLauncherTest fxt = new FXLauncherTest();


### PR DESCRIPTION
Hi,

@dumasun reported the issue:

Configured with jfx-ls-modular-sdk:

```
configure --with-import-modules=modular-sdk
```

`make run-test CONF=fastdebug TEST="tools/launcher/FXLauncherTest.java"` failed:

```
----------System.err:(11/697)----------
java.lang.RuntimeException: JavaFX modules erroneously included in the JDK
    at FXLauncherTest.main(FXLauncherTest.java:451)
    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
    at java.base/java.lang.reflect.Method.invoke(Method.java:578)
    at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
    at java.base/java.lang.Thread.run(Thread.java:1589)

JavaTest Message: Test threw exception: java.lang.RuntimeException: JavaFX modules erroneously included in the JDK
JavaTest Message: shutting down test

STATUS:Failed.`main' threw exception: java.lang.RuntimeException: JavaFX modules erroneously included in the JDK
```

Thanks,
Leslie Zhai

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293910](https://bugs.openjdk.org/browse/JDK-8293910): tools/launcher/FXLauncherTest.java fail with jfx


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10299/head:pull/10299` \
`$ git checkout pull/10299`

Update a local copy of the PR: \
`$ git checkout pull/10299` \
`$ git pull https://git.openjdk.org/jdk pull/10299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10299`

View PR using the GUI difftool: \
`$ git pr show -t 10299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10299.diff">https://git.openjdk.org/jdk/pull/10299.diff</a>

</details>
