### PR TITLE
8294046: Newly added test test/jdk/javax/swing/JTabbedPane/TestNPEStateChgListener.java fails in macos

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneUI.java
@@ -810,6 +810,7 @@ public class AquaTabbedPaneUI extends AquaTabbedPaneCopyFromBasicUI {
     protected ChangeListener createChangeListener() {
         return new ChangeListener() {
             public void stateChanged(final ChangeEvent e) {
+                JTabbedPane tabPane = (JTabbedPane)e.getSource();
                 if (!isTabVisible(tabPane.getSelectedIndex())) popupSelectionChanged = true;
                 tabPane.revalidate();
                 tabPane.repaint();

--- a/test/jdk/javax/swing/JTabbedPane/TestNPEStateChgListener.java
+++ b/test/jdk/javax/swing/JTabbedPane/TestNPEStateChgListener.java
@@ -23,7 +23,7 @@
 /*
  * @test
  * @key headful
- * @bug 6286501
+ * @bug 6286501 8294046
  * @summary  Verifies if NPE is thrown from stateChanged listener of JTabbedPane
   * @run main TestNPEStateChgListener
  */


### PR DESCRIPTION
Test added for fix [JDK-6286501](https://bugs.openjdk.org/browse/JDK-6286501)  fails in macos citing 
```
java.lang.NullPointerException: Cannot invoke "javax.swing.JTabbedPane.getSelectedIndex()" 
because "this.this$0.tabPane" is null
at java.desktop/com.apple.laf.AquaTabbedPaneUI$2.stateChanged(AquaTabbedPaneUI.java:813) 

```
for Aqua L&F owing to same issue as described in https://github.com/openjdk/jdk/pull/10216#discussion_r971787291 wherein the old instance is uninstalled and tabPane is reset to null when updateUI() is called in stateChange Listener in testcase, so we need to use the tabPane instance passed in TabbedPane's stateChange listener as has been done for BasicTabbedPaneUI case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294046](https://bugs.openjdk.org/browse/JDK-8294046): Newly added test test/jdk/javax/swing/JTabbedPane/TestNPEStateChgListener.java fails in macos


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10354/head:pull/10354` \
`$ git checkout pull/10354`

Update a local copy of the PR: \
`$ git checkout pull/10354` \
`$ git pull https://git.openjdk.org/jdk pull/10354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10354`

View PR using the GUI difftool: \
`$ git pr show -t 10354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10354.diff">https://git.openjdk.org/jdk/pull/10354.diff</a>

</details>
