### PR TITLE
8294059: Serial: Refactor GenCollectedHeap::collect

### DIFF
--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -833,8 +833,7 @@ void GenCollectedHeap::collect(GCCause::Cause cause) {
 
   bool should_run_young_gc =  (cause == GCCause::_wb_young_gc)
                            || (cause == GCCause::_gc_locker)
-                DEBUG_ONLY(|| (cause == GCCause::_scavenge_alot))
-                           ;
+                DEBUG_ONLY(|| (cause == GCCause::_scavenge_alot));
 
   const GenerationType max_generation = should_run_young_gc
                                       ? YoungGen

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -813,29 +813,7 @@ bool GenCollectedHeap::no_allocs_since_save_marks() {
 }
 
 // public collection interfaces
-
 void GenCollectedHeap::collect(GCCause::Cause cause) {
-  if ((cause == GCCause::_wb_young_gc) ||
-      (cause == GCCause::_gc_locker)) {
-    // Young collection for WhiteBox or GCLocker.
-    collect(cause, YoungGen);
-  } else {
-#ifdef ASSERT
-  if (cause == GCCause::_scavenge_alot) {
-    // Young collection only.
-    collect(cause, YoungGen);
-  } else {
-    // Stop-the-world full collection.
-    collect(cause, OldGen);
-  }
-#else
-    // Stop-the-world full collection.
-    collect(cause, OldGen);
-#endif
-  }
-}
-
-void GenCollectedHeap::collect(GCCause::Cause cause, GenerationType max_generation) {
   // The caller doesn't have the Heap_lock
   assert(!Heap_lock->owned_by_self(), "this thread should not own the Heap_lock");
 
@@ -852,6 +830,15 @@ void GenCollectedHeap::collect(GCCause::Cause cause, GenerationType max_generati
   if (GCLocker::should_discard(cause, gc_count_before)) {
     return;
   }
+
+  bool should_run_young_gc =  (cause == GCCause::_wb_young_gc)
+                           || (cause == GCCause::_gc_locker)
+                DEBUG_ONLY(|| (cause == GCCause::_scavenge_alot))
+                           ;
+
+  const GenerationType max_generation = should_run_young_gc
+                                      ? YoungGen
+                                      : OldGen;
 
   VM_GenCollectFull op(gc_count_before, full_gc_count_before,
                        cause, max_generation);

--- a/src/hotspot/share/gc/shared/genCollectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.hpp
@@ -186,10 +186,6 @@ public:
   // supports. Caller does not hold the Heap_lock on entry.
   virtual void collect(GCCause::Cause cause);
 
-  // Perform a full collection of generations up to and including max_generation.
-  // Mostly used for testing purposes. Caller does not hold the Heap_lock on entry.
-  void collect(GCCause::Cause cause, GenerationType max_generation);
-
   // Returns "TRUE" iff "p" points into the committed areas of the heap.
   // The methods is_in() and is_in_youngest() may be expensive to compute
   // in general, so, to prevent their inadvertent use in product jvm's, we


### PR DESCRIPTION
Simple cleanup of control flow in `GenCollectedHeap::collect`.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294059](https://bugs.openjdk.org/browse/JDK-8294059): Serial: Refactor GenCollectedHeap::collect


### Reviewers
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to [0baef977](https://git.openjdk.org/jdk/pull/10355/files/0baef977e30ad5cd04932ccb89679a77df10e482)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [0baef977](https://git.openjdk.org/jdk/pull/10355/files/0baef977e30ad5cd04932ccb89679a77df10e482)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10355/head:pull/10355` \
`$ git checkout pull/10355`

Update a local copy of the PR: \
`$ git checkout pull/10355` \
`$ git pull https://git.openjdk.org/jdk pull/10355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10355`

View PR using the GUI difftool: \
`$ git pr show -t 10355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10355.diff">https://git.openjdk.org/jdk/pull/10355.diff</a>

</details>
