### PR TITLE
8294411: SA should provide more useful info when it fails to start up due to "failed to workaround classshareing"

### DIFF
--- a/src/jdk.hotspot.agent/share/native/libsaproc/ps_core_common.c
+++ b/src/jdk.hotspot.agent/share/native/libsaproc/ps_core_common.c
@@ -342,7 +342,7 @@ bool init_classsharing_workaround(struct ps_prochandle* ph) {
       classes_jsa[0] = 0;
       if (read_string(ph, sharedArchivePathAddr, classes_jsa, sizeof(classes_jsa)) != true) {
         print_error("can't read shared archive path value (%p) (%p)\n",
-                           (void*)sharedArchivePathAddrAddr, (void*)sharedArchivePathAddr);
+                    (void*)sharedArchivePathAddrAddr, (void*)sharedArchivePathAddr);
         return false;
       }
 

--- a/src/jdk.hotspot.agent/share/native/libsaproc/ps_core_common.c
+++ b/src/jdk.hotspot.agent/share/native/libsaproc/ps_core_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,7 +123,7 @@ void core_release(struct ps_prochandle* ph) {
 static map_info* allocate_init_map(int fd, off_t offset, uintptr_t vaddr, size_t memsz, uint32_t flags) {
   map_info* map;
   if ( (map = (map_info*) calloc(1, sizeof(map_info))) == NULL) {
-    print_debug("can't allocate memory for map_info\n");
+    print_error("can't allocate memory for map_info\n");
     return NULL;
   }
 
@@ -300,7 +300,7 @@ bool init_classsharing_workaround(struct ps_prochandle* ph) {
       jvm_name = lib->name;
       useSharedSpacesAddr = lookup_symbol(ph, jvm_name, USE_SHARED_SPACES_SYM);
       if (useSharedSpacesAddr == 0) {
-        print_debug("can't lookup 'UseSharedSpaces' symbol\n");
+        print_error("can't lookup 'UseSharedSpaces' symbol\n");
         return false;
       }
 
@@ -308,7 +308,7 @@ bool init_classsharing_workaround(struct ps_prochandle* ph) {
       // using equivalent type jboolean to read the value of
       // UseSharedSpaces which is same as hotspot type "bool".
       if (read_jboolean(ph, useSharedSpacesAddr, &useSharedSpaces) != true) {
-        print_debug("can't read the value of 'UseSharedSpaces' symbol\n");
+        print_error("can't read the value of 'UseSharedSpaces' symbol\n");
         return false;
       }
 
@@ -319,28 +319,30 @@ bool init_classsharing_workaround(struct ps_prochandle* ph) {
 
       sharedBaseAddressAddr = lookup_symbol(ph, jvm_name, SHARED_BASE_ADDRESS_SYM);
       if (sharedBaseAddressAddr == 0) {
-        print_debug("can't lookup 'SharedBaseAddress' flag\n");
+        print_error("can't lookup 'SharedBaseAddress' flag\n");
         return false;
       }
 
       if (read_pointer(ph, sharedBaseAddressAddr, &sharedBaseAddress) != true) {
-        print_debug("can't read the value of 'SharedBaseAddress' flag\n");
+        print_error("can't read the value of 'SharedBaseAddress' flag\n");
         return false;
       }
 
       sharedArchivePathAddrAddr = lookup_symbol(ph, jvm_name, SHARED_ARCHIVE_PATH_SYM);
       if (sharedArchivePathAddrAddr == 0) {
-        print_debug("can't lookup shared archive path symbol\n");
+        print_error("can't lookup shared archive path symbol\n");
         return false;
       }
 
       if (read_pointer(ph, sharedArchivePathAddrAddr, &sharedArchivePathAddr) != true) {
-        print_debug("can't read shared archive path pointer\n");
+        print_error("can't read shared archive path pointer (%p)\n", sharedArchivePathAddrAddr);
         return false;
       }
 
+      classes_jsa[0] = 0;
       if (read_string(ph, sharedArchivePathAddr, classes_jsa, sizeof(classes_jsa)) != true) {
-        print_debug("can't read shared archive path value\n");
+        print_error("can't read shared archive path value (%p) (%p)\n",
+                           (void*)sharedArchivePathAddrAddr, (void*)sharedArchivePathAddr);
         return false;
       }
 
@@ -348,7 +350,7 @@ bool init_classsharing_workaround(struct ps_prochandle* ph) {
       // open the class sharing archive file
       fd = pathmap_open(classes_jsa);
       if (fd < 0) {
-        print_debug("can't open %s!\n", classes_jsa);
+        print_error("can't open %s!\n", classes_jsa);
         ph->core->classes_jsa_fd = -1;
         return false;
       } else {
@@ -360,14 +362,14 @@ bool init_classsharing_workaround(struct ps_prochandle* ph) {
       memset(&header, 0, header_size);
       if ((n = read(fd, &header, header_size))
            != header_size) {
-        print_debug("can't read shared archive file map header from %s\n", classes_jsa);
+        print_error("can't read shared archive file map header from %s\n", classes_jsa);
         close(fd);
         return false;
       }
 
       // check file magic
       if (header._generic_header._magic != CDS_ARCHIVE_MAGIC) {
-        print_debug("%s has bad shared archive file magic number 0x%x, expecting 0x%x\n",
+        print_error("%s has bad shared archive file magic number 0x%x, expecting 0x%x\n",
                     classes_jsa, header._generic_header._magic, CDS_ARCHIVE_MAGIC);
         close(fd);
         return false;
@@ -375,7 +377,7 @@ bool init_classsharing_workaround(struct ps_prochandle* ph) {
 
       // check version
       if (header._generic_header._version != CURRENT_CDS_ARCHIVE_VERSION) {
-        print_debug("%s has wrong shared archive file version %d, expecting %d\n",
+        print_error("%s has wrong shared archive file version %d, expecting %d\n",
                      classes_jsa, header._generic_header._version, CURRENT_CDS_ARCHIVE_VERSION);
         close(fd);
         return false;


### PR DESCRIPTION
Sometimes SA fails to startup with the following error message:

ERROR: failed to workaround classshareing
Unable to open core file

The code in question is init_classsharing_workaround() in ps_core_common.c. There a number of reasons why the class sharing work around can fail, and the reason is usually pretty well described with a print_debug() statement. However, since this is an error, these should really just be print_error() statements so the user doesn't need to figure out how to get more info by setting LIBSAPROC_DEBUG (which may also produce a ton of output unrelated to the error).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294411](https://bugs.openjdk.org/browse/JDK-8294411): SA should provide more useful info when it fails to start up due to "failed to workaround classshareing"


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10438/head:pull/10438` \
`$ git checkout pull/10438`

Update a local copy of the PR: \
`$ git checkout pull/10438` \
`$ git pull https://git.openjdk.org/jdk pull/10438/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10438`

View PR using the GUI difftool: \
`$ git pr show -t 10438`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10438.diff">https://git.openjdk.org/jdk/pull/10438.diff</a>

</details>
