### PR TITLE
8294431: jshell reports error on initialisation of static final field of anonymous class

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/Eval.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/Eval.java
@@ -523,8 +523,9 @@ class Eval {
                 if (member.getKind() == Tree.Kind.VARIABLE) {
                     VariableTree vt = (VariableTree) member;
 
-                    if (vt.getInitializer() != null) {
-                        //for variables with initializer, explicitly move the initializer
+                    if (vt.getInitializer() != null &&
+                        !vt.getModifiers().getFlags().contains(Modifier.STATIC)) {
+                        //for instance variables with initializer, explicitly move the initializer
                         //to the constructor after the captured variables as assigned
                         //(the initializers would otherwise run too early):
                         Range wholeVar = dis.treeToRange(vt);

--- a/test/langtools/jdk/jshell/VariablesTest.java
+++ b/test/langtools/jdk/jshell/VariablesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8144903 8177466 8191842 8211694 8213725 8239536 8257236 8252409
+ * @bug 8144903 8177466 8191842 8211694 8213725 8239536 8257236 8252409 8294431
  * @summary Tests for EvaluationState.variables
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -615,6 +615,10 @@ public class VariablesTest extends KullaTesting {
         assertEval("interface Marker {}");
         assertEval("var v = (Marker & Runnable) () -> {};", added(VALID));
         assertEval("v.run()");
+    }
+
+    public void varAnonymousClassAndStaticField() { //JDK-8294431
+        assertEval("var obj = new Object() { public static final String msg = \"hello\"; };");
     }
 
 }


### PR DESCRIPTION
When variable with an inferred type (i.e. `var`) is initialized with an anonymous class, the inferred type of the variable is the actual anonymous type. To implement this in JShell, JShell will unroll the anonymous class into a normal class, and to do this, it needs to initialize fields inside a constructor.

But, as we can have static fields in the anonymous class now, it is necessary to not try to initialize static fields in the constructor, as we would initialize them too often.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294431](https://bugs.openjdk.org/browse/JDK-8294431): jshell reports error on initialisation of static final field of anonymous class


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10489/head:pull/10489` \
`$ git checkout pull/10489`

Update a local copy of the PR: \
`$ git checkout pull/10489` \
`$ git pull https://git.openjdk.org/jdk pull/10489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10489`

View PR using the GUI difftool: \
`$ git pr show -t 10489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10489.diff">https://git.openjdk.org/jdk/pull/10489.diff</a>

</details>
