### PR TITLE
8225235: Unused field defaultIndex in NetworkInterface

### DIFF
--- a/src/java.base/share/classes/java/net/NetworkInterface.java
+++ b/src/java.base/share/classes/java/net/NetworkInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/net/NetworkInterface.java
+++ b/src/java.base/share/classes/java/net/NetworkInterface.java
@@ -53,18 +53,12 @@ public final class NetworkInterface {
     private NetworkInterface parent = null;
     private boolean virtual = false;
     private static final NetworkInterface defaultInterface;
-    private static final int defaultIndex; /* index of defaultInterface */
 
     static {
         jdk.internal.loader.BootLoader.loadLibrary("net");
 
         init();
         defaultInterface = DefaultInterface.getDefault();
-        if (defaultInterface != null) {
-            defaultIndex = defaultInterface.getIndex();
-        } else {
-            defaultIndex = 0;
-        }
     }
 
     /**

--- a/src/java.base/unix/native/libnet/NetworkInterface.c
+++ b/src/java.base/unix/native/libnet/NetworkInterface.c
@@ -101,7 +101,6 @@ jfieldID ni_bindsID;
 jfieldID ni_virutalID;
 jfieldID ni_childsID;
 jfieldID ni_parentID;
-jfieldID ni_defaultIndexID;
 jmethodID ni_ctrID;
 
 static jclass ni_ibcls;
@@ -187,9 +186,7 @@ JNIEXPORT void JNICALL Java_java_net_NetworkInterface_init
     CHECK_NULL(ni_ib4broadcastID);
     ni_ib4maskID = (*env)->GetFieldID(env, ni_ibcls, "maskLength", "S");
     CHECK_NULL(ni_ib4maskID);
-    ni_defaultIndexID = (*env)->GetStaticFieldID(env, ni_class, "defaultIndex",
-                                                 "I");
-    CHECK_NULL(ni_defaultIndexID);
+
     initInetAddressIDs(env);
 }
 


### PR DESCRIPTION
Removes the `defaultIndex`since it is no longer used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8225235](https://bugs.openjdk.org/browse/JDK-8225235): Unused field defaultIndex in NetworkInterface


### Reviewers
 * [Chris Hegarty](https://openjdk.org/census#chegar) (@ChrisHegarty - **Reviewer**) ⚠️ Review applies to [3a9fe9ac](https://git.openjdk.org/jdk/pull/10471/files/3a9fe9ac069e83744231fa4b602e3bea4d037150)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer) ⚠️ Review applies to [3a9fe9ac](https://git.openjdk.org/jdk/pull/10471/files/3a9fe9ac069e83744231fa4b602e3bea4d037150)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to [3a9fe9ac](https://git.openjdk.org/jdk/pull/10471/files/3a9fe9ac069e83744231fa4b602e3bea4d037150)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10471/head:pull/10471` \
`$ git checkout pull/10471`

Update a local copy of the PR: \
`$ git checkout pull/10471` \
`$ git pull https://git.openjdk.org/jdk pull/10471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10471`

View PR using the GUI difftool: \
`$ git pr show -t 10471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10471.diff">https://git.openjdk.org/jdk/pull/10471.diff</a>

</details>
