### PR TITLE
8293657: sun/management/jmxremote/bootstrap/RmiBootstrapTest.java#id1 failed with "SSLHandshakeException: Remote host terminated the handshake"

### DIFF
--- a/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
+++ b/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package sun.management.jmxremote;
 
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
-import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -924,9 +923,6 @@ public final class ConnectorBootstrap {
     private static class HostAwareSslSocketFactory extends SslRMIServerSocketFactory {
 
         private final String bindAddress;
-        private final String[] enabledCipherSuites;
-        private final String[] enabledProtocols;
-        private final boolean needClientAuth;
         private final SSLContext context;
 
         private HostAwareSslSocketFactory(String[] enabledCipherSuites,
@@ -941,11 +937,9 @@ public final class ConnectorBootstrap {
                                           String[] enabledProtocols,
                                           boolean sslNeedClientAuth,
                                           String bindAddress) throws IllegalArgumentException {
-            this.context = ctx;
+            super(ctx, enabledCipherSuites, enabledProtocols, sslNeedClientAuth);
             this.bindAddress = bindAddress;
-            this.enabledProtocols = enabledProtocols;
-            this.enabledCipherSuites = enabledCipherSuites;
-            this.needClientAuth = sslNeedClientAuth;
+            this.context = ctx;
             checkValues(ctx, enabledCipherSuites, enabledProtocols);
         }
 
@@ -955,14 +949,15 @@ public final class ConnectorBootstrap {
                 try {
                     InetAddress addr = InetAddress.getByName(bindAddress);
                     return new SslServerSocket(port, 0, addr, context,
-                                               enabledCipherSuites, enabledProtocols, needClientAuth);
+                            this.getEnabledCipherSuites(), this.getEnabledProtocols(),
+                            this.getNeedClientAuth());
                 } catch (UnknownHostException e) {
                     return new SslServerSocket(port, context,
-                                               enabledCipherSuites, enabledProtocols, needClientAuth);
+                            this.getEnabledCipherSuites(), this.getEnabledProtocols(), this.getNeedClientAuth());
                 }
             } else {
                 return new SslServerSocket(port, context,
-                                           enabledCipherSuites, enabledProtocols, needClientAuth);
+                        this.getEnabledCipherSuites(), this.getEnabledProtocols(), this.getNeedClientAuth());
             }
         }
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -524,7 +524,6 @@ java/lang/management/ThreadMXBean/ThreadMXBeanStateTest.java    8247426 generic-
 sun/management/jdp/JdpDefaultsTest.java                         8241865 linux-aarch64,macosx-all
 sun/management/jdp/JdpJmxRemoteDynamicPortTest.java             8241865 macosx-all
 sun/management/jdp/JdpSpecificAddressTest.java                  8241865 macosx-all
-sun/management/jmxremote/bootstrap/RmiBootstrapTest.java#id1    8293657 linux-x64
 
 ############################################################################
 

--- a/test/jdk/sun/management/jmxremote/bootstrap/management_ssltest07_ok.properties.in
+++ b/test/jdk/sun/management/jmxremote/bootstrap/management_ssltest07_ok.properties.in
@@ -1,5 +1,5 @@
-com.sun.management.jmxremote.ssl.enabled.cipher.suites=TLS_DHE_DSS_WITH_AES_128_GCM_SHA256
+com.sun.management.jmxremote.ssl.enabled.cipher.suites=TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA
 com.sun.management.jmxremote.ssl.enabled.protocols=SSLv2Hello,SSLv3,TLSv1
 com.sun.management.jmxremote.ssl.need.client.auth=true
 com.sun.management.jmxremote.authenticate=false
-javax.rmi.ssl.client.enabledCipherSuites=TLS_DHE_DSS_WITH_AES_128_GCM_SHA256
+javax.rmi.ssl.client.enabledCipherSuites=TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA


### PR DESCRIPTION
Can I please get a review of this change which proposes to fix the intermittent failures noted in https://bugs.openjdk.org/browse/JDK-8293657?

There are two parts to this fix. One is straightforward fix in the test configuration file where it uses an incompatible cipher suite with the enabled protocols. The details of that are noted in my comment in the JBS https://bugs.openjdk.org/browse/JDK-8293657?focusedCommentId=14524400&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14524400. The fix for that resides solely in `management_ssltest07_ok.properties.in` file.

The more curious part was why this specific test configuration is ever passing instead of always failing. That turned out to be a bug in the `sun.management.jmxremote.HostAwareSslSocketFactory`.  The (internal implementation detail) in `sun.rmi.transport.tcp.TCPEndpoint` holds a cache of `localEndpoints` which effectively are server and client socket factories that get used when creating the corresponding socket/server sockets. The cache uses a key, whose one component is the `HostAwareSslSocketFactory` instance. This class extends from `javax.rmi.ssl.SslRMIServerSocketFactory` which is where the `equals()` is implemented for the `HostAwareSslSocketFactory` instances. The bug resides in the fact that the current implementation of the `HostAwareSslSocketFactory` constructor doesn't pass to its `super` the `enabledCipherSuites`, `enabledProtocols` and  `needClientAuth` values with which the `HostAwareSslSocketFactory` was constructed with. Instead it stores these values as private members and thus the `SslRMIServerSocketFactory` has its own version of these members as `null`. The `SslRMIServerSocketFactory` uses these values in its `equals` implementation and thus ends up computing a wrong output from the `equals` call. This ultimately ends up with the (internal) `TCPEndpoint` returning an incorrect (server) socket factory that gets used during the client/server communication. What this means is that the restrictions imposed on enabled protocols and enabled cipher suites in `management_ssltest07_ok.properties.in` aren't taken into account and instead a different set of (lenient) configurations for these attributes gets used (because of the cached socket factory constructed for  a previous run of a different test configuration).

The commit in this PR fixes the `HostAwareSslSocketFactory` to correctly pass to its `super` the enabled protocols, enabled cipher suites and the client auth mode, instead of saving that state (only) in `HostAwareSslSocketFactory`.

Additionally the commit removes this test from the problem listing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293657](https://bugs.openjdk.org/browse/JDK-8293657): sun/management/jmxremote/bootstrap/RmiBootstrapTest.java#id1 failed with "SSLHandshakeException: Remote host terminated the handshake"


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10323/head:pull/10323` \
`$ git checkout pull/10323`

Update a local copy of the PR: \
`$ git checkout pull/10323` \
`$ git pull https://git.openjdk.org/jdk pull/10323/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10323`

View PR using the GUI difftool: \
`$ git pr show -t 10323`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10323.diff">https://git.openjdk.org/jdk/pull/10323.diff</a>

</details>
