### PR TITLE
8294670: Enhanced switch statements have an implicit default which does not complete normally

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -694,7 +694,7 @@ public class Flow {
                     log.error(tree, Errors.NotExhaustiveStatement);
                 }
             }
-            if (!tree.hasUnconditionalPattern) {
+            if (!tree.hasUnconditionalPattern && !exhaustiveSwitch) {
                 alive = Liveness.ALIVE;
             }
             alive = alive.or(resolveBreaks(tree, prevPendingExits));

--- a/test/langtools/tools/javac/patterns/EnumTypeChanges.java
+++ b/test/langtools/tools/javac/patterns/EnumTypeChanges.java
@@ -84,7 +84,6 @@ public class EnumTypeChanges {
             case B -> { return "B"; }
             case EnumTypeChangesEnum x when e == EnumTypeChangesEnum.A -> throw new AssertionError();
         }
-        return "";
     }
 
     String expressionEnumExhaustive(EnumTypeChangesEnum e) {

--- a/test/langtools/tools/javac/patterns/Exhaustiveness.java
+++ b/test/langtools/tools/javac/patterns/Exhaustiveness.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8262891 8268871 8274363 8281100
+ * @bug 8262891 8268871 8274363 8281100 8294670
  * @summary Check exhaustiveness of switches over sealed types.
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -402,7 +402,7 @@ public class Exhaustiveness extends TestRunner {
                    private void test(Object obj) {
                        switch (obj) {
                            case String s: return;
-                       };
+                       }
                    }
                }
                """,
@@ -1010,6 +1010,7 @@ public class Exhaustiveness extends TestRunner {
                """);
     }
 
+    @Test
     public void testNonPrimitiveBooleanGuard(Path base) throws Exception {
         doTest(base,
                new String[0],
@@ -1054,6 +1055,119 @@ public class Exhaustiveness extends TestRunner {
                "- compiler.note.preview.filename: Test.java, DEFAULT",
                "- compiler.note.preview.recompile",
                "2 errors");
+    }
+
+    @Test //JDK-8294670
+    public void testImplicitDefaultCannotCompleteNormally(Path base) throws Exception {
+        doTest(base,
+               new String[0],
+               """
+               package test;
+               public class Test {
+                   sealed interface A {}
+                   final class B implements A {}
+
+                   int test(A arg) {
+                       switch (arg) {
+                           case B b: return 1;
+                       }
+                   }
+               }
+               """);
+        doTest(base,
+               new String[0],
+               """
+               package test;
+               public class Test {
+                   sealed interface A {}
+                   final class B implements A {}
+
+                   int test(A arg) {
+                       switch (arg) {
+                           case B b: return 1;
+                           default: return 1;
+                       }
+                   }
+               }
+               """);
+        doTest(base,
+               new String[0],
+               """
+               package test;
+               public class Test {
+                   sealed interface A {}
+                   final class B implements A {}
+
+                   int test(A arg) {
+                       switch (arg) {
+                           case B b: break;
+                       }
+                   }
+               }
+               """,
+               "Test.java:10:5: compiler.err.missing.ret.stmt",
+               "- compiler.note.preview.filename: Test.java, DEFAULT",
+               "- compiler.note.preview.recompile",
+               "1 error");
+        doTest(base,
+               new String[0],
+               """
+               package test;
+               public class Test {
+                   sealed interface A {}
+                   final class B implements A {}
+
+                   int test(A arg) {
+                       switch (arg) {
+                           case B b: return 1;
+                           default: break;
+                       }
+                   }
+               }
+               """,
+               "Test.java:11:5: compiler.err.missing.ret.stmt",
+               "- compiler.note.preview.filename: Test.java, DEFAULT",
+               "- compiler.note.preview.recompile",
+               "1 error");
+        doTest(base,
+               new String[0],
+               """
+               package test;
+               public class Test {
+                   sealed interface A {}
+                   final class B implements A {}
+
+                   int test(A arg) {
+                       switch (arg) {
+                           case B b:
+                       }
+                   }
+               }
+               """,
+               "Test.java:10:5: compiler.err.missing.ret.stmt",
+               "- compiler.note.preview.filename: Test.java, DEFAULT",
+               "- compiler.note.preview.recompile",
+               "1 error");
+        doTest(base,
+               new String[0],
+               """
+               package test;
+               public class Test {
+                   sealed interface A {}
+                   final class B implements A {}
+
+                   int test(A arg) {
+                       switch (arg) {
+                           case B b: return 1;
+                           default:
+                       }
+                   }
+               }
+               """,
+               "Test.java:11:5: compiler.err.missing.ret.stmt",
+               "- compiler.note.preview.filename: Test.java, DEFAULT",
+               "- compiler.note.preview.recompile",
+               "1 error");
     }
 
     private void doTest(Path base, String[] libraryCode, String testCode, String... expectedErrors) throws IOException {

--- a/test/langtools/tools/javac/switchnull/SwitchNull.java
+++ b/test/langtools/tools/javac/switchnull/SwitchNull.java
@@ -93,7 +93,6 @@ public class SwitchNull {
             case C: return 2;
             case null: return -1;
         }
-        throw new AssertionError(String.valueOf(e));
     }
 
     private int switchEnumWithDefault(E e) {


### PR DESCRIPTION
When a synthetic `default` is generated for enhanced switch, it never completes normally, which should be used when detecting liveness after the switch statement, which is what this patch is trying to do.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294670](https://bugs.openjdk.org/browse/JDK-8294670): Enhanced switch statements have an implicit default which does not complete normally


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10540/head:pull/10540` \
`$ git checkout pull/10540`

Update a local copy of the PR: \
`$ git checkout pull/10540` \
`$ git pull https://git.openjdk.org/jdk pull/10540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10540`

View PR using the GUI difftool: \
`$ git pr show -t 10540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10540.diff">https://git.openjdk.org/jdk/pull/10540.diff</a>

</details>
