### PR TITLE
8294492: RISC-V: Use li instead of patchable movptr at non-patchable callsites

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.cpp
@@ -116,6 +116,31 @@ void Assembler::_li(Register Rd, int64_t imm) {
   }
 }
 
+void Assembler::li(Register Rd, int64_t imm, int32_t &offset) {
+  // int64_t is in range 0x8000 0000 0000 0000 ~ 0x7fff ffff ffff ffff
+  int shift = 12;
+  int64_t upper = imm, lower = imm;
+  // Split imm to a lower 12-bit sign-extended part and the remainder,
+  // because addi will sign-extend the lower imm.
+  lower = ((int32_t)imm << 20) >> 20;
+  upper -= lower;
+
+  // Test whether imm is a 32-bit integer.
+  if (!(((imm) & ~(int64_t)0x7fffffff) == 0 ||
+        (((imm) & ~(int64_t)0x7fffffff) == ~(int64_t)0x7fffffff))) {
+    while (((upper >> shift) & 1) == 0) { shift++; }
+    upper >>= shift;
+    li(Rd, upper);
+    slli(Rd, Rd, shift);
+  } else {
+    // 32-bit integer
+    if (upper != 0) {
+      lui(Rd, (int32_t)upper);
+    }
+  }
+  offset = lower;
+}
+
 void Assembler::li64(Register Rd, int64_t imm) {
   // Load upper 32 bits. upper = imm[63:32], but if imm[31] == 1 or
   // (imm[31:20] == 0x7ff && imm[19] == 1), upper = imm[63:32] + 1.

--- a/src/hotspot/cpu/riscv/assembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.cpp
@@ -220,15 +220,9 @@ void Assembler::ret() {
   void Assembler::NAME(const address &dest, Register temp) {      \
     assert_cond(dest != NULL);                                    \
     assert(temp != noreg, "temp must not be empty register!");    \
-    int64_t distance = dest - pc();                               \
-    if (is_offset_in_range(distance, 32)) {                       \
-      auipc(temp, distance + 0x800);                              \
-      jalr(REGISTER, temp, ((int32_t)distance << 20) >> 20);      \
-    } else {                                                      \
-      int32_t offset = 0;                                         \
-      li(temp, (uintptr_t)dest, offset);                          \
-      jalr(REGISTER, temp, offset);                               \
-    }                                                             \
+    int32_t offset = 0;                                           \
+    li(temp, (uintptr_t)dest, offset);                            \
+    jalr(REGISTER, temp, offset);                                 \
   }
 
   INSN(call, x1);

--- a/src/hotspot/cpu/riscv/assembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.cpp
@@ -226,7 +226,7 @@ void Assembler::ret() {
       jalr(REGISTER, temp, ((int32_t)distance << 20) >> 20);      \
     } else {                                                      \
       int32_t offset = 0;                                         \
-      movptr(temp, dest, offset);                                 \
+      li(temp, (uintptr_t)dest, offset);                          \
       jalr(REGISTER, temp, offset);                               \
     }                                                             \
   }

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -302,7 +302,7 @@ public:
       lui(Rd, upper);
       offset = lower;
     } else {
-      movptr(Rd, (address)(uintptr_t)adr.offset(), offset);
+      li(Rd, adr.offset(), offset);
     }
     add(Rd, Rd, adr.base());
   }
@@ -318,6 +318,7 @@ public:
   }
 
   void _li(Register Rd, int64_t imm);  // optimized load immediate
+  void li(Register Rd, int64_t imm, int32_t &offset);
   void li32(Register Rd, int32_t imm);
   void li64(Register Rd, int64_t imm);
   void movptr(Register Rd, address addr);

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -302,7 +302,8 @@ public:
       lui(Rd, upper);
       offset = lower;
     } else {
-      li(Rd, adr.offset(), offset);
+      offset = ((int32_t)adr.offset() << 20) >> 20;
+      li(Rd, adr.offset() - offset);
     }
     add(Rd, Rd, adr.base());
   }
