### PR TITLE
8293998: [PPC64] JfrGetCallTrace: assert(_pc != nullptr) failed: must have PC

### DIFF
--- a/src/hotspot/os_cpu/aix_ppc/javaThread_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/javaThread_aix_ppc.cpp
@@ -43,7 +43,9 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   if (has_last_Java_frame() && frame_anchor()->walkable()) {
-    *fr_addr = pd_last_frame();
+    frame last_frame = pd_last_frame();
+    if (last_frame.pc() == nullptr) return false;
+    *fr_addr = last_frame;
     return true;
   }
 

--- a/src/hotspot/os_cpu/linux_ppc/javaThread_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/javaThread_linux_ppc.cpp
@@ -42,7 +42,9 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   if (has_last_Java_frame() && frame_anchor()->walkable()) {
-    *fr_addr = pd_last_frame();
+    frame last_frame = pd_last_frame();
+    if (last_frame.pc() == nullptr) return false;
+    *fr_addr = last_frame;
     return true;
   }
 


### PR DESCRIPTION
JfrGetCallTrace can still observe last_Java_pc == 0 (see JBS for more details). We can just skip the sample in this very rare case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293998](https://bugs.openjdk.org/browse/JDK-8293998): [PPC64] JfrGetCallTrace: assert(_pc != nullptr) failed: must have PC


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10339/head:pull/10339` \
`$ git checkout pull/10339`

Update a local copy of the PR: \
`$ git checkout pull/10339` \
`$ git pull https://git.openjdk.org/jdk pull/10339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10339`

View PR using the GUI difftool: \
`$ git pr show -t 10339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10339.diff">https://git.openjdk.org/jdk/pull/10339.diff</a>

</details>
