### PR TITLE
8294547

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
@@ -425,7 +425,7 @@ public class HotSpotAgent {
         }
         catch (NoSuchSymbolException e) {
             throw new DebuggerException("Doesn't appear to be a HotSpot VM (could not find symbol \"" +
-            e.getSymbol() + "\" in remote process)");
+            e.getSymbol() + "\" in remote process)", e);
         }
 
         if (startupMode != REMOTE_MODE) {


### PR DESCRIPTION
 In `HotSpotAgent.setupVM()`, if there is an underlying exception in the vm setup, the exception is consumed and a `DebuggerException` is thrown, hiding the root cause. When throwing the `DebuggerException`, the "cause" exception should be included. This provides a more detailed exception stack trace, such as the following:

```
Doesn't appear to be a HotSpot VM (could not find symbol "gHotSpotVMTypes" in
remote process)
sun.jvm.hotspot.debugger.DebuggerException: Doesn't appear to be a HotSpot VM (could not find symbol "gHotSpotVMTypes" in remote process)
at jdk.hotspot.agent/sun.jvm.hotspot.HotSpotAgent.setupVM(HotSpotAgent.java:428)
at jdk.hotspot.agent/sun.jvm.hotspot.HotSpotAgent.go(HotSpotAgent.java:338)
at jdk.hotspot.agent/sun.jvm.hotspot.HotSpotAgent.attach(HotSpotAgent.java:158)
at jdk.hotspot.agent/sun.jvm.hotspot.CLHSDB.attachDebugger(CLHSDB.java:210)
at jdk.hotspot.agent/sun.jvm.hotspot.CLHSDB.run(CLHSDB.java:69)
at jdk.hotspot.agent/sun.jvm.hotspot.CLHSDB.main(CLHSDB.java:44)
at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.runCLHSDB(SALauncher.java:281)
at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.main(SALauncher.java:500)
Caused by: sun.jvm.hotspot.debugger.NoSuchSymbolException: Could not find symbol "gHotSpotVMTypes" in any of the known library names (jvm.dll)
at jdk.hotspot.agent/sun.jvm.hotspot.HotSpotTypeDataBase.lookupInProcess(HotSpotTypeDataBase.java:622)
at jdk.hotspot.agent/sun.jvm.hotspot.HotSpotTypeDataBase.readVMTypes(HotSpotTypeDataBase.java:154)
at jdk.hotspot.agent/sun.jvm.hotspot.HotSpotTypeDataBase.<init>(HotSpotTypeDataBase.java:89)
at jdk.hotspot.agent/sun.jvm.hotspot.HotSpotAgent.setupVM(HotSpotAgent.java:407)
... 7 more 
```

I'd like to push this as a trivial change.