@@ -318,7 +319,6 @@ public:
   }
 
   void _li(Register Rd, int64_t imm);  // optimized load immediate
-  void li(Register Rd, int64_t imm, int32_t &offset);
   void li32(Register Rd, int32_t imm);
   void li64(Register Rd, int64_t imm);
   void movptr(Register Rd, address addr);
@@ -332,17 +332,6 @@ public:
   void jal(const Address &adr, Register temp = t0);
   void jr(Register Rs);
   void jalr(Register Rs);
-  void ret();
-  void call(const address &dest, Register temp = t0);
-  void call(const Address &adr, Register temp = t0);
-  void tail(const address &dest, Register temp = t0);
-  void tail(const Address &adr, Register temp = t0);
-  void call(Label &l, Register temp) {
-    call(target(l), temp);
-  }
-  void tail(Label &l, Register temp) {
-    tail(target(l), temp);
-  }
 
   static inline uint32_t extract(uint32_t val, unsigned msb, unsigned lsb) {
     assert_cond(msb >= lsb && msb <= 31);

--- a/src/hotspot/cpu/riscv/gc/shenandoah/shenandoahBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shenandoah/shenandoahBarrierSetAssembler_riscv.cpp
@@ -300,7 +300,7 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier(MacroAssembler* masm,
     assert(!is_narrow, "phantom access cannot be narrow");
     target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak);
   }
-  __ call(target, ra);
+  __ call(target);
   __ mv(t0, x10);
   __ pop_call_clobbered_registers();
   __ mv(x10, t0);
@@ -703,7 +703,7 @@ void ShenandoahBarrierSetAssembler::generate_c1_load_reference_barrier_runtime_s
     assert(is_native, "phantom must only be called off-heap");
     target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_phantom);
   }
-  __ call(target, ra);
+  __ call(target);
   __ mv(t0, x10);
   __ pop_call_clobbered_registers();
   __ mv(x10, t0);

--- a/src/hotspot/cpu/riscv/gc/shenandoah/shenandoahBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shenandoah/shenandoahBarrierSetAssembler_riscv.cpp
@@ -282,24 +282,25 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier(MacroAssembler* masm,
   }
 
   __ push_call_clobbered_registers();
+  address target = NULL;
   if (is_strong) {
     if (is_narrow) {
-      __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong_narrow));
+      target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong_narrow);
     } else {
-      __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong));
+      target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong);
     }
   } else if (is_weak) {
     if (is_narrow) {
-      __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak_narrow));
+      target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak_narrow);
     } else {
-      __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak));
+      target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak);
     }
   } else {
     assert(is_phantom, "only remaining strength");
     assert(!is_narrow, "phantom access cannot be narrow");
-    __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak));
+    target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak);
   }
-  __ jalr(ra);
+  __ call(target, ra);
   __ mv(t0, x10);
   __ pop_call_clobbered_registers();
   __ mv(x10, t0);
@@ -679,29 +680,30 @@ void ShenandoahBarrierSetAssembler::generate_c1_load_reference_barrier_runtime_s
   bool is_weak    = ShenandoahBarrierSet::is_weak_access(decorators);
   bool is_phantom = ShenandoahBarrierSet::is_phantom_access(decorators);
   bool is_native  = ShenandoahBarrierSet::is_native_access(decorators);
+  address target  = NULL;
   if (is_strong) {
     if (is_native) {
-      __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong));
+      target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong);
     } else {
       if (UseCompressedOops) {
-        __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong_narrow));
+        target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong_narrow);
       } else {
-        __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong));
+        target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong);
       }
     }
   } else if (is_weak) {
     assert(!is_native, "weak must not be called off-heap");
     if (UseCompressedOops) {
-      __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak_narrow));
+      target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak_narrow);
     } else {
-      __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak));
+      target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak);
     }
   } else {
     assert(is_phantom, "only remaining strength");
     assert(is_native, "phantom must only be called off-heap");
-    __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_phantom));
+    target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_phantom);
   }
