### PR TITLE
8290964: C2 compilation fails with assert "non-reduction loop contains reduction nodes"

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -3901,17 +3901,6 @@ uint IdealLoopTree::est_loop_flow_merge_sz() const {
   return 0;
 }
 
-#ifdef ASSERT
-bool IdealLoopTree::has_reduction_nodes() const {
-  for (uint i = 0; i < _body.size(); i++) {
-    if (_body[i]->is_reduction()) {
-      return true;
-    }
-  }
-  return false;
-}
-#endif // ASSERT
-
 #ifndef PRODUCT
 //------------------------------dump_head--------------------------------------
 // Dump 1 liner for loop header info

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -778,11 +778,6 @@ public:
 
   void remove_main_post_loops(CountedLoopNode *cl, PhaseIdealLoop *phase);
 
-#ifdef ASSERT
-  // Tell whether the body contains nodes marked as reductions.
-  bool has_reduction_nodes() const;
-#endif // ASSERT
-
 #ifndef PRODUCT
   void dump_head() const;       // Dump loop head only
   void dump() const;            // Dump this loop recursively

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2453,11 +2453,6 @@ bool SuperWord::output() {
     return false;
   }
 
-  // Check that the loop to be vectorized does not have inconsistent reduction
-  // information, which would likely lead to a miscompilation.
-  assert(!lpt()->has_reduction_nodes() || cl->is_reduction_loop(),
-         "non-reduction loop contains reduction nodes");
-
 #ifndef PRODUCT
   if (TraceLoopOpts) {
     tty->print("SuperWord::output    ");


### PR DESCRIPTION
This changeset removes the [reduction information consistency assertion](https://github.com/openjdk/jdk/blob/46633e644a8ab94ceb75803bd40739214f8a60e8/src/hotspot/share/opto/superword.cpp#L2458-L2459) in `SuperWord::output()`, which has proven to report too many false positives (inconsistencies that do not lead to miscompilation) since its introduction by [JDK-8279622](https://bugs.openjdk.org/browse/JDK-8279622), despite the efforts to reduce the false positive rate in [JDK-8286177](https://bugs.openjdk.org/browse/JDK-8286177). During the time the assertion has been enabled in our internal CI system, no true positive case (reported inconsistencies actually leading to a miscompilation or a crash) has been observed.

An alternative solution would be to wait for [JDK-8287087](https://bugs.openjdk.org/browse/JDK-8287087) (work in progress), which proposes a refactoring of the reduction analysis logic that eliminates by construction the need for this assertion. This changeset proposes removing the assertion earlier, to reduce noise in test environments.

#### Testing

- hs-tier1 (windows-x64, linux-x64, linux-aarch64, and macosx-x64).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290964](https://bugs.openjdk.org/browse/JDK-8290964): C2 compilation fails with assert "non-reduction loop contains reduction nodes"


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10535/head:pull/10535` \
`$ git checkout pull/10535`

Update a local copy of the PR: \
`$ git checkout pull/10535` \
`$ git pull https://git.openjdk.org/jdk pull/10535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10535`

View PR using the GUI difftool: \
`$ git pr show -t 10535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10535.diff">https://git.openjdk.org/jdk/pull/10535.diff</a>

</details>
