### PR TITLE
8294578: [PPC64] C2: Missing is_oop information when using disjoint compressed oops mode

### DIFF
--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -6841,9 +6841,9 @@ instruct decodeN_Disjoint_notNull_Ex(iRegPdst dst, iRegNsrc src) %{
     n2->_opnds[1] = op_src;
     n2->_opnds[2] = op_dst;
     n2->_bottom_type = _bottom_type;
-    ra_->set_oop(n2, true);
 
     assert(ra_->is_oop(this) == true, "A decodeN node must produce an oop!");
+    ra_->set_oop(n2, true);
 
     ra_->set_pair(n1->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this));
     ra_->set_pair(n2->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this));
@@ -6879,7 +6879,6 @@ instruct decodeN_Disjoint_isel_Ex(iRegPdst dst, iRegNsrc src, flagsReg crx) %{
     n2->_opnds[1] = op_src;
     n2->_opnds[2] = op_dst;
     n2->_bottom_type = _bottom_type;
-    ra_->set_oop(n2, true);
 
     cond_set_0_ptrNode *n_cond_set = new cond_set_0_ptrNode();
     n_cond_set->add_req(n_region, n_compare, n2);
@@ -6887,9 +6886,9 @@ instruct decodeN_Disjoint_isel_Ex(iRegPdst dst, iRegNsrc src, flagsReg crx) %{
     n_cond_set->_opnds[1] = op_crx;
     n_cond_set->_opnds[2] = op_dst;
     n_cond_set->_bottom_type = _bottom_type;
-    ra_->set_oop(n_cond_set, true);
 
     assert(ra_->is_oop(this) == true, "A decodeN node must produce an oop!");
+    ra_->set_oop(n_cond_set, true);
 
     ra_->set_pair(n1->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this));
     ra_->set_pair(n_compare->_idx, ra_->get_reg_second(n_crx), ra_->get_reg_first(n_crx));

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -6841,6 +6841,9 @@ instruct decodeN_Disjoint_notNull_Ex(iRegPdst dst, iRegNsrc src) %{
     n2->_opnds[1] = op_src;
     n2->_opnds[2] = op_dst;
     n2->_bottom_type = _bottom_type;
+    ra_->set_oop(n2, true);
+
+    assert(ra_->is_oop(this) == true, "A decodeN node must produce an oop!");
 
     ra_->set_pair(n1->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this));
     ra_->set_pair(n2->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this));
@@ -6876,6 +6879,7 @@ instruct decodeN_Disjoint_isel_Ex(iRegPdst dst, iRegNsrc src, flagsReg crx) %{
     n2->_opnds[1] = op_src;
     n2->_opnds[2] = op_dst;
     n2->_bottom_type = _bottom_type;
+    ra_->set_oop(n2, true);
 
     cond_set_0_ptrNode *n_cond_set = new cond_set_0_ptrNode();
     n_cond_set->add_req(n_region, n_compare, n2);
@@ -6883,9 +6887,9 @@ instruct decodeN_Disjoint_isel_Ex(iRegPdst dst, iRegNsrc src, flagsReg crx) %{
     n_cond_set->_opnds[1] = op_crx;
     n_cond_set->_opnds[2] = op_dst;
     n_cond_set->_bottom_type = _bottom_type;
+    ra_->set_oop(n_cond_set, true);
 
     assert(ra_->is_oop(this) == true, "A decodeN node must produce an oop!");
-    ra_->set_oop(n_cond_set, true);
 
     ra_->set_pair(n1->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this));
     ra_->set_pair(n_compare->_idx, ra_->get_reg_second(n_crx), ra_->get_reg_first(n_crx));


### PR DESCRIPTION
Fix missing is_oop information shown by assertion `assert(t->base() == Type::Int || t->base() == Type::Half || t->base() == Type::FloatCon || t->base() == Type::FloatBot) failed: Unexpected type`. See JBS issue for details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294578](https://bugs.openjdk.org/browse/JDK-8294578): [PPC64] C2: Missing is_oop information when using disjoint compressed oops mode


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10484/head:pull/10484` \
`$ git checkout pull/10484`

Update a local copy of the PR: \
`$ git checkout pull/10484` \
`$ git pull https://git.openjdk.org/jdk pull/10484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10484`

View PR using the GUI difftool: \
`$ git pr show -t 10484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10484.diff">https://git.openjdk.org/jdk/pull/10484.diff</a>

</details>
