### PR TITLE
8294186: AArch64: VectorMaskToLong failed on SVE2 machine with -XX:UseSVE=1

### DIFF
--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -996,11 +996,11 @@ void C2_MacroAssembler::sve_vmask_tolong(Register dst, PRegister src, BasicType 
   }
 
   if (UseSVE > 1 && VM_Version::supports_svebitperm()) {
-    // Given by the vector with value 0x00 or 0x01 in each byte, the basic idea
+    // Given a vector with the value 0x00 or 0x01 in each byte, the basic idea
     // is to compress each significant bit of the byte in a cross-lane way. Due
-    // to the lack of cross-lane bit-compress instruction, here we use BEXT
-    // (bit-compress in each lane) with the biggest lane size (T = D) and
-    // concatenates the results then.
+    // to the lack of a cross-lane bit-compress instruction, we use BEXT
+    // (bit-compress in each lane) with the biggest lane size (T = D) then
+    // concatenate the results.
 
     // The second source input of BEXT, initialized with 0x01 in each byte.
     // vtmp2 = 0x01010101 0x01010101 0x01010101 0x01010101

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -977,7 +977,7 @@ void C2_MacroAssembler::bytemask_compress(Register dst) {
 
 // Pack the lowest-numbered bit of each mask element in src into a long value
 // in dst, at most the first 64 lane elements.
-// Clobbers: rscratch1 if hardware doesn't support FEAT_BITPERM.
+// Clobbers: rscratch1, if UseSVE=1 or the hardware doesn't support FEAT_BITPERM.
 void C2_MacroAssembler::sve_vmask_tolong(Register dst, PRegister src, BasicType bt, int lane_cnt,
                                          FloatRegister vtmp1, FloatRegister vtmp2) {
   assert(lane_cnt <= 64 && is_power_of_2(lane_cnt), "Unsupported lane count");
@@ -995,20 +995,7 @@ void C2_MacroAssembler::sve_vmask_tolong(Register dst, PRegister src, BasicType 
     sve_vector_narrow(vtmp1, B, vtmp1, size, vtmp2);
   }
 
-  if (UseSVE > 0 && !VM_Version::supports_svebitperm()) {
-    // Compress the lowest 8 bytes.
-    fmovd(dst, vtmp1);
-    bytemask_compress(dst);
-    if (lane_cnt <= 8) return;
-
-    // Repeat on higher bytes and join the results.
-    // Compress 8 bytes in each iteration.
-    for (int idx = 1; idx < (lane_cnt / 8); idx++) {
-      sve_extract_integral(rscratch1, T_LONG, vtmp1, idx, vtmp2);
-      bytemask_compress(rscratch1);
-      orr(dst, dst, rscratch1, Assembler::LSL, idx << 3);
-    }
-  } else if (UseSVE == 2 && VM_Version::supports_svebitperm()) {
+  if (UseSVE > 1 && VM_Version::supports_svebitperm()) {
     // Given by the vector with value 0x00 or 0x01 in each byte, the basic idea
     // is to compress each significant bit of the byte in a cross-lane way. Due
     // to the lack of cross-lane bit-compress instruction, here we use BEXT
@@ -1041,6 +1028,19 @@ void C2_MacroAssembler::sve_vmask_tolong(Register dst, PRegister src, BasicType 
       // the lowest 64 bits after narrowing vtmp1 from D to B.
       sve_vector_narrow(vtmp1, B, vtmp1, D, vtmp2);
       umov(dst, vtmp1, D, 0);
+    }
+  } else if (UseSVE > 0) {
+    // Compress the lowest 8 bytes.
+    fmovd(dst, vtmp1);
+    bytemask_compress(dst);
+    if (lane_cnt <= 8) return;
+
+    // Repeat on higher bytes and join the results.
+    // Compress 8 bytes in each iteration.
+    for (int idx = 1; idx < (lane_cnt / 8); idx++) {
+      sve_extract_integral(rscratch1, T_LONG, vtmp1, idx, vtmp2);
+      bytemask_compress(rscratch1);
+      orr(dst, dst, rscratch1, Assembler::LSL, idx << 3);
     }
   } else {
     assert(false, "unsupported");


### PR DESCRIPTION
C2_MacroAssembler::sve_vmask_tolong would fail on BITPERM supported SVE2 machine with "-XX:UseSVE=1".

`BITPERM` is an optional feature in SVE2. With this feature, VectorMaskToLong has a more efficent implementation. For other cases, it should generate SVE1 code.

[TEST]
jdk/incubator/vector, hotspot/compiler/vectorapi passed on BITPERM supported SVE2 machine, with option -XX:UseSVE=(0, 1, 2).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294186](https://bugs.openjdk.org/browse/JDK-8294186): AArch64: VectorMaskToLong failed on SVE2 machine with -XX:UseSVE=1


### Reviewers
 * [Ningsheng Jian](https://openjdk.org/census#njian) (@nsjian - Committer)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10443/head:pull/10443` \
`$ git checkout pull/10443`

Update a local copy of the PR: \
`$ git checkout pull/10443` \
`$ git pull https://git.openjdk.org/jdk pull/10443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10443`

View PR using the GUI difftool: \
`$ git pr show -t 10443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10443.diff">https://git.openjdk.org/jdk/pull/10443.diff</a>

</details>
