### PR TITLE
8294958

### DIFF
--- a/test/jdk/java/net/httpclient/AbstractConnectTimeout.java
+++ b/test/jdk/java/net/httpclient/AbstractConnectTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,19 +54,13 @@ public abstract class AbstractConnectTimeout {
 
     static List<List<Duration>> TIMEOUTS = List.of(
                     // connectTimeout   HttpRequest timeout
-            Arrays.asList( NO_DURATION,   ofSeconds(1)  ),
             Arrays.asList( NO_DURATION,   ofMillis(100) ),
-            Arrays.asList( NO_DURATION,   ofNanos(99)   ),
             Arrays.asList( NO_DURATION,   ofNanos(1)    ),
 
-            Arrays.asList( ofSeconds(1),  NO_DURATION   ),
             Arrays.asList( ofMillis(100), NO_DURATION   ),
-            Arrays.asList( ofNanos(99),   NO_DURATION   ),
             Arrays.asList( ofNanos(1),    NO_DURATION   ),
 
-            Arrays.asList( ofSeconds(1),  ofMinutes(1)  ),
             Arrays.asList( ofMillis(100), ofMinutes(1)  ),
-            Arrays.asList( ofNanos(99),   ofMinutes(1)  ),
             Arrays.asList( ofNanos(1),    ofMinutes(1)  )
     );
 

--- a/test/jdk/java/net/httpclient/AbstractConnectTimeoutHandshake.java
+++ b/test/jdk/java/net/httpclient/AbstractConnectTimeoutHandshake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,17 +68,11 @@ public abstract class AbstractConnectTimeoutHandshake {
 
     static List<List<Duration>> TIMEOUTS = List.of(
                     // connectTimeout   HttpRequest timeout
-            Arrays.asList( NO_DURATION,   ofSeconds(1)  ),
-            Arrays.asList( NO_DURATION,   ofSeconds(2)  ),
-            Arrays.asList( NO_DURATION,   ofMillis(500) ),
+            Arrays.asList( NO_DURATION,   ofMillis(100) ),
 
-            Arrays.asList( ofSeconds(1),  NO_DURATION   ),
-            Arrays.asList( ofSeconds(2),  NO_DURATION   ),
-            Arrays.asList( ofMillis(500), NO_DURATION   ),
+            Arrays.asList( ofMillis(100), NO_DURATION   ),
 
-            Arrays.asList( ofSeconds(1),  ofMinutes(1)  ),
-            Arrays.asList( ofSeconds(2),  ofMinutes(1)  ),
-            Arrays.asList( ofMillis(500), ofMinutes(1)  )
+            Arrays.asList( ofMillis(100), ofMinutes(1)  )
     );
 
     static final List<String> METHODS = List.of("GET" , "POST");


### PR DESCRIPTION
Please review this test-only change that improves the execution times of ConnectTimeout tests:
- ConnectTimeoutHandshakeAsync and ConnectTimeoutHandshakeSync: before this change each one takes 80+ seconds to execute.
- ConnectTimeoutNoProxyAsync, ConnectTimeoutNoProxySync, ConnectTimeoutWithProxyAsync, ConnectTimeoutWithProxySync: before this change each one takes 50+ seconds to execute.

After this change each test completes successfully under 10 seconds.