### PR TITLE
JDK-4305789: BasicToolBarUI: Request conversion of private instance variable

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicToolBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicToolBarUI.java
@@ -63,7 +63,7 @@ public class BasicToolBarUI extends ToolBarUI implements SwingConstants
      * The instance of {@code DragWindow}.
      */
     protected DragWindow dragWindow;
-    private Container dockingSource;
+    protected Container dockingSource;
     private int dockingSensitivity = 0;
     /**
      * The index of the focused component.


### PR DESCRIPTION
Fixed Bug JDK-4305789 to support docking to any instantiated JFrame https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4305789

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request to be approved

### Issue
 * [JDK-4305789](https://bugs.openjdk.org/browse/JDK-4305789): BasicToolBarUI: Request conversion of private instance variable


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10309/head:pull/10309` \
`$ git checkout pull/10309`

Update a local copy of the PR: \
`$ git checkout pull/10309` \
`$ git pull https://git.openjdk.org/jdk pull/10309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10309`

View PR using the GUI difftool: \
`$ git pr show -t 10309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10309.diff">https://git.openjdk.org/jdk/pull/10309.diff</a>

</details>
