### PR TITLE
8294569: Remove CardTable::_last_valid_index

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardTable.cpp
+++ b/src/hotspot/share/gc/g1/g1CardTable.cpp
@@ -53,7 +53,6 @@ void G1CardTable::initialize(G1RegionToSpaceMapper* mapper) {
   _byte_map_size = mapper->reserved().byte_size();
 
   size_t num_cards = cards_required(_whole_heap.word_size());
-  _last_valid_index = num_cards - 1;
 
   HeapWord* low_bound  = _whole_heap.start();
   HeapWord* high_bound = _whole_heap.end();
@@ -64,11 +63,11 @@ void G1CardTable::initialize(G1RegionToSpaceMapper* mapper) {
   _byte_map = (CardValue*) mapper->reserved().start();
   _byte_map_base = _byte_map - (uintptr_t(low_bound) >> _card_shift);
   assert(byte_for(low_bound) == &_byte_map[0], "Checking start of map");
-  assert(byte_for(high_bound-1) <= &_byte_map[_last_valid_index], "Checking end of map");
+  assert(byte_for(high_bound-1) <= &_byte_map[last_valid_index()], "Checking end of map");
 
   log_trace(gc, barrier)("G1CardTable::G1CardTable: ");
-  log_trace(gc, barrier)("    &_byte_map[0]: " PTR_FORMAT "  &_byte_map[_last_valid_index]: " PTR_FORMAT,
-                         p2i(&_byte_map[0]), p2i(&_byte_map[_last_valid_index]));
+  log_trace(gc, barrier)("    &_byte_map[0]: " PTR_FORMAT "  &_byte_map[last_valid_index()]: " PTR_FORMAT,
+                         p2i(&_byte_map[0]), p2i(&_byte_map[last_valid_index()]));
   log_trace(gc, barrier)("    _byte_map_base: " PTR_FORMAT,  p2i(_byte_map_base));
 }
 

--- a/src/hotspot/share/gc/shared/cardTable.hpp
+++ b/src/hotspot/share/gc/shared/cardTable.hpp
@@ -44,7 +44,6 @@ protected:
   // The declaration order of these const fields is important; see the
   // constructor before changing.
   const MemRegion _whole_heap;       // the region covered by the card table
-  size_t          _last_valid_index; // index of the last valid element
   const size_t    _page_size;        // page size used when mapping _byte_map
   size_t          _byte_map_size;    // in bytes
   CardValue*      _byte_map;         // the card marking array
@@ -107,6 +106,9 @@ protected:
   static uint _card_size;
   static uint _card_size_in_words;
 
+  size_t last_valid_index() const {
+    return cards_required(_whole_heap.word_size()) - 1;
+  }
 public:
   CardTable(MemRegion whole_heap);
   virtual ~CardTable();
@@ -127,7 +129,7 @@ public:
 
   // Initialization utilities; covered_words is the size of the covered region
   // in, um, words.
-  inline size_t cards_required(size_t covered_words) {
+  inline size_t cards_required(size_t covered_words) const {
     assert(is_aligned(covered_words, _card_size_in_words), "precondition");
     return covered_words / _card_size_in_words;
   }

--- a/src/hotspot/share/gc/shared/vmStructs_gc.hpp
+++ b/src/hotspot/share/gc/shared/vmStructs_gc.hpp
@@ -88,7 +88,6 @@
   nonstatic_field(BarrierSet::FakeRtti,        _concrete_tag,                                 BarrierSet::Name)                      \
                                                                                                                                      \
   nonstatic_field(CardTable,                   _whole_heap,                                   const MemRegion)                       \
-  nonstatic_field(CardTable,                   _last_valid_index,                             const size_t)                          \
   nonstatic_field(CardTable,                   _page_size,                                    const size_t)                          \
   nonstatic_field(CardTable,                   _byte_map_size,                                const size_t)                          \
   nonstatic_field(CardTable,                   _byte_map,                                     CardTable::CardValue*)                                \


### PR DESCRIPTION
Simple change of removing a field.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294569](https://bugs.openjdk.org/browse/JDK-8294569): Remove CardTable::_last_valid_index


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10481/head:pull/10481` \
`$ git checkout pull/10481`

Update a local copy of the PR: \
`$ git checkout pull/10481` \
`$ git pull https://git.openjdk.org/jdk pull/10481/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10481`

View PR using the GUI difftool: \
`$ git pr show -t 10481`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10481.diff">https://git.openjdk.org/jdk/pull/10481.diff</a>

</details>
