### PR TITLE
8288302: Shenandoah: SIGSEGV in vm maybe related to jit compiling xerces

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -1080,7 +1080,8 @@ Node* ShenandoahBarrierSetC2::ideal_node(PhaseGVN* phase, Node* n, bool can_resh
   } else if (can_reshape &&
              n->Opcode() == Op_If &&
              ShenandoahBarrierC2Support::is_heap_stable_test(n) &&
-             n->in(0) != NULL) {
+             n->in(0) != NULL &&
+             n->outcnt() == 2) {
     Node* dom = n->in(0);
     Node* prev_dom = n;
     int op = n->Opcode();


### PR DESCRIPTION
During igvn, at a heap stable test, a dominating heap stable test is
found that can be used to optimize out the current one. But this area
of the graph is actually dying and the current test has lost one of
its projection already, something the logic doesn't expect and which
causes the crash. The fix I propose is to simply detect that the heap
stable test is dying and skip the transformation.


/cc hotspot-compiler

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288302](https://bugs.openjdk.org/browse/JDK-8288302): Shenandoah: SIGSEGV in vm maybe related to jit compiling xerces


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10491/head:pull/10491` \
`$ git checkout pull/10491`

Update a local copy of the PR: \
`$ git checkout pull/10491` \
`$ git pull https://git.openjdk.org/jdk pull/10491/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10491`

View PR using the GUI difftool: \
`$ git pr show -t 10491`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10491.diff">https://git.openjdk.org/jdk/pull/10491.diff</a>

</details>
