### PR TITLE
 8293613: need to properly handle and hide tmp VTMS transitions

### DIFF
--- a/make/data/hotspot-symbols/symbols-unix
+++ b/make/data/hotspot-symbols/symbols-unix
@@ -227,5 +227,5 @@ JVM_VirtualThreadMountBegin
 JVM_VirtualThreadMountEnd
 JVM_VirtualThreadUnmountBegin
 JVM_VirtualThreadUnmountEnd
-JVM_VirtualThreadToggleTmpVTMSTrans
+JVM_VirtualThreadHideFrames
 #

--- a/make/data/hotspot-symbols/symbols-unix
+++ b/make/data/hotspot-symbols/symbols-unix
@@ -227,4 +227,5 @@ JVM_VirtualThreadMountBegin
 JVM_VirtualThreadMountEnd
 JVM_VirtualThreadUnmountBegin
 JVM_VirtualThreadUnmountEnd
+JVM_VirtualThreadToggleTmpVTMSTrans
 #

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -1159,6 +1159,9 @@ JVM_VirtualThreadUnmountBegin(JNIEnv* env, jobject vthread, jboolean last_unmoun
 JNIEXPORT void JNICALL
 JVM_VirtualThreadUnmountEnd(JNIEnv* env, jobject vthread, jboolean last_unmount);
 
+JNIEXPORT void JNICALL
+JVM_VirtualThreadToggleTmpVTMSTrans(JNIEnv* env, jobject vthread, jboolean end_tmp_trans);
+
 /*
  * Core reflection support.
  */

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -1160,7 +1160,7 @@ JNIEXPORT void JNICALL
 JVM_VirtualThreadUnmountEnd(JNIEnv* env, jobject vthread, jboolean last_unmount);
 
 JNIEXPORT void JNICALL
-JVM_VirtualThreadToggleTmpVTMSTrans(JNIEnv* env, jobject vthread, jboolean end_tmp_trans);
+JVM_VirtualThreadHideFrames(JNIEnv* env, jobject vthread, jboolean hide);
 
 /*
  * Core reflection support.

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -4048,13 +4048,13 @@ JVM_ENTRY(void, JVM_VirtualThreadUnmountEnd(JNIEnv* env, jobject vthread, jboole
 #endif
 JVM_END
 
-JVM_ENTRY(void, JVM_VirtualThreadToggleTmpVTMSTrans(JNIEnv* env, jobject vthread, jboolean end_tmp_trans))
+JVM_ENTRY(void, JVM_VirtualThreadHideFrames(JNIEnv* env, jobject vthread, jboolean hide))
 #if INCLUDE_JVMTI
   if (!DoJVMTIVirtualThreadTransitions) {
     assert(!JvmtiExport::can_support_virtual_threads(), "sanity check");
     return;
   }
-  assert(thread->is_in_tmp_VTMS_transition() == (bool)end_tmp_trans, "sanity check");
+  assert(thread->is_in_tmp_VTMS_transition() != (bool)hide, "sanity check");
   thread->toggle_is_in_tmp_VTMS_transition();
 #else
   fatal("Should only be called with JVMTI enabled");

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3947,6 +3947,7 @@ JVM_ENTRY(void, JVM_VirtualThreadMountBegin(JNIEnv* env, jobject vthread, jboole
     assert(!JvmtiExport::can_support_virtual_threads(), "sanity check");
     return;
   }
+  assert(!thread->is_in_tmp_VTMS_transition(), "sanity check");
   assert(!thread->is_in_VTMS_transition(), "sanity check");
   JvmtiVTMSTransitionDisabler::start_VTMS_transition(vthread, /* is_mount */ true);
 #else
@@ -3972,6 +3973,7 @@ JVM_ENTRY(void, JVM_VirtualThreadMountEnd(JNIEnv* env, jobject vthread, jboolean
     }
   }
   assert(thread->is_in_VTMS_transition(), "sanity check");
+  assert(!thread->is_in_tmp_VTMS_transition(), "sanity check");
   JvmtiVTMSTransitionDisabler::finish_VTMS_transition(vthread, /* is_mount */ true);
   if (first_mount) {
     // thread start
@@ -4020,6 +4022,7 @@ JVM_ENTRY(void, JVM_VirtualThreadUnmountBegin(JNIEnv* env, jobject vthread, jboo
       }
     }
   }
