### PR TITLE
8294271: Remove use of ThreadDeath from make utilities

### DIFF
--- a/make/jdk/src/classes/build/tools/dtdbuilder/DTDParser.java
+++ b/make/jdk/src/classes/build/tools/dtdbuilder/DTDParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -919,8 +919,6 @@ class DTDParser implements DTDConstants {
         } catch (Exception e) {
             error("exception", e.getClass().getName(), e.getMessage());
             e.printStackTrace();
-        } catch (ThreadDeath e) {
-            error("terminated");
         }
         return (nerrors > 0) ? null : dtd;
     }


### PR DESCRIPTION
Hi all,

Since `ThreadDeath` would be deprecated soon, I assume it's fine to just remove it.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294271](https://bugs.openjdk.org/browse/JDK-8294271): Remove use of ThreadDeath from make utilities


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10406/head:pull/10406` \
`$ git checkout pull/10406`

Update a local copy of the PR: \
`$ git checkout pull/10406` \
`$ git pull https://git.openjdk.org/jdk pull/10406/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10406`

View PR using the GUI difftool: \
`$ git pr show -t 10406`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10406.diff">https://git.openjdk.org/jdk/pull/10406.diff</a>

</details>
