### PR TITLE
8293986: Incorrect double-checked locking in com.sun.beans.introspect.ClassInfo

### DIFF
--- a/src/java.desktop/share/classes/com/sun/beans/introspect/ClassInfo.java
+++ b/src/java.desktop/share/classes/com/sun/beans/introspect/ClassInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,44 +65,53 @@ public final class ClassInfo {
 
     private final Object mutex = new Object();
     private final Class<?> type;
-    private List<Method> methods;
-    private Map<String,PropertyInfo> properties;
-    private Map<String,EventSetInfo> eventSets;
+    private volatile List<Method> methods;
+    private volatile Map<String,PropertyInfo> properties;
+    private volatile Map<String,EventSetInfo> eventSets;
 
     private ClassInfo(Class<?> type) {
         this.type = type;
     }
 
     public List<Method> getMethods() {
-        if (this.methods == null) {
+        List<Method> methods = this.methods;
+        if (methods == null) {
             synchronized (this.mutex) {
-                if (this.methods == null) {
-                    this.methods = MethodInfo.get(this.type);
+                methods = this.methods;
+                if (methods == null) {
+                    methods = MethodInfo.get(this.type);
+                    this.methods = methods;
                 }
             }
         }
-        return this.methods;
+        return methods;
     }
 
     public Map<String,PropertyInfo> getProperties() {
-        if (this.properties == null) {
+        Map<String, PropertyInfo> properties = this.properties;
+        if (properties == null) {
             synchronized (this.mutex) {
-                if (this.properties == null) {
-                    this.properties = PropertyInfo.get(this.type);
+                properties = this.properties;
+                if (properties == null) {
+                    properties = PropertyInfo.get(this.type);
+                    this.properties = properties;
                 }
             }
         }
-        return this.properties;
+        return properties;
     }
 
     public Map<String,EventSetInfo> getEventSets() {
-        if (this.eventSets == null) {
+        Map<String, EventSetInfo> eventSets = this.eventSets;
+        if (eventSets == null) {
             synchronized (this.mutex) {
-                if (this.eventSets == null) {
-                    this.eventSets = EventSetInfo.get(this.type);
+                eventSets = this.eventSets;
+                if (eventSets == null) {
+                    eventSets = EventSetInfo.get(this.type);
+                    this.eventSets = eventSets;
                 }
             }
         }
-        return this.eventSets;
+        return eventSets;
     }
 }


### PR DESCRIPTION
Fields `methods`, `properties`, `eventSets` are not volatile and read multiple times. This makes it an incorrect DCL.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293986](https://bugs.openjdk.org/browse/JDK-8293986): Incorrect double-checked locking in com.sun.beans.introspect.ClassInfo


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10372/head:pull/10372` \
`$ git checkout pull/10372`

Update a local copy of the PR: \
`$ git checkout pull/10372` \
`$ git pull https://git.openjdk.org/jdk pull/10372/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10372`

View PR using the GUI difftool: \
`$ git pr show -t 10372`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10372.diff">https://git.openjdk.org/jdk/pull/10372.diff</a>

</details>
