### PR TITLE
8294610: java/net/vthread/HttpALot.java is slow on Linux

### DIFF
--- a/test/jdk/java/net/vthread/HttpALot.java
+++ b/test/jdk/java/net/vthread/HttpALot.java
@@ -29,11 +29,9 @@
  * @modules jdk.httpserver
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} HttpALot.java
- * @comment The test launch command intentionally uses -Dsun.net.httpserver.nodelay=true
+ * @comment This test runs with -Dsun.net.httpserver.nodelay=true
  *          to enable TCP_NODELAY on the sockets "accept()"ed by the HttpServer. This is
- *          to avoid (occasional 40 milli seconds) delays in receiving responses from the server.
- *          Given the number of requests being fired in this test, the delayed responses can
- *          accumulate into longer test run duration
+ *          to avoid occasional 40ms delays receiving responses from the server on Linux.
  * @run main/othervm/timeout=600
  *     --enable-preview
  *     -Dsun.net.httpserver.nodelay=true

--- a/test/jdk/java/net/vthread/HttpALot.java
+++ b/test/jdk/java/net/vthread/HttpALot.java
@@ -29,9 +29,9 @@
  * @modules jdk.httpserver
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} HttpALot.java
- * @comment This test runs with -Dsun.net.httpserver.nodelay=true
- *          to enable TCP_NODELAY on the sockets "accept()"ed by the HttpServer. This is
- *          to avoid occasional 40ms delays receiving responses from the server on Linux.
+ * @comment This test runs with -Dsun.net.httpserver.nodelay=true to enable TCP_NODELAY on the
+ *          sockets "accept()"ed by the HttpServer. This is to avoid occasional 40ms delays
+ *          receiving responses from the server on Linux.
  * @run main/othervm/timeout=600
  *     --enable-preview
  *     -Dsun.net.httpserver.nodelay=true

--- a/test/jdk/java/net/vthread/HttpALot.java
+++ b/test/jdk/java/net/vthread/HttpALot.java
@@ -23,13 +23,20 @@
 
 /**
  * @test
+ * @bug 8294610
  * @summary Stress test the HTTP protocol handler and HTTP server
  * @requires vm.debug != true
  * @modules jdk.httpserver
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} HttpALot.java
+ * @comment The test launch command intentionally uses -Dsun.net.httpserver.nodelay=true
+ *          to enable TCP_NODELAY on the sockets "accept()"ed by the HttpServer. This is
+ *          to avoid (occasional 40 milli seconds) delays in receiving responses from the server.
+ *          Given the number of requests being fired in this test, the delayed responses can
+ *          accumulate into longer test run duration
  * @run main/othervm/timeout=600
  *     --enable-preview
+ *     -Dsun.net.httpserver.nodelay=true
  *     -Dsun.net.client.defaultConnectTimeout=5000
  *     -Dsun.net.client.defaultReadTimeout=5000
  *     HttpALot

--- a/test/jdk/java/net/vthread/HttpALot.java
+++ b/test/jdk/java/net/vthread/HttpALot.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8284161 8294610
+ * @bug 8284161
  * @summary Stress test the HTTP protocol handler and HTTP server
  * @requires vm.debug != true
  * @modules jdk.httpserver

--- a/test/jdk/java/net/vthread/HttpALot.java
+++ b/test/jdk/java/net/vthread/HttpALot.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8294610
+ * @bug 8284161 8294610
  * @summary Stress test the HTTP protocol handler and HTTP server
  * @requires vm.debug != true
  * @modules jdk.httpserver


### PR DESCRIPTION
Can I please get a review for this test-only change which proposes to improve the test run duration of `java/net/vthread/HttpALot.java` test, on Linux? This relates to https://bugs.openjdk.org/browse/JDK-8294610

Experiments have shown that on Linux, due to delayed TCP ACKs from the client (for some previous sent data/packet), the server sent response waits for the ACKs before sending the response data (in a TCP packet). Each delayed ACK is 40 milli seconds and given the number of requests this test (intentionally) issues, the delay accumulates causing the test to take longer duration.

With the change in this PR, the test completes in around 6 to 8 seconds on a Linux system as compared to 60 odd seconds previously on the same setup. This change hasn't shown any negative impact on macos (which continues to run this test in around 5 to 6 seconds like previously). I will trigger some runs in our CI setup to make sure this works as expected in all other OS too.

As noted in the linked JBS issue, additional experiments to see if anything can be improved in the JDK network layer will be carried out separately, outside  the context of this test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294610](https://bugs.openjdk.org/browse/JDK-8294610): java/net/vthread/HttpALot.java is slow on Linux


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to [ed3878d2](https://git.openjdk.org/jdk/pull/10504/files/ed3878d29cf02f14ec813881ab9f12ed29f93e1d)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [8b18bc43](https://git.openjdk.org/jdk/pull/10504/files/8b18bc43be98670e7a15ff72b60278aab4e6118a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10504/head:pull/10504` \
`$ git checkout pull/10504`

Update a local copy of the PR: \
`$ git checkout pull/10504` \
`$ git pull https://git.openjdk.org/jdk pull/10504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10504`

View PR using the GUI difftool: \
`$ git pr show -t 10504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10504.diff">https://git.openjdk.org/jdk/pull/10504.diff</a>

</details>
