### PR TITLE
8294696 - BufferedInputStream.transferTo should drain buffer when mark set

### DIFF
--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -604,7 +604,7 @@ public class BufferedInputStream extends FilterInputStream {
     }
 
     private long implTransferTo(OutputStream out) throws IOException {
-        if (getClass() == BufferedInputStream.class && markpos < 0) {
+        if (getClass() == BufferedInputStream.class && markpos == -1) {
             int avail = count - pos;
             if (avail > 0) {
                 out.write(getBufIfOpen(), pos, avail);

--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -25,6 +25,7 @@
 
 package java.io;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 import jdk.internal.misc.InternalLock;
@@ -608,11 +609,8 @@ public class BufferedInputStream extends FilterInputStream {
             int avail = count - pos;
             if (avail > 0) {
                 byte[] buffer = getBufIfOpen();
-                out.write(buffer, pos, avail);
-                count = 0;
-                pos = 0;
 
-                // Allow GC before reallocating possibly large buffer to prevent OOME
+                // Prevent buffer poisoning (by out.write throwing IOException)
                 byte[] emptyBuffer = new byte[0];
                 if (!U.compareAndSetReference(this, BUF_OFFSET, buffer, emptyBuffer)) {
                     // Can't replace buf if there was an async close.
@@ -622,9 +620,20 @@ public class BufferedInputStream extends FilterInputStream {
                     // assert buf == null;
                     throw new IOException("Stream closed");
                 }
+
+                // Prevent leaking of "confidential" buffer content
+                Arrays.fill(buffer, 0, pos, (byte) 0);
+                Arrays.fill(buffer, count, buffer.length, (byte) 0);
+
+                out.write(buffer, pos, avail);
+                count = 0;
+                pos = 0;
+
+                // Allow GC before reallocating possibly large buffer to prevent OOME
                 int bufferSize = buffer.length;
                 buffer = null;
 
+                // Resizing the buffer to respect user's buffer size choice
                 byte[] nbuf = new byte[bufferSize];
                 if (!U.compareAndSetReference(this, BUF_OFFSET, emptyBuffer, nbuf)) {
                     // Can't replace buf if there was an async close.

--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -604,9 +604,13 @@ public class BufferedInputStream extends FilterInputStream {
     }
 
     private long implTransferTo(OutputStream out) throws IOException {
-        if (getClass() == BufferedInputStream.class
-                && ((count - pos) <= 0) && (markpos == -1)) {
-            return getInIfOpen().transferTo(out);
+        if (getClass() == BufferedInputStream.class && markpos < 0) {
+            int avail = count - pos;
+            if (avail > 0) {
+                out.write(getBufIfOpen(), pos, avail);
+                pos = count;
+            }
+            return avail + getInIfOpen().transferTo(out);
         } else {
             return super.transferTo(out);
         }


### PR DESCRIPTION
This PR implements JDK-8294696.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294696](https://bugs.openjdk.org/browse/JDK-8294696): BufferedInputStream.transferTo should drain buffer when mark set


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10525/head:pull/10525` \
`$ git checkout pull/10525`

Update a local copy of the PR: \
`$ git checkout pull/10525` \
`$ git pull https://git.openjdk.org/jdk pull/10525/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10525`

View PR using the GUI difftool: \
`$ git pr show -t 10525`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10525.diff">https://git.openjdk.org/jdk/pull/10525.diff</a>

</details>
