### PR TITLE
8293891: gc/g1/mixedgc/TestOldGenCollectionUsage.java (still) assumes that GCs take 1ms minimum

### DIFF
--- a/test/hotspot/jtreg/gc/g1/mixedgc/TestOldGenCollectionUsage.java
+++ b/test/hotspot/jtreg/gc/g1/mixedgc/TestOldGenCollectionUsage.java
@@ -118,9 +118,6 @@ public class TestOldGenCollectionUsage {
         if (collectionCount <= 0) {
             throw new RuntimeException("Collection count <= 0");
         }
-        if (collectionTime <= 0) {
-            throw new RuntimeException("Collector has not run");
-        }
 
         MixedGCProvoker.provokeMixedGC(liveOldObjects);
 


### PR DESCRIPTION
Hi all,

  please review this fix to a test that performs the faulty assumptions that collections take more than one ms.

Testing: local testing, passes even with changes to the test configuration that reproduce the issue 100%

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293891](https://bugs.openjdk.org/browse/JDK-8293891): gc/g1/mixedgc/TestOldGenCollectionUsage.java (still) assumes that GCs take 1ms minimum


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10303/head:pull/10303` \
`$ git checkout pull/10303`

Update a local copy of the PR: \
`$ git checkout pull/10303` \
`$ git pull https://git.openjdk.org/jdk pull/10303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10303`

View PR using the GUI difftool: \
`$ git pr show -t 10303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10303.diff">https://git.openjdk.org/jdk/pull/10303.diff</a>

</details>
