### PR TITLE
8293567: AbstractSplittableWithBrineGenerator: salt has digits that duplicate the marker

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
@@ -2399,7 +2399,7 @@ public class RandomSupport {
             long multiplier = (1L << SALT_SHIFT) - 1;
             long salt = multiplier << (64 - SALT_SHIFT);
             while ((salt & multiplier) == 0) {
-                long digit = Math.multiplyHigh(bits, multiplier);
+                long digit = Math.unsignedMultiplyHigh(bits, multiplier);
                 salt = (salt >>> SALT_SHIFT) | (digit << (64 - SALT_SHIFT));
                 bits *= multiplier;
             }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293567](https://bugs.openjdk.org/browse/JDK-8293567): AbstractSplittableWithBrineGenerator: salt has digits that duplicate the marker


### Reviewers
 * [Jim Laskey](https://openjdk.org/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10345/head:pull/10345` \
`$ git checkout pull/10345`

Update a local copy of the PR: \
`$ git checkout pull/10345` \
`$ git pull https://git.openjdk.org/jdk pull/10345/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10345`

View PR using the GUI difftool: \
`$ git pr show -t 10345`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10345.diff">https://git.openjdk.org/jdk/pull/10345.diff</a>

</details>
