### PR TITLE
8294058: Early use of lambda introduced in JDK-8285263 cause startup regressions in 20-b02

### DIFF
--- a/src/java.base/share/classes/java/security/SecureClassLoader.java
+++ b/src/java.base/share/classes/java/security/SecureClassLoader.java
@@ -220,6 +220,7 @@ public class SecureClassLoader extends ClassLoader {
         // only), and the fragment is not considered.
         CodeSourceKey key = new CodeSourceKey(cs);
         return pdcache.computeIfAbsent(key, new Function<>() {
+            // Do not turn this into a lambda since it is executed during bootstrap
             @Override
             public ProtectionDomain apply(CodeSourceKey key) {
                 PermissionCollection perms

--- a/src/java.base/share/classes/java/security/SecureClassLoader.java
+++ b/src/java.base/share/classes/java/security/SecureClassLoader.java
@@ -30,6 +30,7 @@ import sun.security.util.Debug;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 /**
  * This class extends {@code ClassLoader} with additional support for defining
@@ -218,16 +219,19 @@ public class SecureClassLoader extends ClassLoader {
         // that no nameservice lookup is done on the hostname (String comparison
         // only), and the fragment is not considered.
         CodeSourceKey key = new CodeSourceKey(cs);
-        return pdcache.computeIfAbsent(key, unused -> {
-            PermissionCollection perms
-                    = SecureClassLoader.this.getPermissions(cs);
-            ProtectionDomain pd = new ProtectionDomain(
-                    cs, perms, SecureClassLoader.this, null);
-            if (DebugHolder.debug != null) {
-                DebugHolder.debug.println(" getPermissions " + pd);
-                DebugHolder.debug.println("");
+        return pdcache.computeIfAbsent(key, new Function<>() {
+            @Override
+            public ProtectionDomain apply(CodeSourceKey key) {
+                PermissionCollection perms
+                        = SecureClassLoader.this.getPermissions(key.cs);
+                ProtectionDomain pd = new ProtectionDomain(
+                        key.cs, perms, SecureClassLoader.this, null);
+                if (DebugHolder.debug != null) {
+                    DebugHolder.debug.println(" getPermissions " + pd);
+                    DebugHolder.debug.println("");
+                }
+                return pd;
             }
-            return pd;
         });
     }
 


### PR DESCRIPTION
[JDK-8285263](https://bugs.openjdk.org/browse/JDK-8285263) innocuously rewrote an anonymous class in `SecureClassLoader.getProtectionDomain` to a (capturing) lambda. Since this is called during early bootstrap this shows up as a regression across the board on all our startup and footprint tests.

Restoring the anonymous class drops no. of classes loaded on a Hello World test from 493 to 448 (macosx).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294058](https://bugs.openjdk.org/browse/JDK-8294058): Early use of lambda introduced in JDK-8285263 cause startup regressions in 20-b02


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10357/head:pull/10357` \
`$ git checkout pull/10357`

Update a local copy of the PR: \
`$ git checkout pull/10357` \
`$ git pull https://git.openjdk.org/jdk pull/10357/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10357`

View PR using the GUI difftool: \
`$ git pr show -t 10357`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10357.diff">https://git.openjdk.org/jdk/pull/10357.diff</a>

</details>
