### PR TITLE
8293976: Use unsigned integers in Assembler/CodeBuffer::emit_int*

### DIFF
--- a/src/hotspot/share/asm/assembler.hpp
+++ b/src/hotspot/share/asm/assembler.hpp
@@ -282,21 +282,21 @@ class AbstractAssembler : public ResourceObj  {
   // ensure buf contains all code (call this before using/copying the code)
   void flush();
 
-  void emit_int8(   int8_t x1)                                  { code_section()->emit_int8(x1); }
+  void emit_int8(   uint8_t x1)                                     { code_section()->emit_int8(x1); }
 
-  void emit_int16(  int16_t x)                                  { code_section()->emit_int16(x); }
-  void emit_int16(  int8_t x1, int8_t x2)                       { code_section()->emit_int16(x1, x2); }
+  void emit_int16(  uint16_t x)                                     { code_section()->emit_int16(x); }
+  void emit_int16(  uint8_t x1, uint8_t x2)                         { code_section()->emit_int16(x1, x2); }
 
-  void emit_int24(  int8_t x1, int8_t x2, int8_t x3)            { code_section()->emit_int24(x1, x2, x3); }
+  void emit_int24(  uint8_t x1, uint8_t x2, uint8_t x3)             { code_section()->emit_int24(x1, x2, x3); }
 
-  void emit_int32(  int32_t x)                                  { code_section()->emit_int32(x); }
-  void emit_int32(  int8_t x1, int8_t x2, int8_t x3, int8_t x4) { code_section()->emit_int32(x1, x2, x3, x4); }
+  void emit_int32(  uint32_t x)                                     { code_section()->emit_int32(x); }
+  void emit_int32(  uint8_t x1, uint8_t x2, uint8_t x3, uint8_t x4) { code_section()->emit_int32(x1, x2, x3, x4); }
 
-  void emit_int64(  int64_t x)                                  { code_section()->emit_int64(x); }
+  void emit_int64(  uint64_t x)                                     { code_section()->emit_int64(x); }
 
-  void emit_float(  jfloat  x)                                  { code_section()->emit_float(x); }
-  void emit_double( jdouble x)                                  { code_section()->emit_double(x); }
-  void emit_address(address x)                                  { code_section()->emit_address(x); }
+  void emit_float(  jfloat  x)                                      { code_section()->emit_float(x); }
+  void emit_double( jdouble x)                                      { code_section()->emit_double(x); }
+  void emit_address(address x)                                      { code_section()->emit_address(x); }
 
   enum { min_simm10 = -512 };
 

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -204,43 +204,43 @@ class CodeSection {
   }
 
   // Code emission
-  void emit_int8(int8_t x1) {
+  void emit_int8(uint8_t x1) {
     address curr = end();
-    *((int8_t*)  curr++) = x1;
+    *((uint8_t*)  curr++) = x1;
     set_end(curr);
   }
 
-  void emit_int16(int16_t x) { *((int16_t*) end()) = x; set_end(end() + sizeof(int16_t)); }
-  void emit_int16(int8_t x1, int8_t x2) {
+  void emit_int16(uint16_t x) { *((uint16_t*) end()) = x; set_end(end() + sizeof(uint16_t)); }
+  void emit_int16(uint8_t x1, uint8_t x2) {
     address curr = end();
-    *((int8_t*)  curr++) = x1;
-    *((int8_t*)  curr++) = x2;
+    *((uint8_t*)  curr++) = x1;
+    *((uint8_t*)  curr++) = x2;
     set_end(curr);
   }
 
-  void emit_int24(int8_t x1, int8_t x2, int8_t x3)  {
+  void emit_int24(uint8_t x1, uint8_t x2, uint8_t x3)  {
     address curr = end();
-    *((int8_t*)  curr++) = x1;
-    *((int8_t*)  curr++) = x2;
-    *((int8_t*)  curr++) = x3;
+    *((uint8_t*)  curr++) = x1;
+    *((uint8_t*)  curr++) = x2;
+    *((uint8_t*)  curr++) = x3;
     set_end(curr);
   }
 
-  void emit_int32(int32_t x) {
+  void emit_int32(uint32_t x) {
     address curr = end();
-    *((int32_t*) curr) = x;
-    set_end(curr + sizeof(int32_t));
+    *((uint32_t*) curr) = x;
+    set_end(curr + sizeof(uint32_t));
   }
-  void emit_int32(int8_t x1, int8_t x2, int8_t x3, int8_t x4)  {
+  void emit_int32(uint8_t x1, uint8_t x2, uint8_t x3, uint8_t x4)  {
     address curr = end();
-    *((int8_t*)  curr++) = x1;
-    *((int8_t*)  curr++) = x2;
-    *((int8_t*)  curr++) = x3;
-    *((int8_t*)  curr++) = x4;
+    *((uint8_t*)  curr++) = x1;
+    *((uint8_t*)  curr++) = x2;
+    *((uint8_t*)  curr++) = x3;
+    *((uint8_t*)  curr++) = x4;
     set_end(curr);
   }
 
-  void emit_int64( int64_t x)  { *((int64_t*) end()) = x; set_end(end() + sizeof(int64_t)); }
+  void emit_int64( uint64_t x)  { *((uint64_t*) end()) = x; set_end(end() + sizeof(uint64_t)); }
 
   void emit_float( jfloat  x)  { *((jfloat*)  end()) = x; set_end(end() + sizeof(jfloat)); }
   void emit_double(jdouble x)  { *((jdouble*) end()) = x; set_end(end() + sizeof(jdouble)); }


### PR DESCRIPTION
Assembler/CodeBuffer::emit_int* accept signed int arguments.

- Since we are trying to emit some bit patterns into the code buffer instead of doing integer arithmetics, it makes more sense to use unsigned parameters.

- It makes usage with constants become inconvenient, as an integer literal is positive, a 0xC0 does not fit into an int8_t, resulting in the compiler complaining about lossy implicit conversions, the current solution is manual casting of the constants to unsigned char, which can be converted to int8_t without complaints.

Please have a look and leave some reviews. Thanks very much.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293976](https://bugs.openjdk.org/browse/JDK-8293976): Use unsigned integers in Assembler/CodeBuffer::emit_int*


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10325/head:pull/10325` \
`$ git checkout pull/10325`

Update a local copy of the PR: \
`$ git checkout pull/10325` \
`$ git pull https://git.openjdk.org/jdk pull/10325/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10325`

View PR using the GUI difftool: \
`$ git pr show -t 10325`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10325.diff">https://git.openjdk.org/jdk/pull/10325.diff</a>

</details>
