### PR TITLE
8293691: converting a defined BasicType value to a string should not crash the VM

### DIFF
--- a/src/hotspot/share/utilities/globalDefinitions.cpp
+++ b/src/hotspot/share/utilities/globalDefinitions.cpp
@@ -236,6 +236,17 @@ const char* type2name_tab[T_CONFLICT+1] = {
   "*narrowklass*",
   "*conflict*"
 };
+const char* type2name(BasicType t) {
+  if (t < (T_CONFLICT + 1)) {
+    return type2name_tab[t];
+  } else if (t == T_ILLEGAL) {
+    return "*illegal*";
+  } else {
+    fatal("invalid type %d", t);
+    return "invalid type";
+  }
+}
+
 
 
 BasicType name2type(const char* name) {

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -786,10 +786,7 @@ extern int type2size[T_CONFLICT+1];         // Map BasicType to result stack ele
 extern const char* type2name_tab[T_CONFLICT+1];     // Map a BasicType to a char*
 extern BasicType name2type(const char* name);
 
-inline const char* type2name(BasicType t) {
-  assert((uint)t < T_CONFLICT + 1, "invalid type");
-  return type2name_tab[t];
-}
+const char* type2name(BasicType t);
 
 inline jlong max_signed_integer(BasicType bt) {
   if (bt == T_INT) {


### PR DESCRIPTION
Hi,

This implements Kim's suggested fix for this ticket.