### PR TITLE
8294717: (bf) DirectByteBuffer constructor will leak if allocating Deallocator or Cleaner fails with OOME

### DIFF
--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -141,7 +141,13 @@ class Direct$Type$Buffer$RW$$BO$
         } else {
             address = base;
         }
-        cleaner = Cleaner.create(this, new Deallocator(base, size, cap));
+        try {
+            cleaner = Cleaner.create(this, new Deallocator(base, size, cap));
+        } catch (Throwable t) {
+            // Prevent leak if the Deallocator or Cleaner fail for any reason
+            UNSAFE.freeMemory(base);
+            throw t;
+        }
         att = null;
 #else[rw]
         super(cap);

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -146,6 +146,7 @@ class Direct$Type$Buffer$RW$$BO$
         } catch (Throwable t) {
             // Prevent leak if the Deallocator or Cleaner fail for any reason
             UNSAFE.freeMemory(base);
+            Bits.unreserveMemory(size, cap);
             throw t;
         }
         att = null;


### PR DESCRIPTION
Catch any `Throwable` from the `Deallocator` constructor or `Cleaner::create` and free memory to prevent a leak.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294717](https://bugs.openjdk.org/browse/JDK-8294717): (bf) DirectByteBuffer constructor will leak if allocating Deallocator or Cleaner fails with OOME


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10588/head:pull/10588` \
`$ git checkout pull/10588`

Update a local copy of the PR: \
`$ git checkout pull/10588` \
`$ git pull https://git.openjdk.org/jdk pull/10588/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10588`

View PR using the GUI difftool: \
`$ git pr show -t 10588`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10588.diff">https://git.openjdk.org/jdk/pull/10588.diff</a>

</details>
