### PR TITLE
8294039: Remove "Classpath" exception from java/awt tests

### DIFF
--- a/test/jdk/java/awt/Component/CompEventOnHiddenComponent/CompEventOnHiddenComponent.java
+++ b/test/jdk/java/awt/Component/CompEventOnHiddenComponent/CompEventOnHiddenComponent.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/java/awt/Focus/ModalDialogActivationTest/ModalDialogActivationTest.java
+++ b/test/jdk/java/awt/Focus/ModalDialogActivationTest/ModalDialogActivationTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/java/awt/MenuBar/DefaultMenuBarDispose.java
+++ b/test/jdk/java/awt/MenuBar/DefaultMenuBarDispose.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/java/awt/MenuBar/TestNoScreenMenuBar.java
+++ b/test/jdk/java/awt/MenuBar/TestNoScreenMenuBar.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/java/awt/Window/FullWindowContentTest/FullWindowContentTest.java
+++ b/test/jdk/java/awt/Window/FullWindowContentTest/FullWindowContentTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/java/awt/Window/GetWindowsTest/GetWindowsTest.java
+++ b/test/jdk/java/awt/Window/GetWindowsTest/GetWindowsTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/java/awt/Window/HandleWindowDestroyTest/HandleWindowDestroyTest.java
+++ b/test/jdk/java/awt/Window/HandleWindowDestroyTest/HandleWindowDestroyTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/java/awt/Window/MainKeyWindowTest/TestMainKeyWindow.java
+++ b/test/jdk/java/awt/Window/MainKeyWindowTest/TestMainKeyWindow.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/java/awt/Window/MainKeyWindowTest/libTestMainKeyWindow.m
+++ b/test/jdk/java/awt/Window/MainKeyWindowTest/libTestMainKeyWindow.m
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/java/awt/datatransfer/Clipboard/BasicClipboardTest.java
+++ b/test/jdk/java/awt/datatransfer/Clipboard/BasicClipboardTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -136,4 +134,3 @@ public class BasicClipboardTest implements ClipboardOwner {
 
     public void lostOwnership (Clipboard clipboard, Transferable contents) { }
 }
-

--- a/test/jdk/java/awt/datatransfer/Clipboard/GetContentsInterruptedTest.java
+++ b/test/jdk/java/awt/datatransfer/Clipboard/GetContentsInterruptedTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -162,4 +160,3 @@ public class GetContentsInterruptedTest implements ClipboardOwner {
         }).start();
     }
 }
-

--- a/test/jdk/java/awt/datatransfer/ImageTransfer/ImageTransferTest.java
+++ b/test/jdk/java/awt/datatransfer/ImageTransfer/ImageTransferTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -187,4 +185,3 @@ public class ImageTransferTest  {
         compareImages();
     }
 }
-

--- a/test/jdk/java/awt/datatransfer/Independence/IndependenceAWTTest.java
+++ b/test/jdk/java/awt/datatransfer/Independence/IndependenceAWTTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -186,4 +184,3 @@ public class IndependenceAWTTest {
         }
     }
 }
-

--- a/test/jdk/java/awt/datatransfer/Independence/IndependenceSwingTest.java
+++ b/test/jdk/java/awt/datatransfer/Independence/IndependenceSwingTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -193,4 +191,3 @@ public class IndependenceSwingTest {
         }
     }
 }
-

--- a/test/jdk/java/awt/datatransfer/SystemFlavorMap/AddFlavorForNativeTest.java
+++ b/test/jdk/java/awt/datatransfer/SystemFlavorMap/AddFlavorForNativeTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -152,4 +150,3 @@ public class AddFlavorForNativeTest {
       test_natives_set = new String[] {test_native};
     }
 }
-

--- a/test/jdk/java/awt/datatransfer/SystemFlavorMap/AddFlavorTest.java
+++ b/test/jdk/java/awt/datatransfer/SystemFlavorMap/AddFlavorTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -144,4 +142,3 @@ public class AddFlavorTest {
         return tempSet;
     }
 }
-

--- a/test/jdk/java/awt/datatransfer/SystemFlavorMap/AddNativeForFlavorTest.java
+++ b/test/jdk/java/awt/datatransfer/SystemFlavorMap/AddNativeForFlavorTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -154,4 +152,3 @@ public class AddNativeForFlavorTest {
       test_natives_set2 = new String[] {test_native1, test_native2, test_native3, test_native4};
     }
 }
