### PR TITLE
8294430: RISC-V: Small refactoring for movptr_with_offset

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.cpp
@@ -164,7 +164,7 @@ void Assembler::li32(Register Rd, int32_t imm) {
     } else {                                                       \
       assert(temp != noreg, "temp must not be empty register!");   \
       int32_t offset = 0;                                          \
-      movptr_with_offset(temp, dest, offset);                      \
+      movptr(temp, dest, offset);                                  \
       jalr(REGISTER, temp, offset);                                \
     }                                                              \
   }                                                                \
@@ -201,7 +201,7 @@ void Assembler::ret() {
       jalr(REGISTER, temp, ((int32_t)distance << 20) >> 20);      \
     } else {                                                      \
       int32_t offset = 0;                                         \
-      movptr_with_offset(temp, dest, offset);                     \
+      movptr(temp, dest, offset);                                 \
       jalr(REGISTER, temp, offset);                               \
     }                                                             \
   }
@@ -272,7 +272,7 @@ void Assembler::wrap_label(Register Rt, Label &L, jal_jalr_insn insn) {
   }
 }
 
-void Assembler::movptr_with_offset(Register Rd, address addr, int32_t &offset) {
+void Assembler::movptr(Register Rd, address addr, int32_t &offset) {
   int64_t imm64 = (int64_t)addr;
 #ifndef PRODUCT
   {
@@ -307,7 +307,7 @@ void Assembler::movptr(Register Rd, uintptr_t imm64) {
 
 void Assembler::movptr(Register Rd, address addr) {
   int offset = 0;
-  movptr_with_offset(Rd, addr, offset);
+  movptr(Rd, addr, offset);
   addi(Rd, Rd, offset);
 }
 

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -302,7 +302,7 @@ public:
       lui(Rd, upper);
       offset = lower;
     } else {
-      movptr_with_offset(Rd, (address)(uintptr_t)adr.offset(), offset);
+      movptr(Rd, (address)(uintptr_t)adr.offset(), offset);
     }
     add(Rd, Rd, adr.base());
   }
@@ -321,7 +321,7 @@ public:
   void li32(Register Rd, int32_t imm);
   void li64(Register Rd, int64_t imm);
   void movptr(Register Rd, address addr);
-  void movptr_with_offset(Register Rd, address addr, int32_t &offset);
+  void movptr(Register Rd, address addr, int32_t &offset);
   void movptr(Register Rd, uintptr_t imm64);
   void j(const address &dest, Register temp = t0);
   void j(const Address &adr, Register temp = t0);
@@ -523,7 +523,7 @@ public:
       NAME(Rd, Rd, ((int32_t)distance << 20) >> 20);                                               \
     } else {                                                                                       \
       int32_t offset = 0;                                                                          \
-      movptr_with_offset(Rd, dest, offset);                                                        \
+      movptr(Rd, dest, offset);                                                                    \
       NAME(Rd, Rd, offset);                                                                        \
     }                                                                                              \
   }                                                                                                \
@@ -597,7 +597,7 @@ public:
       NAME(Rd, temp, ((int32_t)distance << 20) >> 20);                                             \
     } else {                                                                                       \
       int32_t offset = 0;                                                                          \
-      movptr_with_offset(temp, dest, offset);                                                      \
+      movptr(temp, dest, offset);                                                                  \
       NAME(Rd, temp, offset);                                                                      \
     }                                                                                              \
   }                                                                                                \
@@ -742,7 +742,7 @@ public:
       NAME(Rs, temp, ((int32_t)distance << 20) >> 20);                                             \
     } else {                                                                                       \
       int32_t offset = 0;                                                                          \
-      movptr_with_offset(temp, dest, offset);                                                      \
+      movptr(temp, dest, offset);                                                                  \
       NAME(Rs, temp, offset);                                                                      \
     }                                                                                              \
   }                                                                                                \
@@ -786,7 +786,7 @@ public:
       NAME(Rs, temp, ((int32_t)distance << 20) >> 20);                                             \
     } else {                                                                                       \
       int32_t offset = 0;                                                                          \
-      movptr_with_offset(temp, dest, offset);                                                      \
+      movptr(temp, dest, offset);                                                                  \
       NAME(Rs, temp, offset);                                                                      \
     }                                                                                              \
   }                                                                                                \
