### PR TITLE
8294549: configure script should detect unsupported path

### DIFF
--- a/configure
+++ b/configure
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012, 2014, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,16 @@
 # make sure that is called using bash.
 
 # Get an absolute path to this script, since that determines the top-level directory.
-this_script_dir=`dirname $0`
-this_script_dir=`cd $this_script_dir > /dev/null && pwd`
+source_path="$(dirname ${0})"
+
+this_script_dir="$(cd -- "${source_path}" > /dev/null && pwd)"
+
+if [ -z "${this_script_dir}" ]; then
+	echo "# Could not determine location of configure script"
+	exit 1
+fi
 
 # Delegate to wrapper, forcing wrapper to believe $0 is this script by using -c.
 # This trick is needed to get autoconf to co-operate properly.
 # The ${-:+-$-} construction passes on bash options.
-bash ${-:+-$-} -c ". $this_script_dir/make/autoconf/configure" $this_script_dir/configure CHECKME $this_script_dir "$@"
+bash ${-:+-$-} -c ". \"${this_script_dir}/make/autoconf/configure\"" "${this_script_dir}/configure" CHECKME "${this_script_dir}" "$@"


### PR DESCRIPTION
The OpenJDK build system does not support building when the source code resides on a path that contains a space. This requirement is documented in the build instructions but not enforced by the configure script.

This change adds an explicit checks to the wrapper `configure` script that fail the build if the source code to be built is located in a directory who's path contains a space character or the build path cannot be determined.

Includes some idiom modernization and shell scripting best practices changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294549](https://bugs.openjdk.org/browse/JDK-8294549): configure script should detect unsupported path


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10477/head:pull/10477` \
`$ git checkout pull/10477`

Update a local copy of the PR: \
`$ git checkout pull/10477` \
`$ git pull https://git.openjdk.org/jdk pull/10477/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10477`

View PR using the GUI difftool: \
`$ git pr show -t 10477`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10477.diff">https://git.openjdk.org/jdk/pull/10477.diff</a>

</details>
