### PR TITLE
8294954: Remove superfluous ResourceMarks when using LogStream

### DIFF
--- a/src/hotspot/cpu/aarch64/downcallLinker_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/downcallLinker_aarch64.cpp
@@ -112,7 +112,6 @@ RuntimeStub* DowncallLinker::make_downcall_stub(BasicType* signature,
 #ifndef PRODUCT
   LogTarget(Trace, foreign, downcall) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm;
     LogStream ls(lt);
     stub->print_on(&ls);
   }
@@ -145,7 +144,6 @@ void DowncallStubGenerator::generate() {
 #ifndef PRODUCT
   LogTarget(Trace, foreign, downcall) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm;
     LogStream ls(lt);
     arg_shuffle.print_on(&ls);
   }

--- a/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
@@ -135,7 +135,6 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
 #ifndef PRODUCT
   LogTarget(Trace, foreign, upcall) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm;
     LogStream ls(lt);
     arg_shuffle.print_on(&ls);
   }

--- a/src/hotspot/cpu/arm/methodHandles_arm.cpp
+++ b/src/hotspot/cpu/arm/methodHandles_arm.cpp
@@ -506,7 +506,6 @@ void trace_method_handle_stub(const char* adaptername,
   }
   LogTarget(Trace, methodhandles) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm;
     LogStream ls(lt);
     ls.print(" reg dump: ");
     int i;

