### PR TITLE
8270915: GIFImageReader disregards ignoreMetadata flag which causes memory exhaustion

### DIFF
--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/gif/GIFImageReader.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/gif/GIFImageReader.java
@@ -793,10 +793,10 @@ public class GIFImageReader extends ImageReader {
                                 new byte[len + applicationData.length];
 
                             System.arraycopy(blockData, offset,
-                                data, 0, len);
+                                             data, 0, len);
                             System.arraycopy(applicationData, 0,
-                                data, len,
-                                applicationData.length);
+                                             data, len,
+                                             applicationData.length);
 
                             applicationData = data;
                         }

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/gif/GIFImageReader.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/gif/GIFImageReader.java
@@ -774,27 +774,23 @@ public class GIFImageReader extends ImageReader {
                             offset = copyData(blockData, offset, authCode);
                         } else {
                             stream.skipBytes(blockSize);
-                            offset = blockSize;
                         }
 
                         byte[] applicationData = concatenateBlocks();
 
-                        if (offset < blockSize) {
+                        if (!ignoreMetadata &&
+                            offset < blockSize) {
                             int len = blockSize - offset;
-                            if (!ignoreMetadata) {
-                                byte[] data =
-                                    new byte[len + applicationData.length];
+                            byte[] data =
+                                new byte[len + applicationData.length];
 
-                                System.arraycopy(blockData, offset,
-                                    data, 0, len);
-                                System.arraycopy(applicationData, 0,
-                                    data, len,
-                                    applicationData.length);
+                            System.arraycopy(blockData, offset,
+                                data, 0, len);
+                            System.arraycopy(applicationData, 0,
+                                data, len,
+                                applicationData.length);
 
-                                applicationData = data;
-                            } else {
-                                stream.skipBytes(len);
-                            }
+                            applicationData = data;
                         }
 
                         if (!ignoreMetadata) {

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/gif/GIFImageReader.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/gif/GIFImageReader.java
@@ -651,13 +651,12 @@ public class GIFImageReader extends ImageReader {
         byte[] data = new byte[0];
         while (true) {
             int length = stream.readUnsignedByte();
+            if (length == 0) {
+                break;
+            }
             if (ignoreMetadata) {
                 stream.skipBytes(length);
-                if (length > 0) {
-                    continue;
-                } else {
-                    break;
-                }
+                continue;
             }
             byte[] newData = new byte[data.length + length];
             System.arraycopy(data, 0, newData, 0, data.length);


### PR DESCRIPTION
In https://bugs.openjdk.org/browse/JDK-8270915 we have a valid GIF image which was generated using a third party app, but it contains large amount of Metadata(numerous Application extension blocks).

Also GIFImageReader doesn't use ignoreMetadata flag set by user while reading Metadata which causes heavy memory usage in this scenario. We need to provide support for ignoring metadata in GIFImageReader, so readMetadata() is updated to use the "ignoreMetadata" flag and ignore all blocks except "Image Descriptor" and "Graphics Control Extension".

I have updated readMedata() to also use ReaderUtil.staggeredReadByteStream() where we are allocating upfront memory based on parameters from metadata. Also this PR has small refactoring of import statements.

To replicate the bug we need byte stream with large amount of valid metadata, so i am not able to add regression test case. I have run all javax/imageio jtreg tests and there are no issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270915](https://bugs.openjdk.org/browse/JDK-8270915): GIFImageReader disregards ignoreMetadata flag which causes memory exhaustion


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10536/head:pull/10536` \
`$ git checkout pull/10536`

Update a local copy of the PR: \
`$ git checkout pull/10536` \
`$ git pull https://git.openjdk.org/jdk pull/10536/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10536`

View PR using the GUI difftool: \
`$ git pr show -t 10536`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10536.diff">https://git.openjdk.org/jdk/pull/10536.diff</a>

</details>
