### PR TITLE
8294151: JFR: Unclear exception message when dumping stopped in memory recording

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -348,7 +348,7 @@ public final class Recording implements Closeable {
 
     /**
      * Returns a clone of this recording, with a new recording ID and name.
-     *
+     * <p>
      * Clones are useful for dumping data without stopping the recording. After
      * a clone is created, the amount of data to copy is constrained
      * with the {@link #setMaxAge(Duration)} method and the {@link #setMaxSize(long)}method.
@@ -364,21 +364,26 @@ public final class Recording implements Closeable {
     /**
      * Writes recording data to a file.
      * <p>
-     * Recording must be started, but not necessarily stopped.
+     * For a dump to succeed, the recording must either be 1) running, or 2) stopped
+     * and to disk. If the recording is in any other state, an
+     * {@link IOException} is thrown.
      *
      * @param destination the location where recording data is written, not
      *        {@code null}
      *
-     * @throws IOException if the recording can't be copied to the specified
-     *         location
+     * @throws IOException if recording data can't be copied to the specified
+     *         location, for example, if the recording is closed or the
+     *         destination path is not writable
      *
      * @throws SecurityException if a security manager exists and the caller doesn't
      *         have {@code FilePermission} to write to the destination path
+     *
+     * @see #getState()
+     * @see #isToDisk()
      */
     public void dump(Path destination) throws IOException {
         Objects.requireNonNull(destination, "destination");
         internal.dump(new WriteableUserPath(destination));
-
     }
 
     /**

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -321,7 +321,12 @@ public final class PlatformRecording implements AutoCloseable {
         if (state == RecordingState.DELAYED || state == RecordingState.NEW) {
             throw new IOException("Recording \"" + name + "\" (id=" + id + ") has not started, no content to write");
         }
+
         if (state == RecordingState.STOPPED) {
+            if (!isToDisk()) {
+                throw new IOException("Recording \"" + name + "\" (id=" + id + ")"
+                    + " is an in memory recording. No data to copy after it has been stopped.");
+            }
             PlatformRecording clone = recorder.newTemporaryRecording();
             for (RepositoryChunk r : chunks) {
                 clone.add(r);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/WriteableUserPath.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/WriteableUserPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -136,7 +136,11 @@ public final class WriteableUserPath {
         } catch (Throwable t) {
             // prevent malicious user to propagate exception callback
             // in the wrong context
-            throw new IOException("Unexpected error during I/O operation");
+            Throwable cause = null;
+            if (System.getSecurityManager() == null) {
+                cause = t;
+            }
+            throw new IOException("Unexpected error during I/O operation", cause);
         } finally {
             inPrivileged = false;
         }


### PR DESCRIPTION
Hi


Could I have a review of a change that updates the specification for the Recording::dump(Path) method and the exception message if the method fails. 

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8294151](https://bugs.openjdk.org/browse/JDK-8294151): JFR: Unclear exception message when dumping stopped in memory recording
 * [JDK-8294530](https://bugs.openjdk.org/browse/JDK-8294530): Update specification of jdk.jfr.consumer.Recording::dump(Path) in case of an in memory recording (**CSR**)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10488/head:pull/10488` \
`$ git checkout pull/10488`

Update a local copy of the PR: \
`$ git checkout pull/10488` \
`$ git pull https://git.openjdk.org/jdk pull/10488/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10488`

View PR using the GUI difftool: \
`$ git pr show -t 10488`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10488.diff">https://git.openjdk.org/jdk/pull/10488.diff</a>

</details>
