### PR TITLE
8294062: Improve parsing performance of j.l.c.MethodTypeDesc

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ConstantUtils.java
+++ b/src/java.base/share/classes/java/lang/constant/ConstantUtils.java
@@ -204,16 +204,21 @@ class ConstantUtils {
                 case JVM_SIGNATURE_DOUBLE:
                     return index - start + 1;
                 case JVM_SIGNATURE_CLASS:
+                    // state variable for detection of illegal states, such as:
+                    // empty unqualified name, '//', leading '/', or trailing '/'
                     boolean legal = false;
                     while (++index < end) {
                         switch (descriptor.charAt(index)) {
                             case ';' -> {
+                                // illegal state on parser exit indicates empty unqualified name or trailing '/'
                                 return legal ? index - start + 1 : 0;
                             }
                             case '.', '[' -> {
+                                // do not permit '.' or '['
                                 return 0;
                             }
                             case '/' -> {
+                                // illegal state when received '/' indicates '//' or leading '/'
                                 if (!legal) return 0;
                                 legal = false;
                             }

--- a/src/java.base/share/classes/java/lang/constant/ConstantUtils.java
+++ b/src/java.base/share/classes/java/lang/constant/ConstantUtils.java
@@ -137,6 +137,7 @@ class ConstantUtils {
     static List<String> parseMethodDescriptor(String descriptor) {
         int cur = 0, end = descriptor.length();
         ArrayList<String> ptypes = new ArrayList<>();
+        ptypes.add(null); //placeholder for return type
 
         if (cur >= end || descriptor.charAt(cur) != '(')
             throw new IllegalArgumentException("Bad method descriptor: " + descriptor);
@@ -156,7 +157,7 @@ class ConstantUtils {
         int rLen = skipOverFieldSignature(descriptor, cur, end, true);
         if (rLen == 0 || cur + rLen != end)
             throw new IllegalArgumentException("Bad method descriptor: " + descriptor);
-        ptypes.add(0, descriptor.substring(cur, cur + rLen));
+        ptypes.set(0, descriptor.substring(cur, cur + rLen));
         return ptypes;
     }
 
@@ -203,16 +204,22 @@ class ConstantUtils {
                 case JVM_SIGNATURE_DOUBLE:
                     return index - start + 1;
                 case JVM_SIGNATURE_CLASS:
-                    // Skip leading 'L' and ignore first appearance of ';'
-                    index++;
-                    int indexOfSemi = descriptor.indexOf(';', index);
-                    if (indexOfSemi != -1) {
-                        String unqualifiedName = descriptor.substring(index, indexOfSemi);
-                        boolean legal = verifyUnqualifiedClassName(unqualifiedName);
-                        if (!legal) {
-                            return 0;
+                    boolean legal = false;
+                    while (++index < end) {
+                        switch (descriptor.charAt(index)) {
+                            case ';' -> {
+                                return legal ? index - start + 1 : 0;
+                            }
+                            case '.', '[' -> {
+                                return 0;
+                            }
+                            case '/' -> {
+                                if (!legal) return 0;
+                                legal = false;
+                            }
+                            default ->
+                                legal = true;
                         }
-                        return index - start + unqualifiedName.length() + 1;
                     }
                     return 0;
                 case JVM_SIGNATURE_ARRAY:
@@ -230,26 +237,5 @@ class ConstantUtils {
             }
         }
         return 0;
-    }
-
-    static boolean verifyUnqualifiedClassName(String name) {
-        for (int index = 0; index < name.length(); index++) {
-            char ch = name.charAt(index);
-            if (ch < 128) {
-                if (ch == '.' || ch == ';' || ch == '[' ) {
-                    return false;   // do not permit '.', ';', or '['
-                }
-                if (ch == '/') {
-                    // check for '//' or leading or trailing '/' which are not legal
-                    // unqualified name must not be empty
-                    if (index == 0 || index + 1 >= name.length() || name.charAt(index + 1) == '/') {
-                        return false;
-                    }
-                }
-            } else {
-                index ++;
-            }
-        }
-        return true;
     }
 }


### PR DESCRIPTION
Parsing performance of `j.l.c.MethodTypeDescriptor::ofDescriptor` can be significantly improved and add performance boost to intensive users.

Two main reasons have been identified and fixed in this patch:

First glitch is late insertion of return type to the first position of `j.u.ArrayList`, causing all previously parsed parameter types to shift using `System::arraycopy`.

Proposed patch inserts a placeholder for the return type first and replaces it with return type later.

Second performance degradation is in `MethodTypeDescriptor::skipOverFieldSignature`, where each identified class descriptor is exactly located by `String::indexOf`, extracted by `String::substring`, and passed for for the purpose of verification to `ConstantUtils::verifyUnqualifiedClassName`.

Proposed patch inlines the unqualified class name verification into `ConstantUtils::skipOverFieldSignature` parsing loop and so eliminates calls of `String::indexOf` and `String::substring`. Package private method `ConstantUtils::verifyUnqualifiedClassName` has no other use within the package, so it is removed.

Please review proposed performance improving patch.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294062](https://bugs.openjdk.org/browse/JDK-8294062): Improve parsing performance of j.l.c.MethodTypeDesc


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10358/head:pull/10358` \
`$ git checkout pull/10358`

Update a local copy of the PR: \
`$ git checkout pull/10358` \
`$ git pull https://git.openjdk.org/jdk pull/10358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10358`

View PR using the GUI difftool: \
`$ git pr show -t 10358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10358.diff">https://git.openjdk.org/jdk/pull/10358.diff</a>

</details>
