### PR TITLE
JDK-8294901: remove pre-VS2017 checks in Windows related coding

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1699,7 +1699,6 @@ void os::get_summary_os_info(char* buf, size_t buflen) {
 }
 
 int os::vsnprintf(char* buf, size_t len, const char* fmt, va_list args) {
-#if _MSC_VER >= 1900
   // Starting with Visual Studio 2015, vsnprint is C99 compliant.
   ALLOW_C_FUNCTION(::vsnprintf, int result = ::vsnprintf(buf, len, fmt, args);)
   // If an encoding error occurred (result < 0) then it's not clear
@@ -1708,29 +1707,6 @@ int os::vsnprintf(char* buf, size_t len, const char* fmt, va_list args) {
     buf[len - 1] = '\0';
   }
   return result;
-#else
-  // Before Visual Studio 2015, vsnprintf is not C99 compliant, so use
-  // _vsnprintf, whose behavior seems to be *mostly* consistent across
-  // versions.  However, when len == 0, avoid _vsnprintf too, and just
-  // go straight to _vscprintf.  The output is going to be truncated in
-  // that case, except in the unusual case of empty output.  More
-  // importantly, the documentation for various versions of Visual Studio
-  // are inconsistent about the behavior of _vsnprintf when len == 0,
-  // including it possibly being an error.
-  int result = -1;
-  if (len > 0) {
-    result = _vsnprintf(buf, len, fmt, args);
-    // If output (including NUL terminator) is truncated, the buffer
-    // won't be NUL terminated.  Add the trailing NUL specified by C99.
-    if ((result < 0) || ((size_t)result >= len)) {
-      buf[len - 1] = '\0';
-    }
-  }
-  if (result < 0) {
-    result = _vscprintf(fmt, args);
-  }
-  return result;
-#endif // _MSC_VER dispatch
 }
 
 static inline time_t get_mtime(const char* filename) {

--- a/src/hotspot/share/adlc/adlc.hpp
+++ b/src/hotspot/share/adlc/adlc.hpp
@@ -46,10 +46,6 @@ using namespace std;
 
 #define strdup _strdup
 
-#if _MSC_VER < 1900
-#define snprintf _snprintf
-#endif
-
 #ifndef _INTPTR_T_DEFINED
 #ifdef _WIN64
 typedef __int64 intptr_t;

--- a/src/hotspot/share/runtime/abstract_vm_version.cpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.cpp
@@ -203,11 +203,7 @@ const char* Abstract_VM_Version::internal_vm_info_string() {
 
   #ifndef HOTSPOT_BUILD_COMPILER
     #ifdef _MSC_VER
-      #if _MSC_VER == 1800
-        #define HOTSPOT_BUILD_COMPILER "MS VC++ 12.0 (VS2013)"
-      #elif _MSC_VER == 1900
-        #define HOTSPOT_BUILD_COMPILER "MS VC++ 14.0 (VS2015)"
-      #elif _MSC_VER == 1911
+      #if _MSC_VER == 1911
         #define HOTSPOT_BUILD_COMPILER "MS VC++ 15.3 (VS2017)"
       #elif _MSC_VER == 1912
         #define HOTSPOT_BUILD_COMPILER "MS VC++ 15.5 (VS2017)"

--- a/src/java.base/windows/native/libnio/ch/wepoll.c
+++ b/src/java.base/windows/native/libnio/ch/wepoll.c
@@ -858,11 +858,6 @@ int err_check_handle(HANDLE handle) {
 
 #define unused_var(v) ((void) (v))
 
-/* Polyfill `inline` for older versions of msvc (up to Visual Studio 2013) */
-#if defined(_MSC_VER) && _MSC_VER < 1900
-#define inline __inline
-#endif
-
 WEPOLL_INTERNAL int ws_global_init(void);
 WEPOLL_INTERNAL SOCKET ws_get_base_socket(SOCKET socket);
 

--- a/src/java.base/windows/native/libnio/ch/wepoll.c
+++ b/src/java.base/windows/native/libnio/ch/wepoll.c
@@ -858,6 +858,11 @@ int err_check_handle(HANDLE handle) {
 
 #define unused_var(v) ((void) (v))
 
+/* Polyfill `inline` for older versions of msvc (up to Visual Studio 2013) */
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#define inline __inline
+#endif
+
 WEPOLL_INTERNAL int ws_global_init(void);
 WEPOLL_INTERNAL SOCKET ws_get_base_socket(SOCKET socket);
 


### PR DESCRIPTION
After "8293162: Drop support for VS2017" limited current support to VS2019 and VS2022 it is most likely safe to remove various checks/workarounds related to older VS compilers like VS2015 or VS2013.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294901](https://bugs.openjdk.org/browse/JDK-8294901): remove pre-VS2017 checks in Windows related coding


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [75d999ec](https://git.openjdk.org/jdk/pull/10600/files/75d999ec5f8f3725d2a220dc10d55b8bfb73982e)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10600/head:pull/10600` \
`$ git checkout pull/10600`

Update a local copy of the PR: \
`$ git checkout pull/10600` \
`$ git pull https://git.openjdk.org/jdk pull/10600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10600`

View PR using the GUI difftool: \
`$ git pr show -t 10600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10600.diff">https://git.openjdk.org/jdk/pull/10600.diff</a>

</details>
