### PR TITLE
8294752: G1: Remove redundant checks in check_obj_during_refinement

### DIFF
--- a/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
@@ -117,14 +117,9 @@ inline static void check_obj_during_refinement(T* p, oop const obj) {
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
   // can't do because of races
   // assert(oopDesc::is_oop_or_null(obj), "expected an oop");
-  assert(is_object_aligned(obj), "oop must be aligned");
-  assert(g1h->is_in_reserved(obj), "oop must be in reserved");
-
-  HeapRegion* from = g1h->heap_region_containing(p);
-
-  assert(from->is_in_reserved(p) || from->is_humongous(),
-         "p " PTR_FORMAT " is not in the same region %u or part of the correct humongous object starting at region %u.",
-         p2i(p), from->hrm_index(), from->humongous_start_region()->hrm_index());
+  assert(is_object_aligned(obj), "obj must be aligned");
+  assert(g1h->is_in(obj), "invariant");
+  assert(g1h->is_in(p), "invariant");
 #endif // ASSERT
 }
 

--- a/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
@@ -122,10 +122,7 @@ inline static void check_obj_during_refinement(T* p, oop const obj) {
 
   HeapRegion* from = g1h->heap_region_containing(p);
 
-  assert(from->is_in_reserved(p) ||
-         (from->is_humongous() &&
-          g1h->heap_region_containing(p)->is_humongous() &&
-          from->humongous_start_region() == g1h->heap_region_containing(p)->humongous_start_region()),
+  assert(from->is_in_reserved(p) || from->is_humongous(),
          "p " PTR_FORMAT " is not in the same region %u or part of the correct humongous object starting at region %u.",
          p2i(p), from->hrm_index(), from->humongous_start_region()->hrm_index());
 #endif // ASSERT


### PR DESCRIPTION
Simple change of removing redundant assertions.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294752](https://bugs.openjdk.org/browse/JDK-8294752): G1: Remove redundant checks in check_obj_during_refinement


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10551/head:pull/10551` \
`$ git checkout pull/10551`

Update a local copy of the PR: \
`$ git checkout pull/10551` \
`$ git pull https://git.openjdk.org/jdk pull/10551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10551`

View PR using the GUI difftool: \
`$ git pr show -t 10551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10551.diff">https://git.openjdk.org/jdk/pull/10551.diff</a>

</details>