-  __ jalr(ra);
+  __ call(target, ra);
   __ mv(t0, x10);
   __ pop_call_clobbered_registers();
   __ mv(x10, t0);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -563,10 +563,8 @@ void MacroAssembler::emit_static_call_stub() {
 void MacroAssembler::call_VM_leaf_base(address entry_point,
                                        int number_of_arguments,
                                        Label *retaddr) {
-  int32_t offset = 0;
   push_reg(RegSet::of(t0, xmethod), sp);   // push << t0 & xmethod >> to sp
-  mv(t0, entry_point, offset);
-  jalr(x1, t0, offset);
+  call(entry_point, t0);
   if (retaddr != NULL) {
     bind(*retaddr);
   }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -565,7 +565,7 @@ void MacroAssembler::call_VM_leaf_base(address entry_point,
                                        Label *retaddr) {
   int32_t offset = 0;
   push_reg(RegSet::of(t0, xmethod), sp);   // push << t0 & xmethod >> to sp
-  movptr(t0, entry_point, offset);
+  mv(t0, entry_point, offset);
   jalr(x1, t0, offset);
   if (retaddr != NULL) {
     bind(*retaddr);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -564,7 +564,7 @@ void MacroAssembler::call_VM_leaf_base(address entry_point,
                                        int number_of_arguments,
                                        Label *retaddr) {
   push_reg(RegSet::of(t0, xmethod), sp);   // push << t0 & xmethod >> to sp
-  call(entry_point, t0);
+  call(entry_point);
   if (retaddr != NULL) {
     bind(*retaddr);
   }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -528,7 +528,10 @@ public:
 
   // mv
   void mv(Register Rd, address addr)                  { li(Rd, (int64_t)addr); }
-  void mv(Register Rd, address addr, int32_t &offset) { li(Rd, (int64_t)addr, offset); }
+  void mv(Register Rd, address addr, int32_t &offset) {
+    offset = ((int32_t)(uintptr_t)addr << 20) >> 20;
+    li(Rd, (uintptr_t)addr - offset);
+  }
 
   template<typename T, ENABLE_IF(std::is_integral<T>::value)>
   inline void mv(Register Rd, T o)                    { li(Rd, (int64_t)o); }
@@ -890,6 +893,18 @@ public:
                    int* receiver_offset);
 
   void rt_call(address dest, Register tmp = t0);
+
+  void call(const address &dest, Register temp = t0) {
+    assert_cond(dest != NULL);
+    assert(temp != noreg, "temp must not be empty register!");
+    int32_t offset = 0;
+    mv(temp, dest, offset);
+    jalr(x1, temp, offset);
+  }
+
+  void ret() {
+    jalr(x0, x1, 0);
+  }
 
 private:
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -527,12 +527,13 @@ public:
   }
 
   // mv
-  void mv(Register Rd, address addr)          { li(Rd, (int64_t)addr); }
+  void mv(Register Rd, address addr)                  { li(Rd, (int64_t)addr); }
+  void mv(Register Rd, address addr, int32_t &offset) { li(Rd, (int64_t)addr, offset); }
 
   template<typename T, ENABLE_IF(std::is_integral<T>::value)>
-  inline void mv(Register Rd, T o)            { li(Rd, (int64_t)o); }
+  inline void mv(Register Rd, T o)                    { li(Rd, (int64_t)o); }
 
-  inline void mvw(Register Rd, int32_t imm32) { mv(Rd, imm32); }
+  inline void mvw(Register Rd, int32_t imm32)         { mv(Rd, imm32); }
 
   void mv(Register Rd, Address dest);
   void mv(Register Rd, RegisterOrConstant src);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -531,8 +531,8 @@ public:
   void mv(Register Rd, address addr, int32_t &offset) {
     // Split address into a lower 12-bit sign-extended offset and the remainder,
     // so that the offset could be encoded in jalr or load/store instruction.
-    offset = ((int32_t)(uintptr_t)addr << 20) >> 20;
-    li(Rd, (uintptr_t)addr - offset);
+    offset = ((int32_t)(int64_t)addr << 20) >> 20;
+    li(Rd, (int64_t)addr - offset);
   }
 
   template<typename T, ENABLE_IF(std::is_integral<T>::value)>

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -529,6 +529,8 @@ public:
   // mv
   void mv(Register Rd, address addr)                  { li(Rd, (int64_t)addr); }
   void mv(Register Rd, address addr, int32_t &offset) {
+    // Split address into a lower 12-bit sign-extended offset and the remainder,
+    // so that the offset could be encoded in jalr or load/store instruction.
     offset = ((int32_t)(uintptr_t)addr << 20) >> 20;
     li(Rd, (uintptr_t)addr - offset);
   }
@@ -894,7 +896,7 @@ public:
 
   void rt_call(address dest, Register tmp = t0);
 
-  void call(const address &dest, Register temp = t0) {
+  void call(const address dest, Register temp = t0) {
     assert_cond(dest != NULL);
     assert(temp != noreg, "temp must not be empty register!");
     int32_t offset = 0;

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -652,7 +652,7 @@ class StubGenerator: public StubCodeGenerator {
 #endif
     BLOCK_COMMENT("call MacroAssembler::debug");
     int32_t offset = 0;
-    __ movptr(t0, CAST_FROM_FN_PTR(address, MacroAssembler::debug64), offset);
+    __ mv(t0, CAST_FROM_FN_PTR(address, MacroAssembler::debug64), offset);
     __ jalr(x1, t0, offset);
     __ ebreak();
 
@@ -3741,7 +3741,7 @@ class StubGenerator: public StubCodeGenerator {
     __ mv(c_rarg0, xthread);
     BLOCK_COMMENT("call runtime_entry");
     int32_t offset = 0;
-    __ movptr(t0, runtime_entry, offset);
+    __ mv(t0, runtime_entry, offset);
     __ jalr(x1, t0, offset);
 
     // Generate oop map

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -651,9 +651,7 @@ class StubGenerator: public StubCodeGenerator {
     assert(frame::arg_reg_save_area_bytes == 0, "not expecting frame reg save area");
 #endif
     BLOCK_COMMENT("call MacroAssembler::debug");
-    int32_t offset = 0;
-    __ mv(t0, CAST_FROM_FN_PTR(address, MacroAssembler::debug64), offset);
-    __ jalr(x1, t0, offset);
+    __ call(CAST_FROM_FN_PTR(address, MacroAssembler::debug64), t0);
     __ ebreak();
 
     return start;
@@ -3740,9 +3738,7 @@ class StubGenerator: public StubCodeGenerator {
     }
     __ mv(c_rarg0, xthread);
     BLOCK_COMMENT("call runtime_entry");
-    int32_t offset = 0;
-    __ mv(t0, runtime_entry, offset);
-    __ jalr(x1, t0, offset);
+    __ call(runtime_entry, t0);
 
     // Generate oop map
     OopMap* map = new OopMap(framesize, 0);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -651,7 +651,7 @@ class StubGenerator: public StubCodeGenerator {
     assert(frame::arg_reg_save_area_bytes == 0, "not expecting frame reg save area");
 #endif
     BLOCK_COMMENT("call MacroAssembler::debug");
-    __ call(CAST_FROM_FN_PTR(address, MacroAssembler::debug64), t0);
+    __ call(CAST_FROM_FN_PTR(address, MacroAssembler::debug64));
     __ ebreak();
 
     return start;
@@ -3738,7 +3738,7 @@ class StubGenerator: public StubCodeGenerator {
     }
     __ mv(c_rarg0, xthread);
     BLOCK_COMMENT("call runtime_entry");
-    __ call(runtime_entry, t0);
+    __ call(runtime_entry);
 
     // Generate oop map
     OopMap* map = new OopMap(framesize, 0);

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -190,8 +190,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dsin());
       }
-      __ mv(t0, fn);
-      __ jalr(t0);
+      __ call(fn, t0);
       break;
     case Interpreter::java_lang_math_cos :
       entry_point = __ pc();
@@ -204,8 +203,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dcos());
       }
-      __ mv(t0, fn);
-      __ jalr(t0);
+      __ call(fn, t0);
       break;
     case Interpreter::java_lang_math_tan :
       entry_point = __ pc();
@@ -218,8 +216,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dtan());
       }
-      __ mv(t0, fn);
-      __ jalr(t0);
+      __ call(fn, t0);
       break;
     case Interpreter::java_lang_math_log :
       entry_point = __ pc();
@@ -232,8 +229,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dlog());
       }
-      __ mv(t0, fn);
-      __ jalr(t0);
+      __ call(fn, t0);
       break;
     case Interpreter::java_lang_math_log10 :
       entry_point = __ pc();
@@ -246,8 +242,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dlog10());
       }
