### PR TITLE
8293781: RISC-V: Clarify types of calls

### DIFF
--- a/src/hotspot/cpu/riscv/c1_CodeStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_CodeStubs_riscv.cpp
@@ -127,7 +127,7 @@ void DivByZeroStub::emit_code(LIR_Assembler* ce) {
     ce->compilation()->implicit_exception_table()->append(_offset, __ offset());
   }
   __ bind(_entry);
-  __ far_call(Address(Runtime1::entry_for(Runtime1::throw_div0_exception_id), relocInfo::runtime_call_type));
+  __ far_call(RuntimeAddress(Runtime1::entry_for(Runtime1::throw_div0_exception_id)));
   ce->add_call_info_here(_info);
   ce->verify_oop_map(_info);
 #ifdef ASSERT

--- a/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
@@ -392,15 +392,11 @@ frame frame::sender_for_compiled_frame(RegisterMap* map) const {
 // frame::update_map_with_saved_link
 template <typename RegisterMapT>
 void frame::update_map_with_saved_link(RegisterMapT* map, intptr_t** link_addr) {
-  // The interpreter and compiler(s) always save fp in a known
-  // location on entry. We must record where that location is
-  // so that if fp was live on callout from c2 we can find
-  // the saved copy no matter what it called.
-
-  // Since the interpreter always saves fp if we record where it is then
-  // we don't have to always save fp on entry and exit to c2 compiled
-  // code, on entry will be enough.
   assert(map != NULL, "map must be set");
+  // The interpreter and compiler(s) always save FP in a known
+  // location on entry. C2-compiled code uses FP as an allocatable
+  // callee-saved register. We must record where that location is so
+  // that if FP was live on callout from C2 we can find the saved copy.
   map->set_location(::fp->as_VMReg(), (address) link_addr);
   // this is weird "H" ought to be at a higher address however the
   // oopMaps seems to have the "H" regs at the same address and the

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2701,7 +2701,7 @@ void MacroAssembler::la_patchable(Register reg1, const Address &dest, int32_t &o
   // RISC-V doesn't compute a page-aligned address, in order to partially
   // compensate for the use of *signed* offsets in its base+disp12
   // addressing mode (RISC-V's PC-relative reach remains asymmetric
-  // [-(2G + 2K), 2G - 2k).
+  // [-(2G + 2K), 2G - 2K).
   if (offset_high >= -((1L << 31) + (1L << 11)) && offset_low < (1L << 31) - (1L << 11)) {
     int64_t distance = dest.target() - pc();
     auipc(reg1, (int32_t)distance + 0x800);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2439,6 +2439,9 @@ void MacroAssembler::far_jump(Address entry, Register tmp) {
   assert(ReservedCodeCacheSize < 4*G, "branch out of range");
   assert(CodeCache::find_blob(entry.target()) != NULL,
          "destination of far call not found in code cache");
+  assert(entry.rspec().type() == relocInfo::external_word_type
+        || entry.rspec().type() == relocInfo::runtime_call_type
+        || entry.rspec().type() == relocInfo::none, "wrong entry relocInfo type");
   int32_t offset = 0;
   if (far_branches()) {
     // We can use auipc + jalr here because we know that the total size of
@@ -2454,6 +2457,9 @@ void MacroAssembler::far_call(Address entry, Register tmp) {
   assert(ReservedCodeCacheSize < 4*G, "branch out of range");
   assert(CodeCache::find_blob(entry.target()) != NULL,
          "destination of far call not found in code cache");
+  assert(entry.rspec().type() == relocInfo::external_word_type
+        || entry.rspec().type() == relocInfo::runtime_call_type
+        || entry.rspec().type() == relocInfo::none, "wrong entry relocInfo type");
   int32_t offset = 0;
   if (far_branches()) {
     // We can use auipc + jalr here because we know that the total size of

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -645,7 +645,8 @@ public:
   //     This is longer than a direct call. The offset has
   //     the range [-(2G + 2K), 2G - 2K). Addresses out of the range in the code cache
   //     requires indirect call.
-  //     If a jump is needed rather than a call, a far jump 'j reg' can be used instead.
+  //     If a jump is needed rather than a call, a far jump 'jalr x0, reg, offset' can
+  //     be used instead.
   //     All instructions are embedded at a call site.
   //
   //   - trampoline call:
@@ -660,7 +661,7 @@ public:
   //     [Stub code section]
   //     trampoline:
   //       ld    reg, pc + 8 (auipc + ld)
-  //       jalr  reg
+  //       jr    reg
   //       <64-bit destination address>
   //
   //     If the destination is in range when the generated code is moved to the code
@@ -669,10 +670,10 @@ public:
   //     The optimization does not remove the trampoline from the stub section.
 
   //     This is necessary because the trampoline may well be redirected later when
-  //     code is patched, and the new destination may not be reachable by a simple JALR
+  //     code is patched, and the new destination may not be reachable by a simple JAL
   //     instruction.
   //
-  //   - indirect call: move reg, address; jalr reg
+  //   - indirect call: movptr_with_offset + jalr
   //     This too can reach anywhere in the address space, but it cannot be
   //     patched while code is running, so it must only be modified at a safepoint.
   //     This form of call is most suitable for targets at fixed addresses, which

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -652,7 +652,7 @@ public:
   //     This is only available in C1/C2-generated code (nmethod). It is a combination
   //     of a direct call, which is used if the destination of a call is in range,
   //     and a register-indirect call. It has the advantages of reaching anywhere in
-  //     the AArch64 address space and being patchable at runtime when the generated
+  //     the RISCV address space and being patchable at runtime when the generated
   //     code is being executed by other threads.
   //
   //     [Main code section]

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -598,8 +598,13 @@ public:
 
   // Emit a direct call/jump if the entry address will always be in range,
   // otherwise a far call/jump.
-  // Jumps that can reach anywhere in the code cache.
-  // Trashes tmp.
+  // The address must be inside the code cache.
+  // Supported entry.rspec():
+  // - relocInfo::external_word_type
+  // - relocInfo::runtime_call_type
+  // - relocInfo::none
+  // In the case of a far call/jump, the entry address is put in the tmp register.
+  // The tmp register is invalidated.
   void far_call(Address entry, Register tmp = t0);
   void far_jump(Address entry, Register tmp = t0);
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -596,6 +596,8 @@ public:
     return ReservedCodeCacheSize > branch_range;
   }
 
+  // Emit a direct call/jump if the entry address will always be in range,
+  // otherwise a far call/jump.
   // Jumps that can reach anywhere in the code cache.
   // Trashes tmp.
   void far_call(Address entry, Register tmp = t0);
@@ -635,6 +637,69 @@ public:
   void get_polling_page(Register dest, relocInfo::relocType rtype);
   address read_polling_page(Register r, int32_t offset, relocInfo::relocType rtype);
 
+  // RISCV64 OpenJDK uses four different types of calls:
+  //   - direct call: jal pc_relative_offset
+  //     This is the shortest and the fastest, but the offset has the range: +/-1MB.
+  //
+  //   - far call: auipc reg, pc_relative_offset; jalr ra, reg, offset
+  //     This is longer than a direct call. The offset has
+  //     the range [-(2G + 2K), 2G - 2K). Addresses out of the range in the code cache
+  //     requires indirect call.
+  //     If a jump is needed rather than a call, a far jump 'j reg' can be used instead.
+  //     All instructions are embedded at a call site.
+  //
+  //   - trampoline call:
+  //     This is only available in C1/C2-generated code (nmethod). It is a combination
+  //     of a direct call, which is used if the destination of a call is in range,
+  //     and a register-indirect call. It has the advantages of reaching anywhere in
+  //     the AArch64 address space and being patchable at runtime when the generated
+  //     code is being executed by other threads.
+  //
+  //     [Main code section]
+  //       jal trampoline
+  //     [Stub code section]
+  //     trampoline:
+  //       ld    reg, pc + 8 (auipc + ld)
+  //       jalr  reg
+  //       <64-bit destination address>
+  //
+  //     If the destination is in range when the generated code is moved to the code
+  //     cache, 'jal trampoline' is replaced with 'jal destination' and the trampoline
+  //     is not used.
+  //     The optimization does not remove the trampoline from the stub section.
+
+  //     This is necessary because the trampoline may well be redirected later when
+  //     code is patched, and the new destination may not be reachable by a simple JALR
+  //     instruction.
+  //
+  //   - indirect call: move reg, address; jalr reg
+  //     This too can reach anywhere in the address space, but it cannot be
+  //     patched while code is running, so it must only be modified at a safepoint.
+  //     This form of call is most suitable for targets at fixed addresses, which
+  //     will never be patched.
+  //
+  //
+  // To patch a trampoline call when the JAL can't reach, we first modify
+  // the 64-bit destination address in the trampoline, then modify the
+  // JAL to point to the trampoline, then flush the instruction cache to
+  // broadcast the change to all executing threads. See
+  // NativeCall::set_destination_mt_safe for the details.
+  //
+  // There is a benign race in that the other thread might observe the
+  // modified JAL before it observes the modified 64-bit destination
+  // address. That does not matter because the destination method has been
+  // invalidated, so there will be a trap at its start.
+  // For this to work, the destination address in the trampoline is
+  // always updated, even if we're not using the trampoline.
+
+  // Emit a direct call if the entry address will always be in range,
+  // otherwise a trampoline call.
+  // Supported entry.rspec():
+  // - relocInfo::runtime_call_type
+  // - relocInfo::opt_virtual_call_type
+  // - relocInfo::static_call_type
+  // - relocInfo::virtual_call_type
+  //
   // Return: the call PC or NULL if CodeCache is full.
   address trampoline_call(Address entry);
   address ic_call(address entry, jint method_index = 0);


### PR DESCRIPTION
RISCV64 OpenJDK uses different types of calls in generated calls. It should be clarified what they are. And the PR also cleans up some out-of-date comments.

HotSpot tier1 tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293781](https://bugs.openjdk.org/browse/JDK-8293781): RISC-V: clarify types of calls


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Yadong Wang](https://openjdk.org/census#yadongwang) (@yadongw - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10311/head:pull/10311` \
`$ git checkout pull/10311`

Update a local copy of the PR: \
`$ git checkout pull/10311` \
`$ git pull https://git.openjdk.org/jdk pull/10311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10311`

View PR using the GUI difftool: \
`$ git pr show -t 10311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10311.diff">https://git.openjdk.org/jdk/pull/10311.diff</a>

</details>
