### PR TITLE
8292756: java.lang.AssertionError at at jdk.compiler/com.sun.tools.javac.code.Scope$ScopeImpl.leave(Scope.java:386)

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Scope.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Scope.java
@@ -272,9 +272,9 @@ public abstract class Scope {
     }
 
     private static class ScopeImpl extends WriteableScope {
-        /** The number of scopes that share this scope's hash table.
+        /** true if this scope's hash table is shared with a nested scope.
          */
-        private int shared;
+        private boolean shared;
 
         /** Next enclosing scope (with whom this scope may share a hashtable)
          */
@@ -339,8 +339,10 @@ public abstract class Scope {
          *  of fresh tables.
          */
         public WriteableScope dup(Symbol newOwner) {
+            Assert.check(!shared);
+
             ScopeImpl result = new ScopeImpl(this, newOwner, this.table, this.nelems);
-            shared++;
+            shared = true;
             // System.out.println("====> duping scope " + this.hashCode() + " owned by " + newOwner + " to " + result.hashCode());
             // new Error().printStackTrace(System.out);
             return result;
@@ -351,7 +353,7 @@ public abstract class Scope {
          *  the table of its outer scope.
          */
         public WriteableScope dupUnshared(Symbol newOwner) {
-            if (shared > 0) {
+            if (shared) {
                 //The nested Scopes might have already added something to the table, so all items
                 //that don't originate in this Scope or any of its outer Scopes need to be cleared:
                 Set<Scope> acceptScopes = Collections.newSetFromMap(new IdentityHashMap<>());
@@ -383,7 +385,7 @@ public abstract class Scope {
          *  with next.
          */
         public WriteableScope leave() {
-            Assert.check(shared == 0);
+            Assert.check(!shared);
             if (table != next.table) return next;
             while (elems != null) {
                 int hash = getIndex(elems.sym.name);
@@ -392,8 +394,8 @@ public abstract class Scope {
                 table[hash] = elems.shadowed;
                 elems = elems.nextSibling;
             }
-            Assert.check(next.shared > 0);
-            next.shared--;
+            Assert.check(next.shared);
+            next.shared = false;
             next.nelems = nelems;
             // System.out.println("====> leaving scope " + this.hashCode() + " owned by " + this.owner + " to " + next.hashCode());
             // new Error().printStackTrace(System.out);
@@ -403,12 +405,12 @@ public abstract class Scope {
         /** Double size of hash table.
          */
         private void dble() {
-            Assert.check(shared == 0);
+            Assert.check(!shared);
             Entry[] oldtable = table;
             Entry[] newtable = new Entry[oldtable.length * 2];
             for (ScopeImpl s = this; s != null; s = s.next) {
                 if (s.table == oldtable) {
-                    Assert.check(s == this || s.shared != 0);
+                    Assert.check(s == this || s.shared);
                     s.table = newtable;
                     s.hashMask = newtable.length - 1;
                 }
@@ -429,7 +431,7 @@ public abstract class Scope {
         /** Enter symbol sym in this scope.
          */
         public void enter(Symbol sym) {
-            Assert.check(shared == 0);
+            Assert.check(!shared);
             if (nelems * 3 >= hashMask * 2)
                 dble();
             int hash = getIndex(sym.name);
@@ -449,7 +451,7 @@ public abstract class Scope {
         /** Remove symbol from this scope.
          */
         public void remove(Symbol sym) {
-            Assert.check(shared == 0);
+            Assert.check(!shared);
             Entry e = lookup(sym.name, candidate -> candidate == sym);
             if (e.scope == null) return;
 
@@ -487,7 +489,7 @@ public abstract class Scope {
         /** Enter symbol sym in this scope if not already there.
          */
         public void enterIfAbsent(Symbol sym) {
-            Assert.check(shared == 0);
+            Assert.check(!shared);
             Entry e = lookup(sym.name);
             while (e.scope == this && e.sym.kind != sym.kind) e = e.next();
             if (e.scope != this) enter(sym);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1761,7 +1761,7 @@ public class Attr extends JCTree.Visitor {
                         JCExpression guard = patternlabel.guard;
                         if (guard != null) {
                             MatchBindings afterPattern = matchBindings;
-                            Env<AttrContext> bodyEnv = bindingEnv(env, matchBindings.bindingsWhenTrue);
+                            Env<AttrContext> bodyEnv = bindingEnv(switchEnv, matchBindings.bindingsWhenTrue);
                             try {
                                 attribExpr(guard, bodyEnv, syms.booleanType);
                             } finally {

--- a/test/langtools/tools/javac/patterns/ScopeResizeTest.java
+++ b/test/langtools/tools/javac/patterns/ScopeResizeTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8292756
+ * @summary Verify the Scope can be safely and correctly resized to accommodate pattern binding variables
+ *          when the Scope for a guard is constructed.
+ * @library /tools/lib /tools/javac/lib
+ * @modules
+ *      jdk.compiler/com.sun.tools.javac.api
+ *      jdk.compiler/com.sun.tools.javac.file
+ *      jdk.compiler/com.sun.tools.javac.main
+ *      jdk.compiler/com.sun.tools.javac.util
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @build combo.ComboTestHelper
+ * @compile ScopeResizeTest.java
+ * @run main ScopeResizeTest
+ */
+
+import combo.ComboInstance;
+import combo.ComboParameter;
+import combo.ComboTask;
+import combo.ComboTestHelper;
+import java.util.stream.Stream;
+import toolbox.ToolBox;
+
+public class ScopeResizeTest extends ComboInstance<ScopeResizeTest> {
+    protected ToolBox tb;
+
+    ScopeResizeTest() {
+        super();
+        tb = new ToolBox();
+    }
+
+    public static void main(String... args) throws Exception {
+        int variantsSize = 17;
+        PredefinedVariables[] variants = Stream.iterate(0, i -> i + 1)
+                                               .limit(variantsSize)
+                                               .map(s -> new PredefinedVariables(s))
+                                               .toArray(s -> new PredefinedVariables[s]);
+        new ComboTestHelper<ScopeResizeTest>()
+                .withDimension("PREDEFINED_VARIABLES", (x, predefinedVariables) -> x.predefinedVariables = predefinedVariables, variants)
+                .run(ScopeResizeTest::new);
+    }
+
+    private PredefinedVariables predefinedVariables;
+
+    private static final String MAIN_TEMPLATE =
+            """
+            public class Test {
+                public static void test(Object o) {
+                    #{PREDEFINED_VARIABLES}
+                    switch (o) {
+                        case String s when s.isEmpty() -> {}
+                        default -> {}
+                    }
+                }
+            }
+            """;
+
+    @Override
+    protected void doWork() throws Throwable {
+        ComboTask task = newCompilationTask()
+                .withSourceFromTemplate(MAIN_TEMPLATE, pname -> switch (pname) {
+                        case "PREDEFINED_VARIABLES" -> predefinedVariables;
+                        default -> throw new UnsupportedOperationException(pname);
+                    });
+
+        task.analyze(result -> {});
+    }
+
+    public record PredefinedVariables(int size) implements ComboParameter {
+        @Override
+        public String expand(String optParameter) {
+            StringBuilder variables = new StringBuilder();
+            for (int i = 0; i < size(); i++) {
+                variables.append("int i" + i + ";\n");
+            }
+            return variables.toString();
+        }
+    }
+
+}


### PR DESCRIPTION
Consider code like:
```
public class JDK_8292756 {
    private int test(Object o) {
        int i1, i2, i3, i4, i5, i6, i7;
        return switch(o) {
            case Object oo when oo != null -> 0;
            default -> 0;
        };
    }
}
```

Compiling this leads to a crash:
```
$ javac --enable-preview -source 19 /tmp/JDK_8292756.java 
Note: /tmp/JDK_8292756.java uses preview features of Java SE 19.
Note: Recompile with -Xlint:preview for details.
An exception has occurred in the compiler (19-internal). Please file a bug against the Java compiler via the Java bug reporting page (http://bugreport.java.com) after checking the Bug Database (http://bugs.java.com) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
java.lang.AssertionError
        at jdk.compiler/com.sun.tools.javac.util.Assert.error(Assert.java:155)
        at jdk.compiler/com.sun.tools.javac.util.Assert.check(Assert.java:46)
        at jdk.compiler/com.sun.tools.javac.code.Scope$ScopeImpl.leave(Scope.java:386)
        at jdk.compiler/com.sun.tools.javac.comp.Attr.visitBlock(Attr.java:1465)
        at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCBlock.accept(JCTree.java:1082)
        at jdk.compiler/com.sun.tools.javac.comp.Attr.attribTree(Attr.java:687)
        at jdk.compiler/com.sun.tools.javac.comp.Attr.attribStat(Attr.java:761)
        at jdk.compiler/com.sun.tools.javac.comp.Attr.visitMethodDef(Attr.java:1253)
        at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCMethodDecl.accept(JCTree.java:912)
        at jdk.compiler/com.sun.tools.javac.comp.Attr.attribTree(Attr.java:687)
        at jdk.compiler/com.sun.tools.javac.comp.Attr.attribStat(Attr.java:761)
        at jdk.compiler/com.sun.tools.javac.comp.Attr.attribClassBody(Attr.java:5621)
        at jdk.compiler/com.sun.tools.javac.comp.Attr.attribClass(Attr.java:5512)
        at jdk.compiler/com.sun.tools.javac.comp.Attr.attribClass(Attr.java:5336)
        at jdk.compiler/com.sun.tools.javac.comp.Attr.attrib(Attr.java:5275)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.attribute(JavaCompiler.java:1317)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:946)
        at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:317)
        at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:176)
        at jdk.compiler/com.sun.tools.javac.Main.compile(Main.java:64)
        at jdk.compiler/com.sun.tools.javac.Main.main(Main.java:50)
printing javac parameters to: /tmp/javac.20220919_200140.args
```

The reason for the failure is this: in `Attr.handleSwitch`, there is an input scope `env`, and a sub-scope of it, `switchEnv`, is created for the switch. Eventually, another (shared) sub-scope is created for the guard expression, `bodyEnv`. All `env`, `switchEnv` and `bodyEnv` share an internal table. But, the `bodyEnv` sub-scope is created from `env`, not from `switchEnv` (as it should). Which mostly works, but if the internal table for `bodyEnv` is resized, it will correctly fix only `env`, but not `switchEnv`.

The solution to this problem is to simply base the `bodyEnv` on `switchEnv`, not on `env`. But, in addition to that, it does not seem right the scopes don't protect from an accident like this. So the proposed patch here is enhancing the assertions in `Scope` so that a shared duplicate of a Scope can only be done from a leaf Scope.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292756](https://bugs.openjdk.org/browse/JDK-8292756): java.lang.AssertionError at at jdk.compiler/com.sun.tools.javac.code.Scope$ScopeImpl.leave(Scope.java:386)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10347/head:pull/10347` \
`$ git checkout pull/10347`

Update a local copy of the PR: \
`$ git checkout pull/10347` \
`$ git pull https://git.openjdk.org/jdk pull/10347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10347`

View PR using the GUI difftool: \
`$ git pr show -t 10347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10347.diff">https://git.openjdk.org/jdk/pull/10347.diff</a>

</details>
