### PR TITLE
8289561: java/lang/instrument/NativeMethodPrefixAgent.java fails with "ERROR: Injection failure: java.lang.UnsupportedOperationException: Records requires ASM8"

### DIFF
--- a/test/jdk/java/lang/instrument/NativeMethodPrefixAgent.java
+++ b/test/jdk/java/lang/instrument/NativeMethodPrefixAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,13 @@ class NativeMethodPrefixAgent {
 
     static ClassFileTransformer t0, t1, t2;
     static Instrumentation inst;
+    private static Throwable agentError;
+
+    public static void checkErrors() {
+        if (agentError != null) {
+            throw new RuntimeException("Agent error", agentError);
+        }
+    }
 
     static class Tr implements ClassFileTransformer {
         final String trname;
@@ -87,10 +94,12 @@ class NativeMethodPrefixAgent {
 
                     return redef? null : newcf;
                 } catch (Throwable ex) {
+                    if (agentError == null) {
+                        agentError = ex;
+                    }
                     System.err.println("ERROR: Injection failure: " + ex);
                     ex.printStackTrace();
-                    System.err.println("Returning bad class file, to cause test failure");
-                    return new byte[0];
+                    return null;
                 }
             }
             return null;

--- a/test/jdk/java/lang/instrument/NativeMethodPrefixApp.java
+++ b/test/jdk/java/lang/instrument/NativeMethodPrefixApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,8 @@ public class NativeMethodPrefixApp implements StringIdCallback {
         java.lang.reflect.Array.getLength(new short[5]);
         RuntimeMXBean mxbean = ManagementFactory.getRuntimeMXBean();
         System.err.println(mxbean.getVmVendor());
+
+        NativeMethodPrefixAgent.checkErrors();
 
         for (int i = 0; i < gotIt.length; ++i) {
             if (!gotIt[i]) {

--- a/test/jdk/java/lang/instrument/asmlib/Instrumentor.java
+++ b/test/jdk/java/lang/instrument/asmlib/Instrumentor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -124,7 +124,7 @@ public class Instrumentor {
     }
 
     public synchronized Instrumentor addNativeMethodTrackingInjection(String prefix, Consumer<InstrHelper> injector) {
-        instrumentingVisitor = new ClassVisitor(Opcodes.ASM7, instrumentingVisitor) {
+        instrumentingVisitor = new ClassVisitor(Opcodes.ASM9, instrumentingVisitor) {
             private final Set<Consumer<ClassVisitor>> wmGenerators = new HashSet<>();
             private String className;
 


### PR DESCRIPTION
Test failure is a duplicate of [JDK-8284777](https://bugs.openjdk.org/browse/JDK-8284777), but the test needs to be updated:
- the test instruments all loaded classes, so need to updated ASM version to support records and permits;
  Instrumentor.addNativeMethodTrackingInjection is used only by this test;
- return empty array from transforming does not cause test failure, added code to handle agent errors

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289561](https://bugs.openjdk.org/browse/JDK-8289561): java/lang/instrument/NativeMethodPrefixAgent.java fails with "ERROR: Injection failure: java.lang.UnsupportedOperationException: Records requires ASM8"


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10589/head:pull/10589` \
`$ git checkout pull/10589`

Update a local copy of the PR: \
`$ git checkout pull/10589` \
`$ git pull https://git.openjdk.org/jdk pull/10589/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10589`

View PR using the GUI difftool: \
`$ git pr show -t 10589`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10589.diff">https://git.openjdk.org/jdk/pull/10589.diff</a>

</details>
