### PR TITLE
JDK-8294837: unify Windows 2019 version check in os_windows and java_props_md

### DIFF
--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -558,7 +558,7 @@ GetJavaProperties(JNIEnv* env)
                         /* Windows server 2022 build number is 20348 */
                         if (buildNumber > 20347) {
                             sprops.os_name = "Windows Server 2022";
-                        } else if (buildNumber > 17676) {
+                        } else if (buildNumber > 17762) {
                             sprops.os_name = "Windows Server 2019";
                         } else {
                             sprops.os_name = "Windows Server 2016";


### PR DESCRIPTION
Currently the buildNumber check for Windows 2019 server differs in os_windows.cpp and java_props_md.c ( java_props_md.c still checks pre GA versions , this is probably not necessary any more ).
The check should be unified.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294837](https://bugs.openjdk.org/browse/JDK-8294837): unify Windows 2019 version check in os_windows and java_props_md


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10570/head:pull/10570` \
`$ git checkout pull/10570`

Update a local copy of the PR: \
`$ git checkout pull/10570` \
`$ git pull https://git.openjdk.org/jdk pull/10570/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10570`

View PR using the GUI difftool: \
`$ git pr show -t 10570`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10570.diff">https://git.openjdk.org/jdk/pull/10570.diff</a>

</details>
