### PR TITLE
8294370: Fix allocation bug in java_lang_Thread::async_get_stack_trace()

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -1959,11 +1959,12 @@ oop java_lang_Thread::async_get_stack_trace(oop java_thread, TRAPS) {
     GrowableArray<int>*     _bcis;
 
     GetStackTraceClosure(Handle java_thread) :
-        HandshakeClosure("GetStackTraceClosure"), _java_thread(java_thread), _depth(0), _retry_handshake(false) {
-      // Pick some initial length
-      int init_length = MaxJavaStackTraceDepth / 2;
-      _methods = new GrowableArray<Method*>(init_length);
-      _bcis = new GrowableArray<int>(init_length);
+        HandshakeClosure("GetStackTraceClosure"), _java_thread(java_thread), _depth(0), _retry_handshake(false),
+        _methods(nullptr), _bcis(nullptr) {
+    }
+    ~GetStackTraceClosure() {
+      delete _methods;
+      delete _bcis;
     }
 
     bool read_reset_retry() {
@@ -1999,6 +2000,11 @@ oop java_lang_Thread::async_get_stack_trace(oop java_thread, TRAPS) {
 
       const int max_depth = MaxJavaStackTraceDepth;
       const bool skip_hidden = !ShowHiddenFrames;
+
+      // Pick some initial length
+      int init_length = 64;
+      _methods = new (ResourceObj::C_HEAP, mtInternal) GrowableArray<Method*>(init_length, mtInternal);
+      _bcis = new (ResourceObj::C_HEAP, mtInternal) GrowableArray<int>(init_length, mtInternal);
 
       int total_count = 0;
       for (vframeStream vfst(thread, false, false, carrier); // we don't process frames as we don't care about oops

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2001,7 +2001,7 @@ oop java_lang_Thread::async_get_stack_trace(oop java_thread, TRAPS) {
       const int max_depth = MaxJavaStackTraceDepth;
       const bool skip_hidden = !ShowHiddenFrames;
 
-      // Pick some initial length
+      // Pick minimum length that will cover most cases
       int init_length = 64;
       _methods = new (ResourceObj::C_HEAP, mtInternal) GrowableArray<Method*>(init_length, mtInternal);
       _bcis = new (ResourceObj::C_HEAP, mtInternal) GrowableArray<int>(init_length, mtInternal);


### PR DESCRIPTION
Please review this small fix in async_get_stack_trace(). The GrowableArrays created to store the bci and Method* of each frame found while traversing the stack are allocated in the resource area of the thread that calls async_get_stack_trace(). But if the handshake is executed by the target and if the number of frames in the stack exceeds the initial size of the GrowableArrays then we will hit an assertion when trying to grow the size of the arrays (see bug description).
Currently we don't see any issues because the initial size of the GrowableArrays is 512 and our tests don't test beyond that (the maximum value of DEPTH in the vmTestbase/nsk/stress/strace/ tests is 500). The issue can be easily reproduced by either decreasing the initial size of the GrowableArrays or by increasing the value of DEPTH in those strace tests.
To fix it I allocated the arrays in the C heap instead. Also I lowered the initial size of the arrays since 512 seemed too much to start with.
Tested it by running all tests in the vmTestbase/nsk/stress/strace/ directory.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294370](https://bugs.openjdk.org/browse/JDK-8294370): Fix allocation bug in java_lang_Thread::async_get_stack_trace()


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [5e375a83](https://git.openjdk.org/jdk/pull/10424/files/5e375a8325a21df642ffdcee2662479e3da4dfdd)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [5e375a83](https://git.openjdk.org/jdk/pull/10424/files/5e375a8325a21df642ffdcee2662479e3da4dfdd)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10424/head:pull/10424` \
`$ git checkout pull/10424`

Update a local copy of the PR: \
`$ git checkout pull/10424` \
`$ git pull https://git.openjdk.org/jdk pull/10424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10424`

View PR using the GUI difftool: \
`$ git pr show -t 10424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10424.diff">https://git.openjdk.org/jdk/pull/10424.diff</a>

</details>
