### PR TITLE
JDK-8294546: document where javac differs when invoked via launcher and ToolProvider

### DIFF
--- a/src/jdk.compiler/share/classes/module-info.java
+++ b/src/jdk.compiler/share/classes/module-info.java
@@ -23,6 +23,9 @@
  * questions.
  */
 
+import javax.tools.JavaCompiler;
+import javax.tools.StandardLocation;
+
 /**
  * Defines the implementation of the
  * {@linkplain javax.tools.ToolProvider#getSystemJavaCompiler system Java compiler}
@@ -58,6 +61,78 @@
  * this means that a jar file system provider, such as that in the
  * {@code jdk.zipfs} module, must be available if the compiler is to be able
  * to read JAR files.
+ *
+ * <h3>Options and Environment Variables</h3>
+ *
+ * The full set of options and environment variables supported by <em>javac</em>
+ * is given in the <a href="../specs/man/javac.html"><em>javac Tool Guide</em></a>.
+ * However, there are some restrictions when the compiler is invoked through
+ * its API.
+ *
+ * <ul>
+ *     <li><p>The {@code -J} option is not supported.
+ *          Any necessary VM options must be set in the VM used to invoke the API.
+ *          {@code IllegalArgumentException} will be thrown if the option
+ *          is used when invoking the tool through the {@code JavaCompiler} API;
+ *          an error will be reported if the option is used when invoking
+ *          <em>javac</em> through the {@link java.util.spi.ToolProvider ToolProvider}
+ *          or legacy {@link com.sun.tools.javac.Main Main} API.
+ *
+ *     <li><p>The "classpath wildcard" feature is not supported.
+ *          The feature is only supported by the native launcher.
+ *          When invoking the tool through its API, all necessary jar
+ *          files should be included directly in the {@code --class-path}
+ *          option, or the {@code CLASSPATH} environment variable.
+ *          When invoking the tool through its API, all components of the
+ *          class path will be taken literally, and will be ignored if there
+ *          is no matching directory or file. The {@code -Xlint:paths}
+ *          option can be used to generate warnings about missing components.
+ *
+ * </ul>
+ *
+ * The following restrictions apply when invoking the compiler through
+ * the {@link JavaCompiler} interface.
+ *
+ * <ul>
+ *     <li><p>Argument files (so-called @-files) are not supported.
+ *          The content of any such files should be included directly
+ *          in the list of options provided when invoking the tool
+ *          though this API.
+ *          {@code IllegalArgumentException} will be thrown if
+ *          the option is used when invoking the tool through this API.
+ *
+ *     <li><p>The environment variable {@code JDK_JAVAC_OPTIONS} is not supported.
+ *          Any options defined in the environment variable should be included
+ *          directly in the list of options provided when invoking the
+ *          API; any values in the environment variable will be ignored.
+ *
+ *     <li><p>Options that are just used to obtain information (such as
+ *          {@code --help}, {@code --help-extended}, {@code --version} and
+ *          {@code --full-version}) are not supported.
+ *          {@link IllegalArgumentException} will be thrown if any of
+ *          these options are used when invoking the tool through this API.
+ *
+ *      <li>Path-related options depend on the file manager being used
+ *          when calling {@link JavaCompiler#getTask}. The "standard"
+ *          options, such as {@code --class-path}, {@code --module-path},
+ *          and so on are available when using the default file manager,
+ *          or one derived from it. These options may not be available
+ *          and different options may be available, when using a different
+ *          file manager.
+ *          {@link IllegalArgumentException} will be thrown if any option
+ *          that is unknown to the tool or the file manager is used when
+ *          invoking the tool through this API.
+ * </ul>
+ *
+ * Note that the {@code CLASSPATH} environment variable <em>is</em> honored
+ * when invoking the compiler through its API, although such use is discouraged.
+ * An environment variable cannot be unset once a VM has been started,
+ * and so it is recommended to ensure that the environment variable is not set
+ * when starting a VM that will be used to invoke the compiler.
+ * However, if a value has been set, any such value can be overridden by
+ * using the {@code --class-path} option when invoking the compiler,
+ * or setting {@link StandardLocation#CLASS_PATH} in the file manager
+ * when invoking the compiler through the {@link JavaCompiler} interface.
  *
  * <h3>SuppressWarnings</h3>
  *


### PR DESCRIPTION
Please review a doc-only change to specify the differences between using different ways to invoke javac.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8294546](https://bugs.openjdk.org/browse/JDK-8294546): document where javac differs when invoked via launcher and ToolProvider
 * [JDK-8294687](https://bugs.openjdk.org/browse/JDK-8294687): document where javac differs when invoked via launcher and ToolProvider (**CSR**)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10566/head:pull/10566` \
`$ git checkout pull/10566`

Update a local copy of the PR: \
`$ git checkout pull/10566` \
`$ git pull https://git.openjdk.org/jdk pull/10566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10566`

View PR using the GUI difftool: \
`$ git pr show -t 10566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10566.diff">https://git.openjdk.org/jdk/pull/10566.diff</a>

</details>
