### PR TITLE
8294580: frame::interpreter_frame_print_on() crashes if free BasicObjectLock exists in frame

### DIFF
--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -570,8 +570,8 @@ void frame::interpreter_frame_print_on(outputStream* st) const {
   for (BasicObjectLock* current = interpreter_frame_monitor_end();
        current < interpreter_frame_monitor_begin();
        current = next_monitor_in_interpreter_frame(current)) {
-    st->print(" - obj    [");
-    current->obj()->print_value_on(st);
+    st->print(" - obj    [%s", current->obj() == nullptr ? "null" : "");
+    if (current->obj() != nullptr) current->obj()->print_value_on(st);
     st->print_cr("]");
     st->print(" - lock   [");
     current->lock()->print_on(st, current->obj());


### PR DESCRIPTION
Add null check before dereferencing BasicObjectLock::_obj.
BasicObjectLocks are marked as free by setting _obj to null.

I've done manual testing:

```
./images/jdk/bin/java -Xlog:continuations=trace -XX:+VerifyContinuations --enable-preview VTSleepAfterUnlock
```

with the test attached to the JBS item.

Example output:

```
[0.349s][trace][continuations] Interpreted frame (sp=0x000000011d5c6398 unextended sp=0x000000011d5c63b8, fp=0x000000011d5c6420, real_fp=0x000000011d5c6420, pc=0x00007f0ff0199c6a)
[0.349s][trace][continuations] ~return entry points  [0x00007f0ff0199820, 0x00007f0ff019a2e8]  2760 bytes
[0.349s][trace][continuations]  - local  [0x000000011d5c3550]; #0
[0.349s][trace][continuations]  - local  [0x000000011d5c3550]; #1
[0.349s][trace][continuations]  - local  [0x0000000000000000]; #2
[0.349s][trace][continuations]  - stack  [0x0000000000000064]; #1
[0.349s][trace][continuations]  - stack  [0x0000000000000000]; #0
[0.349s][trace][continuations]  - obj    [null]
[0.349s][trace][continuations]  - lock   [monitor mark(is_neutral no_hash age=0)]
[0.349s][trace][continuations]  - monitor[0x000000011d5c63d8]
[0.349s][trace][continuations]  - bcp    [0x00007f0fa8400401]; @17
[0.349s][trace][continuations]  - locals [0x000000011d5c6440]
[0.349s][trace][continuations]  - method [0x00007f0fa8400430]; virtual void VTSleepAfterUnlock.sleepAfterUnlock()
```