### PR TITLE
8293996: C2: fix and simplify IdealLoopTree::do_remove_empty_loop

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -3700,30 +3700,21 @@ bool IdealLoopTree::do_remove_empty_loop(PhaseIdealLoop *phase) {
     phase->do_peeling(this, old_new);
   }
 
-  // Replace the phi at loop head with the final value of the last
-  // iteration.  Then the CountedLoopEnd will collapse (backedge never
-  // taken) and all loop-invariant uses of the exit values will be correct.
-  Node *phi = cl->phi();
-  Node *exact_limit = phase->exact_limit(this);
-  if (exact_limit != cl->limit()) {
-    // We also need to replace the original limit to collapse loop exit.
-    Node* cmp = cl->loopexit()->cmp_node();
-    assert(cl->limit() == cmp->in(2), "sanity");
-    // Duplicate cmp node if it has other users
-    if (cmp->outcnt() > 1) {
-      cmp = cmp->clone();
-      cmp = phase->_igvn.register_new_node_with_optimizer(cmp);
-      BoolNode *bol = cl->loopexit()->in(CountedLoopEndNode::TestValue)->as_Bool();
-      phase->_igvn.replace_input_of(bol, 1, cmp); // put bol on worklist
-    }
-    phase->_igvn._worklist.push(cmp->in(2)); // put limit on worklist
-    phase->_igvn.replace_input_of(cmp, 2, exact_limit); // put cmp on worklist
-  }
+  // We replace phi with final iv (exact_limit - stride), to make sure
+  // the loop exit value is correct.
   // Note: the final value after increment should not overflow since
   // counted loop has limit check predicate.
-  Node *final = new SubINode(exact_limit, cl->stride());
-  phase->register_new_node(final,cl->in(LoopNode::EntryControl));
-  phase->_igvn.replace_node(phi,final);
+  Node* phi = cl->phi();
+  Node* exact_limit = phase->exact_limit(this);
+  Node* final_iv = new SubINode(exact_limit, cl->stride());
+  phase->register_new_node(final_iv, cl->in(LoopNode::EntryControl));
+  phase->_igvn.replace_node(phi, final_iv);
+
+  // Set loop-exit condition to false. Then the CountedLoopEnd will collapse,
+  // because the back edge is never taken.
+  Node* zero = phase->_igvn.intcon(0);
+  phase->_igvn.replace_input_of(cl->loopexit(), CountedLoopEndNode::TestValue, zero);
+
   phase->C->set_major_progress();
   return true;
 }

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -3700,8 +3700,9 @@ bool IdealLoopTree::do_remove_empty_loop(PhaseIdealLoop *phase) {
     phase->do_peeling(this, old_new);
   }
 
-  // We replace phi with final iv (exact_limit - stride), to make sure
-  // the loop exit value is correct.
+  // Replace the phi at loop head with the final value of the last
+  // iteration (exact_limit - stride), to make sure the loop exit value
+  // is correct, for any users after the loop.
   // Note: the final value after increment should not overflow since
   // counted loop has limit check predicate.
   Node* phi = cl->phi();

