### PR TITLE
8294262: AArch64: compiler/vectorapi/TestReverseByteTransforms.java test failed on SVE machine

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransforms.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransforms.java
@@ -39,6 +39,7 @@ import jdk.test.lib.Utils;
  * @bug 8287794
  * @summary Test various reverse bytes ideal transforms on X86(AVX2, AVX512) and AARCH64(NEON)
  * @requires vm.compiler2.enabled
+ * @requires !(vm.cpu.features ~= ".*sve.*")
  * @modules jdk.incubator.vector
  * @library /test/lib /
  * @run driver compiler.vectorapi.TestReverseByteTransforms

--- a/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransforms.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransforms.java
@@ -37,7 +37,10 @@ import jdk.test.lib.Utils;
 /*
  * @test
  * @bug 8287794
- * @summary Test various reverse bytes ideal transforms on X86(AVX2, AVX512) and AARCH64(NEON)
+ * @summary Test various reverse bytes ideal transforms on X86(AVX2, AVX512) and AArch64(NEON).
+ *          For AArch64(SVE), we have a specific optimization,
+ *          ReverseBytesV (ReverseBytesV X MASK) MASK => X, which eliminates both ReverseBytesV
+ *          nodes. The test cases for AArch64(SVE) are in TestReverseByteTransformsSVE.java.
  * @requires vm.compiler2.enabled
  * @requires !(vm.cpu.features ~= ".*sve.*")
  * @modules jdk.incubator.vector


### PR DESCRIPTION
This test failed at cases test_reversebytes_short/int/long_transform2, which expected the ReversBytesV node, but nothing was finally found. On SVE system, we have a specific optimization, `ReverseBytesV (ReverseBytesV X MASK) MASK => X`, which eliminates both ReverseBytesV nodes. This optimization rule is specifically on hardware with native predicate support. See https://github.com/openjdk/jdk/pull/9623 for more details.

As there is an SVE specific case TestReverseByteTransformsSVE.java, this patch simply marks TestReverseByteTransforms.java as non-SVE only.

[TEST]
jdk/incubator/vector, hotspot/compiler/vectorapi pass on SVE machine

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294262](https://bugs.openjdk.org/browse/JDK-8294262): AArch64: compiler/vectorapi/TestReverseByteTransforms.java test failed on SVE machine


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Ningsheng Jian](https://openjdk.org/census#njian) (@nsjian - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10442/head:pull/10442` \
`$ git checkout pull/10442`

Update a local copy of the PR: \
`$ git checkout pull/10442` \
`$ git pull https://git.openjdk.org/jdk pull/10442/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10442`

View PR using the GUI difftool: \
`$ git pr show -t 10442`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10442.diff">https://git.openjdk.org/jdk/pull/10442.diff</a>

</details>
