### PR TITLE
JDK-8294702 - BufferedInputStream uses undefined value range for markpos

### DIFF
--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -543,7 +543,7 @@ public class BufferedInputStream extends FilterInputStream {
 
     private void implReset() throws IOException {
         getBufIfOpen(); // Cause exception if closed
-        if (markpos == -1)
+        if (markpos < 0)
             throw new IOException("Resetting to invalid mark");
         pos = markpos;
     }

--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -223,7 +223,7 @@ public class BufferedInputStream extends FilterInputStream {
      */
     private void fill() throws IOException {
         byte[] buffer = getBufIfOpen();
-        if (markpos < 0)
+        if (markpos == -1)
             pos = 0;            /* no mark: throw away the buffer */
         else if (pos >= buffer.length) { /* no room left in buffer */
             if (markpos > 0) {  /* can throw away early part of the buffer */
@@ -306,7 +306,7 @@ public class BufferedInputStream extends FilterInputStream {
                if there is no mark/reset activity, do not bother to copy the
                bytes into the local buffer.  In this way buffered streams will
                cascade harmlessly. */
-            if (len >= getBufIfOpen().length && markpos < 0) {
+            if (len >= getBufIfOpen().length && markpos == -1) {
                 return getInIfOpen().read(b, off, len);
             }
             fill();
@@ -427,7 +427,7 @@ public class BufferedInputStream extends FilterInputStream {
 
         if (avail <= 0) {
             // If no mark position set then don't keep in buffer
-            if (markpos <0)
+            if (markpos == -1)
                 return getInIfOpen().skip(n);
 
             // Fill in buffer to save bytes for reset
@@ -543,7 +543,7 @@ public class BufferedInputStream extends FilterInputStream {
 
     private void implReset() throws IOException {
         getBufIfOpen(); // Cause exception if closed
-        if (markpos < 0)
+        if (markpos == -1)
             throw new IOException("Resetting to invalid mark");
         pos = markpos;
     }


### PR DESCRIPTION
Fixes JDK-8294702

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294702](https://bugs.openjdk.org/browse/JDK-8294702): BufferedInputStream uses undefined value range for markpos


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [9b8310ad](https://git.openjdk.org/jdk/pull/10528/files/9b8310ad738077d7126f3f025ef88e237f7b09b9)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10528/head:pull/10528` \
`$ git checkout pull/10528`

Update a local copy of the PR: \
`$ git checkout pull/10528` \
`$ git pull https://git.openjdk.org/jdk pull/10528/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10528`

View PR using the GUI difftool: \
`$ git pr show -t 10528`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10528.diff">https://git.openjdk.org/jdk/pull/10528.diff</a>

</details>
