### PR TITLE
8293000: Review running times of jshell regression tests

### DIFF
--- a/test/langtools/jdk/jshell/ClassMembersTest.java
+++ b/test/langtools/jdk/jshell/ClassMembersTest.java
@@ -38,11 +38,18 @@ import javax.tools.Diagnostic;
 import jdk.jshell.SourceCodeAnalysis;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.testng.annotations.BeforeMethod;
 import jdk.jshell.TypeDeclSnippet;
 import static jdk.jshell.Snippet.Status.OVERWRITTEN;
 import static jdk.jshell.Snippet.Status.VALID;
 
 public class ClassMembersTest extends KullaTesting {
+
+    @BeforeMethod
+    @Override
+    public void setUp() {
+        setUp(builder -> builder.executionEngine("local"));
+    }
 
     @Test(dataProvider = "memberTestCase")
     public void memberTest(AccessModifier accessModifier, CodeChunk codeChunk, Static isStaticMember, Static isStaticReference) {

--- a/test/langtools/jdk/jshell/CompletionSuggestionTest.java
+++ b/test/langtools/jdk/jshell/CompletionSuggestionTest.java
@@ -723,7 +723,7 @@ public class CompletionSuggestionTest extends KullaTesting {
 
     @BeforeMethod
     public void setUp() {
-        super.setUp();
+        setUp(builder -> builder.executionEngine("local"));
 
         Path srcZip = Paths.get("src.zip");
 

--- a/test/langtools/jdk/jshell/ExecutionControlTestBase.java
+++ b/test/langtools/jdk/jshell/ExecutionControlTestBase.java
@@ -50,22 +50,30 @@ public class ExecutionControlTestBase extends KullaTesting {
     }
 
     @Test
+    public void test() {
+        variables();
+        testImportOnDemand();
+        classesDeclaration();
+        interfaceTest();
+        methodOverload();
+        testExprSanity();
+    }
+
     public void classesDeclaration() {
-        assertEval("interface A { }");
-        assertEval("class B implements A { }");
-        assertEval("interface C extends A { }");
+        assertEval("interface AA { }");
+        assertEval("class BB implements AA { }");
+        assertEval("interface C extends AA { }");
         assertEval("enum D implements C { }");
         assertEval("@interface E { }");
         assertClasses(
-                clazz(KullaTesting.ClassType.INTERFACE, "A"),
-                clazz(KullaTesting.ClassType.CLASS, "B"),
+                clazz(KullaTesting.ClassType.INTERFACE, "AA"),
+                clazz(KullaTesting.ClassType.CLASS, "BB"),
                 clazz(KullaTesting.ClassType.INTERFACE, "C"),
                 clazz(KullaTesting.ClassType.ENUM, "D"),
                 clazz(KullaTesting.ClassType.ANNOTATION, "E"));
         assertActiveKeys();
     }
 
-    @Test
     public void interfaceTest() {
         String interfaceSource
                 = "interface A {\n"
@@ -93,7 +101,6 @@ public class ExecutionControlTestBase extends KullaTesting {
         assertEval("new B.Inner2();");
     }
 
-    @Test
     public void variables() {
         VarSnippet snx = varKey(assertEval("int x = 10;"));
         VarSnippet sny = varKey(assertEval("String y = \"hi\";"));
@@ -105,7 +112,6 @@ public class ExecutionControlTestBase extends KullaTesting {
         assertActiveKeys();
     }
 
-    @Test
     public void methodOverload() {
         assertEval("int m() { return 1; }");
         assertEval("int m(int x) { return 2; }");
@@ -130,15 +136,13 @@ public class ExecutionControlTestBase extends KullaTesting {
         assertActiveKeys();
     }
 
-    @Test
     public void testExprSanity() {
-        assertEval("int x = 3;", "3");
-        assertEval("int y = 4;", "4");
-        assertEval("x + y;", "7");
+        assertEval("int i = 3;", "3");
+        assertEval("int j = 4;", "4");
+        assertEval("i + j;", "7");
         assertActiveKeys();
     }
 
-    @Test
     public void testImportOnDemand() {
         assertImportKeyMatch("import java.util.*;", "java.util.*", TYPE_IMPORT_ON_DEMAND_SUBKIND, added(VALID));
         assertEval("List<Integer> list = new ArrayList<>();");

--- a/test/langtools/jdk/jshell/SimpleRegressionTest.java
+++ b/test/langtools/jdk/jshell/SimpleRegressionTest.java
@@ -44,9 +44,16 @@ import static org.testng.Assert.assertTrue;
 import static jdk.jshell.Snippet.Status.OVERWRITTEN;
 import static jdk.jshell.Snippet.SubKind.TEMP_VAR_EXPRESSION_SUBKIND;
 import static jdk.jshell.Snippet.Status.VALID;
+import org.testng.annotations.BeforeMethod;
 
 @Test
 public class SimpleRegressionTest extends KullaTesting {
+
+    @BeforeMethod
+    @Override
+    public void setUp() {
+        setUp(builder -> builder.executionEngine("local"));
+    }
 
     public void testSnippetMemberAssignment() {
         assertEval("class C { int y; }");

--- a/test/langtools/jdk/jshell/ToolBasicTest.java
+++ b/test/langtools/jdk/jshell/ToolBasicTest.java
@@ -155,11 +155,6 @@ public class ToolBasicTest extends ReplToolTesting {
             out = new PrintWriter(writer);
             setCommandInput(cmd + "\n");
             t = new Thread(() -> {
-                try {
-                    // no chance to know whether cmd is being evaluated
-                    Thread.sleep(5000);
-                } catch (InterruptedException ignored) {
-                }
                 int i = 1;
                 int n = 30;
                 synchronized (lock) {


### PR DESCRIPTION
Some of the jshell tests have been identified as long-running.

This patch reduces tests runtimes with multiple tricks:

- local execution control is used in heavily parametrized and fragmented tests to eliminate JVM startups
- some tests have been defragmented
- unnecessary Thread::stop has been removed

Measured test run times before and after application of this patch:
- ClassMembersTest 23.964ms ->  9.195ms
- ToolBasicTest 24.281ms -> 14.955ms
- FailOverExecutionControlHangingListenTest 31.221ms -> 5.780ms
- FailOverExecutionControlDyingLaunchTest 31.221ms -> 6.050ms
- FailOverExecutionControlHangingLaunchTest 31.303ms -> 5.832ms
- CompletionSuggestionTest 10.523ms -> 4.940ms
- SimpleRegressionTest 3.629ms -> 1.304ms

Please review the test changes.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293000](https://bugs.openjdk.org/browse/JDK-8293000): Review running times of jshell regression tests


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10428/head:pull/10428` \
`$ git checkout pull/10428`

Update a local copy of the PR: \
`$ git checkout pull/10428` \
`$ git pull https://git.openjdk.org/jdk pull/10428/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10428`

View PR using the GUI difftool: \
`$ git pr show -t 10428`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10428.diff">https://git.openjdk.org/jdk/pull/10428.diff</a>

</details>
