### PR TITLE
8294759: Print actual lock/monitor ranking

### DIFF
--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -427,7 +427,9 @@ void print_lock_ranks(outputStream* st) {
   st->print_cr("VM Mutex/Monitor ranks: ");
 
 #ifdef ASSERT
-  // Defensively figure out the lower/higher bounds on ranks.
+  // Be extra defensive and figure out the bounds on
+  // ranks right here. This also saves a bit of time
+  // in the #ranks*#mutexes loop below.
   int min_rank = INT_MAX;
   int max_rank = INT_MIN;
   for (int i = 0; i < _num_mutex; i++) {
@@ -437,7 +439,7 @@ void print_lock_ranks(outputStream* st) {
     if (max_rank < r) max_rank = r;
   }
 
-  // Print the listings rank-by-rank
+  // Print the listings rank by rank
   for (int r = min_rank; r <= max_rank; r++) {
     bool first = true;
     for (int i = 0; i < _num_mutex; i++) {

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -427,20 +427,21 @@ void print_lock_ranks(outputStream* st) {
   st->print_cr("VM Mutex/Monitor ranks: ");
 
 #ifdef ASSERT
+  // Defensively figure out the lower/higher bounds on ranks.
   int min_rank = INT_MAX;
   int max_rank = INT_MIN;
-
   for (int i = 0; i < _num_mutex; i++) {
-    Mutex *m = _mutex_array[i];
+    Mutex* m = _mutex_array[i];
     int r = (int) m->rank();
     if (min_rank > r) min_rank = r;
     if (max_rank < r) max_rank = r;
   }
 
+  // Print the listings rank-by-rank
   for (int r = min_rank; r <= max_rank; r++) {
     bool first = true;
     for (int i = 0; i < _num_mutex; i++) {
-      Mutex *m = _mutex_array[i];
+      Mutex* m = _mutex_array[i];
       if (r != (int) m->rank()) continue;
 
       if (first) {

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -24,6 +24,9 @@
 
 #include "precompiled.hpp"
 #include "gc/shared/gc_globals.hpp"
+#include "logging/log.hpp"
+#include "logging/logStream.hpp"
+#include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/mutexLocker.hpp"
@@ -380,6 +383,16 @@ void mutex_init() {
 #endif
 }
 
+void MutexLocker::post_initialize() {
+  // Print mutex ranks if requested.
+  LogTarget(Info, vmmutex) lt;
+  if (lt.is_enabled()) {
+    ResourceMark rm;
+    LogStream ls(lt);
+    print_lock_ranks(&ls);
+  }
+}
+
 GCMutexLocker::GCMutexLocker(Mutex* mutex) {
   if (SafepointSynchronize::is_at_safepoint()) {
     _locked = false;
@@ -408,4 +421,37 @@ void print_owned_locks_on_error(outputStream* st) {
      }
   }
   if (none) st->print_cr("None");
+}
+
+void print_lock_ranks(outputStream* st) {
+  st->print_cr("VM Mutex/Monitor ranks: ");
+
+#ifdef ASSERT
+  int min_rank = INT_MAX;
+  int max_rank = INT_MIN;
+
+  for (int i = 0; i < _num_mutex; i++) {
+    Mutex *m = _mutex_array[i];
+    int r = (int) m->rank();
+    if (min_rank > r) min_rank = r;
+    if (max_rank < r) max_rank = r;
+  }
+
+  for (int r = min_rank; r <= max_rank; r++) {
+    bool first = true;
+    for (int i = 0; i < _num_mutex; i++) {
+      Mutex *m = _mutex_array[i];
+      if (r != (int) m->rank()) continue;
+
+      if (first) {
+        st->cr();
+        st->print_cr("Rank \"%s\":", m->rank_name());
+        first = false;
+      }
+      st->print_cr("  %s", m->name());
+    }
+  }
+#else
+  st->print_cr("  Only known in debug builds.");
+#endif // ASSERT
 }

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -175,6 +175,7 @@ extern Mutex* tty_lock;                          // lock to synchronize output.
 // Print all mutexes/monitors that are currently owned by a thread; called
 // by fatal error handler.
 void print_owned_locks_on_error(outputStream* st);
+void print_lock_ranks(outputStream* st);
 
 char *lock_name(Mutex *mutex);
 
@@ -225,6 +226,8 @@ class MutexLocker: public StackObj {
       _mutex->unlock();
     }
   }
+
+  static void post_initialize();
 };
 
 // A MonitorLocker is like a MutexLocker above, except it allows

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -647,6 +647,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
 
   LogConfiguration::post_initialize();
   Metaspace::post_initialize();
+  MutexLocker::post_initialize();
 
   HOTSPOT_VM_INIT_END();
 

--- a/test/hotspot/jtreg/runtime/logging/MutexRankTest.java
+++ b/test/hotspot/jtreg/runtime/logging/MutexRankTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8294759
+ * @summary Verify mutex rank logging works
+ * @requires vm.flagless
+ * @library /test/lib
+ * @run driver MutexRankTest
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.Platform;
+
+public class MutexRankTest {
+    public static void main(String[] args) throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xlog:vmmutex",
+                                                                  "-version");
+        OutputAnalyzer oa = new OutputAnalyzer(pb.start());
+        oa.shouldContain("VM Mutex/Monitor ranks:");
+        if (Platform.isDebugBuild()) {
+            oa.shouldContain("Rank \"safepoint\"");
+            oa.shouldContain("Heap_lock");
+        } else {
+            oa.shouldContain("Only known in debug builds");
+        }
+        oa.shouldHaveExitValue(0);
+    }
+}


### PR DESCRIPTION
When relative lock ranks are changing, it is useful to see what are the final lock ranks are. It can be dumped as optional logging shortly after VM startup. 

Sample output:

```
$ build/linux-x86_64-server-fastdebug/images/jdk/bin/java -Xlog:vmmutex
[0.073s][info][vmmutex] VM Mutex/Monitor ranks: 
[0.073s][info][vmmutex] 
[0.073s][info][vmmutex] Rank "service-2":
[0.073s][info][vmmutex]   Uncommit_lock
[0.073s][info][vmmutex] 
[0.073s][info][vmmutex] Rank "service-1":
[0.073s][info][vmmutex]   FreeList_lock
[0.073s][info][vmmutex]   MonitoringSupport_lock
[0.073s][info][vmmutex] 
[0.073s][info][vmmutex] Rank "service":
[0.073s][info][vmmutex]   Service_lock
[0.073s][info][vmmutex]   Notification_lock
[0.073s][info][vmmutex] 
[0.073s][info][vmmutex] Rank "stackwatermark-1":
[0.073s][info][vmmutex]   JfrStacktrace_lock
[0.073s][info][vmmutex] 
[0.073s][info][vmmutex] Rank "tty-1":
[0.073s][info][vmmutex]   SharedDecoder_lock
[0.073s][info][vmmutex] 
[0.073s][info][vmmutex] Rank "tty":
[0.073s][info][vmmutex]   tty_lock
[0.073s][info][vmmutex] 
[0.073s][info][vmmutex] Rank "nosafepoint-3":
[0.073s][info][vmmutex]   Metaspace_lock
[0.073s][info][vmmutex]   JfrMsg_lock
[0.073s][info][vmmutex]   ContinuationRelativize_lock
[0.073s][info][vmmutex]   ThreadsSMRDelete_lock
[0.073s][info][vmmutex]   CompiledMethod_lock
[0.073s][info][vmmutex] 
[0.073s][info][vmmutex] Rank "nosafepoint-2":
[0.073s][info][vmmutex]   G1DetachedRefinementStats_lock
[0.073s][info][vmmutex]   JmethodIdCreation_lock
[0.073s][info][vmmutex]   CodeCache_lock
[0.073s][info][vmmutex] 
[0.073s][info][vmmutex] Rank "nosafepoint-1":
[0.073s][info][vmmutex]   RootRegionScan_lock
[0.073s][info][vmmutex]   RawMonitor_lock
[0.073s][info][vmmutex]   MetaspaceCritical_lock
[0.073s][info][vmmutex]   NonJavaThreadsList_lock
[0.073s][info][vmmutex]   Zip_lock
[0.073s][info][vmmutex]   InlineCacheBuffer_lock
[0.073s][info][vmmutex]   VtableStubs_lock
[0.073s][info][vmmutex] 
[0.073s][info][vmmutex] Rank "nosafepoint":
[0.073s][info][vmmutex]   STS_lock
[0.073s][info][vmmutex]   CGC_lock
[0.073s][info][vmmutex]   OldSets_lock
[0.073s][info][vmmutex]   MarkStackFreeList_lock
[0.073s][info][vmmutex]   MarkStackChunkList_lock
[0.073s][info][vmmutex]   StringDedup_lock
[0.073s][info][vmmutex]   StringDedupIntern_lock
[0.073s][info][vmmutex]   Patching_lock
[0.073s][info][vmmutex]   MonitorDeflation_lock
[0.073s][info][vmmutex]   SymbolArena_lock
[0.073s][info][vmmutex]   NonJavaThreadsListSync_lock
[0.073s][info][vmmutex]   InitCompleted_lock
[0.073s][info][vmmutex]   CompiledIC_lock
[0.073s][info][vmmutex]   DirectivesStack_lock
[0.073s][info][vmmutex]   EscapeBarrier_lock
[0.073s][info][vmmutex]   JvmtiVTMSTransition_lock
[0.073s][info][vmmutex]   JfrBuffer_lock
[0.073s][info][vmmutex]   JfrThreadSampler_lock
[0.073s][info][vmmutex]   DCmdFactory_lock
[0.073s][info][vmmutex]   DumpTimeTable_lock
[0.073s][info][vmmutex]   CDSLambda_lock
[0.073s][info][vmmutex]   DumpRegion_lock
[0.073s][info][vmmutex]   ClassListFile_lock
[0.073s][info][vmmutex]   Bootclasspath_lock
[0.073s][info][vmmutex] 
[0.073s][info][vmmutex] Rank "safepoint-3":
[0.073s][info][vmmutex]   PerfDataMemAlloc_lock
[0.073s][info][vmmutex]   PerfDataManager_lock
[0.073s][info][vmmutex]   VMOperation_lock
[0.073s][info][vmmutex]   SystemDictionary_lock
[0.073s][info][vmmutex] 
[0.073s][info][vmmutex] Rank "safepoint-2":
[0.073s][info][vmmutex]   Heap_lock
[0.073s][info][vmmutex]   ClassInitError_lock
[0.073s][info][vmmutex]   G1OldGCCount_lock
[0.073s][info][vmmutex]   ParGCRareEvent_lock
[0.073s][info][vmmutex]   OopMapCacheAlloc_lock
[0.073s][info][vmmutex]   Module_lock
[0.073s][info][vmmutex] 
[0.073s][info][vmmutex] Rank "safepoint-1":
[0.073s][info][vmmutex]   Threads_lock
[0.073s][info][vmmutex]   Compile_lock
[0.073s][info][vmmutex]   AdapterHandlerLibrary_lock
[0.073s][info][vmmutex]   ClassLoaderDataGraph_lock
[0.073s][info][vmmutex]   CompileTaskAlloc_lock
[0.073s][info][vmmutex]   JNICritical_lock
[0.073s][info][vmmutex]   JVMCI_lock
[0.073s][info][vmmutex] 
[0.073s][info][vmmutex] Rank "safepoint":
[0.073s][info][vmmutex]   InvokeMethodTable_lock
[0.073s][info][vmmutex]   SharedDictionary_lock
[0.073s][info][vmmutex]   VMStatistic_lock
[0.073s][info][vmmutex]   SignatureHandlerLibrary_lock
[0.073s][info][vmmutex]   ExceptionCache_lock
[0.073s][info][vmmutex]   FullGCALot_lock
[0.073s][info][vmmutex]   BeforeExit_lock
[0.073s][info][vmmutex]   RetData_lock
[0.073s][info][vmmutex]   Terminator_lock
[0.073s][info][vmmutex]   Notify_lock
[0.073s][info][vmmutex]   Heap_lock
[0.073s][info][vmmutex]   JfieldIdCreation_lock
[0.073s][info][vmmutex]   MethodCompileQueue_lock
[0.073s][info][vmmutex]   CompileStatistics_lock
[0.073s][info][vmmutex]   MultiArray_lock
[0.073s][info][vmmutex]   JvmtiThreadState_lock
[0.073s][info][vmmutex]   Management_lock
[0.073s][info][vmmutex]   ConcurrentGCBreakpoints_lock
[0.073s][info][vmmutex]   MethodData_lock
[0.073s][info][vmmutex]   TouchedMethodLog_lock
[0.073s][info][vmmutex]   CompileThread_lock
[0.073s][info][vmmutex]   PeriodicTask_lock
[0.073s][info][vmmutex]   RedefineClasses_lock
[0.073s][info][vmmutex]   Verify_lock
[0.073s][info][vmmutex]   CodeHeapStateAnalytics_lock
[0.073s][info][vmmutex]   ThreadIdTableCreate_lock
[0.073s][info][vmmutex]   NMTQuery_lock
[0.073s][info][vmmutex]   CDSClassFileStream_lock
[0.073s][info][vmmutex]   LambdaFormInvokers_lock
[0.073s][info][vmmutex]   JVMCIRuntime_lock
```

Additional testing:
 - [x] New test on Linux x86_64 {release,fastdebug,slowdebug}

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294759](https://bugs.openjdk.org/browse/JDK-8294759): Print actual lock/monitor ranking


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10556/head:pull/10556` \
`$ git checkout pull/10556`

Update a local copy of the PR: \
`$ git checkout pull/10556` \
`$ git pull https://git.openjdk.org/jdk pull/10556/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10556`

View PR using the GUI difftool: \
`$ git pr show -t 10556`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10556.diff">https://git.openjdk.org/jdk/pull/10556.diff</a>

</details>
