### PR TITLE
8294807: Fix typos and clarify javadoc for SunToolKit.realsSync

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/SunToolkit.java
+++ b/src/java.desktop/share/classes/sun/awt/SunToolkit.java
@@ -1442,21 +1442,21 @@ public abstract class SunToolkit extends Toolkit
      * sub-system, flushing all pending work and waiting for all the
      * events to be processed.  This method guarantees that after
      * return no additional Java events will be generated, unless
-     * cause by user. Obviously, the method cannot be used on the
-     * event dispatch thread (EDT). In case it nevertheless gets
+     * caused by user. Obviously, the method cannot be used on the
+     * event dispatch thread (EDT). In case it gets
      * invoked on this thread, the method throws the
-     * IllegalThreadException runtime exception.
+     * {@code IllegalThreadException} runtime exception.
      *
-     * <p> This method allows to write tests without explicit timeouts
-     * or wait for some event.  Example:
+     * <p> This method allows writing tests without explicit timeouts
+     * or waiting for some event.  Example:
      * <pre>{@code
      * Frame f = ...;
      * f.setVisible(true);
      * ((SunToolkit)Toolkit.getDefaultToolkit()).realSync();
      * }</pre>
      *
-     * <p> After realSync, {@code f} will be completely visible
-     * on the screen, its getLocationOnScreen will be returning the
+     * <p> After {@code realSync}, {@code f} will be completely visible
+     * on the screen, its {@code getLocationOnScreen} will be returning the
      * right result and it will be the focus owner.
      *
      * <p> Another example:
@@ -1465,19 +1465,20 @@ public abstract class SunToolkit extends Toolkit
      * ((SunToolkit)Toolkit.getDefaultToolkit()).realSync();
      * }</pre>
      *
-     * <p> After realSync, {@code b} will be focus owner.
+     * <p> After {@code realSync}, {@code b} will be focus owner.
      *
-     * <p> Notice that realSync isn't guaranteed to work if recurring
-     * actions occur, such as if during processing of some event
+     * <p> Notice that {@code realSync} isn't guaranteed to work if recurring
+     * actions occur, such as if during processing of an event
      * another request which may generate some events occurs.  By
-     * default, sync tries to perform as much as {@value #MAX_ITERS}
+     * default, sync tries to perform as many as {@value #MAX_ITERS}
      * cycles of event processing, allowing for roughly {@value
      * #MAX_ITERS} additional requests.
      *
-     * <p> For example, requestFocus() generates native request, which
-     * generates one or two Java focus events, which then generate a
-     * serie of paint events, a serie of Java focus events, which then
-     * generate a serie of paint events which then are processed -
+     * <p> For example, {@link Component#requestFocus() requestFocus()}
+     * generates a native request, which generates one or two Java
+     * focus events, which then generate a series of paint events,
+     * a series of Java focus events, which then generate
+     * a series of paint events which then are processed &mdash;
      * three cycles, minimum.
      *
      * @param timeout the maximum time to wait in milliseconds, negative means "forever".


### PR DESCRIPTION
I fixed the typo “serie” → "series" which was highlighted by a spellchecker.

I also simplified the description, fixed the grammar, added `{@code}` around types, added link to `requestFocus` in the example.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blockers
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8294807](https://bugs.openjdk.org/browse/JDK-8294807)
&nbsp;⚠️ Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed with the updated jcheck configuration)
&nbsp;⚠️ Whitespace errors (failed with the updated jcheck configuration)

### Issue
 * [JDK-8294807](https://bugs.openjdk.org/browse/JDK-8294807): Fix typos and clarify doc comment for SunToolKit.realSync ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10563/head:pull/10563` \
`$ git checkout pull/10563`

Update a local copy of the PR: \
`$ git checkout pull/10563` \
`$ git pull https://git.openjdk.org/jdk pull/10563/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10563`

View PR using the GUI difftool: \
`$ git pr show -t 10563`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10563.diff">https://git.openjdk.org/jdk/pull/10563.diff</a>

</details>
