### PR TITLE
8293937: x86: Drop LP64 conditions from clearly x86_32 code

### DIFF
--- a/src/hotspot/cpu/x86/jniFastGetField_x86_32.cpp
+++ b/src/hotspot/cpu/x86/jniFastGetField_x86_32.cpp
@@ -222,10 +222,8 @@ address JNI_FastGetField::generate_fast_get_long_field() {
   assert(count < LIST_CAPACITY-1, "LIST_CAPACITY too small");
   speculative_load_pclist[count++] = __ pc();
   __ movptr(rax, Address(rdx, rsi, Address::times_1));
-#ifndef _LP64
   speculative_load_pclist[count] = __ pc();
   __ movl(rdx, Address(rdx, rsi, Address::times_1, 4));
-#endif // _LP64
 
   __ lea(rsi, counter);
   __ xorptr(rsi, rdx);
@@ -314,13 +312,8 @@ address JNI_FastGetField::generate_fast_get_float_field0(BasicType type) {
   assert(count < LIST_CAPACITY, "LIST_CAPACITY too small");
   speculative_load_pclist[count] = __ pc();
   switch (type) {
-#ifndef _LP64
     case T_FLOAT:  __ fld_s (Address(rdx, rax, Address::times_1)); break;
     case T_DOUBLE: __ fld_d (Address(rdx, rax, Address::times_1)); break;
-#else
-    case T_FLOAT:  __ movflt (xmm0, Address(robj, roffset, Address::times_1)); break;
-    case T_DOUBLE: __ movdbl (xmm0, Address(robj, roffset, Address::times_1)); break;
-#endif // _LP64
     default:       ShouldNotReachHere();
   }
 

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -667,16 +667,8 @@ static void gen_c2i_adapter(MacroAssembler *masm,
 
         __ movptr(rdi, Address(rsp, ld_off));
         __ movptr(Address(rsp, next_off), rdi);
-#ifndef _LP64
         __ movptr(rdi, Address(rsp, ld_off + wordSize));
         __ movptr(Address(rsp, st_off), rdi);
-#else
-#ifdef ASSERT
-        // Overwrite the unused slot with known junk
-        __ mov64(rax, CONST64(0xdeadffffdeadaaaa));
-        __ movptr(Address(rsp, st_off), rax);
-#endif /* ASSERT */
-#endif // _LP64
       }
     } else if (r_1->is_Register()) {
       Register r = r_1->as_Register();
@@ -684,20 +676,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
         __ movl(Address(rsp, st_off), r);
       } else {
         // long/double in gpr
-        NOT_LP64(ShouldNotReachHere());
-        // Two VMRegs can be T_OBJECT, T_ADDRESS, T_DOUBLE, T_LONG
-        // T_DOUBLE and T_LONG use two slots in the interpreter
-        if ( sig_bt[i] == T_LONG || sig_bt[i] == T_DOUBLE) {
-          // long/double in gpr
-#ifdef ASSERT
-          // Overwrite the unused slot with known junk
-          LP64_ONLY(__ mov64(rax, CONST64(0xdeadffffdeadaaab)));
-          __ movptr(Address(rsp, st_off), rax);
-#endif /* ASSERT */
-          __ movptr(Address(rsp, next_off), r);
-        } else {
-          __ movptr(Address(rsp, st_off), r);
-        }
+        ShouldNotReachHere();
       }
     } else {
       assert(r_1->is_XMMRegister(), "");
@@ -883,14 +862,10 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm,
         // are accessed as negative so LSW is at LOW address
 
         // ld_off is MSW so get LSW
-        const int offset = (NOT_LP64(true ||) sig_bt[i]==T_LONG||sig_bt[i]==T_DOUBLE)?
-                           next_off : ld_off;
-        __ movptr(rsi, Address(saved_sp, offset));
+        __ movptr(rsi, Address(saved_sp, next_off));
         __ movptr(Address(rsp, st_off), rsi);
-#ifndef _LP64
         __ movptr(rsi, Address(saved_sp, ld_off));
         __ movptr(Address(rsp, st_off + wordSize), rsi);
-#endif // _LP64
       }
     } else if (r_1->is_Register()) {  // Register argument
       Register r = r_1->as_Register();
@@ -901,17 +876,12 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm,
         // the interpreter allocates two slots but only uses one for thr T_LONG or T_DOUBLE case
         // So we must adjust where to pick up the data to match the interpreter.
 
-        const int offset = (NOT_LP64(true ||) sig_bt[i]==T_LONG||sig_bt[i]==T_DOUBLE)?
-                           next_off : ld_off;
-
         // this can be a misaligned move
-        __ movptr(r, Address(saved_sp, offset));
-#ifndef _LP64
+        __ movptr(r, Address(saved_sp, next_off));
         assert(r_2->as_Register() != rax, "need another temporary register");
         // Remember r_1 is low address (and LSB on x86)
         // So r_2 gets loaded from high address regardless of the platform
         __ movptr(r_2->as_Register(), Address(saved_sp, ld_off));
-#endif // _LP64
       } else {
         __ movl(r, Address(saved_sp, ld_off));
       }
