### PR TITLE
8294356: IGV: scheduled graphs contain duplicated elements

### DIFF
--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -731,9 +731,9 @@ Node* IdealGraphPrinter::get_load_node(const Node* node) {
 
 void IdealGraphPrinter::walk_nodes(Node* start, bool edges, VectorSet* temp_set) {
   VectorSet visited;
-  GrowableArray<Node *> nodeStack(Thread::current()->resource_area(), 0, 0, NULL);
+  GrowableArray<Node *> nodeStack(Thread::current()->resource_area(), 0, 0, nullptr);
   nodeStack.push(start);
-  if (C->cfg() != NULL) {
+  if (C->cfg() != nullptr) {
     // once we have a CFG there are some nodes that aren't really
     // reachable but are in the CFG so add them here.
     for (uint i = 0; i < C->cfg()->number_of_blocks(); i++) {
@@ -745,7 +745,6 @@ void IdealGraphPrinter::walk_nodes(Node* start, bool edges, VectorSet* temp_set)
   }
 
   while (nodeStack.length() > 0) {
-
     Node* n = nodeStack.pop();
     if (visited.test_set(n->_idx)) {
       continue;
@@ -760,7 +759,7 @@ void IdealGraphPrinter::walk_nodes(Node* start, bool edges, VectorSet* temp_set)
     }
 
     for (uint i = 0; i < n->len(); i++) {
-      if (n->in(i)) {
+      if (n->in(i) != nullptr) {
         nodeStack.push(n->in(i));
       }
     }

--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -733,7 +733,6 @@ void IdealGraphPrinter::walk_nodes(Node* start, bool edges, VectorSet* temp_set)
   VectorSet visited;
   GrowableArray<Node *> nodeStack(Thread::current()->resource_area(), 0, 0, NULL);
   nodeStack.push(start);
-  visited.test_set(start->_idx);
   if (C->cfg() != NULL) {
     // once we have a CFG there are some nodes that aren't really
     // reachable but are in the CFG so add them here.
@@ -745,25 +744,24 @@ void IdealGraphPrinter::walk_nodes(Node* start, bool edges, VectorSet* temp_set)
     }
   }
 
-  while(nodeStack.length() > 0) {
+  while (nodeStack.length() > 0) {
 
-    Node *n = nodeStack.pop();
+    Node* n = nodeStack.pop();
+    if (visited.test_set(n->_idx)) {
+      continue;
+    }
+
     visit_node(n, edges, temp_set);
 
     if (_traverse_outs) {
       for (DUIterator i = n->outs(); n->has_out(i); i++) {
-        Node* p = n->out(i);
-        if (!visited.test_set(p->_idx)) {
-          nodeStack.push(p);
-        }
+        nodeStack.push(n->out(i));
       }
     }
 
-    for ( uint i = 0; i < n->len(); i++ ) {
-      if ( n->in(i) ) {
-        if (!visited.test_set(n->in(i)->_idx)) {
-          nodeStack.push(n->in(i));
-        }
+    for (uint i = 0; i < n->len(); i++) {
+      if (n->in(i)) {
+        nodeStack.push(n->in(i));
       }
     }
   }


### PR DESCRIPTION
This changeset removes duplicated nodes and edges from graph dumps that include a control-flow graph:
![cfg-before-after](https://user-images.githubusercontent.com/8792647/192294554-73ca3927-dab3-4d8f-9503-0904a4da7434.png)
This is achieved by ensuring that HotSpot only visits each node once when dumping IGV graphs.

#### Testing
- Tested that tens of thousands of graphs do not contain duplicated nodes or edges by instrumenting IGV and running `java -Xcomp -XX:PrintIdealGraphLevel=4`.
- Tested manually that unscheduled graphs are not affected by this changeset.
- Tested that running compiler tests with `-XX:PrintIdealGraphLevel=3` does not trigger any failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294356](https://bugs.openjdk.org/browse/JDK-8294356): IGV: scheduled graphs contain duplicated elements


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10423/head:pull/10423` \
`$ git checkout pull/10423`

Update a local copy of the PR: \
`$ git checkout pull/10423` \
`$ git pull https://git.openjdk.org/jdk pull/10423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10423`

View PR using the GUI difftool: \
`$ git pr show -t 10423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10423.diff">https://git.openjdk.org/jdk/pull/10423.diff</a>

</details>
