### PR TITLE
8294075: gtest/AsyncLogGtest crashes with SEGV

### DIFF
--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -241,11 +241,15 @@ AsyncLogWriter::BufferUpdater::BufferUpdater(size_t newsize) {
 }
 
 AsyncLogWriter::BufferUpdater::~BufferUpdater() {
-  AsyncLogLocker locker;
+  AsyncLogWriter::flush();
   auto p = AsyncLogWriter::_instance;
 
-  delete p->_buffer;
-  delete p->_buffer_staging;
-  p->_buffer = _buf1;
-  p->_buffer_staging = _buf2;
+  {
+    AsyncLogLocker locker;
+
+    delete p->_buffer;
+    delete p->_buffer_staging;
+    p->_buffer = _buf1;
+    p->_buffer_staging = _buf2;
+  }
 }


### PR DESCRIPTION
In order to test "drop messages scenario", I replace the serving buffers with shrunk buffers(1k).
This is done by RAII class 'AsyncLogWriter::BufferUpdater'. There is a race condition between test and AsyncLog thread. 
The race condition exhibits when AsyncLog thread is still processing `buffer_staging` but test thread deletes it in dtor of BufferUpdater. 

This patch issues AsyncLogWriter::flush() before dtor of BufferUpdater. buffers are reverted only when pending messages have all been handled.

I test TEST="jtreg:hotspot/jtreg/gtest/AsyncLogGtest.java" 100 times and never see race condition.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294075](https://bugs.openjdk.org/browse/JDK-8294075): gtest/AsyncLogGtest crashes with SEGV


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10367/head:pull/10367` \
`$ git checkout pull/10367`

Update a local copy of the PR: \
`$ git checkout pull/10367` \
`$ git pull https://git.openjdk.org/jdk pull/10367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10367`

View PR using the GUI difftool: \
`$ git pr show -t 10367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10367.diff">https://git.openjdk.org/jdk/pull/10367.diff</a>

</details>
