### PR TITLE
8293806: JDK_JAVA_OPTIONS picked up twice if LD_LIBRARY_PATH is set

### DIFF
--- a/src/java.base/macosx/native/libjli/java_md_macosx.m
+++ b/src/java.base/macosx/native/libjli/java_md_macosx.m
@@ -361,7 +361,8 @@ void
 CreateExecutionEnvironment(int *pargc, char ***pargv,
                            char jrepath[], jint so_jrepath,
                            char jvmpath[], jint so_jvmpath,
-                           char jvmcfg[],  jint so_jvmcfg) {
+                           char jvmcfg[],  jint so_jvmcfg,
+                           char **orig_argv) {
     /* Compute/set the name of the executable */
     SetExecname(*pargv);
 

--- a/src/java.base/share/native/launcher/main.c
+++ b/src/java.base/share/native/launcher/main.c
@@ -49,6 +49,7 @@ WinMain(HINSTANCE inst, HINSTANCE previnst, LPSTR cmdline, int cmdshow)
     int jargc;
     char** jargv;
     const jboolean const_javaw = JNI_TRUE;
+    char** argv = NULL;
 
     __initenv = _environ;
 
@@ -171,5 +172,6 @@ main(int argc, char **argv)
                    (const_progname != NULL) ? const_progname : *margv,
                    (const_launcher != NULL) ? const_launcher : *margv,
                    jargc > 0,
-                   const_cpwildcard, const_javaw, 0);
+                   const_cpwildcard, const_javaw, 0,
+                   argv);
 }

