### PR TITLE
8293922: Extend barrier-less Java thread transitions to native transitions

### DIFF
--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -29,6 +29,7 @@
 // No interfaceSupport.hpp
 
 #include "gc/shared/gc_globals.hpp"
+#include "runtime/globals.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/javaThread.inline.hpp"
 #include "runtime/mutexLocker.hpp"
@@ -97,7 +98,11 @@ class ThreadStateTransition : public StackObj {
     assert(to == _thread_in_vm || to == _thread_in_Java, "invalid transition");
     assert(!thread->has_last_Java_frame() || thread->frame_anchor()->walkable(), "Unwalkable stack in native transition");
 
-    thread->set_thread_state_fence(_thread_in_vm);
+    if (!UseSystemMemoryBarrier) {
+      thread->set_thread_state_fence(_thread_in_vm);
+    } else {
+      thread->set_thread_state(_thread_in_vm);
+    }
     SafepointMechanism::process_if_requested_with_exit_check(thread, to != _thread_in_Java ? false : check_asyncs);
     thread->set_thread_state(to);
   }

--- a/src/hotspot/share/runtime/javaThread.inline.hpp
+++ b/src/hotspot/share/runtime/javaThread.inline.hpp
@@ -145,9 +145,9 @@ inline JavaThreadState JavaThread::thread_state() const    {
 #if defined(PPC64) || defined (AARCH64) || defined(RISCV64)
   // Use membars when accessing volatile _thread_state. See
   // Threads::create_vm() for size checks.
-  return (JavaThreadState) Atomic::load_acquire((volatile jint*)&_thread_state);
+  return Atomic::load_acquire(&_thread_state);
 #else
-  return _thread_state;
+  return Atomic::load(&_thread_state);
 #endif
 }
 
@@ -157,9 +157,9 @@ inline void JavaThread::set_thread_state(JavaThreadState s) {
 #if defined(PPC64) || defined (AARCH64) || defined(RISCV64)
   // Use membars when accessing volatile _thread_state. See
   // Threads::create_vm() for size checks.
-  Atomic::release_store((volatile jint*)&_thread_state, (jint)s);
+  Atomic::release_store(&_thread_state, s);
 #else
-  _thread_state = s;
+  Atomic::store(&_thread_state, s);
 #endif
 }
 


### PR DESCRIPTION
As suggested by @TheRealMDoerr, avoid the fence for native trans when UseSystemMemoryBarrier is enabled.

Locally I can see methods like Thread.holdsLock() getting a 4 ns speed boost, (~20% faster).

Running t1-5 with UseSystemMemoryBarrier on.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293922](https://bugs.openjdk.org/browse/JDK-8293922): Extend barrier-less Java thread transitions to native transitions


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10302/head:pull/10302` \
`$ git checkout pull/10302`

Update a local copy of the PR: \
`$ git checkout pull/10302` \
`$ git pull https://git.openjdk.org/jdk pull/10302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10302`

View PR using the GUI difftool: \
`$ git pr show -t 10302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10302.diff">https://git.openjdk.org/jdk/pull/10302.diff</a>

</details>
