### PR TITLE
JDK-8294564: IGV: IllegalArgumentException for "Difference to current graph"

### DIFF
--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
@@ -40,7 +40,6 @@ import java.io.ObjectOutput;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
-import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.border.Border;
 import org.openide.ErrorManager;

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
@@ -228,62 +228,52 @@ public final class OutlineTopComponent extends TopComponent implements ExplorerM
 
     @Override
     public void changed(InputGraphProvider lastProvider) {
-        // Wait for LookupHistory to be updated with the last active graph
-        // before selecting it.
-        SwingUtilities.invokeLater(() -> {
+        for (GraphNode graphNode : selectedGraphs) {
+            graphNode.setSelected(false);
+        }
+        for (FolderNode folderNode : selectedFolders) {
+            folderNode.setSelected(false);
+        }
+        selectedGraphs = new GraphNode[0];
+        selectedFolders.clear();
+        if (lastProvider != null) {
+            // Try to fetch and select the latest active graph.
+            InputGraph graph = lastProvider.getGraph();
+            if (graph != null) {
+                if (graph.isDiffGraph()) {
+                    EditorTopComponent editor = EditorTopComponent.getActive();
+                    if (editor != null) {
+                        InputGraph firstGraph = editor.getModel().getFirstGraph();
+                        GraphNode firstNode = FolderNode.getGraphNode(firstGraph);
+                        assert firstNode != null;
+                        InputGraph secondGraph = editor.getModel().getSecondGraph();
+                        GraphNode secondNode = FolderNode.getGraphNode(secondGraph);
+                        assert secondNode != null;
+                        selectedGraphs = new GraphNode[]{firstNode, secondNode};
+                    }
+                } else {
+
+                    GraphNode graphNode = FolderNode.getGraphNode(graph);
+                    assert graphNode != null;
+
+                    selectedGraphs = new GraphNode[]{graphNode};
+                }
+            }
+        }
+        try {
             for (GraphNode graphNode : selectedGraphs) {
-                graphNode.setSelected(false);
-            }
-            for (FolderNode folderNode : selectedFolders) {
-                folderNode.setSelected(false);
-            }
-            selectedGraphs = new GraphNode[0];
-            selectedFolders.clear();
-            if (lastProvider != null) {
-                // Try to fetch and select the latest active graph.
-                InputGraph graph = lastProvider.getGraph();
-                if (graph != null) {
-                    if (graph.isDiffGraph()) {
-                        EditorTopComponent editor = EditorTopComponent.getActive();
-                        if (editor != null) {
-                            InputGraph firstGraph = editor.getModel().getFirstGraph();
-                            assert firstGraph != null;
-                            InputGraph secondGraph = editor.getModel().getSecondGraph();
-                            assert secondGraph != null;
-
-
-                            GraphNode firstNode = FolderNode.getGraphNode(firstGraph);
-                            assert firstNode != null;
-
-                            GraphNode secondNode = FolderNode.getGraphNode(firstGraph);
-                            assert secondNode != null;
-
-                            selection = new GraphNode[]{firstNode, secondNode};
-                        }
-                    } else {
-
-                        GraphNode graphNode = FolderNode.getGraphNode(graph);
-                        assert graphNode != null;
-
-                        selection = new GraphNode[]{graphNode};
-                    }
+                Node parentNode = graphNode.getParentNode();
+                if (parentNode instanceof FolderNode) {
+                    FolderNode folderNode = (FolderNode) graphNode.getParentNode();
+                    folderNode.setSelected(true);
+                    selectedFolders.add(folderNode);
                 }
+                graphNode.setSelected(true);
             }
-            try {
-                for (GraphNode graphNode : selectedGraphs) {
-                    Node parentNode = graphNode.getParentNode();
-                    if (parentNode instanceof FolderNode) {
-                        FolderNode folderNode = (FolderNode) graphNode.getParentNode();
-                        folderNode.setSelected(true);
-                        selectedFolders.add(folderNode);
-                    }
-                    graphNode.setSelected(true);
-                }
-                manager.setSelectedNodes(selectedGraphs);
-            } catch (Exception e) {
-                Exceptions.printStackTrace(e);
-            }
-        });
+            manager.setSelectedNodes(selectedGraphs);
+        } catch (Exception e) {
+            Exceptions.printStackTrace(e);
+        }
     }
 
     @Override

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
@@ -245,18 +245,17 @@ public final class OutlineTopComponent extends TopComponent implements ExplorerM
                     if (editor != null) {
                         InputGraph firstGraph = editor.getModel().getFirstGraph();
                         GraphNode firstNode = FolderNode.getGraphNode(firstGraph);
-                        assert firstNode != null;
                         InputGraph secondGraph = editor.getModel().getSecondGraph();
                         GraphNode secondNode = FolderNode.getGraphNode(secondGraph);
-                        assert secondNode != null;
-                        selectedGraphs = new GraphNode[]{firstNode, secondNode};
+                        if (firstNode != null && secondNode != null) {
+                            selectedGraphs = new GraphNode[]{firstNode, secondNode};
+                        }
                     }
                 } else {
-
                     GraphNode graphNode = FolderNode.getGraphNode(graph);
-                    assert graphNode != null;
-
-                    selectedGraphs = new GraphNode[]{graphNode};
+                    if (graphNode != null) {
+                        selectedGraphs = new GraphNode[]{graphNode};
+                    }
                 }
             }
         }

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
@@ -247,11 +247,25 @@ public final class OutlineTopComponent extends TopComponent implements ExplorerM
                         EditorTopComponent editor = EditorTopComponent.getActive();
                         if (editor != null) {
                             InputGraph firstGraph = editor.getModel().getFirstGraph();
+                            assert firstGraph != null;
                             InputGraph secondGraph = editor.getModel().getSecondGraph();
-                            selectedGraphs = new GraphNode[]{FolderNode.getGraphNode(firstGraph), FolderNode.getGraphNode(secondGraph)};
+                            assert secondGraph != null;
+
+
+                            GraphNode firstNode = FolderNode.getGraphNode(firstGraph);
+                            assert firstNode != null;
+
+                            GraphNode secondNode = FolderNode.getGraphNode(firstGraph);
+                            assert secondNode != null;
+
+                            selection = new GraphNode[]{firstNode, secondNode};
                         }
                     } else {
-                        selectedGraphs = new GraphNode[]{FolderNode.getGraphNode(graph)};
+
+                        GraphNode graphNode = FolderNode.getGraphNode(graph);
+                        assert graphNode != null;
+
+                        selection = new GraphNode[]{graphNode};
                     }
                 }
             }

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/DiffGraphCookie.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/DiffGraphCookie.java
@@ -55,7 +55,7 @@ public class DiffGraphCookie implements Node.Cookie {
 
     public boolean isPossible() {
         InputGraph currentGraph = getCurrentGraph();
-        return currentGraph != null && !currentGraph.isDiffGraph();
+        return currentGraph != null && !currentGraph.isDiffGraph() && currentGraph != graph;
     }
 
     public void openDiff() {

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/DiffGraphCookie.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/DiffGraphCookie.java
@@ -28,6 +28,8 @@ import com.sun.hotspot.igv.data.services.GraphViewer;
 import com.sun.hotspot.igv.data.services.InputGraphProvider;
 import com.sun.hotspot.igv.difference.Difference;
 import com.sun.hotspot.igv.util.LookupHistory;
+import com.sun.hotspot.igv.view.EditorTopComponent;
+import com.sun.hotspot.igv.view.GraphViewerImplementation;
 import org.openide.nodes.Node;
 import org.openide.util.Lookup;
 
@@ -37,7 +39,7 @@ import org.openide.util.Lookup;
  */
 public class DiffGraphCookie implements Node.Cookie {
 
-    private InputGraph graph;
+    private final InputGraph graph;
 
     public DiffGraphCookie(InputGraph graph) {
         this.graph = graph;
@@ -59,9 +61,19 @@ public class DiffGraphCookie implements Node.Cookie {
     public void openDiff() {
         InputGraph other = getCurrentGraph();
         final GraphViewer viewer = Lookup.getDefault().lookup(GraphViewer.class);
-        if (viewer != null) {
-            InputGraph diffGraph = Difference.createDiffGraph(other, graph);
-            viewer.view(diffGraph, true);
+        if (viewer != null && other != null) {
+            if (other.getGroup() != graph.getGroup()) {
+                InputGraph diffGraph = Difference.createDiffGraph(other, graph);
+                viewer.view(diffGraph, true);
+            } else {
+                EditorTopComponent etc = GraphViewerImplementation.findEditorForGraph(graph);
+                if (etc != null) {
+                    // TODO: continue here
+                    //etc.getModel().selectGraph(graph);
+                    etc.requestActive();
+                }
+            }
+
         }
     }
 }

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/DiffGraphCookie.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/DiffGraphCookie.java
@@ -52,7 +52,8 @@ public class DiffGraphCookie implements Node.Cookie {
     }
 
     public boolean isPossible() {
-        return getCurrentGraph() != null;
+        InputGraph currentGraph = getCurrentGraph();
+        return currentGraph != null && !currentGraph.isDiffGraph();
     }
 
     public void openDiff() {

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/DiffGraphCookie.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/DiffGraphCookie.java
@@ -62,7 +62,7 @@ public class DiffGraphCookie implements Node.Cookie {
         InputGraph other = getCurrentGraph();
         final GraphViewer viewer = Lookup.getDefault().lookup(GraphViewer.class);
         if (viewer != null && other != null) {
-            viewer.view_difference(other, graph);
+            viewer.viewDifference(other, graph);
         }
     }
 }

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/DiffGraphCookie.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/DiffGraphCookie.java
@@ -62,18 +62,7 @@ public class DiffGraphCookie implements Node.Cookie {
         InputGraph other = getCurrentGraph();
         final GraphViewer viewer = Lookup.getDefault().lookup(GraphViewer.class);
         if (viewer != null && other != null) {
-            if (other.getGroup() != graph.getGroup()) {
-                InputGraph diffGraph = Difference.createDiffGraph(other, graph);
-                viewer.view(diffGraph, true);
-            } else {
-                EditorTopComponent etc = GraphViewerImplementation.findEditorForGraph(graph);
-                if (etc != null) {
-                    // TODO: continue here
-                    //etc.getModel().selectGraph(graph);
-                    etc.requestActive();
-                }
-            }
-
+            viewer.view_difference(other, graph);
         }
     }
 }

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputGraph.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputGraph.java
@@ -39,10 +39,14 @@ public class InputGraph extends Properties.Entity implements FolderElement {
     private List<InputBlockEdge> blockEdges;
     private Map<Integer, InputBlock> nodeToBlock;
     private boolean isDiffGraph;
+    private InputGraph firstGraph, secondGraph;
 
-    public InputGraph(String name, boolean isDiffGraph) {
-        this(name);
-        this.isDiffGraph = isDiffGraph;
+    public InputGraph(InputGraph firstGraph, InputGraph secondGraph ) {
+        this(firstGraph.getName() + " Δ " + secondGraph.getName());
+        assert !firstGraph.isDiffGraph() && !secondGraph.isDiffGraph();
+        this.firstGraph = firstGraph;
+        this.secondGraph = secondGraph;
+        isDiffGraph = true;
     }
 
     public InputGraph(String name) {
@@ -52,11 +56,21 @@ public class InputGraph extends Properties.Entity implements FolderElement {
         blocks = new LinkedHashMap<>();
         blockEdges = new ArrayList<>();
         nodeToBlock = new LinkedHashMap<>();
+        firstGraph = null;
+        secondGraph = null;
         isDiffGraph = false;
     }
 
     public boolean isDiffGraph() {
         return this.isDiffGraph;
+    }
+
+    public InputGraph getFirstGraph() {
+        return firstGraph;
+    }
+
+    public InputGraph getSecondGraph() {
+        return secondGraph;
     }
 
     @Override

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputGraph.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputGraph.java
@@ -39,9 +39,11 @@ public class InputGraph extends Properties.Entity implements FolderElement {
     private List<InputBlockEdge> blockEdges;
     private Map<Integer, InputBlock> nodeToBlock;
     private boolean isDiffGraph;
-    private InputGraph firstGraph, secondGraph;
+    private InputGraph firstGraph;
+    private InputGraph secondGraph;
 
-    public InputGraph(InputGraph firstGraph, InputGraph secondGraph ) {
+
+    public InputGraph(InputGraph firstGraph, InputGraph secondGraph) {
         this(firstGraph.getName() + " Δ " + secondGraph.getName());
         assert !firstGraph.isDiffGraph() && !secondGraph.isDiffGraph();
         this.firstGraph = firstGraph;

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/services/GraphViewer.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/services/GraphViewer.java
@@ -33,5 +33,5 @@ public interface GraphViewer {
 
     void view(InputGraph graph, boolean clone);
 
-    void view_difference(InputGraph firstGraph, InputGraph secondGraph);
+    void viewDifference(InputGraph firstGraph, InputGraph secondGraph);
 }

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/services/GraphViewer.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/services/GraphViewer.java
@@ -31,5 +31,7 @@ import com.sun.hotspot.igv.data.InputGraph;
  */
 public interface GraphViewer {
 
-    public void view(InputGraph graph, boolean clone);
+    void view(InputGraph graph, boolean clone);
+
+    void view_difference(InputGraph firstGraph, InputGraph secondGraph);
 }

--- a/src/utils/IdealGraphVisualizer/Difference/src/main/java/com/sun/hotspot/igv/difference/Difference.java
+++ b/src/utils/IdealGraphVisualizer/Difference/src/main/java/com/sun/hotspot/igv/difference/Difference.java
@@ -105,7 +105,7 @@ public class Difference {
             }
         }
         g.getProperties().setProperty("name", "Difference");
-        InputGraph graph = new InputGraph(a.getName() + ", " + b.getName(), true);
+        InputGraph graph = new InputGraph(a, b);
         g.addElement(graph);
 
         Map<InputBlock, InputBlock> blocksMap = new HashMap<>();

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
@@ -418,15 +418,32 @@ public class DiagramViewModel extends RangeSliderModel implements ChangedListene
         return getFirstGraph();
     }
 
-    public void selectGraph(InputGraph g) {
-        int index = graphs.indexOf(g);
+    public void selectGraph(InputGraph graph) {
+        int index = graphs.indexOf(graph);
         if (index == -1 && hideDuplicates) {
             // A graph was selected that's currently hidden, so unhide and select it.
             setHideDuplicates(false);
-            index = graphs.indexOf(g);
+            index = graphs.indexOf(graph);
         }
         assert index != -1;
         setPositions(index, index);
+    }
+
+    public void selectDiffGraph(InputGraph graph) {
+        int index = graphs.indexOf(graph);
+        if (index == -1 && hideDuplicates) {
+            // A graph was selected that's currently hidden, so unhide and select it.
+            setHideDuplicates(false);
+            index = graphs.indexOf(graph);
+        }
+        assert index != -1;
+        int firstIndex = getFirstPosition();
+        int secondIndex = getSecondPosition();
+        if (firstIndex <= index) {
+            setPositions(firstIndex, index);
+        } else {
+            setPositions(index, secondIndex);
+        }
     }
 
     private static ColorFilter.ColorRule stateColorRule(String state, Color color) {

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
@@ -405,17 +405,30 @@ public class DiagramViewModel extends RangeSliderModel implements ChangedListene
     }
 
     public InputGraph getFirstGraph() {
+        InputGraph firstGraph;
         if (getFirstPosition() < graphs.size()) {
-            return graphs.get(getFirstPosition());
+            firstGraph = graphs.get(getFirstPosition());
+        } else {
+            firstGraph = graphs.get(graphs.size() - 1);
         }
-        return graphs.get(graphs.size() - 1);
+        if (firstGraph.isDiffGraph()) {
+            firstGraph = firstGraph.getFirstGraph();
+        }
+        return firstGraph;
+
     }
 
     public InputGraph getSecondGraph() {
+        InputGraph secondGraph;
         if (getSecondPosition() < graphs.size()) {
-            return graphs.get(getSecondPosition());
+            secondGraph = graphs.get(getSecondPosition());
+        } else {
+            secondGraph = getFirstGraph();
         }
-        return getFirstGraph();
+        if (secondGraph.isDiffGraph()) {
+            secondGraph = secondGraph.getSecondGraph();
+        }
+        return secondGraph;
     }
 
     public void selectGraph(InputGraph graph) {

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
@@ -415,7 +415,6 @@ public class DiagramViewModel extends RangeSliderModel implements ChangedListene
             firstGraph = firstGraph.getFirstGraph();
         }
         return firstGraph;
-
     }
 
     public InputGraph getSecondGraph() {

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorInputGraphProvider.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorInputGraphProvider.java
@@ -37,9 +37,21 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=InputGraphProvider.class)
 public class EditorInputGraphProvider implements InputGraphProvider {
 
-    private final EditorTopComponent editor;
+    private EditorTopComponent editor;
 
     public EditorInputGraphProvider() {
+        editor = null;
+    }
+
+    private boolean hasEditor() {
+        if (editor != null) {
+            return EditorTopComponent.isOpen(editor);
+        } else {
+            return false;
+        }
+    }
+
+    public void close() {
         editor = null;
     }
 
@@ -49,7 +61,7 @@ public class EditorInputGraphProvider implements InputGraphProvider {
 
     @Override
     public InputGraph getGraph() {
-        if (editor != null) {
+        if (hasEditor()) {
             return editor.getModel().getGraphToView();
         } else {
             return null;
@@ -58,14 +70,14 @@ public class EditorInputGraphProvider implements InputGraphProvider {
 
     @Override
     public void setSelectedNodes(Set<InputNode> nodes) {
-        if (editor != null) {
+        if (hasEditor()) {
             editor.setSelectedNodes(nodes);
         }
     }
 
     @Override
     public Iterable<InputGraph> searchBackward() {
-        if (editor != null) {
+        if (hasEditor()) {
             return editor.getModel().getGraphsBackward();
         } else {
             return null;
@@ -74,7 +86,7 @@ public class EditorInputGraphProvider implements InputGraphProvider {
 
     @Override
     public Iterable<InputGraph> searchForward() {
-        if (editor != null) {
+        if (hasEditor()) {
             return editor.getModel().getGraphsForward();
         } else {
             return null;

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorInputGraphProvider.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorInputGraphProvider.java
@@ -42,7 +42,7 @@ public class EditorInputGraphProvider implements InputGraphProvider {
     public EditorInputGraphProvider() {
         editor = null;
     }
-    
+
     public EditorInputGraphProvider(EditorTopComponent editor) {
         this.editor = editor;
     }

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorInputGraphProvider.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorInputGraphProvider.java
@@ -51,10 +51,6 @@ public class EditorInputGraphProvider implements InputGraphProvider {
         }
     }
 
-    public void close() {
-        editor = null;
-    }
-
     public EditorInputGraphProvider(EditorTopComponent editor) {
         this.editor = editor;
     }

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorInputGraphProvider.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorInputGraphProvider.java
@@ -37,27 +37,19 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=InputGraphProvider.class)
 public class EditorInputGraphProvider implements InputGraphProvider {
 
-    private EditorTopComponent editor;
+    private final EditorTopComponent editor;
 
     public EditorInputGraphProvider() {
         editor = null;
     }
-
-    private boolean hasEditor() {
-        if (editor != null) {
-            return EditorTopComponent.isOpen(editor);
-        } else {
-            return false;
-        }
-    }
-
+    
     public EditorInputGraphProvider(EditorTopComponent editor) {
         this.editor = editor;
     }
 
     @Override
     public InputGraph getGraph() {
-        if (hasEditor()) {
+        if (editor != null && EditorTopComponent.isOpen(editor)) {
             return editor.getModel().getGraphToView();
         } else {
             return null;
@@ -66,14 +58,14 @@ public class EditorInputGraphProvider implements InputGraphProvider {
 
     @Override
     public void setSelectedNodes(Set<InputNode> nodes) {
-        if (hasEditor()) {
+        if (editor != null && EditorTopComponent.isOpen(editor)) {
             editor.setSelectedNodes(nodes);
         }
     }
 
     @Override
     public Iterable<InputGraph> searchBackward() {
-        if (hasEditor()) {
+        if (editor != null && EditorTopComponent.isOpen(editor)) {
             return editor.getModel().getGraphsBackward();
         } else {
             return null;
@@ -82,7 +74,7 @@ public class EditorInputGraphProvider implements InputGraphProvider {
 
     @Override
     public Iterable<InputGraph> searchForward() {
-        if (hasEditor()) {
+        if (editor != null && EditorTopComponent.isOpen(editor)) {
             return editor.getModel().getGraphsForward();
         } else {
             return null;

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorTopComponent.java
@@ -283,6 +283,11 @@ public final class EditorTopComponent extends TopComponent {
         scene.setZoomPercentage(percentage);
     }
 
+    public static boolean isOpen(EditorTopComponent editor) {
+        Set<TopComponent> topComponents = getRegistry().getOpened();
+        return topComponents.contains(editor);
+    }
+
     public static EditorTopComponent getActive() {
         TopComponent topComponent = getRegistry().getActivated();
         if (topComponent instanceof EditorTopComponent) {

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorTopComponent.java
@@ -54,7 +54,9 @@ import org.openide.util.actions.Presenter;
 import org.openide.util.lookup.AbstractLookup;
 import org.openide.util.lookup.InstanceContent;
 import org.openide.util.lookup.ProxyLookup;
+import org.openide.windows.Mode;
 import org.openide.windows.TopComponent;
+import org.openide.windows.WindowManager;
 
 
 /**
@@ -284,14 +286,31 @@ public final class EditorTopComponent extends TopComponent {
     }
 
     public static boolean isOpen(EditorTopComponent editor) {
-        Set<TopComponent> topComponents = getRegistry().getOpened();
-        return topComponents.contains(editor);
+        return WindowManager.getDefault().isOpenedEditorTopComponent(editor);
     }
 
     public static EditorTopComponent getActive() {
         TopComponent topComponent = getRegistry().getActivated();
         if (topComponent instanceof EditorTopComponent) {
             return (EditorTopComponent) topComponent;
+        }
+        return null;
+    }
+
+    public static EditorTopComponent findEditorForGraph(InputGraph graph) {
+        WindowManager manager = WindowManager.getDefault();
+        for (Mode m : manager.getModes()) {
+            List<TopComponent> l = new ArrayList<>();
+            l.add(m.getSelectedTopComponent());
+            l.addAll(Arrays.asList(manager.getOpenedTopComponents(m)));
+            for (TopComponent t : l) {
+                if (t instanceof EditorTopComponent) {
+                    EditorTopComponent etc = (EditorTopComponent) t;
+                    if (etc.getModel().getGroup().getGraphs().contains(graph)) {
+                        return etc;
+                    }
+                }
+            }
         }
         return null;
     }

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/GraphViewerImplementation.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/GraphViewerImplementation.java
@@ -28,12 +28,6 @@ import com.sun.hotspot.igv.data.services.GraphViewer;
 import com.sun.hotspot.igv.difference.Difference;
 import com.sun.hotspot.igv.graph.Diagram;
 import com.sun.hotspot.igv.settings.Settings;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import org.openide.windows.Mode;
-import org.openide.windows.TopComponent;
-import org.openide.windows.WindowManager;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
@@ -43,24 +37,6 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=GraphViewer.class)
 public class GraphViewerImplementation implements GraphViewer {
 
-    public static EditorTopComponent findEditorForGraph(InputGraph graph) {
-        WindowManager manager = WindowManager.getDefault();
-        for (Mode m : manager.getModes()) {
-            List<TopComponent> l = new ArrayList<>();
-            l.add(m.getSelectedTopComponent());
-            l.addAll(Arrays.asList(manager.getOpenedTopComponents(m)));
-            for (TopComponent t : l) {
-                if (t instanceof EditorTopComponent) {
-                    EditorTopComponent etc = (EditorTopComponent) t;
-                    if (etc.getModel().getGroup().getGraphs().contains(graph)) {
-                        return etc;
-                    }
-                }
-            }
-        }
-        return null;
-    }
-
     @Override
     public void view_difference(InputGraph firstGraph, InputGraph secondGraph) {
         if (firstGraph.getGroup() != secondGraph.getGroup()) {
@@ -68,7 +44,7 @@ public class GraphViewerImplementation implements GraphViewer {
             view(diffGraph, true);
         } else {
             view(firstGraph, true);
-            EditorTopComponent etc = findEditorForGraph(firstGraph);
+            EditorTopComponent etc = EditorTopComponent.findEditorForGraph(firstGraph);
             if (etc != null) {
                 etc.getModel().selectDiffGraph(secondGraph);
                 etc.requestActive();
@@ -79,7 +55,7 @@ public class GraphViewerImplementation implements GraphViewer {
     @Override
     public void view(InputGraph graph, boolean clone) {
         if (!clone) {
-            EditorTopComponent etc = findEditorForGraph(graph);
+            EditorTopComponent etc = EditorTopComponent.findEditorForGraph(graph);
             if (etc != null) {
                 etc.getModel().selectGraph(graph);
                 etc.requestActive();

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/GraphViewerImplementation.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/GraphViewerImplementation.java
@@ -42,25 +42,32 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=GraphViewer.class)
 public class GraphViewerImplementation implements GraphViewer {
 
-    @Override
-    public void view(InputGraph graph, boolean clone) {
-
-        if (!clone) {
-            WindowManager manager = WindowManager.getDefault();
-            for (Mode m : manager.getModes()) {
-                List<TopComponent> l = new ArrayList<>();
-                l.add(m.getSelectedTopComponent());
-                l.addAll(Arrays.asList(manager.getOpenedTopComponents(m)));
-                for (TopComponent t : l) {
-                    if (t instanceof EditorTopComponent) {
-                        EditorTopComponent etc = (EditorTopComponent) t;
-                        if (etc.getModel().getGroup().getGraphs().contains(graph)) {
-                            etc.getModel().selectGraph(graph);
-                            t.requestActive();
-                            return;
-                        }
+    public static EditorTopComponent findEditorForGraph(InputGraph graph) {
+        WindowManager manager = WindowManager.getDefault();
+        for (Mode m : manager.getModes()) {
+            List<TopComponent> l = new ArrayList<>();
+            l.add(m.getSelectedTopComponent());
+            l.addAll(Arrays.asList(manager.getOpenedTopComponents(m)));
+            for (TopComponent t : l) {
+                if (t instanceof EditorTopComponent) {
+                    EditorTopComponent etc = (EditorTopComponent) t;
+                    if (etc.getModel().getGroup().getGraphs().contains(graph)) {
+                        return etc;
                     }
                 }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void view(InputGraph graph, boolean clone) {
+        if (!clone) {
+            EditorTopComponent etc = findEditorForGraph(graph);
+            if (etc != null) {
+                etc.getModel().selectGraph(graph);
+                etc.requestActive();
+                return;
             }
         }
 

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/GraphViewerImplementation.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/GraphViewerImplementation.java
@@ -38,7 +38,7 @@ import org.openide.util.lookup.ServiceProvider;
 public class GraphViewerImplementation implements GraphViewer {
 
     @Override
-    public void view_difference(InputGraph firstGraph, InputGraph secondGraph) {
+    public void viewDifference(InputGraph firstGraph, InputGraph secondGraph) {
         if (firstGraph.getGroup() != secondGraph.getGroup()) {
             InputGraph diffGraph = Difference.createDiffGraph(firstGraph, secondGraph);
             view(diffGraph, true);

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/GraphViewerImplementation.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/GraphViewerImplementation.java
@@ -25,6 +25,7 @@ package com.sun.hotspot.igv.view;
 
 import com.sun.hotspot.igv.data.InputGraph;
 import com.sun.hotspot.igv.data.services.GraphViewer;
+import com.sun.hotspot.igv.difference.Difference;
 import com.sun.hotspot.igv.graph.Diagram;
 import com.sun.hotspot.igv.settings.Settings;
 import java.util.ArrayList;
@@ -58,6 +59,21 @@ public class GraphViewerImplementation implements GraphViewer {
             }
         }
         return null;
+    }
+
+    @Override
+    public void view_difference(InputGraph firstGraph, InputGraph secondGraph) {
+        if (firstGraph.getGroup() != secondGraph.getGroup()) {
+            InputGraph diffGraph = Difference.createDiffGraph(firstGraph, secondGraph);
+            view(diffGraph, true);
+        } else {
+            view(firstGraph, true);
+            EditorTopComponent etc = findEditorForGraph(firstGraph);
+            if (etc != null) {
+                etc.getModel().selectDiffGraph(secondGraph);
+                etc.requestActive();
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
"Difference to current graph" opens a new window with a difference graph in IGV. Unfortunately, it was throwing a  `java.lang.IllegalArgumentException`

# Overview 
In IGV, for every opened graph, that is not a difference graph, the user can right-click on any other graph in the Outline and select "Difference to current graph". This opens a difference graph showing the difference between the currently opened graph and the selected graph. 
<img width="478" alt="difference to current" src="https://user-images.githubusercontent.com/71546117/193585135-8e93cb2f-6c05-40c4-9b19-7253ce8d6bd8.png">

If the current graph is already a difference graph, the function is disabled. Same if the selected graph is identical to the opened one. 
<img width="508" alt="difference disabled" src="https://user-images.githubusercontent.com/71546117/193585932-4444bb46-7354-4138-81b6-1b11cfad4a8b.png">

# Implementation
The problem was that the difference graph did not keep track of which two `InputGraphs` it was based on. Therefore the functions `getFirstGraph()` and `getSecondGraph` in `DiagramViewModel` did not work properly. Now, `InputGraph` keeps track of the first and second `InputGraph` if it is a difference graph (`isDiffGraph`). And `getFirstGraph()` and `getSecondGraph` are updated to return the right `InputGraph`s for difference graphs. 

---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294564](https://bugs.openjdk.org/browse/JDK-8294564): IGV: IllegalArgumentException for "Difference to current graph"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10533/head:pull/10533` \
`$ git checkout pull/10533`

Update a local copy of the PR: \
`$ git checkout pull/10533` \
`$ git pull https://git.openjdk.org/jdk pull/10533/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10533`

View PR using the GUI difftool: \
`$ git pr show -t 10533`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10533.diff">https://git.openjdk.org/jdk/pull/10533.diff</a>

</details>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294564](https://bugs.openjdk.org/browse/JDK-8294564): IGV: IllegalArgumentException for "Difference to current graph"


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**) ⚠️ Review applies to [c983dc9a](https://git.openjdk.org/jdk/pull/10533/files/c983dc9a248d32721a8abc6e80bf163be38bc27d)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [f5aacd3b](https://git.openjdk.org/jdk/pull/10533/files/f5aacd3b66045bbc4445d61b05af97bc77aa6662)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10533/head:pull/10533` \
`$ git checkout pull/10533`

Update a local copy of the PR: \
`$ git checkout pull/10533` \
`$ git pull https://git.openjdk.org/jdk pull/10533/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10533`

View PR using the GUI difftool: \
`$ git pr show -t 10533`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10533.diff">https://git.openjdk.org/jdk/pull/10533.diff</a>

</details>
