### PR TITLE
8294693: Add Collections.shuffle overload that accepts RandomGenerator interface

### DIFF
--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -434,21 +434,12 @@ public class Collections {
 
     /**
      * Randomly permute the specified list using the specified source of
-     * randomness.  All permutations occur with equal likelihood
-     * assuming that the source of randomness is fair.<p>
+     * randomness.<p>
      *
-     * This implementation traverses the list backwards, from the last element
-     * up to the second, repeatedly swapping a randomly selected element into
-     * the "current position".  Elements are randomly selected from the
-     * portion of the list that runs from the first element to the current
-     * position, inclusive.<p>
-     *
-     * This method runs in linear time.  If the specified list does not
-     * implement the {@link RandomAccess} interface and is large, this
-     * implementation dumps the specified list into an array before shuffling
-     * it, and dumps the shuffled array back into the list.  This avoids the
-     * quadratic behavior that would result from shuffling a "sequential
-     * access" list in place.
+     * This method is equivalent to {@link #shuffle(List, RandomGenerator)}
+     * and exists for backward compatibility. The {@link #shuffle(List, RandomGenerator)}
+     * method is preferred, as it is not limited to random generators
+     * that extend the {@link Random} class.
      *
      * @param  list the list to be shuffled.
      * @param  rnd the source of randomness to use to shuffle the list.

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -30,7 +30,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.lang.reflect.Array;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -425,8 +424,13 @@ public class Collections {
      *         its list-iterator does not support the {@code set} operation.
      */
     public static void shuffle(List<?> list) {
-        shuffle(list, (RandomGenerator) ThreadLocalRandom.current());
+        Random rnd = r;
+        if (rnd == null)
+            r = rnd = new Random(); // harmless race.
+        shuffle(list, rnd);
     }
+
+    private static Random r;
 
     /**
      * Randomly permute the specified list using the specified source of

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -412,7 +412,7 @@ public class Collections {
      * portion of the list that runs from the first element to the current
      * position, inclusive.
      *
-     * @implSpec This method runs in linear time.  If the specified list does 
+     * @implSpec This method runs in linear time.  If the specified list does
      * not implement the {@link RandomAccess} interface and is large, this
      * implementation dumps the specified list into an array before shuffling
      * it, and dumps the shuffled array back into the list.  This avoids the
@@ -461,7 +461,7 @@ public class Collections {
      * portion of the list that runs from the first element to the current
      * position, inclusive.<p>
      *
-     * @implSpec This method runs in linear time.  If the specified list does 
+     * @implSpec This method runs in linear time.  If the specified list does
      * not implement the {@link RandomAccess} interface and is large, this
      * implementation dumps the specified list into an array before shuffling
      * it, and dumps the shuffled array back into the list.  This avoids the

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -461,8 +461,8 @@ public class Collections {
      * portion of the list that runs from the first element to the current
      * position, inclusive.<p>
      *
-     * This method runs in linear time.  If the specified list does not
-     * implement the {@link RandomAccess} interface and is large, this
+     * @implSpec This method runs in linear time.  If the specified list does 
+     * not implement the {@link RandomAccess} interface and is large, this
      * implementation dumps the specified list into an array before shuffling
      * it, and dumps the shuffled array back into the list.  This avoids the
      * quadratic behavior that would result from shuffling a "sequential

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -472,7 +472,7 @@ public class Collections {
      * @param  rnd the source of randomness to use to shuffle the list.
      * @throws UnsupportedOperationException if the specified list or its
      *         list-iterator does not support the {@code set} operation.
-     * @since 20
+     * @since 21
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
     public static void shuffle(List<?> list, RandomGenerator rnd) {

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -412,8 +412,8 @@ public class Collections {
      * portion of the list that runs from the first element to the current
      * position, inclusive.
      *
-     * <p>This method runs in linear time.  If the specified list does not
-     * implement the {@link RandomAccess} interface and is large, this
+     * @implSpec This method runs in linear time.  If the specified list does 
+     * not implement the {@link RandomAccess} interface and is large, this
      * implementation dumps the specified list into an array before shuffling
      * it, and dumps the shuffled array back into the list.  This avoids the
      * quadratic behavior that would result from shuffling a "sequential

--- a/test/jdk/java/util/Collections/Shuffle.java
+++ b/test/jdk/java/util/Collections/Shuffle.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug     8294693
+ * @summary Basic test for Collections.shuffle
+ */
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.random.RandomGenerator;
+import java.util.random.RandomGeneratorFactory;
+
+public class Shuffle {
+    static final int N = 100;
+
+    public static void main(String[] args) {
+        test(new ArrayList<>());
+        test(new LinkedList<>());
+    }
+
+    static void test(List<Integer> list) {
+        for (int i = 0; i < N; i++) {
+            list.add(i);
+        }
+        Collections.shuffle(list);
+        if (list.size() != N) {
+            throw new RuntimeException(list.getClass() + ": size " + list.size() + " != " + N);
+        }
+        for (int i = 0; i < N; i++) {
+            if (!list.contains(i)) {
+                throw new RuntimeException(list.getClass() + ": does not contain " + i);
+            }
+        }
+        checkRandom(list);
+        checkRandomGenerator(list);
+    }
+
+    private static void checkRandomGenerator(List<Integer> list) {
+        RandomGeneratorFactory<RandomGenerator> factory = RandomGeneratorFactory.getDefault();
+        list.sort(null);
+        Collections.shuffle(list, factory.create(1));
+        ArrayList<Integer> copy = new ArrayList<>(list);
+        list.sort(null);
+        if (list.equals(copy)) {
+            // Assume that at least one pair of elements must be reordered during shuffle
+            throw new RuntimeException(list.getClass() + ": list is not shuffled");
+        }
+        Collections.shuffle(list, factory.create(1));
+        if (!list.equals(copy)) {
+            throw new RuntimeException(list.getClass() + ": " + list + " != " + copy);
+        }
+    }
+
+    private static void checkRandom(List<Integer> list) {
+        list.sort(null);
+        Collections.shuffle(list, new Random(1));
+        ArrayList<Integer> copy = new ArrayList<>(list);
+        list.sort(null);
+        if (list.equals(copy)) {
+            // Assume that at least one pair of elements must be reordered during shuffle
+            throw new RuntimeException(list.getClass() + ": list is not shuffled");
+        }
+        Collections.shuffle(list, new Random(1));
+        if (!list.equals(copy)) {
+            throw new RuntimeException(list.getClass() + ": " + list + " != " + copy);
+        }
+    }
+}

--- a/test/jdk/java/util/Collections/Shuffle.java
+++ b/test/jdk/java/util/Collections/Shuffle.java
@@ -32,8 +32,8 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
+import java.util.function.Consumer;
 import java.util.random.RandomGenerator;
-import java.util.random.RandomGeneratorFactory;
 
 public class Shuffle {
     static final int N = 100;
@@ -56,36 +56,21 @@ public class Shuffle {
                 throw new RuntimeException(list.getClass() + ": does not contain " + i);
             }
         }
-        checkRandom(list);
-        checkRandomGenerator(list);
+        checkRandom(list, l -> Collections.shuffle(l, new Random(1)));
+        RandomGenerator.JumpableGenerator generator = RandomGenerator.JumpableGenerator.of("Xoshiro256PlusPlus");
+        checkRandom(list, l -> Collections.shuffle(l, generator.copy()));
     }
 
