### PR TITLE
JDK-8293978: Duplicate simple loop back-edge will crash the vm

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -3920,7 +3920,8 @@ bool PhaseIdealLoop::duplicate_loop_backedge(IdealLoopTree *loop, Node_List &old
     }
 
     // With an extra phi for the candidate iv?
-    if (!incr->is_Phi()) {
+    // Or the region node is the loop head
+    if (!incr->is_Phi() || incr->in(0) == head) {
       return false;
     }
 
@@ -3969,7 +3970,7 @@ bool PhaseIdealLoop::duplicate_loop_backedge(IdealLoopTree *loop, Node_List &old
     exit_test = back_control->in(0)->as_If();
   }
 
-  if (idom(region)->is_Catch() || region == head) {
+  if (idom(region)->is_Catch()) {
     return false;
   }
 

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -3969,7 +3969,7 @@ bool PhaseIdealLoop::duplicate_loop_backedge(IdealLoopTree *loop, Node_List &old
     exit_test = back_control->in(0)->as_If();
   }
 
-  if (idom(region)->is_Catch()) {
+  if (idom(region)->is_Catch() || region == head) {
     return false;
   }
 

--- a/test/hotspot/jtreg/compiler/c2/TestDuplicateSimpleLoopBackedge.java
+++ b/test/hotspot/jtreg/compiler/c2/TestDuplicateSimpleLoopBackedge.java
@@ -1,0 +1,75 @@
+/*
+  * Copyright (c) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+  *
+  * This code is free software; you can redistribute it and/or modify it
+  * under the terms of the GNU General Public License version 2 only, as
+  * published by the Free Software Foundation.
+  *
+  * This code is distributed in the hope that it will be useful, but WITHOUT
+  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+  * version 2 for more details (a copy is included in the LICENSE file that
+  * accompanied this code).
+  *
+  * You should have received a copy of the GNU General Public License version
+  * 2 along with this work; if not, write to the Free Software Foundation,
+  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+  *
+  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+  * or visit www.oracle.com if you need additional information or have any
+  * questions.
+  */
+
+ /**
+  * @test
+  * @bug 8293978
+  * @library /test/lib
+  * @summary Crash in PhaseIdealLoop::verify_strip_mined_scheduling
+  *
+  * @run main TestDuplicateSimpleLoopBackedge
+  *
+  */
+
+import jdk.test.lib.Utils;
+
+class Foo {
+    static void c(Byte[] a, Byte d) {
+        for (int e = 0; e < a.length; e++)
+            a[e] = 0;
+    }
+}
+
+public class TestDuplicateSimpleLoopBackedge {
+    int f(int g) {
+        Byte h[] = new Byte[500];
+        Foo.c(h, (byte)4);
+        short i = 7;
+        while (i != 1)
+            i = (short)(i - 3);
+        return 0;
+    }
+
+    void j(String[] k) {
+        try {
+            int l = 5;
+            if (l < f(l));
+        } catch (Exception m) {
+        }
+    }
+
+    public static void main(String[] args) throws Exception{
+        Thread thread = new Thread() {
+                public void run() {
+                    TestDuplicateSimpleLoopBackedge n = new TestDuplicateSimpleLoopBackedge();
+                    for (int i = 0; i < 10000; ++i) {
+                        n.j(args);
+                    }
+                }
+            };
+        // Give thread some time to trigger compilation
+        thread.setDaemon(true);
+        thread.start();
+        Thread.sleep(Utils.adjustTimeout(4000));
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/TestDuplicateSimpleLoopBackedge.java
+++ b/test/hotspot/jtreg/compiler/c2/TestDuplicateSimpleLoopBackedge.java
@@ -27,49 +27,37 @@
   * @library /test/lib
   * @summary Crash in PhaseIdealLoop::verify_strip_mined_scheduling
   *
-  * @run main TestDuplicateSimpleLoopBackedge
+  * @run main/othervm -Xbatch TestDuplicateSimpleLoopBackedge
   *
   */
 
-import jdk.test.lib.Utils;
-
-class Foo {
-    static void c(Byte[] a, Byte d) {
+public class TestDuplicateSimpleLoopBackedge {
+    static void zero(Byte[] a) {
         for (int e = 0; e < a.length; e++)
             a[e] = 0;
     }
-}
 
-public class TestDuplicateSimpleLoopBackedge {
-    int f(int g) {
+    int foo(int g) {
         Byte h[] = new Byte[500];
-        Foo.c(h, (byte)4);
+        zero(h);
         short i = 7;
         while (i != 1)
             i = (short)(i - 3);
         return 0;
     }
 
-    void j(String[] k) {
+    void bar(String[] k) {
         try {
             int l = 5;
-            if (l < f(l));
+            if (l < foo(l));
         } catch (Exception m) {
         }
     }
 
-    public static void main(String[] args) throws Exception{
-        Thread thread = new Thread() {
-                public void run() {
-                    TestDuplicateSimpleLoopBackedge n = new TestDuplicateSimpleLoopBackedge();
-                    for (int i = 0; i < 10000; ++i) {
-                        n.j(args);
-                    }
-                }
-            };
-        // Give thread some time to trigger compilation
-        thread.setDaemon(true);
-        thread.start();
-        Thread.sleep(Utils.adjustTimeout(4000));
+    public static void main(String[] args) {
+        TestDuplicateSimpleLoopBackedge n = new TestDuplicateSimpleLoopBackedge();
+        for (int i = 0; i < 10000; ++i) {
+            n.bar(args);
+        }
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/TestDuplicateSimpleLoopBackedge.java
+++ b/test/hotspot/jtreg/compiler/c2/TestDuplicateSimpleLoopBackedge.java
@@ -24,7 +24,6 @@
  /**
   * @test
   * @bug 8293978
-  * @library /test/lib
   * @summary Crash in PhaseIdealLoop::verify_strip_mined_scheduling
   *
   * @run main/othervm -Xbatch TestDuplicateSimpleLoopBackedge
@@ -33,23 +32,26 @@
 
 public class TestDuplicateSimpleLoopBackedge {
     static void zero(Byte[] a) {
-        for (int e = 0; e < a.length; e++)
+        for (int e = 0; e < a.length; e++) {
             a[e] = 0;
+        }
     }
 
     int foo(int g) {
         Byte h[] = new Byte[500];
         zero(h);
         short i = 7;
-        while (i != 1)
+        while (i != 1) {
             i = (short)(i - 3);
+        }
         return 0;
     }
 
     void bar(String[] k) {
         try {
             int l = 5;
-            if (l < foo(l));
+            if (l < foo(l)) {
+            }
         } catch (Exception m) {
         }
     }


### PR DESCRIPTION
Duplicate back-edge of the following simple loop will make jvm crash.

<img width="458" alt="image" src="https://user-images.githubusercontent.com/25214855/190945327-ebce5342-bede-4fad-b940-088753034fa6.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293978](https://bugs.openjdk.org/browse/JDK-8293978): Duplicate simple loop back-edge will crash the vm


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**) ⚠️ Review applies to [474bbeba](https://git.openjdk.org/jdk/pull/10329/files/474bbeba4b7f005c79f8ede0bcc03838b0dd38a7)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [b9f86cde](https://git.openjdk.org/jdk/pull/10329/files/b9f86cde8aa0f4e39edbcd34858a59b7c3cb956e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10329/head:pull/10329` \
`$ git checkout pull/10329`

Update a local copy of the PR: \
`$ git checkout pull/10329` \
`$ git pull https://git.openjdk.org/jdk pull/10329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10329`

View PR using the GUI difftool: \
`$ git pr show -t 10329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10329.diff">https://git.openjdk.org/jdk/pull/10329.diff</a>

</details>
