### PR TITLE
8294142: make test should report only on executed tests

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -855,6 +855,7 @@ define SetupRunJtregTestBody
           -reportDir:$$($1_TEST_RESULTS_DIR) \
           -workDir:$$($1_TEST_SUPPORT_DIR) \
           -status:$$$${JTREG_STATUS} \
+          -report:$$$${JTREG_REPORT} \
           $$(JTREG_OPTIONS) \
           $$(JTREG_FAILURE_HANDLER_OPTIONS) \
           $$(JTREG_COV_OPTIONS) \
@@ -865,6 +866,7 @@ define SetupRunJtregTestBody
 
   ifneq ($$(JTREG_RETRY_COUNT), 0)
     $1_COMMAND_LINE := \
+        export JTREG_REPORT="executed"; \
         for i in {0..$$(JTREG_RETRY_COUNT)}; do \
           if [ "$$$$i" != 0 ]; then \
             $$(PRINTF) "\nRetrying Jtreg run. Attempt: $$$$i\n"; \
@@ -874,11 +876,11 @@ define SetupRunJtregTestBody
             break; \
           fi; \
           export JTREG_STATUS="-status:error,fail"; \
+          export JTREG_REPORT="all-executed"; \
         done
-  endif
-
-  ifneq ($$(JTREG_REPEAT_COUNT), 0)
+  else ifneq ($$(JTREG_REPEAT_COUNT), 0)
     $1_COMMAND_LINE := \
+        export JTREG_REPORT="executed"; \
         for i in {1..$$(JTREG_REPEAT_COUNT)}; do \
           $$(PRINTF) "\nRepeating Jtreg run: $$$$i out of $$(JTREG_REPEAT_COUNT)\n"; \
           $$($1_COMMAND_LINE); \
@@ -887,6 +889,10 @@ define SetupRunJtregTestBody
             break; \
           fi; \
         done
+  else
+    $1_COMMAND_LINE := \
+        export JTREG_REPORT="executed"; \
+        $$($1_COMMAND_LINE);
   endif
 
   run-test-$1: pre-run-test clean-workdir-$1


### PR DESCRIPTION
This should help to speed up tests significantly. Currently, if we run "make test" with a subset of tests, JTReg would still read the entirety of test root to report on tests that were not run. Even with current suite of tests it gets expensive. If you add more tests to suite -- for example, mounting a large test archive like pre-generated fuzzer tests -- it starts to take a lot of time.

We might default to `-report:executed`. My own CI -- that has millions of tests mounted in `test/` -- was running with `JTREG="OPTIONS=-report:executed"` for years now. I think that should be the default way to run the tests in JDK tree.

There is a wrinkle with jtreg retries: we need to collate together the reports for successful retries from multiple runs. Fortunately, we can then fall back to `-report:all-executed`. CODETOOLS-7903318 suggests doing the similar thing at jtreg side, but I think we would be better to pilot this in JDK itself.

Motivational example:

```
$ time CONF=linux-x86_64-server-release make run-test TEST=gc/epsilon/TestHelloWorld.java

# Default JDK tree

# Baseline
real	0m8.813s
user	0m20.846s
sys	0m3.841s

# Patched
real	0m5.926s  ; about 1.5x faster
user	0m14.637s
sys	0m3.451s


# +100K fuzzer tests in tree

# Baseline
real	3m22.978s
user	3m33.417s
sys	0m11.197s

# Patched
real	0m8.415s   ; about 23x faster
user	0m15.623s
sys	0m4.746s
```