### PR TITLE
8287832: jdk/jfr/event/runtime/TestActiveSettingEvent.java failed with "Expected two batches of Active Setting events"

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
@@ -277,9 +277,7 @@ JVM_ENTRY_NO_ENV(void, jfr_set_method_sampling_period(JNIEnv* env, jobject jvm, 
   }
   JfrEventId typed_event_id = (JfrEventId)type;
   assert(EventExecutionSample::eventId == typed_event_id || EventNativeMethodSample::eventId == typed_event_id, "invariant");
-  if (periodMillis > 0) {
-    JfrEventSetting::set_enabled(typed_event_id, true); // ensure sampling event is enabled
-  }
+  JfrEventSetting::set_enabled(typed_event_id, periodMillis > 0);
   if (EventExecutionSample::eventId == type) {
     JfrThreadSampling::set_java_sample_period(periodMillis);
   } else {

--- a/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
@@ -299,14 +299,18 @@ static const uint MAX_NR_OF_NATIVE_SAMPLES = 1;
 void JfrThreadSampleClosure::commit_events(JfrSampleType type) {
   if (JAVA_SAMPLE == type) {
     assert(_added_java > 0 && _added_java <= MAX_NR_OF_JAVA_SAMPLES, "invariant");
-    for (uint i = 0; i < _added_java; ++i) {
-      _events[i].commit();
+    if (EventExecutionSample::is_enabled()) {
+      for (uint i = 0; i < _added_java; ++i) {
+        _events[i].commit();
+      }
     }
   } else {
     assert(NATIVE_SAMPLE == type, "invariant");
     assert(_added_native > 0 && _added_native <= MAX_NR_OF_NATIVE_SAMPLES, "invariant");
-    for (uint i = 0; i < _added_native; ++i) {
-      _events_native[i].commit();
+    if (EventNativeMethodSample::is_enabled()) {
+      for (uint i = 0; i < _added_native; ++i) {
+        _events_native[i].commit();
+      }
     }
   }
 }

--- a/src/hotspot/share/jfr/recorder/service/jfrEvent.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrEvent.hpp
@@ -160,11 +160,13 @@ class JfrEvent {
 
  private:
   bool should_write() {
-    return _evaluated ? _should_commit : is_enabled_for_thread() && evaluate();
-  }
-
-  static bool is_enabled_for_thread() {
-    return is_enabled() && JfrThreadLocal::is_included(Thread::current());
+    if (_evaluated) {
+      return _should_commit;
+    }
+    if (!is_enabled()) {
+      return false;
+    }
+    return evaluate() && JfrThreadLocal::is_included(Thread::current());
   }
 
   bool evaluate() {

--- a/src/hotspot/share/jfr/recorder/service/jfrEvent.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrEvent.hpp
@@ -63,24 +63,20 @@ class JfrEvent {
  private:
   jlong _start_time;
   jlong _end_time;
-  bool _started;
   bool _untimed;
   bool _should_commit;
   bool _evaluated;
 
  protected:
   JfrEvent(EventStartTime timing=TIMED) : _start_time(0), _end_time(0),
-                                          _started(false), _untimed(timing == UNTIMED),
+                                          _untimed(timing == UNTIMED),
                                           _should_commit(false), _evaluated(false)
 #ifdef ASSERT
   , _verifier()
 #endif
   {
-    if (T::is_enabled() && JfrThreadLocal::is_included(Thread::current())) {
-      _started = true;
-      if (TIMED == timing && !T::isInstant) {
-        set_starttime(JfrTicks::now());
-      }
+    if (!T::isInstant && !_untimed && is_enabled()) {
+      set_starttime(JfrTicks::now());
     }
   }
 
@@ -146,19 +142,16 @@ class JfrEvent {
     return T::hasStackTrace;
   }
 
-  bool is_started() const {
-    return _started;
+  bool is_started() {
+    return is_instant() || _start_time != 0 || _untimed;
   }
 
   bool should_commit() {
-    if (!_started) {
+    if (!is_enabled()) {
       return false;
     }
     if (_untimed) {
       return true;
-    }
-    if (_evaluated) {
-      return _should_commit;
     }
     _should_commit = evaluate();
     _evaluated = true;
@@ -167,11 +160,14 @@ class JfrEvent {
 
  private:
   bool should_write() {
-    return _started && (_evaluated ? _should_commit : evaluate());
+    return _evaluated ? _should_commit : is_enabled_for_thread() && evaluate();
+  }
+
+  static bool is_enabled_for_thread() {
+    return is_enabled() && JfrThreadLocal::is_included(Thread::current());
   }
 
   bool evaluate() {
-    assert(_started, "invariant");
     if (_start_time == 0) {
       set_starttime(JfrTicks::now());
     } else if (_end_time == 0) {

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -748,7 +748,6 @@ jdk/jfr/startupargs/TestStartName.java                          8214685 windows-
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
 jdk/jfr/api/consumer/recordingstream/TestOnEvent.java           8255404 linux-x64
-jdk/jfr/event/runtime/TestActiveSettingEvent.java               8287832 generic-all
 jdk/jfr/api/consumer/TestRecordingFileWrite.java                8287699 linux-x64,macosx-x64
 
 ############################################################################


### PR DESCRIPTION
Greetings,

The test fails because of an unexpected event in the event stream. The recording does not explicitly enable any events, yet, occasionally, there are some. From where do these events originate? The JfrEvent C++ classes check enabled state in the constructor, and some event instances have extent across a potential safepoint. A safepoint could result from JFR rotating and stopping to record. As a result, an event can still be enabled after JFR stops and then restarts, resulting in unexpected events in the event stream of the newly started recording.

Most common unexpected events seen are:

jdk.JavaMonitorWait
jdk.Compilation
jdk.NativeMethodSample

A solution to this problem is to move the event-enabled check from the constructor to the shouldCommit() and commit() functions. For durational events, it requires two is_enabled() tests, as one will still be needed in the constructor, for decision about starttime. No tangible performance impact is expected.

Testing: jdk_jfr, stress testing

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287832](https://bugs.openjdk.org/browse/JDK-8287832): jdk/jfr/event/runtime/TestActiveSettingEvent.java failed with "Expected two batches of Active Setting events"


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**) ⚠️ Review applies to [4751fdab](https://git.openjdk.org/jdk/pull/10575/files/4751fdab034f2841053b35e1a6142cebdf07a74a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10575/head:pull/10575` \
`$ git checkout pull/10575`

Update a local copy of the PR: \
`$ git checkout pull/10575` \
`$ git pull https://git.openjdk.org/jdk pull/10575/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10575`

View PR using the GUI difftool: \
`$ git pr show -t 10575`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10575.diff">https://git.openjdk.org/jdk/pull/10575.diff</a>

</details>
