### PR TITLE
8286800: Assert in PhaseIdealLoop::dump_real_LCA is too strong

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -6052,12 +6052,10 @@ void PhaseIdealLoop::dump_real_LCA(Node* early, Node* wrong_lca) {
     nodes_seen.push(n1);
     nodes_seen.push(n2);
   }
-
   if(real_LCA == NULL) {
     tty->print_cr("No LCA found for early %d (idom[%d]) and (wrong) LCA %d (idom[%d]):", early->_idx, count_2, wrong_lca->_idx, count_1);
     return;
   }
-  
   tty->print_cr("Real LCA of early %d (idom[%d]) and (wrong) LCA %d (idom[%d]):", early->_idx, count_2, wrong_lca->_idx, count_1);
   real_LCA->dump();
 }

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -6053,7 +6053,11 @@ void PhaseIdealLoop::dump_real_LCA(Node* early, Node* wrong_lca) {
     nodes_seen.push(n2);
   }
 
-  assert(real_LCA != NULL, "must always find an LCA");
+  if(real_LCA == NULL) {
+    tty->print_cr("No LCA found for early %d (idom[%d]) and (wrong) LCA %d (idom[%d]):", early->_idx, count_2, wrong_lca->_idx, count_1);
+    return;
+  }
+  
   tty->print_cr("Real LCA of early %d (idom[%d]) and (wrong) LCA %d (idom[%d]):", early->_idx, count_2, wrong_lca->_idx, count_1);
   real_LCA->dump();
 }


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8286800

assert(real_LCA != NULL) in dump_real_LCA is not appropriate in bad graph scenario when both wrong_lca & early nodes are start nodes

jvm!PhaseIdealLoop::dump_real_LCA():
// Walk the idom chain up from early and wrong_lca and stop when they intersect.
while (!n1->is_Start() && !n2->is_Start()) {
...
}
assert(real_LCA != NULL, "must always find an LCA");

Fix: replace assert with a console message

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286800](https://bugs.openjdk.org/browse/JDK-8286800): Assert in PhaseIdealLoop::dump_real_LCA is too strong


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10472/head:pull/10472` \
`$ git checkout pull/10472`

Update a local copy of the PR: \
`$ git checkout pull/10472` \
`$ git pull https://git.openjdk.org/jdk pull/10472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10472`

View PR using the GUI difftool: \
`$ git pr show -t 10472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10472.diff">https://git.openjdk.org/jdk/pull/10472.diff</a>

</details>
