### PR TITLE
8283093: JMX connections should default to using an ObjectInputFilter

### DIFF
--- a/src/jdk.management.agent/share/conf/management.properties
+++ b/src/jdk.management.agent/share/conf/management.properties
@@ -302,3 +302,5 @@
 #   If the pattern ends with "*", it matches any class with the pattern as a prefix.
 #   If the pattern is equal to the class name, it matches.
 #   Otherwise, the status is UNDECIDED.
+com.sun.management.jmxremote.serial.filter.pattern=java.lang.*;java.math.BigInteger;java.math.BigDecimal;java.util.*;javax.management.openmbean.*;javax.management.ObjectName;java.rmi.MarshalledObject;javax.security.auth.Subject;!*
+

--- a/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
+++ b/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
@@ -306,7 +306,9 @@ public class DefaultAgentFilterTest {
         }
         try {
             // Add custom filter on command-line.
-            testDefaultAgent(null, "-Dcom.sun.management.jmxremote.serial.filter.pattern=\"java.lang.*;java.math.BigInteger;java.math.BigDecimal;java.util.*;javax.management.openmbean.*;javax.management.ObjectName;java.rmi.MarshalledObject;javax.security.auth.Subject;DefaultAgentFilterTest$MyTestObject;!*\"");
+            testDefaultAgent(null, "-Dcom.sun.management.jmxremote.serial.filter.pattern=\"java.lang.*;java.math.BigInteger;"
+                             + "java.math.BigDecimal;java.util.*;javax.management.openmbean.*;javax.management.ObjectName;"
+                             + "java.rmi.MarshalledObject;javax.security.auth.Subject;DefaultAgentFilterTest$MyTestObject;!*\"");
             System.out.println("----\tTest PASSED: with custom filter on command-line");
         } catch (Exception ex) {
             System.out.println(ex);


### PR DESCRIPTION
Set the management.properties  "com.sun.management.jmxremote.serial.filter.pattern" value by default, to restrict types that can be deserialized.

Use the example value from the Core Libraries guide (see section 2. Serialization Filtering / Built-in Filters / Filters for JMX), plus Subject which is needed when using authentication.

The sun/management tests run OK with this change.  The existing test sun/management/jmxremote/startstop/JMXStartStopTest.java will fail if the filter specified is made too restrictive.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8283093](https://bugs.openjdk.org/browse/JDK-8283093): JMX connections should default to using an ObjectInputFilter
 * [JDK-8294716](https://bugs.openjdk.org/browse/JDK-8294716): JMX connections should default to using an ObjectInputFilter (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to [e6940778](https://git.openjdk.org/jdk/pull/10507/files/e6940778a908957f51e966448291d382e5d611e7)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10507/head:pull/10507` \
`$ git checkout pull/10507`

Update a local copy of the PR: \
`$ git checkout pull/10507` \
`$ git pull https://git.openjdk.org/jdk pull/10507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10507`

View PR using the GUI difftool: \
`$ git pr show -t 10507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10507.diff">https://git.openjdk.org/jdk/pull/10507.diff</a>

</details>
