### PR TITLE
4756278: RFE: Insufficient API documentation for java.awt.Polygon constructor

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Polygon.java
+++ b/src/java.desktop/share/classes/java/awt/Polygon.java
@@ -133,8 +133,10 @@ public class Polygon implements Shape, java.io.Serializable {
     }
 
     /**
-     * Constructs and initializes a {@code Polygon} from the specified
-     * parameters.
+     * Constructs and initializes a {@code Polygon} from the
+     * specified parameters, copying the array contents of
+     * {@code xpoints} and {@code ypoints}.
+     *
      * @param xpoints an array of X coordinates
      * @param ypoints an array of Y coordinates
      * @param npoints the total number of points in the


### PR DESCRIPTION
Appends: `, copying the array contents of {@code xpoints} and {@code ypoints}` to specify that the arrays in the constructor are explicitly copied.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8298351](https://bugs.openjdk.org/browse/JDK-8298351) to be approved

### Issues
 * [JDK-4756278](https://bugs.openjdk.org/browse/JDK-4756278): RFE: Insufficient API documentation for java.awt.Polygon constructor
 * [JDK-8298351](https://bugs.openjdk.org/browse/JDK-8298351): RFE: Insufficient API documentation for java.awt.Polygon constructor (**CSR**)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10418/head:pull/10418` \
`$ git checkout pull/10418`

Update a local copy of the PR: \
`$ git checkout pull/10418` \
`$ git pull https://git.openjdk.org/jdk pull/10418/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10418`

View PR using the GUI difftool: \
`$ git pr show -t 10418`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10418.diff">https://git.openjdk.org/jdk/pull/10418.diff</a>

</details>
