### PR TITLE
8294848: Unnecessary SSLCipher dispose implementations

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
@@ -1670,17 +1670,6 @@ enum SSLCipher {
             }
 
             @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
-            }
-
-            @Override
             int estimateFragmentSize(int packetSize, int headerSize) {
                 return packetSize - headerSize - recordIvSize - tagSize;
             }
@@ -1791,17 +1780,6 @@ enum SSLCipher {
                 }
 
                 return len + nonce.length;
-            }
-
-            @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
             }
 
             @Override
@@ -1967,17 +1945,6 @@ enum SSLCipher {
             }
 
             @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
-            }
-
-            @Override
             int estimateFragmentSize(int packetSize, int headerSize) {
                 return packetSize - headerSize - tagSize;
             }
@@ -2094,17 +2061,6 @@ enum SSLCipher {
                     keyLimitCountdown -= len;
                 }
                 return len;
-            }
-
-            @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
             }
 
             @Override
@@ -2236,17 +2192,6 @@ enum SSLCipher {
             }
 
             @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
-            }
-
-            @Override
             int estimateFragmentSize(int packetSize, int headerSize) {
                 return packetSize - headerSize - tagSize;
             }
@@ -2362,17 +2307,6 @@ enum SSLCipher {
                 }
 
                 return len;
-            }
-
-            @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
             }
 
             @Override
@@ -2527,17 +2461,6 @@ enum SSLCipher {
             }
 
             @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
-            }
-
-            @Override
             int estimateFragmentSize(int packetSize, int headerSize) {
                 return packetSize - headerSize - tagSize;
             }
@@ -2655,17 +2578,6 @@ enum SSLCipher {
                     keyLimitCountdown -= len;
                 }
                 return len;
-            }
-
-            @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
             }
 
             @Override


### PR DESCRIPTION
This PR removes the implementation of `dispose()` method for AEAD SSLCiphers.

Invocations of [readCipher.dispose](https://github.com/openjdk/jdk/blob/4cec141a90bc5d3b8ec17c024291d9c74a112cd4/src/java.base/share/classes/sun/security/ssl/InputRecord.java#L118) and [disposeWriteCipher](https://github.com/openjdk/jdk/blob/4cec141a90bc5d3b8ec17c024291d9c74a112cd4/src/java.base/share/classes/sun/security/ssl/OutputRecord.java#L191) come with a comment:

> Dispose of any intermediate state in the underlying cipher. For PKCS11 ciphers, this will release any attached sessions, and thus make finalization faster.
> Since MAC's doFinal() is called for every SSL/TLS packet, it's not necessary to do the same with MAC's.

Typical non-empty implementation of dispose is a call to cipher.doFinal, which internally releases PKCS11 native resources.

AEAD ciphers are similar to MAC - `doFinal()` is also called for every packet. They don't need another explicit `doFinal` call.

Tier1-3 tests clean. No new tests - this is clean up only.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294848](https://bugs.openjdk.org/browse/JDK-8294848): Unnecessary SSLCipher dispose implementations


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)
 * [Bradford Wetmore](https://openjdk.org/census#wetmore) (@bradfordwetmore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10574/head:pull/10574` \
`$ git checkout pull/10574`

Update a local copy of the PR: \
`$ git checkout pull/10574` \
`$ git pull https://git.openjdk.org/jdk pull/10574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10574`

View PR using the GUI difftool: \
`$ git pr show -t 10574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10574.diff">https://git.openjdk.org/jdk/pull/10574.diff</a>

</details>
