### PR TITLE
8288907: serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java fails with -XX:TieredStopAtLevel=2,3

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java
@@ -29,7 +29,7 @@
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} SuspendResume1.java
  * @run driver jdk.test.lib.FileInstaller . .
- * @run main/othervm/native
+ * @run main/othervm/native/timeout=600
  *      --enable-preview
  *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
  *      -agentlib:SuspendResume1


### PR DESCRIPTION
The test SuspendResume fails on linux-aarch64 with timeouts.
However, it never fails when test timeout is set to a bigger value:
```
diff --git a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java
index cd5b8251fce..562f2eae921 100644
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java
@@ -29,7 +29,7 @@
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} SuspendResume1.java
  * @run driver jdk.test.lib.FileInstaller . .
- * @run main/othervm/native
+ * @run main/othervm/native/timeout=600
  *      --enable-preview
  *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
  *      -agentlib:SuspendResume1
```

I'd like to push this as a trivial fix.

Testing: Submitted mach5 test runs on multiple platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288907](https://bugs.openjdk.org/browse/JDK-8288907): serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java fails with -XX:TieredStopAtLevel=2,3


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10480/head:pull/10480` \
`$ git checkout pull/10480`

Update a local copy of the PR: \
`$ git checkout pull/10480` \
`$ git pull https://git.openjdk.org/jdk pull/10480/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10480`

View PR using the GUI difftool: \
`$ git pr show -t 10480`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10480.diff">https://git.openjdk.org/jdk/pull/10480.diff</a>

</details>
