### PR TITLE
8294008: Grapheme implementation of setText() throws IndexOutOfBoundsException

### DIFF
--- a/src/java.base/share/classes/sun/util/locale/provider/BreakIteratorProviderImpl.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/BreakIteratorProviderImpl.java
@@ -326,6 +326,9 @@ public class BreakIteratorProviderImpl extends BreakIteratorProvider
 
         @Override
         public int length() {
+            // Return the entire CharSequence length (0 to endIndex), not to
+            // be confused with the text range length (beginIndex to endIndex)
+            // in the source CharacterIterator.
             return src.getEndIndex();
         }
 

--- a/src/java.base/share/classes/sun/util/locale/provider/BreakIteratorProviderImpl.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/BreakIteratorProviderImpl.java
@@ -317,7 +317,15 @@ public class BreakIteratorProviderImpl extends BreakIteratorProvider
         }
     }
 
-    // Implementation only for calling Grapheme.nextBoundary()
+    /**
+     * Implementation only for calling Grapheme.nextBoundary().
+     *
+     * This is a special-purpose CharSequence that represents characters in the
+     * index range [0..endIndex) of the underlying CharacterIterator, even if
+     * that CharacterIterator represents the subrange of some string. The calling
+     * code in GraphemeBreakIterator takes care to ensure that only valid indexes
+     * into the src are used.
+     */
     static final class CharacterIteratorCharSequence implements CharSequence {
         CharacterIterator src;
         CharacterIteratorCharSequence(CharacterIterator ci) {
@@ -328,7 +336,7 @@ public class BreakIteratorProviderImpl extends BreakIteratorProvider
         public int length() {
             // Return the entire CharSequence length (0 to endIndex), not to
             // be confused with the text range length (beginIndex to endIndex)
-            // in the source CharacterIterator.
+            // of the underlying CharacterIterator.
             return src.getEndIndex();
         }
 

--- a/src/java.base/share/classes/sun/util/locale/provider/BreakIteratorProviderImpl.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/BreakIteratorProviderImpl.java
@@ -326,7 +326,7 @@ public class BreakIteratorProviderImpl extends BreakIteratorProvider
 
         @Override
         public int length() {
-            return src.getEndIndex() - src.getBeginIndex();
+            return src.getEndIndex();
         }
 
         @Override

--- a/test/jdk/java/text/BreakIterator/BreakIteratorTest.java
+++ b/test/jdk/java/text/BreakIterator/BreakIteratorTest.java
@@ -26,6 +26,7 @@
  * @bug 4035266 4052418 4068133 4068137 4068139 4086052 4095322 4097779
  *      4097920 4098467 4111338 4113835 4117554 4143071 4146175 4152117
  *      4152416 4153072 4158381 4214367 4217703 4638433 8264765 8291660
+ *      8294008
  * @library /java/text/testlib
  * @run main/timeout=2000 BreakIteratorTest
  * @summary test BreakIterator
@@ -1467,5 +1468,9 @@ public class BreakIteratorTest extends IntlTest
                             .toList());
                     generalIteratorTest(characterBreak, expected);
                 });
+    }
+
+    public void TestSetTextIOOBException() {
+        BreakIterator.getCharacterInstance().setText(new StringCharacterIterator("abcfefg", 1, 5, 3));
     }
 }


### PR DESCRIPTION
Fixing JCK failures caused by the new grapheme implementation. The length of a CharSequence should return the `endIndex`, not `endIndex - beginIndex`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294008](https://bugs.openjdk.org/browse/JDK-8294008): Grapheme implementation of setText() throws IndexOutOfBoundsException


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to [2b176cd6](https://git.openjdk.org/jdk/pull/10349/files/2b176cd644afbd0fed862fd691638d5fccfb1f7e)
 * [Stuart Marks](https://openjdk.org/census#smarks) (@stuart-marks - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10349/head:pull/10349` \
`$ git checkout pull/10349`

Update a local copy of the PR: \
`$ git checkout pull/10349` \
`$ git pull https://git.openjdk.org/jdk pull/10349/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10349`

View PR using the GUI difftool: \
`$ git pr show -t 10349`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10349.diff">https://git.openjdk.org/jdk/pull/10349.diff</a>

</details>
