### PR TITLE
JDK-8294567: IGV: IllegalStateException in search

### DIFF
--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorInputGraphProvider.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorInputGraphProvider.java
@@ -49,7 +49,7 @@ public class EditorInputGraphProvider implements InputGraphProvider {
 
     @Override
     public InputGraph getGraph() {
-        if (editor != null && editor.isOpened()) {
+        if (editor != null) {
             return editor.getModel().getGraphToView();
         } else {
             return null;
@@ -58,14 +58,14 @@ public class EditorInputGraphProvider implements InputGraphProvider {
 
     @Override
     public void setSelectedNodes(Set<InputNode> nodes) {
-        if (editor != null && editor.isOpened()) {
+        if (editor != null) {
             editor.setSelectedNodes(nodes);
         }
     }
 
     @Override
     public Iterable<InputGraph> searchBackward() {
-        if (editor != null && editor.isOpened()) {
+        if (editor != null) {
             return editor.getModel().getGraphsBackward();
         } else {
             return null;
@@ -74,7 +74,7 @@ public class EditorInputGraphProvider implements InputGraphProvider {
 
     @Override
     public Iterable<InputGraph> searchForward() {
-        if (editor != null && editor.isOpened()) {
+        if (editor != null) {
             return editor.getModel().getGraphsForward();
         } else {
             return null;


### PR DESCRIPTION
When searching for a node, IGV first looks in the current open graph. If it can find the node here everything works fine. 

# Problem
If if cannot find the node if uses the `searchForward` and `searchBackward` in the `EditorInputGraphProvider` to search in the other graphs. It crashes here because `editor.isOpened()` can only be called from the `EventDispatchThread`

# Solution
The calls to `editor.isOpened()` are not needed because `editor != null` already means that it is open. So just remove all 4 calls to `editor.isOpened()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294567](https://bugs.openjdk.org/browse/JDK-8294567): IGV: IllegalStateException in search


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10483/head:pull/10483` \
`$ git checkout pull/10483`

Update a local copy of the PR: \
`$ git checkout pull/10483` \
`$ git pull https://git.openjdk.org/jdk pull/10483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10483`

View PR using the GUI difftool: \
`$ git pr show -t 10483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10483.diff">https://git.openjdk.org/jdk/pull/10483.diff</a>

</details>
