### PR TITLE
8294183: AArch64: Wrong macro check in SharedRuntime::generate_deopt_blob

### DIFF
--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -2278,8 +2278,7 @@ void SharedRuntime::generate_deopt_blob() {
   __ set_last_Java_frame(sp, noreg, retaddr, rscratch1);
 #ifdef ASSERT
   { Label L;
-    __ ldr(rscratch1, Address(rthread,
-                              JavaThread::last_Java_fp_offset()));
+    __ ldr(rscratch1, Address(rthread, JavaThread::last_Java_fp_offset()));
     __ cbz(rscratch1, L);
     __ stop("SharedRuntime::generate_deopt_blob: last_Java_fp not cleared");
     __ bind(L);

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -2276,7 +2276,7 @@ void SharedRuntime::generate_deopt_blob() {
 
   Label retaddr;
   __ set_last_Java_frame(sp, noreg, retaddr, rscratch1);
-#ifdef ASSERT0
+#ifdef ASSERT
   { Label L;
     __ ldr(rscratch1, Address(rthread,
                               JavaThread::last_Java_fp_offset()));


### PR DESCRIPTION
This is trivial change fixing a wrong macro check in SharedRuntime::generate_deopt_blob on aarch64.

Testing: Tier1 tested with fastdebug build on aarch64-linux server.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294183](https://bugs.openjdk.org/browse/JDK-8294183): AArch64: Wrong macro check in SharedRuntime::generate_deopt_blob


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [fe57bbcc](https://git.openjdk.org/jdk/pull/10382/files/fe57bbcc86f1bee69af4b56d56cfbec37b97cf64)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10382/head:pull/10382` \
`$ git checkout pull/10382`

Update a local copy of the PR: \
`$ git checkout pull/10382` \
`$ git pull https://git.openjdk.org/jdk pull/10382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10382`

View PR using the GUI difftool: \
`$ git pr show -t 10382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10382.diff">https://git.openjdk.org/jdk/pull/10382.diff</a>

</details>
