### PR TITLE
8294377: Prepare to stop auto-inheriting documentation for subclasses of exceptions whose documentation is inherited

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -528,6 +528,10 @@ public abstract class DatagramChannel
      *
      * @throws  NotYetConnectedException
      *          If this channel's socket is not connected
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract int read(ByteBuffer dst) throws IOException;
 
@@ -543,6 +547,10 @@ public abstract class DatagramChannel
      *
      * @throws  NotYetConnectedException
      *          If this channel's socket is not connected
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract long read(ByteBuffer[] dsts, int offset, int length)
         throws IOException;
@@ -559,6 +567,10 @@ public abstract class DatagramChannel
      *
      * @throws  NotYetConnectedException
      *          If this channel's socket is not connected
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public final long read(ByteBuffer[] dsts) throws IOException {
         return read(dsts, 0, dsts.length);
@@ -574,6 +586,10 @@ public abstract class DatagramChannel
      *
      * @throws  NotYetConnectedException
      *          If this channel's socket is not connected
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract int write(ByteBuffer src) throws IOException;
 
@@ -593,6 +609,10 @@ public abstract class DatagramChannel
      *
      * @throws  NotYetConnectedException
      *          If this channel's socket is not connected
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract long write(ByteBuffer[] srcs, int offset, int length)
         throws IOException;
@@ -613,6 +633,10 @@ public abstract class DatagramChannel
      *
      * @throws  NotYetConnectedException
      *          If this channel's socket is not connected
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public final long write(ByteBuffer[] srcs) throws IOException {
         return write(srcs, 0, srcs.length);

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -372,6 +372,10 @@ public abstract class FileChannel
      * then the file position is updated with the number of bytes actually
      * read.  Otherwise this method behaves exactly as specified in the {@link
      * ReadableByteChannel} interface. </p>
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract int read(ByteBuffer dst) throws IOException;
 
@@ -383,6 +387,10 @@ public abstract class FileChannel
      * then the file position is updated with the number of bytes actually
      * read.  Otherwise this method behaves exactly as specified in the {@link
      * ScatteringByteChannel} interface.  </p>
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract long read(ByteBuffer[] dsts, int offset, int length)
         throws IOException;
@@ -394,6 +402,10 @@ public abstract class FileChannel
      * then the file position is updated with the number of bytes actually
      * read.  Otherwise this method behaves exactly as specified in the {@link
      * ScatteringByteChannel} interface.  </p>
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public final long read(ByteBuffer[] dsts) throws IOException {
         return read(dsts, 0, dsts.length);
@@ -412,6 +424,10 @@ public abstract class FileChannel
      *
      * @throws  NonWritableChannelException
      *          If this channel was not opened for writing
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract int write(ByteBuffer src) throws IOException;
 
@@ -429,6 +445,10 @@ public abstract class FileChannel
      *
      * @throws  NonWritableChannelException
      *          If this channel was not opened for writing
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract long write(ByteBuffer[] srcs, int offset, int length)
         throws IOException;
@@ -446,6 +466,10 @@ public abstract class FileChannel
      *
      * @throws  NonWritableChannelException
      *          If this channel was not opened for writing
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public final long write(ByteBuffer[] srcs) throws IOException {
         return write(srcs, 0, srcs.length);

--- a/src/java.base/share/classes/java/nio/channels/SeekableByteChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/SeekableByteChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,10 @@ public interface SeekableByteChannel
      * then the position is updated with the number of bytes actually read.
      * Otherwise this method behaves exactly as specified in the {@link
      * ReadableByteChannel} interface.
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     @Override
     int read(ByteBuffer dst) throws IOException;
@@ -75,6 +79,10 @@ public interface SeekableByteChannel
      * written bytes, and then the position is updated with the number of bytes
      * actually written. Otherwise this method behaves exactly as specified by
      * the {@link WritableByteChannel} interface.
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     @Override
     int write(ByteBuffer src) throws IOException;

--- a/src/java.base/share/classes/java/nio/channels/SocketChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/SocketChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -603,12 +603,18 @@ public abstract class SocketChannel
     /**
      * @throws  NotYetConnectedException
      *          If this channel is not yet connected
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract int read(ByteBuffer dst) throws IOException;
 
     /**
      * @throws  NotYetConnectedException
      *          If this channel is not yet connected
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract long read(ByteBuffer[] dsts, int offset, int length)
         throws IOException;
@@ -616,6 +622,9 @@ public abstract class SocketChannel
     /**
      * @throws  NotYetConnectedException
      *          If this channel is not yet connected
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public final long read(ByteBuffer[] dsts) throws IOException {
         return read(dsts, 0, dsts.length);
@@ -624,12 +633,18 @@ public abstract class SocketChannel
     /**
      * @throws  NotYetConnectedException
      *          If this channel is not yet connected
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract int write(ByteBuffer src) throws IOException;
 
     /**
      * @throws  NotYetConnectedException
      *          If this channel is not yet connected
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract long write(ByteBuffer[] srcs, int offset, int length)
         throws IOException;
@@ -637,6 +652,9 @@ public abstract class SocketChannel
     /**
      * @throws  NotYetConnectedException
      *          If this channel is not yet connected
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public final long write(ByteBuffer[] srcs) throws IOException {
         return write(srcs, 0, srcs.length);

--- a/src/java.base/share/classes/java/nio/channels/spi/AbstractSelectableChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/spi/AbstractSelectableChannel.java
@@ -310,6 +310,8 @@ public abstract class AbstractSelectableChannel
      * mode then this method invokes the {@link #implConfigureBlocking
      * implConfigureBlocking} method, while holding the appropriate locks, in
      * order to change the mode.  </p>
+     *
+     * @throws  ClosedChannelException {@inheritDoc}
      */
     public final SelectableChannel configureBlocking(boolean block)
         throws IOException

--- a/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStreamImpl.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStreamImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -200,6 +200,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         buf.setLength(len);
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public boolean readBoolean() throws IOException {
         int ch = this.read();
         if (ch < 0) {
@@ -208,6 +211,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         return (ch != 0);
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public byte readByte() throws IOException {
         int ch = this.read();
         if (ch < 0) {
@@ -216,6 +222,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         return (byte)ch;
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public int readUnsignedByte() throws IOException {
         int ch = this.read();
         if (ch < 0) {
@@ -224,6 +233,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         return ch;
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public short readShort() throws IOException {
         if (read(byteBuf, 0, 2) != 2) {
             throw new EOFException();
@@ -238,14 +250,23 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         }
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public int readUnsignedShort() throws IOException {
         return ((int)readShort()) & 0xffff;
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public char readChar() throws IOException {
         return (char)readShort();
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public int readInt() throws IOException {
         if (read(byteBuf, 0, 4) !=  4) {
             throw new EOFException();
@@ -262,10 +283,16 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         }
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public long readUnsignedInt() throws IOException {
         return ((long)readInt()) & 0xffffffffL;
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public long readLong() throws IOException {
         // REMIND: Once 6277756 is fixed, we should do a bulk read of all 8
         // bytes here as we do in readShort() and readInt() for even better
@@ -280,10 +307,16 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         }
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public float readFloat() throws IOException {
         return Float.intBitsToFloat(readInt());
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public double readDouble() throws IOException {
         return Double.longBitsToDouble(readLong());
     }
@@ -318,6 +351,10 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         return input.toString();
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     * @throws java.io.UTFDataFormatException {@inheritDoc}
+     */
     public String readUTF() throws IOException {
         this.bitOffset = 0;
 
@@ -340,6 +377,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         return ret;
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public void readFully(byte[] b, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > b.length || off + len < 0) {
@@ -357,10 +397,16 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         }
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public void readFully(byte[] b) throws IOException {
         readFully(b, 0, b.length);
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public void readFully(short[] s, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > s.length || off + len < 0) {
@@ -377,6 +423,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         }
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public void readFully(char[] c, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > c.length || off + len < 0) {
@@ -393,6 +442,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         }
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public void readFully(int[] i, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > i.length || off + len < 0) {
@@ -409,6 +461,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         }
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public void readFully(long[] l, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > l.length || off + len < 0) {
@@ -425,6 +480,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         }
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public void readFully(float[] f, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > f.length || off + len < 0) {
@@ -441,6 +499,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         }
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public void readFully(double[] d, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > d.length || off + len < 0) {
@@ -641,6 +702,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         this.bitOffset = bitOffset;
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public int readBit() throws IOException {
         checkClosed();
 
@@ -663,6 +727,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         return val & 0x1;
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public long readBits(int numBits) throws IOException {
         checkClosed();
 

--- a/src/java.desktop/share/classes/javax/imageio/stream/ImageOutputStreamImpl.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/ImageOutputStreamImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -156,6 +156,9 @@ public abstract class ImageOutputStreamImpl
         write(b, 0, len*2);
     }
 
+    /**
+     * @throws UTFDataFormatException {@inheritDoc}
+     */
     public void writeUTF(String s) throws IOException {
         int strlen = s.length();
         int utflen = 0;

--- a/src/java.naming/share/classes/javax/naming/InitialContext.java
+++ b/src/java.naming/share/classes/javax/naming/InitialContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -413,34 +413,60 @@ public class InitialContext implements Context {
         return getURLOrDefaultInitCtx(name).lookup(name);
     }
 
+    /**
+     * @throws  NameAlreadyBoundException {@inheritDoc}
+     * @throws  javax.naming.directory.InvalidAttributesException {@inheritDoc}
+     */
     public void bind(String name, Object obj) throws NamingException {
         getURLOrDefaultInitCtx(name).bind(name, obj);
     }
 
+    /**
+     * @throws  NameAlreadyBoundException {@inheritDoc}
+     * @throws  javax.naming.directory.InvalidAttributesException {@inheritDoc}
+     */
     public void bind(Name name, Object obj) throws NamingException {
         getURLOrDefaultInitCtx(name).bind(name, obj);
     }
 
+    /**
+     * @throws  javax.naming.directory.InvalidAttributesException {@inheritDoc}
+     */
     public void rebind(String name, Object obj) throws NamingException {
         getURLOrDefaultInitCtx(name).rebind(name, obj);
     }
 
+    /**
+     * @throws  javax.naming.directory.InvalidAttributesException {@inheritDoc}
+     */
     public void rebind(Name name, Object obj) throws NamingException {
         getURLOrDefaultInitCtx(name).rebind(name, obj);
     }
 
+    /**
+     * @throws  NameNotFoundException {@inheritDoc}
+     */
     public void unbind(String name) throws NamingException  {
         getURLOrDefaultInitCtx(name).unbind(name);
     }
 
+    /**
+     * @throws  NameNotFoundException {@inheritDoc}
+     */
     public void unbind(Name name) throws NamingException  {
         getURLOrDefaultInitCtx(name).unbind(name);
     }
 
+    /**
+     * @throws  NameAlreadyBoundException {@inheritDoc}
+     */
     public void rename(String oldName, String newName) throws NamingException {
         getURLOrDefaultInitCtx(oldName).rename(oldName, newName);
     }
 
+    /**
+     * @throws  NameAlreadyBoundException {@inheritDoc}
+     */
     public void rename(Name oldName, Name newName)
         throws NamingException
     {
@@ -469,18 +495,36 @@ public class InitialContext implements Context {
         return getURLOrDefaultInitCtx(name).listBindings(name);
     }
 
+    /**
+     * @throws  NameNotFoundException {@inheritDoc}
+     * @throws  NotContextException {@inheritDoc}
+     * @throws  ContextNotEmptyException {@inheritDoc}
+     */
     public void destroySubcontext(String name) throws NamingException  {
         getURLOrDefaultInitCtx(name).destroySubcontext(name);
     }
 
+    /**
+     * @throws  NameNotFoundException {@inheritDoc}
+     * @throws  NotContextException {@inheritDoc}
+     * @throws  ContextNotEmptyException {@inheritDoc}
+     */
     public void destroySubcontext(Name name) throws NamingException  {
         getURLOrDefaultInitCtx(name).destroySubcontext(name);
     }
 
+    /**
+     * @throws  NameAlreadyBoundException {@inheritDoc}
+     * @throws  javax.naming.directory.InvalidAttributesException {@inheritDoc}
+     */
     public Context createSubcontext(String name) throws NamingException  {
         return getURLOrDefaultInitCtx(name).createSubcontext(name);
     }
 
+    /**
+     * @throws  NameAlreadyBoundException {@inheritDoc}
+     * @throws  javax.naming.directory.InvalidAttributesException {@inheritDoc}
+     */
     public Context createSubcontext(Name name) throws NamingException  {
         return getURLOrDefaultInitCtx(name).createSubcontext(name);
     }
@@ -551,6 +595,9 @@ public class InitialContext implements Context {
         gotDefault = false;
     }
 
+    /**
+     * @throws OperationNotSupportedException {@inheritDoc}
+     */
     public String getNameInNamespace() throws NamingException {
         return getDefaultInitCtx().getNameInNamespace();
     }

--- a/src/java.naming/share/classes/javax/naming/directory/BasicAttribute.java
+++ b/src/java.naming/share/classes/javax/naming/directory/BasicAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -474,6 +474,8 @@ public class BasicAttribute implements Attribute {
       *<p>
       * This method by default throws OperationNotSupportedException. A subclass
       * should override this method if it supports schema.
+      *
+      * @throws OperationNotSupportedException {@inheritDoc}
       */
     public DirContext getAttributeSyntaxDefinition() throws NamingException {
             throw new OperationNotSupportedException("attribute syntax");
@@ -484,6 +486,8 @@ public class BasicAttribute implements Attribute {
       *<p>
       * This method by default throws OperationNotSupportedException. A subclass
       * should override this method if it supports schema.
+      *
+      * @throws OperationNotSupportedException {@inheritDoc}
       */
     public DirContext getAttributeDefinition() throws NamingException {
         throw new OperationNotSupportedException("attribute definition");

--- a/src/java.naming/share/classes/javax/naming/directory/InitialDirContext.java
+++ b/src/java.naming/share/classes/javax/naming/directory/InitialDirContext.java
@@ -181,69 +181,115 @@ public class InitialDirContext extends InitialContext implements DirContext {
         return getURLOrDefaultInitDirCtx(name).getAttributes(name, attrIds);
     }
 
+    /**
+     * @throws  AttributeModificationException {@inheritDoc}
+     */
     public void modifyAttributes(String name, int mod_op, Attributes attrs)
             throws NamingException {
         getURLOrDefaultInitDirCtx(name).modifyAttributes(name, mod_op, attrs);
     }
 
+    /**
+     * @throws  AttributeModificationException {@inheritDoc}
+     */
     public void modifyAttributes(Name name, int mod_op, Attributes attrs)
             throws NamingException  {
         getURLOrDefaultInitDirCtx(name).modifyAttributes(name, mod_op, attrs);
     }
 
+    /**
+     * @throws  AttributeModificationException {@inheritDoc}
+     */
     public void modifyAttributes(String name, ModificationItem[] mods)
             throws NamingException  {
         getURLOrDefaultInitDirCtx(name).modifyAttributes(name, mods);
     }
 
+    /**
+     * @throws  AttributeModificationException {@inheritDoc}
+     */
     public void modifyAttributes(Name name, ModificationItem[] mods)
             throws NamingException  {
         getURLOrDefaultInitDirCtx(name).modifyAttributes(name, mods);
     }
 
+    /**
+     * @throws  NameAlreadyBoundException {@inheritDoc}
+     * @throws  InvalidAttributesException {@inheritDoc}
+     */
     public void bind(String name, Object obj, Attributes attrs)
             throws NamingException  {
         getURLOrDefaultInitDirCtx(name).bind(name, obj, attrs);
     }
 
+    /**
+     * @throws  NameAlreadyBoundException {@inheritDoc}
+     * @throws  InvalidAttributesException {@inheritDoc}
+     */
     public void bind(Name name, Object obj, Attributes attrs)
             throws NamingException  {
         getURLOrDefaultInitDirCtx(name).bind(name, obj, attrs);
     }
 
+    /**
+     * @throws  InvalidAttributesException {@inheritDoc}
+     */
     public void rebind(String name, Object obj, Attributes attrs)
             throws NamingException  {
         getURLOrDefaultInitDirCtx(name).rebind(name, obj, attrs);
     }
 
+    /**
+     * @throws  InvalidAttributesException {@inheritDoc}
+     */
     public void rebind(Name name, Object obj, Attributes attrs)
             throws NamingException  {
         getURLOrDefaultInitDirCtx(name).rebind(name, obj, attrs);
     }
 
+    /**
+     * @throws  NameAlreadyBoundException {@inheritDoc}
+     * @throws  InvalidAttributesException {@inheritDoc}
+     */
     public DirContext createSubcontext(String name, Attributes attrs)
             throws NamingException  {
         return getURLOrDefaultInitDirCtx(name).createSubcontext(name, attrs);
     }
 
+    /**
+     * @throws  NameAlreadyBoundException {@inheritDoc}
+     * @throws  InvalidAttributesException {@inheritDoc}
+     */
     public DirContext createSubcontext(Name name, Attributes attrs)
             throws NamingException  {
         return getURLOrDefaultInitDirCtx(name).createSubcontext(name, attrs);
     }
 
+    /**
+     * @throws  OperationNotSupportedException {@inheritDoc}
+     */
     public DirContext getSchema(String name) throws NamingException {
         return getURLOrDefaultInitDirCtx(name).getSchema(name);
     }
 
+    /**
+     * @throws  OperationNotSupportedException {@inheritDoc}
+     */
     public DirContext getSchema(Name name) throws NamingException {
         return getURLOrDefaultInitDirCtx(name).getSchema(name);
     }
 
+    /**
+     * @throws  OperationNotSupportedException {@inheritDoc}
+     */
     public DirContext getSchemaClassDefinition(String name)
             throws NamingException {
         return getURLOrDefaultInitDirCtx(name).getSchemaClassDefinition(name);
     }
 
+    /**
+     * @throws  OperationNotSupportedException {@inheritDoc}
+     */
     public DirContext getSchemaClassDefinition(Name name)
             throws NamingException {
         return getURLOrDefaultInitDirCtx(name).getSchemaClassDefinition(name);
@@ -287,6 +333,10 @@ public class InitialDirContext extends InitialContext implements DirContext {
                                             attributesToReturn);
     }
 
+    /**
+     * @throws  InvalidSearchFilterException {@inheritDoc}
+     * @throws  InvalidSearchControlsException {@inheritDoc}
+     */
     public NamingEnumeration<SearchResult>
         search(String name,
                String filter,
@@ -296,6 +346,10 @@ public class InitialDirContext extends InitialContext implements DirContext {
         return getURLOrDefaultInitDirCtx(name).search(name, filter, cons);
     }
 
+    /**
+     * @throws  InvalidSearchFilterException {@inheritDoc}
+     * @throws  InvalidSearchControlsException {@inheritDoc}
+     */
     public NamingEnumeration<SearchResult>
         search(Name name,
                String filter,
@@ -305,6 +359,10 @@ public class InitialDirContext extends InitialContext implements DirContext {
         return getURLOrDefaultInitDirCtx(name).search(name, filter, cons);
     }
 
+    /**
+     * @throws  InvalidSearchControlsException {@inheritDoc}
+     * @throws  InvalidSearchFilterException {@inheritDoc}
+     */
     public NamingEnumeration<SearchResult>
         search(String name,
                String filterExpr,
@@ -316,6 +374,10 @@ public class InitialDirContext extends InitialContext implements DirContext {
                                                       filterArgs, cons);
     }
 
+    /**
+     * @throws  InvalidSearchControlsException {@inheritDoc}
+     * @throws  InvalidSearchFilterException {@inheritDoc}
+     */
     public NamingEnumeration<SearchResult>
         search(Name name,
                String filterExpr,

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SeeTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SeeTaglet.java
@@ -42,8 +42,7 @@ import jdk.javadoc.internal.doclets.toolkit.util.Utils;
 /**
  * A taglet that represents the {@code @see} tag.
  */
-public class
-SeeTaglet extends BaseTaglet implements InheritableTaglet {
+public class SeeTaglet extends BaseTaglet implements InheritableTaglet {
 
     public SeeTaglet() {
         super(DocTree.Kind.SEE, false, EnumSet.allOf(Location.class));

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SeeTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SeeTaglet.java
@@ -42,7 +42,8 @@ import jdk.javadoc.internal.doclets.toolkit.util.Utils;
 /**
  * A taglet that represents the {@code @see} tag.
  */
-public class SeeTaglet extends BaseTaglet implements InheritableTaglet {
+public class
+SeeTaglet extends BaseTaglet implements InheritableTaglet {
 
     public SeeTaglet() {
         super(DocTree.Kind.SEE, false, EnumSet.allOf(Location.class));

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/DirectExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/DirectExecutionControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,6 +103,11 @@ public class DirectExecutionControl implements ExecutionControl {
         loaderDelegate.classesRedefined(cbcs);
     }
 
+    /**
+     * @throws ExecutionControl.UserException {@inheritDoc}
+     * @throws ExecutionControl.ResolutionException {@inheritDoc}
+     * @throws ExecutionControl.StoppedException {@inheritDoc}
+     */
     @Override
     public String invoke(String className, String methodName)
             throws RunException, InternalException, EngineTerminationException {
@@ -133,6 +138,11 @@ public class DirectExecutionControl implements ExecutionControl {
         }
     }
 
+    /**
+     * @throws ExecutionControl.UserException {@inheritDoc}
+     * @throws ExecutionControl.ResolutionException {@inheritDoc}
+     * @throws ExecutionControl.StoppedException {@inheritDoc}
+     */
     @Override
     public String varValue(String className, String varName)
             throws RunException, EngineTerminationException, InternalException {
@@ -173,6 +183,13 @@ public class DirectExecutionControl implements ExecutionControl {
         throw new NotImplementedException("stop: Not supported.");
     }
 
+    /**
+     * @throws ExecutionControl.UserException {@inheritDoc}
+     * @throws ExecutionControl.ResolutionException {@inheritDoc}
+     * @throws ExecutionControl.StoppedException {@inheritDoc}
+     * @throws ExecutionControl.EngineTerminationException {@inheritDoc}
+     * @throws ExecutionControl.NotImplementedException {@inheritDoc}
+     */
     @Override
     public Object extensionCommand(String command, Object arg)
             throws RunException, EngineTerminationException, InternalException {

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/JdiDefaultExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/JdiDefaultExecutionControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,6 +148,11 @@ public class JdiDefaultExecutionControl extends JdiExecutionControl {
         deathListeners.add(s -> disposeVM());
      }
 
+    /**
+     * @throws ExecutionControl.UserException {@inheritDoc}
+     * @throws ExecutionControl.ResolutionException {@inheritDoc}
+     * @throws ExecutionControl.StoppedException {@inheritDoc}
+     */
     @Override
     public String invoke(String classname, String methodname)
             throws RunException,

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/RemoteExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/RemoteExecutionControl.java
@@ -110,12 +110,24 @@ public class RemoteExecutionControl extends DirectExecutionControl implements Ex
         // handled by JDI
     }
 
+    /**
+     * @throws ExecutionControl.UserException {@inheritDoc}
+     * @throws ExecutionControl.ResolutionException {@inheritDoc}
+     * @throws ExecutionControl.StoppedException {@inheritDoc}
+     * @throws ExecutionControl.EngineTerminationException {@inheritDoc}
+     * @throws ExecutionControl.NotImplementedException {@inheritDoc}
+     */
     // Overridden only so this stack frame is seen
     @Override
     protected String invoke(Method doitMethod) throws Exception {
         return super.invoke(doitMethod);
     }
 
+    /**
+     * @throws ExecutionControl.UserException {@inheritDoc}
+     * @throws ExecutionControl.ResolutionException {@inheritDoc}
+     * @throws ExecutionControl.StoppedException {@inheritDoc}
+     */
     // Overridden only so this stack frame is seen
     @Override
     public String varValue(String className, String varName) throws RunException, EngineTerminationException, InternalException {

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/StreamingExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/StreamingExecutionControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,6 +87,11 @@ public class StreamingExecutionControl implements ExecutionControl {
         }
     }
 
+    /**
+     * @throws ExecutionControl.UserException {@inheritDoc}
+     * @throws ExecutionControl.ResolutionException {@inheritDoc}
+     * @throws ExecutionControl.StoppedException {@inheritDoc}
+     */
     @Override
     public String invoke(String classname, String methodname)
             throws RunException, EngineTerminationException, InternalException {
@@ -105,6 +110,11 @@ public class StreamingExecutionControl implements ExecutionControl {
         }
     }
 
+    /**
+     * @throws ExecutionControl.UserException {@inheritDoc}
+     * @throws ExecutionControl.ResolutionException {@inheritDoc}
+     * @throws ExecutionControl.StoppedException {@inheritDoc}
+     */
     @Override
     public String varValue(String classname, String varname)
             throws RunException, EngineTerminationException, InternalException {
@@ -151,6 +161,13 @@ public class StreamingExecutionControl implements ExecutionControl {
         }
     }
 
+    /**
+     * @throws ExecutionControl.UserException {@inheritDoc}
+     * @throws ExecutionControl.ResolutionException {@inheritDoc}
+     * @throws ExecutionControl.StoppedException {@inheritDoc}
+     * @throws ExecutionControl.EngineTerminationException {@inheritDoc}
+     * @throws ExecutionControl.NotImplementedException {@inheritDoc}
+     */
     @Override
     public Object extensionCommand(String command, Object arg)
             throws RunException, EngineTerminationException, InternalException {


### PR DESCRIPTION
This adds exception documentation to JDK methods that would otherwise lose that documentation once JDK-8287796 is integrated. While adding this exception documentation now does not change [^1] the JDK API Documentation, it will automatically counterbalance the effect that JDK-8287796 will have.

JDK-8287796 seeks to remove an old, undocumented, and esoteric javadoc feature that cannot be suppressed [^2]. The feature is so little known about that IDEs either do not implement it correctly or do not implement it at all, thus rendering documentation differently from how the javadoc tool renders it.

That feature was introduced in JDK-4947455 and manifests as follows. If a method inherits documentation for an exception, along with that documentation the method automatically inherits documentation for all exceptions that are subclasses of that former exception and are documented in an overridden method.

To illustrate that behavior, consider the following example. A method `Subtype.m` inherits documentation for `SuperException`, while the overridden method `Supertype.m` documents `SuperException`, `SubExceptionA` and `SubExceptionB`, where the latter two exceptions are subclasses of the former exception:

    public class Subtype extends Supertype {

        @Override
        public void m() throws SuperException {
    ...

    public class Supertype {

        /**
         * @throws SuperException general problem
         * @throws SubExceptionA  specific problem A
         * @throws SubExceptionB  specific problem B
         */
        public void m() throws SuperException {
    ...

    public class SuperException extends Exception {
    ...

    public class SubExceptionA extends SuperException {
    ...

    public class SubExceptionB extends SuperException {
    ...

For the above example, the API Documentation for `Subtype.m` will contain documentation for all three exceptions; the page fragment for `Subtype.m` in "Method Details" will look like this:

    public void m()
           throws SuperException

    Overrides:
        m in class Supertype
    Throws:
        SuperException - general problem
        SubExceptionA - specific problem A
        SubExceptionB - specific problem B 

It works for checked and unchecked exceptions, for methods in classes and interfaces.


If it's the first time you hear about that behavior and this change affects your area, it's a good opportunity to reflect on whether the exception documentation this change adds is really needed or you were simply unaware of the fact that it was automatically added before. If exception documentation is not needed, please comment on this PR. Otherwise, consider approving it.

Keep in mind that if some exception documentation is not needed, **leaving it out** from this PR might require a CSR.


[^1]: Aside from insignificant changes on class-use and index pages. There's one relatively significant change. This change is in jdk.jshell, where some methods disappeared from "Methods declared in ..." section and other irregularities. We are aware of this and have filed JDK-8291803 to fix the root cause.
[^2]: In reality, the feature can be suppressed, but it looks like a bug rather than intentional design. If we legitimize the feature and its suppression behavior, the model for exception documentation inheritance might become much more complicated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294377](https://bugs.openjdk.org/browse/JDK-8294377): Prepare to stop auto-inheriting documentation for subclasses of exceptions whose documentation is inherited


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10449/head:pull/10449` \
`$ git checkout pull/10449`

Update a local copy of the PR: \
`$ git checkout pull/10449` \
`$ git pull https://git.openjdk.org/jdk pull/10449/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10449`

View PR using the GUI difftool: \
`$ git pr show -t 10449`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10449.diff">https://git.openjdk.org/jdk/pull/10449.diff</a>

</details>