--- a/src/java.base/share/native/libjli/args.c
+++ b/src/java.base/share/native/libjli/args.c
@@ -86,15 +86,7 @@ static jboolean expand(JLI_List args, const char *str, const char *var_name);
 
 JNIEXPORT void JNICALL
 JLI_InitArgProcessing(jboolean hasJavaArgs, jboolean disableArgFile) {
-    // No expansion for relaunch
-    if (argsCount != 1) {
-        relaunch = JNI_TRUE;
-        stopExpansion = JNI_TRUE;
-        argsCount = 1;
-    } else {
-        stopExpansion = disableArgFile;
-    }
-
+    stopExpansion = disableArgFile;
     expectingNoDashArg = JNI_FALSE;
 
     // for tools, this value remains 0 all the time.
@@ -469,10 +461,6 @@ JLI_AddArgsFromEnvVar(JLI_List args, const char *var_name) {
 
     if (firstAppArgIndex == 0) {
         // Not 'java', return
-        return JNI_FALSE;
-    }
-
-    if (relaunch) {
         return JNI_FALSE;
     }
 

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -234,7 +234,8 @@ JLI_Launch(int argc, char ** argv,              /* main argc, argv */
         jboolean javaargs,                      /* JAVA_ARGS */
         jboolean cpwildcard,                    /* classpath wildcard*/
         jboolean javaw,                         /* windows-only javaw */
-        jint ergo                               /* unused */
+        jint ergo,                              /* unused */
+        char **orig_argv                        /* original argv as it was passed to main */
 )
 {
     int mode = LM_UNKNOWN;
@@ -283,7 +284,8 @@ JLI_Launch(int argc, char ** argv,              /* main argc, argv */
     CreateExecutionEnvironment(&argc, &argv,
                                jrepath, sizeof(jrepath),
                                jvmpath, sizeof(jvmpath),
-                               jvmcfg,  sizeof(jvmcfg));
+                               jvmcfg,  sizeof(jvmcfg),
+                               orig_argv);
 
     ifn.CreateJavaVM = 0;
     ifn.GetDefaultJavaVMInitArgs = 0;

--- a/src/java.base/share/native/libjli/java.h
+++ b/src/java.base/share/native/libjli/java.h
@@ -97,7 +97,8 @@ JLI_Launch(int argc, char ** argv,              /* main argc, argc */
         jboolean javaargs,                      /* JAVA_ARGS */
         jboolean cpwildcard,                    /* classpath wildcard */
         jboolean javaw,                         /* windows-only javaw */
-        jint     ergo_class                     /* ergnomics policy */
+        jint     ergo_class,                    /* ergnomics policy */
+        char** orig_argv                        /* main args unprocessed */
 );
 
 /*
@@ -130,7 +131,8 @@ GetApplicationHomeFromDll(char *buf, jint bufsize);
 void CreateExecutionEnvironment(int *argc, char ***argv,
                                 char *jrepath, jint so_jrepath,
                                 char *jvmpath, jint so_jvmpath,
-                                char *jvmcfg,  jint so_jvmcfg);
+                                char *jvmcfg,  jint so_jvmcfg,
+                                char **orig_argv);
 
 /* Reports an error message to stderr or a window as appropriate. */
 JNIEXPORT void JNICALL

--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -295,7 +295,8 @@ void
 CreateExecutionEnvironment(int *pargc, char ***pargv,
                            char jrepath[], jint so_jrepath,
                            char jvmpath[], jint so_jvmpath,
-                           char jvmcfg[],  jint so_jvmcfg) {
+                           char jvmcfg[],  jint so_jvmcfg,
+                           char **orig_argv) {
 
     char * jvmtype = NULL;
     char **argv = *pargv;
@@ -450,9 +451,9 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
         (void) fflush(stderr);
 #ifdef SETENV_REQUIRED
         if (mustsetenv) {
-            execve(newexec, argv, newenvp);
+            execve(newexec, orig_argv, newenvp);
         } else {
-            execv(newexec, argv);
+            execv(newexec, orig_argv);
         }
 #else /* !SETENV_REQUIRED */
         execv(newexec, argv);

--- a/src/java.base/windows/native/libjli/java_md.c
+++ b/src/java.base/windows/native/libjli/java_md.c
@@ -158,8 +158,10 @@ void
 CreateExecutionEnvironment(int *pargc, char ***pargv,
                            char *jrepath, jint so_jrepath,
                            char *jvmpath, jint so_jvmpath,
-                           char *jvmcfg,  jint so_jvmcfg) {
+                           char *jvmcfg,  jint so_jvmcfg,
+                           char **orig_argv) {
 
+    (void) orig_argv; /* Not used under Windows */
     char *jvmtype;
     int i = 0;
     char** argv = *pargv;

--- a/test/jdk/tools/launcher/exeJliLaunchTest.c
+++ b/test/jdk/tools/launcher/exeJliLaunchTest.c
@@ -40,5 +40,6 @@ main(int argc, char **argv)
                    0, NULL,
                    "1", "0",
                    *argv, *argv,
-                   0, 0, 0, 0);
+                   0, 0, 0, 0,
+                   argv);
 }


### PR DESCRIPTION
If the user has set LD_LIBRARY_PATH to use a particular libjvm.so, options from the JDK_JAVA_OPTIONS environment variable are picked up twice.

If an option cannot be accepted twice (e.g., -agentlib), the application fails to start.

The same happens on operating systems that doesn't support $RPATH/$ORIGIN and always have to set LD_LIBRARY_PATH and re-exec the launcher. 

The fix adds one additional argument - orig_argv to JLI_Launch() and use it in on relaunch in execv() call.

All relevant jtreg tests are passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293806](https://bugs.openjdk.org/browse/JDK-8293806): JDK_JAVA_OPTIONS picked up twice if LD_LIBRARY_PATH is set


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10420/head:pull/10420` \
`$ git checkout pull/10420`

Update a local copy of the PR: \
`$ git checkout pull/10420` \
`$ git pull https://git.openjdk.org/jdk pull/10420/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10420`

View PR using the GUI difftool: \
`$ git pr show -t 10420`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10420.diff">https://git.openjdk.org/jdk/pull/10420.diff</a>

</details>
