### PR TITLE
8294673: JFR: Add SecurityProviderService#threshold to TestActiveSettingEvent.java

### DIFF
--- a/test/jdk/jdk/jfr/event/runtime/TestActiveSettingEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestActiveSettingEvent.java
@@ -264,6 +264,7 @@ public final class TestActiveSettingEvent {
         settingValues.put(EventNames.VirtualThreadEnd + "#stackTrace", "false");
         settingValues.put(EventNames.VirtualThreadEnd + "#threshold", "0 ns");
         settingValues.put(EventNames.VirtualThreadSubmitFailed + "#threshold", "0 ns");
+        settingValues.put(EventNames.SecurityProviderService + "#threshold", "0 ns");
 
         try (Recording recording = new Recording(c)) {
             Map<Long, EventType> eventTypes = new HashMap<>();


### PR DESCRIPTION
Hi,

Could I have review of a fix that adds "threshold" to TestActiveSettingEvent.java. See explanation in testSettingConfiguration(...) why it is needed. 

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294673](https://bugs.openjdk.org/browse/JDK-8294673): JFR: Add SecurityProviderService#threshold to TestActiveSettingEvent.java


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10511/head:pull/10511` \
`$ git checkout pull/10511`

Update a local copy of the PR: \
`$ git checkout pull/10511` \
`$ git pull https://git.openjdk.org/jdk pull/10511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10511`

View PR using the GUI difftool: \
`$ git pr show -t 10511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10511.diff">https://git.openjdk.org/jdk/pull/10511.diff</a>

</details>
