### PR TITLE
8294281: Allow warnings to be disabled on a per-file basis

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -343,10 +343,15 @@ define SetupCompileNativeFileBody
       endif
     endif
 
+    ifneq ($(DISABLE_WARNING_PREFIX), )
+      $1_WARNINGS_FLAGS := $$(addprefix $(DISABLE_WARNING_PREFIX), \
+        $$($$($1_BASE)_DISABLED_WARNINGS_$(TOOLCHAIN_TYPE)_$$($1_FILENAME)))
+    endif
+
     $1_BASE_CFLAGS :=  $$($$($1_BASE)_CFLAGS) $$($$($1_BASE)_EXTRA_CFLAGS) \
-        $$($$($1_BASE)_SYSROOT_CFLAGS)
+        $$($$($1_BASE)_SYSROOT_CFLAGS) $$($1_WARNINGS_FLAGS)
     $1_BASE_CXXFLAGS := $$($$($1_BASE)_CXXFLAGS) $$($$($1_BASE)_EXTRA_CXXFLAGS) \
-        $$($$($1_BASE)_SYSROOT_CFLAGS) $$($1_EXTRA_CXXFLAGS)
+        $$($$($1_BASE)_SYSROOT_CFLAGS) $$($1_EXTRA_CXXFLAGS) $$($1_WARNINGS_FLAGS)
     $1_BASE_ASFLAGS := $$($$($1_BASE)_ASFLAGS) $$($$($1_BASE)_EXTRA_ASFLAGS)
 
     ifneq ($$(filter %.c, $$($1_FILENAME)), )


### PR DESCRIPTION
There have been a long-standing need to be able to disable individual warnings, not only per library, but also per C/C++ file in a library.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294281](https://bugs.openjdk.org/browse/JDK-8294281): Allow warnings to be disabled on a per-file basis


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10408/head:pull/10408` \
`$ git checkout pull/10408`

Update a local copy of the PR: \
`$ git checkout pull/10408` \
`$ git pull https://git.openjdk.org/jdk pull/10408/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10408`

View PR using the GUI difftool: \
`$ git pr show -t 10408`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10408.diff">https://git.openjdk.org/jdk/pull/10408.diff</a>

</details>
