### PR TITLE
8170389: java.text.DigitList.getDouble() : Controversy between javadoc and code

### DIFF
--- a/src/java.base/share/classes/java/text/DigitList.java
+++ b/src/java.base/share/classes/java/text/DigitList.java
@@ -153,7 +153,8 @@ final class DigitList implements Cloneable {
 
     /**
      * Utility routine to get the value of the digit list
-     * If (count == 0) this returns 0.0, unlike Double.parseDouble("") which throws NumberFormatException.
+     * If (count == 0) this returns 0.0,
+     * unlike Double.parseDouble("") which throws NumberFormatException.
      */
     public final double getDouble() {
         if (count == 0) {
@@ -170,7 +171,8 @@ final class DigitList implements Cloneable {
 
     /**
      * Utility routine to get the value of the digit list.
-     * If (count == 0) this returns 0, unlike Long.parseLong("") which throws NumberFormatException.
+     * If (count == 0) this returns 0,
+     * unlike Long.parseLong("") which throws NumberFormatException.
      */
     public final long getLong() {
         // for now, simple implementation; later, do proper IEEE native stuff
@@ -196,7 +198,8 @@ final class DigitList implements Cloneable {
 
     /**
      * Utility routine to get the value of the digit list.
-     * If (count == 0) this does not throw a NumberFormatException, unlike BigDecimal("").
+     * If (count == 0) this does not throw a NumberFormatException,
+     * unlike BigDecimal("").
      */
     public final BigDecimal getBigDecimal() {
         if (count == 0) {

--- a/src/java.base/share/classes/java/text/DigitList.java
+++ b/src/java.base/share/classes/java/text/DigitList.java
@@ -153,8 +153,7 @@ final class DigitList implements Cloneable {
 
     /**
      * Utility routine to get the value of the digit list
-     * If (count == 0) this throws a NumberFormatException, which
-     * mimics Long.parseLong().
+     * If (count == 0) this returns 0.0, unlike Double.parseDouble().
      */
     public final double getDouble() {
         if (count == 0) {

--- a/src/java.base/share/classes/java/text/DigitList.java
+++ b/src/java.base/share/classes/java/text/DigitList.java
@@ -196,6 +196,7 @@ final class DigitList implements Cloneable {
 
     /**
      * Utility routine to get the value of the digit list.
+     * If (count == 0) this does not throw a NumberFormatException, unlike BigDecimal("").
      */
     public final BigDecimal getBigDecimal() {
         if (count == 0) {

--- a/src/java.base/share/classes/java/text/DigitList.java
+++ b/src/java.base/share/classes/java/text/DigitList.java
@@ -153,7 +153,7 @@ final class DigitList implements Cloneable {
 
     /**
      * Utility routine to get the value of the digit list
-     * If (count == 0) this returns 0.0, unlike Double.parseDouble().
+     * If (count == 0) this returns 0.0, unlike Double.parseDouble("") which throws NumberFormatException.
      */
     public final double getDouble() {
         if (count == 0) {
@@ -170,7 +170,7 @@ final class DigitList implements Cloneable {
 
     /**
      * Utility routine to get the value of the digit list.
-     * If (count == 0) this returns 0, unlike Long.parseLong().
+     * If (count == 0) this returns 0, unlike Long.parseLong("") which throws NumberFormatException.
      */
     public final long getLong() {
         // for now, simple implementation; later, do proper IEEE native stuff
@@ -194,6 +194,9 @@ final class DigitList implements Cloneable {
         return Long.parseLong(temp.toString());
     }
 
+    /**
+     * Utility routine to get the value of the digit list.
+     */
     public final BigDecimal getBigDecimal() {
         if (count == 0) {
             if (decimalAt == 0) {


### PR DESCRIPTION
Problem: Outdated doc does not match code. Claimed to throw exception and compared to Long method.
Fix: Update doc to match code, compared to Double.parseDouble() accordingly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8170389](https://bugs.openjdk.org/browse/JDK-8170389): java.text.DigitList.getDouble() : Controversy between javadoc and code


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [55679168](https://git.openjdk.org/jdk/pull/10567/files/55679168b90bb41f7a2a669c62f429073d8f650f)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10567/head:pull/10567` \
`$ git checkout pull/10567`

Update a local copy of the PR: \
`$ git checkout pull/10567` \
`$ git pull https://git.openjdk.org/jdk pull/10567/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10567`

View PR using the GUI difftool: \
`$ git pr show -t 10567`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10567.diff">https://git.openjdk.org/jdk/pull/10567.diff</a>

</details>
