### PR TITLE
8294671: Remove unused CardValues::last_card

### DIFF
--- a/src/hotspot/share/gc/shared/cardTable.hpp
+++ b/src/hotspot/share/gc/shared/cardTable.hpp
@@ -94,8 +94,7 @@ protected:
     clean_card                  = (CardValue)-1,
 
     dirty_card                  =  0,
-    last_card                   =  1,
-    CT_MR_BS_last_reserved      =  2
+    CT_MR_BS_last_reserved      =  1
   };
 
   // a word's worth (row) of clean card values

--- a/src/hotspot/share/gc/shared/vmStructs_gc.hpp
+++ b/src/hotspot/share/gc/shared/vmStructs_gc.hpp
@@ -234,7 +234,6 @@
   declare_constant(BOTConstants::N_powers)                                  \
                                                                             \
   declare_constant(CardTable::clean_card)                                   \
-  declare_constant(CardTable::last_card)                                    \
   declare_constant(CardTable::dirty_card)                                   \
   declare_constant(CardTable::Precise)                                      \
   declare_constant(CardTable::ObjHeadPreciseArray)                          \


### PR DESCRIPTION
Simple change of removing dead code.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294671](https://bugs.openjdk.org/browse/JDK-8294671): Remove unused CardValues::last_card


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10510/head:pull/10510` \
`$ git checkout pull/10510`

Update a local copy of the PR: \
`$ git checkout pull/10510` \
`$ git pull https://git.openjdk.org/jdk pull/10510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10510`

View PR using the GUI difftool: \
`$ git pr show -t 10510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10510.diff">https://git.openjdk.org/jdk/pull/10510.diff</a>

</details>
