### PR TITLE
8291443: Obsolete the PrintSharedDictionary flag

### DIFF
--- a/src/hotspot/share/cds/cds_globals.hpp
+++ b/src/hotspot/share/cds/cds_globals.hpp
@@ -52,10 +52,6 @@
   product(bool, PrintSharedArchiveAndExit, false,                           \
           "Print shared archive file contents")                             \
                                                                             \
-  product(bool, PrintSharedDictionary, false,                               \
-          "If PrintSharedArchiveAndExit is true, also print the shared "    \
-          "dictionary")                                                     \
-                                                                            \
   product(size_t, SharedBaseAddress, LP64_ONLY(32*G)                        \
           NOT_LP64(LINUX_ONLY(2*G) NOT_LINUX(0)),                           \
           "Address to allocate shared memory region for class data")        \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -551,6 +551,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "PreferContainerQuotaForCPUCount", JDK_Version::jdk(19), JDK_Version::jdk(20), JDK_Version::jdk(21) },
   { "AliasLevel",                   JDK_Version::jdk(19), JDK_Version::jdk(20), JDK_Version::jdk(21) },
   { "UseCodeAging",                 JDK_Version::undefined(), JDK_Version::jdk(20), JDK_Version::jdk(21) },
+  { "PrintSharedDictionary",          JDK_Version::undefined(), JDK_Version::jdk(20), JDK_Version::jdk(21) },
 
 #ifdef ASSERT
   { "DummyObsoleteTestFlag",        JDK_Version::undefined(), JDK_Version::jdk(18), JDK_Version::undefined() },

--- a/test/hotspot/jtreg/runtime/cds/NonBootLoaderClasses.java
+++ b/test/hotspot/jtreg/runtime/cds/NonBootLoaderClasses.java
@@ -51,7 +51,7 @@ public class NonBootLoaderClasses {
             .setUseVersion(false)
             .addSuffix("-Djava.class.path=",
                 "-XX:+UnlockDiagnosticVMOptions", "-XX:SharedArchiveFile=./" + archiveName,
-                "-XX:+PrintSharedArchiveAndExit", "-XX:+PrintSharedDictionary");
+                "-XX:+PrintSharedArchiveAndExit");
         CDSTestUtils.run(opts)
             .assertNormalExit(output -> {
                 output.shouldContain("archive is valid");

--- a/test/hotspot/jtreg/runtime/cds/appcds/HelloExtTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/HelloExtTest.java
@@ -62,7 +62,7 @@ public class HelloExtTest {
 
     TestCommon.run("-XX:+UnlockDiagnosticVMOptions", "-XX:+WhiteBoxAPI",
             "-cp", appJar, bootClassPath, "-Xlog:class+load",
-            "-XX:+PrintSharedArchiveAndExit", "-XX:+PrintSharedDictionary",
+            "-XX:+PrintSharedArchiveAndExit",
             "HelloExt")
         .assertNormalExit(output ->  output.shouldNotMatch(class_pattern));
   }

--- a/test/hotspot/jtreg/runtime/cds/appcds/PrintSharedArchiveAndExit.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/PrintSharedArchiveAndExit.java
@@ -72,7 +72,7 @@ public class PrintSharedArchiveAndExit {
 
     TestCommon.run(
         "-cp", cp,
-        "-XX:+PrintSharedArchiveAndExit") 
+        "-XX:+PrintSharedArchiveAndExit")
       .ifNoMappingFailure(output -> check(output, 0, true, lastCheckMsg, "java.lang.Object"));
 
     log("Normal execution -- Make sure -version, help message and app main()\n" +

--- a/test/hotspot/jtreg/runtime/cds/appcds/PrintSharedArchiveAndExit.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/PrintSharedArchiveAndExit.java
@@ -72,8 +72,7 @@ public class PrintSharedArchiveAndExit {
 
     TestCommon.run(
         "-cp", cp,
-        "-XX:+PrintSharedArchiveAndExit",
-        "-XX:+PrintSharedDictionary")  // Test PrintSharedDictionary as well.
+        "-XX:+PrintSharedArchiveAndExit") 
       .ifNoMappingFailure(output -> check(output, 0, true, lastCheckMsg, "java.lang.Object"));
 
     log("Normal execution -- Make sure -version, help message and app main()\n" +
@@ -120,8 +119,7 @@ public class PrintSharedArchiveAndExit {
     log("Even if hello.jar is out of date, we should still be able to print the dictionary.");
     TestCommon.run(
         "-cp", cp,
-        "-XX:+PrintSharedArchiveAndExit",
-        "-XX:+PrintSharedDictionary")  // Test PrintSharedDictionary as well.
+        "-XX:+PrintSharedArchiveAndExit")
       .ifNoMappingFailure(output -> check(output, 1, true, lastCheckMsg, "java.lang.Object"));
 
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/javaldr/AnonVmClassesDuringDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/javaldr/AnonVmClassesDuringDump.java
@@ -83,7 +83,7 @@ public class AnonVmClassesDuringDump {
         // inspect the archive and make sure no anonymous class is in there
         TestCommon.run("-cp", appJar,
             "-XX:+UnlockDiagnosticVMOptions", cdsDiagnosticOption,
-            "-XX:+PrintSharedArchiveAndExit", "-XX:+PrintSharedDictionary", Hello.class.getName())
+            "-XX:+PrintSharedArchiveAndExit", Hello.class.getName())
             .assertNormalExit(dynamicMode ?
                 output -> output.shouldMatch(pattern) :
                 output -> output.shouldNotMatch(pattern));


### PR DESCRIPTION
Obsoleted the unused PrintSharedDictionary flag and removed the flag from all tests. Verified with tier1-4 tests.
<!-- csr: 'update' -->

<!-- csr: 'update' -->

<!-- csr: 'update' -->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8291443](https://bugs.openjdk.org/browse/JDK-8291443): Obsolete the PrintSharedDictionary flag
 * [JDK-8294877](https://bugs.openjdk.org/browse/JDK-8294877): Obsolete the PrintSharedDictionary flag (**CSR**)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10596/head:pull/10596` \
`$ git checkout pull/10596`

Update a local copy of the PR: \
`$ git checkout pull/10596` \
`$ git pull https://git.openjdk.org/jdk pull/10596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10596`

View PR using the GUI difftool: \
`$ git pr show -t 10596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10596.diff">https://git.openjdk.org/jdk/pull/10596.diff</a>

</details>
