### PR TITLE
8294236: [IR Framework] CPU preconditions are overriden by regular preconditions

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -105,8 +105,8 @@ public class IREncodingPrinter {
             if (!check) {
                 TestFrameworkSocket.write("Disabling IR matching for " + m + ": Flag constraint not met.",
                                      "[IREncodingPrinter]", true);
+                return false;
             }
-            return check;
         }
 
         if (irAnno.applyIfNot().length != 0) {
@@ -114,8 +114,8 @@ public class IREncodingPrinter {
             if (!check) {
                 TestFrameworkSocket.write("Disabling IR matching for " + m + ": Flag constraint not met.",
                                      "[IREncodingPrinter]", true);
+                return false;
             }
-            return check;
         }
 
         if (irAnno.applyIfAnd().length != 0) {
@@ -123,8 +123,8 @@ public class IREncodingPrinter {
             if (!check) {
                 TestFrameworkSocket.write("Disabling IR matching for " + m + ": All flag constraints not met.",
                                      "[IREncodingPrinter]", true);
+                return false;
             }
-            return check;
         }
 
         if (irAnno.applyIfOr().length != 0) {
@@ -132,8 +132,8 @@ public class IREncodingPrinter {
             if (check) {
                 TestFrameworkSocket.write("Disabling IR matching for " + m + ": None of the flag constraint met.",
                                      "[IREncodingPrinter]", true);
+                return false;
             }
-            return !check;
         }
 
         if (irAnno.applyIfCPUFeature().length != 0) {
@@ -141,8 +141,8 @@ public class IREncodingPrinter {
             if (!check) {
                 TestFrameworkSocket.write("Disabling IR matching for " + m + ": Feature constraint not met.",
                                      "[IREncodingPrinter]", true);
+                return false;
             }
-            return check;
         }
 
         if (irAnno.applyIfCPUFeatureAnd().length != 0) {
@@ -150,8 +150,8 @@ public class IREncodingPrinter {
             if (!check) {
                 TestFrameworkSocket.write("Disabling IR matching for " + m + ": All feature constraints not met.",
                                      "[IREncodingPrinter]", true);
+                return false;
             }
-            return check;
         }
 
         if (irAnno.applyIfCPUFeatureOr().length != 0) {
@@ -159,10 +159,10 @@ public class IREncodingPrinter {
             if (!check) {
                 TestFrameworkSocket.write("Disabling IR matching for " + m + ": None of the feature constraint met.",
                                      "[IREncodingPrinter]", true);
+                return false;
             }
-            return check;
         }
-        // No conditions, always apply.
+        // All preconditions satisfied: apply rule.
         return true;
     }
 

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPreconditions.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPreconditions.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test 8294236
+ * @summary Tests different sources and combinations of preconditions.
+ * @library /test/lib /
+ * @run driver ir_framework.tests.TestPreconditions
+ */
+
+package ir_framework.tests;
+
+import compiler.lib.ir_framework.*;
+
+public class TestPreconditions {
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("-XX:LoopMaxUnroll=8");
+    }
+
+    // The IR check should not be applied, since LoopMaxUnroll is set to 8.
+    @Test
+    @IR(applyIf = {"LoopMaxUnroll", "= 0"},
+        counts = {IRNode.LOOP, ">= 1000"})
+    public static void testApplyIfOnly() {}
+
+    // The IR check should not be applied, since the CPU feature does not exist.
+    @Test
+    @IR(applyIfCPUFeature={"this-feature-does-not-exist-at-all", "true"},
+        counts = {IRNode.LOOP, ">= 1000"})
+    public static void testApplyIfCPUFeatureOnly() {}
+
+    // The IR check should not be applied, since the CPU feature does not exist.
+    @Test
+    @IR(applyIfCPUFeature={"this-feature-does-not-exist-at-all", "true"},
+        applyIf = {"LoopMaxUnroll", "= 8"},
+        counts = {IRNode.LOOP, ">= 1000"})
+    public static void testApplyBoth() {}
+
+}


### PR DESCRIPTION
This changeset ensures that all preconditions of a IR test (`applyIf`, `applyIfCPUFeature`, etc.) are evaluated as a logical conjunction to determine whether the test's IR check should be applied.

#### Testing

- tier1-3 (windows-x64, linux-x64, linux-aarch64, and macosx-x64).
- IR framework tests in `test/hotspot/jtreg/testlibrary_tests/ir_framework` (linux-x64).