### PR TITLE
8294595: Add javax/swing/plaf/aqua/CustomComboBoxFocusTest.java to problem list

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -666,6 +666,7 @@ javax/swing/JFileChooser/6798062/bug6798062.java 8146446 windows-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all
 javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
+javax/swing/plaf/aqua/CustomComboBoxFocusTest.java 8294254 macosx-all
 
 # Several tests which fail on some hidpi systems/macosx12-aarch64 system
 java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64


### PR DESCRIPTION
Problem listing PR

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294595](https://bugs.openjdk.org/browse/JDK-8294595): Add javax/swing/plaf/aqua/CustomComboBoxFocusTest.java to problem list


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10495/head:pull/10495` \
`$ git checkout pull/10495`

Update a local copy of the PR: \
`$ git checkout pull/10495` \
`$ git pull https://git.openjdk.org/jdk pull/10495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10495`

View PR using the GUI difftool: \
`$ git pr show -t 10495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10495.diff">https://git.openjdk.org/jdk/pull/10495.diff</a>

</details>
