### PR TITLE
8252075: Documentation error in LayoutManager2 interface

### DIFF
--- a/src/java.desktop/share/classes/java/awt/LayoutManager2.java
+++ b/src/java.desktop/share/classes/java/awt/LayoutManager2.java
@@ -33,7 +33,7 @@ package java.awt;
  * components should be added to the layout.
  * <p>
  * This minimal extension to {@code LayoutManager} is intended for tool
- * providers who wish to the creation of constraint-based layouts.
+ * providers who wish to create constraint-based layouts.
  * It does not yet provide full, general support for custom
  * constraint-based layout managers.
  *

--- a/src/java.desktop/share/classes/java/awt/LayoutManager2.java
+++ b/src/java.desktop/share/classes/java/awt/LayoutManager2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,14 +25,14 @@
 package java.awt;
 
 /**
- * Defines an interface for classes that know how to layout Containers
+ * Defines an interface for classes that know how to layout {@code Container}s
  * based on a layout constraints object.
  *
- * This interface extends the LayoutManager interface to deal with layouts
+ * This interface extends the {@code LayoutManager} interface to deal with layouts
  * explicitly in terms of constraint objects that specify how and where
  * components should be added to the layout.
  * <p>
- * This minimal extension to LayoutManager is intended for tool
+ * This minimal extension to {@code LayoutManager} is intended for tool
  * providers who wish to the creation of constraint-based layouts.
  * It does not yet provide full, general support for custom
  * constraint-based layout managers.


### PR DESCRIPTION
Updated the documentation with proper meaningful message for better understanding.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8252075](https://bugs.openjdk.org/browse/JDK-8252075): Documentation error in LayoutManager2 interface


### Reviewers
 * @SWinxy (no known github.com user name / role) ⚠️ Review applies to [e7986971](https://git.openjdk.org/jdk/pull/10549/files/e7986971d30ddc774f2461027ae3758bf3594a0b)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10549/head:pull/10549` \
`$ git checkout pull/10549`

Update a local copy of the PR: \
`$ git checkout pull/10549` \
`$ git pull https://git.openjdk.org/jdk pull/10549/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10549`

View PR using the GUI difftool: \
`$ git pr show -t 10549`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10549.diff">https://git.openjdk.org/jdk/pull/10549.diff</a>

</details>
