### PR TITLE
6616245: NullPointerException when using JFileChooser with a custom FileView

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalFileChooserUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalFileChooserUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1266,11 +1266,7 @@ public class MetalFileChooserUI extends BasicFileChooserUI {
         public void actionPerformed(ActionEvent e) {
             directoryComboBox.hidePopup();
             File f = (File)directoryComboBox.getSelectedItem();
-            File curDir = getFileChooser().getCurrentDirectory();
-
-            if (curDir != null && !curDir.equals(f)) {
-                getFileChooser().setCurrentDirectory(f);
-            }
+            getFileChooser().setCurrentDirectory(f);
         }
     }
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalFileChooserUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalFileChooserUI.java
@@ -1266,7 +1266,9 @@ public class MetalFileChooserUI extends BasicFileChooserUI {
         public void actionPerformed(ActionEvent e) {
             directoryComboBox.hidePopup();
             File f = (File)directoryComboBox.getSelectedItem();
-            if (!getFileChooser().getCurrentDirectory().equals(f)) {
+            File curDir = getFileChooser().getCurrentDirectory();
+
+            if (curDir != null && !curDir.equals(f)) {
                 getFileChooser().setCurrentDirectory(f);
             }
         }

--- a/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
@@ -79,6 +79,7 @@ public class FileViewNPETest {
         frame = new JFrame("JFileChooser File View NPE test");
         passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS, 5L, 13, 40);
         jfc = new JFileChooser();
+
         String userHome = System.getProperty("user.home");
         String docs = userHome + File.separator + "Documents";
         String path = (new File(docs).exists()) ? docs : userHome;

--- a/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
@@ -32,14 +32,14 @@ import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
 import javax.swing.filechooser.FileView;
-import jdk.test.lib.Platform;
+
 /*
  * @test
  * @bug 6616245
  * @key headful
  * @requires (os.family == "windows" | os.family == "linux")
- * @library /java/awt/regtesthelpers /test/lib
- * @build PassFailJFrame jdk.test.lib.Platform
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
  * @summary Test to check if NPE occurs when using custom FileView.
  * @run main/manual FileViewNPETest
  */
@@ -65,23 +65,27 @@ public class FileViewNPETest {
         //Initialize the components
         final String INSTRUCTIONS = """
                 Instructions to Test:
-                1. The traversable folder set is to "user/home" Directory,
-                 other than these folder all other
-                 folders are considered as non-traversable.
-                2. When file chooser appears on screen, select any
-                 non-traversable folder from "Look-In" ComboBox by mouse
-                 click/key press. (The folder will not be opened since its
-                 non-traversable). Select the same folder again.
-                3. If NPE occurs on second selection then test FAILS, else test
-                 is PASS.
+                1. The traversable folder is set to the Documents folder,
+                 if it exists, in the user's home folder, otherwise
+                 it's the user's home. Other folders are non-traversable.
+                2. When the file chooser appears on the screen, select any
+                 non-traversable folder from "Look-In" combo box,
+                 for example the user's folder or a folder above it.
+                 (The folder will not be opened since it's non-traversable).
+                3. Select the Documents folder again.
+                4. If NullPointerException does not occurs in the step 3,
+                 click Pass, otherwise the Test Fails.
                 """;
         frame = new JFrame("JFileChooser File View NPE test");
         passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS, 5L, 13, 40);
         jfc = new JFileChooser();
-        String path = System.getProperty("user.home") + File.separator + "Documents";
+        String userHome = System.getProperty("user.home");
+        String docs = userHome + File.separator + "Documents";
+        String path = (new File(docs).exists()) ? docs : userHome;
 
         jfc.setCurrentDirectory(new File(path));
         jfc.setFileView(new CustomFileView(path));
+        jfc.setControlButtonsAreShown(false);
 
         PassFailJFrame.addTestWindow(frame);
         PassFailJFrame.positionTestWindow(frame, PassFailJFrame.Position.HORIZONTAL);

--- a/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
@@ -36,6 +36,7 @@ import javax.swing.filechooser.FileView;
 /*
  * @test
  * @bug 6616245
+ * @key headful
  * @requires (os.family == "windows" | os.family == "linux")
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame

--- a/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
@@ -36,7 +36,6 @@ import javax.swing.filechooser.FileView;
 /*
  * @test
  * @bug 6616245
- * @key headful
  * @requires (os.family == "windows" | os.family == "linux")
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
@@ -73,11 +72,12 @@ public class FileViewNPETest {
                  for example the user's folder or a folder above it.
                  (The folder will not be opened since it's non-traversable).
                 3. Select the Documents folder again.
-                4. If NullPointerException does not occurs in the step 3,
-                 click Pass, otherwise the Test Fails.
+                4. If NullPointerException does not occur in the step 3,
+                 click Pass, otherwise the test fails automatically.
                 """;
         frame = new JFrame("JFileChooser File View NPE test");
-        passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS, 5L, 13, 40);
+        passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS,
+                5L, 13, 40);
         jfc = new JFileChooser();
 
         String userHome = System.getProperty("user.home");

--- a/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
@@ -78,7 +78,7 @@ public class FileViewNPETest {
         frame = new JFrame("JFileChooser File View NPE test");
         passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS, 5L, 13, 40);
         jfc = new JFileChooser();
-        String path = System.getProperty("user.home");
+        String path = System.getProperty("user.home") + File.separator + "Documents";
 
         jfc.setCurrentDirectory(new File(path));
         jfc.setFileView(new CustomFileView(path));
@@ -94,14 +94,14 @@ public class FileViewNPETest {
 }
 
 class CustomFileView extends FileView {
-    private String basePath;
+    private final String basePath;
 
     public CustomFileView(String path) {
         basePath = path;
     }
 
     public Boolean isTraversable(File filePath) {
-        return ((filePath != null) && (filePath.isDirectory())) &&
-                filePath.getAbsolutePath().startsWith(basePath);
+        return ((filePath != null) && (filePath.isDirectory()))
+                && filePath.getAbsolutePath().startsWith(basePath);
     }
 }

--- a/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
@@ -65,10 +65,16 @@ public class FileViewNPETest {
         //Initialize the components
         final String INSTRUCTIONS = """
                 Instructions to Test:
-                1. Select any folder except "C:\\temp" (In windows) / "/tmp"
-                (In linux) and click to traverse through it.
-                2. Repeat the traversal try (2 times) and on second try if
-                NPE occurs then test FAILS else test PASS.
+                1. The traversable folder set is "C:\\temp" (In windows)
+                & "/tmp" (In linux), other than these folder all other
+                folders are considered as non-traversable.
+                2. When file chooser appears on screen, select any
+                non-traversable folder (ex-C:/ in windows, / folder in linux)
+                from "Look-In" ComboBox by mouse click/key press. (The folder
+                will not be opened since its non-traversable). Select the same
+                folder again.
+                3. If NPE occurs on second selection then test FAILS, else test
+                is PASS.
                 """;
         frame = new JFrame("JFileChooser File View NPE test");
         passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS, 5L, 5, 40);

--- a/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
@@ -78,7 +78,7 @@ public class FileViewNPETest {
         frame = new JFrame("JFileChooser File View NPE test");
         passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS, 5L, 13, 40);
         jfc = new JFileChooser();
-        String path = System.getProperty("user.home")
+        String path = System.getProperty("user.home");
 
         jfc.setCurrentDirectory(new File(path));
         jfc.setFileView(new CustomFileView(path));

--- a/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JFrame;
+import javax.swing.JFileChooser;
+import javax.swing.SwingUtilities;
+import javax.swing.WindowConstants;
+
+import javax.swing.filechooser.FileView;
+import jdk.test.lib.Platform;
+/*
+ * @test
+ * @bug 6616245
+ * @key headful
+ * @requires (os.family == "windows" | os.family == "linux")
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame jdk.test.lib.Platform
+ * @summary Test to check if NPE occurs when using custom FileView.
+ * @run main/manual FileViewNPETest
+ */
+public class FileViewNPETest {
+    static JFrame frame;
+    static JFileChooser jfc;
+    static PassFailJFrame passFailJFrame;
+
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(new Runnable() {
+            public void run() {
+                try {
+                    initialize();
+                } catch (InterruptedException | InvocationTargetException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        passFailJFrame.awaitAndCheck();
+    }
+
+    static void initialize() throws InterruptedException, InvocationTargetException {
+        //Initialize the components
+        final String INSTRUCTIONS = """
+                Instructions to Test:
+                1. Select any folder except "C:\\temp" (In windows) / "/tmp"
+                (In linux) and click to traverse through it.
+                2. Repeat the traversal try (2 times) and on second try if
+                NPE occurs then test FAILS else test PASS.
+                """;
+        frame = new JFrame("JFileChooser File View NPE test");
+        passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS, 5L, 5, 40);
+        jfc = new JFileChooser();
+        String path = "";
+        if (Platform.isWindows()) {
+            path = "C:" + File.separator + "temp";
+        } else {
+            path = File.separator + "tmp";
+        }
+
+        jfc.setCurrentDirectory(new File(path));
+        jfc.setFileView(new CustomFileView(path));
+
+        PassFailJFrame.addTestWindow(frame);
+        PassFailJFrame.positionTestWindow(frame, PassFailJFrame.Position.HORIZONTAL);
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+
+        frame.add(jfc, BorderLayout.CENTER);
+        frame.pack();
+        frame.setVisible(true);
+    }
+}
+
+class CustomFileView extends FileView {
+    private String basePath;
+
+    public CustomFileView(String path) {
+        basePath = path;
+    }
+
+    public Boolean isTraversable(File filePath) {
+        if ((filePath != null) && (filePath.isDirectory())) {
+            return filePath.getAbsolutePath().startsWith(basePath);
+        } else {
+            return false;
+        }
+    }
+}

--- a/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
@@ -44,10 +44,7 @@ import jdk.test.lib.Platform;
  * @run main/manual FileViewNPETest
  */
 public class FileViewNPETest {
-    static JFrame frame;
-    static JFileChooser jfc;
     static PassFailJFrame passFailJFrame;
-
     public static void main(String[] args) throws Exception {
         SwingUtilities.invokeAndWait(new Runnable() {
             public void run() {
@@ -62,29 +59,26 @@ public class FileViewNPETest {
     }
 
     static void initialize() throws InterruptedException, InvocationTargetException {
+        JFrame frame;
+        JFileChooser jfc;
+
         //Initialize the components
         final String INSTRUCTIONS = """
                 Instructions to Test:
-                1. The traversable folder set is "C:\\temp" (In windows)
-                & "/tmp" (In linux), other than these folder all other
-                folders are considered as non-traversable.
+                1. The traversable folder set is to "user/home" Directory,
+                 other than these folder all other
+                 folders are considered as non-traversable.
                 2. When file chooser appears on screen, select any
-                non-traversable folder (ex-C:/ in windows, / folder in linux)
-                from "Look-In" ComboBox by mouse click/key press. (The folder
-                will not be opened since its non-traversable). Select the same
-                folder again.
+                 non-traversable folder from "Look-In" ComboBox by mouse
+                 click/key press. (The folder will not be opened since its
+                 non-traversable). Select the same folder again.
                 3. If NPE occurs on second selection then test FAILS, else test
-                is PASS.
+                 is PASS.
                 """;
         frame = new JFrame("JFileChooser File View NPE test");
-        passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS, 5L, 5, 40);
+        passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS, 5L, 13, 40);
         jfc = new JFileChooser();
-        String path = "";
-        if (Platform.isWindows()) {
-            path = "C:" + File.separator + "temp";
-        } else {
-            path = File.separator + "tmp";
-        }
+        String path = System.getProperty("user.home")
 
         jfc.setCurrentDirectory(new File(path));
         jfc.setFileView(new CustomFileView(path));
@@ -107,10 +101,7 @@ class CustomFileView extends FileView {
     }
 
     public Boolean isTraversable(File filePath) {
-        if ((filePath != null) && (filePath.isDirectory())) {
-            return filePath.getAbsolutePath().startsWith(basePath);
-        } else {
-            return false;
-        }
+        return ((filePath != null) && (filePath.isDirectory())) &&
+                filePath.getAbsolutePath().startsWith(basePath);
     }
 }


### PR DESCRIPTION
When a custom `FileView` is used and folder traversal is restricted to a particular directory NPE occurs when user tries to traverse/select other folders except traversable folder. This is caused because when user selects folder other than traversable, the traversal is rejected and hence no file is selected as `currentDirectory` of `JFileChooser`. When user tries to access the restricted folder second time, previous selected file check is failing because of NPE since `getFileChooser().getCurrentDirectory();` is null. To fix the issue, NPE check is added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6616245](https://bugs.openjdk.org/browse/JDK-6616245): NullPointerException when using JFileChooser with a custom FileView


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * @kumarabhi006 (no known github.com user name / role) ⚠️ Review applies to [f5d345e5](https://git.openjdk.org/jdk/pull/10485/files/f5d345e553d1d1acafe1bdc09fde62c85581b3a8)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10485/head:pull/10485` \
`$ git checkout pull/10485`

Update a local copy of the PR: \
`$ git checkout pull/10485` \
`$ git pull https://git.openjdk.org/jdk pull/10485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10485`

View PR using the GUI difftool: \
`$ git pr show -t 10485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10485.diff">https://git.openjdk.org/jdk/pull/10485.diff</a>

</details>
