### PR TITLE
8294270: make test passes awkward -status:-status:error,fail to jtreg

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -854,7 +854,7 @@ define SetupRunJtregTestBody
           -dir:$$(JTREG_TOPDIR) \
           -reportDir:$$($1_TEST_RESULTS_DIR) \
           -workDir:$$($1_TEST_SUPPORT_DIR) \
-          -status:$$$${JTREG_STATUS} \
+          $$$${JTREG_STATUS} \
           $$(JTREG_OPTIONS) \
           $$(JTREG_FAILURE_HANDLER_OPTIONS) \
           $$(JTREG_COV_OPTIONS) \


### PR DESCRIPTION
[JDK-8230067](https://bugs.openjdk.org/browse/JDK-8230067) added jtreg retries, but it does so awkwardly: it sets `export JTREG_STATUS="-status:error,fail";` on retry, and then uses it as `-status:$$$${JTREG_STATUS}`.

Which means we end up passing either: `-status:` or `-status:-status:error,fail` to jtreg. I confirmed this by also instrumenting the local jtreg build.

Now, it is not a problem for current jtreg, because it checks the status codes awkwardly with `String.contains`:
https://github.com/openjdk/jtreg/blob/aeb552e6df73e039e20de59b3ec847f36ab6e202/src/share/classes/com/sun/javatest/regtest/tool/Tool.java#L1635-L1640

But it will be a problem if jtreg ever starts to validate the arguments properly. I propose we fix this in current build system.

Additional testing:
 - [x] Eyeballing test reports from artificially intermittently failing tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294270](https://bugs.openjdk.org/browse/JDK-8294270): make test passes awkward -status:-status:error,fail to jtreg


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - Committer)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10404/head:pull/10404` \
`$ git checkout pull/10404`

Update a local copy of the PR: \
`$ git checkout pull/10404` \
`$ git pull https://git.openjdk.org/jdk pull/10404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10404`

View PR using the GUI difftool: \
`$ git pr show -t 10404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10404.diff">https://git.openjdk.org/jdk/pull/10404.diff</a>

</details>
