### PR TITLE
JDK-8292073: NMT: remove unused constructor parameter from MallocHeader

### DIFF
--- a/src/hotspot/share/services/mallocHeader.hpp
+++ b/src/hotspot/share/services/mallocHeader.hpp
@@ -116,7 +116,7 @@ class MallocHeader {
 
  public:
 
-  inline MallocHeader(size_t size, MEMFLAGS flags, const NativeCallStack& stack, uint32_t mst_marker);
+  inline MallocHeader(size_t size, MEMFLAGS flags, uint32_t mst_marker);
 
   inline size_t   size()  const { return _size; }
   inline MEMFLAGS flags() const { return (MEMFLAGS)_flags; }

--- a/src/hotspot/share/services/mallocHeader.inline.hpp
+++ b/src/hotspot/share/services/mallocHeader.inline.hpp
@@ -34,7 +34,7 @@
 #include "utilities/macros.hpp"
 #include "utilities/nativeCallStack.hpp"
 
-inline MallocHeader::MallocHeader(size_t size, MEMFLAGS flags, const NativeCallStack& stack, uint32_t mst_marker)
+inline MallocHeader::MallocHeader(size_t size, MEMFLAGS flags, uint32_t mst_marker)
   : _size(size), _mst_marker(mst_marker), _flags(NMTUtil::flag_to_index(flags)),
     _unused(0), _canary(_header_canary_life_mark)
 {

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -174,7 +174,7 @@ void* MallocTracker::record_malloc(void* malloc_base, size_t size, MEMFLAGS flag
   }
 
   // Uses placement global new operator to initialize malloc header
-  MallocHeader* const header = ::new (malloc_base)MallocHeader(size, flags, stack, mst_marker);
+  MallocHeader* const header = ::new (malloc_base)MallocHeader(size, flags, mst_marker);
   void* const memblock = (void*)((char*)malloc_base + sizeof(MallocHeader));
 
   // The alignment check: 8 bytes alignment for 32 bit systems.


### PR DESCRIPTION
Trivial cleanup, removes an unused parameter from `MallocHeader` ctor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292073](https://bugs.openjdk.org/browse/JDK-8292073): NMT: remove unused constructor parameter from MallocHeader


### Reviewers
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10314/head:pull/10314` \
`$ git checkout pull/10314`

Update a local copy of the PR: \
`$ git checkout pull/10314` \
`$ git pull https://git.openjdk.org/jdk pull/10314/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10314`

View PR using the GUI difftool: \
`$ git pr show -t 10314`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10314.diff">https://git.openjdk.org/jdk/pull/10314.diff</a>

</details>
