### PR TITLE
8294729: [s390] Implement nmethod entry barriers

### DIFF
--- a/src/hotspot/cpu/s390/assembler_s390.hpp
+++ b/src/hotspot/cpu/s390/assembler_s390.hpp
@@ -3121,6 +3121,9 @@ class Assembler : public AbstractAssembler {
   static bool is_z_algr(long x) {
     return (ALGR_ZOPC == (x & RRE_MASK));
   }
+  static bool is_z_cfi(long x) {
+    return (CFI_ZOPC == (x & RIL_MASK));
+  }
   static bool is_z_lb(long x) {
     return (LB_ZOPC == (x & LB_MASK));
   }

--- a/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
@@ -76,7 +76,7 @@ void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_by
   push_frame(frame_size_in_bytes);
 
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-  bs->nmethod_entry_barrier(this, Z_R3);
+  bs->nmethod_entry_barrier(this, Z_R0_scratch);
 }
 
 void C1_MacroAssembler::verified_entry(bool breakAtEntry) {

--- a/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
@@ -76,7 +76,7 @@ void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_by
   push_frame(frame_size_in_bytes);
 
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-  bs->nmethod_entry_barrier(this, Z_R0_scratch);
+  bs->nmethod_entry_barrier(this);
 }
 
 void C1_MacroAssembler::verified_entry(bool breakAtEntry) {

--- a/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
@@ -27,6 +27,8 @@
 #include "asm/macroAssembler.inline.hpp"
 #include "c1/c1_MacroAssembler.hpp"
 #include "c1/c1_Runtime1.hpp"
+#include "gc/shared/barrierSet.hpp"
+#include "gc/shared/barrierSetAssembler.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/tlab_globals.hpp"
 #include "interpreter/interpreter.hpp"
@@ -72,6 +74,9 @@ void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_by
   generate_stack_overflow_check(bang_size_in_bytes);
   save_return_pc();
   push_frame(frame_size_in_bytes);
+
+  BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
+  bs->nmethod_entry_barrier(this, Z_R3);
 }
 
 void C1_MacroAssembler::verified_entry(bool breakAtEntry) {

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -71,31 +71,6 @@ void BarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorators,
   }
 }
 
-void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm) {
-  BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
-  if (bs_nm == nullptr) {
-    return;
-  }
-
-  __ block_comment("nmethod_entry_barrier (nmethod_entry_barrier) {");
-
-    // Load jump addr:
-    __ load_const(Z_R1_scratch, (uint64_t)StubRoutines::zarch::nmethod_entry_barrier()); // 2*6 bytes
-
-    // Load value from current java object:
-    __ z_lg(Z_R0_scratch, in_bytes(bs_nm->thread_disarmed_offset()), Z_thread); // 6 bytes
-
-    // Compare to current patched value:
-    __ z_cfi(Z_R0_scratch, /* to be patched */ -1); // 6 bytes (2 + 4 byte imm val)
-
-    // Conditional Jump
-    __ z_larl(Z_R14, (Assembler::instr_len((unsigned long)LARL_ZOPC) + Assembler::instr_len((unsigned long)BCR_ZOPC)) / 2); // 6 bytes
-    __ z_bcr(Assembler::bcondNotEqual, Z_R1_scratch); // 2 bytes
-
-    // Fall through to method body.
-  __ block_comment("} nmethod_entry_barrier (nmethod_entry_barrier)");
-}
-
 void BarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                                    const Address& addr, Register val, Register tmp1, Register tmp2, Register tmp3) {
   bool in_heap = (decorators & IN_HEAP) != 0;
@@ -146,4 +121,29 @@ void BarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm, Re
                                                         Register obj, Register tmp, Label& slowpath) {
   __ z_nill(obj, ~JNIHandles::weak_tag_mask);
   __ z_lg(obj, 0, obj); // Resolve (untagged) jobject.
+}
+
+void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm) {
+  BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
+  if (bs_nm == nullptr) {
+    return;
+  }
+
+  __ block_comment("nmethod_entry_barrier (nmethod_entry_barrier) {");
+
+    // Load jump addr:
+    __ load_const(Z_R1_scratch, (uint64_t)StubRoutines::zarch::nmethod_entry_barrier()); // 2*6 bytes
+
+    // Load value from current java object:
+    __ z_lg(Z_R0_scratch, in_bytes(bs_nm->thread_disarmed_offset()), Z_thread); // 6 bytes
+
+    // Compare to current patched value:
+    __ z_cfi(Z_R0_scratch, /* to be patched */ -1); // 6 bytes (2 + 4 byte imm val)
+
+    // Conditional Jump
+    __ z_larl(Z_R14, (Assembler::instr_len((unsigned long)LARL_ZOPC) + Assembler::instr_len((unsigned long)BCR_ZOPC)) / 2); // 6 bytes
+    __ z_bcr(Assembler::bcondNotEqual, Z_R1_scratch); // 2 bytes
+
+    // Fall through to method body.
+  __ block_comment("} nmethod_entry_barrier (nmethod_entry_barrier)");
 }

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -24,7 +24,6 @@
  */
 
 #include "precompiled.hpp"
-#include "asm/macroAssembler.hpp"
 #include "asm/macroAssembler.inline.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -83,8 +83,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Register t
   __ block_comment("nmethod_entry_barrier (nmethod_entry_barrier) {");
 
     // Load jump addr:
-    // __ z_larl(Z_R1_scratch, StubRoutines::zarch::nmethod_entry_barrier()); // 6 bytes
-    __ load_const(Z_R1_scratch, StubRoutines::zarch::nmethod_entry_barrier()); // 6 bytes
+    __ load_const(Z_R1_scratch, (uint64_t)StubRoutines::zarch::nmethod_entry_barrier()); // 2*6 bytes
 
     // Load value from current java object:
     __ z_lg(tmp, in_bytes(bs_nm->thread_disarmed_offset()), Z_thread); // 6 bytes

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -71,13 +71,11 @@ void BarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorators,
   }
 }
 
