### PR TITLE
8294691: dynamicArchive/RelativePath.java is running other test case

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/RelativePath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/RelativePath.java
@@ -39,7 +39,7 @@ import java.io.File;
 public class RelativePath extends DynamicArchiveTestBase {
 
     public static void main(String[] args) throws Exception {
-        runTest(AppendClasspath::testDefaultBase);
+        runTest(RelativePath::testDefaultBase);
     }
 
     static void testDefaultBase() throws Exception {
@@ -54,6 +54,16 @@ public class RelativePath extends DynamicArchiveTestBase {
         int idx = appJar.lastIndexOf(File.separator);
         String jarName = appJar.substring(idx + 1);
         String jarDir = appJar.substring(0, idx);
+
+        // Create CDS Archive
+        dump(topArchiveName, "-Xlog:cds",
+            "-Xlog:cds+dynamic=debug",
+            "-cp", "." + File.separator + "hello.jar" + File.pathSeparator + appJar2,
+            "HelloMore")
+            .assertNormalExit(output-> {
+                    output.shouldContain("Written dynamic archive 0x");
+            });
+
         // relative path starting with "."
         runWithRelativePath(null, topArchiveName, jarDir,
             "-Xlog:class+load",

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/RelativePath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/RelativePath.java
@@ -58,7 +58,7 @@ public class RelativePath extends DynamicArchiveTestBase {
         // Create CDS Archive
         dump(topArchiveName, "-Xlog:cds",
             "-Xlog:cds+dynamic=debug",
-            "-cp", "." + File.separator + "hello.jar" + File.pathSeparator + appJar2,
+            "-cp", appJar + File.pathSeparator + appJar2,
             "HelloMore")
             .assertNormalExit(output-> {
                     output.shouldContain("Written dynamic archive 0x");


### PR DESCRIPTION
Test case in RelativePath.java corrected. Verified with tier 1-4 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294691](https://bugs.openjdk.org/browse/JDK-8294691): dynamicArchive/RelativePath.java is running other test case


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to [3a92d84d](https://git.openjdk.org/jdk/pull/10597/files/3a92d84d80bc3bfdaa9d8ead131b5cf849f6213b)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10597/head:pull/10597` \
`$ git checkout pull/10597`

Update a local copy of the PR: \
`$ git checkout pull/10597` \
`$ git pull https://git.openjdk.org/jdk pull/10597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10597`

View PR using the GUI difftool: \
`$ git pr show -t 10597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10597.diff">https://git.openjdk.org/jdk/pull/10597.diff</a>

</details>
