### PR TITLE
8294460: CodeSection::alignment checks for CodeBuffer::SECT_STUBS incorrectly

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -752,7 +752,7 @@ inline int CodeSection::alignment(int section) {
   if (section == CodeBuffer::SECT_INSTS) {
     return (int) CodeEntryAlignment;
   }
-  if (CodeBuffer::SECT_STUBS) {
+  if (section == CodeBuffer::SECT_STUBS) {
     // CodeBuffer installer expects sections to be HeapWordSize aligned
     return HeapWordSize;
   }


### PR DESCRIPTION
Code added in `CodeSection::alignment` by [JDK-8287373](https://bugs.openjdk.org/browse/JDK-8287373) triggers `-Wint-in-bool-context` warning on GCC (currently globally ignored), due to apparent bug.

The bug seems innocuous now, as the branch is always taken, and the method checks for the rest of section types exhaustively. But, it would not go to `ShouldNotReachHere` if we pass e.g. `SECT_NONE` into the method.

Attention @bulasevich. 

Additional testing: 
 - [ ] Linux x86_64 fastdebug tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294460](https://bugs.openjdk.org/browse/JDK-8294460): CodeSection::alignment checks for CodeBuffer::SECT_STUBS incorrectly


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10450/head:pull/10450` \
`$ git checkout pull/10450`

Update a local copy of the PR: \
`$ git checkout pull/10450` \
`$ git pull https://git.openjdk.org/jdk pull/10450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10450`

View PR using the GUI difftool: \
`$ git pr show -t 10450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10450.diff">https://git.openjdk.org/jdk/pull/10450.diff</a>

</details>
