### PR TITLE
JDK-8293995: Problem list sun/tools/jstatd/TestJstatdRmiPort.java on all platforms because of 8293577

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -720,7 +720,7 @@ sun/util/locale/provider/CalendarDataRegression.java            8268379 macosx-x
 sun/tools/jhsdb/BasicLauncherTest.java                          8228649 linux-ppc64,linux-ppc64le
 
 sun/tools/jstatd/TestJstatdDefaults.java                        8081569,8226420 windows-all
-sun/tools/jstatd/TestJstatdRmiPort.java                         8226420,8251259 windows-all
+sun/tools/jstatd/TestJstatdRmiPort.java                         8226420,8251259,8293577 generic-all
 sun/tools/jstatd/TestJstatdServer.java                          8081569,8226420 windows-all
 
 sun/tools/jstat/jstatLineCounts1.sh                             8268211 linux-aarch64


### PR DESCRIPTION
We see sporadic failures of sun/tools/jstatd/TestJstatdRmiPort.java on other platforms than Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293995](https://bugs.openjdk.org/browse/JDK-8293995): Problem list sun/tools/jstatd/TestJstatdRmiPort.java on all platforms because of 8293577


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10334/head:pull/10334` \
`$ git checkout pull/10334`

Update a local copy of the PR: \
`$ git checkout pull/10334` \
`$ git pull https://git.openjdk.org/jdk pull/10334/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10334`

View PR using the GUI difftool: \
`$ git pr show -t 10334`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10334.diff">https://git.openjdk.org/jdk/pull/10334.diff</a>

</details>
