### PR TITLE
8294255: Add link to DEFAULT_WAIT_TIME in javadoc for SunToolKit.realsSync

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/SunToolkit.java
+++ b/src/java.desktop/share/classes/sun/awt/SunToolkit.java
@@ -1431,7 +1431,8 @@ public abstract class SunToolkit extends Toolkit
     private static final int MINIMAL_DELAY = 5;
 
     /**
-     * Parameterless version of realsync which uses default timout (see DEFAUL_WAIT_TIME).
+     * Parameterless version of {@link #realSync(long)} which uses
+     * the default timeout of {@link #DEFAULT_WAIT_TIME}.
      */
     public void realSync() {
         realSync(DEFAULT_WAIT_TIME);


### PR DESCRIPTION
I also took the opportunity to link to `realSync(long)`.
```java
/**
  * Parameterless version of realsync which uses default timout (see DEFAUL_WAIT_TIME).
  */
```
```java
/**
  * Parameterless version of {@link #realSync(long)} which uses
  * the default timeout of {@link #DEFAULT_WAIT_TIME}.
  */
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294255](https://bugs.openjdk.org/browse/JDK-8294255): Add link to DEFAULT_WAIT_TIME in javadoc for SunToolKit.realsSync


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10399/head:pull/10399` \
`$ git checkout pull/10399`

Update a local copy of the PR: \
`$ git checkout pull/10399` \
`$ git pull https://git.openjdk.org/jdk pull/10399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10399`

View PR using the GUI difftool: \
`$ git pr show -t 10399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10399.diff">https://git.openjdk.org/jdk/pull/10399.diff</a>

</details>
