### PR TITLE
8293563: [macos-aarch64] SA core file tests failing with sun.jvm.hotspot.oops.UnknownOopException

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -113,13 +113,14 @@ serviceability/jvmti/ModuleAwareAgents/ThreadStart/MAAThreadStart.java 8225354 w
 serviceability/jvmti/vthread/GetSetLocalTest/GetSetLocalTest.java 8286836 generic-all
 serviceability/dcmd/gc/RunFinalizationTest.java 8227120 linux-all,windows-x64
 
-serviceability/sa/ClhsdbCDSCore.java 8269982,8267433 macosx-aarch64,macosx-x64
-serviceability/sa/ClhsdbFindPC.java#xcomp-core 8269982,8267433 macosx-aarch64,macosx-x64
-serviceability/sa/ClhsdbFindPC.java#no-xcomp-core 8269982,8267433 macosx-aarch64,macosx-x64
-serviceability/sa/ClhsdbPmap.java#core 8269982,8267433 macosx-aarch64,macosx-x64
-serviceability/sa/ClhsdbPstack.java#core 8269982,8267433 macosx-aarch64,macosx-x64
-serviceability/sa/TestJmapCore.java 8269982,8267433 macosx-aarch64,macosx-x64
-serviceability/sa/TestJmapCoreMetaspace.java 8269982,8267433 macosx-aarch64,macosx-x64
+serviceability/sa/ClhsdbCDSCore.java 8267433 macosx-x64
+serviceability/sa/ClhsdbFindPC.java#xcomp-core 8267433 macosx-x64
+serviceability/sa/ClhsdbFindPC.java#no-xcomp-core 8267433 macosx-x64
+serviceability/sa/ClhsdbPmap.java#core 8267433 macosx-x64
+serviceability/sa/ClhsdbPstack.java#core 8267433 macosx-x64
+serviceability/sa/TestJmapCore.java 8267433 macosx-x64
+serviceability/sa/TestJmapCoreMetaspace.java 8267433 macosx-x64
+
 serviceability/attach/ConcAttachTest.java 8290043 linux-all
 
 #############################################################################

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,6 +82,7 @@ public class ClhsdbCDSCore {
                 "-Xshare:auto",
                 "-XX:+ProfileInterpreter",
                 "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+                CoreUtils.getAlwaysPretouchArg(true),
                 CrashApp.class.getName()
             };
 

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
@@ -93,9 +93,9 @@ public class ClhsdbFindPC {
             theApp = new LingeredApp();
             theApp.setForceCrash(withCore);
             if (withXcomp) {
-                LingeredApp.startApp(theApp, "-Xcomp");
+                LingeredApp.startApp(theApp, "-Xcomp", CoreUtils.getAlwaysPretouchArg(withCore));
             } else {
-                LingeredApp.startApp(theApp, "-Xint");
+                LingeredApp.startApp(theApp, "-Xint", CoreUtils.getAlwaysPretouchArg(withCore));
             }
             System.out.print("Started LingeredApp ");
             if (withXcomp) {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPmap.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPmap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class ClhsdbPmap {
             ClhsdbLauncher test = new ClhsdbLauncher();
             theApp = new LingeredApp();
             theApp.setForceCrash(withCore);
-            LingeredApp.startApp(theApp);
+            LingeredApp.startApp(theApp, CoreUtils.getAlwaysPretouchArg(withCore));
             System.out.println("Started LingeredApp with pid " + theApp.getPid());
 
             if (withCore) {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPstack.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPstack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class ClhsdbPstack {
             ClhsdbLauncher test = new ClhsdbLauncher();
             theApp = new LingeredApp();
             theApp.setForceCrash(withCore);
-            LingeredApp.startApp(theApp);
+            LingeredApp.startApp(theApp, CoreUtils.getAlwaysPretouchArg(withCore));
             System.out.println("Started LingeredApp with pid " + theApp.getPid());
 
             if (withCore) {

--- a/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,6 +73,7 @@ public class TestJmapCore {
     static void test(String type) throws Throwable {
         ProcessBuilder pb = ProcessTools.createTestJvm("-XX:+CreateCoredumpOnCrash",
                 "-Xmx512m", "-XX:MaxMetaspaceSize=64m", "-XX:+CrashOnOutOfMemoryError",
+                CoreUtils.getAlwaysPretouchArg(true),
                 TestJmapCore.class.getName(), type);
 
         // If we are going to force a core dump, apply "ulimit -c unlimited" if we can.

--- a/test/lib/jdk/test/lib/util/CoreUtils.java
+++ b/test/lib/jdk/test/lib/util/CoreUtils.java
@@ -260,4 +260,14 @@ public class CoreUtils {
         }
     }
 
+    public static String getAlwaysPretouchArg(boolean withCore) {
+        // macosx-aarch64 has an issue where sometimes the java heap will not be dumped to the
+        // core file. Using -XX:+AlwaysPreTouch fixes the problem.
+        if (withCore && Platform.isOSX() && Platform.isAArch64()) {
+            return "-XX:+AlwaysPreTouch";
+        } else {
+            return "-XX:-AlwaysPreTouch";
+        }
+    }
+
 }


### PR DESCRIPTION
JDK-8293563 is due to a macOS bug (or maybe a feature) that is resulting in the java heap not always being present in the core file. Running with `-XX:+AlwaysPreTouch` seems to work around this problem. This issue is only on macosx-aarch64, not x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293563](https://bugs.openjdk.org/browse/JDK-8293563): [macos-aarch64] SA core file tests failing with sun.jvm.hotspot.oops.UnknownOopException


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10458/head:pull/10458` \
`$ git checkout pull/10458`

Update a local copy of the PR: \
`$ git checkout pull/10458` \
`$ git pull https://git.openjdk.org/jdk pull/10458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10458`

View PR using the GUI difftool: \
`$ git pr show -t 10458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10458.diff">https://git.openjdk.org/jdk/pull/10458.diff</a>

</details>
