### PR TITLE
8294548: Problem list SA core file tests on macosx-x64 due to JDK-8294316

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -114,13 +114,13 @@ serviceability/jvmti/ModuleAwareAgents/ThreadStart/MAAThreadStart.java 8225354 w
 serviceability/jvmti/vthread/GetSetLocalTest/GetSetLocalTest.java 8286836 generic-all
 serviceability/dcmd/gc/RunFinalizationTest.java 8227120 linux-all,windows-x64
 
-serviceability/sa/ClhsdbCDSCore.java 8267433 macosx-x64
-serviceability/sa/ClhsdbFindPC.java#xcomp-core 8267433 macosx-x64
-serviceability/sa/ClhsdbFindPC.java#no-xcomp-core 8267433 macosx-x64
-serviceability/sa/ClhsdbPmap.java#core 8267433 macosx-x64
-serviceability/sa/ClhsdbPstack.java#core 8267433 macosx-x64
-serviceability/sa/TestJmapCore.java 8267433 macosx-x64
-serviceability/sa/TestJmapCoreMetaspace.java 8267433 macosx-x64
+serviceability/sa/ClhsdbCDSCore.java 8294316,8267433 macosx-x64
+serviceability/sa/ClhsdbFindPC.java#xcomp-core 8294316,8267433 macosx-x64
+serviceability/sa/ClhsdbFindPC.java#no-xcomp-core 8294316,8267433 macosx-x64
+serviceability/sa/ClhsdbPmap.java#core 8294316,8267433 macosx-x64
+serviceability/sa/ClhsdbPstack.java#core 8294316,8267433 macosx-x64
+serviceability/sa/TestJmapCore.java 8294316,8267433 macosx-x64
+serviceability/sa/TestJmapCoreMetaspace.java 8294316,8267433 macosx-x64
 
 serviceability/attach/ConcAttachTest.java 8290043 linux-all
 


### PR DESCRIPTION
The SA core file tests are already problem listed on macosx-x64 due to [JDK-8267433](https://bugs.openjdk.org/browse/JDK-8267433), but they should also be due to [JDK-8294316](https://bugs.openjdk.org/browse/JDK-8294316), which is actually the much more serious of the two issues.

I'd like to push this as a trivial change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294548](https://bugs.openjdk.org/browse/JDK-8294548): Problem list SA core file tests on macosx-x64 due to JDK-8294316


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10476/head:pull/10476` \
`$ git checkout pull/10476`

Update a local copy of the PR: \
`$ git checkout pull/10476` \
`$ git pull https://git.openjdk.org/jdk pull/10476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10476`

View PR using the GUI difftool: \
`$ git pr show -t 10476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10476.diff">https://git.openjdk.org/jdk/pull/10476.diff</a>

</details>
