### PR TITLE
8294014: Remove redundant UseCompiler conditions

### DIFF
--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -83,7 +83,7 @@ bool CompilationPolicy::must_be_compiled(const methodHandle& m, int comp_level) 
   if (!can_be_compiled(m, comp_level)) return false;
 
   return !UseInterpreter ||                                              // must compile all methods
-         (UseCompiler && AlwaysCompileLoopMethods && m->has_loops() && CompileBroker::should_compile_new_jobs()); // eagerly compile loop methods
+         (AlwaysCompileLoopMethods && m->has_loops() && CompileBroker::should_compile_new_jobs()); // eagerly compile loop methods
 }
 
 void CompilationPolicy::compile_if_required(const methodHandle& m, TRAPS) {

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -331,8 +331,8 @@ public:
     shutdown_compilation = 2
   };
 
-  static jint get_compilation_activity_mode() { return _should_compile_new_jobs; }
-  static bool should_compile_new_jobs() { return UseCompiler && (_should_compile_new_jobs == run_compilation); }
+  static inline jint get_compilation_activity_mode() { return _should_compile_new_jobs; }
+  static inline bool should_compile_new_jobs() { return UseCompiler && (_should_compile_new_jobs == run_compilation); }
   static bool set_should_compile_new_jobs(jint new_state) {
     // Return success if the current caller set it
     jint old = Atomic::cmpxchg(&_should_compile_new_jobs, 1-new_state, new_state);


### PR DESCRIPTION
Several areas that use CompileBroker::should_compile_new_jobs() also contain a UseCompiler check which isn't needed, since the aforementioned already contains a check for this flag. In some areas (Such as with compileBroker.cpp which has AlwaysCompileLoopMethods) this duplicated check is required, so we can mark should_compile_new_jobs() and the related get_compilation_activity_mode() as inline to make the obvious optimization more obvious to the compiler used in the build (This should be fine, since both are small methods).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294014](https://bugs.openjdk.org/browse/JDK-8294014): Remove redundant UseCompiler conditions


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10342/head:pull/10342` \
`$ git checkout pull/10342`

Update a local copy of the PR: \
`$ git checkout pull/10342` \
`$ git pull https://git.openjdk.org/jdk pull/10342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10342`

View PR using the GUI difftool: \
`$ git pr show -t 10342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10342.diff">https://git.openjdk.org/jdk/pull/10342.diff</a>

</details>
