### PR TITLE
8294519: (fs) java/nio/file/Files/CopyProcFile.java fails intermittenly due to unstable /proc/cpuinfo output

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -560,8 +560,6 @@ java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc6
 
 java/nio/channels/DatagramChannel/ManySourcesAndTargets.java    8264385 macosx-aarch64
 
-java/nio/file/Files/CopyProcFile.java                           8294519 linux-all
-
 ############################################################################
 
 # jdk_rmi

--- a/test/jdk/java/nio/file/Files/CopyProcFile.java
+++ b/test/jdk/java/nio/file/Files/CopyProcFile.java
@@ -49,7 +49,7 @@ import org.testng.annotations.Test;
  * @run testng/othervm CopyProcFile
  */
 public class CopyProcFile {
-    static final String SOURCE = "/proc/cpuinfo";
+    static final String SOURCE = "/proc/version";
     static final String BUFFERED_COPY = "bufferedCopy";
     static final String TARGET = "target";
 
@@ -58,7 +58,7 @@ public class CopyProcFile {
     static long theSize;
 
     // copy src to dst via Java buffers
-    static long bufferedCopy(String src, String dst) {
+    static long bufferedCopy(String src, String dst) throws IOException {
         try (InputStream in = new FileInputStream(src);
              OutputStream out = new FileOutputStream(dst)) {
             byte[] b = new byte[BUF_SIZE];
@@ -69,8 +69,6 @@ public class CopyProcFile {
                 total += n;
             }
             return total;
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
         }
     }
 
@@ -115,18 +113,19 @@ public class CopyProcFile {
     }
 
     @BeforeTest(alwaysRun=true)
-    public void createBufferedCopy() {
+    public void createBufferedCopy() throws IOException {
         System.out.printf("Using source file \"%s\"%n", SOURCE);
         try {
             theSize = bufferedCopy(SOURCE, BUFFERED_COPY);
             System.out.printf("Copied %d bytes from %s%n", theSize, SOURCE);
-            if (Files.mismatch(Path.of(BUFFERED_COPY), Path.of(SOURCE)) != -1)
-                throw new RuntimeException("Copy does not match source");
-        } catch (Exception e) {
+        } catch (IOException e) {
             try {
                 Files.delete(Path.of(BUFFERED_COPY));
             } catch (IOException ignore) {}
+            throw e;
         }
+        if (Files.mismatch(Path.of(BUFFERED_COPY), Path.of(SOURCE)) != -1)
+            throw new RuntimeException("Copy does not match source");
     }
 
     @AfterTest(alwaysRun=true)

--- a/test/jdk/java/nio/file/Files/CopyProcFile.java
+++ b/test/jdk/java/nio/file/Files/CopyProcFile.java
@@ -124,8 +124,9 @@ public class CopyProcFile {
             } catch (IOException ignore) {}
             throw e;
         }
-        if (Files.mismatch(Path.of(BUFFERED_COPY), Path.of(SOURCE)) != -1)
+        if (Files.mismatch(Path.of(BUFFERED_COPY), Path.of(SOURCE)) != -1) {
             throw new RuntimeException("Copy does not match source");
+        }
     }
 
     @AfterTest(alwaysRun=true)
@@ -161,13 +162,15 @@ public class CopyProcFile {
     public static void testCopyAndTransfer(FHolder f) throws IOException {
         try {
             long size = f.apply(SOURCE, TARGET);
-            if (size != theSize)
+            if (size != theSize) {
                 throw new RuntimeException("Size: expected " + theSize +
                                            "; actual: " + size);
+            }
             long mismatch = Files.mismatch(Path.of(BUFFERED_COPY),
                                            Path.of(TARGET));
-            if (mismatch != -1)
+            if (mismatch != -1) {
                 throw new RuntimeException("Target does not match copy");
+            }
         } finally {
             try {
                 Files.delete(Path.of(TARGET));


### PR DESCRIPTION
1. Change source from `/proc/cpuinfo` to `/proc/version`.
2. Do not swallow errors in `@BeforeTest` config action.
3. Remove test from problem list.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294519](https://bugs.openjdk.org/browse/JDK-8294519): (fs) java/nio/file/Files/CopyProcFile.java fails intermittenly due to unstable /proc/cpuinfo output


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [c80329e6](https://git.openjdk.org/jdk/pull/10479/files/c80329e63d800a6a78ca7e8dde03118ffb1b0a34)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [c80329e6](https://git.openjdk.org/jdk/pull/10479/files/c80329e63d800a6a78ca7e8dde03118ffb1b0a34)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10479/head:pull/10479` \
`$ git checkout pull/10479`

Update a local copy of the PR: \
`$ git checkout pull/10479` \
`$ git pull https://git.openjdk.org/jdk pull/10479/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10479`

View PR using the GUI difftool: \
`$ git pr show -t 10479`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10479.diff">https://git.openjdk.org/jdk/pull/10479.diff</a>

</details>
