### PR TITLE
8294920: Missing SP value in Linux x86_32 thread context

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/linux_x86/LinuxX86JavaThreadPDAccess.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/linux_x86/LinuxX86JavaThreadPDAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/linux_x86/LinuxX86JavaThreadPDAccess.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/linux_x86/LinuxX86JavaThreadPDAccess.java
@@ -116,7 +116,7 @@ public class LinuxX86JavaThreadPDAccess implements JavaThreadPDAccess {
   public    Address getLastSP(Address addr) {
     ThreadProxy t = getThreadProxy(addr);
     X86ThreadContext context = (X86ThreadContext) t.getContext();
-    return context.getRegisterAsAddress(X86ThreadContext.ESP);
+    return context.getRegisterAsAddress(X86ThreadContext.SP);
   }
 
   public    ThreadProxy getThreadProxy(Address addr) {


### PR DESCRIPTION
See the description in the bug. This fixes only Linux x86_32, because only there I could reproduce the failure. Windows x86_32 seems to be fine. I have no access to BSD x86_32.

Additional testing:
 - [x] Linux x86 fastdebug `serviceability/sa` now cleanly passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294920](https://bugs.openjdk.org/browse/JDK-8294920): Missing SP value in Linux x86_32 thread context


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10598/head:pull/10598` \
`$ git checkout pull/10598`

Update a local copy of the PR: \
`$ git checkout pull/10598` \
`$ git pull https://git.openjdk.org/jdk pull/10598/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10598`

View PR using the GUI difftool: \
`$ git pr show -t 10598`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10598.diff">https://git.openjdk.org/jdk/pull/10598.diff</a>

</details>
