### PR TITLE
8294609: C2: Improve inlining of methods with unloaded signature classes

### DIFF
--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -1161,12 +1161,12 @@ bool ciMethod::was_executed_more_than(int times) {
 // ------------------------------------------------------------------
 // ciMethod::has_unloaded_classes_in_signature
 bool ciMethod::has_unloaded_classes_in_signature() {
-  for (ciSignatureStream str(signature()); !str.is_done(); str.next()) {
-    if (!str.type()->is_loaded()) {
-      return true;
-    }
-  }
-  return false;
+  // ciSignature is resolved against some accessing class and
+  // signature classes aren't required to be local. As a benefit,
+  // it makes signature classes visible through loader constraints.
+  // So, encountering an unloaded class signals it is absent both in
+  // the callee (local) and caller contexts.
+  return signature()->has_unloaded_classes();
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -1161,17 +1161,12 @@ bool ciMethod::was_executed_more_than(int times) {
 // ------------------------------------------------------------------
 // ciMethod::has_unloaded_classes_in_signature
 bool ciMethod::has_unloaded_classes_in_signature() {
-  VM_ENTRY_MARK;
-  {
-    ExceptionMark em(THREAD);
-    methodHandle m(THREAD, get_Method());
-    bool has_unloaded = Method::has_unloaded_classes_in_signature(m, thread);
-    if( HAS_PENDING_EXCEPTION ) {
-      CLEAR_PENDING_EXCEPTION;
-      return true;     // Declare that we may have unloaded classes
+  for (ciSignatureStream str(signature()); !str.is_done(); str.next()) {
+    if (!str.type()->is_loaded()) {
+      return true;
     }
-    return has_unloaded;
   }
+  return false;
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/ci/ciSignature.hpp
+++ b/src/hotspot/share/ci/ciSignature.hpp
@@ -63,6 +63,8 @@ public:
 
   int       arg_size_for_bc(Bytecodes::Code bc)  { return size() + (Bytecodes::has_receiver(bc) ? 1 : 0); }
 
+  bool has_unloaded_classes();
+
   bool equals(ciSignature* that);
 
   void print_signature();

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -1730,20 +1730,6 @@ bool Method::load_signature_classes(const methodHandle& m, TRAPS) {
   return sig_is_loaded;
 }
 
-bool Method::has_unloaded_classes_in_signature(const methodHandle& m, TRAPS) {
-  ResourceMark rm(THREAD);
-  for(ResolvingSignatureStream ss(m()); !ss.is_done(); ss.next()) {
-    if (ss.type() == T_OBJECT) {
-      // Do not use ss.is_reference() here, since we don't care about
-      // unloaded array component types.
-      Klass* klass = ss.as_klass_if_loaded(THREAD);
-      assert(!HAS_PENDING_EXCEPTION, "as_klass_if_loaded contract");
-      if (klass == NULL) return true;
-    }
-  }
-  return false;
-}
-
 // Exposed so field engineers can debug VM
 void Method::print_short_name(outputStream* st) const {
   ResourceMark rm;

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -965,9 +965,6 @@ public:
   // Resolve all classes in signature, return 'true' if successful
   static bool load_signature_classes(const methodHandle& m, TRAPS);
 
-  // Return if true if not all classes references in signature, including return type, has been loaded
-  static bool has_unloaded_classes_in_signature(const methodHandle& m, TRAPS);
-
   // Printing
   void print_short_name(outputStream* st = tty) const; // prints as klassname::methodname; Exposed so field engineers can debug VM
 #if INCLUDE_JVMTI

--- a/test/hotspot/jtreg/compiler/c2/unloaded/TestInlineUnloaded.java
+++ b/test/hotspot/jtreg/compiler/c2/unloaded/TestInlineUnloaded.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8294609
+ * @requires vm.compiler2.enabled & vm.flagless
+ *
+ * @library /test/lib
+ *
+ * @build compiler.c2.unloaded.TestInlineUnloaded
+ *
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar launcher.jar
+ *                  compiler.c2.unloaded.TestInlineUnloaded
+ *                  compiler.c2.unloaded.TestInlineUnloaded$Launcher
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar parent.jar
+ *                  compiler.c2.unloaded.TestInlineUnloaded$Parent
+ *                  compiler.c2.unloaded.TestInlineUnloaded$Parent$U
+ *                  compiler.c2.unloaded.TestInlineUnloaded$Parent$TestCase
+ *                  compiler.c2.unloaded.TestInlineUnloaded$Parent$Invoker
+ *                  compiler.c2.unloaded.TestInlineUnloaded$Parent$TestNull
+ *                  compiler.c2.unloaded.TestInlineUnloaded$Parent$TestLoaded
+ *                  compiler.c2.unloaded.TestInlineUnloaded$Parent$TestUnloaded
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar caller.jar
+ *                  compiler.c2.unloaded.TestInlineUnloaded$Caller
+ *                  compiler.c2.unloaded.TestInlineUnloaded$Caller$TestNull
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar callee.jar
+ *                  compiler.c2.unloaded.TestInlineUnloaded$Callee
+ *                  compiler.c2.unloaded.TestInlineUnloaded$Callee$TestNull
+ *
+ * @run driver compiler.c2.unloaded.TestInlineUnloaded
+ */
+
+package compiler.c2.unloaded;
+
+import jdk.test.lib.JDKToolFinder;
+import jdk.test.lib.Utils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class TestInlineUnloaded {
+    static final String THIS_CLASS = TestInlineUnloaded.class.getName();
+
+    public static class Parent {
+        public class U {
+        }
+
+        public interface TestCase {
+            U test(Invoker obj, U arg);
+
+            void testArg(Invoker obj, U arg);
+
+            U testRet(Invoker obj);
+
+            void test(Invoker obj);
+        }
+
+        public interface Invoker {
+            void invokeArg(U obj);
+
+            U invokeRet();
+
+            U invoke(U obj);
+        }
+
+        private static class TestNull implements Runnable {
+            final TestCase test;
+            final Invoker recv;
+
+            public TestNull(TestCase test, Invoker recv) {
+                this.test = test;
+                this.recv = recv;
+            }
+
+            @Override
+            public void run() {
+                test.testArg(recv, null);
+                test.testRet(recv);
+                test.test(recv, null);
+            }
+        }
+
+        public static class TestLoadedRemotely extends TestNull {
+            public TestLoadedRemotely(TestCase test, Invoker recv) throws Exception {
+                super(test, recv);
+                Class.forName(U.class.getName()); // preload in parent context
+            }
+        }
+
+        public static class TestUnloaded extends TestNull {
+            public TestUnloaded(TestCase test, Invoker recv) {
+                super(test, recv);
+            }
+        }
+    }
+
+    public static class Caller {
+        public static class TestNull implements Parent.TestCase {
+            public TestNull() {}
+
+            public Parent.U test(Parent.Invoker obj, Parent.U arg) {
+                return obj.invoke(arg);
+            }
+
+            public void testArg(Parent.Invoker obj, Parent.U arg) {
+                obj.invokeArg(arg);
+            }
+
+            public Parent.U testRet(Parent.Invoker obj) {
+                return obj.invokeRet();
+            }
+
+            public void test(Parent.Invoker obj) {
+                test(obj, null);
+            }
+        }
+    }
+
+    public static class Callee {
+        public static class TestNull implements Parent.Invoker {
+            public void invokeArg(Parent.U obj) {}
+
+            public Parent.U invokeRet() {
+                return null;
+            }
+
+            public Parent.U invoke(Parent.U obj) {
+                return obj;
+            }
+        }
+    }
+
+    public static class Launcher {
+        public static void main(String... args) throws Exception {
+            final String testName = args[0];
+
+            URLClassLoader parentCL = new URLClassLoader("parent", new URL[] { new URL("file:parent.jar") }, ClassLoader.getSystemClassLoader());
+            URLClassLoader callerCL = new URLClassLoader("caller", new URL[] { new URL("file:caller.jar") }, parentCL);
+            URLClassLoader calleeCL = new URLClassLoader("callee", new URL[] { new URL("file:callee.jar") }, parentCL);
+
+            Object caller = Class.forName(THIS_CLASS + "$Caller$TestNull", false, callerCL)
+                                 .getDeclaredConstructor().newInstance();
+            Object callee = Class.forName(THIS_CLASS + "$Callee$TestNull", false, calleeCL)
+                                 .getDeclaredConstructor().newInstance();
+
+            Class<?> testClass = Class.forName(THIS_CLASS + "$Parent$TestCase", false, parentCL);
+            Class<?> invClass  = Class.forName(THIS_CLASS + "$Parent$Invoker",  false, parentCL);
+            Class<?> test      = Class.forName(THIS_CLASS + "$Parent$" + testName, false, parentCL);
+            Runnable r = (Runnable) test.getDeclaredConstructor(testClass, invClass)
+                                       .newInstance(caller, callee);
+
+            if (args.length > 1 && "-preload".equals(args[1])) {
+                Class.forName(THIS_CLASS + "$Parent$U", false, parentCL);
+            }
+
+            for (int i = 0; i < 20_000; i ++) {
+                r.run();
+            }
+        }
+    }
+
+    static void run(String testCaseName, Consumer<OutputAnalyzer> processor) throws IOException {
+        ProcessBuilder pb = new ProcessBuilder();
+
+        pb.command(JDKToolFinder.getJDKTool("java"),
+            "-cp", "launcher.jar",
+            "-XX:+IgnoreUnrecognizedVMOptions", "-showversion",
+            "-XX:-TieredCompilation", "-Xbatch",
+            "-XX:+PrintCompilation", "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining",
+            "-XX:CompileCommand=quiet", "-XX:CompileCommand=compileonly,*TestNull::run",
+            Launcher.class.getName(), testCaseName);
+
+        System.out.println("Command line: [" + pb.command() + "]");
+
+        OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
+
+        analyzer.shouldHaveExitValue(0);
+
+        // The test is applicable only to C2 (present in Server VM).
+        analyzer.stderrShouldContain("Server VM");
+
+        analyzer.shouldContain("TestNull::run"); // ensure that relevant method is compiled
+
+        processor.accept(analyzer); // test-specific checks
+    }
+
+    public static void main(String[] args) throws Exception {
+        run("TestUnloaded", output -> {
+            output.shouldMatch("TestNull::testArg .* unloaded signature classes");
+            output.shouldMatch("TestNull::testRet .* unloaded signature classes");
+            output.shouldMatch("TestNull::test .* unloaded signature classes");
+
+            output.shouldNotMatch("TestNull::testArg .* inline");
+            output.shouldNotMatch("TestNull::testRet .* inline");
+            output.shouldNotMatch("TestNull::test .* inline");
+        });
+        run("TestLoadedRemotely", output -> {
+            output.shouldMatch("TestNull::testArg .* inline");
+            output.shouldMatch("TestNull::testRet .* inline");
+            output.shouldMatch("TestNull::test .* inline");
+
+            output.shouldNotMatch("TestNull::testArg .* unloaded signature classes");
+            output.shouldNotMatch("TestNull::testRet .* unloaded signature classes");
+            output.shouldNotMatch("TestNull::test .* unloaded signature classes");
+        });
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/unloaded/TestInlineUnloaded.java
+++ b/test/hotspot/jtreg/compiler/c2/unloaded/TestInlineUnloaded.java
@@ -40,7 +40,7 @@
  *                  compiler.c2.unloaded.TestInlineUnloaded$Parent$TestCase
  *                  compiler.c2.unloaded.TestInlineUnloaded$Parent$Invoker
  *                  compiler.c2.unloaded.TestInlineUnloaded$Parent$TestNull
- *                  compiler.c2.unloaded.TestInlineUnloaded$Parent$TestLoaded
+ *                  compiler.c2.unloaded.TestInlineUnloaded$Parent$TestLoadedRemotely
  *                  compiler.c2.unloaded.TestInlineUnloaded$Parent$TestUnloaded
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar caller.jar
  *                  compiler.c2.unloaded.TestInlineUnloaded$Caller
@@ -55,16 +55,11 @@
 package compiler.c2.unloaded;
 
 import jdk.test.lib.JDKToolFinder;
-import jdk.test.lib.Utils;
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.process.ProcessTools;
 
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.function.Consumer;
 
 public class TestInlineUnloaded {

--- a/test/hotspot/jtreg/compiler/c2/unloaded/TestInlineUnloaded.java
+++ b/test/hotspot/jtreg/compiler/c2/unloaded/TestInlineUnloaded.java
@@ -173,10 +173,6 @@ public class TestInlineUnloaded {
             Runnable r = (Runnable) test.getDeclaredConstructor(testClass, invClass)
                                        .newInstance(caller, callee);
 
-            if (args.length > 1 && "-preload".equals(args[1])) {
-                Class.forName(THIS_CLASS + "$Parent$U", false, parentCL);
-            }
-
             for (int i = 0; i < 20_000; i ++) {
                 r.run();
             }


### PR DESCRIPTION
C2 bails out an inlining attempt when the callee method mentions an unloaded
class in its signature (either as an argument or return type).

The current check is too strict (and caused problems in the past [1]) since it
doesn't take into account whether the problematic class is loaded in the caller
context. It's safe to relax the original check in such a way because class
loader constratints ensure that both caller and callee agree on the signature
classes.

(I believe the aforementioned check [2] is redundant and can be removed even when
the class is not yet loaded, but I'll explore it separately.)

Testing: hs-tier1 - hs-tier4

[1] https://mail.openjdk.org/pipermail/hotspot-compiler-dev/2020-June/038604.html
[2] https://github.com/openjdk/jdk/blob/5f6ad926d7ea763bf61aa98c7be7087a7aa6089c/src/hotspot/share/opto/bytecodeInfo.cpp#L226

/cc hotspot-compiler

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294609](https://bugs.openjdk.org/browse/JDK-8294609): C2: Improve inlining of methods with unloaded signature classes


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [68105f92](https://git.openjdk.org/jdk/pull/10496/files/68105f92efd95186aa446e330c0453c336fb85de)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [68105f92](https://git.openjdk.org/jdk/pull/10496/files/68105f92efd95186aa446e330c0453c336fb85de)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10496/head:pull/10496` \
`$ git checkout pull/10496`

Update a local copy of the PR: \
`$ git checkout pull/10496` \
`$ git pull https://git.openjdk.org/jdk pull/10496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10496`

View PR using the GUI difftool: \
`$ git pr show -t 10496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10496.diff">https://git.openjdk.org/jdk/pull/10496.diff</a>

</details>
