### PR TITLE
8294073: Performance improvement for message digest implementations

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/SHA2.java
+++ b/src/java.base/share/classes/sun/security/provider/SHA2.java
@@ -199,7 +199,7 @@ abstract class SHA2 extends DigestBase {
             int ch_efg = g ^ (e & (f ^ g));
 
             // maj(x,y,z) = (x and y) xor (x and z) xor (y and z)
-	    //            = (x and y) xor ((x xor y) and z)
+            //            = (x and y) xor ((x xor y) and z)
             int maj_abc = (a & b) ^ ((a ^ b) & c);
 
             int T1 = h + sigma1_e + ch_efg + ROUND_CONSTS[i] + W[i];

--- a/src/java.base/share/classes/sun/security/provider/SHA2.java
+++ b/src/java.base/share/classes/sun/security/provider/SHA2.java
@@ -195,10 +195,12 @@ abstract class SHA2 extends DigestBase {
                     Integer.rotateRight(e, 25);
 
             // ch(x,y,z) = (x and y) xor ((complement x) and z)
-            int ch_efg = (e & f) ^ ((~e) & g);
+            //           = z xor (x and (y xor z));
+            int ch_efg = g ^ (e & (f ^ g));
 
             // maj(x,y,z) = (x and y) xor (x and z) xor (y and z)
-            int maj_abc = (a & b) ^ (a & c) ^ (b & c);
+	    //            = (x and y) xor ((x xor y) and z)
+            int maj_abc = (a & b) ^ ((a ^ b) & c);
 
             int T1 = h + sigma1_e + ch_efg + ROUND_CONSTS[i] + W[i];
             int T2 = sigma0_a + maj_abc;


### PR DESCRIPTION
Hi,

In the message digest implementation, for example SHA256, in JDK, two bitwise operations could be improved with equivalent arithmetic, and then the number bitwise operations could be reduced accordingly.  Specifically
"(x and y) xor ((complement x) and z)" could be replaced with the equivalent "z xor (x and (y xor z))", and "(x and y) xor (x and z) xor (y and z)" could be replaced with the equivalent "(x and y) xor ((x xor y) and z)".  Each replacement reduces one bitwise operation, and thus improve the performance.

Per my testing on my MacOS laptop, the update on SHA256 improves the message digest throughput by 0.5%-0.8%.  The improvement is not significant, but might be worthy of it as the update is pretty simple and trivial, for those platforms that do not support CPU intrinsic for a certain hash algorithm.

This patch update SHA2 implementation only.  Please let me know what do you think.  If you are good  with this little bit performance, I will update more message digest implementations.  If no one interested in these little benefits, I will close this PR later.

Thanks,
Xuelei

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294073](https://bugs.openjdk.org/browse/JDK-8294073): Performance improvement for message digest implementations


### Reviewers
 * [John Jiang](https://openjdk.org/census#jjiang) (@johnshajiang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10365/head:pull/10365` \
`$ git checkout pull/10365`

Update a local copy of the PR: \
`$ git checkout pull/10365` \
`$ git pull https://git.openjdk.org/jdk pull/10365/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10365`

View PR using the GUI difftool: \
`$ git pr show -t 10365`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10365.diff">https://git.openjdk.org/jdk/pull/10365.diff</a>

</details>
