### PR TITLE
8295026: Remove unused fields in StyleSheet

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
@@ -1818,8 +1818,6 @@ public class StyleSheet extends StyleContext {
     }
 
 
-    static final Border noBorder = new EmptyBorder(0,0,0,0);
-
     /**
      * Class to carry out some of the duties of
      * CSS formatting.  Implementations of this
@@ -2519,7 +2517,6 @@ public class StyleSheet extends StyleContext {
         private boolean checkedForStart;
         private int start;
         private CSS.Value type;
-        URL imageurl;
         private StyleSheet ss = null;
         Icon img = null;
         private int bulletgap = 5;
@@ -3222,8 +3219,6 @@ public class StyleSheet extends StyleContext {
 
 
     // ---- Variables ---------------------------------------------
-
-    static final int DEFAULT_FONT_SIZE = 3;
 
     private transient Object fontSizeInherit;
 


### PR DESCRIPTION
There are 3 unused fields in single `StyleSheet` file:
1. `static final Border noBorder = new EmptyBorder(0,0,0,0);`
2. `static final int DEFAULT_FONT_SIZE = 3;`
3. `URL imageurl;` in nested `javax.swing.text.html.StyleSheet.ListPainter` class

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295026](https://bugs.openjdk.org/browse/JDK-8295026): Remove unused fields in StyleSheet


### Reviewers
 * @SWinxy (no known github.com user name / role)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10523/head:pull/10523` \
`$ git checkout pull/10523`

Update a local copy of the PR: \
`$ git checkout pull/10523` \
`$ git pull https://git.openjdk.org/jdk pull/10523/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10523`

View PR using the GUI difftool: \
`$ git pr show -t 10523`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10523.diff">https://git.openjdk.org/jdk/pull/10523.diff</a>

</details>
