### PR TITLE
8279361: Error in documentation of third Stream.reduce method

### DIFF
--- a/src/java.base/share/classes/java/util/stream/DoubleStream.java
+++ b/src/java.base/share/classes/java/util/stream/DoubleStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/stream/DoubleStream.java
+++ b/src/java.base/share/classes/java/util/stream/DoubleStream.java
@@ -588,14 +588,7 @@ public interface DoubleStream extends BaseStream<Double, DoubleStream> {
      * reduction</a> operation on the elements of this stream.  A mutable
      * reduction is one in which the reduced value is a mutable result container,
      * such as an {@code ArrayList}, and elements are incorporated by updating
-     * the state of the result rather than by replacing the result.  This
-     * produces a result equivalent to:
-     * <pre>{@code
-     *     R result = supplier.get();
-     *     for (double element : this stream)
-     *         accumulator.accept(result, element);
-     *     return result;
-     * }</pre>
+     * the state of the result rather than by replacing the result.
      *
      * <p>Like {@link #reduce(double, DoubleBinaryOperator)}, {@code collect}
      * operations can be parallelized without requiring additional

--- a/src/java.base/share/classes/java/util/stream/IntStream.java
+++ b/src/java.base/share/classes/java/util/stream/IntStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/stream/IntStream.java
+++ b/src/java.base/share/classes/java/util/stream/IntStream.java
@@ -585,14 +585,7 @@ public interface IntStream extends BaseStream<Integer, IntStream> {
      * reduction</a> operation on the elements of this stream.  A mutable
      * reduction is one in which the reduced value is a mutable result container,
      * such as an {@code ArrayList}, and elements are incorporated by updating
-     * the state of the result rather than by replacing the result.  This
-     * produces a result equivalent to:
-     * <pre>{@code
-     *     R result = supplier.get();
-     *     for (int element : this stream)
-     *         accumulator.accept(result, element);
-     *     return result;
-     * }</pre>
+     * the state of the result rather than by replacing the result.
      *
      * <p>Like {@link #reduce(int, IntBinaryOperator)}, {@code collect} operations
      * can be parallelized without requiring additional synchronization.

--- a/src/java.base/share/classes/java/util/stream/LongStream.java
+++ b/src/java.base/share/classes/java/util/stream/LongStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/stream/LongStream.java
+++ b/src/java.base/share/classes/java/util/stream/LongStream.java
@@ -586,14 +586,7 @@ public interface LongStream extends BaseStream<Long, LongStream> {
      * reduction</a> operation on the elements of this stream.  A mutable
      * reduction is one in which the reduced value is a mutable result container,
      * such as an {@code ArrayList}, and elements are incorporated by updating
-     * the state of the result rather than by replacing the result.  This
-     * produces a result equivalent to:
-     * <pre>{@code
-     *     R result = supplier.get();
-     *     for (long element : this stream)
-     *         accumulator.accept(result, element);
-     *     return result;
-     * }</pre>
+     * the state of the result rather than by replacing the result.
      *
      * <p>Like {@link #reduce(long, LongBinaryOperator)}, {@code collect} operations
      * can be parallelized without requiring additional synchronization.

--- a/src/java.base/share/classes/java/util/stream/Stream.java
+++ b/src/java.base/share/classes/java/util/stream/Stream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1003,15 +1003,7 @@ public interface Stream<T> extends BaseStream<T, Stream<T>> {
     /**
      * Performs a <a href="package-summary.html#Reduction">reduction</a> on the
      * elements of this stream, using the provided identity, accumulation and
-     * combining functions.  This is equivalent to:
-     * <pre>{@code
-     *     U result = identity;
-     *     for (T element : this stream)
-     *         result = accumulator.apply(result, element)
-     *     return result;
-     * }</pre>
-     *
-     * but is not constrained to execute sequentially.
+     * combining functions.
      *
      * <p>The {@code identity} value must be an identity for the combiner
      * function.  This means that for all {@code u}, {@code combiner(identity, u)}
@@ -1056,14 +1048,7 @@ public interface Stream<T> extends BaseStream<T, Stream<T>> {
      * reduction</a> operation on the elements of this stream.  A mutable
      * reduction is one in which the reduced value is a mutable result container,
      * such as an {@code ArrayList}, and elements are incorporated by updating
-     * the state of the result rather than by replacing the result.  This
-     * produces a result equivalent to:
-     * <pre>{@code
-     *     R result = supplier.get();
-     *     for (T element : this stream)
-     *         accumulator.accept(result, element);
-     *     return result;
-     * }</pre>
+     * the state of the result rather than by replacing the result.
      *
      * <p>Like {@link #reduce(Object, BinaryOperator)}, {@code collect} operations
      * can be parallelized without requiring additional synchronization.


### PR DESCRIPTION
This JavaDoc change attempts to shine some light on the `combiner`-function as it relates to the third variant of `Stream.reduce` since it according to the bug submission in JBS can be confusing that the `combiner` is not mentioned in the code example in the documentation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279361](https://bugs.openjdk.org/browse/JDK-8279361): Error in documentation of third Stream.reduce method


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10469/head:pull/10469` \
`$ git checkout pull/10469`

Update a local copy of the PR: \
`$ git checkout pull/10469` \
`$ git pull https://git.openjdk.org/jdk pull/10469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10469`

View PR using the GUI difftool: \
`$ git pr show -t 10469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10469.diff">https://git.openjdk.org/jdk/pull/10469.diff</a>

</details>
