### PR TITLE
8294187: RISC-V: Unify all relocations for the backend into AbstractAssembler::relocate()

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.cpp
@@ -215,7 +215,7 @@ void Assembler::ret() {
   void Assembler::NAME(const Address &adr, Register temp) {    \
     switch (adr.getMode()) {                                   \
       case Address::literal: {                                 \
-        code_section()->relocate(pc(), adr.rspec());           \
+        relocate(adr.rspec());                                 \
         NAME(adr.target(), temp);                              \
         break;                                                 \
       }                                                        \

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -2127,21 +2127,6 @@ public:
     }
   };
 
-public:
-  // Emit a relocation.
-  void relocate(address at, RelocationHolder const& rspec, int format = 0) {
-    code_section()->relocate(at, rspec, format);
-  }
-  void relocate(address at, relocInfo::relocType rtype, int format = 0, jint method_index = 0) {
-    code_section()->relocate(at, rtype, format, method_index);
-  }
-  void relocate(RelocationHolder const& rspec, int format = 0) {
-    AbstractAssembler::relocate(rspec, format);
-  }
-  void relocate(relocInfo::relocType rtype, int format = 0) {
-    AbstractAssembler::relocate(rtype, format);
-  }
-
   // patch a 16-bit instruction.
   static void c_patch(address a, unsigned msb, unsigned lsb, uint16_t val) {
     assert_cond(a != NULL);

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -488,7 +488,7 @@ public:
   result_type header {                                                      \
     guarantee(rtype == relocInfo::internal_word_type,                       \
               "only internal_word_type relocs make sense here");            \
-    code_section()->relocate(pc(), InternalAddress(dest).rspec());
+    relocate(InternalAddress(dest).rspec());
 
   // Load/store register (all modes)
 #define INSN(NAME, op, funct3)                                                                     \
@@ -533,7 +533,7 @@ public:
   void NAME(Register Rd, const Address &adr, Register temp = t0) {                                 \
     switch (adr.getMode()) {                                                                       \
       case Address::literal: {                                                                     \
-        code_section()->relocate(pc(), adr.rspec());                                               \
+        relocate(adr.rspec());                                                                     \
         NAME(Rd, adr.target());                                                                    \
         break;                                                                                     \
       }                                                                                            \
@@ -607,7 +607,7 @@ public:
   void NAME(FloatRegister Rd, const Address &adr, Register temp = t0) {                            \
     switch (adr.getMode()) {                                                                       \
       case Address::literal: {                                                                     \
-        code_section()->relocate(pc(), adr.rspec());                                               \
+        relocate(adr.rspec());                                                                     \
         NAME(Rd, adr.target(), temp);                                                              \
         break;                                                                                     \
       }                                                                                            \
@@ -750,7 +750,7 @@ public:
     switch (adr.getMode()) {                                                                       \
       case Address::literal: {                                                                     \
         assert_different_registers(Rs, temp);                                                      \
-        code_section()->relocate(pc(), adr.rspec());                                               \
+        relocate(adr.rspec());                                                                     \
         NAME(Rs, adr.target(), temp);                                                              \
         break;                                                                                     \
       }                                                                                            \
@@ -793,7 +793,7 @@ public:
   void NAME(FloatRegister Rs, const Address &adr, Register temp = t0) {                            \
     switch (adr.getMode()) {                                                                       \
       case Address::literal: {                                                                     \
-        code_section()->relocate(pc(), adr.rspec());                                               \
+        relocate(adr.rspec());                                                                     \
         NAME(Rs, adr.target(), temp);                                                              \
         break;                                                                                     \
       }                                                                                            \
@@ -2126,6 +2126,21 @@ public:
       _masm->set_in_compressible_region(_saved_in_compressible_region);
     }
   };
+
+public:
+  // Emit a relocation.
+  void relocate(address at, RelocationHolder const& rspec, int format = 0) {
+    code_section()->relocate(at, rspec, format);
+  }
+  void relocate(address at, relocInfo::relocType rtype, int format = 0, jint method_index = 0) {
+    code_section()->relocate(at, rtype, format, method_index);
+  }
+  void relocate(RelocationHolder const& rspec, int format = 0) {
+    AbstractAssembler::relocate(rspec, format);
+  }
+  void relocate(relocInfo::relocType rtype, int format = 0) {
+    AbstractAssembler::relocate(rtype, format);
+  }
 
   // patch a 16-bit instruction.
   static void c_patch(address a, unsigned msb, unsigned lsb, uint16_t val) {

--- a/src/hotspot/cpu/riscv/c1_CodeStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_CodeStubs_riscv.cpp
@@ -42,7 +42,7 @@
 void C1SafepointPollStub::emit_code(LIR_Assembler* ce) {
   __ bind(_entry);
   InternalAddress safepoint_pc(__ pc() - __ offset() + safepoint_offset());
-  __ code_section()->relocate(__ pc(), safepoint_pc.rspec());
+  __ relocate(safepoint_pc.rspec());
   __ la(t0, safepoint_pc.target());
   __ sd(t0, Address(xthread, JavaThread::saved_exception_pc_offset()));
 

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -2144,16 +2144,6 @@ void LIR_Assembler::typecheck_lir_store(LIR_OpTypeCheck* op, bool should_profile
   __ bind(done);
 }
 
-void LIR_Assembler::add_debug_info_for_branch(address adr, CodeEmitInfo* info) {
-  _masm->relocate(adr, relocInfo::poll_type);
-  int pc_offset = code_offset();
-  flush_debug_info(pc_offset);
-  info->record_debug_info(compilation()->debug_info_recorder(), pc_offset);
-  if (info->exception_handlers() != NULL) {
-    compilation()->add_exception_handlers_for_pco(pc_offset, info->exception_handlers());
-  }
-}
-
 void LIR_Assembler::type_profile(Register obj, ciMethodData* md, Register klass_RInfo, Register k_RInfo,
                                  ciProfileData* data, Label* success, Label* failure,
                                  Label& profile_cast_success, Label& profile_cast_failure) {

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -2145,7 +2145,7 @@ void LIR_Assembler::typecheck_lir_store(LIR_OpTypeCheck* op, bool should_profile
 }
 
 void LIR_Assembler::add_debug_info_for_branch(address adr, CodeEmitInfo* info) {
-  _masm->code_section()->relocate(adr, relocInfo::poll_type);
+  _masm->relocate(adr, relocInfo::poll_type);
   int pc_offset = code_offset();
   flush_debug_info(pc_offset);
   info->record_debug_info(compilation()->debug_info_recorder(), pc_offset);

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.hpp
@@ -58,8 +58,6 @@ private:
                            ciMethodData *md, ciProfileData *data,
                            Register recv, Label* update_done);
 
-  void add_debug_info_for_branch(address adr, CodeEmitInfo* info);
-
   void casw(Register addr, Register newval, Register cmpval);
   void caswu(Register addr, Register newval, Register cmpval);
   void casl(Register addr, Register newval, Register cmpval);

--- a/src/hotspot/cpu/riscv/c2_safepointPollStubTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_safepointPollStubTable_riscv.cpp
@@ -39,7 +39,7 @@ void C2SafepointPollStubTable::emit_stub_impl(MacroAssembler& masm, C2SafepointP
 
   __ bind(entry->_stub_label);
   InternalAddress safepoint_pc(masm.pc() - masm.offset() + entry->_safepoint_offset);
-  masm.code_section()->relocate(masm.pc(), safepoint_pc.rspec());
+  masm.relocate(safepoint_pc.rspec());
   __ la(t0, safepoint_pc.target());
   __ sd(t0, Address(xthread, JavaThread::saved_exception_pc_offset()));
   __ far_jump(callback_addr);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -730,14 +730,13 @@ void MacroAssembler::la(Register Rd, const address &dest) {
 }
 
 void MacroAssembler::la(Register Rd, const Address &adr) {
-  code_section()->relocate(pc(), adr.rspec());
-  relocInfo::relocType rtype = adr.rspec().reloc()->type();
-
   switch (adr.getMode()) {
     case Address::literal: {
+      relocInfo::relocType rtype = adr.rspec().reloc()->type();
       if (rtype == relocInfo::none) {
         mv(Rd, (intptr_t)(adr.target()));
       } else {
+        relocate(adr.rspec());
         movptr(Rd, adr.target());
       }
       break;
@@ -1349,7 +1348,7 @@ void MacroAssembler::reinit_heapbase() {
 
 void MacroAssembler::mv(Register Rd, Address dest) {
   assert(dest.getMode() == Address::literal, "Address mode should be Address::literal");
-  code_section()->relocate(pc(), dest.rspec());
+  relocate(dest.rspec());
   movptr(Rd, dest.target());
 }
 
@@ -2700,7 +2699,7 @@ void MacroAssembler::la_patchable(Register reg1, const Address &dest, int32_t &o
   assert(is_valid_riscv64_address(dest.target()), "bad address");
   assert(dest.getMode() == Address::literal, "la_patchable must be applied to a literal address");
 
-  code_section()->relocate(pc(), dest.rspec());
+  relocate(dest.rspec());
   // RISC-V doesn't compute a page-aligned address, in order to partially
   // compensate for the use of *signed* offsets in its base+disp12
   // addressing mode (RISC-V's PC-relative reach remains asymmetric
@@ -2764,7 +2763,7 @@ void MacroAssembler::get_polling_page(Register dest, relocInfo::relocType rtype)
 // Read the polling page.  The address of the polling page must
 // already be in r.
 void MacroAssembler::read_polling_page(Register r, int32_t offset, relocInfo::relocType rtype) {
-  code_section()->relocate(pc(), rtype);
+  relocate(rtype);
   lwu(zr, Address(r, offset));
 }
 
@@ -2779,8 +2778,7 @@ void  MacroAssembler::set_narrow_oop(Register dst, jobject obj) {
   }
 #endif
   int oop_index = oop_recorder()->find_index(obj);
-  RelocationHolder rspec = oop_Relocation::spec(oop_index);
-  code_section()->relocate(pc(), rspec);
+  relocate(oop_Relocation::spec(oop_index));
   li32(dst, 0xDEADBEEF);
   zero_extend(dst, dst, 32);
 }
@@ -2791,9 +2789,8 @@ void  MacroAssembler::set_narrow_klass(Register dst, Klass* k) {
   int index = oop_recorder()->find_index(k);
   assert(!Universe::heap()->is_in(k), "should not be an oop");
 
-  RelocationHolder rspec = metadata_Relocation::spec(index);
-  code_section()->relocate(pc(), rspec);
   narrowKlass nk = CompressedKlassPointers::encode(k);
+  relocate(metadata_Relocation::spec(index));
   li32(dst, nk);
   zero_extend(dst, dst, 32);
 }


### PR DESCRIPTION
Unify all relocations into AbstractAssembler::relocate() as a simple cleanup.

Tested hotspot tier1 and tier2 on QEMU.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294187](https://bugs.openjdk.org/browse/JDK-8294187): RISC-V: Unify all relocations for the backend into AbstractAssembler::relocate()


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author) ⚠️ Review applies to [21ba6a61](https://git.openjdk.org/jdk/pull/10384/files/21ba6a611b8de528fa4a625b8086ac89eca62e81)
 * [Yadong Wang](https://openjdk.org/census#yadongwang) (@yadongw - Author) ⚠️ Review applies to [21ba6a61](https://git.openjdk.org/jdk/pull/10384/files/21ba6a611b8de528fa4a625b8086ac89eca62e81)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10384/head:pull/10384` \
`$ git checkout pull/10384`

Update a local copy of the PR: \
`$ git checkout pull/10384` \
`$ git pull https://git.openjdk.org/jdk pull/10384/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10384`

View PR using the GUI difftool: \
`$ git pr show -t 10384`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10384.diff">https://git.openjdk.org/jdk/pull/10384.diff</a>

</details>
