### PR TITLE
8294514: Wrong initialization of nmethod::_consts_offset for native nmethods

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -627,7 +627,7 @@ nmethod::nmethod(
     _orig_pc_offset          = 0;
     _gc_epoch                = CodeCache::gc_epoch();
 
-    _consts_offset           = data_offset();
+    _consts_offset           = content_offset()      + code_buffer->total_offset_of(code_buffer->consts());
     _stub_offset             = content_offset()      + code_buffer->total_offset_of(code_buffer->stubs());
     _oops_offset             = data_offset();
     _metadata_offset         = _oops_offset          + align_up(code_buffer->total_oop_size(), oopSize);

--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -468,6 +468,9 @@ void CompileTask::print_ul(const nmethod* nm, const char* msg) {
                nm->is_osr_method() ? nm->osr_entry_bci() : -1,
                /*is_blocking*/ false,
                msg, /* short form */ true, /* cr */ true);
+    if (nm->consts_size() < 0) {
+      ls.print_cr("NEGATIVE constants section size: %d", nm->consts_size());
+    }
   }
 }
 

--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -468,9 +468,6 @@ void CompileTask::print_ul(const nmethod* nm, const char* msg) {
                nm->is_osr_method() ? nm->osr_entry_bci() : -1,
                /*is_blocking*/ false,
                msg, /* short form */ true, /* cr */ true);
-    if (nm->consts_size() < 0) {
-      ls.print_cr("NEGATIVE constants section size: %d", nm->consts_size());
-    }
   }
 }
 


### PR DESCRIPTION
Hi,

this small fix copies the initialization of `nmethod::_consts_offset` from the nmethod constructor for c1/c2 compiled nmethods to the constructor for native nmethods.

Manual testing:

* I built commit 86097e20df0652c2f0c6865f0ec62e7989db45ca and reproduced the issue on x86_64 as described in the JBS-bug
* Then I build commit 5ce7741ffd9323909b7424255d696525db3d01d2 and found that I could not reproduce the issue. I also verified that on PPC64 the constants section of the continuation enter intrinsic is printed now (-XX:+PrintAssembly).

The fix passed our CI testing: most JCK and JTREG test, also in Xcomp mode, SPECjvm2008, SPECjbb2015, Renaissance Suite and SAP specific tests with fastdebug and release builds on the standard platforms plus PPC64.

Thanks, Richard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294514](https://bugs.openjdk.org/browse/JDK-8294514): Wrong initialization of nmethod::_consts_offset for native nmethods


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10482/head:pull/10482` \
`$ git checkout pull/10482`

Update a local copy of the PR: \
`$ git checkout pull/10482` \
`$ git pull https://git.openjdk.org/jdk pull/10482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10482`

View PR using the GUI difftool: \
`$ git pr show -t 10482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10482.diff">https://git.openjdk.org/jdk/pull/10482.diff</a>

</details>
