### PR TITLE
8294361: Cleanup usages of StringBuffer in SQLOutputImpl

### DIFF
--- a/src/java.sql.rowset/share/classes/javax/sql/rowset/serial/SQLOutputImpl.java
+++ b/src/java.sql.rowset/share/classes/javax/sql/rowset/serial/SQLOutputImpl.java
@@ -321,24 +321,20 @@ public class SQLOutputImpl implements SQLOutput {
      *        use by a <code>SQLData</code> object attempting to write the attribute
      *        values of a UDT to the database.
      */
-    @SuppressWarnings("unchecked")
     public void writeCharacterStream(java.io.Reader x) throws SQLException {
-         BufferedReader bufReader = new BufferedReader(x);
-         try {
-             int i;
-             while( (i = bufReader.read()) != -1 ) {
+        BufferedReader bufReader = new BufferedReader(x);
+        try {
+            int i;
+            while ((i = bufReader.read()) != -1) {
                 char ch = (char)i;
-                StringBuffer strBuf = new StringBuffer();
-                strBuf.append(ch);
 
-                String str = new String(strBuf);
                 String strLine = bufReader.readLine();
 
-                writeString(str.concat(strLine));
-             }
-         } catch(IOException ioe) {
+                writeString(ch + strLine);
+            }
+        } catch (IOException ioe) {
 
-         }
+        }
     }
 
     /**
@@ -351,23 +347,17 @@ public class SQLOutputImpl implements SQLOutput {
      *        use by a <code>SQLData</code> object attempting to write the attribute
      *        values of a UDT to the database.
      */
-    @SuppressWarnings("unchecked")
     public void writeAsciiStream(java.io.InputStream x) throws SQLException {
-         BufferedReader bufReader = new BufferedReader(new InputStreamReader(x));
-         try {
-               int i;
-               while( (i=bufReader.read()) != -1 ) {
+        BufferedReader bufReader = new BufferedReader(new InputStreamReader(x));
+        try {
+            int i;
+            while ((i = bufReader.read()) != -1) {
                 char ch = (char)i;
 
-                StringBuffer strBuf = new StringBuffer();
-                strBuf.append(ch);
-
-                String str = new String(strBuf);
                 String strLine = bufReader.readLine();
-
-                writeString(str.concat(strLine));
+                writeString(ch + strLine);
             }
-          }catch(IOException ioe) {
+        } catch (IOException ioe) {
             throw new SQLException(ioe.getMessage());
         }
     }
@@ -381,23 +371,18 @@ public class SQLOutputImpl implements SQLOutput {
      *        use by a <code>SQLData</code> object attempting to write the attribute
      *        values of a UDT to the database.
      */
-    @SuppressWarnings("unchecked")
     public void writeBinaryStream(java.io.InputStream x) throws SQLException {
-         BufferedReader bufReader = new BufferedReader(new InputStreamReader(x));
-         try {
-               int i;
-             while( (i=bufReader.read()) != -1 ) {
+        BufferedReader bufReader = new BufferedReader(new InputStreamReader(x));
+        try {
+            int i;
+            while ((i = bufReader.read()) != -1) {
                 char ch = (char)i;
 
-                StringBuffer strBuf = new StringBuffer();
-                strBuf.append(ch);
-
-                String str = new String(strBuf);
                 String strLine = bufReader.readLine();
 
-                writeString(str.concat(strLine));
-             }
-        } catch(IOException ioe) {
+                writeString(ch + strLine);
+            }
+        } catch (IOException ioe) {
             throw new SQLException(ioe.getMessage());
         }
     }


### PR DESCRIPTION
There a few unnecessary usages of StringBuffer in SQLOutputImpl class.
All of them create StringBuffer from single character and then concatenate with String. Instead of this, we can concatenate character directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294361](https://bugs.openjdk.org/browse/JDK-8294361): Cleanup usages of StringBuffer in SQLOutputImpl


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10320/head:pull/10320` \
`$ git checkout pull/10320`

Update a local copy of the PR: \
`$ git checkout pull/10320` \
`$ git pull https://git.openjdk.org/jdk pull/10320/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10320`

View PR using the GUI difftool: \
`$ git pr show -t 10320`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10320.diff">https://git.openjdk.org/jdk/pull/10320.diff</a>

</details>
