### PR TITLE
8294740: Add cgroups keyword to TestDockerBasic.java

### DIFF
--- a/test/jdk/jdk/internal/platform/docker/TestDockerBasic.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerBasic.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8293540
  * @summary Verify that -XshowSettings:system works
+ * @key cgroups
  * @requires docker.support
  * @library /test/lib
  * @run main/timeout=360 TestDockerBasic


### PR DESCRIPTION
Please review this trivial fix.  TestDockerBasic.java uses cgroups features so it should be tagged with `@key cgroups`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294740](https://bugs.openjdk.org/browse/JDK-8294740): Add cgroups keyword to TestDockerBasic.java


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.org/census#mseledtsov) (@mseledts - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10547/head:pull/10547` \
`$ git checkout pull/10547`

Update a local copy of the PR: \
`$ git checkout pull/10547` \
`$ git pull https://git.openjdk.org/jdk pull/10547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10547`

View PR using the GUI difftool: \
`$ git pr show -t 10547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10547.diff">https://git.openjdk.org/jdk/pull/10547.diff</a>

</details>
