### PR TITLE
8294003: Don't handle si_addr == 0 && si_code == SI_KERNEL SIGSEGVs

### DIFF
--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -219,15 +219,19 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
   if (info != NULL && uc != NULL && thread != NULL) {
     pc = (address) os::Posix::ucontext_get_pc(uc);
 
+    if (sig == SIGSEGV && info->si_addr == 0 && info->si_code == SI_KERNEL) {
 #ifndef AMD64
     // Halt if SI_KERNEL before more crashes get misdiagnosed as Java bugs
     // This can happen in any running code (currently more frequently in
     // interpreter code but has been seen in compiled code)
-    if (sig == SIGSEGV && info->si_addr == 0 && info->si_code == SI_KERNEL) {
       fatal("An irrecoverable SI_KERNEL SIGSEGV has occurred due "
             "to unstable signal handling in this distribution.");
+#else
+      // An irrecoverable SI_KERNEL SIGSEGV has occurred.
+      // It's likely caused by dereferencing an address larger than TASK_SIZE.
+      return false;
+#endif
     }
-#endif // AMD64
 
     // Handle ALL stack overflow variations here
     if (sig == SIGSEGV) {

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -220,17 +220,9 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
     pc = (address) os::Posix::ucontext_get_pc(uc);
 
     if (sig == SIGSEGV && info->si_addr == 0 && info->si_code == SI_KERNEL) {
-#ifndef AMD64
-    // Halt if SI_KERNEL before more crashes get misdiagnosed as Java bugs
-    // This can happen in any running code (currently more frequently in
-    // interpreter code but has been seen in compiled code)
-      fatal("An irrecoverable SI_KERNEL SIGSEGV has occurred due "
-            "to unstable signal handling in this distribution.");
-#else
       // An irrecoverable SI_KERNEL SIGSEGV has occurred.
       // It's likely caused by dereferencing an address larger than TASK_SIZE.
       return false;
-#endif
     }
 
     // Handle ALL stack overflow variations here


### PR DESCRIPTION
We have this code code in our signal handler:

```
#ifndef AMD64
    // Halt if SI_KERNEL before more crashes get misdiagnosed as Java bugs
    // This can happen in any running code (currently more frequently in
    // interpreter code but has been seen in compiled code)
    if (sig == SIGSEGV && info->si_addr == 0 && info->si_code == SI_KERNEL) {
      fatal("An irrecoverable SI_KERNEL SIGSEGV has occurred due "
            "to unstable signal handling in this distribution.");
    }
#endif // AMD64
```

This bug added that change:
https://bugs.openjdk.java.net/browse/JDK-8004124

In the Generational ZGC we hit the exact same condition whenever we try to (incorrectly) dereference one of our colored pointers. From the bug above:

"A segmentation violation that occurs as a result of userspace process accessing virtual memory above the TASK_SIZE limit will cause a segmentation violation with an si_code of SI_KERNEL"

That is, if we have set high-order bits (past the TASK_SIZE limit), we get these kind of SIGSEGVs.

As the signal handle code is written today, we don't "stop" this signal, and instead try to handle it as an implicit null check. This causes hard-to-debug error messages and crashes in code that incorrectly try to deoptimize the faulty code.

I propose that we short-cut the signal handling code, and let this problematic SIGSEGV get passed to VMError::report_and_die.

We've been running with this patch in the Generational ZGC repository for over a year, without any problems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294003](https://bugs.openjdk.org/browse/JDK-8294003): Don't handle si_addr == 0 && si_code == SI_KERNEL SIGSEGVs


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10340/head:pull/10340` \
`$ git checkout pull/10340`

Update a local copy of the PR: \
`$ git checkout pull/10340` \
`$ git pull https://git.openjdk.org/jdk pull/10340/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10340`

View PR using the GUI difftool: \
`$ git pr show -t 10340`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10340.diff">https://git.openjdk.org/jdk/pull/10340.diff</a>

</details>
