### PR TITLE
JDK-8294869: Correct failure of RemovedJDKInternals.java after JDK-8294618

### DIFF
--- a/test/langtools/tools/jdeps/jdkinternals/RemovedJDKInternals.java
+++ b/test/langtools/tools/jdeps/jdkinternals/RemovedJDKInternals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -184,9 +184,9 @@ public class RemovedJDKInternals {
     private static final Map<String, String> REPLACEMENTS = Map.of(
         "com.sun.image.codec.jpeg.JPEGCodec", "Use javax.imageio @since 1.4",
         "sun.misc.Service", "Use java.util.ServiceLoader @since 1.6",
-        "sun.misc.SoftCache", "Removed. See http://openjdk.java.net/jeps/260",
+        "sun.misc.SoftCache", "Removed. See https://openjdk.org/jeps/260",
         "sun.reflect.Reflection", "Use java.lang.StackWalker @since 9",
-        "sun.reflect.ReflectionFactory", "See http://openjdk.java.net/jeps/260"
+        "sun.reflect.ReflectionFactory", "See https://openjdk.org/jeps/260"
     );
 
     @Test


### PR DESCRIPTION
Fix strings matches to updated strings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294869](https://bugs.openjdk.org/browse/JDK-8294869): Correct failure of RemovedJDKInternals.java after JDK-8294618


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10580/head:pull/10580` \
`$ git checkout pull/10580`

Update a local copy of the PR: \
`$ git checkout pull/10580` \
`$ git pull https://git.openjdk.org/jdk pull/10580/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10580`

View PR using the GUI difftool: \
`$ git pr show -t 10580`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10580.diff">https://git.openjdk.org/jdk/pull/10580.diff</a>

</details>
