### PR TITLE
8294676: [JVMCI] InstalledCode.deoptimize(false) should not touch address field

### DIFF
--- a/test/hotspot/jtreg/compiler/jvmci/common/patches/jdk.internal.vm.ci/jdk/vm/ci/hotspot/CompilerToVMHelper.java
+++ b/test/hotspot/jtreg/compiler/jvmci/common/patches/jdk.internal.vm.ci/jdk/vm/ci/hotspot/CompilerToVMHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -243,8 +243,8 @@ public class CompilerToVMHelper {
         CTVM.reprofile((HotSpotResolvedJavaMethodImpl)method);
     }
 
-    public static void invalidateHotSpotNmethod(HotSpotNmethod nmethodMirror) {
-        CTVM.invalidateHotSpotNmethod(nmethodMirror, true);
+    public static void invalidateHotSpotNmethod(HotSpotNmethod nmethodMirror, boolean deoptimize) {
+        CTVM.invalidateHotSpotNmethod(nmethodMirror, deoptimize);
     }
 
     public static long[] collectCounters() {

--- a/test/hotspot/jtreg/compiler/jvmci/errors/TestInvalidCompilationResult.java
+++ b/test/hotspot/jtreg/compiler/jvmci/errors/TestInvalidCompilationResult.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @library /
  * @requires vm.jvmci
  * @modules jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.code
@@ -30,13 +31,13 @@
  *          jdk.internal.vm.ci/jdk.vm.ci.meta
  *          jdk.internal.vm.ci/jdk.vm.ci.runtime
  *          jdk.internal.vm.ci/jdk.vm.ci.common
- * @compile CodeInstallerTest.java
  * @run junit/othervm -da:jdk.vm.ci... -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI
  *                   -XX:-UseJVMCICompiler compiler.jvmci.errors.TestInvalidCompilationResult
  */
 
 package compiler.jvmci.errors;
 
+import compiler.jvmci.common.CodeInstallerTest;
 import jdk.vm.ci.code.StackSlot;
 import jdk.vm.ci.code.site.ConstantReference;
 import jdk.vm.ci.code.site.DataPatch;

--- a/test/hotspot/jtreg/compiler/jvmci/errors/TestInvalidDebugInfo.java
+++ b/test/hotspot/jtreg/compiler/jvmci/errors/TestInvalidDebugInfo.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @library /
  * @requires vm.jvmci
  * @modules jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.code
@@ -30,13 +31,13 @@
  *          jdk.internal.vm.ci/jdk.vm.ci.meta
  *          jdk.internal.vm.ci/jdk.vm.ci.runtime
  *          jdk.internal.vm.ci/jdk.vm.ci.common
- * @compile CodeInstallerTest.java
  * @run junit/othervm -da:jdk.vm.ci... -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI
  *              -XX:-UseJVMCICompiler compiler.jvmci.errors.TestInvalidDebugInfo
  */
 
 package compiler.jvmci.errors;
 
+import compiler.jvmci.common.CodeInstallerTest;
 import jdk.vm.ci.code.Architecture;
 import jdk.vm.ci.code.BytecodeFrame;
 import jdk.vm.ci.code.DebugInfo;

--- a/test/hotspot/jtreg/compiler/jvmci/errors/TestInvalidOopMap.java
+++ b/test/hotspot/jtreg/compiler/jvmci/errors/TestInvalidOopMap.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @library /
  * @requires vm.jvmci
  * @modules jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.code
@@ -30,13 +31,13 @@
  *          jdk.internal.vm.ci/jdk.vm.ci.meta
  *          jdk.internal.vm.ci/jdk.vm.ci.runtime
  *          jdk.internal.vm.ci/jdk.vm.ci.common
- * @compile CodeInstallerTest.java
  * @run junit/othervm -da:jdk.vm.ci... -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI
  *             -XX:-UseJVMCICompiler compiler.jvmci.errors.TestInvalidOopMap
  */
 
 package compiler.jvmci.errors;
 
+import compiler.jvmci.common.CodeInstallerTest;
 import jdk.vm.ci.code.BytecodePosition;
 import jdk.vm.ci.code.DebugInfo;
 import jdk.vm.ci.code.Location;


### PR DESCRIPTION
The ability to make an nmethod non-entrant via an `InstalledCode` object was added by [JDK-8292917](https://bugs.openjdk.org/browse/JDK-8292917). However, the make non-entrant path clears `InstalledCode.address`.
This breaks the connection between an `InstalledCode` object and the nmethod. This makes it impossible to subsequently deoptimize the code via the `InstalledCode` object as shown below:

```
InstalledCode tier1Code = ...;
// Make tier1Code non-entrant (e.g. it is being replaced by a more optimized version, tier2Code)
// but do not deoptimize it as it is still valid. Let current executions of tier1Code complete.
tier1Code.invalidate(false);

...

// Some assumption used in compiling tier1Code is about to be invalidated
// so it must now be deoptimized.
tier1Code.invalidate(true)
```

Prior to this PR, the last statement above does nothing which leads to `tier1Code` incorrectly being executed as soon as the assumption in question is invalidated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294676](https://bugs.openjdk.org/browse/JDK-8294676): [JVMCI] InstalledCode.deoptimize(false) should not touch address field


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10514/head:pull/10514` \
`$ git checkout pull/10514`

Update a local copy of the PR: \
`$ git checkout pull/10514` \
`$ git pull https://git.openjdk.org/jdk pull/10514/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10514`

View PR using the GUI difftool: \
`$ git pr show -t 10514`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10514.diff">https://git.openjdk.org/jdk/pull/10514.diff</a>

</details>
