### PR TITLE
8292214: Memory leak in getAllConfigs of awt_GraphicsEnv.c:386

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
@@ -572,10 +572,8 @@ getAllConfigs (JNIEnv *env, int screen, AwtScreenDataPtr screenDataPtr) {
 
 cleanup:
     if (success != JNI_TRUE) {
-        for (int i = 0; i < ind-1; i++) {
-            if (graphicsConfigs[i] != 0) {
-                free(graphicsConfigs[i]);
-            }
+        for (int i = 0; i < nConfig; i++) {
+            free(graphicsConfigs[i]);
         }
         free(graphicsConfigs);
     }

--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
@@ -572,7 +572,7 @@ getAllConfigs (JNIEnv *env, int screen, AwtScreenDataPtr screenDataPtr) {
 
 cleanup:
     if (success != JNI_TRUE) {
-        for (int i : graphicsConfigs) {
+        for (int i = 0; i < screenDataPtr->numConfigs; i++) {
             if (graphicsConfigs[i] != 0) {
                 free(graphicsConfigs[i]);
             }

--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
@@ -572,7 +572,7 @@ getAllConfigs (JNIEnv *env, int screen, AwtScreenDataPtr screenDataPtr) {
 
 cleanup:
     if (success != JNI_TRUE) {
-        for (int i = 0; i < screenDataPtr->numConfigs; i++) {
+        for (int i = 0; i < ind-1; i++) {
             if (graphicsConfigs[i] != 0) {
                 free(graphicsConfigs[i]);
             }

--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
@@ -383,7 +383,7 @@ getAllConfigs (JNIEnv *env, int screen, AwtScreenDataPtr screenDataPtr) {
          */
         screenDataPtr->defaultConfig = makeDefaultConfig(env, screen);
         if (screenDataPtr->defaultConfig == NULL) {
-            return;
+            goto cleanup;
         }
     }
 
@@ -572,6 +572,11 @@ getAllConfigs (JNIEnv *env, int screen, AwtScreenDataPtr screenDataPtr) {
 
 cleanup:
     if (success != JNI_TRUE) {
+        for (int i : graphicsConfigs) {
+            if (graphicsConfigs[i] != 0) {
+                free(graphicsConfigs[i]);
+            }
+        }
         free(graphicsConfigs);
     }
     if (n8p != 0)

--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
@@ -572,7 +572,7 @@ getAllConfigs (JNIEnv *env, int screen, AwtScreenDataPtr screenDataPtr) {
 
 cleanup:
     if (success != JNI_TRUE) {
-        for (int i = 0; i < nConfig; i++) {
+        for (i = 0; i < nConfig; i++) {
             free(graphicsConfigs[i]);
         }
         free(graphicsConfigs);


### PR DESCRIPTION
changed return to cleanup in getAllConfigs
changed cleanup to loop thru and free all allocated memory adjacent to graphicsConfig pointer

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292214](https://bugs.openjdk.org/browse/JDK-8292214): Memory leak in getAllConfigs of awt_GraphicsEnv.c:386


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10378/head:pull/10378` \
`$ git checkout pull/10378`

Update a local copy of the PR: \
`$ git checkout pull/10378` \
`$ git pull https://git.openjdk.org/jdk pull/10378/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10378`

View PR using the GUI difftool: \
`$ git pr show -t 10378`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10378.diff">https://git.openjdk.org/jdk/pull/10378.diff</a>

</details>
