### PR TITLE
8294472: Remove redundant rawtypes suppression in AbstractChronology

### DIFF
--- a/src/java.base/share/classes/java/time/chrono/AbstractChronology.java
+++ b/src/java.base/share/classes/java/time/chrono/AbstractChronology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +93,6 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAdjusters;
 import java.time.temporal.TemporalField;
 import java.time.temporal.ValueRange;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -193,8 +192,7 @@ public abstract class AbstractChronology implements Chronology {
             registerChrono(ThaiBuddhistChronology.INSTANCE);
 
             // Register Chronologies from the ServiceLoader
-            @SuppressWarnings("rawtypes")
-            ServiceLoader<AbstractChronology> loader =  ServiceLoader.load(AbstractChronology.class, null);
+            ServiceLoader<AbstractChronology> loader = ServiceLoader.load(AbstractChronology.class, null);
             for (AbstractChronology chrono : loader) {
                 String id = chrono.getId();
                 if (id.equals("ISO") || registerChrono(chrono) != null) {
@@ -238,7 +236,6 @@ public abstract class AbstractChronology implements Chronology {
 
         // Look for a Chronology using ServiceLoader of the Thread's ContextClassLoader
         // Application provided Chronologies must not be cached
-        @SuppressWarnings("rawtypes")
         ServiceLoader<Chronology> loader = ServiceLoader.load(Chronology.class);
         for (Chronology chrono : loader) {
             if (type.equals(chrono.getCalendarType())) {
@@ -271,7 +268,6 @@ public abstract class AbstractChronology implements Chronology {
 
         // Look for a Chronology using ServiceLoader of the Thread's ContextClassLoader
         // Application provided Chronologies must not be cached
-        @SuppressWarnings("rawtypes")
         ServiceLoader<Chronology> loader = ServiceLoader.load(Chronology.class);
         for (Chronology chrono : loader) {
             if (id.equals(chrono.getId()) || id.equals(chrono.getCalendarType())) {
@@ -311,7 +307,6 @@ public abstract class AbstractChronology implements Chronology {
         HashSet<Chronology> chronos = new HashSet<>(CHRONOS_BY_ID.values());
 
         /// Add in Chronologies from the ServiceLoader configuration
-        @SuppressWarnings("rawtypes")
         ServiceLoader<Chronology> loader = ServiceLoader.load(Chronology.class);
         for (Chronology chrono : loader) {
             chronos.add(chrono);


### PR DESCRIPTION
Found this redundant suppressions by IntelliJ IDEA inspection.
Seems initially `Chronology` was generic class?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294472](https://bugs.openjdk.org/browse/JDK-8294472): Remove redundant rawtypes suppression in AbstractChronology


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10433/head:pull/10433` \
`$ git checkout pull/10433`

Update a local copy of the PR: \
`$ git checkout pull/10433` \
`$ git pull https://git.openjdk.org/jdk pull/10433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10433`

View PR using the GUI difftool: \
`$ git pr show -t 10433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10433.diff">https://git.openjdk.org/jdk/pull/10433.diff</a>

</details>
