### PR TITLE
8294953: Deprecate -XX:-UseCompressedClassPointers for removal

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -538,6 +538,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "DynamicDumpSharedSpaces",      JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
   { "RequireSharedSpaces",          JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
   { "UseSharedSpaces",              JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
+  { "UseCompressedClassPointers",   JDK_Version::jdk(20), JDK_Version::jdk(21), JDK_Version::jdk(22) },
 
   // --- Deprecated alias flags (see also aliased_jvm_flags) - sorted by obsolete_in then expired_in:
   { "DefaultMaxRAMFraction",        JDK_Version::jdk(8),  JDK_Version::undefined(), JDK_Version::undefined() },

--- a/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
@@ -61,7 +61,7 @@ public class VMDeprecatedOptions {
             {"InitialRAMFraction",        "64"},
             {"TLABStats",                 "false"},
             {"AllowRedefinitionToAddDeleteMethods", "true"},
-	    {"UseCompressedClassPointers", Platform.is32bit() ? "false": "true"},
+	    {"UseCompressedClassPointers", "true"},
 
             // deprecated alias flags (see also aliased_jvm_flags):
             {"DefaultMaxRAMFraction", "4"},

--- a/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
@@ -61,6 +61,7 @@ public class VMDeprecatedOptions {
             {"InitialRAMFraction",        "64"},
             {"TLABStats",                 "false"},
             {"AllowRedefinitionToAddDeleteMethods", "true"},
+	    {"UseCompressedClassPointers", Platform.is32bit() ? "false": "true"},
 
             // deprecated alias flags (see also aliased_jvm_flags):
             {"DefaultMaxRAMFraction", "4"},


### PR DESCRIPTION
For Lilliput, I'd like to put the class-pointer of objects into the upper bits of the object header. This is only possible with class pointer compression. Class pointer compression has been on by default for a long time, and afaik, there is no reason to turn it off. The performance benefit of raw class pointer is surely negligible. CCP allows to address 32GB of class space, which seems excessive, even for humongous workloads. (Altough, in the future I'd like to use only 27 bits for CCP, but greater alignment of Klass allocation would help to address enough space, still.)

There is one situation where CCP depends on compressed-oops, and that is JVMCI, e.g. Graal. I would like to understand why that is so (why can't Graal use compressed class pointers even when compressed oops is off?) and if it can be fixed in Graal. I wouldn't like this to block this PR and Lilliput, if it can be avoided.

Testing:
 - [x] runtime/CommandLine/VMDeprecatedOptions.java
 - [x] tier1
<!-- csr: 'update' -->

<!-- csr: 'update' -->

<!-- csr: 'update' -->

<!-- csr: 'update' -->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request to be approved

### Issues
 * [JDK-8294953](https://bugs.openjdk.org/browse/JDK-8294953): Deprecate -XX:-UseCompressedClassPointers for removal
 * [JDK-8294955](https://bugs.openjdk.org/browse/JDK-8294955): Deprecate -XX:-UseCompressedClassPointers for removal (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10603/head:pull/10603` \
`$ git checkout pull/10603`

Update a local copy of the PR: \
`$ git checkout pull/10603` \
`$ git pull https://git.openjdk.org/jdk pull/10603/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10603`

View PR using the GUI difftool: \
`$ git pr show -t 10603`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10603.diff">https://git.openjdk.org/jdk/pull/10603.diff</a>

</details>
