### PR TITLE
8247804: Possible bug in JdbcRowSetResourceBundle.java resource name

### DIFF
--- a/src/java.sql.rowset/share/classes/com/sun/rowset/JdbcRowSetResourceBundle.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/JdbcRowSetResourceBundle.java
@@ -80,7 +80,7 @@ public class JdbcRowSetResourceBundle implements Serializable {
      * The variable where the default resource bundle will
      * be placed.
      **/
-    private static final String PATH = "com/sun/rowset/RowSetResourceBundle";
+    private static final String PATH = "com.sun.rowset.RowSetResourceBundle";
 
     /**
      * The constructor which initializes the resource bundle.


### PR DESCRIPTION
Problem: Improper bundle naming within JdbcRowSetResourceBundle.java

Fix: Adjust base name of resource bundle to a proper class name adhering to [getBundle(baseName...)](https://docs.oracle.com/javase/8/docs/api/java/util/ResourceBundle.html#getBundle-java.lang.String-java.util.Locale-)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8247804](https://bugs.openjdk.org/browse/JDK-8247804): Possible bug in JdbcRowSetResourceBundle.java resource name


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10584/head:pull/10584` \
`$ git checkout pull/10584`

Update a local copy of the PR: \
`$ git checkout pull/10584` \
`$ git pull https://git.openjdk.org/jdk pull/10584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10584`

View PR using the GUI difftool: \
`$ git pr show -t 10584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10584.diff">https://git.openjdk.org/jdk/pull/10584.diff</a>

</details>
