### PR TITLE
8234262: Unmask SIGQUIT in a child process

### DIFF
--- a/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
+++ b/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
@@ -25,6 +25,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -132,6 +133,7 @@ int main(int argc, char *argv[]) {
     struct stat buf;
     /* argv[0] contains the fd number to read all the child info */
     int r, fdin, fdout;
+    sigset_t unblock_signals;
 
     r = sscanf (argv[argc-1], "%d:%d", &fdin, &fdout);
     if (r == 2 && fcntl(fdin, F_GETFD) != -1) {
@@ -141,6 +143,11 @@ int main(int argc, char *argv[]) {
     } else {
         shutItDown();
     }
+
+    // Reset any mask signals from parent
+    sigemptyset(&unblock_signals);
+    sigprocmask(SIG_SETMASK, &unblock_signals, NULL);
+
     initChildStuff (fdin, fdout, &c);
 
     childProcess (&c);

--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -490,6 +490,8 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
     char *buf, buf1[16];
     char *hlpargs[2];
     SpawnInfo sp;
+    posix_spawnattr_t spawnattr;
+    sigset_t unblock_signals;
 
     /* need to tell helper which fd is for receiving the childstuff
      * and which fd to send response back on
@@ -498,6 +500,14 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
     /* put the fd string as argument to the helper cmd */
     hlpargs[0] = buf1;
     hlpargs[1] = 0;
+
+    /* Unmask all signals in the child. */
+    sigemptyset(&unblock_signals);
+    if (posix_spawnattr_init(&spawnattr) != 0 ||
+        posix_spawnattr_setflags(&spawnattr, POSIX_SPAWN_SETSIGMASK) != 0 ||
+        posix_spawnattr_setsigmask(&spawnattr, &unblock_signals) != 0) {
+        return -1;      // errno is set
+    }
 
     /* Following items are sent down the pipe to the helper
      * after it is spawned.
@@ -532,7 +542,9 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
         }
     }
 
-    rval = posix_spawn(&resultPid, helperpath, 0, 0, (char * const *) hlpargs, environ);
+    rval = posix_spawn(&resultPid, helperpath, 0, &spawnattr, (char * const *) hlpargs, environ);
+
+    posix_spawnattr_destroy(&spawnattr);
 
     if (rval != 0) {
         return -1;
@@ -773,4 +785,3 @@ Java_java_lang_ProcessImpl_forkAndExec(JNIEnv *env,
     closeSafely(err[0]); err[0] = -1;
     goto Finally;
 }
-

--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -490,8 +490,6 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
     char *buf, buf1[16];
     char *hlpargs[2];
     SpawnInfo sp;
-    posix_spawnattr_t spawnattr;
-    sigset_t unblock_signals;
 
     /* need to tell helper which fd is for receiving the childstuff
      * and which fd to send response back on
@@ -500,14 +498,6 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
     /* put the fd string as argument to the helper cmd */
     hlpargs[0] = buf1;
     hlpargs[1] = 0;
-
-    /* Unmask all signals in the child. */
-    sigemptyset(&unblock_signals);
-    if (posix_spawnattr_init(&spawnattr) != 0 ||
-        posix_spawnattr_setflags(&spawnattr, POSIX_SPAWN_SETSIGMASK) != 0 ||
-        posix_spawnattr_setsigmask(&spawnattr, &unblock_signals) != 0) {
-        return -1;      // errno is set
-    }
 
     /* Following items are sent down the pipe to the helper
      * after it is spawned.
@@ -542,9 +532,7 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
         }
     }
 
-    rval = posix_spawn(&resultPid, helperpath, 0, &spawnattr, (char * const *) hlpargs, environ);
-
-    posix_spawnattr_destroy(&spawnattr);
+    rval = posix_spawn(&resultPid, helperpath, 0, 0, (char * const *) hlpargs, environ);
 
     if (rval != 0) {
         return -1;

--- a/test/jdk/java/lang/ProcessBuilder/UnblockSignals.java
+++ b/test/jdk/java/lang/ProcessBuilder/UnblockSignals.java
@@ -28,7 +28,8 @@ import java.io.IOException;
  * @test
  * @summary Verify Signal mask is cleared by ProcessBuilder start
  * @bug 8234262
- * @run main UnblockSignals
+ * @run main/othervm UnblockSignals
+ * @run main/othervm -Xrs UnblockSignals
  */
 public class UnblockSignals {
     public static void main(String[] args)  throws IOException, InterruptedException {

--- a/test/jdk/java/lang/ProcessBuilder/UnblockSignals.java
+++ b/test/jdk/java/lang/ProcessBuilder/UnblockSignals.java
@@ -20,14 +20,14 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-import java.lang.Process;
-import java.lang.ProcessBuilder;
+
 import java.io.IOException;
 
 /*
  * @test
  * @summary Verify Signal mask is cleared by ProcessBuilder start
  * @bug 8234262
+ * @requires (os.family == "linux" | os.family == "mac")
  * @run main/othervm UnblockSignals
  * @run main/othervm -Xrs UnblockSignals
  */

--- a/test/jdk/java/lang/ProcessBuilder/UnblockSignals.java
+++ b/test/jdk/java/lang/ProcessBuilder/UnblockSignals.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import java.lang.Process;
+import java.lang.ProcessBuilder;
+import java.io.IOException;
+
+/*
+ * @test
+ * @summary Verify Signal mask is cleared by ProcessBuilder start
+ * @bug 8234262
+ * @run main UnblockSignals
+ */
+public class UnblockSignals {
+    public static void main(String[] args)  throws IOException, InterruptedException {
+        // Check that SIGQUIT is not masked, in previous releases it was masked
+        final ProcessBuilder pb = new ProcessBuilder("sleep", "30").inheritIO();
+        Process p = pb.start();
+        System.out.printf("Child %d, %s%n", p.pid(), pb.command());
+        ProcessBuilder killpb = new ProcessBuilder("kill", "-s", "QUIT", Long.toString(p.pid()));
+        Process killp = killpb.start();
+        System.out.printf("Child %d, %s%n", killp.pid(), killpb.command());
+        int killst = killp.waitFor();
+        if (killst != 0) {
+            throw new RuntimeException("Kill process failed, exit status: " + killst);
+        }
+        int sleepStatus = p.waitFor();
+        if (sleepStatus == 0) {
+            throw new RuntimeException("Child not killed");
+        }
+    }
+}


### PR DESCRIPTION
Clear the signal mask of the child when launching with posix_spawn.

SIGQUIT signals are handled on non-Java Threads by the VM.
For Java threads the signal mask blocks SIGQUIT.  
The ProcessBuilder uses posix_spawn on all platforms to create new processes.
Without a specific request, the child process inherits the signal masks from the parent.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8234262](https://bugs.openjdk.org/browse/JDK-8234262): Unmask SIGQUIT in a child process


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to [e0e854bd](https://git.openjdk.org/jdk/pull/10379/files/e0e854bdac25164ff23b6f2820c516cbdb0195f1)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [dc56e0d8](https://git.openjdk.org/jdk/pull/10379/files/dc56e0d8d17cb0c201d516d9777da08506c57bea)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer) ⚠️ Review applies to [dc56e0d8](https://git.openjdk.org/jdk/pull/10379/files/dc56e0d8d17cb0c201d516d9777da08506c57bea)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [dc56e0d8](https://git.openjdk.org/jdk/pull/10379/files/dc56e0d8d17cb0c201d516d9777da08506c57bea)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [dc56e0d8](https://git.openjdk.org/jdk/pull/10379/files/dc56e0d8d17cb0c201d516d9777da08506c57bea)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10379/head:pull/10379` \
`$ git checkout pull/10379`

Update a local copy of the PR: \
`$ git checkout pull/10379` \
`$ git pull https://git.openjdk.org/jdk pull/10379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10379`

View PR using the GUI difftool: \
`$ git pr show -t 10379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10379.diff">https://git.openjdk.org/jdk/pull/10379.diff</a>

</details>
