### PR TITLE
8292602: ZGC: C2 late barrier analysis uses invalid dominator information

### DIFF
--- a/src/hotspot/share/opto/block.hpp
+++ b/src/hotspot/share/opto/block.hpp
@@ -643,6 +643,8 @@ class PhaseCFG : public Phase {
   // Check that block b is in the home loop (or an ancestor) of n, if n is a
   // memory writer.
   void verify_memory_writer_placement(const Block* b, const Node* n) const NOT_DEBUG_RETURN;
+  // Check local dominator tree invariants.
+  void verify_dominator_tree() const NOT_DEBUG_RETURN;
   void verify() const NOT_DEBUG_RETURN;
 };
 

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2970,6 +2970,7 @@ void Compile::Code_Gen() {
     }
     cfg.fixup_flow();
     cfg.remove_unreachable_blocks();
+    cfg.verify_dominator_tree();
   }
 
   // Apply peephole optimizations

--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -387,6 +387,12 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
         print_prop("block", C->cfg()->get_block(0)->_pre_order);
       } else {
         print_prop("block", block->_pre_order);
+        if (node == block->head()) {
+          if (block->_idom != NULL) {
+            print_prop("idom", block->_idom->_pre_order);
+          }
+          print_prop("dom_depth", block->_dom_depth);
+        }
         // Print estimated execution frequency, normalized within a [0,1] range.
         buffer[0] = 0;
         stringStream freq(buffer, sizeof(buffer) - 1);


### PR DESCRIPTION
Late ZGC barrier analysis (`ZBarrierSetC2::analyze_dominating_barriers()`) uses dominator information to elide unnecessary load barriers. This information is invalidated whenever the block ordering phase (`PhaseCFG::fixup_flow()`) inserts a new block (`PhaseCFG::insert_goto_at()`).

This changeset updates the dominator information phase after each goto-block insertion in `insert_goto_at()`, to ensure that late ZGC barrier analysis works correctly. Domination information is encoded in two `Block` member variables: `_idom` and `_dom_depth`. The immediate dominator (`_idom`) of the new goto-block (`block`) and its successor (`out`) are trivially remapped after the insertion of `block`, whereas the dominator tree depth (`_dom_depth`) of the `out` subtree is updated by a depth-first search of the descendants of `out`.

Additionally, the changeset adds dominator tree checks (`PhaseCFG::verify_dominator_tree()`) every time `PhaseCFG::verify()` is called and also at the end of the `blockOrdering` phase (where `insert_goto_at()` might be called); and includes dominator information in IGV graphs for ease of debugging.

#### Alternative Solutions

An alternative solution would be to rebuild the dominator tree before using dominator information in ZGC's late barrier analysis. The alternative [has been explored](https://github.com/robcasloz/jdk/tree/JDK-8292602-recompute) and found to be more complex than this changeset, as `PhaseCFG::build_dominator_tree()` makes multiple assumptions on the shape of the Ideal graph that do not hold at a later C2 phase.

Another alternative would be to update the dominator tree only if ZGC, the only late consumer of domination information, is enabled. This changeset proposes updating the dominator tree unconditionally for simplicity, uniformity, and better test coverage. The overhead of doing so is insignificant for the main standard benchmark suites (DaCapo, SPECjbb2005, SPECjvm2008, SPECjbb2015, ...). A closer study of the DaCapo benchmarks shows that, on average, `insert_goto_at()` is called less than once per C2 compilation, and each call traverses less than 1% of the total blocks in the CFG.

#### Testing

- tier1-3 (windows-x64, linux-x64, linux-aarch64, and macosx-x64; release and debug mode).
- tier4-7 (linux-x64; debug mode).
- fuzzing (~1 h. on each platform).
- verified the dominator trees and node depths of 615 graphs updated by `insert_goto_at()` by comparing them with the result of an [independent dominator construction implementation](https://github.com/robcasloz/jdk/blob/ideal-check/src/utils/IdealTools/ideal-check.py) (based on Python's NetworkX package).

Thanks to Nils Eliasson for finding the issue and providing an initial fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292602](https://bugs.openjdk.org/browse/JDK-8292602): ZGC: C2 late barrier analysis uses invalid dominator information


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Contributors
 * Nils Eliasson `<neliasso@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10353/head:pull/10353` \
`$ git checkout pull/10353`

Update a local copy of the PR: \
`$ git checkout pull/10353` \
`$ git pull https://git.openjdk.org/jdk pull/10353/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10353`

View PR using the GUI difftool: \
`$ git pr show -t 10353`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10353.diff">https://git.openjdk.org/jdk/pull/10353.diff</a>

</details>