-void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Register tmp) {
+void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm) {
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
   if (bs_nm == nullptr) {
     return;
   }
-
-  assert_different_registers(tmp, Z_R1_scratch);
 
   __ block_comment("nmethod_entry_barrier (nmethod_entry_barrier) {");
 
@@ -85,10 +83,10 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Register t
     __ load_const(Z_R1_scratch, (uint64_t)StubRoutines::zarch::nmethod_entry_barrier()); // 2*6 bytes
 
     // Load value from current java object:
-    __ z_lg(tmp, in_bytes(bs_nm->thread_disarmed_offset()), Z_thread); // 6 bytes
+    __ z_lg(Z_R0_scratch, in_bytes(bs_nm->thread_disarmed_offset()), Z_thread); // 6 bytes
 
     // Compare to current patched value:
-    __ z_cfi(tmp, /* to be patched */ -1); // 6 bytes (2 + 4 byte imm val)
+    __ z_cfi(Z_R0_scratch, /* to be patched */ -1); // 6 bytes (2 + 4 byte imm val)
 
     // Conditional Jump
     __ z_larl(Z_R14, (Assembler::instr_len((unsigned long)LARL_ZOPC) + Assembler::instr_len((unsigned long)BCR_ZOPC)) / 2); // 6 bytes

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -83,7 +83,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Register t
   __ block_comment("nmethod_entry_barrier (nmethod_entry_barrier) {");
 
     // Load jump addr:
-    __ load_const(Z_R1_scratch, (uint64_t)&StubRoutines::zarch::nmethod_entry_barrier); // 2*6 bytes
+    __ load_const(Z_R1_scratch, (uint64_t)StubRoutines::zarch::nmethod_entry_barrier()); // 2*6 bytes
 
     // Load value from current java object:
     __ z_lg(tmp, in_bytes(bs_nm->thread_disarmed_offset()), Z_thread); // 6 bytes

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -83,7 +83,8 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Register t
   __ block_comment("nmethod_entry_barrier (nmethod_entry_barrier) {");
 
     // Load jump addr:
-    __ load_const(Z_R1_scratch, (uint64_t)StubRoutines::zarch::nmethod_entry_barrier()); // 2*6 bytes
+    // __ z_larl(Z_R1_scratch, StubRoutines::zarch::nmethod_entry_barrier()); // 6 bytes
+    __ load_const(Z_R1_scratch, StubRoutines::zarch::nmethod_entry_barrier()); // 6 bytes
 
     // Load value from current java object:
     __ z_lg(tmp, in_bytes(bs_nm->thread_disarmed_offset()), Z_thread); // 6 bytes

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -92,6 +92,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Register t
     __ z_cfi(tmp, /* to be patched */ -1); // 6 bytes (2 + 4 byte imm val)
 
     // Conditional Jump
+    __ z_larl(Z_R14, (Assembler::instr_len((unsigned long)LARL_ZOPC) + Assembler::instr_len((unsigned long)BCR_ZOPC)) / 2); // 6 bytes
     __ z_bcr(Assembler::bcondNotEqual, Z_R1_scratch); // 2 bytes
 
   __ block_comment("} nmethod_entry_barrier (nmethod_entry_barrier)");

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -92,6 +92,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm) {
     __ z_larl(Z_R14, (Assembler::instr_len((unsigned long)LARL_ZOPC) + Assembler::instr_len((unsigned long)BCR_ZOPC)) / 2); // 6 bytes
     __ z_bcr(Assembler::bcondNotEqual, Z_R1_scratch); // 2 bytes
 
+    // Fall through to method body.
   __ block_comment("} nmethod_entry_barrier (nmethod_entry_barrier)");
 }
 

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -85,9 +85,9 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Register t
     // Zero R1
     __ z_xgr(Z_R1_scratch, Z_R1_scratch);
     // Add high-order bits
-    __ z_aih(Z_R1_scratch, (long)StubRoutines::zarch::nmethod_entry_barrier() >> 32);
+    __ z_aih(Z_R1_scratch, (int64_t)StubRoutines::zarch::nmethod_entry_barrier() >> 32);
     // Add low-order bits
-    __ z_afi(Z_R1_scratch, (long)StubRoutines::zarch::nmethod_entry_barrier());
+    __ z_afi(Z_R1_scratch, (int64_t)StubRoutines::zarch::nmethod_entry_barrier());
 
     // Load value from current java object:
     __ z_lg(tmp, in_bytes(bs_nm->thread_disarmed_offset()), Z_thread);

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -25,7 +25,9 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.inline.hpp"
+#include "gc/shared/barrierSet.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
+#include "gc/shared/barrierSetNMethod.hpp"
 #include "interpreter/interp_masm.hpp"
 #include "oops/compressedOops.hpp"
 #include "runtime/jniHandles.hpp"
@@ -66,6 +68,19 @@ void BarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorators,
   }
   default: Unimplemented();
   }
+}
+
+void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Register tmp) {
+  BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
+  if (bs_nm == nullptr) {
+    return;
+  }
+
+  __ block_comment("nmethod_entry_barrier (nmethod_entry_barrier) {");
+
+    ShouldNotReachHere(); // TODO
+
+  __ block_comment("} nmethod_entry_barrier (nmethod_entry_barrier)");
 }
 
 void BarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.hpp
@@ -41,7 +41,7 @@ public:
 
   virtual void load_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                        const Address& addr, Register dst, Register tmp1, Register tmp2, Label *L_handle_null = NULL);
-  virtual void nmethod_entry_barrier(MacroAssembler* masm, Register tmp);
+  virtual void nmethod_entry_barrier(MacroAssembler* masm);
   virtual void store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                         const Address& addr, Register val, Register tmp1, Register tmp2, Register tmp3);
 

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.hpp
@@ -41,7 +41,6 @@ public:
 
   virtual void load_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                        const Address& addr, Register dst, Register tmp1, Register tmp2, Label *L_handle_null = NULL);
-  virtual void nmethod_entry_barrier(MacroAssembler* masm);
   virtual void store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                         const Address& addr, Register val, Register tmp1, Register tmp2, Register tmp3);
 
@@ -49,6 +48,8 @@ public:
 
   virtual void try_resolve_jobject_in_native(MacroAssembler* masm, Register jni_env,
                                              Register obj, Register tmp, Label& slowpath);
+
+  virtual void nmethod_entry_barrier(MacroAssembler* masm);
 
   virtual void barrier_stubs_init() {}
 };

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -41,6 +41,7 @@ public:
 
   virtual void load_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                        const Address& addr, Register dst, Register tmp1, Register tmp2, Label *L_handle_null = NULL);
+  virtual void nmethod_entry_barrier(MacroAssembler* masm, Register tmp);
   virtual void store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                         const Address& addr, Register val, Register tmp1, Register tmp2, Register tmp3);
 

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
@@ -97,7 +97,7 @@ static NativeMethodBarrier* get_nmethod_barrier(nmethod* nm) {
 }
 
 void BarrierSetNMethod::deoptimize(nmethod* nm, address* return_address_ptr) {
-  // TODO: Implement
+  // TODO: Implement?
   ShouldNotReachHere();
 }
 

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
@@ -61,26 +61,33 @@ class NativeMethodBarrier: public NativeInstruction {
       guard_addr->set_offset(value);
     }
 
