### PR TITLE
8294404: [BACKOUT] JDK-8294142: make test should report only executed tests

### DIFF
--- a/doc/testing.html
+++ b/doc/testing.html
@@ -200,8 +200,6 @@ TEST FAILURE</code></pre>
 <p>Retry failed tests up to a set number of times, until they pass. This allows to pass the tests with intermittent failures. Defaults to 0.</p>
 <h4 id="repeat_count">REPEAT_COUNT</h4>
 <p>Repeat the tests up to a set number of times, stopping at first failure. This helps to reproduce intermittent test failures. Defaults to 0.</p>
-<h4 id="report">REPORT</h4>
-<p>Use this report style when reporting test results (sent to JTReg as <code>-report</code>). Defaults to <code>executed</code>.</p>
 <h3 id="gtest-keywords">Gtest keywords</h3>
 <h4 id="repeat">REPEAT</h4>
 <p>The number of times to repeat the tests (<code>--gtest_repeat</code>).</p>

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -456,11 +456,6 @@ Repeat the tests up to a set number of times, stopping at first failure.
 This helps to reproduce intermittent test failures.
 Defaults to 0.
 
-#### REPORT
-
-Use this report style when reporting test results (sent to JTReg as `-report`).
-Defaults to `executed`.
-
 ### Gtest keywords
 
 #### REPEAT

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -196,12 +196,11 @@ $(eval $(call SetTestOpt,JAVA_OPTIONS,JTREG))
 $(eval $(call SetTestOpt,JOBS,JTREG))
 $(eval $(call SetTestOpt,TIMEOUT_FACTOR,JTREG))
 $(eval $(call SetTestOpt,FAILURE_HANDLER_TIMEOUT,JTREG))
-$(eval $(call SetTestOpt,REPORT,JTREG))
 
 $(eval $(call ParseKeywordVariable, JTREG, \
     SINGLE_KEYWORDS := JOBS TIMEOUT_FACTOR FAILURE_HANDLER_TIMEOUT \
         TEST_MODE ASSERT VERBOSE RETAIN MAX_MEM RUN_PROBLEM_LISTS \
-        RETRY_COUNT REPEAT_COUNT MAX_OUTPUT REPORT $(CUSTOM_JTREG_SINGLE_KEYWORDS), \
+        RETRY_COUNT REPEAT_COUNT MAX_OUTPUT $(CUSTOM_JTREG_SINGLE_KEYWORDS), \
     STRING_KEYWORDS := OPTIONS JAVA_OPTIONS VM_OPTIONS KEYWORDS \
         EXTRA_PROBLEM_LISTS LAUNCHER_OPTIONS \
         $(CUSTOM_JTREG_STRING_KEYWORDS), \
@@ -746,7 +745,6 @@ define SetupRunJtregTestBody
   JTREG_RUN_PROBLEM_LISTS ?= false
   JTREG_RETRY_COUNT ?= 0
   JTREG_REPEAT_COUNT ?= 0
-  JTREG_REPORT ?= executed
 
   ifneq ($$(JTREG_RETRY_COUNT), 0)
     ifneq ($$(JTREG_REPEAT_COUNT), 0)
@@ -856,7 +854,6 @@ define SetupRunJtregTestBody
           -dir:$$(JTREG_TOPDIR) \
           -reportDir:$$($1_TEST_RESULTS_DIR) \
           -workDir:$$($1_TEST_SUPPORT_DIR) \
-          -report:$$$${JTREG_REPORT_ITERATION} \
           $$$${JTREG_STATUS} \
           $$(JTREG_OPTIONS) \
           $$(JTREG_FAILURE_HANDLER_OPTIONS) \
@@ -868,7 +865,6 @@ define SetupRunJtregTestBody
 
   ifneq ($$(JTREG_RETRY_COUNT), 0)
     $1_COMMAND_LINE := \
-        export JTREG_REPORT_ITERATION=$$(JTREG_REPORT); \
         for i in {0..$$(JTREG_RETRY_COUNT)}; do \
           if [ "$$$$i" != 0 ]; then \
             $$(PRINTF) "\nRetrying Jtreg run. Attempt: $$$$i\n"; \
@@ -878,11 +874,11 @@ define SetupRunJtregTestBody
             break; \
           fi; \
           export JTREG_STATUS="-status:error,fail"; \
-          export JTREG_REPORT_ITERATION="all-executed"; \
         done
-  else ifneq ($$(JTREG_REPEAT_COUNT), 0)
+  endif
+
+  ifneq ($$(JTREG_REPEAT_COUNT), 0)
     $1_COMMAND_LINE := \
-        export JTREG_REPORT_ITERATION=$$(JTREG_REPORT); \
         for i in {1..$$(JTREG_REPEAT_COUNT)}; do \
           $$(PRINTF) "\nRepeating Jtreg run: $$$$i out of $$(JTREG_REPEAT_COUNT)\n"; \
           $$($1_COMMAND_LINE); \
@@ -891,10 +887,6 @@ define SetupRunJtregTestBody
             break; \
           fi; \
         done
-  else
-    $1_COMMAND_LINE := \
-        export JTREG_REPORT_ITERATION=$$(JTREG_REPORT); \
-        $$($1_COMMAND_LINE);
   endif
 
   run-test-$1: pre-run-test clean-workdir-$1


### PR DESCRIPTION
Revert "8294142: make test should report only on executed tests"

This reverts commit 91a23d775fbf482244ace5758f7b3084ea564460.

Triggers an issue with javatest that causes CI test tasks to fail - see [CODETOOLS-7903331](https://bugs.openjdk.org/browse/CODETOOLS-7903331). Backing out until the matter can be resolved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294404](https://bugs.openjdk.org/browse/JDK-8294404): [BACKOUT] JDK-8294142: make test should report only executed tests


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10436/head:pull/10436` \
`$ git checkout pull/10436`

Update a local copy of the PR: \
`$ git checkout pull/10436` \
`$ git pull https://git.openjdk.org/jdk pull/10436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10436`

View PR using the GUI difftool: \
`$ git pr show -t 10436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10436.diff">https://git.openjdk.org/jdk/pull/10436.diff</a>

</details>
