### PR TITLE
8294551: Put java/io/BufferedInputStream/TransferTo.java on problem list

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -507,6 +507,7 @@ java/lang/instrument/RetransformBigClass.sh                     8065756 generic-
 # jdk_io
 
 java/io/pathNames/GeneralWin32.java                             8180264 windows-all
+java/io/BufferedInputStream/TransferTo.java                     8294541 generic-all
 java/io/File/createTempFile/SpecialTempFile.java                8274122 windows11
 java/io/File/GetXSpace.java                                     8291911 windows-all
 


### PR DESCRIPTION
The test is failing randomly with OOME, probably as a result of varying test node resources.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294551](https://bugs.openjdk.org/browse/JDK-8294551): Put java/io/BufferedInputStream/TransferTo.java on problem list


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10478/head:pull/10478` \
`$ git checkout pull/10478`

Update a local copy of the PR: \
`$ git checkout pull/10478` \
`$ git pull https://git.openjdk.org/jdk pull/10478/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10478`

View PR using the GUI difftool: \
`$ git pr show -t 10478`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10478.diff">https://git.openjdk.org/jdk/pull/10478.diff</a>

</details>
