### PR TITLE
8294406: Test runtime/handshake/HandshakeDirectTest.java failed: JVMTI_ERROR_WRONG_PHASE

### DIFF
--- a/test/hotspot/jtreg/runtime/handshake/HandshakeDirectTest.java
+++ b/test/hotspot/jtreg/runtime/handshake/HandshakeDirectTest.java
@@ -52,7 +52,8 @@ public class HandshakeDirectTest  implements Runnable {
         try {
             JVMTIUtils.suspendThread(t);
         } catch (JVMTIUtils.JvmtiException e) {
-            if (e.getCode() != JVMTIUtils.JVMTI_ERROR_THREAD_NOT_ALIVE) {
+            if (e.getCode() != JVMTIUtils.JVMTI_ERROR_THREAD_NOT_ALIVE
+                && e.getCode() != JVMTIUtils.JVMTI_ERROR_WRONG_PHASE) {
                 throw e;
             }
         }
@@ -62,7 +63,8 @@ public class HandshakeDirectTest  implements Runnable {
         try {
             JVMTIUtils.resumeThread(t);
         } catch (JVMTIUtils.JvmtiException e) {
-            if (e.getCode() != JVMTIUtils.JVMTI_ERROR_THREAD_NOT_ALIVE) {
+            if (e.getCode() != JVMTIUtils.JVMTI_ERROR_THREAD_NOT_ALIVE
+                && e.getCode() != JVMTIUtils.JVMTI_ERROR_WRONG_PHASE) {
                 throw e;
             }
         }

--- a/test/hotspot/jtreg/testlibrary/jvmti/JVMTIUtils.java
+++ b/test/hotspot/jtreg/testlibrary/jvmti/JVMTIUtils.java
@@ -31,6 +31,7 @@ public class JVMTIUtils {
     public static int JVMTI_ERROR_THREAD_SUSPENDED = 14;
     public static int JVMTI_ERROR_THREAD_NOT_ALIVE = 15;
 
+    public static int JVMTI_ERROR_WRONG_PHASE = 112;
 
     public static class JvmtiException extends RuntimeException {
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294406](https://bugs.openjdk.org/browse/JDK-8294406): Test runtime/handshake/HandshakeDirectTest.java failed: JVMTI_ERROR_WRONG_PHASE


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10502/head:pull/10502` \
`$ git checkout pull/10502`

Update a local copy of the PR: \
`$ git checkout pull/10502` \
`$ git pull https://git.openjdk.org/jdk pull/10502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10502`

View PR using the GUI difftool: \
`$ git pr show -t 10502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10502.diff">https://git.openjdk.org/jdk/pull/10502.diff</a>

</details>
