### PR TITLE
8294550: Sealed check for casts isn't applied to array components

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1852,7 +1852,7 @@ public class Types {
                     if (elemtype(t).isPrimitive() || elemtype(s).isPrimitive()) {
                         return elemtype(t).hasTag(elemtype(s).getTag());
                     } else {
-                        return visit(elemtype(t), elemtype(s));
+                        return isCastable(elemtype(t), elemtype(s), warnStack.head);
                     }
                 default:
                     return false;

--- a/test/langtools/tools/javac/sealed/SealedCompilationTests.java
+++ b/test/langtools/tools/javac/sealed/SealedCompilationTests.java
@@ -25,7 +25,7 @@
  * SealedCompilationTests
  *
  * @test
- * @bug 8246353 8273257
+ * @bug 8246353 8273257 8294550
  * @summary Negative compilation tests, and positive compilation (smoke) tests for sealed classes
  * @library /lib/combo /tools/lib
  * @modules
@@ -1146,6 +1146,19 @@ public class SealedCompilationTests extends CompilationTestCase {
                         C c = (C) i;
                     }
                 }
+                """,
+                //JDK-8294550:
+                """
+                interface I {}
+                sealed class C permits D {}
+                final class D extends C {}
+
+                class Test {
+                    void test () {
+                        C[] c = null;
+                        I[] i = (I[]) c;
+                    }
+                }
                 """
         )) {
             assertFail("compiler.err.prob.found.req", s);
@@ -1232,6 +1245,17 @@ public class SealedCompilationTests extends CompilationTestCase {
                 class Test {
                     void f(A.B a, A<Object> b) {
                         a = (A.B)b;
+                    }
+                }
+                """,
+                """
+                sealed class C permits D {}
+                final class D extends C {}
+
+                class Test {
+                    void test () {
+                        C[] c = null;
+                        D[] d = (D[]) c;
                     }
                 }
                 """


### PR DESCRIPTION
For code like:
```
sealed interface I permits A {}
final class A implements I {}
interface J {}

J j = null;
I i = (I) j; //error reported here, as no instance of J can implement I
J[] jj = null;
I[] i = (I[]) jj; //incorrectly no error reported here, despite JLS saying there must be a narrowing conversion from J to I in this case, which there isn't as per the case above
```

The cause for this is that we check the sealed constraints at the end of `Types.isCastable`, and only for classes, not for arrays. It would be possible to enhance the check to include array types, but feels clearer and more reliable to recurse, and do a full castability check on the element types.

A sketch of a CSR is here:
https://bugs.openjdk.org/browse/JDK-8294586

Feedback is welcome!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8294550](https://bugs.openjdk.org/browse/JDK-8294550): Sealed check for casts isn't applied to array components
 * [JDK-8294586](https://bugs.openjdk.org/browse/JDK-8294586): Sealed check for casts isn't applied to array components (**CSR**)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10490/head:pull/10490` \
`$ git checkout pull/10490`

Update a local copy of the PR: \
`$ git checkout pull/10490` \
`$ git pull https://git.openjdk.org/jdk pull/10490/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10490`

View PR using the GUI difftool: \
`$ git pr show -t 10490`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10490.diff">https://git.openjdk.org/jdk/pull/10490.diff</a>

</details>
