### PR TITLE
8294705: Disable an assertion in test/jdk/java/util/DoubleStreamSums/CompensatedSums.java

### DIFF
--- a/test/jdk/java/util/DoubleStreamSums/CompensatedSums.java
+++ b/test/jdk/java/util/DoubleStreamSums/CompensatedSums.java
@@ -91,7 +91,13 @@ public class CompensatedSums {
         }
 
         Assert.assertTrue(jdkParallelStreamError <= goodParallelStreamError);
-//        Assert.assertTrue(badParallelStreamError >= jdkParallelStreamError);
+        /*
+         * Due to floating-point addition being inherently non-associative,
+         * and due to the unpredictable scheduling of the threads used
+         * in parallel streams, this assertion can fail intermittently,
+         * hence is suppressed for now.
+         */
+        // Assert.assertTrue(badParallelStreamError >= jdkParallelStreamError);
 
         Assert.assertTrue(goodSequentialStreamError >= jdkSequentialStreamError);
         Assert.assertTrue(naive > jdkSequentialStreamError);

--- a/test/jdk/java/util/DoubleStreamSums/CompensatedSums.java
+++ b/test/jdk/java/util/DoubleStreamSums/CompensatedSums.java
@@ -91,7 +91,7 @@ public class CompensatedSums {
         }
 
         Assert.assertTrue(jdkParallelStreamError <= goodParallelStreamError);
-        Assert.assertTrue(badParallelStreamError >= jdkParallelStreamError);
+//        Assert.assertTrue(badParallelStreamError >= jdkParallelStreamError);
 
         Assert.assertTrue(goodSequentialStreamError >= jdkSequentialStreamError);
         Assert.assertTrue(naive > jdkSequentialStreamError);


### PR DESCRIPTION
Disables a specific assertion that causes intermittent failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294705](https://bugs.openjdk.org/browse/JDK-8294705): Disable an assertion in test/jdk/java/util/DoubleStreamSums/CompensatedSums.java


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to [9b7b33fb](https://git.openjdk.org/jdk/pull/10529/files/9b7b33fbce9b128f8c7fe34ffd4cfd7d330eccd7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10529/head:pull/10529` \
`$ git checkout pull/10529`

Update a local copy of the PR: \
`$ git checkout pull/10529` \
`$ git pull https://git.openjdk.org/jdk pull/10529/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10529`

View PR using the GUI difftool: \
`$ git pr show -t 10529`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10529.diff">https://git.openjdk.org/jdk/pull/10529.diff</a>

</details>
