### PR TITLE
8294698: Remove unused 'checkedExceptions' param from MethodAccessorGenerator.generateMethod()

### DIFF
--- a/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,14 +69,12 @@ class MethodAccessorGenerator extends AccessorGenerator {
                                          String   name,
                                          Class<?>[] parameterTypes,
                                          Class<?>   returnType,
-                                         Class<?>[] checkedExceptions,
                                          int modifiers)
     {
         return (MethodAccessor) generate(declaringClass,
                                          name,
                                          parameterTypes,
                                          returnType,
-                                         checkedExceptions,
                                          modifiers,
                                          false,
                                          false,
@@ -86,14 +84,12 @@ class MethodAccessorGenerator extends AccessorGenerator {
     /** This routine is not thread-safe */
     public ConstructorAccessor generateConstructor(Class<?> declaringClass,
                                                    Class<?>[] parameterTypes,
-                                                   Class<?>[] checkedExceptions,
                                                    int modifiers)
     {
         return (ConstructorAccessor) generate(declaringClass,
                                               "<init>",
                                               parameterTypes,
                                               Void.TYPE,
-                                              checkedExceptions,
                                               modifiers,
                                               true,
                                               false,
@@ -104,7 +100,6 @@ class MethodAccessorGenerator extends AccessorGenerator {
     public SerializationConstructorAccessorImpl
     generateSerializationConstructor(Class<?> declaringClass,
                                      Class<?>[] parameterTypes,
-                                     Class<?>[] checkedExceptions,
                                      int modifiers,
                                      Class<?> targetConstructorClass)
     {
@@ -113,7 +108,6 @@ class MethodAccessorGenerator extends AccessorGenerator {
                      "<init>",
                      parameterTypes,
                      Void.TYPE,
-                     checkedExceptions,
                      modifiers,
                      true,
                      true,
@@ -126,7 +120,6 @@ class MethodAccessorGenerator extends AccessorGenerator {
                                        String name,
                                        Class<?>[] parameterTypes,
                                        Class<?>   returnType,
-                                       Class<?>[] checkedExceptions,
                                        int modifiers,
                                        boolean isConstructor,
                                        boolean forSerialization,

--- a/src/java.base/share/classes/jdk/internal/reflect/NativeConstructorAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/NativeConstructorAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,6 @@ class NativeConstructorAccessorImpl extends ConstructorAccessorImpl {
                     new MethodAccessorGenerator().
                         generateConstructor(c.getDeclaringClass(),
                                             c.getParameterTypes(),
-                                            c.getExceptionTypes(),
                                             c.getModifiers());
                 parent.setDelegate(acc);
             } catch (Throwable t) {

--- a/src/java.base/share/classes/jdk/internal/reflect/NativeMethodAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/NativeMethodAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,6 @@ class NativeMethodAccessorImpl extends MethodAccessorImpl {
                                        method.getName(),
                                        method.getParameterTypes(),
                                        method.getReturnType(),
-                                       method.getExceptionTypes(),
                                        method.getModifiers());
                 parent.setDelegate(acc);
             } catch (Throwable t) {

--- a/src/java.base/share/classes/jdk/internal/reflect/ReflectionFactory.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/ReflectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,7 +177,6 @@ public class ReflectionFactory {
                                 method.getName(),
                                 method.getParameterTypes(),
                                 method.getReturnType(),
-                                method.getExceptionTypes(),
                                 method.getModifiers());
     }
 
@@ -211,7 +210,6 @@ public class ReflectionFactory {
                 return new MethodAccessorGenerator().
                         generateConstructor(c.getDeclaringClass(),
                                             c.getParameterTypes(),
-                                            c.getExceptionTypes(),
                                             c.getModifiers());
             } else {
                 NativeConstructorAccessorImpl acc = new NativeConstructorAccessorImpl(c);
@@ -421,7 +419,6 @@ public class ReflectionFactory {
         ConstructorAccessor acc = new MethodAccessorGenerator().
             generateSerializationConstructor(cl,
                                              constructorToCall.getParameterTypes(),
-                                             constructorToCall.getExceptionTypes(),
                                              constructorToCall.getModifiers(),
                                              constructorToCall.getDeclaringClass());
         Constructor<?> c = newConstructor(constructorToCall.getDeclaringClass(),


### PR DESCRIPTION
`checkedExceptions` param of `MethodAccessorGenerator.generateMethod()` is unused and should be removed in order to prevent allocations from `Method.getExceptionTypes()`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294698](https://bugs.openjdk.org/browse/JDK-8294698): Remove unused 'checkedExceptions' param from MethodAccessorGenerator.generateMethod()


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10526/head:pull/10526` \
`$ git checkout pull/10526`

Update a local copy of the PR: \
`$ git checkout pull/10526` \
`$ git pull https://git.openjdk.org/jdk pull/10526/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10526`

View PR using the GUI difftool: \
`$ git pr show -t 10526`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10526.diff">https://git.openjdk.org/jdk/pull/10526.diff</a>

</details>
