### PR TITLE
I think it maybe a problem. But now I think I'm wrong, it's a feature, I think too little

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/DelayQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/DelayQueue.java
@@ -268,7 +268,7 @@ public class DelayQueue<E extends Delayed> extends AbstractQueue<E>
                     if (delay <= 0L)
                         return q.poll();
                     if (nanos <= 0L)
-                        return null;
+                        return q.poll();
                     first = null; // don't retain ref while waiting
                     if (nanos < delay || leader != null)
                         nanos = available.awaitNanos(nanos);


### PR DESCRIPTION
The value of parameter (timeout) will compare to the value of delay. If the value of timeout less than the value of delay may cause the problem. When you enter a method (available.awaitNanos(nanos)), the method may update the nanos (timeout is already assigned to nanos) after LockSupport.parknanos(). The value of nanos may become nagative. Now delay is positive, but nanos is nagative. As a result, the method return null and the queue still has items. I think it maybe a bug. If you would accept my advice, it is my pleasure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10338/head:pull/10338` \
`$ git checkout pull/10338`

Update a local copy of the PR: \
`$ git checkout pull/10338` \
`$ git pull https://git.openjdk.org/jdk pull/10338/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10338`

View PR using the GUI difftool: \
`$ git pr show -t 10338`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10338.diff">https://git.openjdk.org/jdk/pull/10338.diff</a>

</details>
