### PR TITLE
JDK-8294109: JavaDoc search should search whole index

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
@@ -43,7 +43,7 @@ const categories = {
 };
 const highlight = "<span class='result-highlight'>$&</span>";
 const NO_MATCH = {};
-const MAX_RESULTS = 500;
+const MAX_RESULTS = 300;
 function checkUnnamed(name, separator) {
     return name === "<Unnamed>" || !name ? "" : name + separator;
 }
@@ -300,11 +300,11 @@ function doSearch(request, response) {
                 }
                 matches.push(m);
             }
-            return matches.length < maxResults;
+            return true;
         });
         return matches.sort(function(e1, e2) {
             return e2.score - e1.score;
-        });
+        }).slice(0, maxResults);
     }
 
     var result = searchIndex(moduleSearchIndex, "modules")

--- a/test/langtools/jdk/javadoc/doclet/testSearchScript/javadoc-search.js
+++ b/test/langtools/jdk/javadoc/doclet/testSearchScript/javadoc-search.js
@@ -86,6 +86,9 @@ var $ = function(f) {
             click: function() {
                 return this;
             },
+            hover: function() {
+                return this;
+            },
             catcomplete: function(o) {
                 o.close = function() {};
                 search = function(term) {


### PR DESCRIPTION
Please review a simple change in JavaDoc search to always search the whole index. Currently we stop searching when the number of results in a category reaches the maximum number of results (500 per category). This can lead to results being omitted that should be ranked very high in the result list.

With this change, we always search the full index, then sort the results according to their ranking and only then trim the result to the maximum number of results per category. 

Since stopping the search early was partly done for performance reasons I did test the performance impact of the change. On my computer, searching the index of the JDK documentation is still very fast, searching the biggest index (members) with lots of matches still takes less than 50 milliseconds. On my phone it is already a bit above 100 milliseconds, which is still ok (the other index files are much smaller and faster). 

However, while measuring performance I noticed that by far the biggest impact on performance is the rendering of the result list. We currently show at most 500 results per category, which is a lot - probably more than anybody would scroll through looking for a result. I therefore changed the maximum number of results per category to 300. It's still more than enough, and it makes the result list a bit easier to manage and faster to render on slow devices. 

The change in the test is not really related to this change, the test was broken due to an earlier change in script.js (the test is skipped by default and needs to be run manually).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294109](https://bugs.openjdk.org/browse/JDK-8294109): JavaDoc search should search whole index


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10470/head:pull/10470` \
`$ git checkout pull/10470`

Update a local copy of the PR: \
`$ git checkout pull/10470` \
`$ git pull https://git.openjdk.org/jdk pull/10470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10470`

View PR using the GUI difftool: \
`$ git pr show -t 10470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10470.diff">https://git.openjdk.org/jdk/pull/10470.diff</a>

</details>
