### PR TITLE
8294000: Filler array klass should be in jdk/vm/internal, not in java/vm/internal

### DIFF
--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -328,7 +328,7 @@ void Universe::genesis(TRAPS) {
         // Initialization of the fillerArrayKlass must come before regular
         // int-TypeArrayKlass so that the int-Array mirror points to the
         // int-TypeArrayKlass.
-        _fillerArrayKlassObj = TypeArrayKlass::create_klass(T_INT, "jdk/internal/vm/FillerArray", CHECK);
+        _fillerArrayKlassObj = TypeArrayKlass::create_klass(T_INT, "Ljdk/internal/vm/FillerArray;", CHECK);
         for (int i = T_BOOLEAN; i < T_LONG+1; i++) {
           _typeArrayKlassObjs[i] = TypeArrayKlass::create_klass((BasicType)i, CHECK);
         }

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -328,7 +328,7 @@ void Universe::genesis(TRAPS) {
         // Initialization of the fillerArrayKlass must come before regular
         // int-TypeArrayKlass so that the int-Array mirror points to the
         // int-TypeArrayKlass.
-        _fillerArrayKlassObj = TypeArrayKlass::create_klass(T_INT, "Ljava/internal/vm/FillerArray;", CHECK);
+        _fillerArrayKlassObj = TypeArrayKlass::create_klass(T_INT, "jdk/internal/vm/FillerArray", CHECK);
         for (int i = T_BOOLEAN; i < T_LONG+1; i++) {
           _typeArrayKlassObjs[i] = TypeArrayKlass::create_klass((BasicType)i, CHECK);
         }


### PR DESCRIPTION
Hi all,

  can I have reviews for the move of the internal filler array klass from `java/vm/internal/` to `jdk/vm/internal` - I noticed that typo in some recent `jmap` dump. All internal klasses are in the `jdk.` package... idk how this slipped through the original change.

With this change it shows up as
`   2:           428       13291728  jdk.internal.vm.FillerArray (java.base@20-internal)`
which I believe is best.

Testing: local compilation, checking `jmap` output for instances of this klass directly, the `gc/TestFillerObjectInstantiation.java` jtreg test

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294000](https://bugs.openjdk.org/browse/JDK-8294000): Filler array klass should be in jdk/vm/internal, not in java/vm/internal


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10336/head:pull/10336` \
`$ git checkout pull/10336`

Update a local copy of the PR: \
`$ git checkout pull/10336` \
`$ git pull https://git.openjdk.org/jdk pull/10336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10336`

View PR using the GUI difftool: \
`$ git pr show -t 10336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10336.diff">https://git.openjdk.org/jdk/pull/10336.diff</a>

</details>
