### PR TITLE
8294242: JFR: jfr print doesn't handle infinite duration well

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -364,21 +364,16 @@ public final class Recording implements Closeable {
     /**
      * Writes recording data to a file.
      * <p>
-     * For a dump to succeed the recording must be be running, or
-     * both stopped and to disk. If the recording is in any other state, an
-     * {@link IOException} is thrown.
+     * Recording must be started, but not necessarily stopped.
      *
      * @param destination the location where recording data is written, not
      *        {@code null}
      *
      * @throws IOException if the recording can't be copied to the specified
-     *         location, for example if the recording is closed
+     *         location
      *
      * @throws SecurityException if a security manager exists and the caller doesn't
      *         have {@code FilePermission} to write to the destination path
-     *
-     *  @see #getState()
-     *  @see #isToDisk()
      */
     public void dump(Path destination) throws IOException {
         Objects.requireNonNull(destination, "destination");

--- a/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -364,16 +364,21 @@ public final class Recording implements Closeable {
     /**
      * Writes recording data to a file.
      * <p>
-     * Recording must be started, but not necessarily stopped.
+     * For a dump to succeed the recording must be be running, or
+     * both stopped and to disk. If the recording is in any other state, an
+     * {@link IOException} is thrown.
      *
      * @param destination the location where recording data is written, not
      *        {@code null}
      *
      * @throws IOException if the recording can't be copied to the specified
-     *         location
+     *         location, for example if the recording is closed
      *
      * @throws SecurityException if a security manager exists and the caller doesn't
      *         have {@code FilePermission} to write to the destination path
+     *
+     *  @see #getState()
+     *  @see #isToDisk()
      */
     public void dump(Path destination) throws IOException {
         Objects.requireNonNull(destination, "destination");

--- a/src/jdk.jfr/share/classes/jdk/jfr/Timespan.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Timespan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,8 @@ import java.lang.annotation.Target;
 
 /**
  * Event field annotation, specifies that the value is a duration.
+ * <p>
+ * If the annotated value equals {@code Long.MAX_VALUE), it represents forever.
  *
  * @since 9
  */

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
@@ -31,6 +31,7 @@ import java.io.StringWriter;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -755,6 +756,10 @@ public sealed class RecordedObject
      * the following types: {@code long}, {@code int}, {@code short}, {@code char},
      * and {@code byte}.
      * <p>
+     * If the committed event value was {@code Long.MAX_VALUE},
+     * regardless of the unit set by {@code @Timespan}, this method returns
+     * {@link ChronoUnit.FOREVER.getDuration()}.
+     * <p>
      * It's possible to index into a nested object using {@code "."} (for example,
      * {@code "aaa.bbb"}).
      * <p>
@@ -810,6 +815,9 @@ public sealed class RecordedObject
         }
         if (timespan == Long.MIN_VALUE) {
             return Duration.ofSeconds(Long.MIN_VALUE, 0);
+        }
+        if (timespan == Long.MAX_VALUE) {
+            return ChronoUnit.FOREVER.getDuration();
         }
         Timespan ts = v.getAnnotation(Timespan.class);
         if (ts != null) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
@@ -29,6 +29,7 @@ import java.io.PrintWriter;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
@@ -551,6 +552,10 @@ public final class PrettyWriter extends EventPrintWriter {
         if (value instanceof Duration d) {
             if (d.getSeconds() == Long.MIN_VALUE && d.getNano() == 0)  {
                 println("N/A");
+                return true;
+            }
+            if (d.equals(ChronoUnit.FOREVER.getDuration())) {
+                println("Forever");
                 return true;
             }
             println(Utils.formatDuration(d));

--- a/test/jdk/jdk/jfr/api/consumer/TestRecordedObject.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestRecordedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package jdk.jfr.api.consumer;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -91,6 +92,12 @@ public class TestRecordedObject {
 
         @Timespan(Timespan.SECONDS)
         long durationSeconds = DURATION_VALUE.toSeconds();
+
+        @Timespan(Timespan.SECONDS)
+        long foreverMillis = Long.MAX_VALUE;
+
+        @Timespan(Timespan.NANOSECONDS)
+        long foreverNanoseconds = Long.MAX_VALUE;
 
         @Timestamp(Timestamp.MILLISECONDS_SINCE_EPOCH)
         long instantMillis = 1000;
@@ -179,6 +186,9 @@ public class TestRecordedObject {
         Asserts.assertEquals(event.getDuration("durationMicros"), DURATION_VALUE);
         Asserts.assertEquals(event.getDuration("durationMillis"), DURATION_VALUE);
         Asserts.assertEquals(event.getDuration("durationSeconds"), DURATION_VALUE);
+        Asserts.assertEquals(event.getDuration("foreverMillis"), ChronoUnit.FOREVER.getDuration());
+        Asserts.assertEquals(event.getDuration("foreverNanoseconds"), ChronoUnit.FOREVER.getDuration());
+
         Asserts.assertEquals(event.getInstant("instantMillis").toEpochMilli(), 1000L);
         if (!event.getInstant("instantTicks").isBefore(INSTANT_VALUE)) {
             throw new AssertionError("Expected start time of JVM to before call to Instant.now()");


### PR DESCRIPTION
Hi,

Could I have review of a fix that improves the output of the jfr tool when there are event values that are infinite

Testing: jdk/jdk/jfr

Thanks
Erik
<!-- csr: 'update' -->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8294242](https://bugs.openjdk.org/browse/JDK-8294242): JFR: jfr print doesn't handle infinite duration well
 * [JDK-8294518](https://bugs.openjdk.org/browse/JDK-8294518): Return ChronoUnit.FOREVER.getDuration() for unlimited timespans in JFR events (**CSR**)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10497/head:pull/10497` \
`$ git checkout pull/10497`

Update a local copy of the PR: \
`$ git checkout pull/10497` \
`$ git pull https://git.openjdk.org/jdk pull/10497/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10497`

View PR using the GUI difftool: \
`$ git pr show -t 10497`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10497.diff">https://git.openjdk.org/jdk/pull/10497.diff</a>

</details>