--- a/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyLoop.java
@@ -48,7 +48,7 @@ public class TestRemoveEmptyLoop {
     }
 
     public void test_cmp() {
-	// Loop is OSR compiled, and test_cmp_helper inlined
+        // Loop is OSR compiled, and test_cmp_helper inlined
         for (int i = 0; i < 50000; i++) {
             test_cmp_helper();
         }
@@ -69,7 +69,7 @@ public class TestRemoveEmptyLoop {
     }
 
     public void test_collapse() {
-	// Loop is OSR compiled, and test_collapse_helper inlined
+        // Loop is OSR compiled, and test_collapse_helper inlined
         for (int i = 0; i < 50000; i++) {
             test_collapse_helper();
         }

--- a/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyLoop.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +24,7 @@
 
 /**
  * @test
- * @bug 8231988
+ * @bug 8231988 8293996
  * @summary Unexpected test result caused by C2 IdealLoopTree::do_remove_empty_loop
  *
  * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation
@@ -34,9 +35,11 @@ package compiler.loopopts;
 
 public class TestRemoveEmptyLoop {
 
-    public void test() {
+    public void test_cmp_helper() {
         int i = 34;
+        // The empty loop that collapses
         for (; i > 0; i -= 11);
+        // If uses same Cmp node as the loop condition
         if (i < 0) {
             // do nothing
         } else {
@@ -44,12 +47,38 @@ public class TestRemoveEmptyLoop {
         }
     }
 
-    public static void main(String[] args) {
-        TestRemoveEmptyLoop _instance = new TestRemoveEmptyLoop();
+    public void test_cmp() {
+	// Loop is OSR compiled, and test_cmp_helper inlined
         for (int i = 0; i < 50000; i++) {
-            _instance.test();
+            test_cmp_helper();
         }
-        System.out.println("Test passed.");
     }
 
+    void test_collapse_helper() {
+        int o = 11;
+        int e = 43542;
+        for (int i = 524; i < 19325; i += 1) {
+            // The empty loop that is supposed to collapse
+            for (int j = 0; j < 32767; j++) {
+                o++;
+            }
+            for (int k = 0; k < o; k++) {
+                e++;
+            }
+        }
+    }
+
+    public void test_collapse() {
+	// Loop is OSR compiled, and test_collapse_helper inlined
+        for (int i = 0; i < 50000; i++) {
+            test_collapse_helper();
+        }
+    }
+
+    public static void main(String[] args) {
+        TestRemoveEmptyLoop _instance = new TestRemoveEmptyLoop();
+        _instance.test_cmp();
+        _instance.test_collapse();
+        System.out.println("Test passed.");
+    }
 }


### PR DESCRIPTION
**Context**
In `IdealLoopTree::do_remove_empty_loop`, we detect empty loops, and break them such that `IGVN` can clean away the loops.

For this, we used to simply replace the tripcount `Phi` node with the final iv. This has two intended effects:
1. The loop-condition collapses to false, and the `CountedLoopEnd` node itself collapses, as the back edge is not taken.
2. The Phi may have had other users after the loop, that effectively want to use the loop exit value. Replacing the Phi with the final iv makes sure those values are still correct.

**Problem**
We assume that replacing the tripcount necessarily leads to Optimizations of the nodes down to the `CountedLoopEnd`. If this optimization is not done, we are left with a broken loop that IGVN does not clean up. Later optimizations might now find the remnants of the loop, and assume the tripcount `Phi` still exists - but it does not.

In this concrete example, I had an AddI node that did not do the constant folding. We had
```
100 AddI <x> <y>
101 AddI 100 <int:1>
```
Now, if `<y>` gets replaced with a constant `<int:2>`, output node `100 AddI` is notified via `PhaseIterGVN::add_users_to_worklist`, however node `101 AddI` is an output of the output - we currently do not notify it. But we would expect that it is folded to:

```
102 AddI <x> <int:3>
```
This optimization does not happen, and the propagation down does not take place, prohibiting that the loop condition is determined to be `false` during IGVN.

**Solution**
I saw two approaches to fix this issue:

1. Ensure that all required optimizations down to the `CountedLoopEnd` are performed. This is difficult as it is easy to miss a small pattern. Here I could simply notify outputs of outputs, if they are both `AddI` nodes. Probably there will eventually be other little Optimizations that were missed, and then we have to fix them all one by one.
2. Simplify the required optimization. If we already know that the loop condition is `false`, why not directly replace the condition of the `CountedLoopEnd` with `int:0`? We still need to replace the tripcount `Phi` with the final iv, to ensure exit values are correct for users after the loop. But we can simplify the code in `IdealLoopTree::do_remove_empty_loop` substantially, as we do not need to clone the `cmp` node any more.

I picked solution 2. I suggest that we still perform solution 1, in an RFE like [JDK-8257197](https://bugs.openjdk.org/browse/JDK-8257197), which catches all optimizations that IGVN could have done but failed to do.

I added to the regression test.

- The regression test fails (java assert in test) if I remove the fix belonging to the original regression test:
https://github.com/openjdk/jdk/commit/4fb2bb554d0d437905ce17b2942e2465cd7f79af#diff-6a59f91cb710d682247df87c75faf602f0ff9f87e2855ead1b80719704fbedffR3132-R3138
- The regression test fails (dead loop assert) before I apply my fix.
- Test passes after my fix.

I ran a large test suite.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293996](https://bugs.openjdk.org/browse/JDK-8293996): C2: fix and simplify IdealLoopTree::do_remove_empty_loop


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10393/head:pull/10393` \
`$ git checkout pull/10393`

Update a local copy of the PR: \
`$ git checkout pull/10393` \
`$ git pull https://git.openjdk.org/jdk pull/10393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10393`

View PR using the GUI difftool: \
`$ git pr show -t 10393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10393.diff">https://git.openjdk.org/jdk/pull/10393.diff</a>

</details>
