### PR TITLE
8293810: Remove granting of RuntimePermission("stopThread") from tests

### DIFF
--- a/test/jdk/java/lang/System/System.policy
+++ b/test/jdk/java/lang/System/System.policy
@@ -4,16 +4,6 @@
 // default permissions granted to all domains
 
 grant { 
-	// Allows any thread to stop itself using the java.lang.Thread.stop()
-	// method that takes no argument.
-	// Note that this permission is granted by default only to remain
-	// backwards compatible.
-	// It is strongly recommended that you either remove this permission
-	// from this policy file or further restrict it to code sources
-	// that you specify, because Thread.stop() is potentially unsafe.
-	// See "http://java.sun.com/notes" for more information.
-	permission java.lang.RuntimePermission "stopThread";
-
 	// These two added for SecurityRace test
 
 	permission java.lang.RuntimePermission "setSecurityManager";

--- a/test/jdk/java/nio/charset/spi/default-pol
+++ b/test/jdk/java/nio/charset/spi/default-pol
@@ -9,16 +9,6 @@ grant codeBase "jrt:/jdk.charsets" {
 // default permissions granted to all domains
 
 grant { 
-	// Allows any thread to stop itself using the java.lang.Thread.stop()
-	// method that takes no argument.
-	// Note that this permission is granted by default only to remain
-	// backwards compatible.
-	// It is strongly recommended that you either remove this permission
-	// from this policy file or further restrict it to code sources
-	// that you specify, because Thread.stop() is potentially unsafe.
-	// See "http://java.sun.com/notes" for more information.
-	permission java.lang.RuntimePermission "stopThread";
-
 	// allows anyone to listen on un-privileged ports
 	permission java.net.SocketPermission "localhost:1024-", "listen";
 

--- a/test/jdk/java/security/Policy/Dynamic/DynamicPolicy.java
+++ b/test/jdk/java/security/Policy/Dynamic/DynamicPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,6 @@ public class DynamicPolicy extends Policy{
 
         perms.add(new java.security.SecurityPermission("getPolicy"));
         perms.add(new java.security.SecurityPermission("setPolicy"));
-        perms.add(new java.lang.RuntimePermission("stopThread"));
         perms.add(new java.net.SocketPermission("localhost:1024-", "listen"));
         perms.add(new PropertyPermission("java.version","read"));
         perms.add(new PropertyPermission("java.vendor","read"));

--- a/test/jdk/javax/management/security/java.policy.authorization
+++ b/test/jdk/javax/management/security/java.policy.authorization
@@ -6,16 +6,6 @@ grant codeBase "file:${java.home}/lib/ext/*" {
 
 // default permissions granted to all domains
 grant { 
-	// Allows any thread to stop itself using the java.lang.Thread.stop()
-	// method that takes no argument.
-	// Note that this permission is granted by default only to remain
-	// backwards compatible.
-	// It is strongly recommended that you either remove this permission
-	// from this policy file or further restrict it to code sources
-	// that you specify, because Thread.stop() is potentially unsafe.
-	// See "http://java.sun.com/notes" for more information.
-	permission java.lang.RuntimePermission "stopThread";
-
 	// allows anyone to listen on un-privileged ports
 	permission java.net.SocketPermission "localhost:1024-", "listen";
 

--- a/test/jdk/sun/net/www/http/HttpClient/IsKeepingAlive.policy
+++ b/test/jdk/sun/net/www/http/HttpClient/IsKeepingAlive.policy
@@ -8,16 +8,6 @@ grant {
 // default permissions granted to all domains
 
 grant { 
-	// Allows any thread to stop itself using the java.lang.Thread.stop()
-	// method that takes no argument.
-	// Note that this permission is granted by default only to remain
-	// backwards compatible.
-	// It is strongly recommended that you either remove this permission
-	// from this policy file or further restrict it to code sources
-	// that you specify, because Thread.stop() is potentially unsafe.
-	// See "http://java.sun.com/notes" for more information.
-	permission java.lang.RuntimePermission "stopThread";
-
 	// allows anyone to listen on un-privileged ports
 	permission java.net.SocketPermission "localhost:1024-", "listen";
 

--- a/test/jdk/sun/net/www/http/HttpClient/OpenServer.policy
+++ b/test/jdk/sun/net/www/http/HttpClient/OpenServer.policy
@@ -8,16 +8,6 @@ grant {
 // default permissions granted to all domains
 
 grant { 
-	// Allows any thread to stop itself using the java.lang.Thread.stop()
-	// method that takes no argument.
-	// Note that this permission is granted by default only to remain
-	// backwards compatible.
-	// It is strongly recommended that you either remove this permission
-	// from this policy file or further restrict it to code sources
-	// that you specify, because Thread.stop() is potentially unsafe.
-	// See "http://java.sun.com/notes" for more information.
-	permission java.lang.RuntimePermission "stopThread";
-
 	// allows anyone to listen on un-privileged ports
 	permission java.net.SocketPermission "localhost:1024-", "listen";
 


### PR DESCRIPTION
This is a test only change to remove the granting of RuntimePermission("stopThread") from the tests. With Thread.stop changed to throw UOE it means there is nothing that requires this permission.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293810](https://bugs.openjdk.org/browse/JDK-8293810): Remove granting of RuntimePermission("stopThread") from tests


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [Chris Hegarty](https://openjdk.org/census#chegar) (@ChrisHegarty - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10577/head:pull/10577` \
`$ git checkout pull/10577`

Update a local copy of the PR: \
`$ git checkout pull/10577` \
`$ git pull https://git.openjdk.org/jdk pull/10577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10577`

View PR using the GUI difftool: \
`$ git pr show -t 10577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10577.diff">https://git.openjdk.org/jdk/pull/10577.diff</a>

</details>
