### PR TITLE
4668290: unclear spec for Polygon.bounds field

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Polygon.java
+++ b/src/java.desktop/share/classes/java/awt/Polygon.java
@@ -103,7 +103,11 @@ public class Polygon implements Shape, java.io.Serializable {
 
     /**
      * The bounds of this {@code Polygon}.
-     * This value can be null.
+     * <p>
+     * When created, {@link #invalidate() invalidated}, or {@link #reset() reset},
+     * this becomes {@code null}. To get out of the null state,
+     * {@link #getBounds()} called with {@link #npoints} being greater than
+     * {@code 0} will transfer into a non-null {@link Rectangle}.
      *
      * @serial
      * @see #getBoundingBox()

--- a/src/java.desktop/share/classes/java/awt/Polygon.java
+++ b/src/java.desktop/share/classes/java/awt/Polygon.java
@@ -104,10 +104,9 @@ public class Polygon implements Shape, java.io.Serializable {
     /**
      * The bounds of this {@code Polygon}.
      * <p>
-     * When created, {@link #invalidate() invalidated}, or {@link #reset() reset},
-     * this becomes {@code null}. To get out of the null state,
-     * {@link #getBounds()} called with {@link #npoints} being greater than
-     * {@code 0} will transfer into a non-null {@link Rectangle}.
+     * The value of this field is updated by the implementation which
+     * may set it to null and will reevaluate it as needed. Application
+     * sub-classes should never access this field.
      *
      * @serial
      * @see #getBoundingBox()

--- a/src/java.desktop/share/classes/java/awt/Polygon.java
+++ b/src/java.desktop/share/classes/java/awt/Polygon.java
@@ -105,8 +105,8 @@ public class Polygon implements Shape, java.io.Serializable {
      * The bounds of this {@code Polygon}.
      * <p>
      * The value of this field is updated by the implementation which
-     * may set it to null and will reevaluate it as needed. Application
-     * sub-classes should never access this field.
+     * may set it to {@code null} and will reevaluate it as needed.
+     * Application sub-classes should never access this field.
      *
      * @serial
      * @see #getBoundingBox()

--- a/src/java.desktop/share/classes/java/awt/Polygon.java
+++ b/src/java.desktop/share/classes/java/awt/Polygon.java
@@ -105,7 +105,7 @@ public class Polygon implements Shape, java.io.Serializable {
      * The bounds of this {@code Polygon}.
      * <p>
      * The value of this field is updated by the implementation which
-     * may set it to {@code null} and will reevaluate it as needed.
+     * may set it to {@code null} and will re-evaluate it as needed.
      * Application sub-classes should never access this field.
      *
      * @serial

--- a/src/java.desktop/share/classes/javax/swing/text/html/Map.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/Map.java
@@ -386,8 +386,8 @@ class Map implements Serializable {
                                           lastHeight == height)) {
                 return contains(x, y);
             }
-            // Force the bounding box to be recalced.
-            bounds = null;
+
+            invalidate(); // Force the bounding box to be recalced.
             lastWidth = width;
             lastHeight = height;
             float fWidth = (float)width;


### PR DESCRIPTION
New documentation replaces the `This value can be null.`:
```
When created, {@link #invalidate() invalidated}, or {@link #reset() reset},
this becomes {@code null}. To get out of the null state,
{@link #getBounds()} called with {@link #npoints} being greater than
{@code 0} will transfer into a non-null {@link Rectangle}.
```

I think I've got the reason for why it can be `null` correct, but you never know.

In javax.swing.text.html.Map, I've replaced setting the field to null with the equivalent #invalidate(). This may mean we can make the field private in the future.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Change requires CSR request [JDK-8298864](https://bugs.openjdk.org/browse/JDK-8298864) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-4668290](https://bugs.openjdk.org/browse/JDK-4668290): unclear spec for Polygon.bounds field
 * [JDK-8298864](https://bugs.openjdk.org/browse/JDK-8298864): unclear spec for Polygon.bounds field (**CSR**)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10417/head:pull/10417` \
`$ git checkout pull/10417`

Update a local copy of the PR: \
`$ git checkout pull/10417` \
`$ git pull https://git.openjdk.org/jdk pull/10417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10417`

View PR using the GUI difftool: \
`$ git pr show -t 10417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10417.diff">https://git.openjdk.org/jdk/pull/10417.diff</a>

</details>
