### PR TITLE
8294758: JFR: Docs build fails after changes to RecordedObject and Timespan

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/Timespan.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Timespan.java
@@ -33,7 +33,7 @@ import java.lang.annotation.Target;
 /**
  * Event field annotation, specifies that the value is a duration.
  * <p>
- * If the annotated value equals {@code Long.MAX_VALUE), it represents forever.
+ * If the annotated value equals {@code Long.MAX_VALUE}, it represents forever.
  *
  * @since 9
  */

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
@@ -758,7 +758,7 @@ public sealed class RecordedObject
      * <p>
      * If the committed event value was {@code Long.MAX_VALUE},
      * regardless of the unit set by {@code @Timespan}, this method returns
-     * {@link ChronoUnit.FOREVER.getDuration()}.
+     * {@link ChronoUnit#FOREVER}.
      * <p>
      * It's possible to index into a nested object using {@code "."} (for example,
      * {@code "aaa.bbb"}).


### PR DESCRIPTION
Hi,

Could I have a review of a change that fixes a docs build failure after JDK-8294242.

Testing: build docs

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294758](https://bugs.openjdk.org/browse/JDK-8294758): JFR: Docs build fails after changes to RecordedObject and Timespan


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10555/head:pull/10555` \
`$ git checkout pull/10555`

Update a local copy of the PR: \
`$ git checkout pull/10555` \
`$ git pull https://git.openjdk.org/jdk pull/10555/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10555`

View PR using the GUI difftool: \
`$ git pr show -t 10555`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10555.diff">https://git.openjdk.org/jdk/pull/10555.diff</a>

</details>
