### PR TITLE
JDK-8294840: langtools OptionalDependencyTest.java use File.pathSeparator

### DIFF
--- a/test/langtools/tools/jdeps/optionalDependency/OptionalDependencyTest.java
+++ b/test/langtools/tools/jdeps/optionalDependency/OptionalDependencyTest.java
@@ -30,6 +30,7 @@
  * @summary Tests optional dependency handling
  */
 
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
@@ -71,7 +72,7 @@ public class OptionalDependencyTest {
      */
     @Test
     public void optionalDependenceNotResolved() {
-        JdepsRunner jdepsRunner = new JdepsRunner("--module-path", "m2.jar:m3.jar",
+        JdepsRunner jdepsRunner = new JdepsRunner("--module-path", "m2.jar" + File.pathSeparator + "m3.jar",
                                                   "--inverse",
                                                   "--package", "p2", "m1.jar");
         int rc = jdepsRunner.run(true);
@@ -83,7 +84,7 @@ public class OptionalDependencyTest {
      */
     @Test
     public void optionalDependenceResolved() {
-        JdepsRunner jdepsRunner = new JdepsRunner("--module-path", "m2.jar:m3.jar",
+        JdepsRunner jdepsRunner = new JdepsRunner("--module-path", "m2.jar" + File.pathSeparator + "m3.jar",
                                                   "--inverse", "--add-modules", "m3",
                                                   "--package", "p2", "m1.jar");
         int rc = jdepsRunner.run(true);


### PR DESCRIPTION
The test/langtools/tools/jdeps/optionalDependency/OptionalDependencyTest.java:
introduced with 8293701 needs to use File.pathSeparator instead of ":" to work on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294840](https://bugs.openjdk.org/browse/JDK-8294840): langtools OptionalDependencyTest.java use File.pathSeparator


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10572/head:pull/10572` \
`$ git checkout pull/10572`

Update a local copy of the PR: \
`$ git checkout pull/10572` \
`$ git pull https://git.openjdk.org/jdk pull/10572/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10572`

View PR using the GUI difftool: \
`$ git pr show -t 10572`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10572.diff">https://git.openjdk.org/jdk/pull/10572.diff</a>

</details>
