### PR TITLE
8292780: misc tests failed "assert(false) failed: graph should be schedulable"

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1485,7 +1485,7 @@ static bool stable_phi(PhiNode* phi, PhaseGVN *phase) {
 }
 //------------------------------split_through_phi------------------------------
 // Split instance or boxed field load through Phi.
-Node* LoadNode::split_through_phi(PhaseGVN *phase) {
+Node* LoadNode::split_through_phi(PhaseGVN* phase) {
   if (req() > 3) {
     assert(is_LoadVector() && Opcode() != Op_LoadVector, "load has too many inputs");
     // LoadVector subclasses such as LoadVectorMasked have extra inputs that the logic below doesn't take into account

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1485,7 +1485,12 @@ static bool stable_phi(PhiNode* phi, PhaseGVN *phase) {
 }
 //------------------------------split_through_phi------------------------------
 // Split instance or boxed field load through Phi.
-Node *LoadNode::split_through_phi(PhaseGVN *phase) {
+Node* LoadNode::split_through_phi(PhaseGVN *phase) {
+  if (req() > 3) {
+    assert(is_LoadVector() && Opcode() != Op_LoadVector, "load has too many inputs");
+    // LoadVector subclasses such as LoadVectorMasked have extra inputs that the logic below doesn't take into account
+    return NULL;
+  }
   Node* mem     = in(Memory);
   Node* address = in(Address);
   const TypeOopPtr *t_oop = phase->type(address)->isa_oopptr();

--- a/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyPartialInliningLoadSplit.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyPartialInliningLoadSplit.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug JDK-8292780
+ * @summary misc tests failed "assert(false) failed: graph should be schedulable"
+ *
+ * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement TestArrayCopyPartialInliningLoadSplit
+ */
+
+public class TestArrayCopyPartialInliningLoadSplit {
+    public static void main(String[] args) {
+        byte[] array = new byte[16];
+        for (int i = 0; i < 20_0000; i++) {
+            test(array, 16, 0, 0);
+        }
+    }
+
+    private static void test(byte[] array, int length, int srcPos, int dstPos) {
+        byte[] nonEscaping = new byte[16];
+        nonEscaping[0] = 0x42;
+        System.arraycopy(array, srcPos, nonEscaping, 1, 8);
+        System.arraycopy(nonEscaping, 0, array, 0, length);
+    }
+}


### PR DESCRIPTION
PhaseMacroExpand::generate_partial_inlining_block() adds
LoadVectorMasked nodes to the IR graph and then
LoadNode::split_through_phi() tries to split one of them through phi
but because that method ignores the mask input to that LoadNode (it
only knows about control, memory and address inputs) the resulting
graph is broken. Fix I propose is to skip
LoadNode::split_through_phi() for those LoadVector nodes that have
extra inputs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8292780](https://bugs.openjdk.org/browse/JDK-8292780): misc tests failed "assert(false) failed: graph should be schedulable"


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [826cabe7](https://git.openjdk.org/jdk/pull/10410/files/826cabe7d092da027d9effd580409f17ad20dd61)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [826cabe7](https://git.openjdk.org/jdk/pull/10410/files/826cabe7d092da027d9effd580409f17ad20dd61)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10410/head:pull/10410` \
`$ git checkout pull/10410`

Update a local copy of the PR: \
`$ git checkout pull/10410` \
`$ git pull https://git.openjdk.org/jdk pull/10410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10410`

View PR using the GUI difftool: \
`$ git pr show -t 10410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10410.diff">https://git.openjdk.org/jdk/pull/10410.diff</a>

</details>
