### PR TITLE
8293897: Synthetic final modifier is part of the AST for a try-with-resource resource

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1900,6 +1900,8 @@ public class Attr extends JCTree.Visitor {
                         checkAutoCloseable(resource.pos(), localEnv, resource.type);
 
                         VarSymbol var = ((JCVariableDecl) resource).sym;
+
+                        var.flags_field |= Flags.FINAL;
                         var.setData(ElementKind.RESOURCE_VARIABLE);
                     } else {
                         attribTree(resource, tryEnv, twrResult);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3662,15 +3662,14 @@ public class JavacParser implements Parser {
      *           | Expression
      */
     protected JCTree resource() {
-        int startPos = token.pos;
         if (token.kind == FINAL || token.kind == MONKEYS_AT) {
-            JCModifiers mods = optFinal(Flags.FINAL);
+            JCModifiers mods = optFinal(0);
             JCExpression t = parseType(true);
             return variableDeclaratorRest(token.pos, mods, t, ident(), true, null, true, false);
         }
         JCExpression t = term(EXPR | TYPE);
         if ((lastmode & TYPE) != 0 && LAX_IDENTIFIER.test(token.kind)) {
-            JCModifiers mods = toP(F.at(startPos).Modifiers(Flags.FINAL));
+            JCModifiers mods = F.Modifiers(0);
             return variableDeclaratorRest(token.pos, mods, t, ident(), true, null, true, false);
         } else {
             checkSourceLevel(Feature.EFFECTIVELY_FINAL_VARIABLES_IN_TRY_WITH_RESOURCES);

--- a/test/langtools/tools/javac/parser/JavacParserTest.java
+++ b/test/langtools/tools/javac/parser/JavacParserTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7073631 7159445 7156633 8028235 8065753 8205418 8205913 8228451 8237041 8253584 8246774 8256411 8256149 8259050 8266436 8267221 8271928 8275097
+ * @bug 7073631 7159445 7156633 8028235 8065753 8205418 8205913 8228451 8237041 8253584 8246774 8256411 8256149 8259050 8266436 8267221 8271928 8275097 8293897
  * @summary tests error and diagnostics positions
  * @author  Jan Lahoda
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -71,6 +71,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
+import javax.lang.model.element.Modifier;
 import javax.lang.model.type.TypeKind;
 import javax.tools.Diagnostic;
 import javax.tools.DiagnosticCollector;
@@ -1903,6 +1904,70 @@ public class JavacParserTest extends TestCase {
                 else
                     scan(node.getStatements(), p);
                 return null;
+            }
+        }.scan(cut, null);
+    }
+
+    @Test //JDK-8293897
+    void testImplicitFinalInTryWithResources() throws IOException {
+        String code = """
+                      package t;
+                      class Test {
+                          void test1() {
+                              try (AutoCloseable ac = null) {}
+                          }
+                          void test2() {
+                              try (@Ann AutoCloseable withAnnotation = null) {}
+                          }
+                          @interface Ann {}
+                      }
+                      """;
+
+        JavacTaskImpl ct = (JavacTaskImpl) tool.getTask(null, fm, null, null,
+                null, Arrays.asList(new MyFileObject(code)));
+        CompilationUnitTree cut = ct.parse().iterator().next();
+        Trees t = Trees.instance(ct);
+        SourcePositions sp = t.getSourcePositions();
+        new TreeScanner<Void, Void>() {
+            boolean modifiersHaveSpan;
+
+            @Override
+            public Void visitVariable(VariableTree node, Void p) {
+                boolean prevModifiersHaveSpan = modifiersHaveSpan;
+                try {
+                    modifiersHaveSpan = node.getName().contentEquals("withAnnotation");
+                    return super.visitVariable(node, p);
+                } finally {
+                    modifiersHaveSpan = prevModifiersHaveSpan;
+                }
+            }
+            @Override
+            public Void visitClass(ClassTree node, Void p) {
+                boolean prevModifiersHaveSpan = modifiersHaveSpan;
+                try {
+                    modifiersHaveSpan = node.getKind() == Kind.ANNOTATION_TYPE;
+                    return super.visitClass(node, p);
+                } finally {
+                    modifiersHaveSpan = prevModifiersHaveSpan;
+                }
+            }
+            @Override
+            public Void visitModifiers(ModifiersTree node, Void p) {
+                if (node.getFlags().contains(Modifier.FINAL)) {
+                    throw new AssertionError("Unexpected final modified.");
+                }
+                long start = sp.getStartPosition(cut, node);
+                long end = sp.getEndPosition(cut, node);
+                if (modifiersHaveSpan) {
+                    if (start == (-1) || end == (-1)) {
+                        throw new AssertionError("Incorrect modifier span: " + start + "-" + end);
+                    }
+                } else {
+                    if (start != (-1) || end != (-1)) {
+                        throw new AssertionError("Incorrect modifier span: " + start + "-" + end);
+                    }
+                }
+                return super.visitModifiers(node, p);
             }
         }.scan(cut, null);
     }


### PR DESCRIPTION
The resources in try-with-resource are implicitly final (unless they are marked as final in the source code). But, in javac, the `FINAL` modifier is part of the modifiers on the AST, which is in contrary to the usual direction of having the AST closely model the source code.

The proposal here is to not add the synthetic `FINAL` modifier to the AST, but add it to the given `VarSymbol`. The positions of the `ModifiersTree` are also tweaked, so that for a synthetic tree, the positions are `NOPOS`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293897](https://bugs.openjdk.org/browse/JDK-8293897): Synthetic final modifier is part of the AST for a try-with-resource resource


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10348/head:pull/10348` \
`$ git checkout pull/10348`

Update a local copy of the PR: \
`$ git checkout pull/10348` \
`$ git pull https://git.openjdk.org/jdk pull/10348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10348`

View PR using the GUI difftool: \
`$ git pr show -t 10348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10348.diff">https://git.openjdk.org/jdk/pull/10348.diff</a>

</details>
