### PR TITLE
8294623: gtests does not work with googletest release-1.12.0+

### DIFF
--- a/test/hotspot/gtest/gtestMain.cpp
+++ b/test/hotspot/gtest/gtestMain.cpp
@@ -232,7 +232,11 @@ static void runUnitTestsInner(int argc, char** argv) {
   bool is_vmassert_test = false;
   bool is_othervm_test = false;
   // death tests facility is used for both regular death tests, other vm and vmassert tests
+#ifndef GTEST_FLAG_GET
   if (::testing::internal::GTEST_FLAG(internal_run_death_test).length() > 0) {
+#else
+  if (::testing::GTEST_FLAG(internal_run_death_test).length() > 0) {
+#endif
     // when we execute death test, filter value equals to test name
     const char* test_name = ::testing::GTEST_FLAG(filter).c_str();
     const char* const othervm_suffix = "_other_vm"; // TEST_OTHER_VM


### PR DESCRIPTION
The scope of `GTEST_DECLARE_string_(internal_run_death_test)` has been changed in googletest 1.12.0 [1]. So we can see some new compiler errors as below:

```
$ bash configure --with-gtest=/home/dingli/jdk-tools/googletest && make run-test TEST="gtest:all"

* For target hotspot_variant-server_libjvm_gtest_objs_gtestMain.o:
In file included from /home/dingli/jdk-tools/googletest/googlemock/include/gmock/internal/gmock-port.h:57,
                 from /home/dingli/jdk-tools/googletest/googlemock/include/gmock/internal/gmock-internal-utils.h:49,
                 from /home/dingli/jdk-tools/googletest/googlemock/include/gmock/gmock-actions.h:145,
                 from /home/dingli/jdk-tools/googletest/googlemock/include/gmock/gmock.h:56,
                 from /home/dingli/jdk/test/hotspot/gtest/unittest.hpp:51,
                 from /home/dingli/jdk/test/hotspot/gtest/gtestMain.cpp:39:
/home/dingli/jdk/test/hotspot/gtest/gtestMain.cpp: In function 'void runUnitTestsInner(int, char**)':
/home/dingli/jdk-tools/googletest/googletest/include/gtest/internal/gtest-port.h:2181:26: error: 'FLAGS_gtest_internal_run_death_test' is not a member of 'testing::internal'; did you mean 'testing::FLAGS_gtest_internal_run_death_test'?
 2181 | #define GTEST_FLAG(name) FLAGS_gtest_##name
      |                          ^~~~~~~~~~~~
/home/dingli/jdk/test/hotspot/gtest/gtestMain.cpp:235:28: note: in expansion of macro 'GTEST_FLAG'
  235 |   if (::testing::internal::GTEST_FLAG(internal_run_death_test).length() > 0) {
      |                            ^~~~~~~~~~
/home/dingli/jdk-tools/googletest/googletest/include/gtest/internal/gtest-port.h:2181:26: note: 'testing::FLAGS_gtest_internal_run_death_test' declared here
 2181 | #define GTEST_FLAG(name) FLAGS_gtest_##name
   ... (rest of output omitted)
```

I use `GTEST_FLAG_GET` macro to detect googletest version because it was introduced at the same time as the scope of `GTEST_DECLARE_string_(internal_run_death_test)` changed.

## Testing:

- gtest:all on x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294623](https://bugs.openjdk.org/browse/JDK-8294623): gtests does not work with googletest release-1.12.0+


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10503/head:pull/10503` \
`$ git checkout pull/10503`

Update a local copy of the PR: \
`$ git checkout pull/10503` \
`$ git pull https://git.openjdk.org/jdk pull/10503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10503`

View PR using the GUI difftool: \
`$ git pr show -t 10503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10503.diff">https://git.openjdk.org/jdk/pull/10503.diff</a>

</details>
