### PR TITLE
8294245: Make Compile::print_inlining_stream stack allocated

### DIFF
--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -447,7 +447,7 @@ class Compile : public Phase {
     void set_cg(CallGenerator* cg) { _cg = cg; }
   };
 
-  stringStream* _print_inlining_stream;
+  stringStream _print_inlining_stream;
   GrowableArray<PrintInliningBuffer*>* _print_inlining_list;
   int _print_inlining_idx;
   char* _print_inlining_output;
@@ -463,7 +463,6 @@ class Compile : public Phase {
 
   void* _replay_inline_data; // Pointer to data loaded from file
 
-  void print_inlining_stream_free();
   void print_inlining_init();
   void print_inlining_reinit();
   void print_inlining_commit();
@@ -477,9 +476,9 @@ class Compile : public Phase {
 
   void* barrier_set_state() const { return _barrier_set_state; }
 
-  outputStream* print_inlining_stream() const {
+  stringStream* print_inlining_stream() {
     assert(print_inlining() || print_intrinsics(), "PrintInlining off?");
-    return _print_inlining_stream;
+    return &_print_inlining_stream;
   }
 
   void print_inlining_update(CallGenerator* cg);


### PR DESCRIPTION
Hi,

Could I have  a review for this? It simplifies some auxiliary code in the Compile class related to its usage of stringStream.
The only notable disadvantage is that Compile will take up `sizeof(stringStream) - sizeof(stringStream*)` more space on the stack. 

Thanks,
Johan