### PR TITLE
8294839: Disable StressLongCountedLoop in compiler/loopopts/TestRemoveEmptyLoop.java

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyLoop.java
@@ -28,6 +28,7 @@
  * @summary Unexpected test result caused by C2 IdealLoopTree::do_remove_empty_loop
  *
  * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation
+ *      -XX:StressLongCountedLoop=0
  *      compiler.loopopts.TestRemoveEmptyLoop
  */
 


### PR DESCRIPTION
As I have explained in [JDK-8294838](https://bugs.openjdk.org/browse/JDK-8294838), `-XX:StressLongCountedLoop=200000000` leads to a timeout in `compiler/loopopts/TestRemoveEmptyLoop.java` because an int-loop is transformed into a long-loop, but the loop is not collapsed/removed because we only remove empty int-loops.

This is a sub-task of [JDK-8294838](https://bugs.openjdk.org/browse/JDK-8294838), where we hope to implement empty loop removal for LongCountedLoops.

Manually tested the test with and without the flag.
Test suite passes too, with and without the flag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294839](https://bugs.openjdk.org/browse/JDK-8294839): Disable StressLongCountedLoop in compiler/loopopts/TestRemoveEmptyLoop.java


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10569/head:pull/10569` \
`$ git checkout pull/10569`

Update a local copy of the PR: \
`$ git checkout pull/10569` \
`$ git pull https://git.openjdk.org/jdk pull/10569/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10569`

View PR using the GUI difftool: \
`$ git pr show -t 10569`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10569.diff">https://git.openjdk.org/jdk/pull/10569.diff</a>

</details>
