### PR TITLE
8294087: RISC-V: RVC: Fix a potential alignment issue and add more alignment assertions for the patchable calls/nops

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -1372,7 +1372,7 @@ void LIR_Assembler::ic_call(LIR_OpJavaCall* op) {
 
 void LIR_Assembler::emit_static_call_stub() {
   address call_pc = __ pc();
-  __ assert_alignment(call_pc, NativeInstruction::instruction_size);
+  __ assert_alignment(call_pc);
   address stub = __ start_a_stub(call_stub_size());
   if (stub == NULL) {
     bailout("static call stub overflow");

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -1349,7 +1349,7 @@ void LIR_Assembler::align_call(LIR_Code code) {
   // With RVC a call instruction may get 2-byte aligned.
   // The address of the call instruction needs to be 4-byte aligned to
   // ensure that it does not span a cache line so that it can be patched.
-  __ align(4);
+  __ align(NativeInstruction::instruction_size);
 }
 
 void LIR_Assembler::call(LIR_OpJavaCall* op, relocInfo::relocType rtype) {
@@ -1372,7 +1372,7 @@ void LIR_Assembler::ic_call(LIR_OpJavaCall* op) {
 
 void LIR_Assembler::emit_static_call_stub() {
   address call_pc = __ pc();
-  assert((__ offset() % 4) == 0, "bad alignment");
+  __ assert_alignment(call_pc);
   address stub = __ start_a_stub(call_stub_size());
   if (stub == NULL) {
     bailout("static call stub overflow");

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -1372,7 +1372,7 @@ void LIR_Assembler::ic_call(LIR_OpJavaCall* op) {
 
 void LIR_Assembler::emit_static_call_stub() {
   address call_pc = __ pc();
-  __ assert_alignment(call_pc);
+  __ assert_alignment(call_pc, NativeInstruction::instruction_size);
   address stub = __ start_a_stub(call_stub_size());
   if (stub == NULL) {
     bailout("static call stub overflow");

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -1372,7 +1372,7 @@ void LIR_Assembler::ic_call(LIR_OpJavaCall* op) {
 
 void LIR_Assembler::emit_static_call_stub() {
   address call_pc = __ pc();
-  __ assert_alignment(call_pc);
+  MacroAssembler::assert_alignment(call_pc);
   address stub = __ start_a_stub(call_stub_size());
   if (stub == NULL) {
     bailout("static call stub overflow");

--- a/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
@@ -32,7 +32,6 @@
 #include "gc/shared/barrierSetAssembler.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "interpreter/interpreter.hpp"
-#include "nativeInst_riscv.hpp"
 #include "oops/arrayOop.hpp"
 #include "oops/markWord.hpp"
 #include "runtime/basicLock.hpp"
@@ -324,7 +323,7 @@ void C1_MacroAssembler::verified_entry(bool breakAtEntry) {
   // first instruction with a jump. For this action to be legal we
   // must ensure that this first instruction is a J, JAL or NOP.
   // Make it a NOP.
-  assert_alignment(NativeInstruction::instruction_size);
+  assert_alignment();
   nop();
 }
 

--- a/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
@@ -323,7 +323,7 @@ void C1_MacroAssembler::verified_entry(bool breakAtEntry) {
   // first instruction with a jump. For this action to be legal we
   // must ensure that this first instruction is a J, JAL or NOP.
   // Make it a NOP.
-  assert_alignment();
+  assert_alignment(pc());
   nop();
 }
 

--- a/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
@@ -32,6 +32,7 @@
 #include "gc/shared/barrierSetAssembler.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "interpreter/interpreter.hpp"
+#include "nativeInst_riscv.hpp"
 #include "oops/arrayOop.hpp"
 #include "oops/markWord.hpp"
 #include "runtime/basicLock.hpp"
@@ -323,7 +324,7 @@ void C1_MacroAssembler::verified_entry(bool breakAtEntry) {
   // first instruction with a jump. For this action to be legal we
   // must ensure that this first instruction is a J, JAL or NOP.
   // Make it a NOP.
-  assert_alignment();
+  assert_alignment(NativeInstruction::instruction_size);
   nop();
 }
 

--- a/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
@@ -323,7 +323,7 @@ void C1_MacroAssembler::verified_entry(bool breakAtEntry) {
   // first instruction with a jump. For this action to be legal we
   // must ensure that this first instruction is a J, JAL or NOP.
   // Make it a NOP.
-
+  assert_alignment();
   nop();
 }
 

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -255,7 +255,7 @@ void C2_MacroAssembler::emit_entry_barrier_stub(C2EntryBarrierStub* stub) {
 
   bind(stub->guard());
   relocate(entry_guard_Relocation::spec());
-  assert_alignment(NativeInstruction::instruction_size);
+  assert_alignment();
   emit_int32(0);  // nmethod guard value
   // make sure the stub with a fixed code size
   if (alignment_bytes == 2) {

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -255,7 +255,7 @@ void C2_MacroAssembler::emit_entry_barrier_stub(C2EntryBarrierStub* stub) {
 
   bind(stub->guard());
   relocate(entry_guard_Relocation::spec());
-  assert(offset() % 4 == 0, "bad alignment");
+  assert_alignment();
   emit_int32(0);  // nmethod guard value
   // make sure the stub with a fixed code size
   if (alignment_bytes == 2) {

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -255,7 +255,7 @@ void C2_MacroAssembler::emit_entry_barrier_stub(C2EntryBarrierStub* stub) {
 
   bind(stub->guard());
   relocate(entry_guard_Relocation::spec());
-  assert_alignment();
+  assert_alignment(pc());
   emit_int32(0);  // nmethod guard value
   // make sure the stub with a fixed code size
   if (alignment_bytes == 2) {

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -255,7 +255,7 @@ void C2_MacroAssembler::emit_entry_barrier_stub(C2EntryBarrierStub* stub) {
 
   bind(stub->guard());
   relocate(entry_guard_Relocation::spec());
-  assert_alignment();
+  assert_alignment(NativeInstruction::instruction_size);
   emit_int32(0);  // nmethod guard value
   // make sure the stub with a fixed code size
   if (alignment_bytes == 2) {

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
@@ -262,7 +262,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
 
     __ bind(local_guard);
 
-    assert(__ offset() % 4 == 0, "bad alignment");
+    __ assert_alignment();
     __ emit_int32(0); // nmethod guard value. Skipped over in common case.
     __ bind(skip_barrier);
   } else {

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
@@ -262,7 +262,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
 
     __ bind(local_guard);
 
-    __ assert_alignment();
+    __ assert_alignment(__ pc());
     __ emit_int32(0); // nmethod guard value. Skipped over in common case.
     __ bind(skip_barrier);
   } else {

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
@@ -31,6 +31,7 @@
 #include "gc/shared/collectedHeap.hpp"
 #include "interpreter/interp_masm.hpp"
 #include "memory/universe.hpp"
+#include "nativeInst_riscv.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/jniHandles.hpp"
 #include "runtime/sharedRuntime.hpp"
@@ -262,7 +263,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
 
     __ bind(local_guard);
 
-    __ assert_alignment();
+    __ assert_alignment(NativeInstruction::instruction_size);
     __ emit_int32(0); // nmethod guard value. Skipped over in common case.
     __ bind(skip_barrier);
   } else {

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
@@ -31,7 +31,6 @@
 #include "gc/shared/collectedHeap.hpp"
 #include "interpreter/interp_masm.hpp"
 #include "memory/universe.hpp"
-#include "nativeInst_riscv.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/jniHandles.hpp"
 #include "runtime/sharedRuntime.hpp"
@@ -263,7 +262,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
 
     __ bind(local_guard);
 
-    __ assert_alignment(NativeInstruction::instruction_size);
+    __ assert_alignment();
     __ emit_int32(0); // nmethod guard value. Skipped over in common case.
     __ bind(skip_barrier);
   } else {

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
@@ -262,7 +262,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
 
     __ bind(local_guard);
 
-    __ assert_alignment(__ pc());
+    MacroAssembler::assert_alignment(__ pc());
     __ emit_int32(0); // nmethod guard value. Skipped over in common case.
     __ bind(skip_barrier);
   } else {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -91,6 +91,14 @@ int MacroAssembler::align(int modulus, int extra_offset) {
   return (int)(offset() - before);
 }
 
+void MacroAssembler::assert_alignment() {
+  assert_alignment(pc());
+}
+
+void MacroAssembler::assert_alignment(address pc) {
+  assert(is_aligned(pc, NativeInstruction::instruction_size), "bad alignment");
+}
+
 void MacroAssembler::call_VM_helper(Register oop_result, address entry_point, int number_of_arguments, bool check_exceptions) {
   call_VM_base(oop_result, noreg, noreg, entry_point, number_of_arguments, check_exceptions);
 }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2847,6 +2847,7 @@ address MacroAssembler::trampoline_call(Address entry) {
   }
 
   address call_pc = pc();
+  assert(entry.rspec().type() == relocInfo::runtime_call_type || is_aligned(call_pc, 4), "bad alignment for patchable calls");
   relocate(entry.rspec());
   if (!far_branches()) {
     jal(entry.target());

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -91,12 +91,12 @@ int MacroAssembler::align(int modulus, int extra_offset) {
   return (int)(offset() - before);
 }
 
-void MacroAssembler::assert_alignment() {
-  assert_alignment(pc());
+void MacroAssembler::assert_alignment(int alignment) {
+  assert_alignment(pc(), alignment);
 }
 
-void MacroAssembler::assert_alignment(address pc) {
-  assert(is_aligned(pc, NativeInstruction::instruction_size), "bad alignment");
+void MacroAssembler::assert_alignment(address pc, int alignment) {
+  assert(is_aligned(pc, alignment), "bad alignment");
 }
 
 void MacroAssembler::call_VM_helper(Register oop_result, address entry_point, int number_of_arguments, bool check_exceptions) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2839,7 +2839,11 @@ address MacroAssembler::trampoline_call(Address entry) {
   }
 
   address call_pc = pc();
-  assert(entry.rspec().type() == relocInfo::runtime_call_type || is_aligned(call_pc, NativeInstruction::instruction_size), "bad alignment for patchable calls");
+#ifdef ASSERT
+  if (entry.rspec().type() != relocInfo::runtime_call_type) {
+    assert_alignment(call_pc);
+  }
+#endif
   relocate(entry.rspec());
   if (!far_branches()) {
     jal(entry.target());

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2847,7 +2847,7 @@ address MacroAssembler::trampoline_call(Address entry) {
   }
 
   address call_pc = pc();
-  assert(entry.rspec().type() == relocInfo::runtime_call_type || is_aligned(call_pc, 4), "bad alignment for patchable calls");
+  assert(entry.rspec().type() == relocInfo::runtime_call_type || is_aligned(call_pc, NativeInstruction::instruction_size), "bad alignment for patchable calls");
   relocate(entry.rspec());
   if (!far_branches()) {
     jal(entry.target());

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -91,14 +91,6 @@ int MacroAssembler::align(int modulus, int extra_offset) {
   return (int)(offset() - before);
 }
 
-void MacroAssembler::assert_alignment(int alignment) {
-  assert_alignment(pc(), alignment);
-}
-
-void MacroAssembler::assert_alignment(address pc, int alignment) {
-  assert(is_aligned(pc, alignment), "bad alignment");
-}
-
 void MacroAssembler::call_VM_helper(Register oop_result, address entry_point, int number_of_arguments, bool check_exceptions) {
   call_VM_base(oop_result, noreg, noreg, entry_point, number_of_arguments, check_exceptions);
 }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -49,8 +49,9 @@ class MacroAssembler: public Assembler {
 
   // Alignment
   int align(int modulus, int extra_offset = 0);
-  static void assert_alignment(address pc, int alignment = NativeInstruction::instruction_size);
-  void assert_alignment(int alignment = NativeInstruction::instruction_size);
+  static inline void assert_alignment(address pc, int alignment = NativeInstruction::instruction_size) {
+    assert(is_aligned(pc, alignment), "bad alignment");
+  }
 
   // Stack frame creation/removal
   // Note that SP must be updated to the right place before saving/restoring RA and FP

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -29,6 +29,7 @@
 
 #include "asm/assembler.hpp"
 #include "metaprogramming/enableIf.hpp"
+#include "nativeInst_riscv.hpp"
 #include "oops/compressedOops.hpp"
 #include "utilities/powerOfTwo.hpp"
 
@@ -48,8 +49,8 @@ class MacroAssembler: public Assembler {
 
   // Alignment
   int align(int modulus, int extra_offset = 0);
-  static void assert_alignment(address pc, int alignment);
-  void assert_alignment(int alignment);
+  static void assert_alignment(address pc, int alignment = NativeInstruction::instruction_size);
+  void assert_alignment(int alignment = NativeInstruction::instruction_size);
 
   // Stack frame creation/removal
   // Note that SP must be updated to the right place before saving/restoring RA and FP

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -48,6 +48,8 @@ class MacroAssembler: public Assembler {
 
   // Alignment
   int align(int modulus, int extra_offset = 0);
+  static void assert_alignment(address pc);
+  void assert_alignment();
 
   // Stack frame creation/removal
   // Note that SP must be updated to the right place before saving/restoring RA and FP

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -29,7 +29,6 @@
 
 #include "asm/assembler.hpp"
 #include "metaprogramming/enableIf.hpp"
-#include "nativeInst_riscv.hpp"
 #include "oops/compressedOops.hpp"
 #include "utilities/powerOfTwo.hpp"
 
@@ -49,8 +48,8 @@ class MacroAssembler: public Assembler {
 
   // Alignment
   int align(int modulus, int extra_offset = 0);
-  static void assert_alignment(address pc, int alignment = NativeInstruction::instruction_size);
-  void assert_alignment(int alignment = NativeInstruction::instruction_size);
+  static void assert_alignment(address pc, int alignment);
+  void assert_alignment(int alignment);
 
   // Stack frame creation/removal
   // Note that SP must be updated to the right place before saving/restoring RA and FP

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -29,6 +29,7 @@
 
 #include "asm/assembler.hpp"
 #include "metaprogramming/enableIf.hpp"
+#include "nativeInst_riscv.hpp"
 #include "oops/compressedOops.hpp"
 #include "utilities/powerOfTwo.hpp"
 
@@ -48,8 +49,8 @@ class MacroAssembler: public Assembler {
 
   // Alignment
   int align(int modulus, int extra_offset = 0);
-  static void assert_alignment(address pc);
-  void assert_alignment();
+  static void assert_alignment(address pc, int alignment = NativeInstruction::instruction_size);
+  void assert_alignment(int alignment = NativeInstruction::instruction_size);
 
   // Stack frame creation/removal
   // Note that SP must be updated to the right place before saving/restoring RA and FP

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -265,6 +265,13 @@ void NativeJump::verify() { }
 
 
 void NativeJump::check_verified_entry_alignment(address entry, address verified_entry) {
+  // Patching to not_entrant can happen while activations of the method are
+  // in use. The patching in that instance must happen only when certain
+  // alignment restrictions are true. These guarantees check those
+  // conditions.
+
+  // Must be 4 byte aligned
+  MacroAssembler::assert_alignment(verified_entry);
 }
 
 
@@ -354,6 +361,8 @@ void NativeJump::patch_verified_entry(address entry, address verified_entry, add
   assert(nativeInstruction_at(verified_entry)->is_jump_or_nop() ||
          nativeInstruction_at(verified_entry)->is_sigill_not_entrant(),
          "riscv cannot replace non-jump with jump");
+
+  check_verified_entry_alignment(entry, verified_entry);
 
   // Patch this nmethod atomically.
   if (Assembler::reachable_from_branch_at(verified_entry, dest)) {

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -270,7 +270,7 @@ void NativeJump::check_verified_entry_alignment(address entry, address verified_
   // alignment restrictions are true. These guarantees check those
   // conditions.
 
-  // Must be 4 byte aligned
+  // Must be 4 bytes aligned
   MacroAssembler::assert_alignment(verified_entry);
 }
 

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -271,7 +271,7 @@ void NativeJump::check_verified_entry_alignment(address entry, address verified_
   // conditions.
 
   // Must be 4 byte aligned
-  MacroAssembler::assert_alignment(verified_entry, NativeInstruction::instruction_size);
+  MacroAssembler::assert_alignment(verified_entry);
 }
 
 

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -271,7 +271,7 @@ void NativeJump::check_verified_entry_alignment(address entry, address verified_
   // conditions.
 
   // Must be 4 byte aligned
-  MacroAssembler::assert_alignment(verified_entry);
+  MacroAssembler::assert_alignment(verified_entry, NativeInstruction::instruction_size);
 }
 
 

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1318,7 +1318,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 
   // insert a nop at the start of the prolog so we can patch in a
   // branch if we need to invalidate the method later
-  __ assert_alignment(NativeInstruction::instruction_size);
+  __ assert_alignment();
   __ nop();
 
   assert_cond(C != NULL);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1318,7 +1318,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 
   // insert a nop at the start of the prolog so we can patch in a
   // branch if we need to invalidate the method later
-  __ assert_alignment();
+  __ assert_alignment(__ pc());
   __ nop();
 
   assert_cond(C != NULL);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1318,7 +1318,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 
   // insert a nop at the start of the prolog so we can patch in a
   // branch if we need to invalidate the method later
-  __ assert_alignment();
+  __ assert_alignment(NativeInstruction::instruction_size);
   __ nop();
 
   assert_cond(C != NULL);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1318,6 +1318,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 
   // insert a nop at the start of the prolog so we can patch in a
   // branch if we need to invalidate the method later
+  __ assert_alignment();
   __ nop();
 
   assert_cond(C != NULL);
@@ -1735,6 +1736,10 @@ void MachUEPNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const
   __ cmp_klass(j_rarg0, t1, t0, skip);
   __ far_jump(RuntimeAddress(SharedRuntime::get_ic_miss_stub()));
   __ bind(skip);
+
+  // These NOPs are critical so that verified entry point is properly
+  // 4 bytes aligned for patching by NativeJump::patch_verified_entry()
+  __ align(NativeInstruction::instruction_size);
 }
 
 uint MachUEPNode::size(PhaseRegAlloc* ra_) const

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1318,7 +1318,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 
   // insert a nop at the start of the prolog so we can patch in a
   // branch if we need to invalidate the method later
-  __ assert_alignment(__ pc());
+  MacroAssembler::assert_alignment(__ pc());
   __ nop();
 
   assert_cond(C != NULL);

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1140,6 +1140,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     int vep_offset = ((intptr_t)__ pc()) - start;
 
     // First instruction must be a nop as it may need to be patched on deoptimisation
+    __ assert_alignment();
     __ nop();
     gen_special_dispatch(masm,
                          method,
@@ -1291,6 +1292,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   // If we have to make this method not-entrant we'll overwrite its
   // first instruction with a jump.
+  __ assert_alignment();
   __ nop();
 
   if (VM_Version::supports_fast_class_init_checks() && method->needs_clinit_barrier()) {

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1140,7 +1140,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     int vep_offset = ((intptr_t)__ pc()) - start;
 
     // First instruction must be a nop as it may need to be patched on deoptimisation
-    __ assert_alignment();
+    __ assert_alignment(NativeInstruction::instruction_size);
     __ nop();
     gen_special_dispatch(masm,
                          method,
@@ -1292,7 +1292,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   // If we have to make this method not-entrant we'll overwrite its
   // first instruction with a jump.
-  __ assert_alignment();
+  __ assert_alignment(NativeInstruction::instruction_size);
   __ nop();
 
   if (VM_Version::supports_fast_class_init_checks() && method->needs_clinit_barrier()) {

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1140,7 +1140,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     int vep_offset = ((intptr_t)__ pc()) - start;
 
     // First instruction must be a nop as it may need to be patched on deoptimisation
-    __ assert_alignment(__ pc());
+    MacroAssembler::assert_alignment(__ pc());
     __ nop();
     gen_special_dispatch(masm,
                          method,
@@ -1292,7 +1292,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   // If we have to make this method not-entrant we'll overwrite its
   // first instruction with a jump.
-  __ assert_alignment(__ pc());
+  MacroAssembler::assert_alignment(__ pc());
   __ nop();
 
   if (VM_Version::supports_fast_class_init_checks() && method->needs_clinit_barrier()) {

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1140,7 +1140,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     int vep_offset = ((intptr_t)__ pc()) - start;
 
     // First instruction must be a nop as it may need to be patched on deoptimisation
-    __ assert_alignment(NativeInstruction::instruction_size);
+    __ assert_alignment();
     __ nop();
     gen_special_dispatch(masm,
                          method,
@@ -1292,7 +1292,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   // If we have to make this method not-entrant we'll overwrite its
   // first instruction with a jump.
-  __ assert_alignment(NativeInstruction::instruction_size);
+  __ assert_alignment();
   __ nop();
 
   if (VM_Version::supports_fast_class_init_checks() && method->needs_clinit_barrier()) {

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1140,7 +1140,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     int vep_offset = ((intptr_t)__ pc()) - start;
 
     // First instruction must be a nop as it may need to be patched on deoptimisation
-    __ assert_alignment();
+    __ assert_alignment(__ pc());
     __ nop();
     gen_special_dispatch(masm,
                          method,
@@ -1292,7 +1292,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   // If we have to make this method not-entrant we'll overwrite its
   // first instruction with a jump.
-  __ assert_alignment();
+  __ assert_alignment(__ pc());
   __ nop();
 
   if (VM_Version::supports_fast_class_init_checks() && method->needs_clinit_barrier()) {


### PR DESCRIPTION
With RVC turning on, we must carefully keep all runtime-patchable instructions aligned. Code is running at full speed, when patching unaligned instructions spanning cache lines, concurrency issues may occur. This patch fixes a potential alignment issue of the patchable nop after MachUEPNode, with adding some strong alignment assertions as well. (In fact, currently the `nop` in the Verified Entry Point is fortunately aligned to 4 under RVC even without this patch, so this patch doesn't change program behaviors.)

Tested hotspot tier1 and tier2 together with other patches on QEMU.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294087](https://bugs.openjdk.org/browse/JDK-8294087): RISC-V: RVC: Fix a potential alignment issue and add more alignment assertions for the patchable calls/nops


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [8ab3377d](https://git.openjdk.org/jdk/pull/10370/files/8ab3377d720b6c933fd85104b0a8bea98132d8ab)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10370/head:pull/10370` \
`$ git checkout pull/10370`

Update a local copy of the PR: \
`$ git checkout pull/10370` \
`$ git pull https://git.openjdk.org/jdk pull/10370/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10370`

View PR using the GUI difftool: \
`$ git pr show -t 10370`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10370.diff">https://git.openjdk.org/jdk/pull/10370.diff</a>

</details>