-    void verify() const {
-      int offset = 0;
-      const address start = get_barrier_start_address();
+    #ifdef ASSERT
+      void verify() const {
+        int offset = 0;
+        const address start = get_barrier_start_address();
 
-      assert(Assembler::is_equal(start[offset],  IIHF_ZOPC, RIL_MASK), "check load_const (1/2)");
-      offset += Assembler::instr_len(IIHF_ZOPC);
-      assert(Assembler::is_equal(start[offset],  IILF_ZOPC, RIL_MASK), "check load_const (2/2)");
-      offset += Assembler::instr_len(IILF_ZOPC);
-      assert(Assembler::is_equal(start[offset], LG_ZOPC, RIL_MASK), "check LG");
-      offset += Assembler::instr_len(LG_ZOPC);
-      assert(Assembler::is_equal(start[offset], CFI_ZOPC, RIL_MASK), "check CFI");
-      get_patchable_instruction_handle()->verify();
-      offset += Assembler::instr_len(CFI_ZOPC);
-      assert(Assembler::is_equal(start[offset], LARL_ZOPC, RIL_MASK), "check LARL");
-      offset += Assembler::instr_len(LARL_ZOPC);
-      assert(Assembler::is_equal(start[offset], BCR_ZOPC, RIL_MASK), "check BCR");
-      offset += Assembler::instr_len((unsigned long)BCR_ZOPC);
+        assert(Assembler::is_equal(start[offset],  IIHF_ZOPC, RIL_MASK), "check load_const (1/2)");
+        offset += Assembler::instr_len(&start[offset]);
 
-      assert(offset == BARRIER_TOTAL_LENGTH, "check offset == barrier length constant");
-    }
+        assert(Assembler::is_equal(start[offset],  IILF_ZOPC, RIL_MASK), "check load_const (2/2)");
+        offset += Assembler::instr_len(&start[offset]);
+
+        assert(Assembler::is_equal(start[offset], LG_ZOPC, RIL_MASK), "check LG");
+        offset += Assembler::instr_len(&start[offset]);
+
+        assert(Assembler::is_equal(start[offset], CFI_ZOPC, RIL_MASK), "check CFI");
+        get_patchable_instruction_handle()->verify();
+        offset += Assembler::instr_len(&start[offset]);
+
+        assert(Assembler::is_equal(start[offset], LARL_ZOPC, RIL_MASK), "check LARL");
+        offset += Assembler::instr_len(&start[offset]);
+
+        assert(Assembler::is_equal(start[offset], BCR_ZOPC, RIL_MASK), "check BCR");
+        offset += Assembler::instr_len(&start[offset]);
+
+        assert(offset == BARRIER_TOTAL_LENGTH, "check offset == barrier length constant");
+      }
+    #endif
 
 };
 

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
@@ -32,21 +32,21 @@
 
 class NativeMethodBarrier: public NativeInstruction {
   private:
-    static const int GUARD_INSTRUCTION_OFFSET = 3*6; // bytes
+    static const int PATCHABLE_INSTRUCTION_OFFSET = 3*6; // bytes
 
     address get_barrier_start_address() const {
       return NativeInstruction::addr_at(0);
     }
 
     address get_patchable_data_address() const {
-      address inst_addr = get_barrier_start_address() + GUARD_INSTRUCTION_OFFSET;
+      address inst_addr = get_barrier_start_address() + PATCHABLE_INSTRUCTION_OFFSET;
 
       debug_only(Assembler::is_z_cfi(*((long*)inst_addr)));
       return inst_addr + 2;
     }
 
   public:
-    static const int BARRIER_TOTAL_LENGTH = GUARD_INSTRUCTION_OFFSET + 2*6 + 2; // bytes
+    static const int BARRIER_TOTAL_LENGTH = PATCHABLE_INSTRUCTION_OFFSET + 2*6 + 2; // bytes
 
     int get_guard_value() const {
       address data_addr = get_patchable_data_address();

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
@@ -45,7 +45,7 @@ class NativeMethodBarrier: public NativeInstruction {
     }
 
   public:
-    static const int BARRIER_TOTAL_LENGTH = GUARD_INSTRUCTION_OFFSET + 6 + 2; // bytes
+    static const int BARRIER_TOTAL_LENGTH = GUARD_INSTRUCTION_OFFSET + 2*6 + 2; // bytes
 
     int get_guard_value() const {
       NativeMovRegMem* guard_addr = get_patchable_instruction_handle();

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
@@ -62,14 +62,24 @@ class NativeMethodBarrier: public NativeInstruction {
     }
 
     void verify() const {
+      int offset = 0;
       const address start = get_barrier_start_address();
 
-      assert(Assembler::is_equal(start[0],  IIHF_ZOPC, RIL_MASK), "check load_const (1/2)");
-      assert(Assembler::is_equal(start[6],  IILF_ZOPC, RIL_MASK), "check load_const (2/2)");
-      assert(Assembler::is_equal(start[12], LG_ZOPC, RIL_MASK), "check LG");
-      assert(Assembler::is_equal(start[18], CFI_ZOPC, RIL_MASK), "check CFI");
+      assert(Assembler::is_equal(start[offset],  IIHF_ZOPC, RIL_MASK), "check load_const (1/2)");
+      offset += Assembler::instr_len(IIHF_ZOPC);
+      assert(Assembler::is_equal(start[offset],  IILF_ZOPC, RIL_MASK), "check load_const (2/2)");
+      offset += Assembler::instr_len(IILF_ZOPC);
+      assert(Assembler::is_equal(start[offset], LG_ZOPC, RIL_MASK), "check LG");
+      offset += Assembler::instr_len(LG_ZOPC);
+      assert(Assembler::is_equal(start[offset], CFI_ZOPC, RIL_MASK), "check CFI");
       get_patchable_instruction_handle()->verify();
-      assert(Assembler::is_equal(start[22], BCR_ZOPC, RIL_MASK), "check BCR");
+      offset += Assembler::instr_len(CFI_ZOPC);
+      assert(Assembler::is_equal(start[offset], LARL_ZOPC, RIL_MASK), "check LARL");
+      offset += Assembler::instr_len(LARL_ZOPC);
+      assert(Assembler::is_equal(start[offset], BCR_ZOPC, RIL_MASK), "check BCR");
+      offset += Assembler::instr_len((unsigned long)BCR_ZOPC);
+
+      assert(offset == BARRIER_TOTAL_LENGTH, "check offset == barrier length constant");
     }
 
 };

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
@@ -42,7 +42,7 @@ class NativeMethodBarrier: public NativeInstruction {
       address inst_addr = get_barrier_start_address() + GUARD_INSTRUCTION_OFFSET;
 
       debug_only(Assembler::is_z_cfi(*((long*)inst_addr)));
-      return inst_addr + Assembler::instr_len(inst_addr);
+      return inst_addr + 2;
     }
 
   public:
@@ -55,7 +55,8 @@ class NativeMethodBarrier: public NativeInstruction {
     }
 
     void set_guard_value(int value) {
-      address data_addr = get_patchable_data_address();
+      int32_t* data_addr = (int32_t*)get_patchable_data_address();
+
 
       // Set guard instruction value
       *data_addr = value;

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
@@ -57,7 +57,6 @@ class NativeMethodBarrier: public NativeInstruction {
     void set_guard_value(int value) {
       int32_t* data_addr = (int32_t*)get_patchable_data_address();
 
-
       // Set guard instruction value
       *data_addr = value;
     }

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
@@ -50,32 +50,18 @@ class NativeMethodBarrier: public NativeInstruction {
     int get_guard_value() const {
       NativeMovRegMem* guard_addr = get_patchable_instruction_handle();
 
-      // TODO: This returns the value at the start of the instruction
-      // NOT the constant (to be patched value)
-
-      // Access memory at guard address
+      // Return guard instruction and value
       return guard_addr->offset();
     }
 
     void set_guard_value(int value) {
       NativeMovRegMem* guard_addr = get_patchable_instruction_handle();
 
-      // TODO: This returns the value at the start of the instruction
-      // NOT the constant (to be patched value)
-
-      // Set memory at guard address
+      // Set guard instruction and value
       guard_addr->set_offset(value);
     }
 
     void verify() const {
-      /* Expect the following instruction sequence:
-       * iihf + 0
-       * iilf + 6
-       * lg   +12
-       * cfi  +18 (patchable)
-       * bcr  +22
-       * ---  +24
-       */
       const address start = get_barrier_start_address();
 
       assert(Assembler::is_equal(start[0],  IIHF_ZOPC, RIL_MASK), "check load_const (1/2)");
@@ -97,8 +83,8 @@ static NativeMethodBarrier* get_nmethod_barrier(nmethod* nm) {
 }
 
 void BarrierSetNMethod::deoptimize(nmethod* nm, address* return_address_ptr) {
-  // TODO: Implement?
-  ShouldNotReachHere();
+  // Not required on s390 as a valid backchain is present
+  return;
 }
 
 void BarrierSetNMethod::arm(nmethod* nm, int arm_value) {

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
@@ -23,18 +23,66 @@
  */
 
 #include "precompiled.hpp"
+#include "code/nativeInst.hpp"
+#include "code/nmethod.hpp"
 #include "gc/shared/barrierSetNMethod.hpp"
 #include "utilities/debug.hpp"
 
+class NativeMethodBarrier: public NativeInstruction {
+  private:
+
+  public:
+    int get_guard_value() const {
+      // Unimplemented();
+      return -1;
+    }
+
+    void release_set_guard_value(int value) {
+      // Unimplemented();
+    }
+
+};
+
+static const int entry_barrier_offset() {
+  // TODO: Implement this procedure
+  return 0;
+}
+
+static NativeMethodBarrier* get_nmethod_barrier(nmethod* nm) {
+  address barrier_address = nm->code_begin() + nm->frame_complete_offset() + entry_barrier_offset();
+  auto barrier = reinterpret_cast<NativeMethodBarrier*>(barrier_address);
+
+  return barrier;
+}
+
 void BarrierSetNMethod::deoptimize(nmethod* nm, address* return_address_ptr) {
+  // TODO: Implement
   ShouldNotReachHere();
+}
+
+void BarrierSetNMethod::arm(nmethod* nm, int arm_value) {
+  if (!supports_entry_barrier(nm)) {
+    return;
+  }
+
+  NativeMethodBarrier* barrier = get_nmethod_barrier(nm);
+  barrier->release_set_guard_value(arm_value);
 }
 
 void BarrierSetNMethod::disarm(nmethod* nm) {
-  ShouldNotReachHere();
+  if (!supports_entry_barrier(nm)) {
+    return;
+  }
+
+  NativeMethodBarrier* barrier = get_nmethod_barrier(nm);
+  barrier->release_set_guard_value(disarmed_value());
 }
 
 bool BarrierSetNMethod::is_armed(nmethod* nm) {
-  ShouldNotReachHere();
-  return false;
+  if (!supports_entry_barrier(nm)) {
+    return false;
+  }
+
+  NativeMethodBarrier* barrier = get_nmethod_barrier(nm);
+  return barrier->get_guard_value() != disarmed_value();
 }

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -810,6 +810,8 @@ void MachConstantBaseNode::format(PhaseRegAlloc* ra_, outputStream* st) const {
 
 //=============================================================================
 
+#include "gc/shared/barrierSetAssembler.hpp"
+
 #if !defined(PRODUCT)
 void MachPrologNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
   Compile* C = ra_->C;

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -899,7 +899,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 
   if (C->stub_function() == NULL) {
     BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-    bs->nmethod_entry_barrier(&_masm, Z_R0_scratch);
+    bs->nmethod_entry_barrier(&_masm);
   }
 
   C->output()->set_frame_complete(cbuf.insts_size());

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -848,7 +848,7 @@ void MachPrologNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
 void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   Compile* C = ra_->C;
   C2_MacroAssembler _masm(&cbuf);
-  Register nmethod_tmp = Z_R3;
+  // Register nmethod_tmp = Z_R3;
 
   __ verify_thread();
 

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -897,7 +897,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 
   if (C->stub_function() == NULL) {
     BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-    bs->nmethod_entry_barrier(&_masm, push_frame_temp);
+    bs->nmethod_entry_barrier(&_masm, Z_R0_scratch);
   }
 
   C->output()->set_frame_complete(cbuf.insts_size());

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -869,13 +869,6 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
     __ load_const_optimized(klass, SharedRuntime::get_handle_wrong_method_stub());
     __ z_br(klass);
 
-    if (C->stub_function() == NULL) {
-      BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-      bs->nmethod_entry_barrier(&_masm, push_frame_temp);
-    }
-
-    C->output()->set_frame_complete(cbuf.insts_size());
-
     __ bind(L_skip_barrier);
   }
 
@@ -901,6 +894,13 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
     ConstantTable& constant_table = C->output()->constant_table();
     constant_table.set_table_base_offset(constant_table.calculate_table_base_offset());
   }
+
+  if (C->stub_function() == NULL) {
+    BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
+    bs->nmethod_entry_barrier(&_masm, push_frame_temp);
+  }
+
+  C->output()->set_frame_complete(cbuf.insts_size());
 }
 
 uint MachPrologNode::size(PhaseRegAlloc *ra_) const {

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -837,6 +837,10 @@ void MachPrologNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
   }
   st->print_cr("push_frame %d", (int)-framesize);
   st->print("\t");
+
+  if (C->stub_function() == NULL) {
+    st->print("nmethod entry barrier\n\t");
+  }
 }
 #endif
 
@@ -864,6 +868,13 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 
     __ load_const_optimized(klass, SharedRuntime::get_handle_wrong_method_stub());
     __ z_br(klass);
+
+    if (C->stub_function() == NULL) {
+      BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
+      bs->nmethod_entry_barrier(&_masm, push_frame_temp);
+    }
+
+    C->output()->set_frame_complete(cbuf.insts_size());
 
     __ bind(L_skip_barrier);
   }

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -837,18 +837,12 @@ void MachPrologNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
   }
   st->print_cr("push_frame %d", (int)-framesize);
   st->print("\t");
-
-  // TODO: Check this!
-  // if (C->stub_function() == NULL) {
-  //   st->print("nmethod entry barrier\n\t");
-  // }
 }
 #endif
 
 void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   Compile* C = ra_->C;
   C2_MacroAssembler _masm(&cbuf);
-  // Register nmethod_tmp = Z_R3;
 
   __ verify_thread();
 
@@ -896,12 +890,6 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
     ConstantTable& constant_table = C->output()->constant_table();
     constant_table.set_table_base_offset(constant_table.calculate_table_base_offset());
   }