@@ -881,7 +881,7 @@ public:
     } else {                                                                                  \
       assert_different_registers(Rd, temp);                                                   \
       int32_t off = 0;                                                                        \
-      movptr_with_offset(temp, dest, off);                                                    \
+      movptr(temp, dest, off);                                                                \
       jalr(Rd, temp, off);                                                                    \
     }                                                                                         \
   }                                                                                           \

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -248,9 +248,9 @@ void C2_MacroAssembler::emit_entry_barrier_stub(C2EntryBarrierStub* stub) {
 
   bind(stub->slow_path());
 
-  int32_t _offset = 0;
-  movptr_with_offset(t0, StubRoutines::riscv::method_entry_barrier(), _offset);
-  jalr(ra, t0, _offset);
+  int32_t offset = 0;
+  movptr(t0, StubRoutines::riscv::method_entry_barrier(), offset);
+  jalr(ra, t0, offset);
   j(stub->continuation());
 
   bind(stub->guard());

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
@@ -256,7 +256,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
     __ beq(t0, t1, skip_barrier);
 
     int32_t offset = 0;
-    __ movptr_with_offset(t0, StubRoutines::riscv::method_entry_barrier(), offset);
+    __ movptr(t0, StubRoutines::riscv::method_entry_barrier(), offset);
     __ jalr(ra, t0, offset);
     __ j(skip_barrier);
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -556,7 +556,7 @@ void MacroAssembler::emit_static_call_stub() {
 
   // Jump to the entry point of the i2c stub.
   int32_t offset = 0;
-  movptr_with_offset(t0, 0, offset);
+  movptr(t0, 0, offset);
   jalr(x0, t0, offset);
 }
 
@@ -565,7 +565,7 @@ void MacroAssembler::call_VM_leaf_base(address entry_point,
                                        Label *retaddr) {
   int32_t offset = 0;
   push_reg(RegSet::of(t0, xmethod), sp);   // push << t0 & xmethod >> to sp
-  movptr_with_offset(t0, entry_point, offset);
+  movptr(t0, entry_point, offset);
   jalr(x1, t0, offset);
   if (retaddr != NULL) {
     bind(*retaddr);
@@ -2689,7 +2689,6 @@ void MacroAssembler::load_byte_map_base(Register reg) {
 }
 
 void MacroAssembler::la_patchable(Register reg1, const Address &dest, int32_t &offset) {
-  relocInfo::relocType rtype = dest.rspec().reloc()->type();
   unsigned long low_address = (uintptr_t)CodeCache::low_bound();
   unsigned long high_address = (uintptr_t)CodeCache::high_bound();
   unsigned long dest_address = (uintptr_t)dest.target();
@@ -2709,7 +2708,7 @@ void MacroAssembler::la_patchable(Register reg1, const Address &dest, int32_t &o
     auipc(reg1, (int32_t)distance + 0x800);
     offset = ((int32_t)distance << 20) >> 20;
   } else {
-    movptr_with_offset(reg1, dest.target(), offset);
+    movptr(reg1, dest.target(), offset);
   }
 }
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -683,7 +683,7 @@ public:
   //     code is patched, and the new destination may not be reachable by a simple JAL
   //     instruction.
   //
-  //   - indirect call: movptr_with_offset + jalr
+  //   - indirect call: movptr + jalr
   //     This too can reach anywhere in the address space, but it cannot be
   //     patched while code is running, so it must only be modified at a safepoint.
   //     This form of call is most suitable for targets at fixed addresses, which

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -280,7 +280,7 @@ address NativeJump::jump_destination() const {
 
   // We use jump to self as the unresolved address which the inline
   // cache code (and relocs) know about
-  // As a special case we also use sequence movptr_with_offset(r,0), jalr(r,0)
+  // As a special case we also use sequence movptr(r,0), jalr(r,0)
   // i.e. jump to 0 when we need leave space for a wide immediate
   // load
 
@@ -392,7 +392,7 @@ void NativeGeneralJump::insert_unconditional(address code_pos, address entry) {
   MacroAssembler a(&cb);
 
   int32_t offset = 0;
-  a.movptr_with_offset(t0, entry, offset); // lui, addi, slli, addi, slli
+  a.movptr(t0, entry, offset); // lui, addi, slli, addi, slli
   a.jalr(x0, t0, offset); // jalr
 
   ICache::invalidate_range(code_pos, instruction_size);

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -328,7 +328,6 @@ class NativeMovConstReg: public NativeInstruction {
  public:
   enum RISCV_specific_constants {
     movptr_instruction_size             =    6 * NativeInstruction::instruction_size, // lui, addi, slli, addi, slli, addi.  See movptr().
-    movptr_with_offset_instruction_size =    5 * NativeInstruction::instruction_size, // lui, addi, slli, addi, slli. See movptr_with_offset().
     load_pc_relative_instruction_size   =    2 * NativeInstruction::instruction_size, // auipc, ld
     instruction_offset                  =    0,
     displacement_offset                 =    0
@@ -342,12 +341,12 @@ class NativeMovConstReg: public NativeInstruction {
     // However, when the instruction at 5 * instruction_size isn't addi,
     // the next instruction address should be addr_at(5 * instruction_size)
     if (nativeInstruction_at(instruction_address())->is_movptr()) {
-      if (is_addi_at(addr_at(movptr_with_offset_instruction_size))) {
+      if (is_addi_at(addr_at(movptr_instruction_size - NativeInstruction::instruction_size))) {
         // Assume: lui, addi, slli, addi, slli, addi
         return addr_at(movptr_instruction_size);
       } else {
         // Assume: lui, addi, slli, addi, slli
-        return addr_at(movptr_with_offset_instruction_size);
+        return addr_at(movptr_instruction_size - NativeInstruction::instruction_size);
       }
     } else if (is_load_pc_relative_at(instruction_address())) {
       // Assume: auipc, ld

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -652,7 +652,7 @@ class StubGenerator: public StubCodeGenerator {
 #endif
     BLOCK_COMMENT("call MacroAssembler::debug");
     int32_t offset = 0;
-    __ movptr_with_offset(t0, CAST_FROM_FN_PTR(address, MacroAssembler::debug64), offset);
+    __ movptr(t0, CAST_FROM_FN_PTR(address, MacroAssembler::debug64), offset);
     __ jalr(x1, t0, offset);
     __ ebreak();
 
@@ -3741,7 +3741,7 @@ class StubGenerator: public StubCodeGenerator {
     __ mv(c_rarg0, xthread);
     BLOCK_COMMENT("call runtime_entry");
     int32_t offset = 0;
-    __ movptr_with_offset(t0, runtime_entry, offset);
+    __ movptr(t0, runtime_entry, offset);
     __ jalr(x1, t0, offset);
 
     // Generate oop map

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -387,7 +387,7 @@ void TemplateTable::fast_aldc(bool wide) {
 
     // Stash null_sentinel address to get its value later
     int32_t offset = 0;
-    __ movptr_with_offset(rarg, Universe::the_null_sentinel_addr(), offset);
+    __ movptr(rarg, Universe::the_null_sentinel_addr(), offset);
     __ ld(tmp, Address(rarg, offset));
     __ resolve_oop_handle(tmp, x15, t1);
     __ bne(result, tmp, notNull);


### PR DESCRIPTION
The name of function 'movptr_with_offset' looks misleading. It actually returns an offset to its caller.
We could rename this function to 'movptr' so that it overloads existing function 'movptr'.

```
   void movptr(Register Rd, address addr);
- void movptr_with_offset(Register Rd, address addr, int32_t &offset);
+ void movptr(Register Rd, address addr, int32_t &offset);
```

Testing: Tier1 hotspot on HiFive Linux-riscv64 Unmatched board.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294430](https://bugs.openjdk.org/browse/JDK-8294430): RISC-V: Small refactoring for movptr_with_offset


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author)
 * [Yadong Wang](https://openjdk.org/census#yadongwang) (@yadongw - Author)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10439/head:pull/10439` \
`$ git checkout pull/10439`

Update a local copy of the PR: \
`$ git checkout pull/10439` \
`$ git pull https://git.openjdk.org/jdk pull/10439/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10439`

View PR using the GUI difftool: \
`$ git pr show -t 10439`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10439.diff">https://git.openjdk.org/jdk/pull/10439.diff</a>

</details>
