### PR TITLE
8294593: Check the size of the target on invocations of BigInteger::isProbablePrime

### DIFF
--- a/src/java.base/share/classes/java/math/BigInteger.java
+++ b/src/java.base/share/classes/java/math/BigInteger.java
@@ -3889,7 +3889,9 @@ public class BigInteger extends Number implements Comparable<BigInteger> {
             return true;
         if (!w.testBit(0) || w.equals(ONE))
             return false;
-
+        if (w.bitLength() > PRIME_SEARCH_BIT_LENGTH_LIMIT + 1) {
+            throw new ArithmeticException("Primality test implementation restriction on bitLength");
+        }
         return w.primeToCertainty(certainty, null);
     }
 

--- a/test/jdk/java/math/BigInteger/PrimeTest.java
+++ b/test/jdk/java/math/BigInteger/PrimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @library /test/lib
  * @build jdk.test.lib.RandomFactory
  * @run main PrimeTest
- * @bug 8026236 8074460 8078672
+ * @bug 8026236 8074460 8078672 8294593
  * @summary test primality verification methods in BigInteger (use -Dseed=X to set PRNG seed)
  * @author bpb
  * @key randomness
@@ -84,6 +84,10 @@ public class PrimeTest {
 
         if (!primeTest || !nonPrimeTest || !mersennePrimeTest) {
             throw new Exception("PrimeTest FAILED!");
+        }
+
+        if (!checkHugeFails()) {
+            throw new Exception("Primality test on huge integer should fail but succeeded");
         }
 
         System.out.println("PrimeTest succeeded!");
@@ -230,4 +234,19 @@ public class PrimeTest {
 
         return result;
     }
+
+    private static boolean checkHugeFails() {
+        try {
+            // huge odd integer
+            BigInteger a = BigInteger.ONE.shiftLeft(500_000_000 + 1)
+                    .setBit(0);
+            a.isProbablePrime(1);
+            // not expected to reach here
+            return false;
+        } catch (ArithmeticException e) {
+            // this is the expected behavior
+            return true;
+        }
+    }
+
 }


### PR DESCRIPTION
Throws an `ArithemticException` when the target is huge.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294593](https://bugs.openjdk.org/browse/JDK-8294593): Check the size of the target on invocations of BigInteger::isProbablePrime


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10541/head:pull/10541` \
`$ git checkout pull/10541`

Update a local copy of the PR: \
`$ git checkout pull/10541` \
`$ git pull https://git.openjdk.org/jdk pull/10541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10541`

View PR using the GUI difftool: \
`$ git pr show -t 10541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10541.diff">https://git.openjdk.org/jdk/pull/10541.diff</a>

</details>
