### PR TITLE
8294695: Remove redundant deprecation suppression in ThreadGroup

### DIFF
--- a/src/java.base/share/classes/java/lang/ThreadGroup.java
+++ b/src/java.base/share/classes/java/lang/ThreadGroup.java
@@ -375,7 +375,6 @@ public class ThreadGroup implements Thread.UncaughtExceptionHandler {
     public int activeCount() {
         int n = 0;
         for (Thread thread : Thread.getAllThreads()) {
-            @SuppressWarnings("deprecation")
             ThreadGroup g = thread.getThreadGroup();
             if (parentOf(g)) {
                 n++;
@@ -446,7 +445,6 @@ public class ThreadGroup implements Thread.UncaughtExceptionHandler {
         int n = 0;
         if (list.length > 0) {
             for (Thread thread : Thread.getAllThreads()) {
-                @SuppressWarnings("deprecation")
                 ThreadGroup g = thread.getThreadGroup();
                 if (g == this || (recurse && parentOf(g))) {
                     list[n++] = thread;
@@ -582,7 +580,6 @@ public class ThreadGroup implements Thread.UncaughtExceptionHandler {
     public final void interrupt() {
         checkAccess();
         for (Thread thread : Thread.getAllThreads()) {
-            @SuppressWarnings("deprecation")
             ThreadGroup g = thread.getThreadGroup();
             if (parentOf(g)) {
                 thread.interrupt();


### PR DESCRIPTION
This suppression were added with Loom integration, but method `Thread.getThreadGroup()` is not deprecated.
Let's cleanup code a bit.
https://mail.openjdk.org/pipermail/core-libs-dev/2022-September/094907.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294695](https://bugs.openjdk.org/browse/JDK-8294695): Remove redundant deprecation suppression in ThreadGroup


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10521/head:pull/10521` \
`$ git checkout pull/10521`

Update a local copy of the PR: \
`$ git checkout pull/10521` \
`$ git pull https://git.openjdk.org/jdk pull/10521/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10521`

View PR using the GUI difftool: \
`$ git pr show -t 10521`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10521.diff">https://git.openjdk.org/jdk/pull/10521.diff</a>

</details>
