### PR TITLE
8294197: Zero: JVM_handle_linux_signal should not assume deopt NOPs

### DIFF
--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -624,6 +624,7 @@ int JVM_HANDLE_XXX_SIGNAL(int sig, siginfo_t* info,
     signal_was_handled = true; // unconditionally.
   }
 
+#ifndef ZERO
   // Check for UD trap caused by NOP patching.
   // If it is, patch return address to be deopt handler.
   if (!signal_was_handled) {
@@ -648,6 +649,7 @@ int JVM_HANDLE_XXX_SIGNAL(int sig, siginfo_t* info,
       }
     }
   }
+#endif
 
   // Call platform dependent signal handler.
   if (!signal_was_handled) {

--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -649,7 +649,7 @@ int JVM_HANDLE_XXX_SIGNAL(int sig, siginfo_t* info,
       }
     }
   }
-#endif
+#endif // ZERO
 
   // Call platform dependent signal handler.
   if (!signal_was_handled) {

--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -649,7 +649,7 @@ int JVM_HANDLE_XXX_SIGNAL(int sig, siginfo_t* info,
       }
     }
   }
-#endif // ZERO
+#endif // !ZERO
 
   // Call platform dependent signal handler.
   if (!signal_was_handled) {


### PR DESCRIPTION
This is a simple regression from Loom added code. In `JVM_handle_linux_signal` there is a new block that handles deopt NOPs. Zero does not have them, and so it currently encounters `ShouldNotReachHere()` when entering the block and doing either `os::Posix::ucontext_get_pc(uc)` or `NativeDeoptInstruction::is_deopt_at(pc)`.

This block should not be entered with Zero at all. 

Additional testing:
 - [x] Artificially crashing Linux x86_64 Zero fastdebug now produces a sensible hs_err

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294197](https://bugs.openjdk.org/browse/JDK-8294197): Zero: JVM_handle_linux_signal should not assume deopt NOPs


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10389/head:pull/10389` \
`$ git checkout pull/10389`

Update a local copy of the PR: \
`$ git checkout pull/10389` \
`$ git pull https://git.openjdk.org/jdk pull/10389/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10389`

View PR using the GUI difftool: \
`$ git pr show -t 10389`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10389.diff">https://git.openjdk.org/jdk/pull/10389.diff</a>

</details>
