### PR TITLE
8293942: [JVMCI] data section entries must be 4-byte aligned on AArch64

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
@@ -1212,6 +1212,9 @@ void CodeInstaller::site_DataPatch(CodeBuffer& buffer, jint pc_offset, HotSpotCo
     case PATCH_DATA_SECTION_REFERENCE: {
       int data_offset = stream->read_u4("data:offset");
       if (0 <= data_offset && data_offset < _constants_size) {
+        if (!is_aligned(data_offset, CompilerToVM::Data::get_data_section_item_alignment())) {
+          JVMCI_ERROR("data offset 0x%x is not %d-byte aligned%s", data_offset, relocInfo::addr_unit(), stream->context());
+        }
         pd_patch_DataSectionReference(pc_offset, data_offset, JVMCI_CHECK);
       } else {
         JVMCI_ERROR("data offset 0x%x points outside data section (size 0x%x)%s", data_offset, _constants_size, stream->context());

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.hpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.hpp
@@ -91,12 +91,19 @@ class CompilerToVM {
     static address symbol_init;
     static address symbol_clinit;
 
+    // Minimum alignment of an offset into CodeBuffer::SECT_CONSTS
+    static int data_section_item_alignment;
+
    public:
      static void initialize(JVMCI_TRAPS);
 
     static int max_oop_map_stack_offset() {
       assert(_max_oop_map_stack_offset > 0, "must be initialized");
       return Data::_max_oop_map_stack_offset;
+    }
+
+    static int get_data_section_item_alignment() {
+      return data_section_item_alignment;
     }
   };
 

--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -95,6 +95,8 @@ address CompilerToVM::Data::dpow;
 address CompilerToVM::Data::symbol_init;
 address CompilerToVM::Data::symbol_clinit;
 
+int CompilerToVM::Data::data_section_item_alignment;
+
 void CompilerToVM::Data::initialize(JVMCI_TRAPS) {
   Klass_vtable_start_offset = in_bytes(Klass::vtable_start_offset());
   Klass_vtable_length_offset = in_bytes(Klass::vtable_length_offset());
@@ -132,6 +134,8 @@ void CompilerToVM::Data::initialize(JVMCI_TRAPS) {
   symbol_clinit = (address) vmSymbols::class_initializer_name();
 
   _fields_annotations_base_offset = Array<AnnotationArray*>::base_offset_in_bytes();
+
+  data_section_item_alignment = relocInfo::addr_unit();
 
   BarrierSet* bs = BarrierSet::barrier_set();
   if (bs->is_a(BarrierSet::CardTableBarrierSet)) {

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -100,6 +100,8 @@
   static_field(CompilerToVM::Data,             symbol_init,                            address)                                      \
   static_field(CompilerToVM::Data,             symbol_clinit,                          address)                                      \
                                                                                                                                      \
+  static_field(CompilerToVM::Data,             data_section_item_alignment,            int)                                          \
+                                                                                                                                     \
   static_field(Abstract_VM_Version,            _features,                              uint64_t)                                     \
                                                                                                                                      \
   nonstatic_field(Annotations,                 _fields_annotations,                    Array<AnnotationArray*>*)                     \


### PR DESCRIPTION
As a result of [JDK-8283626](https://bugs.openjdk.org/browse/JDK-8283626), each entry in a data section in a CodeBuffer on AArch64 needs to be 4-byte aligned. This PR exposes this alignment requirement via JVMCI so that Graal can adhere to it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293942](https://bugs.openjdk.org/browse/JDK-8293942): [JVMCI] data section entries must be 4-byte aligned on AArch64


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10308/head:pull/10308` \
`$ git checkout pull/10308`

Update a local copy of the PR: \
`$ git checkout pull/10308` \
`$ git pull https://git.openjdk.org/jdk pull/10308/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10308`

View PR using the GUI difftool: \
`$ git pr show -t 10308`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10308.diff">https://git.openjdk.org/jdk/pull/10308.diff</a>

</details>
