### PR TITLE
8294037: Using alias template to unify hashtables in AsyncLogWriter

### DIFF
--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -116,10 +116,7 @@ AsyncLogWriter::AsyncLogWriter()
 
 void AsyncLogWriter::write() {
   ResourceMark rm;
-  // Similar to AsyncLogMap but on resource_area
-  ResourceHashtable<LogFileStreamOutput*, uint32_t,
-                          17/*table_size*/, ResourceObj::RESOURCE_AREA,
-                          mtLogging> snapshot;
+  AsyncLogMap<ResourceObj::RESOURCE_AREA> snapshot;
 
   // lock protection. This guarantees I/O jobs don't block logsites.
   {

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -58,11 +58,12 @@ class AsyncLogWriter : public NonJavaThread {
   friend class AsyncLogTest;
   friend class AsyncLogTest_logBuffer_vm_Test;
   class AsyncLogLocker;
+
+  // account for dropped messages
+  template <ResourceObj::allocation_type ALLOC_TYPE>
   using AsyncLogMap = ResourceHashtable<LogFileStreamOutput*,
-                          uint32_t,
-                          17, /*table_size*/
-                          ResourceObj::C_HEAP,
-                          mtLogging>;
+                          uint32_t, 17, /*table_size*/
+                          ALLOC_TYPE, mtLogging>;
 
   // Messsage is the envelop of a log line and its associative data.
   // Its length is variable because of the zero-terminated c-str. It is only valid when we create it using placement new
@@ -154,7 +155,7 @@ class AsyncLogWriter : public NonJavaThread {
   PlatformMonitor _lock;
   bool _data_available;
   volatile bool _initialized;
-  AsyncLogMap _stats; // statistics for dropped messages
+  AsyncLogMap<ResourceObj::C_HEAP> _stats;
 
   // ping-pong buffers
   Buffer* _buffer;


### PR DESCRIPTION
This change is only for clear code. No functional change is intended.

Currently, there are two hashtables. One is this on c-heap.
```
  using AsyncLogMap = ResourceHashtable<LogFileStreamOutput*,
                          uint32_t,
                          17, /*table_size*/
                          ResourceObj::C_HEAP,
                          mtLogging>;
```
and the other one is its mirror on ResourceArena. It's not accident. The 2nd one is the snapshot of prior one. 
We use this approach to release lock early. Flushing snapshot doesn't require lock protection and therefore 
won't block logsites.

```
  ResourceMark rm;
  // Similar to AsyncLogMap but on resource_area
  ResourceHashtable<LogFileStreamOutput*, uint32_t,
                          17/*table_size*/, ResourceObj::RESOURCE_AREA,
                          mtLogging> snapshot;
```
C++11 has a new feature called [alias template](https://en.cppreference.com/w/cpp/language/type_alias). We can
use this feature to unify two types.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294037](https://bugs.openjdk.org/browse/JDK-8294037): Using alias template to unify hashtables in AsyncLogWriter


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10350/head:pull/10350` \
`$ git checkout pull/10350`

Update a local copy of the PR: \
`$ git checkout pull/10350` \
`$ git pull https://git.openjdk.org/jdk pull/10350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10350`

View PR using the GUI difftool: \
`$ git pr show -t 10350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10350.diff">https://git.openjdk.org/jdk/pull/10350.diff</a>

</details>
