### PR TITLE
8294057: Parallel: Tighten ParallelCompactData::initialize_region_data

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -432,8 +432,6 @@ bool ParallelCompactData::initialize(MemRegion covered_region)
 
   assert(region_align_down(_region_start) == _region_start,
          "region start not aligned");
-  assert((region_size & RegionSizeOffsetMask) == 0,
-         "region size not a multiple of RegionSize");
 
   bool result = initialize_region_data(region_size) && initialize_block_data();
   return result;
@@ -470,7 +468,10 @@ ParallelCompactData::create_vspace(size_t count, size_t element_size)
 
 bool ParallelCompactData::initialize_region_data(size_t region_size)
 {
-  const size_t count = (region_size + RegionSizeOffsetMask) >> Log2RegionSize;
+  assert((region_size & RegionSizeOffsetMask) == 0,
+         "region size not a multiple of RegionSize");
+
+  const size_t count = region_size >> Log2RegionSize;
   _region_vspace = create_vspace(count, sizeof(RegionData));
   if (_region_vspace != 0) {
     _region_data = (RegionData*)_region_vspace->reserved_low_addr();


### PR DESCRIPTION
Simple change of removing some unnecessary code.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294057](https://bugs.openjdk.org/browse/JDK-8294057): Parallel: Tighten ParallelCompactData::initialize_region_data


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10356/head:pull/10356` \
`$ git checkout pull/10356`

Update a local copy of the PR: \
`$ git checkout pull/10356` \
`$ git pull https://git.openjdk.org/jdk pull/10356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10356`

View PR using the GUI difftool: \
`$ git pr show -t 10356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10356.diff">https://git.openjdk.org/jdk/pull/10356.diff</a>

</details>
