### PR TITLE
8237467: jlink plugin to save the argument files as input to jlink in the output image

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/CommandLine.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/CommandLine.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.tools.jlink.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.List;
+
+/**
+ * This file was originally a copy of CommandLine.java in
+ * com.sun.tools.javac.main.
+ * It should track changes made to that file.
+ */
+
+/**
+ * Various utility methods for processing Java tool command line arguments.
+ *
+ *  <p><b>This is NOT part of any supported API.
+ *  If you write code that depends on this, you do so at your own risk.
+ *  This code and its internal interfaces are subject to change or
+ *  deletion without notice.</b>
+ */
+public class CommandLine {
+
+    static void loadCmdFile(InputStream in, List<String> args)
+            throws IOException {
+        try (Reader r = new InputStreamReader(in)) {
+            Tokenizer t = new Tokenizer(r);
+            String s;
+            while ((s = t.nextToken()) != null) {
+                args.add(s);
+            }
+        }
+    }
+    public static class Tokenizer {
+        private final Reader in;
+        private int ch;
+
+        public Tokenizer(Reader in) throws IOException {
+            this.in = in;
+            ch = in.read();
+        }
+
+        public String nextToken() throws IOException {
+            skipWhite();
+            if (ch == -1) {
+                return null;
+            }
+
+            StringBuilder sb = new StringBuilder();
+            char quoteChar = 0;
+
+            while (ch != -1) {
+                switch (ch) {
+                    case ' ':
+                    case '\t':
+                    case '\f':
+                        if (quoteChar == 0) {
+                            return sb.toString();
+                        }
+                        sb.append((char) ch);
+                        break;
+
+                    case '\n':
+                    case '\r':
+                        return sb.toString();
+
+                    case '\'':
+                    case '"':
+                        if (quoteChar == 0) {
+                            quoteChar = (char) ch;
+                        } else if (quoteChar == ch) {
+                            quoteChar = 0;
+                        } else {
+                            sb.append((char) ch);
+                        }
+                        break;
+
+                    case '\\':
+                        if (quoteChar != 0) {
+                            ch = in.read();
+                            switch (ch) {
+                                case '\n':
+                                case '\r':
+                                    while (ch == ' ' || ch == '\n'
+                                            || ch == '\r' || ch == '\t'
+                                            || ch == '\f') {
+                                        ch = in.read();
+                                    }
+                                    continue;
+
+                                case 'n':
+                                    ch = '\n';
+                                    break;
+                                case 'r':
+                                    ch = '\r';
+                                    break;
+                                case 't':
+                                    ch = '\t';
+                                    break;
+                                case 'f':
+                                    ch = '\f';
+                                    break;
+                                default:
+                                    break;
+                            }
+                        }
+                        sb.append((char) ch);
+                        break;
+
+                    default:
+                        sb.append((char) ch);
+                }
+
+                ch = in.read();
+            }
+
+            return sb.toString();
+        }
+
+        void skipWhite() throws IOException {
+            while (ch != -1) {
+                switch (ch) {
+                    case ' ':
+                    case '\t':
+                    case '\n':
+                    case '\r':
+                    case '\f':
+                        break;
+
+                    case '#':
+                        ch = in.read();
+                        while (ch != '\n' && ch != '\r' && ch != -1) {
+                            ch = in.read();
+                        }
+                        break;
+
+                    default:
+                        return;
+                }
+
+                ch = in.read();
+            }
+        }
+    }
+}

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/CommandLine.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/CommandLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,11 +39,6 @@ import java.util.List;
 
 /**
  * Various utility methods for processing Java tool command line arguments.
- *
- *  <p><b>This is NOT part of any supported API.
- *  If you write code that depends on this, you do so at your own risk.
- *  This code and its internal interfaces are subject to change or
- *  deletion without notice.</b>
  */
 public class CommandLine {
 

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
@@ -224,6 +224,8 @@ public class JlinkTask {
         boolean suggestProviders = false;
     }
 
+    public static final String OPTIONS_RESOURCE = "jdk/tools/jlink/internal/options";
+
     int run(String[] args) {
         if (log == null) {
             setLog(new PrintWriter(System.out, true),
@@ -231,13 +233,14 @@ public class JlinkTask {
         }
         Path outputPath = null;
         try {
-            try (InputStream savedOptions = JlinkTask.class.getModule().getResourceAsStream("jdk/tools/jlink/internal/options")) {
+            Module m = JlinkTask.class.getModule();
+            try (InputStream savedOptions = m.getResourceAsStream(OPTIONS_RESOURCE)) {
                 if (savedOptions != null) {
-                    List<String> newArgs = new ArrayList<>();
-                    CommandLine.loadCmdFile(savedOptions, newArgs);
-                    if (!newArgs.isEmpty()) {
-                        newArgs.addAll(Arrays.asList(args));
-                        args = newArgs.toArray(new String[newArgs.size()]);
+                    List<String> prependArgs = new ArrayList<>();
+                    CommandLine.loadCmdFile(savedOptions, prependArgs);
+                    if (!prependArgs.isEmpty()) {
+                        prependArgs.addAll(Arrays.asList(args));
+                        args = prependArgs.toArray(new String[prependArgs.size()]);
                     }
                 }
             }

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
@@ -27,6 +27,7 @@ package jdk.tools.jlink.internal;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.UncheckedIOException;
 import java.lang.module.Configuration;
@@ -230,6 +231,17 @@ public class JlinkTask {
         }
         Path outputPath = null;
         try {
+            try (InputStream savedOptions = JlinkTask.class.getModule().getResourceAsStream("jdk/tools/jlink/internal/options")) {
+                if (savedOptions != null) {
+                    List<String> newArgs = new ArrayList<>();
+                    CommandLine.loadCmdFile(savedOptions, newArgs);
+                    if (!newArgs.isEmpty()) {
+                        newArgs.addAll(Arrays.asList(args));
+                        args = newArgs.toArray(new String[newArgs.size()]);
+                    }
+                }
+            }
+
             List<String> remaining = optionsHelper.handleOptions(this, args);
             if (remaining.size() > 0 && !options.suggestProviders) {
                 throw taskHelper.newBadArgs("err.orphan.arguments",

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/SaveJlinkArgfilesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/SaveJlinkArgfilesPlugin.java
@@ -33,7 +33,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -95,6 +94,9 @@ public final class SaveJlinkArgfilesPlugin extends AbstractPlugin {
     @Override
     public ResourcePool transform(ResourcePool in, ResourcePoolBuilder out) {
         in.transformAndCopy(Function.identity(), out);
+        if (!in.moduleView().findModule("jdk.jlink").isPresent()) {
+            throw new PluginException("--save-jlink-argfiles requires jdk.jlink to be in the output image");
+        }
         byte[] savedOptions = argfiles.stream()
                                       .collect(Collectors.joining("\n"))
                                       .getBytes(StandardCharsets.UTF_8);

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/SaveJlinkArgfilesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/SaveJlinkArgfilesPlugin.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.tools.jlink.internal.plugins;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import jdk.tools.jlink.plugin.PluginException;
+import jdk.tools.jlink.plugin.ResourcePool;
+import jdk.tools.jlink.plugin.ResourcePoolBuilder;
+import jdk.tools.jlink.plugin.ResourcePoolEntry;
+
+/**
+ * Saves the arguments in the specified argument files to a resource that's read
+ * by jlink in the output image. The saved arguments are prepended to the arguments
+ * specified on the jlink command line.
+ */
+public final class SaveJlinkArgfilesPlugin extends AbstractPlugin {
+
+    public SaveJlinkArgfilesPlugin() {
+        super("save-jlink-argfiles");
+    }
+
+    private List<String> argfiles = new ArrayList<>();
+
+    @Override
+    public Category getType() {
+        return Category.ADDER;
+    }
+
+    @Override
+    public boolean hasArguments() {
+        return true;
+    }
+
+    @Override
+    public boolean hasRawArgument() {
+        return true;
+    }
+
+    @Override
+    public void configure(Map<String, String> config) {
+        var v = config.get(getName());
+
+        if (v == null)
+            throw new AssertionError();
+
+        for (String argfile : v.split(File.pathSeparator)) {
+            argfiles.add(readArgfile(argfile));
+        }
+    }
+
+    private static String readArgfile(String argfile) {
+        try {
+            return Files.readString(Path.of(argfile));
+        } catch (IOException e) {
+            throw new PluginException("Argfile " + argfile + " is not readable");
+        }
+    }
+
+    @Override
+    public ResourcePool transform(ResourcePool in, ResourcePoolBuilder out) {
+        in.transformAndCopy(Function.identity(), out);
+        byte[] savedOptions = argfiles.stream().
+                        collect(Collectors.joining("\n")).
+                        getBytes(StandardCharsets.UTF_8);
+        out.add(ResourcePoolEntry.create("/jdk.jlink/jdk/tools/jlink/internal/options",
+                                         savedOptions));
+        return out.build();
+    }
+}

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/SaveJlinkArgfilesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/SaveJlinkArgfilesPlugin.java
@@ -25,6 +25,8 @@
 
 package jdk.tools.jlink.internal.plugins;
 
+import static jdk.tools.jlink.internal.JlinkTask.OPTIONS_RESOURCE;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -93,10 +95,10 @@ public final class SaveJlinkArgfilesPlugin extends AbstractPlugin {
     @Override
     public ResourcePool transform(ResourcePool in, ResourcePoolBuilder out) {
         in.transformAndCopy(Function.identity(), out);
-        byte[] savedOptions = argfiles.stream().
-                        collect(Collectors.joining("\n")).
-                        getBytes(StandardCharsets.UTF_8);
-        out.add(ResourcePoolEntry.create("/jdk.jlink/jdk/tools/jlink/internal/options",
+        byte[] savedOptions = argfiles.stream()
+                                      .collect(Collectors.joining("\n"))
+                                      .getBytes(StandardCharsets.UTF_8);
+        out.add(ResourcePoolEntry.create("/jdk.jlink/" + OPTIONS_RESOURCE,
                                          savedOptions));
         return out.build();
     }

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
@@ -192,14 +192,14 @@ save-jlink-argfiles.argument=<filenames>
 save-jlink-argfiles.description=\
 Save the specified argument files that contain the arguments \n\
 to be prepended to the execution of jlink in the output image. \n\
-<filenames> is a ':' (';' on Windows) path of command-line argument files.
+<filenames> is a ':' (';' on Windows) separated path of command-line argument files.
 
 save-jlink-argfiles.usage=\
 \  --save-jlink-argfiles <filenames>\n\
 \                            Save the specified argument files that contain \n\
 \                            the arguments to be prepended to the execution of \n\
 \                            jlink in the output image. <filenames> is a \n\
-\                            ':' (';' on Windows) path of command-line argument files.
+\                            ':' (';' on Windows) separated path of command-line argument files.
 
 strip-debug.description=\
 Strip debug information from the output image

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
@@ -187,6 +187,20 @@ order-resources.usage=\
 \                            e.g.: **/module-info.class,@classlist,\n\
 \                            /java.base/java/lang/**
 
+save-jlink-argfiles.argument=<filenames>
+
+save-jlink-argfiles.description=\
+Save the specified argument files that contain the arguments \n\
+to be prepended to the execution of jlink in the output image. \n\
+<filenames> is a ':' (';' on Windows) path of command-line argument files.
+
+save-jlink-argfiles.usage=\
+\  --save-jlink-argfiles <filenames>\n\
+\                            Save the specified argument files that contain \n\
+\                            the arguments to be prepended to the execution of \n\
+\                            jlink in the output image. <filenames> is a \n\
+\                            ':' (';' on Windows) path of command-line argument files.
+
 strip-debug.description=\
 Strip debug information from the output image
 

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
@@ -192,14 +192,14 @@ save-jlink-argfiles.argument=<filenames>
 save-jlink-argfiles.description=\
 Save the specified argument files that contain the arguments \n\
 to be prepended to the execution of jlink in the output image. \n\
-<filenames> is a ':' (';' on Windows) separated path of command-line argument files.
+<filenames> is a ':' (';' on Windows) separated list of command-line argument files.
 
 save-jlink-argfiles.usage=\
 \  --save-jlink-argfiles <filenames>\n\
 \                            Save the specified argument files that contain \n\
 \                            the arguments to be prepended to the execution of \n\
 \                            jlink in the output image. <filenames> is a \n\
-\                            ':' (';' on Windows) separated path of command-line argument files.
+\                            ':' (';' on Windows) separated list of command-line argument files.
 
 strip-debug.description=\
 Strip debug information from the output image

--- a/src/jdk.jlink/share/classes/module-info.java
+++ b/src/jdk.jlink/share/classes/module-info.java
@@ -80,6 +80,7 @@ module jdk.jlink {
         jdk.tools.jlink.internal.plugins.VendorBugURLPlugin,
         jdk.tools.jlink.internal.plugins.VendorVMBugURLPlugin,
         jdk.tools.jlink.internal.plugins.VendorVersionPlugin,
-        jdk.tools.jlink.internal.plugins.CDSPlugin;
+        jdk.tools.jlink.internal.plugins.CDSPlugin,
+        jdk.tools.jlink.internal.plugins.SaveJlinkArgfilesPlugin;
 
 }

--- a/test/jdk/tools/jlink/plugins/SaveJlinkArgfilesPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/SaveJlinkArgfilesPluginTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test --save-jlink-argfiles plugin
+ * @library ../../lib
+ * @library /test/lib
+ * @modules java.base/jdk.internal.jimage
+ *          jdk.jdeps/com.sun.tools.classfile
+ *          jdk.jlink/jdk.tools.jlink.internal
+ *          jdk.jlink/jdk.tools.jmod
+ *          jdk.jlink/jdk.tools.jimage
+ *          jdk.compiler
+ * @build tests.*
+ * @run main SaveJlinkArgfilesPluginTest
+ */
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import jdk.test.lib.process.ProcessTools;
+
+import tests.Helper;
+
+public class SaveJlinkArgfilesPluginTest {
+
+    public static void main(String[] args) throws Throwable {
+
+        Helper helper = Helper.newHelper();
+        if (helper == null) {
+            System.err.println("Test not run");
+            return;
+        }
+
+        String exe = System.getProperty("os.name").startsWith("Windows") ? ".exe" : "";
+        Path argfile1 = Path.of("argfile1");
+        Path argfile2 = Path.of("argfile2");
+
+        Files.writeString(argfile1, "--add-modules jdk.internal.vm.ci --add-options=-Dfoo=xyzzy");
+        Files.writeString(argfile2, "--vendor-version=\"XyzzyVM 3.14.15\" --vendor-bug-url=https://bugs.xyzzy.com/");
+
+        var module = "base";
+        helper.generateDefaultJModule(module);
+        var image = helper.generateDefaultImage(new String[] {
+                "--add-modules", "jdk.jlink,jdk.jdeps,jdk.internal.opt,jdk.compiler,java.compiler,jdk.zipfs,jdk.internal.vm.ci",
+                "--keep-packaged-modules", "images/base.image/jmods",
+                "--save-jlink-argfiles", argfile1 + File.pathSeparator + argfile2
+            }, module)
+            .assertSuccess();
+        helper.checkImage(image, module, null, null);
+
+        Path launcher = image.resolve("bin/java" + exe);
+        var oa = ProcessTools.executeProcess(launcher.toString(), "-XshowSettings:properties", "--version");
+
+        // Check that the primary image creation ignored the saved args
+        oa.shouldHaveExitValue(0);
+        oa.shouldNotMatch("yzzy");
+
+        // Create a secondary image
+        Path image2 = Path.of("image2").toAbsolutePath();
+        launcher = image.resolve("bin/jlink" + exe);
+        oa = ProcessTools.executeProcess(launcher.toString(), "--output", image2.toString(), "--add-modules=java.base");
+        oa.shouldHaveExitValue(0);
+
+        // Ensure the saved `--add-options` and `--vendor-*` options
+        // were applied when creating the secondary image.
+        launcher = image2.resolve(Path.of("bin", "java" + exe));
+        oa = ProcessTools.executeProcess(launcher.toString(), "-XshowSettings:properties", "--version");
+        oa.shouldHaveExitValue(0);
+        expectNMatchingLines(oa.getStdout(), "yzzy", 2);
+        expectNMatchingLines(oa.getStderr(), "yzzy", 3);
+
+        // Ensure the saved `--add-modules` option
+        // was applied when creating the secondary image.
+        oa = ProcessTools.executeProcess(launcher.toString(), "-d", "jdk.internal.vm.ci");
+        oa.shouldHaveExitValue(0);
+    }
+
+    /**
+     * Splits {@code input} into lines and ensures that the number of lines containing
+     * {@code substring} is {@code n}.
+     *
+     * @throws AssertionError if the check fails
+     */
+    private static void expectNMatchingLines(String input, String substring, int n) {
+        long actual = Stream.of(input.split("\\R")).filter(l -> l.contains(substring)).count();
+        if (actual != n) {
+            String msg = String.format("Expected %d lines containing \"%s\" in output, got %s%nOutput: %s",
+                n, substring, actual, input);
+            throw new AssertionError(msg);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new jlink plugin (`--save-jlink-argfiles=<filenames>`) to support persisting jlink options.

```
> echo "--add-modules jdk.internal.vm.ci --add-options=-Dfoo=xyzzy --vendor-version=\"XyzzyVM 3.14.15\" --vendor-bug-url=https://bugs.xyzzy.com/" > my_image.argfile
> export ALL_MODULES=$(java --list-modules | sed 's:@.*::g' | tr '\n' ',')
> jlink --keep-packaged-modules=my_image/jmods --add-modules $ALL_MODULES --output=my_image --save-jlink-argfiles my_image.argfile
> my_image/bin/java -XshowSettings:properties --version 2>&1 | grep yzzy
> my_image/bin/jlink --add-modules=java.base --output=my_image2
> my_image2/bin/java -XshowSettings:properties --version 2>&1 | grep yzzy
    foo = xyzzy
    java.vendor.url.bug = https://bugs.xyzzy.com/
    java.vendor.version = XyzzyVM 3.14.15
OpenJDK Runtime Environment XyzzyVM 3.14.15 (build 20-internal-2022-09-22-0951036.dnsimon...)
OpenJDK 64-Bit Server VM XyzzyVM 3.14.15 (build 20-internal-2022-09-22-0951036.dnsimon..., mixed mode)
> my_image2/bin/java -d jdk.internal.vm.ci | head -1
jdk.internal.vm.ci@20-internal
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8237467](https://bugs.openjdk.org/browse/JDK-8237467): jlink plugin to save the argument files as input to jlink in the output image
 * [JDK-8294485](https://bugs.openjdk.org/browse/JDK-8294485): jlink plugin to save the argument files as input to jlink in the output image (**CSR**)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to [91938caa](https://git.openjdk.org/jdk/pull/10445/files/91938caa8936dea5d897b8f83702ed52b8e7bc4f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10445/head:pull/10445` \
`$ git checkout pull/10445`

Update a local copy of the PR: \
`$ git checkout pull/10445` \
`$ git pull https://git.openjdk.org/jdk pull/10445/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10445`

View PR using the GUI difftool: \
`$ git pr show -t 10445`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10445.diff">https://git.openjdk.org/jdk/pull/10445.diff</a>

</details>
