### PR TITLE
8282900: runtime/stringtable/StringTableCleaningTest.java verify unavailable at this moment

### DIFF
--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -47,10 +47,10 @@
 #include "oops/weakHandle.inline.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/handles.inline.hpp"
+#include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/safepointVerifiers.hpp"
 #include "runtime/timerTrace.hpp"
-#include "runtime/interfaceSupport.inline.hpp"
 #include "services/diagnosticCommand.hpp"
 #include "utilities/concurrentHashTable.inline.hpp"
 #include "utilities/concurrentHashTableTasks.inline.hpp"
@@ -605,9 +605,7 @@ class VerifyStrings : StackObj {
 void StringTable::verify() {
   Thread* thr = Thread::current();
   VerifyStrings vs;
-  if (!_local_table->try_scan(thr, vs)) {
-    log_info(stringtable)("verify unavailable at this moment");
-  }
+  _local_table->do_safepoint_scan(vs);
 }
 
 // Verification and comp
@@ -643,9 +641,7 @@ class VerifyCompStrings : StackObj {
 size_t StringTable::verify_and_compare_entries() {
   Thread* thr = Thread::current();
   VerifyCompStrings vcs;
-  if (!_local_table->try_scan(thr, vcs)) {
-    log_info(stringtable)("verify unavailable at this moment");
-  }
+  _local_table->do_scan(thr, vcs);
   return vcs._errors;
 }
 

--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -603,7 +603,6 @@ class VerifyStrings : StackObj {
 
 // This verification is part of Universe::verify() and needs to be quick.
 void StringTable::verify() {
-  Thread* thr = Thread::current();
   VerifyStrings vs;
   _local_table->do_safepoint_scan(vs);
 }


### PR DESCRIPTION
Hi, please consider:

verify() is called by GC in safepoint so it should use the corresponding scanning method.
verify_and_compare_entries() can wait for until there is no resize.

This makes these methods always succeed, passes t1-t6.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282900](https://bugs.openjdk.org/browse/JDK-8282900): runtime/stringtable/StringTableCleaningTest.java verify unavailable at this moment


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [29e957c4](https://git.openjdk.org/jdk/pull/10527/files/29e957c454a36dece6614fa0787841bc53cfdbbb)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10527/head:pull/10527` \
`$ git checkout pull/10527`

Update a local copy of the PR: \
`$ git checkout pull/10527` \
`$ git pull https://git.openjdk.org/jdk pull/10527/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10527`

View PR using the GUI difftool: \
`$ git pr show -t 10527`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10527.diff">https://git.openjdk.org/jdk/pull/10527.diff</a>

</details>
