### PR TITLE
8293964: Unused check_for_duplicates parameter in ClassLoaderExt::process_jar_manifest

### DIFF
--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -830,7 +830,7 @@ void ClassLoader::add_to_app_classpath_entries(JavaThread* current,
   }
 
   if (entry->is_jar_file()) {
-    ClassLoaderExt::process_jar_manifest(current, entry, check_for_duplicates);
+    ClassLoaderExt::process_jar_manifest(current, entry);
   }
 #endif
 }

--- a/src/hotspot/share/classfile/classLoaderExt.cpp
+++ b/src/hotspot/share/classfile/classLoaderExt.cpp
@@ -182,8 +182,7 @@ char* ClassLoaderExt::get_class_path_attr(const char* jar_path, char* manifest, 
   return found;
 }
 
-void ClassLoaderExt::process_jar_manifest(JavaThread* current, ClassPathEntry* entry,
-                                          bool check_for_duplicates) {
+void ClassLoaderExt::process_jar_manifest(JavaThread* current, ClassPathEntry* entry) {
   ResourceMark rm(current);
   jint manifest_size;
   char* manifest = read_manifest(current, entry, &manifest_size);

--- a/src/hotspot/share/classfile/classLoaderExt.hpp
+++ b/src/hotspot/share/classfile/classLoaderExt.hpp
@@ -61,7 +61,7 @@ private:
   static char* read_manifest(JavaThread* current, ClassPathEntry* entry, jint *manifest_size, bool clean_text);
 
 public:
-  static void process_jar_manifest(JavaThread* current, ClassPathEntry* entry, bool check_for_duplicates);
+  static void process_jar_manifest(JavaThread* current, ClassPathEntry* entry);
 
   // Called by JVMTI code to add boot classpath
   static void append_boot_classpath(ClassPathEntry* new_entry);


### PR DESCRIPTION
The check_for_duplicates parameter in ClassLoaderExt::process_jar_manifest was removed due to it being unused. Ran tier1 to verify. Please review