### PR TITLE
8294368: Java incremental builds broken on Windows after JDK-8293116

### DIFF
--- a/make/common/JavaCompilation.gmk
+++ b/make/common/JavaCompilation.gmk
@@ -403,6 +403,7 @@ define SetupJavaCompilationBody
     $1_COMPILE_TARGET := $$($1_BIN)$$($1_MODULE_SUBDIR)/_the.$1_batch
     $1_FILELIST := $$($1_BIN)$$($1_MODULE_SUBDIR)/_the.$1_batch.filelist
     $1_MODFILELIST := $$($1_BIN)$$($1_MODULE_SUBDIR)/_the.$1_batch.modfiles
+    $1_MODFILELIST_FIXED := $$($1_MODFILELIST).fixed
 
     $1_API_TARGET := $$($1_BIN)$$($1_MODULE_SUBDIR)/_the.$1_pubapi
     $1_API_INTERNAL := $$($1_BIN)$$($1_MODULE_SUBDIR)/_the.$1_internalapi
@@ -469,15 +470,18 @@ define SetupJavaCompilationBody
 		$$(eval $1_MODFILES := $$?)
 		$$(eval $$(call ListPathsSafely, $1_MODFILES, $$($1_MODFILELIST)))
 
+    $$($1_MODFILELIST_FIXED): $$($1_MODFILELIST)
+		$$(call FixPathFile, $$($1_MODFILELIST), $$($1_MODFILELIST_FIXED))
+
     # Do the actual compilation
     $$($1_COMPILE_TARGET): $$($1_SRCS) $$($1_FILELIST) $$($1_DEPENDS) \
         $$($1_VARDEPS_FILE) $$($1_EXTRA_DEPS) $$($1_JAVAC_SERVER_CONFIG) \
-        $$($1_MODFILELIST)
+        $$($1_MODFILELIST_FIXED)
 		$$(call MakeDir, $$(@D))
 		$$(call ExecuteWithLog, $$($1_BIN)$$($1_MODULE_SUBDIR)/_the.$$($1_SAFE_NAME)_batch, \
 		    $$($1_JAVAC_CMD) $$($1_FLAGS) \
 		        $$($1_API_DIGEST_FLAGS) \
-		        -XDmodifiedInputs=$$($1_MODFILELIST) \
+		        -XDmodifiedInputs=$$($1_MODFILELIST_FIXED) \
 		        -d $$($1_BIN) $$($1_HEADERS_ARG) @$$($1_FILELIST)) && \
 		$(TOUCH) $$@
 

--- a/make/common/JavaCompilation.gmk
+++ b/make/common/JavaCompilation.gmk
@@ -470,6 +470,9 @@ define SetupJavaCompilationBody
 		$$(eval $1_MODFILES := $$?)
 		$$(eval $$(call ListPathsSafely, $1_MODFILES, $$($1_MODFILELIST)))
 
+    # Convert the paths in the MODFILELIST file to Windows-style paths
+    # on Windows. This is needed because javac operates on Windows-style paths
+    # when running on Windows. On other platforms this just copies the MODFILELIST file.
     $$($1_MODFILELIST_FIXED): $$($1_MODFILELIST)
 		$$(call FixPathFile, $$($1_MODFILELIST), $$($1_MODFILELIST_FIXED))
 

--- a/make/common/MakeBase.gmk
+++ b/make/common/MakeBase.gmk
@@ -446,9 +446,13 @@ endif
 ifeq ($(call isTargetOs, windows), true)
   FixPath = \
     $(strip $(subst \,\\, $(shell $(FIXPATH_BASE) print $(patsubst $(FIXPATH), , $1))))
+  FixPathFile = \
+    $(shell $(FIXPATH_BASE) convert $1 $2)
 else
   FixPath = \
       $1
+  FixPathFile = \
+      $(shell $(CP) $1 $2)
 endif
 
 ################################################################################

--- a/make/common/MakeBase.gmk
+++ b/make/common/MakeBase.gmk
@@ -443,6 +443,13 @@ endif
 # list.
 # This is normally not needed since we use the FIXPATH prefix for command lines,
 # but might be needed in certain circumstances.
