### PR TITLE
8293999: [JVMCI] need support for aligned constants in generated code larger than 8 bytes

### DIFF
--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -236,8 +236,9 @@ void MachConstantBaseNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const {
 
   Register r = as_Register(ra_->get_encode(this));
   CodeSection* consts_section = __ code()->consts();
+  CodeSection* insts_section = __ code()->insts();
   // constants section size is aligned according to the align_at_start settings of the next section
-  int consts_size = CodeSection::align_at_start(consts_section->size(), CodeBuffer::SECT_INSTS);
+  int consts_size = insts_section->align_at_start(consts_section->size());
   assert(constant_table.size() == consts_size, "must be: %d == %d", constant_table.size(), consts_size);
 
   // Materialize the constant table base.

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -422,6 +422,21 @@ void CodeSection::expand_locs(int new_capacity) {
   }
 }
 
+int CodeSection::alignment() const {
+  if (_index == CodeBuffer::SECT_CONSTS) {
+    // CodeBuffer controls the alignment of the constants section
+    return _outer->_const_section_alignment;
+  }
+  if (_index == CodeBuffer::SECT_INSTS) {
+    return (int) CodeEntryAlignment;
+  }
+  if (_index == CodeBuffer::SECT_STUBS) {
+    // CodeBuffer installer expects sections to be HeapWordSize aligned
+    return HeapWordSize;
+  }
+  ShouldNotReachHere();
+  return 0;
+}
 
 /// Support for emitting the code to its final location.
 /// The pattern is the same for all functions.

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -454,7 +454,8 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
     _insts.initialize_outer(this,  SECT_INSTS);
     _stubs.initialize_outer(this,  SECT_STUBS);
 
-    // default value. should be changed if vectorization requires large aligned constants
+    // Default is to align on 8 bytes. A compiler can change this
+    // if larger alignment (e.g., 32-byte vector masks) is required.
     _const_section_alignment = (int) sizeof(jdouble);
 
 #ifndef PRODUCT

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -27,6 +27,7 @@
 
 #include "code/oopRecorder.hpp"
 #include "code/relocInfo.hpp"
+#include "compiler/compiler_globals.hpp"
 #include "utilities/align.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/growableArray.hpp"
