### PR TITLE
8294012: RISC-V: get/put_native_u8 missing the case when address&7 is 6

### DIFF
--- a/src/hotspot/cpu/riscv/bytes_riscv.hpp
+++ b/src/hotspot/cpu/riscv/bytes_riscv.hpp
@@ -75,6 +75,7 @@ class Bytes: AllStatic {
                ((u8)(((u4*)p)[0]));
 
       case 2:
+      case 6:
         return ((u8)(((u2*)p)[3]) << 48) |
                ((u8)(((u2*)p)[2]) << 32) |
                ((u8)(((u2*)p)[1]) << 16) |
@@ -133,6 +134,7 @@ class Bytes: AllStatic {
         break;
 
       case 2:
+      case 6:
         ((u2*)p)[3] = x >> 48;
         ((u2*)p)[2] = x >> 32;
         ((u2*)p)[1] = x >> 16;


### PR DESCRIPTION
Please review this small fix, making get/put_native_u8 a slightly more efficient on riscv
original code misses the case when address AND 7 is 6, and making such cases to be read/write with a 1 byte move.

Test results on risc-v to follow soon.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294012](https://bugs.openjdk.org/browse/JDK-8294012): RISC-V: get/put_native_u8 missing the case when address&7 is 6


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10344/head:pull/10344` \
`$ git checkout pull/10344`

Update a local copy of the PR: \
`$ git checkout pull/10344` \
`$ git pull https://git.openjdk.org/jdk pull/10344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10344`

View PR using the GUI difftool: \
`$ git pr show -t 10344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10344.diff">https://git.openjdk.org/jdk/pull/10344.diff</a>

</details>
