### PR TITLE
8294293: Remove unused _width and _newlines field in outputStream

### DIFF
--- a/src/hotspot/share/utilities/ostream.hpp
+++ b/src/hotspot/share/utilities/ostream.hpp
@@ -29,6 +29,7 @@
 #include "runtime/timer.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
+#include <cstdint>
 
 DEBUG_ONLY(class ResourceMark;)
 
@@ -48,15 +49,14 @@ class outputStream : public ResourceObj {
 
  protected:
    int _indentation; // current indentation
-   int _width;       // width of the page
-   int _position;    // position on the current line
-   int _newlines;    // number of '\n' output so far
-   julong _precount; // number of chars output, less _position
+   int _position;    // visual position on the current line
+   uint64_t _precount; // number of chars output, less than _position
    TimeStamp _stamp; // for time stamps
    char* _scratch;   // internal scratch buffer for printf
    size_t _scratch_len; // size of internal scratch buffer
 
-   void update_position(const char* s, size_t len);
+  // Returns whether a newline was seen or not
+   bool update_position(const char* s, size_t len);
    static const char* do_vsnprintf(char* buffer, size_t buflen,
                                    const char* format, va_list ap,
                                    bool add_cr,
@@ -71,8 +71,8 @@ class outputStream : public ResourceObj {
 
  public:
    // creation
-   outputStream(int width = 80);
-   outputStream(int width, bool has_time_stamps);
+   outputStream();
+   outputStream(bool has_time_stamps);
 
    // indentation
    outputStream& indent();
@@ -86,7 +86,6 @@ class outputStream : public ResourceObj {
    void move_to(int col, int slop = 6, int min_space = 2);
 
    // sizing
-   int width()    const { return _width;    }
    int position() const { return _position; }
    julong count() const { return _precount + _position; }
    void set_count(julong count) { _precount = count - _position; }

--- a/src/hotspot/share/utilities/ostream.hpp
+++ b/src/hotspot/share/utilities/ostream.hpp
@@ -29,7 +29,6 @@
 #include "runtime/timer.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
-#include <cstdint>
 
 DEBUG_ONLY(class ResourceMark;)
 


### PR DESCRIPTION
1. `_width` is unused so I deleted it
2. `_newlines` was used in one place, and only to check if any new lines had been seen. I removed `_newlines` and instead used `update_position`'s unused return value to indicate whether any newlines has been seen. This required expanding the call of `xmlTextStream::write` in `defaultStream`.

This removes some cruft from `outputStream` and saves us 8 bytes on the size of `outputStream`.

I also noted that `_position` isn't number of chars into a line, but rather a "visual position". It's a bit surprising, which is why I added this comment. This can be seen in the `\t` case in `update_position`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294293](https://bugs.openjdk.org/browse/JDK-8294293): Remove unused _width and _newlines field in outputStream


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**) ⚠️ Review applies to [18847c61](https://git.openjdk.org/jdk/pull/10411/files/18847c6162e5e3f7d0303804313adcb35ed4aa74)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10411/head:pull/10411` \
`$ git checkout pull/10411`

Update a local copy of the PR: \
`$ git checkout pull/10411` \
`$ git pull https://git.openjdk.org/jdk pull/10411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10411`

View PR using the GUI difftool: \
`$ git pr show -t 10411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10411.diff">https://git.openjdk.org/jdk/pull/10411.diff</a>

</details>