@@ -748,6 +749,12 @@ inline bool CodeSection::maybe_expand_to_ensure_remaining(csize_t amount) {
 
 inline int CodeSection::alignment(int section) {
   if (section == CodeBuffer::SECT_CONSTS) {
+#if INCLUDE_JVMCI
+    if (EnableJVMCI) {
+      // Graal vectorization requires larger aligned constants
+      return 64;
+    }
+#endif
     return (int) sizeof(jdouble);
   }
   if (section == CodeBuffer::SECT_INSTS) {

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -257,18 +257,13 @@ class CodeSection {
   void relocate(address at, RelocationHolder const& rspec, int format = 0);
   void relocate(address at,    relocInfo::relocType rtype, int format = 0, jint method_index = 0);
 
-  static int alignment(int section);
-  int alignment() { return alignment(_index); }
+  int alignment() const;
 
   // Slop between sections, used only when allocating temporary BufferBlob buffers.
   static csize_t end_slop()         { return MAX2((int)sizeof(jdouble), (int)CodeEntryAlignment); }
 
-  static csize_t align_at_start(csize_t off, int section) {
-    return (csize_t) align_up(off, alignment(section));
-  }
-
   csize_t align_at_start(csize_t off) const {
-    return align_at_start(off, _index);
+    return (csize_t) align_up(off, alignment());
   }
 
   // Ensure there's enough space left in the current section.
@@ -432,6 +427,8 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
   SharedTrampolineRequests*   _shared_trampoline_requests;     // used to collect requests for shared trampolines
   bool         _finalize_stubs; // Indicate if we need to finalize stubs to make CodeBuffer final.
 
+  int          _const_section_alignment;
+
 #ifndef PRODUCT
   AsmRemarks   _asm_remarks;
   DbgStrings   _dbg_strings;
@@ -456,6 +453,9 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
     _consts.initialize_outer(this, SECT_CONSTS);
     _insts.initialize_outer(this,  SECT_INSTS);
     _stubs.initialize_outer(this,  SECT_STUBS);
+
+    // default value. should be changed if vectorization requires large aligned constants
+    _const_section_alignment = (int) sizeof(jdouble);
 
 #ifndef PRODUCT
     _decode_begin    = NULL;
@@ -710,6 +710,10 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
   // Request for a shared stub to the interpreter
   void shared_stub_to_interp_for(ciMethod* callee, csize_t call_offset);
 
+  void set_const_section_alignment(int align) {
+    _const_section_alignment = align_up(align, HeapWordSize);
+  }
+
 #ifndef PRODUCT
  public:
   // Printing / Decoding
@@ -745,27 +749,6 @@ class SharedStubToInterpRequest : public ResourceObj {
 inline bool CodeSection::maybe_expand_to_ensure_remaining(csize_t amount) {
   if (remaining() < amount) { _outer->expand(this, amount); return true; }
   return false;
-}
-
-inline int CodeSection::alignment(int section) {
-  if (section == CodeBuffer::SECT_CONSTS) {
-#if INCLUDE_JVMCI
-    if (EnableJVMCI) {
-      // Graal vectorization requires larger aligned constants
-      return 64;
-    }
-#endif
-    return (int) sizeof(jdouble);
-  }
-  if (section == CodeBuffer::SECT_INSTS) {
-    return (int) CodeEntryAlignment;
-  }
-  if (section == CodeBuffer::SECT_STUBS) {
-    // CodeBuffer installer expects sections to be HeapWordSize aligned
-    return HeapWordSize;
-  }
-  ShouldNotReachHere();
-  return 0;
 }
 
 #endif // SHARE_ASM_CODEBUFFER_HPP

--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.hpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.hpp
@@ -361,7 +361,7 @@ protected:
   GrowableArray<MonitorValue*>* read_monitor_values(HotSpotCompiledCodeStream* stream, u1 frame_flags, JVMCI_TRAPS);
 
   // extract the fields of the HotSpotCompiledCode
-  void initialize_fields(HotSpotCompiledCodeStream* stream, u1 code_flags, methodHandle& method, JVMCI_TRAPS);
+  void initialize_fields(HotSpotCompiledCodeStream* stream, u1 code_flags, methodHandle& method, CodeBuffer& buffer, JVMCI_TRAPS);
   void initialize_dependencies(HotSpotCompiledCodeStream* stream, u1 code_flags, OopRecorder* oop_recorder, JVMCI_TRAPS);
 
   int estimate_stubs_size(HotSpotCompiledCodeStream* stream, JVMCI_TRAPS);

--- a/test/hotspot/jtreg/compiler/jvmci/errors/TestInvalidCompilationResult.java
+++ b/test/hotspot/jtreg/compiler/jvmci/errors/TestInvalidCompilationResult.java
@@ -99,6 +99,16 @@ public class TestInvalidCompilationResult extends CodeInstallerTest {
         installEmptyCode(new Site[0], new Assumption[0], new Comment[0], 7, new DataPatch[0], null);
     }
 
+    @Test
+    public void testValidAlignment32() {
+        installEmptyCode(new Site[0], new Assumption[0], new Comment[0], 32, new DataPatch[0], null);
+    }
+
+    @Test
+    public void testValidAlignment64() {
+        installEmptyCode(new Site[0], new Assumption[0], new Comment[0], 64, new DataPatch[0], null);
+    }
+
     @Test(expected = NullPointerException.class)
     public void testNullDataPatchInDataSection() {
         installEmptyCode(new Site[0], new Assumption[0], new Comment[0], validDataSectionAlignment, new DataPatch[]{null}, null);

--- a/test/hotspot/jtreg/compiler/jvmci/errors/TestInvalidCompilationResult.java
+++ b/test/hotspot/jtreg/compiler/jvmci/errors/TestInvalidCompilationResult.java
@@ -99,16 +99,6 @@ public class TestInvalidCompilationResult extends CodeInstallerTest {
         installEmptyCode(new Site[0], new Assumption[0], new Comment[0], 7, new DataPatch[0], null);
     }
 
-    @Test
-    public void testValidAlignment32() {
-        installEmptyCode(new Site[0], new Assumption[0], new Comment[0], 32, new DataPatch[0], null);
-    }
-
-    @Test
-    public void testValidAlignment64() {
-        installEmptyCode(new Site[0], new Assumption[0], new Comment[0], 64, new DataPatch[0], null);
-    }
-
     @Test(expected = NullPointerException.class)
     public void testNullDataPatchInDataSection() {
         installEmptyCode(new Site[0], new Assumption[0], new Comment[0], validDataSectionAlignment, new DataPatch[]{null}, null);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293999](https://bugs.openjdk.org/browse/JDK-8293999): [JVMCI] need support for aligned constants in generated code larger than 8 bytes


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [59ff8c44](https://git.openjdk.org/jdk/pull/10392/files/59ff8c44a8199831a7d1e9b6153cf40da20dc306)
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - Committer) ⚠️ Review applies to [102e33c7](https://git.openjdk.org/jdk/pull/10392/files/102e33c7698f6e6dde962ec61d05f00d9df2f44b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10392/head:pull/10392` \
`$ git checkout pull/10392`

Update a local copy of the PR: \
`$ git checkout pull/10392` \
`$ git pull https://git.openjdk.org/jdk pull/10392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10392`

View PR using the GUI difftool: \
`$ git pr show -t 10392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10392.diff">https://git.openjdk.org/jdk/pull/10392.diff</a>

</details>