-      __ mv(t0, fn);
-      __ jalr(t0);
+      __ call(fn, t0);
       break;
     case Interpreter::java_lang_math_exp :
       entry_point = __ pc();
@@ -260,8 +255,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dexp());
       }
-      __ mv(t0, fn);
-      __ jalr(t0);
+      __ call(fn, t0);
       break;
     case Interpreter::java_lang_math_pow :
       entry_point = __ pc();
@@ -275,8 +269,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dpow());
       }
-      __ mv(t0, fn);
-      __ jalr(t0);
+      __ call(fn, t0);
       break;
     case Interpreter::java_lang_math_fmaD :
       if (UseFMA) {
@@ -1169,8 +1162,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
     // hand.
     //
     __ mv(c_rarg0, xthread);
-    __ mv(t1, CAST_FROM_FN_PTR(address, JavaThread::check_special_condition_for_native_trans));
-    __ jalr(t1);
+    __ call(CAST_FROM_FN_PTR(address, JavaThread::check_special_condition_for_native_trans), t1);
     __ get_method(xmethod);
     __ reinit_heapbase();
     __ bind(Continue);
@@ -1219,8 +1211,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
 
     __ push_call_clobbered_registers();
     __ mv(c_rarg0, xthread);
-    __ mv(t1, CAST_FROM_FN_PTR(address, SharedRuntime::reguard_yellow_pages));
-    __ jalr(t1);
+    __ call(CAST_FROM_FN_PTR(address, SharedRuntime::reguard_yellow_pages), t1);
     __ pop_call_clobbered_registers();
     __ bind(no_reguard);
   }

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -190,7 +190,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dsin());
       }
