### PR TITLE
8292336: JFR: Warn users if -XX:StartFlightRecording:disk=false is specified with maxage or maxsize

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -139,6 +139,14 @@ final class DCmdStart extends AbstractDCmd {
         }
 
         if (disk != null) {
+            if (!disk) {
+                if (maxAge != null) {
+                    logWarning("Option maxage has no effect with disk=false.");
+                }
+                if (maxSize != null) {
+                    logWarning("Option maxsize has no effect with disk=false.");
+                }
+            }
             recording.setToDisk(disk.booleanValue());
         }
 


### PR DESCRIPTION
Hi,

Could I have a review of PR that adds a warning message if maxage or maxsize is set when disk = false.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292336](https://bugs.openjdk.org/browse/JDK-8292336): JFR: Warn users if -XX:StartFlightRecording:disk=false is specified with maxage or maxsize


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10508/head:pull/10508` \
`$ git checkout pull/10508`

Update a local copy of the PR: \
`$ git checkout pull/10508` \
`$ git pull https://git.openjdk.org/jdk pull/10508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10508`

View PR using the GUI difftool: \
`$ git pr show -t 10508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10508.diff">https://git.openjdk.org/jdk/pull/10508.diff</a>

</details>
