### PR TITLE
8292975: javac produces code that crashes with LambdaConversionException

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -2309,7 +2309,8 @@ public class LambdaToMethod extends TreeTranslator {
                 List<Type> tl = tree.getDescriptorType(types).getParameterTypes();
                 for (; tl.nonEmpty(); tl = tl.tail) {
                     Type pt = tl.head;
-                    return isIntersectionOrUnionType(pt);
+                    if (isIntersectionOrUnionType(pt))
+                        return true;
                 }
                 return false;
             }

--- a/test/langtools/tools/javac/lambda/methodReference/IntersectionParameterTypeTest.java
+++ b/test/langtools/tools/javac/lambda/methodReference/IntersectionParameterTypeTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8292975
+ * @summary Javac produces code that crashes with LambdaConversionException
+ * @run main IntersectionParameterTypeTest
+ */
+
+import java.util.function.BiFunction;
+
+public class IntersectionParameterTypeTest {
+
+    sealed interface Term {
+        record Lit() implements Term {}
+        record Lam(String x, Term a) implements Term {}
+    }
+
+    public static <U, T> void call(BiFunction<U, T, T> op, U x, T t) {
+      op.apply(x, t);
+    }
+
+    public static void main(String[] args) {
+      // this code works
+      call(Term.Lam::new, "x", (Term) new Term.Lit());
+
+      // this does not
+      call(Term.Lam::new, "x", new Term.Lit());
+  }
+}

--- a/test/langtools/tools/javac/lambda/methodReference/IntersectionParameterTypeTest2.java
+++ b/test/langtools/tools/javac/lambda/methodReference/IntersectionParameterTypeTest2.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8269983
+ * @summary BootstrapMethodError with method reference and intersection type
+ * @run main IntersectionParameterTypeTest2
+ */
+
+public class IntersectionParameterTypeTest2 {
+
+    public static void main(String[] args) {
+        f();
+    }
+
+    static <T extends Comparable<T> & G> C<T> f() {
+        return new C<>(Q::g);
+    }
+
+    public interface G {}
+
+    private interface E<T> {
+        void g(Q g, T value);
+    }
+
+    static class C<T extends Comparable<?>> {
+        C(E<T> g) {}
+    }
+
+    static class Q {
+        void g(G g) {}
+    }
+}


### PR DESCRIPTION
Ensure that when functional interface parameters involve intersection types,
    we fold the method reference to a lambda expression to work around
    limitations/constraints in lambda meta factory.

    Also fixes JDK-8269983

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8292975](https://bugs.openjdk.org/browse/JDK-8292975): javac produces code that crashes with LambdaConversionException
 * [JDK-8269983](https://bugs.openjdk.org/browse/JDK-8269983): BootstrapMethodError with method reference and intersection type


### Reviewers
 * [Dan Smith](https://openjdk.org/census#dlsmith) (@dansmithcode - Committer)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10548/head:pull/10548` \
`$ git checkout pull/10548`

Update a local copy of the PR: \
`$ git checkout pull/10548` \
`$ git pull https://git.openjdk.org/jdk pull/10548/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10548`

View PR using the GUI difftool: \
`$ git pr show -t 10548`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10548.diff">https://git.openjdk.org/jdk/pull/10548.diff</a>

</details>
