### PR TITLE
8292879: com/sun/jdi/ClassUnloadEventTest.java failed due to classes not unloading

### DIFF
--- a/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
+++ b/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
@@ -118,7 +118,7 @@ public class ClassUnloadEventTest {
         ClassUnloadCommon.triggerUnloading();
 
         // Do a short delay to make sure all ClassUnloadEvents have been sent
-        // before VMDeathEvent is genareated.
+        // before VMDeathEvent is generated.
         try {
             Thread.sleep(5000);
         } catch (InterruptedException e) {

--- a/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
+++ b/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
@@ -105,10 +105,19 @@ public class ClassUnloadEventTest {
             }
         }
         loader = null;
+
+        // Do a short delay to make sure that the debug agent is done processing all
+        // ClassPrepare events. Otherwise the debug agent might still be holding on to
+        // a reference to a class, which will prevent it from unloading during the GC.
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+        }
+
         // Trigger class unloading
         ClassUnloadCommon.triggerUnloading();
 
-        // Short delay to make sure all ClassUnloadEvents have been sent
+        // Do a short delay to make sure all ClassUnloadEvents have been sent
         // before VMDeathEvent is genareated.
         try {
             Thread.sleep(5000);


### PR DESCRIPTION
The bug is due to the debug agent still having a reference to one of the classes when the full GC is issued by the debuggee, thus keeping the classes loaded. The debug agent it about to free the reference, but doesn't do it quite soon enough, and then it is blocked from freeing it by the full GC. It does free it after the full GC, but by then it is too late, and the full GC has already failed to unload all the classes.

The debug agent class reference is coming from the ClassPrepareEvent that is sent for the last class loaded. The event has been sent to the debugger and the debug agent is about to free the reference, but the debuggee main thread has already resumed and gets to the full GC first. Adding a short delay in the debuggee main thread allows the debug agent to finish freeing the reference before the full GC is done.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292879](https://bugs.openjdk.org/browse/JDK-8292879): com/sun/jdi/ClassUnloadEventTest.java failed due to classes not unloading


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10519/head:pull/10519` \
`$ git checkout pull/10519`

Update a local copy of the PR: \
`$ git checkout pull/10519` \
`$ git pull https://git.openjdk.org/jdk pull/10519/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10519`

View PR using the GUI difftool: \
`$ git pr show -t 10519`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10519.diff">https://git.openjdk.org/jdk/pull/10519.diff</a>

</details>