-

--- a/test/jdk/java/awt/datatransfer/SystemFlavorMap/AddNativeTest.java
+++ b/test/jdk/java/awt/datatransfer/SystemFlavorMap/AddNativeTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -142,4 +140,3 @@ public class AddNativeTest {
         return result;
     }
 }
-

--- a/test/jdk/java/awt/datatransfer/SystemFlavorMap/GetFlavorsForNewNativeTest.java
+++ b/test/jdk/java/awt/datatransfer/SystemFlavorMap/GetFlavorsForNewNativeTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -128,4 +126,3 @@ public class GetFlavorsForNewNativeTest {
     }
 
 }
-

--- a/test/jdk/java/awt/datatransfer/SystemFlavorMap/GetNativesForNewFlavorTest.java
+++ b/test/jdk/java/awt/datatransfer/SystemFlavorMap/GetNativesForNewFlavorTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -109,4 +107,3 @@ public class GetNativesForNewFlavorTest {
         test_natives_set = new String[] {test_encoded};
     }
 }
-

--- a/test/jdk/java/awt/datatransfer/SystemFlavorMap/InvalidMapArgumentsTest.java
+++ b/test/jdk/java/awt/datatransfer/SystemFlavorMap/InvalidMapArgumentsTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -137,4 +135,3 @@ public class InvalidMapArgumentsTest {
         }
     }
 }
-

--- a/test/jdk/java/awt/datatransfer/SystemFlavorMap/ManyFlavorMapTest.java
+++ b/test/jdk/java/awt/datatransfer/SystemFlavorMap/ManyFlavorMapTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -180,4 +178,3 @@ public class ManyFlavorMapTest {
         }
     }
 }
-

--- a/test/jdk/java/awt/datatransfer/SystemFlavorMap/SetDataFlavorsTest.java
+++ b/test/jdk/java/awt/datatransfer/SystemFlavorMap/SetDataFlavorsTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -129,4 +127,3 @@ public class SetDataFlavorsTest {
         System.out.println("*** DataFlavor size = " + hashVerify.size());
     }
 }
-

--- a/test/jdk/java/awt/datatransfer/SystemFlavorMap/SetFlavorsForNativeTest.java
+++ b/test/jdk/java/awt/datatransfer/SystemFlavorMap/SetFlavorsForNativeTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -163,4 +161,3 @@ public class SetFlavorsForNativeTest {
         test_natives_set2 = new String[] {test_native3, test_native4};
     }
 }
-

--- a/test/jdk/java/awt/datatransfer/SystemFlavorMap/SetNativesForFlavor.java
+++ b/test/jdk/java/awt/datatransfer/SystemFlavorMap/SetNativesForFlavor.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -162,4 +160,3 @@ public class SetNativesForFlavor {
         test_natives_set2 = new String[] {test_native3, test_native4};
     }
 }
-

--- a/test/jdk/java/awt/datatransfer/SystemFlavorMap/SetNativesTest.java
+++ b/test/jdk/java/awt/datatransfer/SystemFlavorMap/SetNativesTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -120,4 +118,3 @@ public class SetNativesTest {
         System.out.println("*** native size = " + hashVerify.size());
     }
 }
-

--- a/test/jdk/java/awt/datatransfer/SystemSelection/SystemSelectionAWTTest.java
+++ b/test/jdk/java/awt/datatransfer/SystemSelection/SystemSelectionAWTTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -169,4 +167,3 @@ public class SystemSelectionAWTTest {
         }
     }
 }
-

--- a/test/jdk/java/awt/datatransfer/SystemSelection/SystemSelectionSwingTest.java
+++ b/test/jdk/java/awt/datatransfer/SystemSelection/SystemSelectionSwingTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -171,4 +169,3 @@ public class SystemSelectionSwingTest {
         }
     }
 }
-

--- a/test/jdk/java/awt/event/ComponentEvent/MovedResizedTwiceTest/MovedResizedTwiceTest.java
+++ b/test/jdk/java/awt/event/ComponentEvent/MovedResizedTwiceTest/MovedResizedTwiceTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or


### PR DESCRIPTION
Remove *the "Classpath" exception* from tests in `javax/awt`. The tests should not have it.