-      __ call(fn, t0);
+      __ call(fn);
       break;
     case Interpreter::java_lang_math_cos :
       entry_point = __ pc();
@@ -203,7 +203,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dcos());
       }
-      __ call(fn, t0);
+      __ call(fn);
       break;
     case Interpreter::java_lang_math_tan :
       entry_point = __ pc();
@@ -216,7 +216,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dtan());
       }
-      __ call(fn, t0);
+      __ call(fn);
       break;
     case Interpreter::java_lang_math_log :
       entry_point = __ pc();
@@ -229,7 +229,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dlog());
       }
-      __ call(fn, t0);
+      __ call(fn);
       break;
     case Interpreter::java_lang_math_log10 :
       entry_point = __ pc();
@@ -242,7 +242,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dlog10());
       }
-      __ call(fn, t0);
+      __ call(fn);
       break;
     case Interpreter::java_lang_math_exp :
       entry_point = __ pc();
@@ -255,7 +255,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dexp());
       }
-      __ call(fn, t0);
+      __ call(fn);
       break;
     case Interpreter::java_lang_math_pow :
       entry_point = __ pc();
@@ -269,7 +269,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dpow());
       }
-      __ call(fn, t0);
+      __ call(fn);
       break;
     case Interpreter::java_lang_math_fmaD :
       if (UseFMA) {
@@ -1162,7 +1162,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
     // hand.
     //
     __ mv(c_rarg0, xthread);
-    __ call(CAST_FROM_FN_PTR(address, JavaThread::check_special_condition_for_native_trans), t1);
+    __ call(CAST_FROM_FN_PTR(address, JavaThread::check_special_condition_for_native_trans));
     __ get_method(xmethod);
     __ reinit_heapbase();
     __ bind(Continue);
@@ -1211,7 +1211,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
 
     __ push_call_clobbered_registers();
     __ mv(c_rarg0, xthread);
-    __ call(CAST_FROM_FN_PTR(address, SharedRuntime::reguard_yellow_pages), t1);
+    __ call(CAST_FROM_FN_PTR(address, SharedRuntime::reguard_yellow_pages));
     __ pop_call_clobbered_registers();
     __ bind(no_reguard);
   }

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -387,7 +387,7 @@ void TemplateTable::fast_aldc(bool wide) {
 
     // Stash null_sentinel address to get its value later
     int32_t offset = 0;
-    __ movptr(rarg, Universe::the_null_sentinel_addr(), offset);
+    __ mv(rarg, Universe::the_null_sentinel_addr(), offset);
     __ ld(tmp, Address(rarg, offset));
     __ resolve_oop_handle(tmp, x15, t1);
     __ bne(result, tmp, notNull);


### PR DESCRIPTION
A cleanup which can also reduce some code size. The main purpose is to separate the current mixed movptr usages: movptr's semantics allow it to be used for fixed-length patchable addresses. In the current backend several callsites which are not patchable use movptr (6 instructions) as well, but that's unnecessary for we can use li(1~6 instructions) to substitute them.

This patch extracts the last 12-bit offset from the li(), a recursive function, to merge it into the rest "jalr/ld/sd..." that can accept a 12-bit offset as an operand, same as the movptr_with_offset before.

Originally some non-patchable callsites:
```
;; 0x401ab1dc40
0x000000401372b324:   lui	t0,0x201
0x000000401372b328:   addi	t0,t0,-680 # 0x0000000000200d58
0x000000401372b32c:   slli	t0,t0,0xb
0x000000401372b32e:   addi	t0,t0,1905
0x000000401372b332:   slli	t0,t0,0x6
0x000000401372b334:   jalr	t0
```
Now:
```
0x000000401b2bd9f4:   lui	t0,0x4003
0x000000401b2bd9f8:   addiw	t0,t0,-1275
0x000000401b2bd9fc:   slli	t0,t0,0xc
0x000000401b2bda00:   jalr	1080(t0) # 0x0000000004003438
```
Not so much, but the main purpose is to clarify the usage of movptr and li.

The first commit has gone through a hotspot tier1~tier4; the other ones are testing under a hotspot tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294492](https://bugs.openjdk.org/browse/JDK-8294492): RISC-V: Use li instead of patchable movptr at non-patchable callsites


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) ⚠️ Review applies to [60608a30](https://git.openjdk.org/jdk/pull/10462/files/60608a3035a031122dc9a8c550f1d360d99dd1b8)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10462/head:pull/10462` \
`$ git checkout pull/10462`

Update a local copy of the PR: \
`$ git checkout pull/10462` \
`$ git pull https://git.openjdk.org/jdk pull/10462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10462`

View PR using the GUI difftool: \
`$ git pr show -t 10462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10462.diff">https://git.openjdk.org/jdk/pull/10462.diff</a>

</details>
