### PR TITLE
8294083: RISC-V: Minimal build failed with --disable-precompiled-headers

### DIFF
--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -26,6 +26,7 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.inline.hpp"
+#include "classfile/javaClasses.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
 #include "interpreter/bytecodeHistogram.hpp"
 #include "interpreter/bytecodeTracer.hpp"


### PR DESCRIPTION
The build failed due to undeclared 'java_lang_ref_Reference'.
Including the corresponding header (classfile/javaClasses.hpp) will fix it.
I see a similar issue was once fixed for aarch64: https://bugs.openjdk.org/browse/JDK-8257743

Testing: Minimal builds with this fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294083](https://bugs.openjdk.org/browse/JDK-8294083): RISC-V: Minimal build failed with --disable-precompiled-headers


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author)
 * [Yadong Wang](https://openjdk.org/census#yadongwang) (@yadongw - Author)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10368/head:pull/10368` \
`$ git checkout pull/10368`

Update a local copy of the PR: \
`$ git checkout pull/10368` \
`$ git pull https://git.openjdk.org/jdk pull/10368/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10368`

View PR using the GUI difftool: \
`$ git pr show -t 10368`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10368.diff">https://git.openjdk.org/jdk/pull/10368.diff</a>

</details>
