### PR TITLE
8293861: G1: Disable preventive GCs by default

### DIFF
--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -367,7 +367,7 @@
           "percentage of the currently used memory.")                       \
           range(0.0, 1.0)                                                   \
                                                                             \
-  product(bool, G1UsePreventiveGC, true, DIAGNOSTIC,                        \
+  product(bool, G1UsePreventiveGC, false, DIAGNOSTIC,                       \
           "Allows collections to be triggered proactively based on the      \
            number of free regions and the expected survival rates in each   \
            section of the heap.")                                           \


### PR DESCRIPTION
Hi all,

  can I get reviews for this change that disables preventive collections by default?

[JDK-8257774](https://bugs.openjdk.org/browse/JDK-8257774) added "preventive" garbage collections in G1: speculative garbage collections added to avoid costly evacuation failures due to allocation bursts filling up the heap quickly.

These preventive garbage collections have some issues: the main issue is that it's an additional gc:

* object aging is based on number of gcs, so additional gcs cause premature promotion
* more promotion means more mixed gc phases
* additional, potentially unnecessary gc pause

This is somewhat compounded by that the current prediction to trigger preventive garbage collections is very conservative, triggering preventive garbage collections too often and too early.

As we have gathered experience with this feature, we found that in many cases it is a net loss - particularly since its introduction the reason for existing, evacuation failures, got extremely fast (e.g. [JDK-8256265](https://bugs.openjdk.org/browse/JDK-8256265)).

At this point the suggestion is to disable this feature by default. In the future it might be completely removed.

Since this is a diagnostic option, there is no CSR required. There will be a release note for this change.

Testing: tier1, made sure that no test expects preventive gcs

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293861](https://bugs.openjdk.org/browse/JDK-8293861): G1: Disable preventive GCs by default


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Monica Beckwith](https://openjdk.org/census#mbeckwit) (@mo-beck - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10304/head:pull/10304` \
`$ git checkout pull/10304`

Update a local copy of the PR: \
`$ git checkout pull/10304` \
`$ git pull https://git.openjdk.org/jdk pull/10304/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10304`

View PR using the GUI difftool: \
`$ git pr show -t 10304`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10304.diff">https://git.openjdk.org/jdk/pull/10304.diff</a>

</details>
