### PR TITLE
8186765: Speed up test sun/net/www/protocol/https/HttpsClient/ProxyAuthTest.java

### DIFF
--- a/test/jdk/sun/net/www/protocol/https/HttpsClient/ProxyAuthTest.java
+++ b/test/jdk/sun/net/www/protocol/https/HttpsClient/ProxyAuthTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/net/www/protocol/https/HttpsClient/ProxyAuthTest.java
+++ b/test/jdk/sun/net/www/protocol/https/HttpsClient/ProxyAuthTest.java
@@ -101,6 +101,17 @@ public class ProxyAuthTest extends SSLSocketTemplate {
     }
 
     @Override
+    protected void doServerSide() throws Exception {
+        if (expectSuccess) {
+            super.doServerSide();
+        } else {
+            // we don't expect anything to connect to the server
+            serverPort = 443;
+            serverCondition.countDown();
+        }
+    }
+
+    @Override
     protected void runServerApplication(SSLSocket socket) throws Exception {
         String response = "Proxy authentication for tunneling succeeded ..";
         DataOutputStream out = new DataOutputStream(socket.getOutputStream());


### PR DESCRIPTION
This PR reduces the execution time of ProxyAuthTest.

Before this change the test always required at least 3 minutes to complete (6x 30 seconds timeout in `SSLSocketTemplate`'s `sslServerSocket.accept()`).
After this change the test does not open a server socket when it is not necessary.

The test continues to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8186765](https://bugs.openjdk.org/browse/JDK-8186765): Speed up test sun/net/www/protocol/https/HttpsClient/ProxyAuthTest.java


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10539/head:pull/10539` \
`$ git checkout pull/10539`

Update a local copy of the PR: \
`$ git checkout pull/10539` \
`$ git pull https://git.openjdk.org/jdk pull/10539/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10539`

View PR using the GUI difftool: \
`$ git pr show -t 10539`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10539.diff">https://git.openjdk.org/jdk/pull/10539.diff</a>

</details>
