### PR TITLE
8293920: G1: Add index based heap region iteration

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2285,6 +2285,10 @@ void G1CollectedHeap::heap_region_iterate(HeapRegionClosure* cl) const {
   _hrm.iterate(cl);
 }
 
+void G1CollectedHeap::heap_region_iterate(HeapRegionIndexClosure* cl) const {
+  _hrm.iterate(cl);
+}
+
 void G1CollectedHeap::heap_region_par_iterate_from_worker_offset(HeapRegionClosure* cl,
                                                                  HeapRegionClaimer *hrclaimer,
                                                                  uint worker_id) const {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1080,6 +1080,7 @@ public:
   // Iterate over heap regions, in address order, terminating the
   // iteration early if the "do_heap_region" method returns "true".
   void heap_region_iterate(HeapRegionClosure* blk) const;
+  void heap_region_iterate(HeapRegionIndexClosure* blk) const;
 
   // Return the region with the given index. It assumes the index is valid.
   inline HeapRegion* region_at(uint index) const;

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -609,4 +609,23 @@ public:
   bool is_complete() { return _is_complete; }
 };
 
+class HeapRegionIndexClosure : public StackObj {
+  friend class HeapRegionManager;
+  friend class G1CollectionSet;
+  friend class G1CollectionSetCandidates;
+
+  bool _is_complete;
+  void set_incomplete() { _is_complete = false; }
+
+public:
+  HeapRegionIndexClosure(): _is_complete(true) {}
+
+  // Typically called on each region until it returns true.
+  virtual bool do_heap_region_index(uint region_index) = 0;
+
+  // True after iteration if the closure was applied to all heap regions
+  // and returned "false" in all cases.
+  bool is_complete() { return _is_complete; }
+};
+
 #endif // SHARE_GC_G1_HEAPREGION_HPP

--- a/src/hotspot/share/gc/g1/heapRegionManager.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionManager.cpp
@@ -526,6 +526,21 @@ void HeapRegionManager::iterate(HeapRegionClosure* blk) const {
   }
 }
 
+void HeapRegionManager::iterate(HeapRegionIndexClosure* blk) const {
+  uint len = reserved_length();
+
+  for (uint i = 0; i < len; i++) {
+    if (!is_available(i)) {
+      continue;
+    }
+    bool res = blk->do_heap_region_index(i);
+    if (res) {
+      blk->set_incomplete();
+      return;
+    }
+  }
+}
+
 uint HeapRegionManager::find_highest_free(bool* expanded) {
   // Loop downwards from the highest region index, looking for an
   // entry which is either free or not yet committed.  If not yet

--- a/src/hotspot/share/gc/g1/heapRegionManager.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionManager.hpp
@@ -271,6 +271,7 @@ public:
   // Apply blk->do_heap_region() on all committed regions in address order,
   // terminating the iteration early if do_heap_region() returns true.
   void iterate(HeapRegionClosure* blk) const;
+  void iterate(HeapRegionIndexClosure* blk) const;
 
   void par_iterate(HeapRegionClosure* blk, HeapRegionClaimer* hrclaimer, const uint start_index) const;
 


### PR DESCRIPTION
Simple change of introducing a new `iterate` method. It's dead code for now, and will be used soon in [JDK-8293210](https://bugs.openjdk.org/browse/JDK-8293210).

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293920](https://bugs.openjdk.org/browse/JDK-8293920): G1: Add index based heap region iteration


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10301/head:pull/10301` \
`$ git checkout pull/10301`

Update a local copy of the PR: \
`$ git checkout pull/10301` \
`$ git pull https://git.openjdk.org/jdk pull/10301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10301`

View PR using the GUI difftool: \
`$ git pr show -t 10301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10301.diff">https://git.openjdk.org/jdk/pull/10301.diff</a>

</details>
