### PR TITLE
8294541 - java/io/BufferedInputStream/TransferTo.java fails with OOME

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -507,7 +507,6 @@ java/lang/instrument/RetransformBigClass.sh                     8065756 generic-
 # jdk_io
 
 java/io/pathNames/GeneralWin32.java                             8180264 windows-all
-java/io/BufferedInputStream/TransferTo.java                     8294541 generic-all
 java/io/File/createTempFile/SpecialTempFile.java                8274122 windows11
 java/io/File/GetXSpace.java                                     8291911 windows-all
 

--- a/test/jdk/java/io/BufferedInputStream/TransferTo.java
+++ b/test/jdk/java/io/BufferedInputStream/TransferTo.java
@@ -61,7 +61,7 @@ import static org.testng.Assert.assertTrue;
  * @test
  * @library /test/lib
  * @build jdk.test.lib.RandomFactory
- * @run testng/othervm/timeout=180 -Xmx1g TransferTo
+ * @run testng/othervm/timeout=180 -Xmx1280m TransferTo
  * @bug 8279283 8294541
  * @summary Tests whether java.io.BufferedInputStream.transferTo conforms to the
  *          InputStream.transferTo specification

--- a/test/jdk/java/io/BufferedInputStream/TransferTo.java
+++ b/test/jdk/java/io/BufferedInputStream/TransferTo.java
@@ -61,8 +61,8 @@ import static org.testng.Assert.assertTrue;
  * @test
  * @library /test/lib
  * @build jdk.test.lib.RandomFactory
- * @run testng/othervm/timeout=180 TransferTo
- * @bug 8279283
+ * @run testng/othervm/timeout=180 -Xmx1g TransferTo
+ * @bug 8279283 8294541
  * @summary Tests whether java.io.BufferedInputStream.transferTo conforms to the
  *          InputStream.transferTo specification
  * @key randomness


### PR DESCRIPTION
Fixes 8294541

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294541](https://bugs.openjdk.org/browse/JDK-8294541): java/io/BufferedInputStream/TransferTo.java fails with OOME


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10524/head:pull/10524` \
`$ git checkout pull/10524`

Update a local copy of the PR: \
`$ git checkout pull/10524` \
`$ git pull https://git.openjdk.org/jdk pull/10524/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10524`

View PR using the GUI difftool: \
`$ git pr show -t 10524`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10524.diff">https://git.openjdk.org/jdk/pull/10524.diff</a>

</details>
