### PR TITLE
8293989: [JVMCI] re-use cleared oop handles

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -2208,11 +2208,9 @@ C2V_VMENTRY_0(jint, arrayIndexScale, (JNIEnv* env, jobject, jchar type_char))
   return type2aelembytes(type);
 C2V_END
 
-C2V_VMENTRY(void, deleteGlobalHandle, (JNIEnv* env, jobject, jlong handle))
-  if (handle != 0) {
-    JVMCIENV->runtime()->destroy_oop_handle(handle);
-  }
-}
+C2V_VMENTRY(void, releaseClearedOopHandles, (JNIEnv* env, jobject))
+  JVMCIENV->runtime()->release_cleared_oop_handles();
+C2V_END
 
 static void requireJVMCINativeLibrary(JVMCI_TRAPS) {
   if (!UseJVMCINativeLibrary) {
@@ -2903,7 +2901,7 @@ JNINativeMethod CompilerToVM::methods[] = {
   {CC "readArrayElement",                             CC "(" OBJECTCONSTANT "I)Ljava/lang/Object;",                                         FN_PTR(readArrayElement)},
   {CC "arrayBaseOffset",                              CC "(C)I",                                                                            FN_PTR(arrayBaseOffset)},
   {CC "arrayIndexScale",                              CC "(C)I",                                                                            FN_PTR(arrayIndexScale)},
-  {CC "deleteGlobalHandle",                           CC "(J)V",                                                                            FN_PTR(deleteGlobalHandle)},
+  {CC "releaseClearedOopHandles",                     CC "()V",                                                                             FN_PTR(releaseClearedOopHandles)},
   {CC "registerNativeMethods",                        CC "(" CLASS ")[J",                                                                   FN_PTR(registerNativeMethods)},
   {CC "isCurrentThreadAttached",                      CC "()Z",                                                                             FN_PTR(isCurrentThreadAttached)},
   {CC "getCurrentJavaThread",                         CC "()J",                                                                             FN_PTR(getCurrentJavaThread)},

--- a/src/hotspot/share/jvmci/jvmciRuntime.hpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.hpp
@@ -223,14 +223,9 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
   // JVMCI_lock must be held by current thread
   static JVMCIRuntime* select_runtime_in_shutdown(JavaThread* thread);
 
-  // Helpers for destroy_oop_handle
-  int _last_found_oop_handle_index;
-  bool probe_oop_handle(jlong handle, int index);
-  int find_oop_handle(jlong handle);
-
   // Releases all the non-null entries in _oop_handles and then clears
-  // the list. Returns the number of non-null entries prior to clearing.
-  int release_and_clear_globals();
+  // the list. Returns the number released handles.
+  int release_and_clear_oop_handles();
 
  public:
   JVMCIRuntime(JVMCIRuntime* next, int id, bool for_compile_broker);
@@ -277,10 +272,12 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
   // used when creating an IndirectHotSpotObjectConstantImpl in the
   // shared library JavaVM.
   jlong make_oop_handle(const Handle& obj);
-  bool is_oop_handle(jlong handle);
 
-  // Called from IndirectHotSpotObjectConstantImpl.clear(Object)
-  void destroy_oop_handle(jlong handle);
+  // Releases all the non-null entries in _oop_handles whose referent is null.
+  // Returns the number of handles released by this call.
+  // The method also resets _last_found_oop_handle_index to -1
+  // and _null_oop_handles to 0.
+  int release_cleared_oop_handles();
 
   // Allocation and management of metadata handles.
   jmetadata allocate_handle(const methodHandle& handle);

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/Cleaner.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/Cleaner.java
@@ -97,18 +97,28 @@ abstract class Cleaner extends WeakReference<Object> {
 
     /**
      * Performs the cleanup action now that this object's referent has become weakly reachable.
+     *
+     * @returns true if the clean up action cleared the referent of an oop handle and requires a
+     *          subsequent call to {@link CompilerToVM#releaseClearedOopHandles()} to reclaim the
+     *          resources of the handle itself
      */
-    abstract void doCleanup();
+    abstract boolean doCleanup();
 
     /**
      * Remove the cleaners whose referents have become weakly reachable.
      */
     static void clean() {
         Cleaner c = (Cleaner) queue.poll();
+        boolean oopHandleCleared = false;
         while (c != null) {
             remove(c);
-            c.doCleanup();
+            if (c.doCleanup()) {
+                oopHandleCleared = true;
+            }
             c = (Cleaner) queue.poll();
+        }
+        if (oopHandleCleared) {
+            CompilerToVM.compilerToVM().releaseClearedOopHandles();
         }
     }
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -1175,10 +1175,9 @@ final class CompilerToVM {
     native boolean isTrustedForIntrinsics(HotSpotResolvedObjectTypeImpl klass, long klassPointer);
 
     /**
-     * Releases the resources backing the global JNI {@code handle}. This is equivalent to the
-     * {@code DeleteGlobalRef} JNI function.
+     * Releases all oop handles whose referent is null.
      */
-    native void deleteGlobalHandle(long handle);
+    native void releaseClearedOopHandles();
 
     /**
      * Gets the failed speculations pointed to by {@code *failedSpeculationsAddress}.

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HandleCleaner.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HandleCleaner.java
@@ -57,18 +57,17 @@ final class HandleCleaner extends Cleaner {
      * Releases the resource associated with {@code this.handle}.
      */
     @Override
-    void doCleanup() {
+    boolean doCleanup() {
         if (isJObject) {
-            // The sentinel value used to denote a free handle is
-            // an object on the HotSpot heap so we call into the
-            // VM to set the target of an object handle to this value.
-            CompilerToVM.compilerToVM().deleteGlobalHandle(handle);
+            IndirectHotSpotObjectConstantImpl.clearHandle(handle);
+            return true;
         } else {
             // Setting the target of a jmetadata handle to 0 enables
             // the handle to be reused. See MetadataHandles in
             // metadataHandles.hpp for more info.
             long value = UNSAFE.getLong(null, handle);
             UNSAFE.compareAndSetLong(null, handle, value, 0);
+            return false;
         }
     }
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotObjectConstantScope.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotObjectConstantScope.java
@@ -115,6 +115,7 @@ public final class HotSpotObjectConstantScope implements AutoCloseable {
                 obj.clear(localScopeDescription);
             }
             foreignObjects = null;
+            CompilerToVM.compilerToVM().releaseClearedOopHandles();
         }
         CURRENT.set(parent);
     }

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotSpeculationLog.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotSpeculationLog.java
@@ -354,12 +354,13 @@ public class HotSpotSpeculationLog implements SpeculationLog {
         }
 
         @Override
-        void doCleanup() {
+        boolean doCleanup() {
             long pointer = UnsafeAccess.UNSAFE.getAddress(address);
             if (pointer != 0) {
                 compilerToVM().releaseFailedSpeculations(address);
             }
             UnsafeAccess.UNSAFE.freeMemory(address);
+            return false;
         }
 
         final long address;

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/IndirectHotSpotObjectConstantImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/IndirectHotSpotObjectConstantImpl.java
@@ -23,6 +23,7 @@
 package jdk.vm.ci.hotspot;
 
 import static jdk.vm.ci.hotspot.HotSpotJVMCIRuntime.runtime;
+import static jdk.vm.ci.hotspot.UnsafeAccess.UNSAFE;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -144,11 +145,20 @@ final class IndirectHotSpotObjectConstantImpl extends HotSpotObjectConstantImpl 
      */
     void clear(Object scopeDescription) {
         checkHandle();
-        CompilerToVM.compilerToVM().deleteGlobalHandle(objectHandle);
         if (rawAudit == null) {
             rawAudit = scopeDescription;
         }
+
+        clearHandle(objectHandle);
         objectHandle = 0L;
+    }
+
+    /**
+     * Sets the referent of {@code handle} to 0 so that it will be reclaimed when calling
+     * {@link CompilerToVM#releaseClearedOopHandles}.
+     */
+    static void clearHandle(long handle) {
+        UNSAFE.putLong(handle, 0);
     }
 
     @Override


### PR DESCRIPTION
It's possible for a libgraal isolate to live long enough that `JVMCIRuntime::__oop_handles` grows so much that it overflows when trying to expand. This results in a VM crash something like:
```
# There is insufficient memory for the Java Runtime Environment to continue.
# Native memory allocation (malloc) failed to allocate 18446744056529682432 bytes for AllocateHeap

...

V [libjvm.so+0xe1f441] VMError::report_and_die(int, char const*, char const*, __va_list_tag*, Thread*, unsigned char*, void*, void*, char const*, int, unsigned long)+0x1a1
V [libjvm.so+0xe2006d] VMError::report_and_die(Thread*, char const*, int, unsigned long, VMErrorType, char const*, __va_list_tag*)+0x2d
V [libjvm.so+0x5d8ed3] report_vm_out_of_memory(char const*, int, unsigned long, VMErrorType, char const*, ...)+0xc3
V [libjvm.so+0x39f7c2] AllocateHeap(unsigned long, MEMFLAGS, AllocFailStrategy::AllocFailEnum)+0x92
V [libjvm.so+0x8303f2] GrowableArrayWithAllocator<_jobject*, GrowableArray<_jobject*> >::grow(int)+0x112
V [libjvm.so+0x995385] JVMCIRuntime::make_global(Handle const&)+0x105
```

The solution implemented in this PR is to clear and re-use entries in `JVMCIRuntime::__oop_handles`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293989](https://bugs.openjdk.org/browse/JDK-8293989): [JVMCI] re-use cleared oop handles


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10337/head:pull/10337` \
`$ git checkout pull/10337`

Update a local copy of the PR: \
`$ git checkout pull/10337` \
`$ git pull https://git.openjdk.org/jdk pull/10337/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10337`

View PR using the GUI difftool: \
`$ git pr show -t 10337`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10337.diff">https://git.openjdk.org/jdk/pull/10337.diff</a>

</details>
