### PR TITLE
8294626: Improve URL protocol lower casing

### DIFF
--- a/src/java.base/share/classes/java/net/URL.java
+++ b/src/java.base/share/classes/java/net/URL.java
@@ -38,7 +38,6 @@ import java.io.ObjectStreamException;
 import java.io.ObjectStreamField;
 import java.io.ObjectInputStream.GetField;
 import java.util.Iterator;
-import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
@@ -48,6 +47,7 @@ import jdk.internal.access.SharedSecrets;
 import jdk.internal.misc.ThreadTracker;
 import jdk.internal.misc.VM;
 import sun.net.util.IPAddressUtil;
+import sun.net.util.URLUtil;
 import sun.security.util.SecurityConstants;
 import sun.security.action.GetPropertyAction;
 
@@ -440,7 +440,7 @@ public final class URL implements java.io.Serializable {
             }
         }
 
-        protocol = toLowerCase(protocol);
+        protocol = URLUtil.lowerCaseProtocol(protocol);
         this.protocol = protocol;
         if (host != null) {
 
@@ -633,7 +633,7 @@ public final class URL implements java.io.Serializable {
             for (i = start ; !aRef && (i < limit) &&
                      ((c = spec.charAt(i)) != '/') ; i++) {
                 if (c == ':') {
-                    String s = toLowerCase(spec.substring(start, i));
+                    String s = URLUtil.lowerCaseProtocol(spec.substring(start, i));
                     if (isValidProtocol(s)) {
                         newProtocol = s;
                         start = i + 1;
@@ -1377,18 +1377,6 @@ public final class URL implements java.io.Serializable {
                 });
         } finally {
             endLookup(key);
-        }
-    }
-
-    /**
-     * Returns the protocol in lower case. Special cases known protocols
-     * to avoid loading locale classes during startup.
-     */
-    static String toLowerCase(String protocol) {
-        if (protocol.equals("jrt") || protocol.equals("file") || protocol.equals("jar")) {
-            return protocol;
-        } else {
-            return protocol.toLowerCase(Locale.ROOT);
         }
     }
 

--- a/src/java.base/share/classes/java/net/URLConnection.java
+++ b/src/java.base/share/classes/java/net/URLConnection.java
@@ -43,6 +43,8 @@ import java.util.Map;
 import java.util.List;
 import java.security.Permission;
 import java.security.AccessController;
+
+import sun.net.util.URLUtil;
 import sun.security.util.SecurityConstants;
 import sun.net.www.MessageHeader;
 import sun.security.action.GetPropertyAction;
@@ -1092,7 +1094,7 @@ public abstract class URLConnection {
      * @since 9
      */
     public static void setDefaultUseCaches(String protocol, boolean defaultVal) {
-        protocol = protocol.toLowerCase(Locale.US);
+        protocol = URLUtil.lowerCaseProtocol(protocol);
         defaultCaching.put(protocol, defaultVal);
     }
 
@@ -1108,7 +1110,7 @@ public abstract class URLConnection {
      * @since 9
      */
     public static boolean getDefaultUseCaches(String protocol) {
-        Boolean protoDefault = defaultCaching.get(protocol.toLowerCase(Locale.US));
+        Boolean protoDefault = defaultCaching.get(URLUtil.lowerCaseProtocol(protocol));
         if (protoDefault != null) {
             return protoDefault.booleanValue();
         } else {

--- a/src/java.base/share/classes/sun/net/util/URLUtil.java
+++ b/src/java.base/share/classes/sun/net/util/URLUtil.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLPermission;
 import java.security.Permission;
+import java.util.Locale;
 
 /**
  * URL Utility class.
@@ -50,16 +51,16 @@ public class URLUtil {
         String protocol = url.getProtocol();
         if (protocol != null) {
             /* protocol is compared case-insensitive, so convert to lowercase */
-            protocol = protocol.toLowerCase();
-            strForm.append(protocol);
+            strForm.append(lowerCaseProtocol(protocol));
             strForm.append("://");
         }
 
         String host = url.getHost();
         if (host != null) {
             /* host is compared case-insensitive, so convert to lowercase */
-            host = host.toLowerCase();
-            strForm.append(host);
+            if (!host.isEmpty()) {
+                strForm.append(host.toLowerCase());
+            }
 
             int port = url.getPort();
             if (port == -1) {
@@ -78,6 +79,22 @@ public class URLUtil {
         }
 
         return strForm.toString();
+    }
+
+    /**
+     * Returns the protocol in lower case. Special cases known protocols
+     * to avoid loading locale classes during startup.
+     */
+    public static String lowerCaseProtocol(String protocol) {
+        if (protocol.equals("jrt")) {
+            return "jrt";
+        } else if (protocol.equals("file")) {
+            return "file";
+        } else if (protocol.equals("jar")) {
+            return "jar";
+        } else {
+            return protocol.toLowerCase(Locale.ROOT);
+        }
     }
 
     public static Permission getConnectPermission(URL url) throws IOException {


### PR DESCRIPTION
Move a simple utility method from `URL` to the shared `sun.net.util.URLUtil` class, rename it for clarity and enhance it so that it returns a string literal. This helps reduce dependencies from bootstrap code on `Locale` while improving the performance and allocation pressure in certain applications.  