### PR TITLE
8294110: compiler/uncommontrap/Decompile.java fails after JDK-8293798

### DIFF
--- a/test/hotspot/jtreg/compiler/uncommontrap/Decompile.java
+++ b/test/hotspot/jtreg/compiler/uncommontrap/Decompile.java
@@ -36,7 +36,7 @@
  *                   -Xbatch -XX:-UseOnStackReplacement -XX:-TieredCompilation
  *                   -XX:+UnlockExperimentalVMOptions -XX:PerMethodTrapLimit=100 -XX:PerBytecodeTrapLimit=4
  *                   -XX:TypeProfileLevel=0
- *                   -XX:-AlwaysIncrementalInline
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-AlwaysIncrementalInline
  *                   -XX:CompileCommand=compileonly,compiler.uncommontrap.Decompile::uncommonTrap
  *                   -XX:CompileCommand=inline,compiler.uncommontrap.Decompile*::foo
  *                   compiler.uncommontrap.Decompile


### PR DESCRIPTION
It fails with release VMs.
```
STDERR:
Error: VM option 'AlwaysIncrementalInline' is develop and is available only in debug version of VM.
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

`-XX:+IgnoreUnrecognizedVMOptions` is added to fix it.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294110](https://bugs.openjdk.org/browse/JDK-8294110): compiler/uncommontrap/Decompile.java fails after JDK-8293798


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10374/head:pull/10374` \
`$ git checkout pull/10374`

Update a local copy of the PR: \
`$ git checkout pull/10374` \
`$ git pull https://git.openjdk.org/jdk pull/10374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10374`

View PR using the GUI difftool: \
`$ git pr show -t 10374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10374.diff">https://git.openjdk.org/jdk/pull/10374.diff</a>

</details>
