### PR TITLE
8294067: [macOS] javax/swing/JComboBox/6559152/bug6559152.java Cannot select an item from popup with the ENTER key.

### DIFF
--- a/test/jdk/javax/swing/JComboBox/6559152/bug6559152.java
+++ b/test/jdk/javax/swing/JComboBox/6559152/bug6559152.java
@@ -99,9 +99,6 @@ public class bug6559152 {
     private static void test() throws Exception {
         robot.mouseMove(p.x, p.y);
         robot.waitForIdle();
-//        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-//        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-//        robot.waitForIdle();
         testImpl();
         checkResult();
     }

--- a/test/jdk/javax/swing/JComboBox/6559152/bug6559152.java
+++ b/test/jdk/javax/swing/JComboBox/6559152/bug6559152.java
@@ -30,6 +30,7 @@
  * @run main bug6559152
  */
 
+import java.awt.Dimension;
 import java.awt.Point;
 import java.awt.Robot;
 import java.awt.event.InputEvent;
@@ -48,6 +49,7 @@ public class bug6559152 {
     private static JComboBox cb;
     private static Robot robot;
     private static Point p = null;
+    private static Dimension d;
 
     public static void main(String[] args) throws Exception {
         robot = new Robot();
@@ -70,6 +72,7 @@ public class bug6559152 {
             try {
                 SwingUtilities.invokeAndWait(() -> {
                     p = comp.getLocationOnScreen();
+                    d = comp.getSize();
                 });
             } catch (IllegalStateException e) {
                 try {
@@ -98,7 +101,7 @@ public class bug6559152 {
     }
 
     private static void test() throws Exception {
-        robot.mouseMove(p.x + cb.getWidth() / 2, p.y + cb.getHeight() / 2);
+        robot.mouseMove(p.x + (int)(d.getWidth() / 2), p.y + (int)(d.getHeight() / 2));
         robot.waitForIdle();
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);

--- a/test/jdk/javax/swing/JComboBox/6559152/bug6559152.java
+++ b/test/jdk/javax/swing/JComboBox/6559152/bug6559152.java
@@ -32,6 +32,7 @@
 
 import java.awt.Point;
 import java.awt.Robot;
+import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 
 import javax.swing.DefaultCellEditor;
@@ -97,7 +98,10 @@ public class bug6559152 {
     }
 
     private static void test() throws Exception {
-        robot.mouseMove(p.x, p.y);
+        robot.mouseMove(p.x + cb.getWidth() / 2, p.y + cb.getHeight() / 2);
+        robot.waitForIdle();
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
         testImpl();
         checkResult();

--- a/test/jdk/javax/swing/JComboBox/6559152/bug6559152.java
+++ b/test/jdk/javax/swing/JComboBox/6559152/bug6559152.java
@@ -24,23 +24,23 @@
 /*
  * @test
  * @key headful
- * @bug 6559152
+ * @bug 6559152 8294067
  * @summary Checks that you can select an item in JComboBox with keyboard
  *          when it is a JTable cell editor.
  * @run main bug6559152
  */
 
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+
 import javax.swing.DefaultCellEditor;
+import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JFrame;
-import javax.swing.JComboBox;
+import javax.swing.JTable;
 import javax.swing.SwingUtilities;
 import javax.swing.table.DefaultTableModel;
-import javax.swing.JTable;
-import java.awt.Point;
-import java.awt.event.KeyEvent;
-import java.awt.event.InputEvent;
-import java.awt.Robot;
 
 public class bug6559152 {
     private static JFrame frame;
@@ -99,9 +99,9 @@ public class bug6559152 {
     private static void test() throws Exception {
         robot.mouseMove(p.x, p.y);
         robot.waitForIdle();
-        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-        robot.waitForIdle();
+//        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+//        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+//        robot.waitForIdle();
         testImpl();
         checkResult();
     }

--- a/test/jdk/javax/swing/JComboBox/6559152/bug6559152.java
+++ b/test/jdk/javax/swing/JComboBox/6559152/bug6559152.java
@@ -101,7 +101,7 @@ public class bug6559152 {
     }
 
     private static void test() throws Exception {
-        robot.mouseMove(p.x + (int)(d.getWidth() / 2), p.y + (int)(d.getHeight() / 2));
+        robot.mouseMove(p.x + d.width / 2, p.y + d.height / 2);
         robot.waitForIdle();
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);


### PR DESCRIPTION
The newly fix-sized JComboBox has its dropdown menu opened with this test's mouse click. The goal of the test is to focus the JComboBox, open the dropdown menu, and select the 2nd option of the menu using arrow keys and ENTER key. Since the JComboBox is focused without the click already, the click can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294067](https://bugs.openjdk.org/browse/JDK-8294067): [macOS] javax/swing/JComboBox/6559152/bug6559152.java Cannot select an item from popup with the ENTER key.


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**) ⚠️ Review applies to [9b2a8f6a](https://git.openjdk.org/jdk/pull/10359/files/9b2a8f6af600c32f7bc56996317541914b9b8c2a)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10359/head:pull/10359` \
`$ git checkout pull/10359`

Update a local copy of the PR: \
`$ git checkout pull/10359` \
`$ git pull https://git.openjdk.org/jdk pull/10359/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10359`

View PR using the GUI difftool: \
`$ git pr show -t 10359`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10359.diff">https://git.openjdk.org/jdk/pull/10359.diff</a>

</details>
