### PR TITLE
JDK-8293997: Unify os::current_thread_cpu_time_info and os::thread_cpu_time_info

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -2691,20 +2691,6 @@ jlong os::thread_cpu_time(Thread *thread, bool user_sys_cpu_time) {
   return user_sys_cpu_time ? sys_time + user_time : user_time;
 }
 
-void os::current_thread_cpu_time_info(jvmtiTimerInfo *info_ptr) {
-  info_ptr->max_value = ALL_64_BITS;       // will not wrap in less than 64 bits
-  info_ptr->may_skip_backward = false;     // elapsed time not wall time
-  info_ptr->may_skip_forward = false;      // elapsed time not wall time
-  info_ptr->kind = JVMTI_TIMER_TOTAL_CPU;  // user+system time is returned
-}
-
-void os::thread_cpu_time_info(jvmtiTimerInfo *info_ptr) {
-  info_ptr->max_value = ALL_64_BITS;       // will not wrap in less than 64 bits
-  info_ptr->may_skip_backward = false;     // elapsed time not wall time
-  info_ptr->may_skip_forward = false;      // elapsed time not wall time
-  info_ptr->kind = JVMTI_TIMER_TOTAL_CPU;  // user+system time is returned
-}
-
 bool os::is_thread_cpu_time_supported() {
   return true;
 }

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2354,21 +2354,6 @@ jlong os::thread_cpu_time(Thread *thread, bool user_sys_cpu_time) {
 #endif
 }
 
-
-void os::current_thread_cpu_time_info(jvmtiTimerInfo *info_ptr) {
-  info_ptr->max_value = ALL_64_BITS;       // will not wrap in less than 64 bits
-  info_ptr->may_skip_backward = false;     // elapsed time not wall time
-  info_ptr->may_skip_forward = false;      // elapsed time not wall time
-  info_ptr->kind = JVMTI_TIMER_TOTAL_CPU;  // user+system time is returned
-}
-
-void os::thread_cpu_time_info(jvmtiTimerInfo *info_ptr) {
-  info_ptr->max_value = ALL_64_BITS;       // will not wrap in less than 64 bits
-  info_ptr->may_skip_backward = false;     // elapsed time not wall time
-  info_ptr->may_skip_forward = false;      // elapsed time not wall time
-  info_ptr->kind = JVMTI_TIMER_TOTAL_CPU;  // user+system time is returned
-}
-
 bool os::is_thread_cpu_time_supported() {
 #ifdef __APPLE__
   return true;

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -132,9 +132,6 @@
 
 #define MAX_SECS 100000000
 
-// for timer info max values which include all bits
-#define ALL_64_BITS CONST64(0xFFFFFFFFFFFFFFFF)
-
 #ifdef MUSL_LIBC
 // dlvsym is not a part of POSIX
 // and musl libc doesn't implement it.
@@ -5121,20 +5118,6 @@ static jlong slow_thread_cpu_time(Thread *thread, bool user_sys_cpu_time) {
   } else {
     return (jlong)user_time * (1000000000 / clock_tics_per_sec);
   }
-}
-
-void os::current_thread_cpu_time_info(jvmtiTimerInfo *info_ptr) {
-  info_ptr->max_value = ALL_64_BITS;       // will not wrap in less than 64 bits
-  info_ptr->may_skip_backward = false;     // elapsed time not wall time
-  info_ptr->may_skip_forward = false;      // elapsed time not wall time
-  info_ptr->kind = JVMTI_TIMER_TOTAL_CPU;  // user+system time is returned
-}
-
-void os::thread_cpu_time_info(jvmtiTimerInfo *info_ptr) {
-  info_ptr->max_value = ALL_64_BITS;       // will not wrap in less than 64 bits
-  info_ptr->may_skip_backward = false;     // elapsed time not wall time
-  info_ptr->may_skip_forward = false;      // elapsed time not wall time
-  info_ptr->kind = JVMTI_TIMER_TOTAL_CPU;  // user+system time is returned
 }
 
 bool os::is_thread_cpu_time_supported() {

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -887,6 +887,23 @@ void os::naked_short_sleep(jlong ms) {
   return;
 }
 
+// for timer info max values which include all bits
+#define ALL_64_BITS CONST64(0xFFFFFFFFFFFFFFFF)
+
+void os::current_thread_cpu_time_info(jvmtiTimerInfo *info_ptr) {
+  info_ptr->max_value = ALL_64_BITS;       // will not wrap in less than 64 bits
+  info_ptr->may_skip_backward = false;     // elapsed time not wall time
+  info_ptr->may_skip_forward = false;      // elapsed time not wall time
+  info_ptr->kind = JVMTI_TIMER_TOTAL_CPU;  // user+system time is returned
+}
+
+void os::thread_cpu_time_info(jvmtiTimerInfo *info_ptr) {
+  info_ptr->max_value = ALL_64_BITS;       // will not wrap in less than 64 bits
+  info_ptr->may_skip_backward = false;     // elapsed time not wall time
+  info_ptr->may_skip_forward = false;      // elapsed time not wall time
+  info_ptr->kind = JVMTI_TIMER_TOTAL_CPU;  // user+system time is returned
+}
+
 char* os::Posix::describe_pthread_attr(char* buf, size_t buflen, const pthread_attr_t* attr) {
   size_t stack_size = 0;
   size_t guard_size = 0;


### PR DESCRIPTION
The 2 methods os::current_thread_cpu_time_info and os::thread_cpu_time_info could be unified across the posix platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293997](https://bugs.openjdk.org/browse/JDK-8293997): Unify os::current_thread_cpu_time_info and  os::thread_cpu_time_info


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10335/head:pull/10335` \
`$ git checkout pull/10335`

Update a local copy of the PR: \
`$ git checkout pull/10335` \
`$ git pull https://git.openjdk.org/jdk pull/10335/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10335`

View PR using the GUI difftool: \
`$ git pr show -t 10335`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10335.diff">https://git.openjdk.org/jdk/pull/10335.diff</a>

</details>
