### PR TITLE
8294394: running jlink in GraalVM must copy libgraal into the output image

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/CopyFilesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/CopyFilesPlugin.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.tools.jlink.internal.plugins;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import jdk.tools.jlink.plugin.ResourcePool;
+import jdk.tools.jlink.plugin.ResourcePoolBuilder;
+import jdk.tools.jlink.plugin.ResourcePoolEntry;
+import jdk.tools.jlink.plugin.ResourcePoolEntry.Type;
+
+/**
+ * Jlink plugin to copy files in the current runtime image into the output image.
+ * The files to copy are specified as {@link File#pathSeparatorChar} separated
+ * paths relative to the image root directory.
+ */
+public final class CopyFilesPlugin extends AbstractPlugin {
+
+    /**
+     * List of relative path names for the files to copy.
+     */
+    private final List<String> files = new ArrayList<>();
+
+    public CopyFilesPlugin() {
+        super("copy-files");
+    }
+
+    @Override
+    public Category getType() {
+        return Category.ADDER;
+    }
+
+    @Override
+    public boolean hasArguments() {
+        return true;
+    }
+
+    @Override
+    public boolean hasRawArgument() {
+        return true;
+    }
+
+    @Override
+    public void configure(Map<String, String> config) {
+        String arg = config.get(getName());
+        if (arg == null) {
+            throw new AssertionError();
+        }
+        for (String relativePath : arg.split(File.pathSeparator)) {
+            files.add(relativePath);
+        }
+    }
+
+    @Override
+    public ResourcePool transform(ResourcePool in, ResourcePoolBuilder out) {
+        if (!files.isEmpty()) {
+            in.transformAndCopy(Function.identity(), out);
+
+            String javaHome = System.getProperty("java.home");
+            for (String relativePath : files) {
+                Path file = Paths.get(javaHome, relativePath);
+                out.add(ResourcePoolEntry.create("/java.base/top/" + relativePath, Type.TOP, file));
+            }
+        }
+        return out.build();
+    }
+}

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
@@ -92,6 +92,17 @@ compact-cp.usage=\
 \                             You can express the set of resources to\n\
 \                             compress or not compress (use ^ for negation).
 
+copy-files.description=\
+Copies files from the current image to the output image. \n\
+The files to copy are specified as ':' (';' on Windows) separated paths \n\
+relative to the image root.
+
+copy-files.usage=\
+\  --copy-files              Copies files from the current image to the \n\
+\                            output image. The files to copy are specified as \n\
+\                            ':' (';' on Windows) separated paths relative \n\
+\                            to the image root.
+
 dedup-legal-notices.argument=[error-if-not-same-content]
 
 dedup-legal-notices.description=\

--- a/src/jdk.jlink/share/classes/module-info.java
+++ b/src/jdk.jlink/share/classes/module-info.java
@@ -69,6 +69,7 @@ module jdk.jlink {
         jdk.tools.jlink.internal.plugins.ExcludeJmodSectionPlugin,
         jdk.tools.jlink.internal.plugins.LegalNoticeFilePlugin,
         jdk.tools.jlink.internal.plugins.SystemModulesPlugin,
+        jdk.tools.jlink.internal.plugins.CopyFilesPlugin,
         jdk.tools.jlink.internal.plugins.StripNativeCommandsPlugin,
         jdk.tools.jlink.internal.plugins.OrderResourcesPlugin,
         jdk.tools.jlink.internal.plugins.DefaultCompressPlugin,

--- a/test/jdk/tools/jlink/plugins/CopyFilesPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/CopyFilesPluginTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test copy files plugin
+ * @library ../../lib
+ * @library /test/lib
+ * @modules java.base/jdk.internal.jimage
+ *          jdk.jdeps/com.sun.tools.classfile
+ *          jdk.jlink/jdk.tools.jlink.internal
+ *          jdk.jlink/jdk.tools.jmod
+ *          jdk.jlink/jdk.tools.jimage
+ *          jdk.compiler
+ * @build tests.*
+ * @run main CopyFilesPluginTest
+ */
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.Path;
+
+import jdk.test.lib.process.ProcessTools;
+
+import tests.Helper;
+
+public class CopyFilesPluginTest {
+
+    public static void main(String[] args) throws Throwable {
+
+        Helper helper = Helper.newHelper();
+        if (helper == null) {
+            System.err.println("Test not run");
+            return;
+        }
+
+        var module = "copyfiles";
+        helper.generateDefaultJModule(module);
+        var image = helper.generateDefaultImage(new String[] {
+                "--add-modules", "jdk.jlink,jdk.jdeps,jdk.internal.opt,jdk.compiler,jdk.zipfs,java.compiler",
+                "--keep-packaged-modules", "images/copyfiles.image/jmods"
+            }, module)
+            .assertSuccess();
+        helper.checkImage(image, module, null, null);
+
+        String[] files = {
+            "lib/foo",
+            "bin/bar",
+            "foreign/baz"
+        };
+
+        for (String file : files) {
+            Path path = image.resolve(file);
+            Files.createDirectories(path.getParent());
+            Files.writeString(image.resolve(file), file);
+        }
+
+        var launcher = image.resolve("bin/jlink"
+                                     + (System.getProperty("os.name").startsWith("Windows")
+                                        ? ".exe" : ""));
+
+
+        var oa = ProcessTools.executeProcess(launcher.toString(),
+                                             "--add-modules", "ALL-MODULE-PATH",
+                                             "--copy-files=" + String.join(File.pathSeparator, files),
+                                             "--output", "image2");
+        oa.shouldHaveExitValue(0);
+
+        for (String file : files) {
+            Path path = Paths.get("image2", file);
+            String content = Files.readString(path);
+            if (!file.equals(content)) {
+                throw new AssertionError(path + ": expected \"" + file + "\", got \"" + content + "\"");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new jlink plugin (`--copy-files=<filenames>`) that copies specified files from the current image into the output image.
This is useful in the context of GraalVM where libgraal (e.g. `lib/libjvmcicompiler.so`) is produced after the final jlink step in the GraalVM JDK build process. The plugin makes it possible for jlink in a GraalVM JDK to propagate libgraal.

The advantages of this solution over packaging libgraal as a module are:
* No need to complicate and slow down the GraalVM JDK build process with an extra jlink step.
* No need to pay the footprint of libgraal twice in a GraalVM JDK (i.e., once in,`lib/libjvmcicompiler.so` and again in a jmod file).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294394](https://bugs.openjdk.org/browse/JDK-8294394): running jlink in GraalVM must copy libgraal into the output image


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10448/head:pull/10448` \
`$ git checkout pull/10448`

Update a local copy of the PR: \
`$ git checkout pull/10448` \
`$ git pull https://git.openjdk.org/jdk pull/10448/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10448`

View PR using the GUI difftool: \
`$ git pr show -t 10448`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10448.diff">https://git.openjdk.org/jdk/pull/10448.diff</a>

</details>
