### PR TITLE
6560981: (cal) unused local variables in GregorianCalendar, etc.

### DIFF
--- a/src/java.base/share/classes/java/util/GregorianCalendar.java
+++ b/src/java.base/share/classes/java/util/GregorianCalendar.java
@@ -2431,7 +2431,6 @@ public class GregorianCalendar extends Calendar {
             long fixedDateJan1 = calsys.getFixedDate(normalizedYear, 1, 1, cdate);
             int dayOfYear = (int)(fixedDate - fixedDateJan1) + 1;
             long fixedDateMonth1 = fixedDate - dayOfMonth + 1;
-            int cutoverGap = 0;
             int cutoverYear = (calsys == gcal) ? gregorianCutoverYear : gregorianCutoverYearJulian;
             int relativeDayOfMonth = dayOfMonth - 1;
 
@@ -2447,9 +2446,7 @@ public class GregorianCalendar extends Calendar {
                         fixedDateMonth1 = getFixedDateMonth1(cdate, fixedDate);
                     }
                 }
-                int realDayOfYear = (int)(fixedDate - fixedDateJan1) + 1;
-                cutoverGap = dayOfYear - realDayOfYear;
-                dayOfYear = realDayOfYear;
+                dayOfYear = (int)(fixedDate - fixedDateJan1) + 1;
                 relativeDayOfMonth = (int)(fixedDate - fixedDateMonth1);
             }
             internalSet(DAY_OF_YEAR, dayOfYear);

--- a/src/java.base/share/classes/java/util/JapaneseImperialCalendar.java
+++ b/src/java.base/share/classes/java/util/JapaneseImperialCalendar.java
@@ -2118,7 +2118,6 @@ class JapaneseImperialCalendar extends Calendar {
      * @param fixedDate the fixed date representation of the date
      */
     private long getFixedDateJan1(LocalGregorianCalendar.Date date, long fixedDate) {
-        Era era = date.getEra();
         if (date.getEra() != null && date.getYear() == 1) {
             for (int eraIndex = getEraIndex(date); eraIndex > 0; eraIndex--) {
                 CalendarDate d = eras[eraIndex].getSinceDate();

--- a/src/java.base/share/classes/sun/util/calendar/BaseCalendar.java
+++ b/src/java.base/share/classes/sun/util/calendar/BaseCalendar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/util/calendar/BaseCalendar.java
+++ b/src/java.base/share/classes/sun/util/calendar/BaseCalendar.java
@@ -494,7 +494,7 @@ public abstract class BaseCalendar extends AbstractCalendar {
      */
     final int getGregorianYearFromFixedDate(long fixedDate) {
         long d0;
-        int  d1, d2, d3, d4;
+        int  d1, d2, d3;
         int  n400, n100, n4, n1;
         int  year;
 
@@ -507,7 +507,6 @@ public abstract class BaseCalendar extends AbstractCalendar {
             n4 = d2 / 1461;
             d3 = d2 % 1461;
             n1 = d3 / 365;
-            d4 = (d3 % 365) + 1;
         } else {
             d0 = fixedDate - 1;
             n400 = (int)CalendarUtils.floorDivide(d0, 146097L);
@@ -517,7 +516,6 @@ public abstract class BaseCalendar extends AbstractCalendar {
             n4 = CalendarUtils.floorDivide(d2, 1461);
             d3 = CalendarUtils.mod(d2, 1461);
             n1 = CalendarUtils.floorDivide(d3, 365);
-            d4 = CalendarUtils.mod(d3, 365) + 1;
         }
         year = 400 * n400 + 100 * n100 + 4 * n4 + n1;
         if (!(n100 == 4 || n1 == 4)) {


### PR DESCRIPTION
Problem: Unused variables in GregorianCalendar, JapaneseImperialCalendar, and Base Calendar.

Fix: Removed all unused variables in bug description except normalizedYear in JapaneseImpericalCalendar.getActualMaximum.() as there was no matching unused variable within that method.

Additionally removed realDayOfYear in GregorianCalendar.computeFields.() due to redundancy.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6560981](https://bugs.openjdk.org/browse/JDK-6560981): (cal) unused local variables in GregorianCalendar, etc.


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Brent Christian](https://openjdk.org/census#bchristi) (@bchristi-git - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10585/head:pull/10585` \
`$ git checkout pull/10585`

Update a local copy of the PR: \
`$ git checkout pull/10585` \
`$ git pull https://git.openjdk.org/jdk pull/10585/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10585`

View PR using the GUI difftool: \
`$ git pr show -t 10585`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10585.diff">https://git.openjdk.org/jdk/pull/10585.diff</a>

</details>