+  assert(!thread->is_in_tmp_VTMS_transition(), "sanity check");
   assert(!thread->is_in_VTMS_transition(), "sanity check");
   JvmtiVTMSTransitionDisabler::start_VTMS_transition(vthread, /* is_mount */ false);
 
@@ -4042,6 +4045,7 @@ JVM_ENTRY(void, JVM_VirtualThreadUnmountEnd(JNIEnv* env, jobject vthread, jboole
     return;
   }
   assert(thread->is_in_VTMS_transition(), "sanity check");
+  assert(!thread->is_in_tmp_VTMS_transition(), "sanity check");
   JvmtiVTMSTransitionDisabler::finish_VTMS_transition(vthread, /* is_mount */ false);
 #else
   fatal("Should only be called with JVMTI enabled");
@@ -4054,6 +4058,7 @@ JVM_ENTRY(void, JVM_VirtualThreadHideFrames(JNIEnv* env, jobject vthread, jboole
     assert(!JvmtiExport::can_support_virtual_threads(), "sanity check");
     return;
   }
+  assert(!thread->is_in_VTMS_transition(), "sanity check");
   assert(thread->is_in_tmp_VTMS_transition() != (bool)hide, "sanity check");
   thread->toggle_is_in_tmp_VTMS_transition();
 #else

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -703,12 +703,12 @@ JvmtiEnvBase::get_vthread_jvf(oop vthread) {
 javaVFrame*
 JvmtiEnvBase::get_cthread_last_java_vframe(JavaThread* jt, RegisterMap* reg_map_p) {
   // Strip vthread frames in case of carrier thread with mounted continuation.
-  javaVFrame *jvf = JvmtiEnvBase::is_cthread_with_continuation(jt) ?
-                        jt->carrier_last_java_vframe(reg_map_p) :
-                        jt->last_java_vframe(reg_map_p);
-  // Skipping hidden frames when jt->is_in_tmp_VTMS_transition()==true results
-  // in returning jvf==NULL, and so, empty stack traces for carrier threads.
-  if (!jt->is_in_tmp_VTMS_transition()) {
+  bool cthread_with_cont = JvmtiEnvBase::is_cthread_with_continuation(jt);
+  javaVFrame *jvf = cthread_with_cont ? jt->carrier_last_java_vframe(reg_map_p)
+                                      : jt->last_java_vframe(reg_map_p);
+  // Skip hidden frames only for carrier threads
+  // which are in non-temporary VTMS transition.
+  if (jt->is_in_VTMS_transition()) {
     jvf = check_and_skip_hidden_frames(jt, jvf);
   }
   return jvf;
@@ -1597,7 +1597,7 @@ JvmtiEnvBase::suspend_thread(oop thread_oop, JavaThread* java_thread, bool singl
     }
     java_thread->set_carrier_thread_suspended();
   }
-  assert(!java_thread->is_in_non_tmp_VTMS_transition(), "sanity check");
+  assert(!java_thread->is_in_VTMS_transition(), "sanity check");
 
   assert(!single_suspend || (!is_virtual && java_thread->is_carrier_thread_suspended()) ||
           (is_virtual && JvmtiVTSuspender::is_vthread_suspended(thread_h())),
@@ -1664,7 +1664,7 @@ JvmtiEnvBase::resume_thread(oop thread_oop, JavaThread* java_thread, bool single
     }
     java_thread->clear_carrier_thread_suspended();
   }
-  assert(!java_thread->is_in_non_tmp_VTMS_transition(), "sanity check");
+  assert(!java_thread->is_in_VTMS_transition(), "sanity check");
 
   if (!is_passive_cthread) {
     assert(single_resume || is_virtual, "ResumeAllVirtualThreads should never resume non-virtual threads");

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -893,7 +893,7 @@ class JvmtiClassFileLoadHookPoster : public StackObj {
     _cached_class_file_ptr = cache_ptr;
     _has_been_modified = false;
 
-    assert(!_thread->is_in_VTMS_transition(), "CFLH events are not allowed in VTMS transition");
+    assert(!_thread->is_in_any_VTMS_transition(), "CFLH events are not allowed in any VTMS transition");
     _state = _thread->jvmti_thread_state();
     if (_state != NULL) {
       _class_being_redefined = _state->get_class_being_redefined();
@@ -1051,7 +1051,7 @@ bool JvmtiExport::post_class_file_load_hook(Symbol* h_name,
     return false;
   }
   if (JavaThread::current()->is_in_tmp_VTMS_transition()) {
-    return false;
+    return false; // skip CFLH events in tmp VTMS transition
   }
 
   JvmtiClassFileLoadHookPoster poster(h_name, class_loader,
@@ -1187,8 +1187,8 @@ void JvmtiExport::post_raw_breakpoint(JavaThread *thread, Method* method, addres
   if (state == NULL) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in a VTMS transition
+  if (thread->is_in_any_VTMS_transition()) {
+    return; // no events should be posted if thread is in any VTMS transition
   }
 
   EVT_TRIG_TRACE(JVMTI_EVENT_BREAKPOINT, ("[%s] Trg Breakpoint triggered",
@@ -1344,9 +1344,9 @@ void JvmtiExport::post_class_load(JavaThread *thread, Klass* klass) {
     return;
   }
   if (thread->is_in_tmp_VTMS_transition()) {
-    return;
+    return; // skip ClassLoad events in tmp VTMS transition
   }
-  assert(!thread->is_in_VTMS_transition(), "class load events are not allowed in VTMS transition");
+  assert(!thread->is_in_any_VTMS_transition(), "class load events are not allowed in any VTMS transition");
 
   EVT_TRIG_TRACE(JVMTI_EVENT_CLASS_LOAD, ("[%s] Trg Class Load triggered",
                       JvmtiTrace::safe_get_thread_name(thread)));
@@ -1382,9 +1382,9 @@ void JvmtiExport::post_class_prepare(JavaThread *thread, Klass* klass) {
     return;
   }
   if (thread->is_in_tmp_VTMS_transition()) {
-    return;
+    return; // skip ClassPrepare events in tmp VTMS transition
   }
-  assert(!thread->is_in_VTMS_transition(), "class prepare events are not allowed in VTMS transition");
+  assert(!thread->is_in_any_VTMS_transition(), "class prepare events are not allowed in any VTMS transition");
 
   EVT_TRIG_TRACE(JVMTI_EVENT_CLASS_PREPARE, ("[%s] Trg Class Prepare triggered",
                       JvmtiTrace::safe_get_thread_name(thread)));
@@ -1703,8 +1703,8 @@ void JvmtiExport::post_object_free(JvmtiEnv* env, GrowableArray<jlong>* objects)
   assert(objects != NULL, "Nothing to post");
 
   JavaThread *javaThread = JavaThread::current();
-  if (javaThread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in a VTMS transition
+  if (javaThread->is_in_any_VTMS_transition()) {
+    return; // no events should be posted if thread is in any VTMS transition
   }
   if (!env->is_enabled(JVMTI_EVENT_OBJECT_FREE)) {
     return; // the event type has been already disabled
@@ -1727,8 +1727,8 @@ void JvmtiExport::post_resource_exhausted(jint resource_exhausted_flags, const c
 
   JavaThread *thread  = JavaThread::current();
 
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in a VTMS transition
+  if (thread->is_in_any_VTMS_transition()) {
+    return; // no events should be posted if thread is in any VTMS transition
   }
 
   log_error(jvmti)("Posting Resource Exhausted event: %s",
@@ -1770,8 +1770,8 @@ void JvmtiExport::post_method_entry(JavaThread *thread, Method* method, frame cu
     // for any thread that actually wants method entry, interp_only_mode is set
     return;
   }
-  if (mh->jvmti_mount_transition() || thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in a VTMS transition
+  if (mh->jvmti_mount_transition() || thread->is_in_any_VTMS_transition()) {
+    return; // no events should be posted if thread is in any VTMS transition
   }
   EVT_TRIG_TRACE(JVMTI_EVENT_METHOD_ENTRY, ("[%s] Trg Method Entry triggered %s.%s",
                      JvmtiTrace::safe_get_thread_name(thread),
@@ -1854,8 +1854,8 @@ void JvmtiExport::post_method_exit_inner(JavaThread* thread,
                                          bool exception_exit,
                                          frame current_frame,
                                          jvalue& value) {
-  if (mh->jvmti_mount_transition() || thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in a VTMS transition
+  if (mh->jvmti_mount_transition() || thread->is_in_any_VTMS_transition()) {
+    return; // no events should be posted if thread is in any VTMS transition
   }
 
   EVT_TRIG_TRACE(JVMTI_EVENT_METHOD_EXIT, ("[%s] Trg Method Exit triggered %s.%s",
@@ -1930,8 +1930,8 @@ void JvmtiExport::post_single_step(JavaThread *thread, Method* method, address l
   if (state == NULL) {
     return;
   }
-  if (mh->jvmti_mount_transition() || thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in a VTMS transition
+  if (mh->jvmti_mount_transition() || thread->is_in_any_VTMS_transition()) {
+    return; // no events should be posted if thread is in any VTMS transition
   }
 
   JvmtiEnvThreadStateIterator it(state);
@@ -1967,8 +1967,8 @@ void JvmtiExport::post_exception_throw(JavaThread *thread, Method* method, addre
   if (state == NULL) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in a VTMS transition
+  if (thread->is_in_any_VTMS_transition()) {
+    return; // no events should be posted if thread is in any VTMS transition
   }
 
   EVT_TRIG_TRACE(JVMTI_EVENT_EXCEPTION, ("[%s] Trg Exception thrown triggered",
@@ -2089,8 +2089,8 @@ void JvmtiExport::notice_unwind_due_to_exception(JavaThread *thread, Method* met
       assert(!state->is_exception_caught(), "exception must not be caught yet.");
       state->set_exception_caught();
 
-      if (mh->jvmti_mount_transition() || thread->is_in_VTMS_transition()) {
-        return; // no events should be posted if thread is in a VTMS transition
+      if (mh->jvmti_mount_transition() || thread->is_in_any_VTMS_transition()) {
+        return; // no events should be posted if thread is in any VTMS transition
       }
       JvmtiEnvThreadStateIterator it(state);
       for (JvmtiEnvThreadState* ets = it.first(); ets != NULL; ets = it.next(ets)) {
@@ -2135,8 +2135,8 @@ void JvmtiExport::post_field_access_by_jni(JavaThread *thread, oop obj,
   // function don't make the call unless there is a Java context.
   assert(thread->has_last_Java_frame(), "must be called with a Java context");
 
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in a VTMS transition
+  if (thread->is_in_any_VTMS_transition()) {
+    return; // no events should be posted if thread is in any VTMS transition
   }
 
   ResourceMark rm;
@@ -2171,8 +2171,8 @@ void JvmtiExport::post_field_access(JavaThread *thread, Method* method,
   if (state == NULL) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in a VTMS transition
+  if (thread->is_in_any_VTMS_transition()) {
+    return; // no events should be posted if thread is in any VTMS transition
   }
 
   EVT_TRIG_TRACE(JVMTI_EVENT_FIELD_ACCESS, ("[%s] Trg Field Access event triggered",
@@ -2221,8 +2221,8 @@ void JvmtiExport::post_field_modification_by_jni(JavaThread *thread, oop obj,
   // function don't make the call unless there is a Java context.
   assert(thread->has_last_Java_frame(), "must be called with Java context");
 
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in a VTMS transition
+  if (thread->is_in_any_VTMS_transition()) {
+    return; // no events should be posted if thread is in any VTMS transition
   }
 
   ResourceMark rm;
@@ -2252,8 +2252,8 @@ void JvmtiExport::post_raw_field_modification(JavaThread *thread, Method* method
   address location, Klass* field_klass, Handle object, jfieldID field,
   char sig_type, jvalue *value) {
 
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in a VTMS transition
+  if (thread->is_in_any_VTMS_transition()) {
+    return; // no events should be posted if thread is in any VTMS transition
   }
 
   if (sig_type == JVM_SIGNATURE_INT || sig_type == JVM_SIGNATURE_BOOLEAN ||
@@ -2327,8 +2327,8 @@ void JvmtiExport::post_field_modification(JavaThread *thread, Method* method,
   if (state == NULL) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in a VTMS transition
+  if (thread->is_in_any_VTMS_transition()) {
+    return; // no events should be posted if thread is in any VTMS transition
   }
 
   EVT_TRIG_TRACE(JVMTI_EVENT_FIELD_MODIFICATION,
@@ -2366,8 +2366,8 @@ void JvmtiExport::post_native_method_bind(Method* method, address* function_ptr)
   HandleMark hm(thread);
   methodHandle mh(thread, method);
 
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in a VTMS transition
+  if (thread->is_in_any_VTMS_transition()) {
+    return; // no events should be posted if thread is in any VTMS transition
   }
   EVT_TRIG_TRACE(JVMTI_EVENT_NATIVE_METHOD_BIND, ("[%s] Trg Native Method Bind event triggered",
                       JvmtiTrace::safe_get_thread_name(thread)));
@@ -2440,7 +2440,7 @@ void JvmtiExport::post_compiled_method_load(nmethod *nm) {
   }
   JavaThread* thread = JavaThread::current();
 
-  assert(!thread->is_in_VTMS_transition(), "compiled method load events are not allowed in VTMS transition");
+  assert(!thread->is_in_any_VTMS_transition(), "compiled method load events are not allowed in any VTMS transition");
 
   EVT_TRIG_TRACE(JVMTI_EVENT_COMPILED_METHOD_LOAD,
                  ("[%s] method compile load event triggered",
@@ -2463,7 +2463,7 @@ void JvmtiExport::post_compiled_method_load(JvmtiEnv* env, nmethod *nm) {
   }
   JavaThread* thread = JavaThread::current();
 
-  assert(!thread->is_in_VTMS_transition(), "compiled method load events are not allowed in VTMS transition");
+  assert(!thread->is_in_any_VTMS_transition(), "compiled method load events are not allowed in any VTMS transition");
 
   EVT_TRACE(JVMTI_EVENT_COMPILED_METHOD_LOAD,
            ("[%s] method compile load event sent %s.%s  ",
@@ -2488,7 +2488,7 @@ void JvmtiExport::post_dynamic_code_generated_internal(const char *name, const v
 
   JavaThread* thread = JavaThread::current();
 
-  assert(!thread->is_in_VTMS_transition(), "dynamic code generated events are not allowed in VTMS transition");
+  assert(!thread->is_in_any_VTMS_transition(), "dynamic code generated events are not allowed in any VTMS transition");
 
   // In theory everyone coming thru here is in_vm but we need to be certain
   // because a callee will do a vm->native transition
@@ -2536,7 +2536,7 @@ void JvmtiExport::post_dynamic_code_generated(JvmtiEnv* env, const char *name,
 {
   JavaThread* thread = JavaThread::current();
 
-  assert(!thread->is_in_VTMS_transition(), "dynamic code generated events are not allowed in VTMS transition");
+  assert(!thread->is_in_any_VTMS_transition(), "dynamic code generated events are not allowed in any VTMS transition");
 
   EVT_TRIG_TRACE(JVMTI_EVENT_DYNAMIC_CODE_GENERATED,
                  ("[%s] dynamic code generated event triggered (by GenerateEvents)",
@@ -2560,7 +2560,7 @@ void JvmtiExport::post_dynamic_code_generated_while_holding_locks(const char* na
                                                                   address code_begin, address code_end)
 {
   JavaThread* thread = JavaThread::current();
-  assert(!thread->is_in_VTMS_transition(), "dynamic code generated events are not allowed in VTMS transition");
+  assert(!thread->is_in_any_VTMS_transition(), "dynamic code generated events are not allowed in any VTMS transition");
 
   // register the stub with the current dynamic code event collector
   // Cannot take safepoint here so do not use state_for to get
@@ -2690,8 +2690,8 @@ void JvmtiExport::post_monitor_contended_enter(JavaThread *thread, ObjectMonitor
   if (state == NULL) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in a VTMS transition
+  if (thread->is_in_any_VTMS_transition()) {
+    return; // no events should be posted if thread is in any VTMS transition
   }
 
   HandleMark hm(thread);
@@ -2723,8 +2723,8 @@ void JvmtiExport::post_monitor_contended_entered(JavaThread *thread, ObjectMonit
   if (state == NULL) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in a VTMS transition
+  if (thread->is_in_any_VTMS_transition()) {
+    return; // no events should be posted if thread is in any VTMS transition
   }
 
   HandleMark hm(thread);
@@ -2757,8 +2757,8 @@ void JvmtiExport::post_monitor_wait(JavaThread *thread, oop object,
   if (state == NULL) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in a VTMS transition
+  if (thread->is_in_any_VTMS_transition()) {
+    return; // no events should be posted if thread is in any VTMS transition
   }
 
   HandleMark hm(thread);
@@ -2791,8 +2791,8 @@ void JvmtiExport::post_monitor_waited(JavaThread *thread, ObjectMonitor *obj_mnt
   if (state == NULL) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in a VTMS transition
+  if (thread->is_in_any_VTMS_transition()) {
+    return; // no events should be posted if thread is in any VTMS transition
   }
 
   HandleMark hm(thread);
@@ -2823,8 +2823,8 @@ void JvmtiExport::post_vm_object_alloc(JavaThread *thread, oop object) {
   if (object == NULL) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in a VTMS transition
+  if (thread->is_in_any_VTMS_transition()) {
+    return; // no events should be posted if thread is in any VTMS transition
   }
   HandleMark hm(thread);
   Handle h(thread, object);
@@ -2857,8 +2857,8 @@ void JvmtiExport::post_sampled_object_alloc(JavaThread *thread, oop object) {
   if (object == NULL) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in a VTMS transition
+  if (thread->is_in_any_VTMS_transition()) {
+    return; // no events should be posted if thread is in any VTMS transition
   }
   HandleMark hm(thread);
   Handle h(thread, object);

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -1050,6 +1050,9 @@ bool JvmtiExport::post_class_file_load_hook(Symbol* h_name,
   if (JvmtiEnv::get_phase() < JVMTI_PHASE_PRIMORDIAL) {
     return false;
   }
+  if (JavaThread::current()->is_in_tmp_VTMS_transition()) {
+    return false;
+  }
 
   JvmtiClassFileLoadHookPoster poster(h_name, class_loader,
                                       h_protection_domain,
@@ -1340,6 +1343,9 @@ void JvmtiExport::post_class_load(JavaThread *thread, Klass* klass) {
   if (state == NULL) {
     return;
   }
+  if (thread->is_in_tmp_VTMS_transition()) {
+    return;
+  }
   assert(!thread->is_in_VTMS_transition(), "class load events are not allowed in VTMS transition");
 
   EVT_TRIG_TRACE(JVMTI_EVENT_CLASS_LOAD, ("[%s] Trg Class Load triggered",
@@ -1373,6 +1379,9 @@ void JvmtiExport::post_class_prepare(JavaThread *thread, Klass* klass) {
 
   JvmtiThreadState* state = thread->jvmti_thread_state();
   if (state == NULL) {
+    return;
+  }
+  if (thread->is_in_tmp_VTMS_transition()) {
     return;
   }
   assert(!thread->is_in_VTMS_transition(), "class prepare events are not allowed in VTMS transition");

--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -269,6 +269,7 @@ JvmtiVTMSTransitionDisabler::disable_VTMS_transitions() {
     ThreadBlockInVM tbivm(thread);
     MonitorLocker ml(JvmtiVTMSTransition_lock, Mutex::_no_safepoint_check_flag);
 
+    assert(!thread->is_in_tmp_VTMS_transition(), "sanity check");
     assert(!thread->is_in_VTMS_transition(), "VTMS_transition sanity check");
     while (_SR_mode) { // Suspender or resumer is a JvmtiVTMSTransitionDisabler monopolist.
       ml.wait(10);     // Wait while there is an active suspender or resumer.

--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -754,7 +754,7 @@ public:
 };
 
 bool HandshakeState::suspend() {
-  JVMTI_ONLY(assert(!_handshakee->is_in_non_tmp_VTMS_transition(), "no suspend allowed in VTMS transition");)
+  JVMTI_ONLY(assert(!_handshakee->is_in_VTMS_transition(), "no suspend allowed in VTMS transition");)
   JavaThread* self = JavaThread::current();
   if (_handshakee == self) {
     // If target is the current thread we can bypass the handshake machinery

--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -754,7 +754,7 @@ public:
 };
 
 bool HandshakeState::suspend() {
-  JVMTI_ONLY(assert(!_handshakee->is_in_VTMS_transition(), "no suspend allowed in VTMS transition");)
+  JVMTI_ONLY(assert(!_handshakee->is_in_non_tmp_VTMS_transition(), "no suspend allowed in VTMS transition");)
   JavaThread* self = JavaThread::current();
   if (_handshakee == self) {
     // If target is the current thread we can bypass the handshake machinery

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -421,6 +421,7 @@ JavaThread::JavaThread() :
 #if INCLUDE_JVMTI
   _carrier_thread_suspended(false),
   _is_in_VTMS_transition(false),
+  _is_in_tmp_VTMS_transition(false),
 #ifdef ASSERT
   _is_VTMS_transition_disabler(false),
 #endif
@@ -1170,7 +1171,7 @@ void JavaThread::set_is_VTMS_transition_disabler(bool val) {
 bool JavaThread::java_suspend() {
 #if INCLUDE_JVMTI
   // Suspending a JavaThread in VTMS transition or disabling VTMS transitions can cause deadlocks.
-  assert(!is_in_VTMS_transition(), "no suspend allowed in VTMS transition");
+  assert(!is_in_non_tmp_VTMS_transition(), "no suspend allowed in VTMS transition");
   assert(!is_VTMS_transition_disabler(), "no suspend allowed for VTMS transition disablers");
 #endif
 

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1171,7 +1171,7 @@ void JavaThread::set_is_VTMS_transition_disabler(bool val) {
 bool JavaThread::java_suspend() {
 #if INCLUDE_JVMTI
   // Suspending a JavaThread in VTMS transition or disabling VTMS transitions can cause deadlocks.
-  assert(!is_in_non_tmp_VTMS_transition(), "no suspend allowed in VTMS transition");
+  assert(!is_in_VTMS_transition(), "no suspend allowed in VTMS transition");
   assert(!is_VTMS_transition_disabler(), "no suspend allowed for VTMS transition disablers");
 #endif
 

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -643,11 +643,13 @@ private:
     return _carrier_thread_suspended;
   }
 
-  bool is_in_non_tmp_VTMS_transition() const     { return _is_in_VTMS_transition; }
-  bool is_in_VTMS_transition() const             { return _is_in_VTMS_transition || _is_in_tmp_VTMS_transition; }
-  void set_is_in_VTMS_transition(bool val);
+  bool is_in_VTMS_transition() const             { return _is_in_VTMS_transition; }
   bool is_in_tmp_VTMS_transition() const         { return _is_in_tmp_VTMS_transition; }
+  bool is_in_any_VTMS_transition() const         { return _is_in_VTMS_transition || _is_in_tmp_VTMS_transition; }
+
+  void set_is_in_VTMS_transition(bool val);
   void toggle_is_in_tmp_VTMS_transition()        { _is_in_tmp_VTMS_transition = !_is_in_tmp_VTMS_transition; };
+
 #ifdef ASSERT
   bool is_VTMS_transition_disabler() const       { return _is_VTMS_transition_disabler; }
   void set_is_VTMS_transition_disabler(bool val);

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -310,6 +310,7 @@ class JavaThread: public Thread {
 #if INCLUDE_JVMTI
   volatile bool         _carrier_thread_suspended;       // Carrier thread is externally suspended
   bool                  _is_in_VTMS_transition;          // thread is in virtual thread mount state transition
+  bool                  _is_in_tmp_VTMS_transition;      // thread is in temporary virtual thread mount state transition
 #ifdef ASSERT
   bool                  _is_VTMS_transition_disabler;    // thread currently disabled VTMS transitions
 #endif
@@ -642,8 +643,11 @@ private:
     return _carrier_thread_suspended;
   }
 
-  bool is_in_VTMS_transition() const             { return _is_in_VTMS_transition; }
+  bool is_in_non_tmp_VTMS_transition() const     { return _is_in_VTMS_transition; }
+  bool is_in_VTMS_transition() const             { return _is_in_VTMS_transition || _is_in_tmp_VTMS_transition; }
   void set_is_in_VTMS_transition(bool val);
+  bool is_in_tmp_VTMS_transition() const         { return _is_in_tmp_VTMS_transition; }
+  void toggle_is_in_tmp_VTMS_transition()        { _is_in_tmp_VTMS_transition = !_is_in_tmp_VTMS_transition; };
 #ifdef ASSERT
   bool is_VTMS_transition_disabler() const       { return _is_VTMS_transition_disabler; }
   void set_is_VTMS_transition_disabler(bool val);

--- a/src/java.base/share/native/libjava/VirtualThread.c
+++ b/src/java.base/share/native/libjava/VirtualThread.c
@@ -36,6 +36,7 @@ static JNINativeMethod methods[] = {
     { "notifyJvmtiMountEnd",     "(Z)V", (void *)&JVM_VirtualThreadMountEnd },
     { "notifyJvmtiUnmountBegin", "(Z)V", (void *)&JVM_VirtualThreadUnmountBegin },
     { "notifyJvmtiUnmountEnd",   "(Z)V", (void *)&JVM_VirtualThreadUnmountEnd },
+    { "toggleJvmtiTmpVTMSTrans", "(Z)V", (void *)&JVM_VirtualThreadToggleTmpVTMSTrans },
 };
 
 JNIEXPORT void JNICALL

--- a/src/java.base/share/native/libjava/VirtualThread.c
+++ b/src/java.base/share/native/libjava/VirtualThread.c
@@ -36,7 +36,7 @@ static JNINativeMethod methods[] = {
     { "notifyJvmtiMountEnd",     "(Z)V", (void *)&JVM_VirtualThreadMountEnd },
     { "notifyJvmtiUnmountBegin", "(Z)V", (void *)&JVM_VirtualThreadUnmountBegin },
     { "notifyJvmtiUnmountEnd",   "(Z)V", (void *)&JVM_VirtualThreadUnmountEnd },
-    { "toggleJvmtiTmpVTMSTrans", "(Z)V", (void *)&JVM_VirtualThreadToggleTmpVTMSTrans },
+    { "toggleJvmtiHideFrames",   "(Z)V", (void *)&JVM_VirtualThreadHideFrames },
 };
 
 JNIEXPORT void JNICALL

--- a/src/java.base/share/native/libjava/VirtualThread.c
+++ b/src/java.base/share/native/libjava/VirtualThread.c
@@ -36,7 +36,7 @@ static JNINativeMethod methods[] = {
     { "notifyJvmtiMountEnd",     "(Z)V", (void *)&JVM_VirtualThreadMountEnd },
     { "notifyJvmtiUnmountBegin", "(Z)V", (void *)&JVM_VirtualThreadUnmountBegin },
     { "notifyJvmtiUnmountEnd",   "(Z)V", (void *)&JVM_VirtualThreadUnmountEnd },
-    { "toggleJvmtiHideFrames",   "(Z)V", (void *)&JVM_VirtualThreadHideFrames },
+    { "notifyJvmtiHideFrames",   "(Z)V", (void *)&JVM_VirtualThreadHideFrames },
 };
 
 JNIEXPORT void JNICALL


### PR DESCRIPTION
There are several places in VirtualThread class implementation where virtual threads are being mounted or unmounted, so there is a transition of the JavaThread identity from carrier thread to virtual thread and back. The execution state in such transitions is inconsistent, and so, has to be invisible to JVM TI agents. Such transitions are named as VTMS (virtual thread mount state) transitions, and there is a JVM TI mechanism which supports them. Besides normal VTMS transitions there are also a couple of performance-critical contexts (in `VirtualThread` methods: `scheduleUnpark()`, `cancel()` and `unpark()`) which can be named as temporary VTMS transitions. Execution state of such temporary VTMS transitions has to be also invisible to the JVM TI agent which is implemented in the current update.

There are a couple of details of this fix to highlight:
-  A JavaThread which is in temporary VTMS transition is marked with a special bit `_is_in_tmp_VTMS_transition`. It is done with the native notification method `toggleJvmtiTmpVTMSTrans()`.
- A couple of lambda form classes can be created in context of temporary VTMS transitions, so their `ClassLoad`, `ClassPrepare` and `CFLH` events are ignored.
- Suspending threads in temporary transition is allowed.

The fix was tested in Loom repository by using `JTREG_MAIN_WRAPPER=Virtual` mode of execution which forces all main threads to be run as virtual. All `JVM TI` and `JDI` tests were run on all platforms. It includes `Kitchensink` and `JCK` tests. Additionally, the fix was tested in the jdk 20 repository. It includes `JVM TI` and `JDI` tests and tiers 1-6.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293613](https://bugs.openjdk.org/browse/JDK-8293613): need to properly handle and hide tmp VTMS transitions


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10321/head:pull/10321` \
`$ git checkout pull/10321`

Update a local copy of the PR: \
`$ git checkout pull/10321` \
`$ git pull https://git.openjdk.org/jdk pull/10321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10321`

View PR using the GUI difftool: \
`$ git pr show -t 10321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10321.diff">https://git.openjdk.org/jdk/pull/10321.diff</a>

</details>