-
-  // TODO: Check this!
-  // if (C->stub_function() == NULL) {
-  //   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-  //   bs->nmethod_entry_barrier(&_masm, nmethod_tmp);
-  // }
 }
 
 uint MachPrologNode::size(PhaseRegAlloc *ra_) const {

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -837,12 +837,18 @@ void MachPrologNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
   }
   st->print_cr("push_frame %d", (int)-framesize);
   st->print("\t");
+
+  // TODO: Check this!
+  // if (C->stub_function() == NULL) {
+  //   st->print("nmethod entry barrier\n\t");
+  // }
 }
 #endif
 
 void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   Compile* C = ra_->C;
   C2_MacroAssembler _masm(&cbuf);
+  Register nmethod_tmp = Z_R3;
 
   __ verify_thread();
 
@@ -890,6 +896,12 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
     ConstantTable& constant_table = C->output()->constant_table();
     constant_table.set_table_base_offset(constant_table.calculate_table_base_offset());
   }
+
+  // TODO: Check this!
+  // if (C->stub_function() == NULL) {
+  //   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
+  //   bs->nmethod_entry_barrier(&_masm, nmethod_tmp);
+  // }
 }
 
 uint MachPrologNode::size(PhaseRegAlloc *ra_) const {

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -1543,7 +1543,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
 #endif
 
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-  bs->nmethod_entry_barrier(masm, Z_R3);
+  bs->nmethod_entry_barrier(masm, Z_R0_scratch);
 
   wrapper_FrameDone = __ offset();
 

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -1543,7 +1543,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
 #endif
 
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-  bs->nmethod_entry_barrier(masm, Z_R0_scratch);
+  bs->nmethod_entry_barrier(masm);
 
   wrapper_FrameDone = __ offset();
 

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -29,6 +29,7 @@
 #include "code/icBuffer.hpp"
 #include "code/vtableStubs.hpp"
 #include "compiler/oopMap.hpp"
+#include "gc/shared/barrierSetAssembler.hpp"
 #include "gc/shared/gcLocker.hpp"
 #include "interpreter/interpreter.hpp"
 #include "interpreter/interp_masm.hpp"
@@ -1540,6 +1541,9 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
   __ resize_frame(-frame_size_in_bytes, Z_R0_scratch);    // No new frame for the wrapper.
                                                           // Just resize the existing one.
 #endif
+
+  BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
+  bs->nmethod_entry_barrier(masm, Z_R3);
 
   wrapper_FrameDone = __ offset();
 

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2872,11 +2872,7 @@ class StubGenerator: public StubCodeGenerator {
     __ save_volatile_regs(Z_SP, frame::z_abi_160_size, true, false);
 
     // Prep arg for VM call
-    // Create PTR to (R14 - Barrier_Length)
-    // This is the address of the entry point for the compiled fn we are examining.
-    // __ z_lay(Z_R1_scratch, -32, Z_R0, Z_R14);           // R1 <- R14 - 32
-    // __ z_stg(Z_R1_scratch, _z_abi(carg_2), Z_R0, Z_SP); // SP[abi_carg2] <- R1
-    // __ z_la(Z_ARG1, _z_abi(carg_2), Z_R0, Z_SP);        // R2 <- SP + abi_carg2
+    // Create ptr to stored return_pc in caller frame.
     __ z_la(Z_ARG1, _z_abi(return_pc) + frame::z_abi_160_size + nbytes_volatile, Z_R0, Z_SP);
 
     // VM-Call: BarrierSetNMethod::nmethod_stub_entry_barrier(address* return_address_ptr)

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2864,20 +2864,28 @@ class StubGenerator: public StubCodeGenerator {
 
     address start = __ pc();
 
-    // VM-call prelude
-    __ save_return_pc();
-    __ push_frame_abi160(10*BytesPerWord);
-    __ z_stmg(Z_R6, Z_R15, frame::z_abi_160_size, Z_SP);
+    // Save caller's sp & return_pc
+    __ push_frame(frame::z_abi_16_size);
+    __ z_stmg(Z_R14, Z_R15, _z_abi16(callers_sp), Z_SP);
 
-    __ call_VM_leaf(CAST_FROM_FN_PTR(address, BarrierSetNMethod::nmethod_stub_entry_barrier));
+    // Prep arg for VM call
+    // Since we call address* -> int and not address -> int, we must provide an extra level of indirection.
+    // We construct a pointer to the location of R14 stored above.
+    __ z_xgr(Z_R2, Z_R2);
+    __ z_ag(Z_R2, _z_abi(return_pc), 0, Z_SP);
 
-    // VM-call epilogue
-    __ z_lmg(Z_R0, Z_R15, frame::z_abi_160_size, Z_SP);
+    // Call BarrierSetNMethod::nmethod_stub_entry_barrier(address* return_address_ptr)
+    __ push_frame_abi160(0);
+    __ call_VM_leaf(CAST_FROM_FN_PTR(address, BarrierSetNMethod::nmethod_stub_entry_barrier), Z_R2);
     __ pop_frame();
-    __ restore_return_pc();
 
-    // Check return val and
-    // return to caller if return val == 0
+    // Restore caller's sp & return_pc
+    __ z_lmg(Z_R14, Z_R15, _z_abi(callers_sp), Z_SP);
+    __ pop_frame();
+
+    // Check return val of vm call
+    // if (return val != 0)
+    // return to caller
     __ z_cfi(Z_R2, 0);
     __ z_bcr(Assembler::bcondNotEqual, Z_R14);
 
@@ -2885,10 +2893,6 @@ class StubGenerator: public StubCodeGenerator {
     // Get handle to wrong-method-stub for s390
     __ load_const_optimized(Z_R1_scratch, SharedRuntime::get_handle_wrong_method_stub());
     __ z_br(Z_R1_scratch);
-
-    // TODO: PPC has an extra pop_frame, and restore LR_CR here. Is this required on s390?
-    // __ pop_frame();
-    // __ restore_return_pc();
 
     // Call wrong-method-stub
     __ z_br(Z_R2);

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2870,12 +2870,12 @@ class StubGenerator: public StubCodeGenerator {
 
     // Prep arg for VM call
     // Since we call address* -> int and not address -> int, we must provide an extra level of indirection.
-    // We construct a pointer to the location of R14 stored above.
-    __ z_la(Z_R2, _z_abi(return_pc), Z_R0, Z_SP);
+    // We construct a pointer to the location of the return pc stored above.
+    __ z_la(Z_ARG1, _z_abi(return_pc), Z_R0, Z_SP);
 
     // Call BarrierSetNMethod::nmethod_stub_entry_barrier(address* return_address_ptr)
     __ push_frame_abi160(0);
-    __ call_VM_leaf(CAST_FROM_FN_PTR(address, BarrierSetNMethod::nmethod_stub_entry_barrier), Z_R2);
+    __ call_VM_leaf(CAST_FROM_FN_PTR(address, BarrierSetNMethod::nmethod_stub_entry_barrier));
     __ pop_frame();
 
     // Restore caller's sp & return_pc

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2871,7 +2871,7 @@ class StubGenerator: public StubCodeGenerator {
     // Prep arg for VM call
     // Create PTR to (R14 - Barrier_Length)
     // This is the address of the entry point for the compiled fn we are examining.
-    __ z_lay(Z_R1_scratch, -32, Z_R0, Z_R14);             // R1 <- R14 - 32
+    __ z_lay(Z_R1_scratch, -32, Z_R0, Z_R14);           // R1 <- R14 - 32
     __ z_stg(Z_R1_scratch, _z_abi(carg_2), Z_R0, Z_SP); // SP[abi_carg2] <- R1
     __ z_la(Z_ARG1, _z_abi(carg_2), Z_R0, Z_SP);        // R2 <- SP + abi_carg2
 

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2865,8 +2865,8 @@ class StubGenerator: public StubCodeGenerator {
     address start = __ pc();
 
     // Save caller's sp & return_pc
-    __ push_frame(frame::z_abi_16_size);
     __ save_return_pc();
+    __ push_frame(frame::z_abi_16_size);
 
     // Prep arg for VM call
     // Since we call address* -> int and not address -> int, we must provide an extra level of indirection.
@@ -2879,8 +2879,8 @@ class StubGenerator: public StubCodeGenerator {
     __ pop_frame();
 
     // Restore caller's sp & return_pc
-    __ restore_return_pc();
     __ pop_frame();
+    __ restore_return_pc();
 
     // Check return val of vm call
     // if (return val != 0)

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2874,10 +2874,10 @@ class StubGenerator: public StubCodeGenerator {
     // Prep arg for VM call
     // Create PTR to (R14 - Barrier_Length)
     // This is the address of the entry point for the compiled fn we are examining.
-    // __ z_lay(Z_R1_scratch, -32, Z_R0, Z_R14);           // R1 <- R14 - 32
-    // __ z_stg(Z_R1_scratch, _z_abi(carg_2), Z_R0, Z_SP); // SP[abi_carg2] <- R1
-    // __ z_la(Z_ARG1, _z_abi(carg_2), Z_R0, Z_SP);        // R2 <- SP + abi_carg2
-    __ z_la(Z_ARG1, _z_abi(return_pc), Z_R0, Z_SP);
+    __ z_lay(Z_R1_scratch, -32, Z_R0, Z_R14);           // R1 <- R14 - 32
+    __ z_stg(Z_R1_scratch, _z_abi(carg_2), Z_R0, Z_SP); // SP[abi_carg2] <- R1
+    __ z_la(Z_ARG1, _z_abi(carg_2), Z_R0, Z_SP);        // R2 <- SP + abi_carg2
+    // __ z_la(Z_ARG1, _z_abi(return_pc), Z_R0, Z_SP);
 
     // VM-Call: BarrierSetNMethod::nmethod_stub_entry_barrier(address* return_address_ptr)
     __ call_VM_leaf(CAST_FROM_FN_PTR(address, BarrierSetNMethod::nmethod_stub_entry_barrier));

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2880,7 +2880,7 @@ class StubGenerator: public StubCodeGenerator {
 
     // VM-Call: BarrierSetNMethod::nmethod_stub_entry_barrier(address* return_address_ptr)
     __ call_VM_leaf(CAST_FROM_FN_PTR(address, BarrierSetNMethod::nmethod_stub_entry_barrier));
-    __ z_ltr(Z_R0, Z_RET);
+    __ z_ltr(Z_R0_scratch, Z_RET);
 
     // VM-Call Epilogue
     __ restore_volatile_regs(Z_SP, frame::z_abi_160_size, true, false);
@@ -2890,7 +2890,7 @@ class StubGenerator: public StubCodeGenerator {
     // Check return val of vm call
     // if (return val != 0)
     // return to caller
-    __ z_ltr(Z_R2, Z_R2);
+    __ z_ltr(Z_R0_scratch, Z_R0_scratch);
     __ z_bcr(Assembler::bcondNotZero, Z_R14);
 
     // O.W. call indicates deoptimization required

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2874,9 +2874,10 @@ class StubGenerator: public StubCodeGenerator {
     // Prep arg for VM call
     // Create PTR to (R14 - Barrier_Length)
     // This is the address of the entry point for the compiled fn we are examining.
-    __ z_lay(Z_R1_scratch, -32, Z_R0, Z_R14);           // R1 <- R14 - 32
-    __ z_stg(Z_R1_scratch, _z_abi(carg_2), Z_R0, Z_SP); // SP[abi_carg2] <- R1
-    __ z_la(Z_ARG1, _z_abi(carg_2), Z_R0, Z_SP);        // R2 <- SP + abi_carg2
+    // __ z_lay(Z_R1_scratch, -32, Z_R0, Z_R14);           // R1 <- R14 - 32
+    // __ z_stg(Z_R1_scratch, _z_abi(carg_2), Z_R0, Z_SP); // SP[abi_carg2] <- R1
+    // __ z_la(Z_ARG1, _z_abi(carg_2), Z_R0, Z_SP);        // R2 <- SP + abi_carg2
+    __ z_la(Z_ARG1, _z_abi(return_pc), Z_R0, Z_SP);
 
     // VM-Call: BarrierSetNMethod::nmethod_stub_entry_barrier(address* return_address_ptr)
     __ call_VM_leaf(CAST_FROM_FN_PTR(address, BarrierSetNMethod::nmethod_stub_entry_barrier));

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2889,6 +2889,10 @@ class StubGenerator: public StubCodeGenerator {
     // return to caller
     __ z_bcr(Assembler::bcondNotZero, Z_R14);
 
+    // Pop frame built in prologue.
+    __ pop_frame();
+    __ restore_return_pc();
+
     // O.W. call indicates deoptimization required
     // Get handle to wrong-method-stub for s390
     __ load_const_optimized(Z_R1_scratch, SharedRuntime::get_handle_wrong_method_stub());

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2869,7 +2869,7 @@ class StubGenerator: public StubCodeGenerator {
     // VM-Call Prologue
     __ save_return_pc();
     __ push_frame_abi160(nbytes_volatile);
-    __ save_volatile_registers(Z_SP, frame::z_abi_160_size, true, false);
+    __ save_volatile_regs(Z_SP, frame::z_abi_160_size, true, false);
 
     // Prep arg for VM call
     // Create PTR to (R14 - Barrier_Length)
@@ -2883,7 +2883,7 @@ class StubGenerator: public StubCodeGenerator {
     __ z_ltr(Z_R0, Z_RET);
 
     // VM-Call Epilogue
-    __ restore_volatile_registers(Z_SP, frame::z_abi_160_size, true, false);
+    __ restore_volatile_regs(Z_SP, frame::z_abi_160_size, true, false);
     __ pop_frame();
     __ restore_return_pc();
 

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2869,9 +2869,11 @@ class StubGenerator: public StubCodeGenerator {
     __ push_frame_abi160(0);
 
     // Prep arg for VM call
-    // Since we call address* -> int and not address -> int, we must provide an extra level of indirection.
-    // We construct a pointer to the location of the return pc stored above.
-    __ z_la(Z_ARG1, _z_abi(return_pc), Z_R0, Z_SP);
+    // Create PTR to (R14 - Barrier_Length)
+    // This is the address of the entry point for the compiled fn we are examining.
+    __ z_lay(Z_R1_scratch, -32, Z_R0, R14);            // R1 <- R14 - 32
+    __ z_stg(Z_R1_scratch, _z_abi(carg2), Z_R0, Z_SP); // SP[abi_carg2] <- R1
+    __ z_la(Z_ARG1, _z_abi(carg2), Z_R0, Z_SP);        // R2 <- SP + abi_carg2
 
     // Call BarrierSetNMethod::nmethod_stub_entry_barrier(address* return_address_ptr)
     __ call_VM_leaf(CAST_FROM_FN_PTR(address, BarrierSetNMethod::nmethod_stub_entry_barrier));

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2866,11 +2866,13 @@ class StubGenerator: public StubCodeGenerator {
 
     // VM-call prelude
     __ save_return_pc();
-    __ push_frame_abi160(0);
+    __ push_frame_abi160(10*BytesPerWord);
+    __ z_stmg(Z_R6, Z_R15, frame::z_abi_160_size, Z_SP);
 
     __ call_VM_leaf(CAST_FROM_FN_PTR(address, BarrierSetNMethod::nmethod_stub_entry_barrier));
 
     // VM-call epilogue
+    __ z_lmg(Z_R0, Z_R15, frame::z_abi_160_size, Z_SP);
     __ pop_frame();
     __ restore_return_pc();
 

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2874,10 +2874,10 @@ class StubGenerator: public StubCodeGenerator {
     // Prep arg for VM call
     // Create PTR to (R14 - Barrier_Length)
     // This is the address of the entry point for the compiled fn we are examining.
-    __ z_lay(Z_R1_scratch, -32, Z_R0, Z_R14);           // R1 <- R14 - 32
-    __ z_stg(Z_R1_scratch, _z_abi(carg_2), Z_R0, Z_SP); // SP[abi_carg2] <- R1
-    __ z_la(Z_ARG1, _z_abi(carg_2), Z_R0, Z_SP);        // R2 <- SP + abi_carg2
-    // __ z_la(Z_ARG1, _z_abi(return_pc), Z_R0, Z_SP);
+    // __ z_lay(Z_R1_scratch, -32, Z_R0, Z_R14);           // R1 <- R14 - 32
+    // __ z_stg(Z_R1_scratch, _z_abi(carg_2), Z_R0, Z_SP); // SP[abi_carg2] <- R1
+    // __ z_la(Z_ARG1, _z_abi(carg_2), Z_R0, Z_SP);        // R2 <- SP + abi_carg2
+    __ z_la(Z_ARG1, _z_abi(return_pc) + frame::z_abi_160_size + nbytes_volatile, Z_R0, Z_SP);
 
     // VM-Call: BarrierSetNMethod::nmethod_stub_entry_barrier(address* return_address_ptr)
     __ call_VM_leaf(CAST_FROM_FN_PTR(address, BarrierSetNMethod::nmethod_stub_entry_barrier));
@@ -2891,7 +2891,6 @@ class StubGenerator: public StubCodeGenerator {
     // Check return val of vm call
     // if (return val != 0)
     // return to caller
-    __ z_ltr(Z_R0_scratch, Z_R0_scratch);
     __ z_bcr(Assembler::bcondNotZero, Z_R14);
 
     // O.W. call indicates deoptimization required

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2886,7 +2886,7 @@ class StubGenerator: public StubCodeGenerator {
     // if (return val != 0)
     // return to caller
     __ z_ltr(Z_R2, Z_R2);
-    __ z_bcr(Assembler::bcondNotEqual, Z_R14);
+    __ z_bcr(Assembler::bcondNotZero, Z_R14);
 
     // O.W. call indicates deoptimization required
     // Get handle to wrong-method-stub for s390

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2864,9 +2864,9 @@ class StubGenerator: public StubCodeGenerator {
 
     address start = __ pc();
 
-    // Save caller's sp & return_pc
+    // Save caller's sp, return_pc in frame large enough for vm call
     __ save_return_pc();
-    __ push_frame(frame::z_abi_16_size);
+    __ push_frame_abi160(0);
 
     // Prep arg for VM call
     // Since we call address* -> int and not address -> int, we must provide an extra level of indirection.
@@ -2874,9 +2874,7 @@ class StubGenerator: public StubCodeGenerator {
     __ z_la(Z_ARG1, _z_abi(return_pc), Z_R0, Z_SP);
 
     // Call BarrierSetNMethod::nmethod_stub_entry_barrier(address* return_address_ptr)
-    __ push_frame_abi160(0);
     __ call_VM_leaf(CAST_FROM_FN_PTR(address, BarrierSetNMethod::nmethod_stub_entry_barrier));
-    __ pop_frame();
 
     // Restore caller's sp & return_pc
     __ pop_frame();

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2887,7 +2887,7 @@ class StubGenerator: public StubCodeGenerator {
     // Check return val of vm call
     // if (return val != 0)
     // return to caller
-    __ z_bcr(Assembler::bcondNotZero, Z_R14);
+    __ z_bcr(Assembler::bcondZero, Z_R14);
 
     // Pop frame built in prologue.
     __ pop_frame();

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2884,17 +2884,15 @@ class StubGenerator: public StubCodeGenerator {
     __ pop_frame();
     __ restore_return_pc();
 
-    // Check return val of vm call
-    // if (return val != 0)
-    // return to caller
+    // Check return val of VM-Call
     __ z_bcr(Assembler::bcondZero, Z_R14);
 
     // Pop frame built in prologue.
+    // Required so wrong_method_stub can deduce caller.
     __ pop_frame();
     __ restore_return_pc();
 
-    // O.W. call indicates deoptimization required
-    // Get handle to wrong-method-stub for s390
+    // VM-Call indicates deoptimization required
     __ load_const_optimized(Z_R1_scratch, SharedRuntime::get_handle_wrong_method_stub());
     __ z_br(Z_R1_scratch);
 

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2871,9 +2871,9 @@ class StubGenerator: public StubCodeGenerator {
     // Prep arg for VM call
     // Create PTR to (R14 - Barrier_Length)
     // This is the address of the entry point for the compiled fn we are examining.
-    __ z_lay(Z_R1_scratch, -32, Z_R0, R14);            // R1 <- R14 - 32
-    __ z_stg(Z_R1_scratch, _z_abi(carg2), Z_R0, Z_SP); // SP[abi_carg2] <- R1
-    __ z_la(Z_ARG1, _z_abi(carg2), Z_R0, Z_SP);        // R2 <- SP + abi_carg2
+    __ z_lay(Z_R1_scratch, -32, Z_R0, Z_R14);             // R1 <- R14 - 32
+    __ z_stg(Z_R1_scratch, _z_abi(carg_2), Z_R0, Z_SP); // SP[abi_carg2] <- R1
+    __ z_la(Z_ARG1, _z_abi(carg_2), Z_R0, Z_SP);        // R2 <- SP + abi_carg2
 
     // Call BarrierSetNMethod::nmethod_stub_entry_barrier(address* return_address_ptr)
     __ call_VM_leaf(CAST_FROM_FN_PTR(address, BarrierSetNMethod::nmethod_stub_entry_barrier));

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2886,7 +2886,7 @@ class StubGenerator: public StubCodeGenerator {
     // if (return val != 0)
     // return to caller
     __ z_ltr(Z_R2, Z_R2);
-    __ z_brnz(Z_R14);
+    __ z_bcr(Assembler::bcondNotEqual, Z_R14);
 
     // O.W. call indicates deoptimization required
     // Get handle to wrong-method-stub for s390

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2857,6 +2857,11 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
+  address generate_nmethod_entry_barrier() {
+    // TODO
+    return nullptr;
+  }
+
   address generate_cont_thaw(bool return_barrier, bool exception) {
     if (!Continuations::enabled()) return nullptr;
     Unimplemented();
@@ -2996,6 +3001,12 @@ class StubGenerator: public StubCodeGenerator {
     if (UseSHA512Intrinsics) {
       StubRoutines::_sha512_implCompress   = generate_SHA512_stub(false, "SHA512_singleBlock");
       StubRoutines::_sha512_implCompressMB = generate_SHA512_stub(true,  "SHA512_multiBlock");
+    }
+
+    // nmethod entry barriers for concurrent class unloading
+    BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
+    if (bs_nm != NULL) {
+      StubRoutines::zarch::_nmethod_entry_barrier = generate_nmethod_entry_barrier();
     }
 
 #ifdef COMPILER2

--- a/src/hotspot/cpu/s390/stubRoutines_s390.cpp
+++ b/src/hotspot/cpu/s390/stubRoutines_s390.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2016, 2017 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/s390/stubRoutines_s390.cpp
+++ b/src/hotspot/cpu/s390/stubRoutines_s390.cpp
@@ -38,14 +38,11 @@ address StubRoutines::zarch::_partial_subtype_check = NULL;
 // Comapct string intrinsics: Translate table for string inflate intrinsic. Used by trot instruction.
 address StubRoutines::zarch::_trot_table_addr = NULL;
 
+address StubRoutines::zarch::_nmethod_entry_barrier = NULL;
+
 int StubRoutines::zarch::_atomic_memory_operation_lock = StubRoutines::zarch::unlocked;
 
 #define __ masm->
-
-address StubRoutines::zarch::generate_nmethod_entry_barrier() {
-     // TODO
-     return nullptr;
-}
 
 void StubRoutines::zarch::generate_load_absolute_address(MacroAssembler* masm, Register table, address table_addr, uint64_t table_contents) {
   __ load_absolute_address(table, table_addr);

--- a/src/hotspot/cpu/s390/stubRoutines_s390.cpp
+++ b/src/hotspot/cpu/s390/stubRoutines_s390.cpp
@@ -42,6 +42,11 @@ int StubRoutines::zarch::_atomic_memory_operation_lock = StubRoutines::zarch::un
 
 #define __ masm->
 
+address StubRoutines::zarch::generate_nmethod_entry_barrier() {
+     // TODO
+     return nullptr;
+}
+
 void StubRoutines::zarch::generate_load_absolute_address(MacroAssembler* masm, Register table, address table_addr, uint64_t table_contents) {
   __ load_absolute_address(table, table_addr);
 

--- a/src/hotspot/cpu/s390/stubRoutines_s390.hpp
+++ b/src/hotspot/cpu/s390/stubRoutines_s390.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2016, 2017 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/s390/stubRoutines_s390.hpp
+++ b/src/hotspot/cpu/s390/stubRoutines_s390.hpp
@@ -78,6 +78,8 @@ class zarch {
   static address _trot_table_addr;
   static jlong   _trot_table[TROT_COLUMN_SIZE];
 
+  static address _nmethod_entry_barrier;
+
  public:
   // Global lock for everyone who needs to use atomic_compare_and_exchange
   // or atomic_increment -- should probably use more locks for more
@@ -98,6 +100,8 @@ class zarch {
 
   // Comapct string intrinsics: Translate table for string inflate intrinsic. Used by trot instruction.
   static void generate_load_trot_table_addr(MacroAssembler* masm, Register table);
+
+  static address nmethod_entry_barrier() { return _nmethod_entry_barrier; }
 };
 
 #endif // CPU_S390_STUBROUTINES_S390_HPP

--- a/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
@@ -153,7 +153,12 @@ int BarrierSetNMethod::nmethod_stub_entry_barrier(address* return_address_ptr) {
 
   address return_address = *return_address_ptr;
   AARCH64_PORT_ONLY(return_address = pauth_strip_pointer(return_address));
+
   CodeBlob* cb = CodeCache::find_blob(return_address);
+
+  // FIXME: Remove
+  if (cb == NULL) printf("Failed to find %lx (return_address) from %lx (return_address_ptr) in CodeCache\n", return_address, return_address_ptr);
+
   assert(cb != NULL, "invariant");
 
   nmethod* nm = cb->as_nmethod();

--- a/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
@@ -153,12 +153,7 @@ int BarrierSetNMethod::nmethod_stub_entry_barrier(address* return_address_ptr) {
 
   address return_address = *return_address_ptr;
   AARCH64_PORT_ONLY(return_address = pauth_strip_pointer(return_address));
-
   CodeBlob* cb = CodeCache::find_blob(return_address);
-
-  // FIXME: Remove
-  if (cb == NULL) printf("Failed to find %lx (return_address) from %lx (return_address_ptr) in CodeCache\n", return_address, return_address_ptr);
-
   assert(cb != NULL, "invariant");
 
   nmethod* nm = cb->as_nmethod();


### PR DESCRIPTION
This draft PR implements native method barriers on s390. When complete, this will fix the build, and bring the other benefits of [JDK-8290025](https://bugs.openjdk.org/browse/JDK-8290025) to that platform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294729](https://bugs.openjdk.org/browse/JDK-8294729): [s390] Implement nmethod entry barriers


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to [49e701d9](https://git.openjdk.org/jdk/pull/10558/files/49e701d9a5edeae5ee1f7a3771bb44a3e0aa85dd)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10558/head:pull/10558` \
`$ git checkout pull/10558`

Update a local copy of the PR: \
`$ git checkout pull/10558` \
`$ git pull https://git.openjdk.org/jdk pull/10558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10558`

View PR using the GUI difftool: \
`$ git pr show -t 10558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10558.diff">https://git.openjdk.org/jdk/pull/10558.diff</a>

</details>
