### PR TITLE
5080391: ArrayIndexOutOfBounds during "undo" of Right-to-Left text insert

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/AbstractDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/AbstractDocument.java
@@ -955,7 +955,7 @@ public abstract class AbstractDocument implements Document, Serializable {
                 Element bidiRoot = adoc.getBidiRootElement();
                 int index = bidiRoot.getElementIndex(p0);
                 Element bidiElem = bidiRoot.getElement(index);
-                if (bidiElem.getEndOffset() >= p1) {
+                if (bidiElem != null && bidiElem.getEndOffset() >= p1) {
                     AttributeSet bidiAttrs = bidiElem.getAttributes();
                     return ((StyleConstants.getBidiLevel(bidiAttrs) % 2) == 0);
                 }
@@ -2320,9 +2320,9 @@ public abstract class AbstractDocument implements Document, Serializable {
          */
         public void replace(int offset, int length, Element[] elems) {
             int delta = elems.length - length;
-            int src = offset + length;
-            int nmove = nchildren - src;
-            int dest = src + delta;
+            int src = Math.abs(offset + length);
+            int nmove = Math.abs(nchildren - src);
+            int dest = Math.abs(src + delta);
             if ((nchildren + delta) >= children.length) {
                 // need to grow the array
                 int newLength = Math.max(2*children.length, nchildren + delta);

--- a/test/jdk/javax/swing/text/AbstractDocument/TestUndoError.java
+++ b/test/jdk/javax/swing/text/AbstractDocument/TestUndoError.java
@@ -22,6 +22,7 @@
  */
 /*
  * @test
+ * @key headful
  * @bug 5080391
  * @summary  Verifies if AIOOBE is thrown when we do undo of text
  *           inserted in RTL orientation

--- a/test/jdk/javax/swing/text/AbstractDocument/TestUndoError.java
+++ b/test/jdk/javax/swing/text/AbstractDocument/TestUndoError.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 5080391
+ * @summary  Verifies if AIOOBE is thrown when we do undo of text
+ *           inserted in RTL orientation
+ * @run main TestUndoError
+ */
+import java.awt.BorderLayout;
+import java.awt.ComponentOrientation;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import javax.swing.undo.UndoManager;
+
+public class TestUndoError {
+
+    private static JTextArea textArea_;
+    private static UndoManager manager_;
+    private static JFrame frame;
+
+    public static void main(String[] args) throws Exception {
+
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                textArea_ = new JTextArea();
+                manager_ = new UndoManager();
+                frame = new JFrame("Undo - Redo Error");
+                frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+                JScrollPane scrollPane = new JScrollPane(textArea_);
+
+                textArea_.getDocument().addUndoableEditListener(manager_);
+
+                frame.getContentPane().setLayout(new BorderLayout());
+                frame.getContentPane().add(scrollPane, BorderLayout.CENTER);
+                frame.setLocationRelativeTo(null);
+                frame.setSize(100, 100);
+                frame.setVisible(true);
+            });
+            Thread.sleep(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                textArea_.insert("\u0633", textArea_.getText().length());
+                textArea_.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+            });
+            Thread.sleep(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                if (manager_.canUndo()) {
+                    manager_.undo();
+                }
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}
+

--- a/test/jdk/javax/swing/text/AbstractDocument/TestUndoInsertArabicText.java
+++ b/test/jdk/javax/swing/text/AbstractDocument/TestUndoInsertArabicText.java
@@ -22,11 +22,10 @@
  */
 /*
  * @test
- * @key headful
  * @bug 5080391
  * @summary  Verifies if AIOOBE is thrown when we do undo of text
- *           inserted in RTL orientation
- * @run main TestUndoError
+ *           inserted in RTL
+ * @run main TestUndoInsertArabicText
  */
 import java.awt.BorderLayout;
 import java.awt.ComponentOrientation;
@@ -36,24 +35,24 @@ import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
 import javax.swing.undo.UndoManager;
 
-public class TestUndoError {
+public class TestUndoInsertArabicText {
 
-    private static JTextArea textArea_;
-    private static UndoManager manager_;
+    private static JTextArea textArea;
+    private static UndoManager manager;
     private static JFrame frame;
 
     public static void main(String[] args) throws Exception {
 
         try {
             SwingUtilities.invokeAndWait(() -> {
-                textArea_ = new JTextArea();
-                manager_ = new UndoManager();
+                textArea = new JTextArea();
+                manager = new UndoManager();
                 frame = new JFrame("Undo - Redo Error");
                 frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
-                JScrollPane scrollPane = new JScrollPane(textArea_);
+                JScrollPane scrollPane = new JScrollPane(textArea);
 
-                textArea_.getDocument().addUndoableEditListener(manager_);
+                textArea.getDocument().addUndoableEditListener(manager);
 
                 frame.getContentPane().setLayout(new BorderLayout());
                 frame.getContentPane().add(scrollPane, BorderLayout.CENTER);
@@ -62,16 +61,46 @@ public class TestUndoError {
                 frame.setVisible(true);
             });
             Thread.sleep(1000);
+            // insert at end of existing text and undo
             SwingUtilities.invokeAndWait(() -> {
-                textArea_.insert("\u0633", textArea_.getText().length());
-                textArea_.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+                for (int i = 0; i < 5 ; i++) {
+                    textArea.insert("\u0633", textArea.getText().length());
+                }
+                textArea.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
             });
             Thread.sleep(1000);
             SwingUtilities.invokeAndWait(() -> {
-                if (manager_.canUndo()) {
-                    manager_.undo();
+                if (manager.canUndo()) {
+                    manager.undo();
                 }
             });
+            Thread.sleep(1000);
+
+            // insert at beginning of existing text and undo
+            SwingUtilities.invokeAndWait(() -> {
+                textArea.setCaretPosition(0);
+                textArea.insert("\u0633", 0);
+            });
+            Thread.sleep(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                if (manager.canUndo()) {
+                    manager.undo();
+                }
+            });
+            Thread.sleep(1000);
+
+            // insert at middle of existing text and undo
+            SwingUtilities.invokeAndWait(() -> {
+                textArea.setCaretPosition(2);
+                textArea.insert("\u0633", 2);
+            });
+            Thread.sleep(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                if (manager.canUndo()) {
+                    manager.undo();
+                }
+            });
+            Thread.sleep(1000);
         } finally {
             SwingUtilities.invokeAndWait(() -> {
                 if (frame != null) {
@@ -79,6 +108,7 @@ public class TestUndoError {
                 }
             });
         }
+
     }
 }
 

--- a/test/jdk/javax/swing/text/AbstractDocument/TestUndoInsertArabicText.java
+++ b/test/jdk/javax/swing/text/AbstractDocument/TestUndoInsertArabicText.java
@@ -42,65 +42,114 @@ public class TestUndoInsertArabicText {
     private static JFrame frame;
 
     public static void main(String[] args) throws Exception {
+        testEnd();
+        Thread.sleep(1000);
+        testMiddle();
+        Thread.sleep(1000);
+        testBeginning();
+    }
 
+    private static void createUI() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            textArea = new JTextArea();
+            manager = new UndoManager();
+            frame = new JFrame("Undo - Redo Error");
+            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+            JScrollPane scrollPane = new JScrollPane(textArea);
+
+            textArea.getDocument().addUndoableEditListener(manager);
+
+            frame.getContentPane().setLayout(new BorderLayout());
+            frame.getContentPane().add(scrollPane, BorderLayout.CENTER);
+            frame.setLocationRelativeTo(null);
+            frame.setSize(100, 100);
+            frame.setVisible(true);
+        });
+    }
+
+    private static void undoAndCheck() throws Exception {
+
+        if (textArea.getText().contains("\u0633")) {
+            System.out.println("\u0633 is present");
+        }
+        SwingUtilities.invokeAndWait(() -> {
+            if (manager.canUndo()) {
+                manager.undo();
+            }
+        });
+        Thread.sleep(1000);
+        if (textArea.getText().contains("\u0633")) {
+            throw new RuntimeException("Undo-ed arabic character still present");
+        }
+    }
+
+    private static void testEnd() throws Exception {
         try {
-            SwingUtilities.invokeAndWait(() -> {
-                textArea = new JTextArea();
-                manager = new UndoManager();
-                frame = new JFrame("Undo - Redo Error");
-                frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-
-                JScrollPane scrollPane = new JScrollPane(textArea);
-
-                textArea.getDocument().addUndoableEditListener(manager);
-
-                frame.getContentPane().setLayout(new BorderLayout());
-                frame.getContentPane().add(scrollPane, BorderLayout.CENTER);
-                frame.setLocationRelativeTo(null);
-                frame.setSize(100, 100);
-                frame.setVisible(true);
-            });
+            createUI();
             Thread.sleep(1000);
             // insert at end of existing text and undo
             SwingUtilities.invokeAndWait(() -> {
-                for (int i = 0; i < 5 ; i++) {
-                    textArea.insert("\u0633", textArea.getText().length());
-                }
+                textArea.insert("\u0631", textArea.getText().length());
+                textArea.insert("\u0632", textArea.getText().length());
+                textArea.insert("\u0633", textArea.getText().length());
                 textArea.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
             });
+
             Thread.sleep(1000);
+            undoAndCheck();
+        } finally {
             SwingUtilities.invokeAndWait(() -> {
-                if (manager.canUndo()) {
-                    manager.undo();
+                if (frame != null) {
+                    frame.dispose();
                 }
             });
+        }
+
+    }
+
+    private static void testBeginning() throws Exception {
+        try {
+            createUI();
             Thread.sleep(1000);
 
             // insert at beginning of existing text and undo
             SwingUtilities.invokeAndWait(() -> {
+                textArea.insert("\u0631", textArea.getText().length());
+                textArea.insert("\u0632", textArea.getText().length());
                 textArea.setCaretPosition(0);
                 textArea.insert("\u0633", 0);
+                textArea.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
             });
             Thread.sleep(1000);
+            undoAndCheck();
+        } finally {
             SwingUtilities.invokeAndWait(() -> {
-                if (manager.canUndo()) {
-                    manager.undo();
+                if (frame != null) {
+                    frame.dispose();
                 }
             });
+        }
+
+    }
+
+    private static void testMiddle() throws Exception {
+        try {
+            createUI();
             Thread.sleep(1000);
 
             // insert at middle of existing text and undo
             SwingUtilities.invokeAndWait(() -> {
+                textArea.insert("\u0631", textArea.getText().length());
+                textArea.insert("\u0632", textArea.getText().length());
+                textArea.insert("\u0634", textArea.getText().length());
+                textArea.insert("\u0635", textArea.getText().length());
                 textArea.setCaretPosition(2);
                 textArea.insert("\u0633", 2);
+                textArea.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
             });
             Thread.sleep(1000);
-            SwingUtilities.invokeAndWait(() -> {
-                if (manager.canUndo()) {
-                    manager.undo();
-                }
-            });
-            Thread.sleep(1000);
+            undoAndCheck();
         } finally {
             SwingUtilities.invokeAndWait(() -> {
                 if (frame != null) {


### PR DESCRIPTION
javax.swing.text.AbstractDocument$BranchElement.replace(...) method throws an `ArrayIndexOutOfBoundsException: arraycopy: length -1 is negative` when using an UndoManager on the default document of a JTextArea and you try to undo the insertion of a LEFT-TO-RIGHT language (e.g. Arabic) that is immediately followed by setting the component orientation on the JTextArea.

This is because System.arrayCopy() is called with -ve length because of the calculation done in AbstractDocment.replace where `src` is of 2bytes because of unicode text causing `nmove` to become -ve if `nchildren` is 1 (an unicode character is inserted)

System.arrayCopy throws `IndexOutOfBoundsException if:

    The srcPos argument is negative.
    The destPos argument is negative.
    The length argument is negative


so the fix is made to make  nmove, src, dest +ve
Also, Element.getElement() can return null which is not checked, causing NPE, if deletion of text is done which results in no element, which is also fixed in the PR

All jtreg testsuite tests are run without any regression.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-5080391](https://bugs.openjdk.org/browse/JDK-5080391): ArrayIndexOutOfBounds during "undo" of Right-to-Left text insert


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer) ⚠️ Review applies to [c1020f15](https://git.openjdk.org/jdk/pull/10446/files/c1020f1569bacd7a9e81c8a7fdfbcf44abd0e3c7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10446/head:pull/10446` \
`$ git checkout pull/10446`

Update a local copy of the PR: \
`$ git checkout pull/10446` \
`$ git pull https://git.openjdk.org/jdk pull/10446/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10446`

View PR using the GUI difftool: \
`$ git pr show -t 10446`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10446.diff">https://git.openjdk.org/jdk/pull/10446.diff</a>

</details>