--- a/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
+++ b/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
@@ -505,7 +505,6 @@ void trace_method_handle_stub(const char* adaptername,
 
   LogTarget(Trace, methodhandles) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm;
     LogStream ls(lt);
     ls.print_cr("Registers:");
     const int abi_offset = frame::abi_reg_args_size / 8;

--- a/src/hotspot/cpu/s390/methodHandles_s390.cpp
+++ b/src/hotspot/cpu/s390/methodHandles_s390.cpp
@@ -572,7 +572,6 @@ void trace_method_handle_stub(const char* adaptername,
   LogTarget(Trace, methodhandles) lt;
   if (lt.is_enabled()) {
     // Dumping last frame with frame::describe.
-    ResourceMark rm;
     LogStream ls(lt);
     JavaThread* p = JavaThread::active();
 

--- a/src/hotspot/cpu/x86/downcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/downcallLinker_x86_64.cpp
@@ -111,7 +111,6 @@ RuntimeStub* DowncallLinker::make_downcall_stub(BasicType* signature,
 #ifndef PRODUCT
   LogTarget(Trace, foreign, downcall) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm;
     LogStream ls(lt);
     stub->print_on(&ls);
   }
@@ -141,7 +140,6 @@ void DowncallStubGenerator::generate() {
 #ifndef PRODUCT
   LogTarget(Trace, foreign, downcall) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm;
     LogStream ls(lt);
     arg_shuffle.print_on(&ls);
   }

--- a/src/hotspot/cpu/x86/methodHandles_x86.cpp
+++ b/src/hotspot/cpu/x86/methodHandles_x86.cpp
@@ -529,7 +529,6 @@ void trace_method_handle_stub(const char* adaptername,
 
   LogTarget(Trace, methodhandles) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm;
     LogStream ls(lt);
     ls.print_cr("Registers:");
     const int saved_regs_count = Register::number_of_registers;

--- a/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
@@ -185,7 +185,6 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
 #ifndef PRODUCT
   LogTarget(Trace, foreign, upcall) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm;
     LogStream ls(lt);
     arg_shuffle.print_on(&ls);
   }

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -92,7 +92,6 @@ void ClassLoaderData::init_null_class_loader_data() {
 
   LogTarget(Trace, class, loader, data) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm;
     LogStream ls(lt);
     ls.print("create ");
     _the_null_class_loader_data->print_value_on(&ls);
@@ -451,7 +450,6 @@ void ClassLoaderData::record_dependency(const Klass* k) {
     NOT_PRODUCT(Atomic::inc(&_dependency_count));
     LogTarget(Trace, class, loader, data) lt;
     if (lt.is_enabled()) {
-      ResourceMark rm;
       LogStream ls(lt);
       ls.print("adding dependency from ");
       print_value_on(&ls);
@@ -537,7 +535,6 @@ void ClassLoaderData::unload() {
 
   LogTarget(Trace, class, loader, data) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm;
     LogStream ls(lt);
     ls.print("unload");
     print_value_on(&ls);

--- a/src/hotspot/share/classfile/classLoaderDataGraph.cpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.cpp
@@ -238,7 +238,6 @@ ClassLoaderData* ClassLoaderDataGraph::add_to_graph(Handle loader, bool has_clas
   // Lastly log, if requested
   LogTarget(Trace, class, loader, data) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm;
     LogStream ls(lt);
     ls.print("create ");
     cld->print_value_on(&ls);

--- a/src/hotspot/share/classfile/defaultMethods.cpp
+++ b/src/hotspot/share/classfile/defaultMethods.cpp
@@ -677,7 +677,6 @@ static void find_empty_vtable_slots(GrowableArray<EmptyVtableSlot*>* slots,
   LogTarget(Debug, defaultmethods) lt;
   if (lt.is_enabled()) {
     lt.print("Slots that need filling:");
-    ResourceMark rm;
     LogStream ls(lt);
     streamIndentor si(&ls);
     for (int i = 0; i < slots->length(); ++i) {
@@ -965,7 +964,6 @@ static void create_defaults_and_exceptions(GrowableArray<EmptyVtableSlot*>* slot
 
       LogTarget(Debug, defaultmethods) lt;
       if (lt.is_enabled()) {
-        ResourceMark rm(THREAD);
         LogStream ls(lt);
         ls.print("for slot: ");
         slot->print_on(&ls);

--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -259,7 +259,6 @@ void Dictionary::add_klass(JavaThread* current, Symbol* class_name,
     // It would be nice to have a JFR event here, add some logging.
     LogTarget(Info, class, loader, data) lt;
     if (lt.is_enabled()) {
-      ResourceMark rm;
       LogStream ls(&lt);
       ls.print("Dictionary resized to %d entries %d for ", table_size(), _number_of_entries);
       loader_data()->print_value_on(&ls);
@@ -375,7 +374,6 @@ void Dictionary::validate_protection_domain(InstanceKlass* klass,
 
     LogTarget(Debug, protectiondomain) lt;
     if (lt.is_enabled()) {
-      ResourceMark rm(THREAD);
       // Print out trace information
       LogStream ls(lt);
       ls.print_cr("Checking package access");
@@ -428,7 +426,6 @@ void Dictionary::clean_cached_protection_domains(GrowableArray<ProtectionDomainE
         if (current->object_no_keepalive() == NULL) {
           LogTarget(Debug, protectiondomain) lt;
           if (lt.is_enabled()) {
-            ResourceMark rm;
             // Print out trace information
             LogStream ls(lt);
             ls.print_cr("PD in set is not alive:");

--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -698,7 +698,6 @@ jobject Modules::get_module(jclass clazz, TRAPS) {
 
   LogTarget(Debug,module) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm(THREAD);
     LogStream ls(lt);
     Klass* klass = java_lang_Class::as_Klass(mirror);
     oop module_name = java_lang_Module::name(module);
@@ -709,6 +708,7 @@ jobject Modules::get_module(jclass clazz, TRAPS) {
       ls.print("get_module(): Unnamed Module");
     }
     if (klass != NULL) {
+      ResourceMark rm(THREAD);
       ls.print_cr(" for class %s", klass->external_name());
     } else {
       ls.print_cr(" for primitive class");

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -2095,7 +2095,6 @@ static Method* unpack_method_and_appendix(Handle mname,
       oop appendix = appendix_box->obj_at(0);
       LogTarget(Info, methodhandles) lt;
       if (lt.develop_is_enabled()) {
-        ResourceMark rm(THREAD);
         LogStream ls(lt);
         ls.print("Linked method=" INTPTR_FORMAT ": ", p2i(m));
         m->print_on(&ls);

--- a/src/hotspot/share/gc/g1/g1AllocRegion.cpp
+++ b/src/hotspot/share/gc/g1/g1AllocRegion.cpp
@@ -218,7 +218,6 @@ void G1AllocRegion::trace(const char* str, size_t min_word_size, size_t desired_
   bool detailed_info = log.is_trace();
 
   if ((actual_word_size == 0 && result == NULL) || detailed_info) {
-    ResourceMark rm;
     LogStream ls_trace(log.trace());
     LogStream ls_debug(log.debug());
     outputStream* out = detailed_info ? &ls_trace : &ls_debug;

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
@@ -338,7 +338,6 @@ void G1GCPhaseTimes::log_phase(WorkerDataArray<double>* phase, uint indent_level
 void G1GCPhaseTimes::debug_phase(WorkerDataArray<double>* phase, uint extra_indent) const {
   LogTarget(Debug, gc, phases) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm;
     LogStream ls(lt);
     log_phase(phase, 2 + extra_indent, &ls, true);
   }

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -68,7 +68,6 @@ public:
         Log(gc, verify) log;
         log.error("Root location " PTR_FORMAT " points to dead obj " PTR_FORMAT " in region " HR_FORMAT,
                   p2i(p), p2i(obj), HR_FORMAT_PARAMS(_g1h->heap_region_containing(obj)));
-        ResourceMark rm;
         LogStream ls(log.error());
         obj->print_on(&ls);
         _failures = true;
@@ -493,7 +492,6 @@ void G1HeapVerifier::verify(VerifyOption vo) {
     // help us track down what went wrong. This is why we call
     // print_extended_on() instead of print_on().
     Log(gc, verify) log;
-    ResourceMark rm;
     LogStream ls(log.error());
     _g1h->print_extended_on(&ls);
 

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -592,7 +592,6 @@ public:
           log.error("Missing rem set entry:");
           log.error("Field " PTR_FORMAT " of obj " PTR_FORMAT " in region " HR_FORMAT,
                     p2i(p), p2i(_containing_obj), HR_FORMAT_PARAMS(from));
-          ResourceMark rm;
           LogStream ls(log.error());
           _containing_obj->print_on(&ls);
           log.error("points to obj " PTR_FORMAT " in region " HR_FORMAT " remset %s",

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -226,7 +226,6 @@ void PSParallelCompact::print_region_ranges() {
     return;
   }
   Log(gc, compaction) log;
-  ResourceMark rm;
   LogStream ls(log.trace());
   Universe::print_on(&ls);
   log.trace("space  bottom     top        end        new_top");
@@ -2339,7 +2338,6 @@ void PSParallelCompact::write_block_fill_histogram()
   }
 
   Log(gc, compaction) log;
-  ResourceMark rm;
   LogStream ls(log.trace());
   outputStream* out = &ls;
 

--- a/src/hotspot/share/gc/parallel/psPromotionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.cpp
@@ -153,7 +153,6 @@ void PSPromotionManager::print_taskqueue_stats() {
     return;
   }
   Log(gc, task, stats) log;
-  ResourceMark rm;
   LogStream ls(log.trace());
 
   stack_array_depth()->print_taskqueue_stats(&ls, "Oop Queue");

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -572,7 +572,6 @@ void CollectedHeap::full_gc_dump(GCTimer* timer, bool before) {
   LogTarget(Trace, gc, classhisto) lt;
   if (lt.is_enabled()) {
     GCTraceTime(Trace, gc, classhisto) tm(before ? "Class Histogram (before full gc)" : "Class Histogram (after full gc)", timer);
-    ResourceMark rm;
     LogStream ls(lt);
     VM_GC_HeapInspection inspector(&ls, false /* ! full gc */);
     inspector.doit();

--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
@@ -268,7 +268,6 @@ void ReferenceProcessorPhaseTimes::print_reference(ReferenceType ref_type, uint 
 
   if (lt.is_enabled()) {
     LogStream ls(lt);
-    ResourceMark rm;
 
     int const ref_type_index = ref_type_2_index(ref_type);
 

--- a/src/hotspot/share/gc/shared/taskqueue.inline.hpp
+++ b/src/hotspot/share/gc/shared/taskqueue.inline.hpp
@@ -89,7 +89,6 @@ inline void GenericTaskQueueSet<T, F>::print_and_reset_taskqueue_stats(const cha
     return;
   }
   Log(gc, task, stats) log;
-  ResourceMark rm;
   LogStream ls(log.trace());
 
   print_taskqueue_stats(&ls, label);

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -265,7 +265,6 @@ void ShenandoahControlThread::run_service() {
       {
         LogTarget(Info, gc, stats) lt;
         if (lt.is_enabled()) {
-          ResourceMark rm;
           LogStream ls(lt);
           heap->phase_timings()->print_cycle_on(&ls);
           if (ShenandoahPacing) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -448,7 +448,6 @@ void ShenandoahFreeSet::log_status() {
 
   LogTarget(Info, gc, ergo) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm;
     LogStream ls(lt);
 
     {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1193,7 +1193,6 @@ void ShenandoahHeap::gc_threads_do(ThreadClosure* tcl) const {
 void ShenandoahHeap::print_tracing_info() const {
   LogTarget(Info, gc, stats) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm;
     LogStream ls(lt);
 
     phase_timings()->print_global_on(&ls);

--- a/src/hotspot/share/gc/shenandoah/shenandoahTaskqueue.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahTaskqueue.cpp
@@ -63,7 +63,6 @@ void ShenandoahObjToScanQueueSet::print_taskqueue_stats() const {
     return;
   }
   Log(gc, task, stats) log;
-  ResourceMark rm;
   LogStream ls(log.trace());
   outputStream* st = &ls;
   print_taskqueue_stats_hdr(st);

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -848,7 +848,6 @@ void Metaspace::global_initialize() {
     // Note: "cds" would be a better fit but keep this for backward compatibility.
     LogTarget(Info, gc, metaspace) lt;
     if (lt.is_enabled()) {
-      ResourceMark rm;
       LogStream ls(lt);
       CDS_ONLY(MetaspaceShared::print_on(&ls);)
       Metaspace::print_compressed_class_space(&ls);
@@ -941,7 +940,6 @@ void Metaspace::report_metadata_oome(ClassLoaderData* loader_data, size_t word_s
   if (log.is_info()) {
     log.info("Metaspace (%s) allocation failed for size " SIZE_FORMAT,
              is_class_space_allocation(mdtype) ? "class" : "data", word_size);
-    ResourceMark rm;
     if (log.is_debug()) {
       if (loader_data->metaspace_or_null() != NULL) {
         LogStream ls(log.debug());

--- a/src/hotspot/share/oops/compressedOops.cpp
+++ b/src/hotspot/share/oops/compressedOops.cpp
@@ -68,7 +68,6 @@ void CompressedOops::initialize(const ReservedHeapSpace& heap_space) {
 
   LogTarget(Debug, gc, heap, coops) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm;
     LogStream ls(lt);
     print_mode(&ls);
   }

--- a/src/hotspot/share/oops/cpCache.cpp
+++ b/src/hotspot/share/oops/cpCache.cpp
@@ -399,7 +399,6 @@ void ConstantPoolCacheEntry::set_method_handle_common(const constantPoolHandle& 
   LogStream* log_stream = NULL;
   LogStreamHandle(Debug, methodhandles, indy) lsh_indy;
   if (lsh_indy.is_enabled()) {
-    ResourceMark rm;
     log_stream = &lsh_indy;
     log_stream->print_cr("set_method_handle bc=%d appendix=" PTR_FORMAT "%s method=" PTR_FORMAT " (local signature) ",
                          invoke_code,

--- a/src/hotspot/share/oops/generateOopMap.cpp
+++ b/src/hotspot/share/oops/generateOopMap.cpp
@@ -1280,7 +1280,6 @@ void GenerateOopMap::do_exception_edge(BytecodeStream* itr) {
 }
 
 void GenerateOopMap::report_monitor_mismatch(const char *msg) {
-  ResourceMark rm;
   LogStream ls(Log(monitormismatch)::info());
   ls.print("Monitor mismatch in method ");
   method()->print_short_name(&ls);

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1471,7 +1471,6 @@ void InstanceKlass::call_class_initializer(TRAPS) {
   assert(!is_initialized(), "we cannot initialize twice");
   LogTarget(Info, class, init) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm(THREAD);
     LogStream ls(lt);
     ls.print("%d Initializing ", call_class_initializer_counter++);
     name()->print_value_on(&ls);

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -1329,7 +1329,6 @@ JRT_ENTRY_NO_ASYNC(address, OptoRuntime::handle_exception_C_helper(JavaThread* c
 
   LogTarget(Info, exceptions) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm;
     LogStream ls(lt);
     trace_exception(&ls, exception(), pc, "");
   }

--- a/src/hotspot/share/prims/methodHandles.cpp
+++ b/src/hotspot/share/prims/methodHandles.cpp
@@ -251,7 +251,6 @@ oop MethodHandles::init_method_MemberName(Handle mname, CallInfo& info) {
     assert(m_klass->verify_itable_index(vmindex), "");
     flags |= IS_METHOD | (JVM_REF_invokeInterface << REFERENCE_KIND_SHIFT);
     if (lt_indy.is_enabled()) {
-      ResourceMark rm;
       LogStream ls(lt_indy);
       ls.print_cr("memberName: invokeinterface method_holder::method: %s, itableindex: %d, access_flags:",
                   Method::name_and_sig_as_C_string(m->method_holder(), m->name(), m->signature()),

--- a/src/hotspot/share/prims/stackwalk.cpp
+++ b/src/hotspot/share/prims/stackwalk.cpp
@@ -184,7 +184,6 @@ int StackWalk::fill_in_frames(jlong mode, BaseFrameStream& stream,
       if (method->is_hidden()) {
         LogTarget(Debug, stackwalk) lt;
         if (lt.is_enabled()) {
-          ResourceMark rm(THREAD);
           LogStream ls(lt);
           ls.print("  hidden method: ");
           method->print_short_name(&ls);
@@ -197,7 +196,6 @@ int StackWalk::fill_in_frames(jlong mode, BaseFrameStream& stream,
     int index = end_index++;
     LogTarget(Debug, stackwalk) lt;
     if (lt.is_enabled()) {
-      ResourceMark rm(THREAD);
       LogStream ls(lt);
       ls.print("  %d: frame method: ", index);
       method->print_short_name(&ls);
@@ -215,7 +213,6 @@ int StackWalk::fill_in_frames(jlong mode, BaseFrameStream& stream,
     stream.fill_frame(index, frames_array, methodHandle(THREAD, method), CHECK_0);
 
     if (lt.is_enabled()) {
-      ResourceMark rm(THREAD);
       LogStream ls(lt);
       ls.print("  %d: done frame method: ", index);
       method->print_short_name(&ls);
@@ -414,7 +411,6 @@ oop StackWalk::walk(Handle stackStream, jlong mode, int skip_frames, Handle cont
   log_debug(stackwalk)("Start walking: mode " JLONG_FORMAT " skip %d frames batch size %d", mode, skip_frames, frame_count);
   LogTarget(Debug, stackwalk) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm(THREAD);
     LogStream ls(lt);
     if (cont_scope() != nullptr) {
       ls.print("cont_scope: ");
@@ -462,7 +458,6 @@ oop StackWalk::fetchFirstBatch(BaseFrameStream& stream, Handle stackStream,
 
       LogTarget(Debug, stackwalk) lt;
       if (lt.is_enabled()) {
-        ResourceMark rm(THREAD);
         LogStream ls(lt);
         ls.print("  skip ");
         stream.method()->print_short_name(&ls);
@@ -476,7 +471,6 @@ oop StackWalk::fetchFirstBatch(BaseFrameStream& stream, Handle stackStream,
     for (int n=0; n < skip_frames && !stream.at_end(); stream.next(), n++) {
       LogTarget(Debug, stackwalk) lt;
       if (lt.is_enabled()) {
-        ResourceMark rm(THREAD);
         LogStream ls(lt);
         ls.print("  skip ");
         stream.method()->print_short_name(&ls);

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1856,6 +1856,7 @@ static void log_deopt(CompiledMethod* nm, Method* tm, intptr_t pc, frame& fr, in
                               const char* reason_name, const char* reason_action) {
   LogTarget(Debug, deoptimization) lt;
   if (lt.is_enabled()) {
+    ResourceMark rm;
     LogStream ls(lt);
     bool is_osr = nm->is_osr_method();
     ls.print("cid=%4d %s level=%d",

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -456,7 +456,6 @@ void before_exit(JavaThread* thread, bool halt) {
   // Print GC/heap related information.
   Log(gc, heap, exit) log;
   if (log.is_info()) {
-    ResourceMark rm;
     LogStream ls_info(log.info());
     Universe::print_on(&ls_info);
     if (log.is_trace()) {

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -172,7 +172,6 @@ bool SafepointSynchronize::thread_not_running(ThreadSafepointState *cur_state) {
     // Robustness: asserted in the caller, but handle/tolerate it for release bits.
     LogTarget(Error, safepoint) lt;
     if (lt.is_enabled()) {
-      ResourceMark rm;
       LogStream ls(lt);
       ls.print("Illegal initial state detected: ");
       cur_state->print_on(&ls);
@@ -185,7 +184,6 @@ bool SafepointSynchronize::thread_not_running(ThreadSafepointState *cur_state) {
   }
   LogTarget(Trace, safepoint) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm;
     LogStream ls(lt);
     cur_state->print_on(&ls);
   }
@@ -764,7 +762,6 @@ void SafepointSynchronize::print_safepoint_timeout() {
     // purposes (useful when there are lots of threads in the debugger).
     LogTarget(Warning, safepoint) lt;
     if (lt.is_enabled()) {
-      ResourceMark rm;
       LogStream ls(lt);
 
       ls.cr();

--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -60,7 +60,6 @@ void VM_Operation::set_calling_thread(Thread* thread) {
 }
 
 void VM_Operation::evaluate() {
-  ResourceMark rm;
   LogTarget(Debug, vmoperation) lt;
   if (lt.is_enabled()) {
     LogStream ls(lt);

--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -60,6 +60,7 @@ void VM_Operation::set_calling_thread(Thread* thread) {
 }
 
 void VM_Operation::evaluate() {
+  ResourceMark rm;
   LogTarget(Debug, vmoperation) lt;
   if (lt.is_enabled()) {
     LogStream ls(lt);

--- a/src/hotspot/share/runtime/vm_version.cpp
+++ b/src/hotspot/share/runtime/vm_version.cpp
@@ -33,7 +33,6 @@ void VM_Version_init() {
 
   if (log_is_enabled(Info, os, cpu)) {
     char buf[1024];
-    ResourceMark rm;
     LogStream ls(Log(os, cpu)::info());
     os::print_cpu_info(&ls, buf, sizeof(buf));
   }

--- a/src/hotspot/share/utilities/exceptions.cpp
+++ b/src/hotspot/share/utilities/exceptions.cpp
@@ -62,7 +62,6 @@ void ThreadShadow::set_pending_exception(oop exception, const char* file, int li
 void ThreadShadow::clear_pending_exception() {
   LogTarget(Debug, exceptions) lt;
   if (_pending_exception != NULL && lt.is_enabled()) {
-    ResourceMark rm;
     LogStream ls(lt);
     ls.print("Thread::clear_pending_exception: cleared exception:");
     _pending_exception->print_on(&ls);


### PR DESCRIPTION
Hi,

I went through all of the places where LogStreams are created and removed the unnecessary ResourceMarks. I also added a ResourceMark in one place, where it was needed because of a call to `::name_and_sig_as_C_string` and moved one to the smallest scope where it is used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294954](https://bugs.openjdk.org/browse/JDK-8294954): Remove superfluous ResourceMarks when using LogStream


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10602/head:pull/10602` \
`$ git checkout pull/10602`

Update a local copy of the PR: \
`$ git checkout pull/10602` \
`$ git pull https://git.openjdk.org/jdk pull/10602/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10602`

View PR using the GUI difftool: \
`$ git pr show -t 10602`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10602.diff">https://git.openjdk.org/jdk/pull/10602.diff</a>

</details>