-    private static void checkRandomGenerator(List<Integer> list) {
-        RandomGeneratorFactory<RandomGenerator> factory = RandomGeneratorFactory.getDefault();
+    private static void checkRandom(List<Integer> list, Consumer<List<?>> randomizer) {
         list.sort(null);
-        Collections.shuffle(list, factory.create(1));
+        randomizer.accept(list);
         ArrayList<Integer> copy = new ArrayList<>(list);
         list.sort(null);
         if (list.equals(copy)) {
             // Assume that at least one pair of elements must be reordered during shuffle
             throw new RuntimeException(list.getClass() + ": list is not shuffled");
         }
-        Collections.shuffle(list, factory.create(1));
-        if (!list.equals(copy)) {
-            throw new RuntimeException(list.getClass() + ": " + list + " != " + copy);
-        }
-    }
-
-    private static void checkRandom(List<Integer> list) {
-        list.sort(null);
-        Collections.shuffle(list, new Random(1));
-        ArrayList<Integer> copy = new ArrayList<>(list);
-        list.sort(null);
-        if (list.equals(copy)) {
-            // Assume that at least one pair of elements must be reordered during shuffle
-            throw new RuntimeException(list.getClass() + ": list is not shuffled");
-        }
-        Collections.shuffle(list, new Random(1));
+        randomizer.accept(list);
         if (!list.equals(copy)) {
             throw new RuntimeException(list.getClass() + ": " + list + " != " + copy);
         }

--- a/test/jdk/java/util/Collections/Shuffle.java
+++ b/test/jdk/java/util/Collections/Shuffle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug     8294693
  * @summary Basic test for Collections.shuffle
+ * @key     randomness
  */
 
 import java.util.ArrayList;


### PR DESCRIPTION
Java 17 added RandomGenerator interface. However, existing method Collections.shuffle accepts old java.util.Random class. While since Java 19, it's possible to use Random.from(RandomGenerator) wrapper, it would be more convenient to provide direct overload shuffle(List<?> list, RandomGenerator rnd).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8294694](https://bugs.openjdk.org/browse/JDK-8294694) to be approved

### Issues
 * [JDK-8294693](https://bugs.openjdk.org/browse/JDK-8294693): Add Collections.shuffle overload that accepts RandomGenerator interface
 * [JDK-8294694](https://bugs.openjdk.org/browse/JDK-8294694): Add Collections.shuffle overload that accepts RandomGenerator interface (**CSR**)


### Reviewers
 * [Stuart Marks](https://openjdk.org/census#smarks) (@stuart-marks - **Reviewer**) ⚠️ Review applies to [7b4486f8](https://git.openjdk.org/jdk/pull/10520/files/7b4486f86dfbc1d0ae11ff5c9729acf8c2cf3e72)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10520/head:pull/10520` \
`$ git checkout pull/10520`

Update a local copy of the PR: \
`$ git checkout pull/10520` \
`$ git pull https://git.openjdk.org/jdk pull/10520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10520`

View PR using the GUI difftool: \
`$ git pr show -t 10520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10520.diff">https://git.openjdk.org/jdk/pull/10520.diff</a>

</details>
