### PR TITLE
8293984: Unnecessary Vector usage in PropertyEditorSupport

### DIFF
--- a/src/java.desktop/share/classes/java/beans/PropertyEditorSupport.java
+++ b/src/java.desktop/share/classes/java/beans/PropertyEditorSupport.java
@@ -285,7 +285,7 @@ public class PropertyEditorSupport implements PropertyEditor {
             if (listeners == null) {
                 return;
             }
-            targets = unsafeClone(listeners);
+            targets = new ArrayList<>(listeners);
         }
         // Tell our listeners that "everything" has changed.
         PropertyChangeEvent evt = new PropertyChangeEvent(source, null, null, null);
@@ -294,11 +294,6 @@ public class PropertyEditorSupport implements PropertyEditor {
             PropertyChangeListener target = targets.get(i);
             target.propertyChange(evt);
         }
-    }
-
-    @SuppressWarnings("unchecked")
-    private <T> ArrayList<T> unsafeClone(ArrayList<T> v) {
-        return (ArrayList<T>)v.clone();
     }
 
     //----------------------------------------------------------------------

--- a/src/java.desktop/share/classes/java/beans/PropertyEditorSupport.java
+++ b/src/java.desktop/share/classes/java/beans/PropertyEditorSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 
 package java.beans;
 
-import java.beans.*;
+import java.util.ArrayList;
 
 /**
  * This is a support class to help build property editors.
@@ -253,9 +253,9 @@ public class PropertyEditorSupport implements PropertyEditor {
     public synchronized void addPropertyChangeListener(
                                 PropertyChangeListener listener) {
         if (listeners == null) {
-            listeners = new java.util.Vector<>();
+            listeners = new ArrayList<>();
         }
-        listeners.addElement(listener);
+        listeners.add(listener);
     }
 
     /**
@@ -273,14 +273,14 @@ public class PropertyEditorSupport implements PropertyEditor {
         if (listeners == null) {
             return;
         }
-        listeners.removeElement(listener);
+        listeners.remove(listener);
     }
 
     /**
      * Report that we have been modified to any interested listeners.
      */
     public void firePropertyChange() {
-        java.util.Vector<PropertyChangeListener> targets;
+        ArrayList<PropertyChangeListener> targets;
         synchronized (this) {
             if (listeners == null) {
                 return;
@@ -291,19 +291,19 @@ public class PropertyEditorSupport implements PropertyEditor {
         PropertyChangeEvent evt = new PropertyChangeEvent(source, null, null, null);
 
         for (int i = 0; i < targets.size(); i++) {
-            PropertyChangeListener target = targets.elementAt(i);
+            PropertyChangeListener target = targets.get(i);
             target.propertyChange(evt);
         }
     }
 
     @SuppressWarnings("unchecked")
-    private <T> java.util.Vector<T> unsafeClone(java.util.Vector<T> v) {
-        return (java.util.Vector<T>)v.clone();
+    private <T> ArrayList<T> unsafeClone(ArrayList<T> v) {
+        return (ArrayList<T>)v.clone();
     }
 
     //----------------------------------------------------------------------
 
     private Object value;
     private Object source;
-    private java.util.Vector<PropertyChangeListener> listeners;
+    private ArrayList<PropertyChangeListener> listeners;
 }


### PR DESCRIPTION
Field PropertyEditorSupport.listeners is accessed only under `synchronized(this)`.
It means extra synchronization by Vector is not needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293984](https://bugs.openjdk.org/browse/JDK-8293984): Unnecessary Vector usage in PropertyEditorSupport


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10331/head:pull/10331` \
`$ git checkout pull/10331`

Update a local copy of the PR: \
`$ git checkout pull/10331` \
`$ git pull https://git.openjdk.org/jdk pull/10331/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10331`

View PR using the GUI difftool: \
`$ git pr show -t 10331`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10331.diff">https://git.openjdk.org/jdk/pull/10331.diff</a>

</details>
