### PR TITLE
8294734: Redundant override in AES implementation

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/AESCipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/AESCipher.java
@@ -548,22 +548,4 @@ abstract class AESCipher extends CipherSpi {
         return core.unwrap(wrappedKey, wrappedKeyAlgorithm,
                            wrappedKeyType);
     }
-
-    /**
-     * Finalize crypto operation with ByteBuffers
-     *
-     * @param input the input ByteBuffer
-     * @param output the output ByteBuffer
-     *
-     * @return output length
-     * @throws ShortBufferException
-     * @throws IllegalBlockSizeException
-     * @throws BadPaddingException
-     */
-    @Override
-    protected int engineDoFinal(ByteBuffer input, ByteBuffer output)
-        throws ShortBufferException, IllegalBlockSizeException,
-        BadPaddingException {
-        return super.engineDoFinal(input, output);
-    }
 }


### PR DESCRIPTION
Hi,

May I have this simple code clean-up patch reviewed?

In the AES cipher implementation, the override of engineDoFinal() method in the following code is not necessary as it only calls super.  The throws descriptions are missed in the method description.  It may be better to remove this override implementation, rather than fix the method description.

```
    /**
     * Finalize crypto operation with ByteBuffers
     *
     * @param input the input ByteBuffer
     * @param output the output ByteBuffer
     *
     * @return output length
     * @throws ShortBufferException
     * @throws IllegalBlockSizeException
     * @throws BadPaddingException
     */
    protected int engineDoFinal(ByteBuffer input, ByteBuffer output)
        throws ShortBufferException, IllegalBlockSizeException,
        BadPaddingException {
        return super.engineDoFinal(input, output);
    }

``` 

Code clean-up, not new regression test added.

Thanks,
Xuelei

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294734](https://bugs.openjdk.org/browse/JDK-8294734): Redundant override in AES implementation


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)
 * [Bradford Wetmore](https://openjdk.org/census#wetmore) (@bradfordwetmore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10545/head:pull/10545` \
`$ git checkout pull/10545`

Update a local copy of the PR: \
`$ git checkout pull/10545` \
`$ git pull https://git.openjdk.org/jdk pull/10545/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10545`

View PR using the GUI difftool: \
`$ git pr show -t 10545`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10545.diff">https://git.openjdk.org/jdk/pull/10545.diff</a>

</details>
