### PR TITLE
8293099: JFR: Typo in TestRemoteDump.java

### DIFF
--- a/test/jdk/jdk/jfr/jmx/streaming/TestRemoteDump.java
+++ b/test/jdk/jdk/jfr/jmx/streaming/TestRemoteDump.java
@@ -119,7 +119,7 @@ public class TestRemoteDump {
             var f1 = service.submit(f);
             var f2 = service.submit(f);
             var f3 = service.submit(f);
-            if (!f1.get() && !f1.get() && !f3.get()) {
+            if (!f1.get() || !f2.get() || !f3.get()) {
                 throw new Exception("Failed to dump multiple recordings simultanously");
             }
             service.shutdown();


### PR DESCRIPTION
Could I have a review of this test fix.

Testing: jdk/jdk/jfr/jmx/TestRemoteDump.java

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293099](https://bugs.openjdk.org/browse/JDK-8293099): JFR: Typo in TestRemoteDump.java


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10509/head:pull/10509` \
`$ git checkout pull/10509`

Update a local copy of the PR: \
`$ git checkout pull/10509` \
`$ git pull https://git.openjdk.org/jdk pull/10509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10509`

View PR using the GUI difftool: \
`$ git pr show -t 10509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10509.diff">https://git.openjdk.org/jdk/pull/10509.diff</a>

</details>