@@ -1159,9 +1129,9 @@ static void long_move(MacroAssembler* masm, VMRegPair src, VMRegPair dst) {
   if (src.first()->is_stack() && dst.first()->is_stack()) {
     assert(src.second()->is_stack() && dst.second()->is_stack(), "must be all stack");
     __ movptr(rax, Address(rbp, reg2offset_in(src.first())));
-    NOT_LP64(__ movptr(rbx, Address(rbp, reg2offset_in(src.second()))));
+    __ movptr(rbx, Address(rbp, reg2offset_in(src.second())));
     __ movptr(Address(rsp, reg2offset_out(dst.first())), rax);
-    NOT_LP64(__ movptr(Address(rsp, reg2offset_out(dst.second())), rbx));
+    __ movptr(Address(rsp, reg2offset_out(dst.second())), rbx);
   } else {
     ShouldNotReachHere();
   }
@@ -1183,9 +1153,9 @@ static void double_move(MacroAssembler* masm, VMRegPair src, VMRegPair dst) {
   if (src.first()->is_stack()) {
     // source is all stack
     __ movptr(rax, Address(rbp, reg2offset_in(src.first())));
-    NOT_LP64(__ movptr(rbx, Address(rbp, reg2offset_in(src.second()))));
+    __ movptr(rbx, Address(rbp, reg2offset_in(src.second())));
     __ movptr(Address(rsp, reg2offset_out(dst.first())), rax);
-    NOT_LP64(__ movptr(Address(rsp, reg2offset_out(dst.second())), rbx));
+    __ movptr(Address(rsp, reg2offset_out(dst.second())), rbx);
   } else {
     // reg to stack
     // No worries about stack alignment
@@ -1207,7 +1177,7 @@ void SharedRuntime::save_native_result(MacroAssembler *masm, BasicType ret_type,
   case T_VOID:  break;
   case T_LONG:
     __ movptr(Address(rbp, -wordSize), rax);
-    NOT_LP64(__ movptr(Address(rbp, -2*wordSize), rdx));
+    __ movptr(Address(rbp, -2*wordSize), rdx);
     break;
   default: {
     __ movptr(Address(rbp, -wordSize), rax);
@@ -1227,7 +1197,7 @@ void SharedRuntime::restore_native_result(MacroAssembler *masm, BasicType ret_ty
     break;
   case T_LONG:
     __ movptr(rax, Address(rbp, -wordSize));
-    NOT_LP64(__ movptr(rdx, Address(rbp, -2*wordSize)));
+    __ movptr(rdx, Address(rbp, -2*wordSize));
     break;
   case T_VOID:  break;
   default: {


### PR DESCRIPTION
Noticed this when porting Loom on x86_32. There are `*_x86_32.cpp` files that use `_LP64` as if it matters for them. It does not make sense, as in those files we always have `!_LP64`. We can drop the conditionals and clean the code. 

Proof of completeness:

```
$ ack LP64 src/hotspot/ | grep _32
src/hotspot/cpu/x86/register_x86.hpp:386:                          NOT_LP64( 8 + ) // FILL0-FILL7 in x86_32.ad
src/hotspot/cpu/x86/vm_version_x86.hpp:733:    return LP64_ONLY(true) NOT_LP64(false); // not implemented on x86_32
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293937](https://bugs.openjdk.org/browse/JDK-8293937): x86: Drop LP64 conditions from clearly x86_32 code


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10305/head:pull/10305` \
`$ git checkout pull/10305`

Update a local copy of the PR: \
`$ git checkout pull/10305` \
`$ git pull https://git.openjdk.org/jdk pull/10305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10305`

View PR using the GUI difftool: \
`$ git pr show -t 10305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10305.diff">https://git.openjdk.org/jdk/pull/10305.diff</a>

</details>
