### PR TITLE
JDK-8293701: jdeps InverseDepsAnalyzer runs into NoSuchElementException: No value present

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/InverseDepsAnalyzer.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/InverseDepsAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -147,7 +147,7 @@ public class InverseDepsAnalyzer extends DepsAnalyzer {
                     m.descriptor().requires().stream()
                         .map(Requires::name)
                         .map(configuration::findModule)  // must be present
-                        .forEach(v -> builder.addEdge(v.get(), m));
+                        .forEach(v -> builder.addEdge(v.isPresent() ? v.get() : null, m));
                 });
 
             // add the dependences from the analysis

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/InverseDepsAnalyzer.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/InverseDepsAnalyzer.java
@@ -147,10 +147,10 @@ public class InverseDepsAnalyzer extends DepsAnalyzer {
                     m.descriptor().requires().stream()
                         // filter "requires static" if the module is not resolved in the configuration
                         .filter(req -> !req.modifiers().contains(Requires.Modifier.STATIC)
-                        || configuration.findModule(req.name()).isPresent())
-                        .map(Requires::name)
-                        .map(configuration::findModule)  // must be present
-                        .forEach(v -> builder.addEdge(v.get(), m));
+                            || configuration.findModule(req.name()).isPresent())
+                            .map(Requires::name)
+                            .map(configuration::findModule)  // must be present
+                            .forEach(v -> builder.addEdge(v.get(), m));
                 });
 
             // add the dependences from the analysis

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/InverseDepsAnalyzer.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/InverseDepsAnalyzer.java
@@ -145,9 +145,12 @@ public class InverseDepsAnalyzer extends DepsAnalyzer {
                 .forEach(m -> {
                     builder.addNode(m);
                     m.descriptor().requires().stream()
+                        // filter "requires static" if the module is not resolved in the configuration
+                        .filter(req -> !req.modifiers().contains(Requires.Modifier.STATIC)
+                        || configuration.findModule(req.name()).isPresent())
                         .map(Requires::name)
                         .map(configuration::findModule)  // must be present
-                        .forEach(v -> builder.addEdge(v.isPresent() ? v.get() : null, m));
+                        .forEach(v -> builder.addEdge(v.get(), m));
                 });
 
             // add the dependences from the analysis

--- a/test/langtools/tools/jdeps/optionalDependency/OptionalDependencyError.java
+++ b/test/langtools/tools/jdeps/optionalDependency/OptionalDependencyError.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8293701
+ * @library ../lib
+ * @build CompilerUtils
+ * @run testng OptionalDependencyError
+ * @summary Tests optional dependency handling
+ */
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.spi.ToolProvider;
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+
+public class OptionalDependencyError {
+    private static final String TEST_SRC = System.getProperty("test.src");
+    private static final Path SRC_DIR = Paths.get(TEST_SRC, "src");
+
+    private static final Path MODS_DIR = Paths.get("mods");
+
+    private static final ToolProvider JAR_TOOL = ToolProvider.findFirst("jar").orElseThrow();
+    private static final Set<String> modules = Set.of("m1", "m2", "m3");
+
+    @BeforeTest
+    public void compileAll() throws Exception {
+        CompilerUtils.cleanDir(MODS_DIR);
+        modules.forEach(mn ->
+                assertTrue(CompilerUtils.compileModule(SRC_DIR, MODS_DIR, mn)));
+
+        Path m1 = MODS_DIR.resolve("m1");
+        Path m2 = MODS_DIR.resolve("m2");
+        Path m3 = MODS_DIR.resolve("m3");
+        jar("cf", "m1.jar", "-C", m1.toString(), "p1/P.class",
+                "-C", m1.toString(), "module-info.class");
+        jar("cf", "m2.jar", "-C", m2.toString(), "p2/Q.class",
+                "-C", m2.toString(), "module-info.class");
+        jar("cf", "m3.jar", "-C", m3.toString(), "p3/R.class",
+                "-C", m3.toString(), "module-info.class");
+    }
+
+    /*
+     * 
+     */
+    @Test
+    public void noOptionalDependencyError() {
+        JdepsRunner jdepsRunner = new JdepsRunner("--module-path", "m2.jar:m3.jar",
+                                                  "--inverse", "--add-modules", "m3",
+                                                  "--package", "p2", "m1.jar");
+        int rc = jdepsRunner.run(true);
+        assertTrue(rc == 0);
+    }
+
+
+    private static void jar(String... options) {
+        int rc = JAR_TOOL.run(System.out, System.err, options);
+        assertTrue(rc == 0);
+    }
+}

--- a/test/langtools/tools/jdeps/optionalDependency/OptionalDependencyTest.java
+++ b/test/langtools/tools/jdeps/optionalDependency/OptionalDependencyTest.java
@@ -26,7 +26,7 @@
  * @bug 8293701
  * @library ../lib
  * @build CompilerUtils
- * @run testng OptionalDependencyError
+ * @run testng OptionalDependencyTest
  * @summary Tests optional dependency handling
  */
 
@@ -40,7 +40,7 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertTrue;
 
-public class OptionalDependencyError {
+public class OptionalDependencyTest {
     private static final String TEST_SRC = System.getProperty("test.src");
     private static final Path SRC_DIR = Paths.get(TEST_SRC, "src");
 
@@ -67,12 +67,12 @@ public class OptionalDependencyError {
     }
 
     /*
-     * 
+     * Test if a requires static dependence is resolved in the configuration.
      */
     @Test
-    public void noOptionalDependencyError() {
+    public void optionalDependenceResolved() {
         JdepsRunner jdepsRunner = new JdepsRunner("--module-path", "m2.jar:m3.jar",
-                                                  "--inverse", "--add-modules", "m3",
+                                                  "--inverse",
                                                   "--package", "p2", "m1.jar");
         int rc = jdepsRunner.run(true);
         assertTrue(rc == 0);

--- a/test/langtools/tools/jdeps/optionalDependency/OptionalDependencyTest.java
+++ b/test/langtools/tools/jdeps/optionalDependency/OptionalDependencyTest.java
@@ -67,10 +67,10 @@ public class OptionalDependencyTest {
     }
 
     /*
-     * Test if a requires static dependence is resolved in the configuration.
+     * Test if a requires static dependence is not resolved in the configuration.
      */
     @Test
-    public void optionalDependenceResolved() {
+    public void optionalDependenceNotResolved() {
         JdepsRunner jdepsRunner = new JdepsRunner("--module-path", "m2.jar:m3.jar",
                                                   "--inverse",
                                                   "--package", "p2", "m1.jar");
@@ -78,6 +78,17 @@ public class OptionalDependencyTest {
         assertTrue(rc == 0);
     }
 
+    /*
+     * Test if a requires static dependence is resolved in the configuration.
+     */
+    @Test
+    public void optionalDependenceResolved() {
+        JdepsRunner jdepsRunner = new JdepsRunner("--module-path", "m2.jar:m3.jar",
+                                                  "--inverse", "--add-modules", "m3",
+                                                  "--package", "p2", "m1.jar");
+        int rc = jdepsRunner.run(true);
+        assertTrue(rc == 0);
+    }
 
     private static void jar(String... options) {
         int rc = JAR_TOOL.run(System.out, System.err, options);

--- a/test/langtools/tools/jdeps/optionalDependency/src/m1/module-info.java
+++ b/test/langtools/tools/jdeps/optionalDependency/src/m1/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+module m1 {
+    requires transitive m2;
+    exports p1;
+}

--- a/test/langtools/tools/jdeps/optionalDependency/src/m1/p1/P.java
+++ b/test/langtools/tools/jdeps/optionalDependency/src/m1/p1/P.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package p1;
+public class P {
+    public void m() {}
+}

--- a/test/langtools/tools/jdeps/optionalDependency/src/m2/module-info.java
+++ b/test/langtools/tools/jdeps/optionalDependency/src/m2/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+module m2 {
+    requires static m3;
+    exports p2;
+}

--- a/test/langtools/tools/jdeps/optionalDependency/src/m2/p2/Q.java
+++ b/test/langtools/tools/jdeps/optionalDependency/src/m2/p2/Q.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package p2;
+public class Q {
+    @p3.R
+    public void m() {}
+}

--- a/test/langtools/tools/jdeps/optionalDependency/src/m3/module-info.java
+++ b/test/langtools/tools/jdeps/optionalDependency/src/m3/module-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+module m3 {
+    exports p3;
+}

--- a/test/langtools/tools/jdeps/optionalDependency/src/m3/p3/R.java
+++ b/test/langtools/tools/jdeps/optionalDependency/src/m3/p3/R.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package p3;
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.SOURCE)
+public @interface R {
+}


### PR DESCRIPTION
We noticed that with certain jar file input, jdeps runs into the following exception, this happens with jdk11, 17 and 20.

jdeps.exe --multi-release 11 --module-path . --inverse --package com.sap.nw.performance.supa.client test.jar

Inverse transitive dependences matching packages [com.sap.nw.performance.supa.client]
Exception in thread "main" java.util.NoSuchElementException: No value present
        at java.base/java.util.Optional.get(Optional.java:148)
        at jdk.jdeps/com.sun.tools.jdeps.InverseDepsAnalyzer.lambda$inverseDependences$2(InverseDepsAnalyzer.java:150)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
        at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
        at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)

So an additional  check might be a good idea.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293701](https://bugs.openjdk.org/browse/JDK-8293701): jdeps InverseDepsAnalyzer runs into NoSuchElementException: No value present


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10300/head:pull/10300` \
`$ git checkout pull/10300`

Update a local copy of the PR: \
`$ git checkout pull/10300` \
`$ git pull https://git.openjdk.org/jdk pull/10300/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10300`

View PR using the GUI difftool: \
`$ git pr show -t 10300`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10300.diff">https://git.openjdk.org/jdk/pull/10300.diff</a>

</details>
