### PR TITLE
8294533: Documentation mistake in Process::getErrorStream and getInputStream

### DIFF
--- a/src/java.base/share/classes/java/lang/Process.java
+++ b/src/java.base/share/classes/java/lang/Process.java
@@ -158,7 +158,7 @@ public abstract class Process {
      * merged standard output and the standard error of the process.
      *
      * @apiNote
-     * Use {@link #getInputStream} and {@link #inputReader} with extreme care.
+     * Use {@link #getInputStream()} and {@link #inputReader()} with extreme care.
      * The {@code BufferedReader} may have buffered input from the input stream.
      *
      * @implNote
@@ -184,8 +184,8 @@ public abstract class Process {
      * <a href="ProcessBuilder.html#redirect-output">null input stream</a>.
      *
      * @apiNote
-     * Use {@link #getInputStream} and {@link #inputReader} with extreme care.
-     * The {@code BufferedReader} may have buffered input from the input stream.
+     * Use {@link #getErrorStream()} and {@link #errorReader()} with extreme care.
+     * The {@code BufferedReader} may have buffered input from the error stream.
      *
      * @implNote
      * Implementation note: It is a good idea for the returned


### PR DESCRIPTION
Correct javadoc links and references.

The links should refer to the method `()` instead of field.

The apiNote in `getErrorStream` should refer to the error stream not the input stream and reader.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294533](https://bugs.openjdk.org/browse/JDK-8294533): Documentation mistake in Process::getErrorStream and getInputStream


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10492/head:pull/10492` \
`$ git checkout pull/10492`

Update a local copy of the PR: \
`$ git checkout pull/10492` \
`$ git pull https://git.openjdk.org/jdk pull/10492/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10492`

View PR using the GUI difftool: \
`$ git pr show -t 10492`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10492.diff">https://git.openjdk.org/jdk/pull/10492.diff</a>

</details>
