### PR TITLE
8294053: Unneeded local variable in handle_safefetch()

### DIFF
--- a/src/hotspot/os/posix/safefetch_static_posix.cpp
+++ b/src/hotspot/os/posix/safefetch_static_posix.cpp
@@ -48,7 +48,6 @@ extern "C" char _SafeFetchN_fault[] __attribute__ ((visibility ("hidden")));
 bool handle_safefetch(int sig, address pc, void* context) {
   ucontext_t* uc = (ucontext_t*)context;
   if ((sig == SIGSEGV || sig == SIGBUS) && uc != NULL) {
-    address pc = os::Posix::ucontext_get_pc(uc);
     if (pc == (address)_SafeFetch32_fault) {
       os::Posix::ucontext_set_pc(uc, (address)_SafeFetch32_continuation);
       return true;


### PR DESCRIPTION
The input argument "pc" is shadowed by a local variable with the same type and name, and is initialized to the same value as is passed into the handle_safefetch() function by its callers. The local "pc" variable can therefore be removed from handle_safefetch().

Tested tier1, tier2 and  tier3 without any new problems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294053](https://bugs.openjdk.org/browse/JDK-8294053): Unneeded local variable in handle_safefetch()


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10373/head:pull/10373` \
`$ git checkout pull/10373`

Update a local copy of the PR: \
`$ git checkout pull/10373` \
`$ git pull https://git.openjdk.org/jdk pull/10373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10373`

View PR using the GUI difftool: \
`$ git pr show -t 10373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10373.diff">https://git.openjdk.org/jdk/pull/10373.diff</a>

</details>
