### PR TITLE
8294941: GHA: Cut down cross-compilation sysroots

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -145,7 +145,9 @@ jobs:
           # Prepare sysroot and remove unused files to minimize cache
           sudo chroot sysroot symlinks -cr .
           sudo chown ${USER} -R sysroot
-          rm -rf sysroot/{dev,proc,run,sys}
+          rm -rf sysroot/{dev,proc,run,sys,var}
+          rm -rf sysroot/usr/{sbin,bin,share}
+          rm -rf sysroot/usr/lib/{apt,udev,systemd}
         if: steps.get-cached-sysroot.outputs.cache-hit != 'true'
 
       - name: 'Configure'


### PR DESCRIPTION
In GHA cross-compilation, we don't need everything from the sysroot, because we use native compilers for the compilation. Therefore, we can cut them even deeper and reclaim significant amount of cache space. This would also make cache eviction less likely, which saves time on recreating the sysroots when that happens.

Current sysroots take about 300M per arch, which quickly multiplies up for multiple arches (we build 5 now), users (ballparking at about 200 active contributors). This amounts to about 1500M caches per job, and 300G in caches across our org for a single JDK tree. Update releases also use GHA for their testing, but the number of contributors there is lower. Still, I think it slides to TB territory now.

In my local tests, new aarch64 sysroot tar.gz gets reduced from 315M to just 85M, about 3.7x improvement. Even deeper cuts are possible, but they would affect the redundant `.so`-s in `/usr/lib/${arch}/`. That would be much more fragile to do and might affect our builds. Therefore, I stopped at doing just these.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294941](https://bugs.openjdk.org/browse/JDK-8294941): GHA: Cut down cross-compilation sysroots


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10601/head:pull/10601` \
`$ git checkout pull/10601`

Update a local copy of the PR: \
`$ git checkout pull/10601` \
`$ git pull https://git.openjdk.org/jdk pull/10601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10601`

View PR using the GUI difftool: \
`$ git pr show -t 10601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10601.diff">https://git.openjdk.org/jdk/pull/10601.diff</a>

</details>
