### PR TITLE
8298352: apple.laf.JRSUIUtils class creates many indirections

### DIFF
--- a/src/java.desktop/macosx/classes/apple/laf/JRSUIConstants.java
+++ b/src/java.desktop/macosx/classes/apple/laf/JRSUIConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/classes/apple/laf/JRSUIConstants.java
+++ b/src/java.desktop/macosx/classes/apple/laf/JRSUIConstants.java
@@ -313,6 +313,13 @@ public final class JRSUIConstants {
             super(scrollBarPart, value);
         }
 
+        /**
+         * @return the {@link Property}'s {@link #ordinal}.
+         */
+        public int ordinal() {
+            return ordinal;
+        }
+
         @Native private static final byte _none = 1;
         public static final ScrollBarPart NONE = new ScrollBarPart(_none);
         @Native private static final byte _thumb = 2;

--- a/src/java.desktop/macosx/classes/apple/laf/JRSUIControl.java
+++ b/src/java.desktop/macosx/classes/apple/laf/JRSUIControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/classes/apple/laf/JRSUIControl.java
+++ b/src/java.desktop/macosx/classes/apple/laf/JRSUIControl.java
@@ -276,7 +276,7 @@ public final class JRSUIControl {
     }
 
 
-    Hit getHitForPoint(final int x, final int y, final int w, final int h, final int hitX, final int hitY) {
+    public Hit getHitForPoint(int x, int y, int w, int h, int hitX, int hitY) {
         sync();
         // reflect hitY about the midline of the control before sending to native
         final Hit hit = JRSUIConstants.getHit(getNativeHitPart(cfDictionaryPtr, priorEncodedProperties, currentEncodedProperties, x, y, w, h, hitX, 2 * y + h - hitY));
@@ -284,7 +284,7 @@ public final class JRSUIControl {
         return hit;
     }
 
-    void getPartBounds(final double[] rect, final int x, final int y, final int w, final int h, final int part) {
+    public void getPartBounds(double[] rect, int x, int y, int w, int h, int part) {
         if (rect == null) throw new NullPointerException("Cannot load null rect");
         if (rect.length != 4) throw new IllegalArgumentException("Rect must have four elements");
 
@@ -293,7 +293,7 @@ public final class JRSUIControl {
         priorEncodedProperties = currentEncodedProperties;
     }
 
-    double getScrollBarOffsetChange(final int x, final int y, final int w, final int h, final int offset, final int visibleAmount, final int extent) {
+    public double getScrollBarOffsetChange(int x, int y, int w, int h, int offset, int visibleAmount, int extent) {
         sync();
         final double offsetChange = getNativeScrollBarOffsetChange(cfDictionaryPtr, priorEncodedProperties, currentEncodedProperties, x, y, w, h, offset, visibleAmount, extent);
         priorEncodedProperties = currentEncodedProperties;

--- a/src/java.desktop/macosx/classes/apple/laf/JRSUIUtils.java
+++ b/src/java.desktop/macosx/classes/apple/laf/JRSUIUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/classes/apple/laf/JRSUIUtils.java
+++ b/src/java.desktop/macosx/classes/apple/laf/JRSUIUtils.java
@@ -27,44 +27,44 @@ package apple.laf;
 
 import java.security.AccessController;
 
-import apple.laf.JRSUIConstants.Hit;
-import apple.laf.JRSUIConstants.ScrollBarPart;
-import com.apple.laf.AquaImageFactory.NineSliceMetrics;
 import sun.security.action.GetPropertyAction;
 
+/**
+ * Utility class for JRSUI.
+ */
 public final class JRSUIUtils {
 
-    static boolean isLeopard = isMacOSXLeopard();
-    static boolean isSnowLeopardOrBelow = isMacOSXSnowLeopardOrBelow();
+    /**
+     * True if OSX is 10.5 exactly (ignoring patch versions).
+     */
+    public static boolean isLeopard = currentMacOSXVersionMatchesGivenVersionRange(10, 5,
+            true, false, false);
 
-    public static boolean isMacOSXBigSurOrAbove() {
-        return currentMacOSXVersionMatchesGivenVersionRange(10, 16, true,
-                false, true);
-    }
+    /**
+     * True if OSX is 10.6 or below.
+     */
+    public static boolean isSnowLeopardOrBelow = currentMacOSXVersionMatchesGivenVersionRange(10, 6,
+            true, true, false);
 
-    static boolean isMacOSXLeopard() {
-        return isCurrentMacOSXVersion(5);
-    }
+    /**
+     * True if macOS is 10.16 or higher.
+     */
+    public static boolean isBigSurOrAbove = currentMacOSXVersionMatchesGivenVersionRange(10, 16,
+            true, false, true);
 
-    static boolean isMacOSXSnowLeopardOrBelow() {
-        return currentMacOSXVersionMatchesGivenVersionRange(10, 6, true,
-                true, false);
-    }
+    // DENY
+    private JRSUIUtils() {}
 
-    static boolean isCurrentMacOSXVersion(final int version) {
-        return isCurrentMacOSXVersion(10, version);
-    }
-
-    static boolean isCurrentMacOSXVersion(final int major, final int minor) {
-        return currentMacOSXVersionMatchesGivenVersionRange(major, minor, true, false, false);
-    }
-
-    static boolean currentMacOSXVersionMatchesGivenVersionRange(
-            final int version, final boolean inclusive,
-            final boolean matchBelow, final boolean matchAbove) {
-        return currentMacOSXVersionMatchesGivenVersionRange(10, version, inclusive, matchBelow, matchAbove);
-    }
-
+    /**
+     * Method for checking macOS version compatibility (ignores the patch).
+     *
+     * @param majorVersion major release (e.g. 10 for OSX)
+     * @param minorVersion minor release
+     * @param inclusive set to true to return true for an equal version
+     * @param matchBelow set to true to return true when the version is smaller
+     * @param matchAbove set to true to return true when the version is greater
+     * @return true if the running version matches
+     */
     static boolean currentMacOSXVersionMatchesGivenVersionRange(
             final int majorVersion, final int minorVersion, final boolean inclusive,
             final boolean matchBelow, final boolean matchAbove) {
@@ -94,69 +94,8 @@ public final class JRSUIUtils {
         return false;
     }
 
-    public static class TabbedPane {
-        public static boolean useLegacyTabs() {
-            return isLeopard;
-        }
-        public static boolean shouldUseTabbedPaneContrastUI() {
-            return !isSnowLeopardOrBelow;
-        }
-    }
-
-    public static class InternalFrame {
-        public static boolean shouldUseLegacyBorderMetrics() {
-            return isSnowLeopardOrBelow;
-        }
-    }
-
-    public static class Tree {
-        public static boolean useLegacyTreeKnobs() {
-            return isLeopard;
-        }
-    }
-
-    public static class ScrollBar {
-        private static native boolean shouldUseScrollToClick();
-
-        public static boolean useScrollToClick() {
-            return shouldUseScrollToClick();
-        }
-
-        public static void getPartBounds(final double[] rect,
-                                         final JRSUIControl control,
-                                         final int x, final int y, final int w,
-                                         final int h,
-                                         final ScrollBarPart part) {
-            control.getPartBounds(rect, x, y, w, h, part.ordinal);
-        }
-
-        public static double getNativeOffsetChange(final JRSUIControl control,
-                                                   final int x, final int y,
-                                                   final int w, final int h,
-                                                   final int offset,
-                                                   final int visibleAmount,
-                                                   final int extent) {
-            return control.getScrollBarOffsetChange(x, y, w, h, offset,
-                                                    visibleAmount, extent);
-        }
-    }
-
-    public static class Images {
-        public static boolean shouldUseLegacySecurityUIPath() {
-            return isSnowLeopardOrBelow;
-        }
-    }
-
-    public static class HitDetection {
-        public static Hit getHitForPoint(final JRSUIControl control,
-                                         final int x, final int y, final int w,
-                                         final int h, final int hitX,
-                                         final int hitY) {
-            return control.getHitForPoint(x, y, w, h, hitX, hitY);
-        }
-    }
-
-    public interface NineSliceMetricsProvider {
-        public NineSliceMetrics getNineSliceMetricsForState(JRSUIState state);
-    }
+    /**
+     * Returns {@code JRSUIControlShouldScrollToClick();} from native code.
+     */
+    public static native boolean shouldUseScrollToClick();
 }

--- a/src/java.desktop/macosx/classes/apple/laf/JRSUIUtils.java
+++ b/src/java.desktop/macosx/classes/apple/laf/JRSUIUtils.java
@@ -37,62 +37,55 @@ public final class JRSUIUtils {
     /**
      * True if OSX is 10.5 exactly (ignoring patch versions).
      */
-    public static boolean isLeopard = currentMacOSXVersionMatchesGivenVersionRange(10, 5,
-            true, false, false);
+    public static final boolean isLeopard;
 
     /**
      * True if OSX is 10.6 or below.
      */
-    public static boolean isSnowLeopardOrBelow = currentMacOSXVersionMatchesGivenVersionRange(10, 6,
-            true, true, false);
+    public static final boolean isSnowLeopardOrBelow;
 
     /**
      * True if macOS is 10.16 or higher.
      */
-    public static boolean isBigSurOrAbove = currentMacOSXVersionMatchesGivenVersionRange(10, 16,
-            true, false, true);
+    public static final boolean isBigSurOrAbove;
 
-    // DENY
-    private JRSUIUtils() {}
-
-    /**
-     * Method for checking macOS version compatibility (ignores the patch).
-     *
-     * @param majorVersion major release (e.g. 10 for OSX)
-     * @param minorVersion minor release
-     * @param inclusive set to true to return true for an equal version
-     * @param matchBelow set to true to return true when the version is smaller
-     * @param matchAbove set to true to return true when the version is greater
-     * @return true if the running version matches
-     */
-    static boolean currentMacOSXVersionMatchesGivenVersionRange(
-            final int majorVersion, final int minorVersion, final boolean inclusive,
-            final boolean matchBelow, final boolean matchAbove) {
+    static {
         // split the "x.y.z" version number
         @SuppressWarnings("removal")
         String osVersion = AccessController.doPrivileged(new GetPropertyAction("os.version"));
         String[] fragments = osVersion.split("\\.");
 
-        if (fragments.length < 2) return false;
+        if (fragments.length < 2) {
+            isLeopard = false;
+            isSnowLeopardOrBelow = false;
+            isBigSurOrAbove = false;
+        } else {
+            boolean isBigSurOrAbove1;
+            boolean isSnowLeopardOrBelow1;
+            boolean isLeopard1;
 
-        // check if os.version matches the given version using the given match method
-        try {
-            int majorVers = Integer.parseInt(fragments[0]);
-            int minorVers = Integer.parseInt(fragments[1]);
+            try {
+                int majorVersion = Integer.parseInt(fragments[0]);
+                int minorVersion = Integer.parseInt(fragments[1]);
 
-            if (inclusive && majorVers == majorVersion && minorVers == minorVersion) return true;
-            if (matchBelow &&
-                    (majorVers < majorVersion ||
-                            (majorVers == majorVersion && minorVers < minorVersion))) return true;
-            if (matchAbove &&
-                    (majorVers > majorVersion ||
-                            (majorVers == majorVersion && minorVers > minorVersion))) return true;
+                isLeopard1 = majorVersion == 10 && minorVersion == 5; // exactly OSX 10.5
+                isSnowLeopardOrBelow1 = majorVersion < 10 || majorVersion == 10 && minorVersion <= 6; // OSX 10.6 or below
+                isBigSurOrAbove1 = majorVersion > 10 || majorVersion == 10 && minorVersion >= 16; // OSX 10.16 or above
+            } catch (NumberFormatException e) {
+                // was not an integer
+                isLeopard1 = false;
+                isSnowLeopardOrBelow1 = false;
+                isBigSurOrAbove1 = false;
+            }
 
-        } catch (NumberFormatException e) {
-            // was not an integer
+            isBigSurOrAbove = isBigSurOrAbove1;
+            isSnowLeopardOrBelow = isSnowLeopardOrBelow1;
+            isLeopard = isLeopard1;
         }
-        return false;
     }
+
+    // DENY
+    private JRSUIUtils() {}
 
     /**
      * Returns {@code JRSUIControlShouldScrollToClick();} from native code.

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaImageFactory.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaImageFactory.java
@@ -48,7 +48,6 @@ import com.apple.laf.AquaUtils.RecyclableObject;
 import com.apple.laf.AquaUtils.RecyclableSingleton;
 import sun.awt.image.MultiResolutionCachedImage;
 import sun.lwawt.macosx.CImage;
-import sun.swing.ImageIconUIResource;
 
 public class AquaImageFactory {
     public static IconUIResource getConfirmImageIcon() {
@@ -71,14 +70,15 @@ public class AquaImageFactory {
         return getAppIconCompositedOn(AquaIcon.SystemIcon.getStopIcon());
     }
 
+    // public, because UIDefaults.ProxyLazyValue uses reflection to get this value
     public static IconUIResource getLockImageIcon() {
-        // public, because UIDefaults.ProxyLazyValue uses reflection to get this value
-        if (JRSUIUtils.Images.shouldUseLegacySecurityUIPath()) {
-            final Image lockIcon = CImage.createImageFromFile("/System/Library/CoreServices/SecurityAgent.app/Contents/Resources/Security.icns", kAlertIconSize, kAlertIconSize);
-            return getAppIconCompositedOn(lockIcon);
+        Image lockIcon;
+        if (JRSUIUtils.isSnowLeopardOrBelow) {
+            lockIcon = CImage.createImageFromFile("/System/Library/CoreServices/SecurityAgent.app/Contents/Resources/Security.icns", kAlertIconSize, kAlertIconSize);
+        } else {
+            lockIcon = Toolkit.getDefaultToolkit().getImage("NSImage://NSSecurity");
         }
 
-        final Image lockIcon = Toolkit.getDefaultToolkit().getImage("NSImage://NSSecurity");
         return getAppIconCompositedOn(lockIcon);
     }
 

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaInternalFrameBorderMetrics.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaInternalFrameBorderMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaInternalFrameBorderMetrics.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaInternalFrameBorderMetrics.java
@@ -31,7 +31,6 @@ import apple.laf.JRSUIUtils;
 import com.apple.laf.AquaUtils.RecyclableSingleton;
 
 public abstract class AquaInternalFrameBorderMetrics {
-    private static final boolean useLegacyBorderMetrics = JRSUIUtils.InternalFrame.shouldUseLegacyBorderMetrics();
 
     public Font font;
     public int titleBarHeight;
@@ -48,7 +47,7 @@ public abstract class AquaInternalFrameBorderMetrics {
     protected abstract void initialize();
 
     public static AquaInternalFrameBorderMetrics getMetrics(boolean isUtility) {
-        if (useLegacyBorderMetrics) {
+        if (JRSUIUtils.isSnowLeopardOrBelow) {
             return isUtility ? legacyUtilityMetrics.get() : legacyStandardMetrics.get();
         } else {
             return isUtility ? utilityMetrics.get() : standardMetrics.get();

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
@@ -873,10 +873,10 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
             //"TabbedPane.selectedTabPadInsets", new InsetsUIResource(0, 0, 1, 0), // Really outsets, this is where we allow for overlap
             "TabbedPane.selectedTabPadInsets", new InsetsUIResource(0, 0, 0, 0), // Really outsets, this is where we allow for overlap
             "TabbedPane.tabsOverlapBorder", Boolean.TRUE,
-            "TabbedPane.selectedTabTitlePressedColor", JRSUIUtils.isMacOSXBigSurOrAbove() ? selectedControlTextColor : selectedTabTitlePressedColor,
+            "TabbedPane.selectedTabTitlePressedColor", JRSUIUtils.isBigSurOrAbove ? selectedControlTextColor : selectedTabTitlePressedColor,
             "TabbedPane.selectedTabTitleDisabledColor", selectedTabTitleDisabledColor,
             "TabbedPane.selectedTabTitleNonFocusColor", selectedTabTitleNonFocusColor,
-            "TabbedPane.selectedTabTitleNormalColor", JRSUIUtils.isMacOSXBigSurOrAbove() ? selectedControlTextColor : selectedTabTitleNormalColor,
+            "TabbedPane.selectedTabTitleNormalColor", JRSUIUtils.isBigSurOrAbove ? selectedControlTextColor : selectedTabTitleNormalColor,
             "TabbedPane.selectedTabTitleShadowDisabledColor", selectedTabTitleShadowDisabledColor,
             "TabbedPane.selectedTabTitleShadowNormalColor", selectedTabTitleShadowNormalColor,
             "TabbedPane.nonSelectedTabTitleNormalColor", nonSelectedTabTitleNormalColor,
@@ -1086,7 +1086,7 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
             "RootPaneUI", PKG_PREFIX + "AquaRootPaneUI",
             "SliderUI", PKG_PREFIX + "AquaSliderUI",
             "ScrollBarUI", PKG_PREFIX + "AquaScrollBarUI",
-            "TabbedPaneUI", PKG_PREFIX + (JRSUIUtils.TabbedPane.shouldUseTabbedPaneContrastUI() ? "AquaTabbedPaneContrastUI" : "AquaTabbedPaneUI"),
+            "TabbedPaneUI", PKG_PREFIX + (JRSUIUtils.isSnowLeopardOrBelow ? "AquaTabbedPaneUI" : "AquaTabbedPaneContrastUI"),
             "TableUI", PKG_PREFIX + "AquaTableUI",
             "ToggleButtonUI", PKG_PREFIX + "AquaButtonToggleUI",
             "ToolBarUI", PKG_PREFIX + "AquaToolBarUI",

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaPainter.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaPainter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaScrollBarUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaScrollBarUI.java
@@ -236,7 +236,7 @@ public class AquaScrollBarUI extends ScrollBarUI {
     protected Hit getPartHit(final int x, final int y) {
         syncState(fScrollBar);
         Insets insets = fScrollBar.getInsets();
-        return JRSUIUtils.HitDetection.getHitForPoint(painter.getControl(), insets.left, insets.top,
+        return painter.getControl().getHitForPoint(insets.left, insets.top,
                 fScrollBar.getWidth() - (insets.left + insets.right),
                 fScrollBar.getHeight() - (insets.top + insets.bottom), x, y);
     }
@@ -355,8 +355,8 @@ public class AquaScrollBarUI extends ScrollBarUI {
             // remaining 80.
             syncState(fScrollBar);
             final Rectangle limitRect = getDragBounds(); // GetThemeTrackDragRect
-            final double offsetChange = JRSUIUtils.ScrollBar.getNativeOffsetChange(painter.getControl(),
-                    limitRect.x, limitRect.y, limitRect.width, limitRect.height, offsetWeCareAbout, visibleAmt, extent);
+            double offsetChange = painter.getControl().getScrollBarOffsetChange(limitRect.x, limitRect.y,
+                    limitRect.width, limitRect.height, offsetWeCareAbout, visibleAmt, extent);
 
             // the scrollable area is the extent - visible amount;
             final int scrollableArea = extent - visibleAmt;
@@ -435,7 +435,7 @@ public class AquaScrollBarUI extends ScrollBarUI {
             fScrollBar.setValueIsAdjusting(true);
 
             // If option-click, toggle scroll-to-here
-            boolean shouldScrollToHere = (part != ScrollBarHit.THUMB) && JRSUIUtils.ScrollBar.useScrollToClick();
+            boolean shouldScrollToHere = part != ScrollBarHit.THUMB && JRSUIUtils.shouldUseScrollToClick();
             if (e.isAltDown()) shouldScrollToHere = !shouldScrollToHere;
 
             // pretend the mouse was dragged from a point in the current thumb to the current mouse point in one big jump
@@ -609,7 +609,8 @@ public class AquaScrollBarUI extends ScrollBarUI {
         // determine the bounding rectangle for our thumb region
         syncState(fScrollBar);
         double[] rect = new double[4];
-        JRSUIUtils.ScrollBar.getPartBounds(rect, painter.getControl(), limitRect.x, limitRect.y, limitRect.width, limitRect.height, ScrollBarPart.THUMB);
+        painter.getControl().getPartBounds(rect, limitRect.x, limitRect.y, limitRect.width, limitRect.height,
+                ScrollBarPart.THUMB.ordinal());
         final Rectangle r = new Rectangle((int)rect[0], (int)rect[1], (int)rect[2], (int)rect[3]);
 
         // figure out the scroll-to-here start location based on our orientation, the

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaSliderUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaSliderUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaSliderUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaSliderUI.java
@@ -34,7 +34,6 @@ import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicSliderUI;
 
 import apple.laf.*;
-import apple.laf.JRSUIUtils.NineSliceMetricsProvider;
 import apple.laf.JRSUIConstants.*;
 
 import com.apple.laf.AquaUtilControlSize.*;
@@ -70,14 +69,11 @@ public class AquaSliderUI extends BasicSliderUI implements Sizeable {
         }
     };
 
-    static final AquaPainter<JRSUIState> trackPainter = AquaPainter.create(JRSUIStateFactory.getSliderTrack(), new NineSliceMetricsProvider() {
-        @Override
-        public NineSliceMetrics getNineSliceMetricsForState(JRSUIState state) {
-            if (state.is(Orientation.VERTICAL)) {
-                return new NineSliceMetrics(5, 7, 0, 0, 3, 3, true, false, true);
-            }
-            return new NineSliceMetrics(7, 5, 3, 3, 0, 0, true, true, false);
+    static final AquaPainter<JRSUIState> trackPainter = AquaPainter.create(JRSUIStateFactory.getSliderTrack(), state -> {
+        if (state.is(Orientation.VERTICAL)) {
+            return new NineSliceMetrics(5, 7, 0, 0, 3, 3, true, false, true);
         }
+        return new NineSliceMetrics(7, 5, 3, 3, 0, 0, true, true, false);
     });
     final AquaPainter<JRSUIState> thumbPainter = AquaPainter.create(JRSUIStateFactory.getSliderThumb());
 

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneContrastUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneContrastUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneContrastUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneContrastUI.java
@@ -82,10 +82,10 @@ public class AquaTabbedPaneContrastUI extends AquaTabbedPaneUI {
             return UIManager.getColor("TabbedPane.selectedTabTitlePressedColor");
         } else if (!enabled) {
             return UIManager.getColor("TabbedPane.selectedTabTitleDisabledColor");
-        } else if (!JRSUIUtils.isMacOSXBigSurOrAbove() && !isFrameActive) {
-            return UIManager.getColor("TabbedPane.selectedTabTitleNonFocusColor");
-        } else {
+        } else if (JRSUIUtils.isBigSurOrAbove || isFrameActive) {
             return UIManager.getColor("TabbedPane.selectedTabTitleNormalColor");
+        } else {
+            return UIManager.getColor("TabbedPane.selectedTabTitleNonFocusColor");
         }
     }
 

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneUI.java
@@ -531,7 +531,7 @@ public class AquaTabbedPaneUI extends AquaTabbedPaneCopyFromBasicUI {
     protected State getState(final int index, final boolean frameActive, final boolean isSelected) {
         if (!frameActive) return State.INACTIVE;
         if (!tabPane.isEnabled()) return State.DISABLED;
-        if (JRSUIUtils.TabbedPane.useLegacyTabs()) {
+        if (JRSUIUtils.isLeopard) {
             if (isSelected) return State.PRESSED;
             if (pressedTab == index) return State.INACTIVE;
         } else {

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTreeUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTreeUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTreeUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTreeUI.java
@@ -241,7 +241,7 @@ public class AquaTreeUI extends BasicTreeUI {
         if (!fIsInBounds && state == State.PRESSED) state = State.ACTIVE;
 
         painter.state.set(state);
-        if (JRSUIUtils.Tree.useLegacyTreeKnobs()) {
+        if (JRSUIUtils.isLeopard) {
             if (fAnimationFrame == -1) {
                 painter.state.set(isExpanded ? Direction.DOWN : Direction.RIGHT);
             } else {

--- a/src/java.desktop/macosx/native/libosxui/JRSUIController.m
+++ b/src/java.desktop/macosx/native/libosxui/JRSUIController.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/native/libosxui/JRSUIController.m
+++ b/src/java.desktop/macosx/native/libosxui/JRSUIController.m
@@ -252,11 +252,11 @@ JNIEXPORT jint JNICALL Java_apple_laf_JRSUIControl_getNativeHitPart
 }
 
 /*
- * Class:     apple_laf_JRSUIUtils_ScrollBar
+ * Class:     apple_laf_JRSUIUtils
  * Method:    shouldUseScrollToClick
  * Signature: ()Z
  */
-JNIEXPORT jboolean JNICALL Java_apple_laf_JRSUIUtils_00024ScrollBar_shouldUseScrollToClick
+JNIEXPORT jboolean JNICALL Java_apple_laf_JRSUIUtils_shouldUseScrollToClick
 (JNIEnv *env, jclass clazz)
 {
     return JRSUIControlShouldScrollToClick();


### PR DESCRIPTION
`JRSUIUtils.java` structurally does things weirdly. The utility class mostly passes parameters from functions to other functions. The indirection makes things harder to understand the eventual purpose.

Take `AquaInternalFrameBorderMetrics.java`. It has a `static boolean` that caches a call to `shouldUseLegacyBorderMetrics()`, which returns `isSnowLeopardOrBelow`, itself a cached call to `isMacOSXSnowLeopardOrBelow()`, which is what finally calls `currentMacOSXVersionMatchesGivenVersionRange()`. When looking at the code, it takes time to unravel the path it takes. Instead of that, a `public static final boolean` can expose the cached value and, in doing so, exposes the *meaning* behind the check.

In `AquaLookAndFeel.java`, the value of `TabbedPaneUI` is calculated using `JRSUIUtils.TabbedPane.shouldUseTabbedPaneContrastUI()`, but that could mean any reason for why `"AquaTabbedPaneContrastUI"` may be the value as opposed to `"AquaTabbedPaneUI"`. Replacing it with `JRSUIUtils.isSnowLeopardOrBelow` reveals that it actually has to do with the OS version being, well, Snow Leopard or below.

These change makes understanding the code easier and quicker. Also more optimized.

Changes:
* add JRSUIConstants.ScrollBarPart.ordinal() to return the property's ordinal value, which is not public
* change 3 access modifiers in JRSUIControl to public allowing for access outside the package
* JRSUIConstants.NineSliceMetricsProvider changed to a normal Function<>
* cache `isMacOSXBigSurOrAbove` rather than calling it twice
* inline the functions for clarity
* change static initialization to group all version checks together
* document JRSUIUtils

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298352](https://bugs.openjdk.org/browse/JDK-8298352): apple.laf.JRSUIUtils class creates many indirections


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10326/head:pull/10326` \
`$ git checkout pull/10326`

Update a local copy of the PR: \
`$ git checkout pull/10326` \
`$ git pull https://git.openjdk.org/jdk pull/10326/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10326`

View PR using the GUI difftool: \
`$ git pr show -t 10326`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10326.diff">https://git.openjdk.org/jdk/pull/10326.diff</a>

</details>
