### PR TITLE
8295323: Unnecessary HashTable usage in StyleSheet

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
@@ -1421,7 +1421,7 @@ public class StyleSheet extends StyleContext {
         SearchBuffer sb = SearchBuffer.obtainSearchBuffer();
         @SuppressWarnings("unchecked")
         Vector<SelectorMapping> tempVector = sb.getVector();
-        HashSet<SelectorMapping> tempHashSet = sb.getHashSet();
+        HashSet<SelectorMapping> alreadyChecked = sb.getHashSet();
         // Determine all the Styles that are appropriate, placing them
         // in tempVector
         try {
@@ -1432,7 +1432,7 @@ public class StyleSheet extends StyleContext {
                                                    tagString, false);
             if (childMapping != null) {
                 getStyles(childMapping, tempVector, tags, ids, classes, 1,
-                          numElements, tempHashSet);
+                          numElements, alreadyChecked);
             }
             if (classes[0] != null) {
                 String className = classes[0];
@@ -1440,13 +1440,13 @@ public class StyleSheet extends StyleContext {
                                        tagString + "." + className, false);
                 if (childMapping != null) {
                     getStyles(childMapping, tempVector, tags, ids, classes, 1,
-                              numElements, tempHashSet);
+                              numElements, alreadyChecked);
                 }
                 childMapping = mapping.getChildSelectorMapping(
                                        "." + className, false);
                 if (childMapping != null) {
                     getStyles(childMapping, tempVector, tags, ids, classes,
-                              1, numElements, tempHashSet);
+                              1, numElements, alreadyChecked);
                 }
             }
             if (ids[0] != null) {
@@ -1455,13 +1455,13 @@ public class StyleSheet extends StyleContext {
                                        tagString + "#" + idName, false);
                 if (childMapping != null) {
                     getStyles(childMapping, tempVector, tags, ids, classes,
-                              1, numElements, tempHashSet);
+                              1, numElements, alreadyChecked);
                 }
                 childMapping = mapping.getChildSelectorMapping(
                                        "#" + idName, false);
                 if (childMapping != null) {
                     getStyles(childMapping, tempVector, tags, ids, classes,
-                              1, numElements, tempHashSet);
+                              1, numElements, alreadyChecked);
                 }
             }
             // Create a new Style that will delegate to all the matching

--- a/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
@@ -1359,12 +1359,11 @@ public class StyleSheet extends StyleContext {
                            Vector<SelectorMapping> styles,
                            String[] tags, String[] ids, String[] classes,
                            int index, int numElements,
-                           Hashtable<SelectorMapping, SelectorMapping> alreadyChecked) {
-        // Avoid desending the same mapping twice.
-        if (alreadyChecked.contains(parentMapping)) {
+                           HashSet<SelectorMapping> alreadyChecked) {
+        // Avoid descending the same mapping twice.
+        if (!alreadyChecked.add(parentMapping)) {
             return;
         }
-        alreadyChecked.put(parentMapping, parentMapping);
         Style style = parentMapping.getStyle();
         if (style != null) {
             addSortedStyle(parentMapping, styles);
@@ -1422,8 +1421,7 @@ public class StyleSheet extends StyleContext {
         SearchBuffer sb = SearchBuffer.obtainSearchBuffer();
         @SuppressWarnings("unchecked")
         Vector<SelectorMapping> tempVector = sb.getVector();
-        @SuppressWarnings("unchecked")
-        Hashtable<SelectorMapping, SelectorMapping> tempHashtable = sb.getHashtable();
+        HashSet<SelectorMapping> tempHashSet = sb.getHashSet();
         // Determine all the Styles that are appropriate, placing them
         // in tempVector
         try {
@@ -1434,7 +1432,7 @@ public class StyleSheet extends StyleContext {
                                                    tagString, false);
             if (childMapping != null) {
                 getStyles(childMapping, tempVector, tags, ids, classes, 1,
-                          numElements, tempHashtable);
+                          numElements, tempHashSet);
             }
             if (classes[0] != null) {
                 String className = classes[0];
@@ -1442,13 +1440,13 @@ public class StyleSheet extends StyleContext {
                                        tagString + "." + className, false);
                 if (childMapping != null) {
                     getStyles(childMapping, tempVector, tags, ids, classes, 1,
-                              numElements, tempHashtable);
+                              numElements, tempHashSet);
                 }
                 childMapping = mapping.getChildSelectorMapping(
                                        "." + className, false);
                 if (childMapping != null) {
                     getStyles(childMapping, tempVector, tags, ids, classes,
-                              1, numElements, tempHashtable);
+                              1, numElements, tempHashSet);
                 }
             }
             if (ids[0] != null) {
@@ -1457,13 +1455,13 @@ public class StyleSheet extends StyleContext {
                                        tagString + "#" + idName, false);
                 if (childMapping != null) {
                     getStyles(childMapping, tempVector, tags, ids, classes,
-                              1, numElements, tempHashtable);
+                              1, numElements, tempHashSet);
                 }
                 childMapping = mapping.getChildSelectorMapping(
                                        "#" + idName, false);
                 if (childMapping != null) {
                     getStyles(childMapping, tempVector, tags, ids, classes,
-                              1, numElements, tempHashtable);
+                              1, numElements, tempHashSet);
                 }
             }
             // Create a new Style that will delegate to all the matching
@@ -1754,7 +1752,7 @@ public class StyleSheet extends StyleContext {
         // A set of temporary variables that can be used in whatever way.
         Vector vector = null;
         StringBuffer stringBuffer = null;
-        Hashtable hashtable = null;
+        HashSet<SelectorMapping> hashSet = null;
 
         /**
          * Returns an instance of SearchBuffer. Be sure and issue
@@ -1797,11 +1795,11 @@ public class StyleSheet extends StyleContext {
             return vector;
         }
 
-        Hashtable getHashtable() {
-            if (hashtable == null) {
-                hashtable = new Hashtable();
+        HashSet<SelectorMapping> getHashSet() {
+            if (hashSet == null) {
+                hashSet = new HashSet<>();
             }
-            return hashtable;
+            return hashSet;
         }
 
         void empty() {
@@ -1811,8 +1809,8 @@ public class StyleSheet extends StyleContext {
             if (vector != null) {
                 vector.removeAllElements();
             }
-            if (hashtable != null) {
-                hashtable.clear();
+            if (hashSet != null) {
+                hashSet.clear();
             }
         }
     }


### PR DESCRIPTION
Hashtable was used only from single thread. And only non-null key/values added to it. We can safely replace it with HashSet.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295323](https://bugs.openjdk.org/browse/JDK-8295323): Unnecessary HashTable usage in StyleSheet


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**) ⚠️ Review applies to [ee8cbfd5](https://git.openjdk.org/jdk/pull/10522/files/ee8cbfd58f204b729d57edffa95c3eed11cb7b20)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [ee8cbfd5](https://git.openjdk.org/jdk/pull/10522/files/ee8cbfd58f204b729d57edffa95c3eed11cb7b20)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10522/head:pull/10522` \
`$ git checkout pull/10522`

Update a local copy of the PR: \
`$ git checkout pull/10522` \
`$ git pull https://git.openjdk.org/jdk pull/10522/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10522`

View PR using the GUI difftool: \
`$ git pr show -t 10522`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10522.diff">https://git.openjdk.org/jdk/pull/10522.diff</a>

</details>
