### PR TITLE
8294521: Parallel: Remove unused field in UpdateDensePrefixAndCompactionTask

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2406,14 +2406,12 @@ static void compaction_with_stealing_work(TaskTerminator* terminator, uint worke
 class UpdateDensePrefixAndCompactionTask: public WorkerTask {
   TaskQueue& _tq;
   TaskTerminator _terminator;
-  uint _active_workers;
 
 public:
   UpdateDensePrefixAndCompactionTask(TaskQueue& tq, uint active_workers) :
       WorkerTask("UpdateDensePrefixAndCompactionTask"),
       _tq(tq),
-      _terminator(active_workers, ParCompactionManager::region_task_queues()),
-      _active_workers(active_workers) {
+      _terminator(active_workers, ParCompactionManager::region_task_queues()) {
   }
   virtual void work(uint worker_id) {
     ParCompactionManager* cm = ParCompactionManager::gc_thread_compaction_manager(worker_id);


### PR DESCRIPTION
Trivial change of removing dead code.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294521](https://bugs.openjdk.org/browse/JDK-8294521): Parallel: Remove unused field in UpdateDensePrefixAndCompactionTask


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10466/head:pull/10466` \
`$ git checkout pull/10466`

Update a local copy of the PR: \
`$ git checkout pull/10466` \
`$ git pull https://git.openjdk.org/jdk pull/10466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10466`

View PR using the GUI difftool: \
`$ git pr show -t 10466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10466.diff">https://git.openjdk.org/jdk/pull/10466.diff</a>

</details>