+#
+# FixPathFile is the file version of FixPath. It instead takes a file with paths in $1
+# and outputs the 'fixed' paths into the file in $2. If the file in $2 already exists
+# it is overwritten.
+# On non-Windows platforms this instead does a copy, so that $2 can still be used
+# as a depenendency of a make rule, instead of having to conditionally depend on
+# $1 instead, based on the target platform.
 ifeq ($(call isTargetOs, windows), true)
   FixPath = \
     $(strip $(subst \,\\, $(shell $(FIXPATH_BASE) print $(patsubst $(FIXPATH), , $1))))

--- a/make/scripts/fixpath.sh
+++ b/make/scripts/fixpath.sh
@@ -353,7 +353,8 @@ function convert_path() {
 }
 
 # Treat $1 as name of a file containing paths. Convert those paths to Windows style,
-# in the file specified by $2
+# and output them to the file specified by $2.
+# If the output file already exists, it is overwritten.
 function convert_file() {
   infile="$1"
   outfile="$2"

--- a/make/scripts/fixpath.sh
+++ b/make/scripts/fixpath.sh
@@ -359,11 +359,11 @@ function convert_file() {
   infile="$1"
   outfile="$2"
   if [[ -e $outfile ]] ; then
-	rm $outfile
+    rm $outfile
   fi
   while read line; do
-	convert_path "$line"
-	echo "$result" >> $outfile
+    convert_path "$line"
+    echo "$result" >> $outfile
   done < $infile
 }
 

--- a/make/scripts/fixpath.sh
+++ b/make/scripts/fixpath.sh
@@ -353,6 +353,20 @@ function convert_path() {
 }
 
 # Treat $1 as name of a file containing paths. Convert those paths to Windows style,
+# in the file specified by $2
+function convert_file() {
+  infile="$1"
+  outfile="$2"
+  if [[ -e $outfile ]] ; then
+	rm $outfile
+  fi
+  while read line; do
+	convert_path "$line"
+	echo "$result" >> $outfile
+  done < $infile
+}
+
+# Treat $1 as name of a file containing paths. Convert those paths to Windows style,
 # in a new temporary file, and return a string "@<temp file>" pointing to that
 # new file.
 function convert_at_file() {
@@ -498,6 +512,8 @@ if [[ "$ACTION" == "import" ]] ; then
 elif [[ "$ACTION" == "print" ]] ; then
   print_command_line "$@"
   echo "$result"
+elif [[ "$ACTION" == "convert" ]] ; then
+  convert_file "$@"
 elif [[ "$ACTION" == "exec" ]] ; then
   exec_command_line "$@"
   # Propagate exit code


### PR DESCRIPTION
This patch fixes incremental builds on Windows.

There are 2 parts to this:
1. the build system needs to run the paths in the modified file list through fixpath. I've added a `convert` mode to `fixpath.sh` for that. There's an extra target for generating the file with fixed paths. On non-windows platforms this is just a simple `cp` of the file.
2. the dependency plugin of `javac` was using string-based path comparison. But, the paths fed by the build system and the paths used internally by javac could be in slightly different formats, meaning that files were not detected properly as changed. I switched to `Path`-based comparison instead and that fixes the issue.

Testing:
tested this manually by doing the following:
1. `make clean`
2. `make images`
3. put garbage in one of the files in `java.base`
4. `make images` (incremental)
5. verify that the build reported an error
6. verify the contents of `<build>\jdk\modules\java.base\_the.java.base_batch.modfiles.fixed`
7. revert the changes of 3, and do the same for another file
8. `make images` (incremental)
9. verify that the build reported an error
10. verify the contents of `<build>\jdk\modules\java.base\_the.java.base_batch.modfiles.fixed`
11. remove garbage from file modified by 9 again
12. `make images` (incremental)
13. verify that build succeeds as in 2

I've tested the build on Windows and Linux (WSL) using the above steps.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294368](https://bugs.openjdk.org/browse/JDK-8294368): Java incremental builds broken on Windows after JDK-8293116


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - Committer)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10560/head:pull/10560` \
`$ git checkout pull/10560`

Update a local copy of the PR: \
`$ git checkout pull/10560` \
`$ git pull https://git.openjdk.org/jdk pull/10560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10560`

View PR using the GUI difftool: \
`$ git pr show -t 10560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10560.diff">https://git.openjdk.org/jdk/pull/10560.diff</a>

</details>
