### PR TITLE
8294317: Insufficient build rules for tzdb.dat

### DIFF
--- a/make/modules/java.base/gendata/GendataTZDB.gmk
+++ b/make/modules/java.base/gendata/GendataTZDB.gmk
@@ -30,7 +30,7 @@ GENDATA_TZDB :=
 #
 TZDATA_DIR := $(MODULE_SRC)/share/data/tzdata
 TZDATA_TZFILE := africa antarctica asia australasia europe northamerica southamerica backward etcetera gmt jdk11_backward
-TZDATA_TZFILES := $(TZDATA_DIR)/*
+TZDATA_TZFILES := $(wildcard $(TZDATA_DIR)/*)
 
 GENDATA_TZDB_DAT := $(SUPPORT_OUTPUTDIR)/modules_libs/$(MODULE)/tzdb.dat
 

--- a/make/modules/java.base/gendata/GendataTZDB.gmk
+++ b/make/modules/java.base/gendata/GendataTZDB.gmk
@@ -30,7 +30,7 @@ GENDATA_TZDB :=
 #
 TZDATA_DIR := $(MODULE_SRC)/share/data/tzdata
 TZDATA_TZFILE := africa antarctica asia australasia europe northamerica southamerica backward etcetera gmt jdk11_backward
-TZDATA_TZFILES := $(addprefix $(TZDATA_DIR)/,$(TZDATA_TZFILE))
+TZDATA_TZFILES := $(TZDATA_DIR)/*
 
 GENDATA_TZDB_DAT := $(SUPPORT_OUTPUTDIR)/modules_libs/$(MODULE)/tzdb.dat
 


### PR DESCRIPTION
The current makefile for `tzdb.dat` won't recompile if some dependent files (e.g. `VERSION`) are updated. Adding all files under the tzdb directory to the dependency will fix this issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294317](https://bugs.openjdk.org/browse/JDK-8294317): Insufficient build rules for tzdb.dat


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to [8e260f28](https://git.openjdk.org/jdk/pull/10415/files/8e260f2831ac1c9530ab3003efaf2786fa28ea8f)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10415/head:pull/10415` \
`$ git checkout pull/10415`

Update a local copy of the PR: \
`$ git checkout pull/10415` \
`$ git pull https://git.openjdk.org/jdk pull/10415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10415`

View PR using the GUI difftool: \
`$ git pr show -t 10415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10415.diff">https://git.openjdk.org/jdk/pull/10415.diff</a>

</details>
