### PR TITLE
8288415: java/awt/PopupMenu/PopupMenuLocation.java is unstable in MacOS machines

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -145,7 +145,9 @@ jobs:
           # Prepare sysroot and remove unused files to minimize cache
           sudo chroot sysroot symlinks -cr .
           sudo chown ${USER} -R sysroot
-          rm -rf sysroot/{dev,proc,run,sys}
+          rm -rf sysroot/{dev,proc,run,sys,var}
+          rm -rf sysroot/usr/{sbin,bin,share}
+          rm -rf sysroot/usr/lib/{apt,udev,systemd}
         if: steps.get-cached-sysroot.outputs.cache-hit != 'true'
 
       - name: 'Configure'

--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: 'Create sysroot'
         run: >
-          sudo qemu-debootstrap
+          sudo debootstrap
           --arch=${{ matrix.debian-arch }}
           --verbose
           --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev

--- a/make/autoconf/jvm-features.m4
+++ b/make/autoconf/jvm-features.m4
@@ -275,6 +275,8 @@ AC_DEFUN_ONCE([JVM_FEATURES_CHECK_JVMCI],
       AC_MSG_RESULT([yes])
     elif test "x$OPENJDK_TARGET_CPU" = "xaarch64"; then
       AC_MSG_RESULT([yes])
+    elif test "x$OPENJDK_TARGET_CPU" = "xriscv64"; then
+      AC_MSG_RESULT([yes])
     else
       AC_MSG_RESULT([no, $OPENJDK_TARGET_CPU])
       AVAILABLE=false

--- a/make/modules/jdk.naming.dns/Java.gmk
+++ b/make/modules/jdk.naming.dns/Java.gmk
@@ -1,1 +1,0 @@
-DISABLED_WARNINGS_java += lossy-conversions

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -460,6 +460,7 @@ alloc_class chunk1(
 );
 
 alloc_class chunk2 (
+    // Governing predicates for load/store and arithmetic
     P0,
     P1,
     P2,
@@ -467,8 +468,8 @@ alloc_class chunk2 (
     P4,
     P5,
     P6,
-    P7,
 
+    // Extra predicates
     P8,
     P9,
     P10,
@@ -477,6 +478,9 @@ alloc_class chunk2 (
     P13,
     P14,
     P15,
+
+    // Preserved for all-true predicate
+    P7,
 );
 
 alloc_class chunk3(RFLAGS);
@@ -5538,6 +5542,7 @@ operand pRegGov()
 %{
   constraint(ALLOC_IN_RC(gov_pr));
   match(RegVectMask);
+  match(pReg);
   op_cost(0);
   format %{ %}
   interface(REG_INTER);

--- a/src/hotspot/cpu/aarch64/aarch64_vector.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_vector.ad
@@ -4659,7 +4659,7 @@ instruct vloadmask_neon(vReg dst, vReg src) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vloadmaskB_sve(pRegGov dst, vReg src, rFlagsReg cr) %{
+instruct vloadmaskB_sve(pReg dst, vReg src, rFlagsReg cr) %{
   predicate(UseSVE > 0 && Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst (VectorLoadMask src));
   effect(KILL cr);
@@ -4671,7 +4671,7 @@ instruct vloadmaskB_sve(pRegGov dst, vReg src, rFlagsReg cr) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vloadmask_extend_sve(pRegGov dst, vReg src, vReg tmp, rFlagsReg cr) %{
+instruct vloadmask_extend_sve(pReg dst, vReg src, vReg tmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 && Matcher::vector_element_basic_type(n) != T_BYTE);
   match(Set dst (VectorLoadMask src));
   effect(TEMP tmp, KILL cr);
@@ -4685,7 +4685,7 @@ instruct vloadmask_extend_sve(pRegGov dst, vReg src, vReg tmp, rFlagsReg cr) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vloadmaskB_masked(pRegGov dst, vReg src, pRegGov pg, rFlagsReg cr) %{
+instruct vloadmaskB_masked(pReg dst, vReg src, pRegGov pg, rFlagsReg cr) %{
   predicate(UseSVE > 0 && Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst (VectorLoadMask src pg));
   effect(KILL cr);
@@ -4697,7 +4697,7 @@ instruct vloadmaskB_masked(pRegGov dst, vReg src, pRegGov pg, rFlagsReg cr) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vloadmask_extend_masked(pRegGov dst, vReg src, pRegGov pg, vReg tmp, rFlagsReg cr) %{
+instruct vloadmask_extend_masked(pReg dst, vReg src, pRegGov pg, vReg tmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 && Matcher::vector_element_basic_type(n) != T_BYTE);
   match(Set dst (VectorLoadMask src pg));
   effect(TEMP tmp, KILL cr);
@@ -4751,7 +4751,7 @@ instruct vstoremask_narrow_neon(vReg dst, vReg src, immI_gt_1 size) %{
 
 // vector store mask - sve
 
-instruct vstoremaskB_sve(vReg dst, pRegGov src, immI_1 size) %{
+instruct vstoremaskB_sve(vReg dst, pReg src, immI_1 size) %{
   predicate(UseSVE > 0);
   match(Set dst (VectorStoreMask src size));
   format %{ "vstoremaskB_sve $dst, $src" %}
@@ -4761,7 +4761,7 @@ instruct vstoremaskB_sve(vReg dst, pRegGov src, immI_1 size) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vstoremask_narrow_sve(vReg dst, pRegGov src, immI_gt_1 size, vReg tmp) %{
+instruct vstoremask_narrow_sve(vReg dst, pReg src, immI_gt_1 size, vReg tmp) %{
   predicate(UseSVE > 0);
   match(Set dst (VectorStoreMask src size));
   effect(TEMP_DEF dst, TEMP tmp);
@@ -4778,7 +4778,7 @@ instruct vstoremask_narrow_sve(vReg dst, pRegGov src, immI_gt_1 size, vReg tmp) 
 // Combined rules for vector mask load when the vector element type is not T_BYTE
 
 // VectorLoadMask+LoadVector, and the VectorLoadMask is unpredicated.
-instruct vloadmask_loadV(pRegGov dst, indirect mem, vReg tmp, rFlagsReg cr) %{
+instruct vloadmask_loadV(pReg dst, indirect mem, vReg tmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             type2aelembytes(Matcher::vector_element_basic_type(n)) > 1);
   match(Set dst (VectorLoadMask (LoadVector mem)));
@@ -4800,7 +4800,7 @@ instruct vloadmask_loadV(pRegGov dst, indirect mem, vReg tmp, rFlagsReg cr) %{
 %}
 
 // VectorLoadMask+LoadVector, and the VectorLoadMask is predicated.
-instruct vloadmask_loadV_masked(pRegGov dst, indirect mem, pRegGov pg,
+instruct vloadmask_loadV_masked(pReg dst, indirect mem, pRegGov pg,
                                 vReg tmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             type2aelembytes(Matcher::vector_element_basic_type(n)) > 1);
@@ -4821,7 +4821,7 @@ instruct vloadmask_loadV_masked(pRegGov dst, indirect mem, pRegGov pg,
 %}
 
 // VectorLoadMask+LoadVectorMasked, and the VectorLoadMask is unpredicated.
-instruct vloadmask_loadVMasked(pRegGov dst, vmemA mem, pRegGov pg, vReg tmp, rFlagsReg cr) %{
+instruct vloadmask_loadVMasked(pReg dst, vmemA mem, pRegGov pg, vReg tmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             type2aelembytes(Matcher::vector_element_basic_type(n)) > 1);
   match(Set dst (VectorLoadMask (LoadVectorMasked mem pg)));
@@ -4848,7 +4848,7 @@ instruct vloadmask_loadVMasked(pRegGov dst, vmemA mem, pRegGov pg, vReg tmp, rFl
 %}
 
 // VectorLoadMask+LoadVectorMasked, and the VectorLoadMask is predicated.
-instruct vloadmask_loadVMasked_masked(pRegGov dst, vmemA mem, pRegGov pg1, pRegGov pg2,
+instruct vloadmask_loadVMasked_masked(pReg dst, vmemA mem, pRegGov pg1, pRegGov pg2,
                                       vReg tmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             type2aelembytes(Matcher::vector_element_basic_type(n)) > 1);
@@ -4878,7 +4878,7 @@ instruct vloadmask_loadVMasked_masked(pRegGov dst, vmemA mem, pRegGov pg1, pRegG
 // Combined rules for vector mask store when the vector element type is not T_BYTE
 
 // StoreVector+VectorStoreMask, and the vector size of "src" is equal to the MaxVectorSize.
-instruct storeV_vstoremask(indirect mem, pRegGov src, immI_gt_1 esize, vReg tmp) %{
+instruct storeV_vstoremask(indirect mem, pReg src, immI_gt_1 esize, vReg tmp) %{
   predicate(UseSVE > 0 &&
             Matcher::vector_length_in_bytes(n->as_StoreVector()->in(MemNode::ValueIn)->in(1)) == MaxVectorSize);
   match(Set mem (StoreVector mem (VectorStoreMask src esize)));
@@ -4899,7 +4899,7 @@ instruct storeV_vstoremask(indirect mem, pRegGov src, immI_gt_1 esize, vReg tmp)
 %}
 
 // StoreVector+VectorStoreMask, and the vector size of "src" is less than the MaxVectorSize.
-instruct storeV_vstoremask_masked(indirect mem, pRegGov src, immI_gt_1 esize,
+instruct storeV_vstoremask_masked(indirect mem, pReg src, immI_gt_1 esize,
                                   vReg tmp, pRegGov pgtmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             Matcher::vector_length_in_bytes(n->as_StoreVector()->in(MemNode::ValueIn)->in(1)) < MaxVectorSize);
@@ -4921,7 +4921,7 @@ instruct storeV_vstoremask_masked(indirect mem, pRegGov src, immI_gt_1 esize,
 %}
 
 // StoreVectorMasked+VectorStoreMask, and the vector size of "src" is equal to the MaxVectorSize.
-instruct storeVMasked_vstoremask(vmemA mem, pRegGov src, pRegGov pg, immI_gt_1 esize, vReg tmp) %{
+instruct storeVMasked_vstoremask(vmemA mem, pReg src, pRegGov pg, immI_gt_1 esize, vReg tmp) %{
   predicate(UseSVE > 0 &&
             Matcher::vector_length_in_bytes(n->as_StoreVector()->in(MemNode::ValueIn)->in(1)) == MaxVectorSize);
   match(Set mem (StoreVectorMasked mem (Binary (VectorStoreMask src esize) pg)));
@@ -4947,7 +4947,7 @@ instruct storeVMasked_vstoremask(vmemA mem, pRegGov src, pRegGov pg, immI_gt_1 e
 %}
 
 // StoreVectorMasked+VectorStoreMask, and the vector size of "src" is less than the MaxVectorSize.
-instruct storeVMasked_vstoremask_masked(vmemA mem, pRegGov src, pRegGov pg, immI_gt_1 esize,
+instruct storeVMasked_vstoremask_masked(vmemA mem, pReg src, pRegGov pg, immI_gt_1 esize,
                                         vReg tmp, pRegGov pgtmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             Matcher::vector_length_in_bytes(n->as_StoreVector()->in(MemNode::ValueIn)->in(1)) < MaxVectorSize);
@@ -4977,7 +4977,7 @@ instruct storeVMasked_vstoremask_masked(vmemA mem, pRegGov src, pRegGov pg, immI
 
 // vector mask logical ops: and/or/xor/and_not
 
-instruct vmask_and(pRegGov pd, pRegGov pn, pRegGov pm) %{
+instruct vmask_and(pReg pd, pReg pn, pReg pm) %{
   predicate(UseSVE > 0);
   match(Set pd (AndVMask pn pm));
   format %{ "vmask_and $pd, $pn, $pm" %}
@@ -4987,7 +4987,7 @@ instruct vmask_and(pRegGov pd, pRegGov pn, pRegGov pm) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmask_or(pRegGov pd, pRegGov pn, pRegGov pm) %{
+instruct vmask_or(pReg pd, pReg pn, pReg pm) %{
   predicate(UseSVE > 0);
   match(Set pd (OrVMask pn pm));
   format %{ "vmask_or $pd, $pn, $pm" %}
@@ -4997,7 +4997,7 @@ instruct vmask_or(pRegGov pd, pRegGov pn, pRegGov pm) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmask_xor(pRegGov pd, pRegGov pn, pRegGov pm) %{
+instruct vmask_xor(pReg pd, pReg pn, pReg pm) %{
   predicate(UseSVE > 0);
   match(Set pd (XorVMask pn pm));
   format %{ "vmask_xor $pd, $pn, $pm" %}
@@ -5007,7 +5007,7 @@ instruct vmask_xor(pRegGov pd, pRegGov pn, pRegGov pm) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmask_and_notI(pRegGov pd, pRegGov pn, pRegGov pm, immI_M1 m1) %{
+instruct vmask_and_notI(pReg pd, pReg pn, pReg pm, immI_M1 m1) %{
   predicate(UseSVE > 0);
   match(Set pd (AndVMask pn (XorVMask pm (MaskAll m1))));
   format %{ "vmask_and_notI $pd, $pn, $pm" %}
@@ -5017,7 +5017,7 @@ instruct vmask_and_notI(pRegGov pd, pRegGov pn, pRegGov pm, immI_M1 m1) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmask_and_notL(pRegGov pd, pRegGov pn, pRegGov pm, immL_M1 m1) %{
+instruct vmask_and_notL(pReg pd, pReg pn, pReg pm, immL_M1 m1) %{
   predicate(UseSVE > 0);
   match(Set pd (AndVMask pn (XorVMask pm (MaskAll m1))));
   format %{ "vmask_and_notL $pd, $pn, $pm" %}
@@ -5045,7 +5045,7 @@ instruct vmaskcmp_neon(vReg dst, vReg src1, vReg src2, immI cond) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmaskcmp_sve(pRegGov dst, vReg src1, vReg src2, immI cond, rFlagsReg cr) %{
+instruct vmaskcmp_sve(pReg dst, vReg src1, vReg src2, immI cond, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
   effect(KILL cr);
@@ -5060,7 +5060,7 @@ instruct vmaskcmp_sve(pRegGov dst, vReg src1, vReg src2, immI cond, rFlagsReg cr
   ins_pipe(pipe_slow);
 %}
 
-instruct vmaskcmp_masked(pRegGov dst, vReg src1, vReg src2, immI cond,
+instruct vmaskcmp_masked(pReg dst, vReg src1, vReg src2, immI cond,
                          pRegGov pg, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set dst (VectorMaskCmp (Binary src1 src2) (Binary cond pg)));
@@ -5087,7 +5087,7 @@ instruct vmaskcast_same_esize_neon(vReg dst_src) %{
   ins_pipe(pipe_class_empty);
 %}
 
-instruct vmaskcast_same_esize_sve(pRegGov dst_src) %{
+instruct vmaskcast_same_esize_sve(pReg dst_src) %{
   predicate(UseSVE > 0 &&
             Matcher::vector_length_in_bytes(n) == Matcher::vector_length_in_bytes(n->in(1)));
   match(Set dst_src (VectorMaskCast dst_src));
@@ -5097,7 +5097,7 @@ instruct vmaskcast_same_esize_sve(pRegGov dst_src) %{
   ins_pipe(pipe_class_empty);
 %}
 
-instruct vmaskcast_extend(pRegGov dst, pReg src) %{
+instruct vmaskcast_extend(pReg dst, pReg src) %{
   predicate(UseSVE > 0 &&
             Matcher::vector_length_in_bytes(n) > Matcher::vector_length_in_bytes(n->in(1)));
   match(Set dst (VectorMaskCast src));
@@ -5114,7 +5114,7 @@ instruct vmaskcast_extend(pRegGov dst, pReg src) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmaskcast_narrow(pRegGov dst, pReg src) %{
+instruct vmaskcast_narrow(pReg dst, pReg src) %{
   predicate(UseSVE > 0 &&
             Matcher::vector_length_in_bytes(n) < Matcher::vector_length_in_bytes(n->in(1)));
   match(Set dst (VectorMaskCast src));
@@ -5133,7 +5133,7 @@ instruct vmaskcast_narrow(pRegGov dst, pReg src) %{
 
 // vector mask reinterpret
 
-instruct vmask_reinterpret_same_esize(pRegGov dst_src) %{
+instruct vmask_reinterpret_same_esize(pReg dst_src) %{
   predicate(UseSVE > 0 &&
             Matcher::vector_length(n) == Matcher::vector_length(n->in(1)) &&
             Matcher::vector_length_in_bytes(n) == Matcher::vector_length_in_bytes(n->in(1)));
@@ -5144,7 +5144,7 @@ instruct vmask_reinterpret_same_esize(pRegGov dst_src) %{
   ins_pipe(pipe_class_empty);
 %}
 
-instruct vmask_reinterpret_diff_esize(pRegGov dst, pRegGov src, vReg tmp, rFlagsReg cr) %{
+instruct vmask_reinterpret_diff_esize(pReg dst, pReg src, vReg tmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             Matcher::vector_length(n) != Matcher::vector_length(n->in(1)) &&
             Matcher::vector_length_in_bytes(n) == Matcher::vector_length_in_bytes(n->in(1)));
@@ -5290,7 +5290,7 @@ instruct vmask_firsttrue_sve(iRegINoSp dst, pReg src, pReg ptmp) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmask_firsttrue_masked(iRegINoSp dst, pReg src, pRegGov pg, pReg ptmp) %{
+instruct vmask_firsttrue_masked(iRegINoSp dst, pReg src, pReg pg, pReg ptmp) %{
   predicate(UseSVE > 0);
   match(Set dst (VectorMaskFirstTrue src pg));
   effect(TEMP ptmp);
@@ -5402,7 +5402,7 @@ instruct vmask_tolong_sve(iRegLNoSp dst, pReg src, vReg tmp1, vReg tmp2) %{
 
 // fromlong
 
-instruct vmask_fromlong(pRegGov dst, iRegL src, vReg tmp1, vReg tmp2) %{
+instruct vmask_fromlong(pReg dst, iRegL src, vReg tmp1, vReg tmp2) %{
   match(Set dst (VectorLongToMask src));
   effect(TEMP tmp1, TEMP tmp2);
   format %{ "vmask_fromlong $dst, $src\t# vector (sve2). KILL $tmp1, $tmp2" %}
@@ -5419,7 +5419,7 @@ instruct vmask_fromlong(pRegGov dst, iRegL src, vReg tmp1, vReg tmp2) %{
 
 // maskAll
 
-instruct vmaskAll_immI(pRegGov dst, immI src, rFlagsReg cr) %{
+instruct vmaskAll_immI(pReg dst, immI src, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set dst (MaskAll src));
   effect(KILL cr);
@@ -5437,7 +5437,7 @@ instruct vmaskAll_immI(pRegGov dst, immI src, rFlagsReg cr) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmaskAllI(pRegGov dst, iRegIorL2I src, vReg tmp, rFlagsReg cr) %{
+instruct vmaskAllI(pReg dst, iRegIorL2I src, vReg tmp, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set dst (MaskAll src));
   effect(TEMP tmp, KILL cr);
@@ -5453,7 +5453,7 @@ instruct vmaskAllI(pRegGov dst, iRegIorL2I src, vReg tmp, rFlagsReg cr) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmaskAllI_masked(pRegGov dst, iRegIorL2I src, pRegGov pg, vReg tmp, rFlagsReg cr) %{
+instruct vmaskAllI_masked(pReg dst, iRegIorL2I src, pRegGov pg, vReg tmp, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set dst (MaskAll src pg));
   effect(TEMP tmp, KILL cr);
@@ -5468,7 +5468,7 @@ instruct vmaskAllI_masked(pRegGov dst, iRegIorL2I src, pRegGov pg, vReg tmp, rFl
   ins_pipe(pipe_slow);
 %}
 
-instruct vmaskAll_immL(pRegGov dst, immL src, rFlagsReg cr) %{
+instruct vmaskAll_immL(pReg dst, immL src, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set dst (MaskAll src));
   effect(KILL cr);
@@ -5486,7 +5486,7 @@ instruct vmaskAll_immL(pRegGov dst, immL src, rFlagsReg cr) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmaskAllL(pRegGov dst, iRegL src, vReg tmp, rFlagsReg cr) %{
+instruct vmaskAllL(pReg dst, iRegL src, vReg tmp, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set dst (MaskAll src));
   effect(TEMP tmp, KILL cr);
@@ -5502,7 +5502,7 @@ instruct vmaskAllL(pRegGov dst, iRegL src, vReg tmp, rFlagsReg cr) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmaskAllL_masked(pRegGov dst, iRegL src, pRegGov pg, vReg tmp, rFlagsReg cr) %{
+instruct vmaskAllL_masked(pReg dst, iRegL src, pRegGov pg, vReg tmp, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set dst (MaskAll src pg));
   effect(TEMP tmp, KILL cr);
@@ -5519,7 +5519,7 @@ instruct vmaskAllL_masked(pRegGov dst, iRegL src, pRegGov pg, vReg tmp, rFlagsRe
 
 // vetcor mask generation
 
-instruct vmask_gen_I(pRegGov pd, iRegIorL2I src, rFlagsReg cr) %{
+instruct vmask_gen_I(pReg pd, iRegIorL2I src, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set pd (VectorMaskGen (ConvI2L src)));
   effect(KILL cr);
@@ -5531,7 +5531,7 @@ instruct vmask_gen_I(pRegGov pd, iRegIorL2I src, rFlagsReg cr) %{
   ins_pipe(pipe_class_default);
 %}
 
-instruct vmask_gen_L(pRegGov pd, iRegL src, rFlagsReg cr) %{
+instruct vmask_gen_L(pReg pd, iRegL src, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set pd (VectorMaskGen src));
   effect(KILL cr);
@@ -5543,7 +5543,7 @@ instruct vmask_gen_L(pRegGov pd, iRegL src, rFlagsReg cr) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmask_gen_imm(pRegGov pd, immL con, rFlagsReg cr) %{
+instruct vmask_gen_imm(pReg pd, immL con, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set pd (VectorMaskGen con));
   effect(KILL cr);
@@ -5837,7 +5837,7 @@ instruct vtest_anytrue_neon(iRegINoSp dst, vReg src1, vReg src2, vReg tmp, rFlag
   ins_pipe(pipe_slow);
 %}
 
-instruct vtest_anytrue_sve(iRegINoSp dst, pRegGov src1, pRegGov src2, rFlagsReg cr) %{
+instruct vtest_anytrue_sve(iRegINoSp dst, pReg src1, pReg src2, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::ne);
   match(Set dst (VectorTest src1 src2));
@@ -5871,7 +5871,7 @@ instruct vtest_alltrue_neon(iRegINoSp dst, vReg src1, vReg src2, vReg tmp, rFlag
   ins_pipe(pipe_slow);
 %}
 
-instruct vtest_alltrue_sve(iRegINoSp dst, pRegGov src1, pRegGov src2, pReg ptmp, rFlagsReg cr) %{
+instruct vtest_alltrue_sve(iRegINoSp dst, pReg src1, pReg src2, pReg ptmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::overflow);
   match(Set dst (VectorTest src1 src2));

--- a/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
@@ -3093,7 +3093,7 @@ instruct vloadmask_neon(vReg dst, vReg src) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vloadmaskB_sve(pRegGov dst, vReg src, rFlagsReg cr) %{
+instruct vloadmaskB_sve(pReg dst, vReg src, rFlagsReg cr) %{
   predicate(UseSVE > 0 && Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst (VectorLoadMask src));
   effect(KILL cr);
@@ -3105,7 +3105,7 @@ instruct vloadmaskB_sve(pRegGov dst, vReg src, rFlagsReg cr) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vloadmask_extend_sve(pRegGov dst, vReg src, vReg tmp, rFlagsReg cr) %{
+instruct vloadmask_extend_sve(pReg dst, vReg src, vReg tmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 && Matcher::vector_element_basic_type(n) != T_BYTE);
   match(Set dst (VectorLoadMask src));
   effect(TEMP tmp, KILL cr);
@@ -3119,7 +3119,7 @@ instruct vloadmask_extend_sve(pRegGov dst, vReg src, vReg tmp, rFlagsReg cr) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vloadmaskB_masked(pRegGov dst, vReg src, pRegGov pg, rFlagsReg cr) %{
+instruct vloadmaskB_masked(pReg dst, vReg src, pRegGov pg, rFlagsReg cr) %{
   predicate(UseSVE > 0 && Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst (VectorLoadMask src pg));
   effect(KILL cr);
@@ -3131,7 +3131,7 @@ instruct vloadmaskB_masked(pRegGov dst, vReg src, pRegGov pg, rFlagsReg cr) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vloadmask_extend_masked(pRegGov dst, vReg src, pRegGov pg, vReg tmp, rFlagsReg cr) %{
+instruct vloadmask_extend_masked(pReg dst, vReg src, pRegGov pg, vReg tmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 && Matcher::vector_element_basic_type(n) != T_BYTE);
   match(Set dst (VectorLoadMask src pg));
   effect(TEMP tmp, KILL cr);
@@ -3185,7 +3185,7 @@ instruct vstoremask_narrow_neon(vReg dst, vReg src, immI_gt_1 size) %{
 
 // vector store mask - sve
 
-instruct vstoremaskB_sve(vReg dst, pRegGov src, immI_1 size) %{
+instruct vstoremaskB_sve(vReg dst, pReg src, immI_1 size) %{
   predicate(UseSVE > 0);
   match(Set dst (VectorStoreMask src size));
   format %{ "vstoremaskB_sve $dst, $src" %}
@@ -3195,7 +3195,7 @@ instruct vstoremaskB_sve(vReg dst, pRegGov src, immI_1 size) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vstoremask_narrow_sve(vReg dst, pRegGov src, immI_gt_1 size, vReg tmp) %{
+instruct vstoremask_narrow_sve(vReg dst, pReg src, immI_gt_1 size, vReg tmp) %{
   predicate(UseSVE > 0);
   match(Set dst (VectorStoreMask src size));
   effect(TEMP_DEF dst, TEMP tmp);
@@ -3212,7 +3212,7 @@ instruct vstoremask_narrow_sve(vReg dst, pRegGov src, immI_gt_1 size, vReg tmp) 
 // Combined rules for vector mask load when the vector element type is not T_BYTE
 
 // VectorLoadMask+LoadVector, and the VectorLoadMask is unpredicated.
-instruct vloadmask_loadV(pRegGov dst, indirect mem, vReg tmp, rFlagsReg cr) %{
+instruct vloadmask_loadV(pReg dst, indirect mem, vReg tmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             type2aelembytes(Matcher::vector_element_basic_type(n)) > 1);
   match(Set dst (VectorLoadMask (LoadVector mem)));
@@ -3234,7 +3234,7 @@ instruct vloadmask_loadV(pRegGov dst, indirect mem, vReg tmp, rFlagsReg cr) %{
 %}
 
 // VectorLoadMask+LoadVector, and the VectorLoadMask is predicated.
-instruct vloadmask_loadV_masked(pRegGov dst, indirect mem, pRegGov pg,
+instruct vloadmask_loadV_masked(pReg dst, indirect mem, pRegGov pg,
                                 vReg tmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             type2aelembytes(Matcher::vector_element_basic_type(n)) > 1);
@@ -3255,7 +3255,7 @@ instruct vloadmask_loadV_masked(pRegGov dst, indirect mem, pRegGov pg,
 %}
 
 // VectorLoadMask+LoadVectorMasked, and the VectorLoadMask is unpredicated.
-instruct vloadmask_loadVMasked(pRegGov dst, vmemA mem, pRegGov pg, vReg tmp, rFlagsReg cr) %{
+instruct vloadmask_loadVMasked(pReg dst, vmemA mem, pRegGov pg, vReg tmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             type2aelembytes(Matcher::vector_element_basic_type(n)) > 1);
   match(Set dst (VectorLoadMask (LoadVectorMasked mem pg)));
@@ -3282,7 +3282,7 @@ instruct vloadmask_loadVMasked(pRegGov dst, vmemA mem, pRegGov pg, vReg tmp, rFl
 %}
 
 // VectorLoadMask+LoadVectorMasked, and the VectorLoadMask is predicated.
-instruct vloadmask_loadVMasked_masked(pRegGov dst, vmemA mem, pRegGov pg1, pRegGov pg2,
+instruct vloadmask_loadVMasked_masked(pReg dst, vmemA mem, pRegGov pg1, pRegGov pg2,
                                       vReg tmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             type2aelembytes(Matcher::vector_element_basic_type(n)) > 1);
@@ -3312,7 +3312,7 @@ instruct vloadmask_loadVMasked_masked(pRegGov dst, vmemA mem, pRegGov pg1, pRegG
 // Combined rules for vector mask store when the vector element type is not T_BYTE
 
 // StoreVector+VectorStoreMask, and the vector size of "src" is equal to the MaxVectorSize.
-instruct storeV_vstoremask(indirect mem, pRegGov src, immI_gt_1 esize, vReg tmp) %{
+instruct storeV_vstoremask(indirect mem, pReg src, immI_gt_1 esize, vReg tmp) %{
   predicate(UseSVE > 0 &&
             Matcher::vector_length_in_bytes(n->as_StoreVector()->in(MemNode::ValueIn)->in(1)) == MaxVectorSize);
   match(Set mem (StoreVector mem (VectorStoreMask src esize)));
@@ -3333,7 +3333,7 @@ instruct storeV_vstoremask(indirect mem, pRegGov src, immI_gt_1 esize, vReg tmp)
 %}
 
 // StoreVector+VectorStoreMask, and the vector size of "src" is less than the MaxVectorSize.
-instruct storeV_vstoremask_masked(indirect mem, pRegGov src, immI_gt_1 esize,
+instruct storeV_vstoremask_masked(indirect mem, pReg src, immI_gt_1 esize,
                                   vReg tmp, pRegGov pgtmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             Matcher::vector_length_in_bytes(n->as_StoreVector()->in(MemNode::ValueIn)->in(1)) < MaxVectorSize);
@@ -3355,7 +3355,7 @@ instruct storeV_vstoremask_masked(indirect mem, pRegGov src, immI_gt_1 esize,
 %}
 
 // StoreVectorMasked+VectorStoreMask, and the vector size of "src" is equal to the MaxVectorSize.
-instruct storeVMasked_vstoremask(vmemA mem, pRegGov src, pRegGov pg, immI_gt_1 esize, vReg tmp) %{
+instruct storeVMasked_vstoremask(vmemA mem, pReg src, pRegGov pg, immI_gt_1 esize, vReg tmp) %{
   predicate(UseSVE > 0 &&
             Matcher::vector_length_in_bytes(n->as_StoreVector()->in(MemNode::ValueIn)->in(1)) == MaxVectorSize);
   match(Set mem (StoreVectorMasked mem (Binary (VectorStoreMask src esize) pg)));
@@ -3381,7 +3381,7 @@ instruct storeVMasked_vstoremask(vmemA mem, pRegGov src, pRegGov pg, immI_gt_1 e
 %}
 
 // StoreVectorMasked+VectorStoreMask, and the vector size of "src" is less than the MaxVectorSize.
-instruct storeVMasked_vstoremask_masked(vmemA mem, pRegGov src, pRegGov pg, immI_gt_1 esize,
+instruct storeVMasked_vstoremask_masked(vmemA mem, pReg src, pRegGov pg, immI_gt_1 esize,
                                         vReg tmp, pRegGov pgtmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             Matcher::vector_length_in_bytes(n->as_StoreVector()->in(MemNode::ValueIn)->in(1)) < MaxVectorSize);
@@ -3413,7 +3413,7 @@ dnl
 dnl VMASK_BITWISE_OP($1,   $2,      $3  )
 dnl VMASK_BITWISE_OP(type, op_name, insn)
 define(`VMASK_BITWISE_OP', `
-instruct vmask_$1(pRegGov pd, pRegGov pn, pRegGov pm) %{
+instruct vmask_$1(pReg pd, pReg pn, pReg pm) %{
   predicate(UseSVE > 0);
   match(Set pd ($2 pn pm));
   format %{ "vmask_$1 $pd, $pn, $pm" %}
@@ -3426,7 +3426,7 @@ dnl
 dnl VMASK_AND_NOT($1  )
 dnl VMASK_AND_NOT(type)
 define(`VMASK_AND_NOT', `
-instruct vmask_and_not$1(pRegGov pd, pRegGov pn, pRegGov pm, imm$1_M1 m1) %{
+instruct vmask_and_not$1(pReg pd, pReg pn, pReg pm, imm$1_M1 m1) %{
   predicate(UseSVE > 0);
   match(Set pd (AndVMask pn (XorVMask pm (MaskAll m1))));
   format %{ "vmask_and_not$1 $pd, $pn, $pm" %}
@@ -3461,7 +3461,7 @@ instruct vmaskcmp_neon(vReg dst, vReg src1, vReg src2, immI cond) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmaskcmp_sve(pRegGov dst, vReg src1, vReg src2, immI cond, rFlagsReg cr) %{
+instruct vmaskcmp_sve(pReg dst, vReg src1, vReg src2, immI cond, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
   effect(KILL cr);
@@ -3476,7 +3476,7 @@ instruct vmaskcmp_sve(pRegGov dst, vReg src1, vReg src2, immI cond, rFlagsReg cr
   ins_pipe(pipe_slow);
 %}
 
-instruct vmaskcmp_masked(pRegGov dst, vReg src1, vReg src2, immI cond,
+instruct vmaskcmp_masked(pReg dst, vReg src1, vReg src2, immI cond,
                          pRegGov pg, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set dst (VectorMaskCmp (Binary src1 src2) (Binary cond pg)));
@@ -3503,7 +3503,7 @@ instruct vmaskcast_same_esize_neon(vReg dst_src) %{
   ins_pipe(pipe_class_empty);
 %}
 
-instruct vmaskcast_same_esize_sve(pRegGov dst_src) %{
+instruct vmaskcast_same_esize_sve(pReg dst_src) %{
   predicate(UseSVE > 0 &&
             Matcher::vector_length_in_bytes(n) == Matcher::vector_length_in_bytes(n->in(1)));
   match(Set dst_src (VectorMaskCast dst_src));
@@ -3513,7 +3513,7 @@ instruct vmaskcast_same_esize_sve(pRegGov dst_src) %{
   ins_pipe(pipe_class_empty);
 %}
 
-instruct vmaskcast_extend(pRegGov dst, pReg src) %{
+instruct vmaskcast_extend(pReg dst, pReg src) %{
   predicate(UseSVE > 0 &&
             Matcher::vector_length_in_bytes(n) > Matcher::vector_length_in_bytes(n->in(1)));
   match(Set dst (VectorMaskCast src));
@@ -3530,7 +3530,7 @@ instruct vmaskcast_extend(pRegGov dst, pReg src) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmaskcast_narrow(pRegGov dst, pReg src) %{
+instruct vmaskcast_narrow(pReg dst, pReg src) %{
   predicate(UseSVE > 0 &&
             Matcher::vector_length_in_bytes(n) < Matcher::vector_length_in_bytes(n->in(1)));
   match(Set dst (VectorMaskCast src));
@@ -3549,7 +3549,7 @@ instruct vmaskcast_narrow(pRegGov dst, pReg src) %{
 
 // vector mask reinterpret
 
-instruct vmask_reinterpret_same_esize(pRegGov dst_src) %{
+instruct vmask_reinterpret_same_esize(pReg dst_src) %{
   predicate(UseSVE > 0 &&
             Matcher::vector_length(n) == Matcher::vector_length(n->in(1)) &&
             Matcher::vector_length_in_bytes(n) == Matcher::vector_length_in_bytes(n->in(1)));
@@ -3560,7 +3560,7 @@ instruct vmask_reinterpret_same_esize(pRegGov dst_src) %{
   ins_pipe(pipe_class_empty);
 %}
 
-instruct vmask_reinterpret_diff_esize(pRegGov dst, pRegGov src, vReg tmp, rFlagsReg cr) %{
+instruct vmask_reinterpret_diff_esize(pReg dst, pReg src, vReg tmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             Matcher::vector_length(n) != Matcher::vector_length(n->in(1)) &&
             Matcher::vector_length_in_bytes(n) == Matcher::vector_length_in_bytes(n->in(1)));
@@ -3706,7 +3706,7 @@ instruct vmask_firsttrue_sve(iRegINoSp dst, pReg src, pReg ptmp) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmask_firsttrue_masked(iRegINoSp dst, pReg src, pRegGov pg, pReg ptmp) %{
+instruct vmask_firsttrue_masked(iRegINoSp dst, pReg src, pReg pg, pReg ptmp) %{
   predicate(UseSVE > 0);
   match(Set dst (VectorMaskFirstTrue src pg));
   effect(TEMP ptmp);
@@ -3818,7 +3818,7 @@ instruct vmask_tolong_sve(iRegLNoSp dst, pReg src, vReg tmp1, vReg tmp2) %{
 
 // fromlong
 
-instruct vmask_fromlong(pRegGov dst, iRegL src, vReg tmp1, vReg tmp2) %{
+instruct vmask_fromlong(pReg dst, iRegL src, vReg tmp1, vReg tmp2) %{
   match(Set dst (VectorLongToMask src));
   effect(TEMP tmp1, TEMP tmp2);
   format %{ "vmask_fromlong $dst, $src\t# vector (sve2). KILL $tmp1, $tmp2" %}
@@ -3838,7 +3838,7 @@ dnl
 dnl VMASKALL_IMM($1,   $2      )
 dnl VMASKALL_IMM(type, var_type)
 define(`VMASKALL_IMM', `
-instruct vmaskAll_imm$1(pRegGov dst, imm$1 src, rFlagsReg cr) %{
+instruct vmaskAll_imm$1(pReg dst, imm$1 src, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set dst (MaskAll src));
   effect(KILL cr);
@@ -3859,7 +3859,7 @@ dnl
 dnl VMASKALL($1,   $2      )
 dnl VMASKALL(type, arg_type)
 define(`VMASKALL', `
-instruct vmaskAll$1(pRegGov dst, $2 src, vReg tmp, rFlagsReg cr) %{
+instruct vmaskAll$1(pReg dst, $2 src, vReg tmp, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set dst (MaskAll src));
   effect(TEMP tmp, KILL cr);
@@ -3878,7 +3878,7 @@ dnl
 dnl VMASKALL_PREDICATE($1,   $2      )
 dnl VMASKALL_PREDICATE(type, arg_type)
 define(`VMASKALL_PREDICATE', `
-instruct vmaskAll$1_masked(pRegGov dst, $2 src, pRegGov pg, vReg tmp, rFlagsReg cr) %{
+instruct vmaskAll$1_masked(pReg dst, $2 src, pRegGov pg, vReg tmp, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set dst (MaskAll src pg));
   effect(TEMP tmp, KILL cr);
@@ -3902,7 +3902,7 @@ VMASKALL_PREDICATE(L, iRegL)
 
 // vetcor mask generation
 
-instruct vmask_gen_I(pRegGov pd, iRegIorL2I src, rFlagsReg cr) %{
+instruct vmask_gen_I(pReg pd, iRegIorL2I src, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set pd (VectorMaskGen (ConvI2L src)));
   effect(KILL cr);
@@ -3914,7 +3914,7 @@ instruct vmask_gen_I(pRegGov pd, iRegIorL2I src, rFlagsReg cr) %{
   ins_pipe(pipe_class_default);
 %}
 
-instruct vmask_gen_L(pRegGov pd, iRegL src, rFlagsReg cr) %{
+instruct vmask_gen_L(pReg pd, iRegL src, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set pd (VectorMaskGen src));
   effect(KILL cr);
@@ -3926,7 +3926,7 @@ instruct vmask_gen_L(pRegGov pd, iRegL src, rFlagsReg cr) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmask_gen_imm(pRegGov pd, immL con, rFlagsReg cr) %{
+instruct vmask_gen_imm(pReg pd, immL con, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set pd (VectorMaskGen con));
   effect(KILL cr);
@@ -4209,7 +4209,7 @@ instruct vtest_anytrue_neon(iRegINoSp dst, vReg src1, vReg src2, vReg tmp, rFlag
   ins_pipe(pipe_slow);
 %}
 
-instruct vtest_anytrue_sve(iRegINoSp dst, pRegGov src1, pRegGov src2, rFlagsReg cr) %{
+instruct vtest_anytrue_sve(iRegINoSp dst, pReg src1, pReg src2, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::ne);
   match(Set dst (VectorTest src1 src2));
@@ -4243,7 +4243,7 @@ instruct vtest_alltrue_neon(iRegINoSp dst, vReg src1, vReg src2, vReg tmp, rFlag
   ins_pipe(pipe_slow);
 %}
 
-instruct vtest_alltrue_sve(iRegINoSp dst, pRegGov src1, pRegGov src2, pReg ptmp, rFlagsReg cr) %{
+instruct vtest_alltrue_sve(iRegINoSp dst, pReg src1, pReg src2, pReg ptmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::overflow);
   match(Set dst (VectorTest src1 src2));

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2394,9 +2394,9 @@ int MacroAssembler::push_p(unsigned int bitset, Register stack) {
     return 0;
   }
 
-  unsigned char regs[PRegister::number_of_saved_registers];
+  unsigned char regs[PRegister::number_of_registers];
   int count = 0;
-  for (int reg = 0; reg < PRegister::number_of_saved_registers; reg++) {
+  for (int reg = 0; reg < PRegister::number_of_registers; reg++) {
     if (1 & bitset)
       regs[count++] = reg;
     bitset >>= 1;
@@ -2431,9 +2431,9 @@ int MacroAssembler::pop_p(unsigned int bitset, Register stack) {
     return 0;
   }
 
-  unsigned char regs[PRegister::number_of_saved_registers];
+  unsigned char regs[PRegister::number_of_registers];
   int count = 0;
-  for (int reg = 0; reg < PRegister::number_of_saved_registers; reg++) {
+  for (int reg = 0; reg < PRegister::number_of_registers; reg++) {
     if (1 & bitset)
       regs[count++] = reg;
     bitset >>= 1;
@@ -2937,7 +2937,7 @@ void MacroAssembler::push_CPU_state(bool save_vectors, bool use_sve,
   }
   if (save_vectors && use_sve && total_predicate_in_bytes > 0) {
     sub(sp, sp, total_predicate_in_bytes);
-    for (int i = 0; i < PRegister::number_of_saved_registers; i++) {
+    for (int i = 0; i < PRegister::number_of_registers; i++) {
       sve_str(as_PRegister(i), Address(sp, i));
     }
   }
@@ -2946,7 +2946,7 @@ void MacroAssembler::push_CPU_state(bool save_vectors, bool use_sve,
 void MacroAssembler::pop_CPU_state(bool restore_vectors, bool use_sve,
                                    int sve_vector_size_in_bytes, int total_predicate_in_bytes) {
   if (restore_vectors && use_sve && total_predicate_in_bytes > 0) {
-    for (int i = PRegister::number_of_saved_registers - 1; i >= 0; i--) {
+    for (int i = PRegister::number_of_registers - 1; i >= 0; i--) {
       sve_ldr(as_PRegister(i), Address(sp, i));
     }
     add(sp, sp, total_predicate_in_bytes);

--- a/src/hotspot/cpu/aarch64/register_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/register_aarch64.hpp
@@ -296,11 +296,6 @@ public:
   enum {
     number_of_registers = 16,
     number_of_governing_registers = 8,
-    // p0-p7 are governing predicates for load/store and arithmetic, but p7 is
-    // preserved as an all-true predicate in OpenJDK. And since we don't support
-    // non-governing predicate registers allocation for non-temp register, the
-    // predicate registers to be saved are p0-p6.
-    number_of_saved_registers = number_of_governing_registers - 1,
     max_slots_per_register = 1
   };
 

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -161,11 +161,8 @@ int RegisterSaver::v0_offset_in_bytes() {
 int RegisterSaver::total_sve_predicate_in_bytes() {
 #ifdef COMPILER2
   if (_save_vectors && Matcher::supports_scalable_vector()) {
-    // The number of total predicate bytes is unlikely to be a multiple
-    // of 16 bytes so we manually align it up.
-    return align_up(Matcher::scalable_predicate_reg_slots() *
-                    VMRegImpl::stack_slot_size *
-                    PRegister::number_of_saved_registers, 16);
+    return (Matcher::scalable_vector_reg_size(T_BYTE) >> LogBitsPerByte) *
+           PRegister::number_of_registers;
   }
 #endif
   return 0;
@@ -249,14 +246,6 @@ OopMap* RegisterSaver::save_live_registers(MacroAssembler* masm, int additional_
       sp_offset = FloatRegister::save_slots_per_register * i;
     }
     oop_map->set_callee_saved(VMRegImpl::stack2reg(sp_offset), r->as_VMReg());
-  }
-
-  if (_save_vectors && use_sve) {
-    for (int i = 0; i < PRegister::number_of_saved_registers; i++) {
-      PRegister r = as_PRegister(i);
-      int sp_offset = sve_predicate_size_in_slots * i;
-      oop_map->set_callee_saved(VMRegImpl::stack2reg(sp_offset), r->as_VMReg());
-    }
   }
 
   return oop_map;

--- a/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
@@ -323,8 +323,9 @@ void C1_MacroAssembler::verified_entry(bool breakAtEntry) {
   // first instruction with a jump. For this action to be legal we
   // must ensure that this first instruction is a J, JAL or NOP.
   // Make it a NOP.
+  IncompressibleRegion ir(this);  // keep the nop as 4 bytes for patching.
   assert_alignment(pc());
-  nop();
+  nop();  // 4 bytes
 }
 
 void C1_MacroAssembler::load_parameter(int offset_in_words, Register reg) {

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -243,6 +243,8 @@ void C2_MacroAssembler::string_indexof_char(Register str1, Register cnt1,
 typedef void (MacroAssembler::* load_chr_insn)(Register rd, const Address &adr, Register temp);
 
 void C2_MacroAssembler::emit_entry_barrier_stub(C2EntryBarrierStub* stub) {
+  IncompressibleRegion ir(this);  // Fixed length: see C2_MacroAssembler::entry_barrier_stub_size()
+
   // make guard value 4-byte aligned so that it can be accessed by atomic instructions on riscv
   int alignment_bytes = align(4);
 

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
@@ -193,6 +193,8 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
     return;
   }
 
+  Assembler::IncompressibleRegion ir(masm);  // Fixed length: see entry_barrier_offset()
+
   Label local_guard;
   NMethodPatchingType patching_type = nmethod_patching_type();
 

--- a/src/hotspot/cpu/riscv/jvmciCodeInstaller_riscv.cpp
+++ b/src/hotspot/cpu/riscv/jvmciCodeInstaller_riscv.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "asm/macroAssembler.hpp"
+#include "jvmci/jvmci.hpp"
+#include "jvmci/jvmciCodeInstaller.hpp"
+#include "jvmci/jvmciRuntime.hpp"
+#include "jvmci/jvmciCompilerToVM.hpp"
+#include "jvmci/jvmciJavaClasses.hpp"
+#include "oops/oop.inline.hpp"
+#include "runtime/handles.inline.hpp"
+#include "runtime/jniHandles.hpp"
+#include "runtime/sharedRuntime.hpp"
+#include "vmreg_riscv.inline.hpp"
+
+jint CodeInstaller::pd_next_offset(NativeInstruction* inst, jint pc_offset, JVMCI_TRAPS) {
+  address pc = (address) inst;
+  if (inst->is_call()) {
+    return pc_offset + NativeCall::instruction_size;
+  } else if (inst->is_jump()) {
+    return pc_offset + NativeJump::instruction_size;
+  } else if (inst->is_movptr()) {
+    return pc_offset + NativeMovConstReg::movptr_instruction_size;
+  } else {
+    JVMCI_ERROR_0("unsupported type of instruction for call site");
+  }
+}
+
+void CodeInstaller::pd_patch_OopConstant(int pc_offset, Handle& obj, bool compressed, JVMCI_TRAPS) {
+  address pc = _instructions->start() + pc_offset;
+  jobject value = JNIHandles::make_local(obj());
+  MacroAssembler::patch_oop(pc, cast_from_oop<address>(obj()));
+  int oop_index = _oop_recorder->find_index(value);
+  RelocationHolder rspec = oop_Relocation::spec(oop_index);
+  _instructions->relocate(pc, rspec);
+}
+
+void CodeInstaller::pd_patch_MetaspaceConstant(int pc_offset, HotSpotCompiledCodeStream* stream, u1 tag, JVMCI_TRAPS) {
+  address pc = _instructions->start() + pc_offset;
+  if (tag == PATCH_NARROW_KLASS) {
+    narrowKlass narrowOop = record_narrow_metadata_reference(_instructions, pc, stream, tag, JVMCI_CHECK);
+    MacroAssembler::pd_patch_instruction_size(pc, (address) (long) narrowOop);
+    JVMCI_event_3("relocating (narrow metaspace constant) at " PTR_FORMAT "/0x%x", p2i(pc), narrowOop);
+  } else {
+    NativeMovConstReg* move = nativeMovConstReg_at(pc);
+    void* reference = record_metadata_reference(_instructions, pc, stream, tag, JVMCI_CHECK);
+    move->set_data((intptr_t) reference);
+    JVMCI_event_3("relocating (metaspace constant) at " PTR_FORMAT "/" PTR_FORMAT, p2i(pc), p2i(reference));
+  }
+}
+
+void CodeInstaller::pd_patch_DataSectionReference(int pc_offset, int data_offset, JVMCI_TRAPS) {
+  address pc = _instructions->start() + pc_offset;
+  address dest = _constants->start() + data_offset;
+  _instructions->relocate(pc, section_word_Relocation::spec((address) dest, CodeBuffer::SECT_CONSTS));
+  JVMCI_event_3("relocating at " PTR_FORMAT " (+%d) with destination at %d", p2i(pc), pc_offset, data_offset);
+}
+
+void CodeInstaller::pd_relocate_ForeignCall(NativeInstruction* inst, jlong foreign_call_destination, JVMCI_TRAPS) {
+  address pc = (address) inst;
+  if (inst->is_jal()) {
+    NativeCall* call = nativeCall_at(pc);
+    call->set_destination((address) foreign_call_destination);
+    _instructions->relocate(call->instruction_address(), runtime_call_Relocation::spec());
+  } else if (inst->is_jump()) {
+    NativeJump* jump = nativeJump_at(pc);
+    jump->set_jump_destination((address) foreign_call_destination);
+    _instructions->relocate(jump->instruction_address(), runtime_call_Relocation::spec());
+  } else if (inst->is_movptr()) {
+    NativeMovConstReg* movptr = nativeMovConstReg_at(pc);
+    movptr->set_data((intptr_t) foreign_call_destination);
+    _instructions->relocate(movptr->instruction_address(), runtime_call_Relocation::spec());
+  } else {
+    JVMCI_ERROR("unknown call or jump instruction at " PTR_FORMAT, p2i(pc));
+  }
+  JVMCI_event_3("relocating (foreign call) at " PTR_FORMAT, p2i(inst));
+}
+
+void CodeInstaller::pd_relocate_JavaMethod(CodeBuffer &cbuf, methodHandle& method, jint pc_offset, JVMCI_TRAPS) {
+  Unimplemented();
+}
+
+void CodeInstaller::pd_relocate_poll(address pc, jint mark, JVMCI_TRAPS) {
+  Unimplemented();
+}
+
+// convert JVMCI register indices (as used in oop maps) to HotSpot registers
+VMReg CodeInstaller::get_hotspot_reg(jint jvmci_reg, JVMCI_TRAPS) {
+  if (jvmci_reg < Register::number_of_registers) {
+    return as_Register(jvmci_reg)->as_VMReg();
+  } else {
+    jint floatRegisterNumber = jvmci_reg - Register::number_of_registers;
+    if (floatRegisterNumber >= 0 && floatRegisterNumber < FloatRegister::number_of_registers) {
+      return as_FloatRegister(floatRegisterNumber)->as_VMReg();
+    }
+    JVMCI_ERROR_NULL("invalid register number: %d", jvmci_reg);
+  }
+}
+
+bool CodeInstaller::is_general_purpose_reg(VMReg hotspotRegister) {
+  return !(hotspotRegister->is_FloatRegister() || hotspotRegister->is_VectorRegister());
+}

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -241,6 +241,7 @@ void MacroAssembler::set_last_Java_frame(Register last_java_sp,
     set_last_Java_frame(last_java_sp, last_java_fp, target(L), tmp);
   } else {
     L.add_patch_at(code(), locator());
+    IncompressibleRegion ir(this);  // the label address will be patched back.
     set_last_Java_frame(last_java_sp, last_java_fp, pc() /* Patched later */, tmp);
   }
 }
@@ -549,6 +550,7 @@ void MacroAssembler::unimplemented(const char* what) {
 }
 
 void MacroAssembler::emit_static_call_stub() {
+  IncompressibleRegion ir(this);  // Fixed length: see CompiledStaticCall::to_interp_stub_size().
   // CompiledDirectStaticCall::set_to_interpreted knows the
   // exact layout of this stub.
 
@@ -751,6 +753,7 @@ void MacroAssembler::la(Register Rd, const Address &adr) {
 }
 
 void MacroAssembler::la(Register Rd, Label &label) {
+  IncompressibleRegion ir(this);   // the label address may be patched back.
   la(Rd, target(label));
 }
 
@@ -2437,6 +2440,7 @@ void MacroAssembler::far_jump(Address entry, Register tmp) {
   assert(entry.rspec().type() == relocInfo::external_word_type
         || entry.rspec().type() == relocInfo::runtime_call_type
         || entry.rspec().type() == relocInfo::none, "wrong entry relocInfo type");
+  IncompressibleRegion ir(this);  // Fixed length: see MacroAssembler::far_branch_size()
   int32_t offset = 0;
   if (far_branches()) {
     // We can use auipc + jalr here because we know that the total size of
@@ -2455,6 +2459,7 @@ void MacroAssembler::far_call(Address entry, Register tmp) {
   assert(entry.rspec().type() == relocInfo::external_word_type
         || entry.rspec().type() == relocInfo::runtime_call_type
         || entry.rspec().type() == relocInfo::none, "wrong entry relocInfo type");
+  IncompressibleRegion ir(this);  // Fixed length: see MacroAssembler::far_branch_size()
   int32_t offset = 0;
   if (far_branches()) {
     // We can use auipc + jalr here because we know that the total size of

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -390,6 +390,7 @@ void NativeJump::patch_verified_entry(address entry, address verified_entry, add
 void NativeGeneralJump::insert_unconditional(address code_pos, address entry) {
   CodeBuffer cb(code_pos, instruction_size);
   MacroAssembler a(&cb);
+  Assembler::IncompressibleRegion ir(&a);  // Fixed length: see NativeGeneralJump::get_instruction_size()
 
   int32_t offset = 0;
   a.movptr(t0, entry, offset); // lui, addi, slli, addi, slli

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1318,8 +1318,11 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 
   // insert a nop at the start of the prolog so we can patch in a
   // branch if we need to invalidate the method later
-  MacroAssembler::assert_alignment(__ pc());
-  __ nop();
+  {
+    Assembler::IncompressibleRegion ir(&_masm);  // keep the nop as 4 bytes for patching.
+    MacroAssembler::assert_alignment(__ pc());
+    __ nop();  // 4 bytes
+  }
 
   assert_cond(C != NULL);
 
@@ -1680,6 +1683,7 @@ void BoxLockNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
 
 void BoxLockNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   C2_MacroAssembler _masm(&cbuf);
+  Assembler::IncompressibleRegion ir(&_masm);  // Fixed length: see BoxLockNode::size()
 
   assert_cond(ra_ != NULL);
   int offset = ra_->reg2offset(in_RegMask(0).find_first_elem());
@@ -2268,6 +2272,7 @@ encode %{
 
   enc_class riscv_enc_java_static_call(method meth) %{
     C2_MacroAssembler _masm(&cbuf);
+    Assembler::IncompressibleRegion ir(&_masm);  // Fixed length: see ret_addr_offset
 
     address addr = (address)$meth$$method;
     address call = NULL;
@@ -2306,6 +2311,7 @@ encode %{
 
   enc_class riscv_enc_java_dynamic_call(method meth) %{
     C2_MacroAssembler _masm(&cbuf);
+    Assembler::IncompressibleRegion ir(&_masm);  // Fixed length: see ret_addr_offset
     int method_index = resolved_method_index(cbuf);
     address call = __ ic_call((address)$meth$$method, method_index);
     if (call == NULL) {
@@ -2324,6 +2330,7 @@ encode %{
 
   enc_class riscv_enc_java_to_runtime(method meth) %{
     C2_MacroAssembler _masm(&cbuf);
+    Assembler::IncompressibleRegion ir(&_masm);  // Fixed length: see ret_addr_offset
 
     // some calls to generated routines (arraycopy code) are scheduled
     // by C2 as runtime calls. if so we can call them using a jr (they

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -956,8 +956,11 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     int vep_offset = ((intptr_t)__ pc()) - start;
 
     // First instruction must be a nop as it may need to be patched on deoptimisation
-    MacroAssembler::assert_alignment(__ pc());
-    __ nop();
+    {
+      Assembler::IncompressibleRegion ir(masm);  // keep the nop as 4 bytes for patching.
+      MacroAssembler::assert_alignment(__ pc());
+      __ nop();  // 4 bytes
+    }
     gen_special_dispatch(masm,
                          method,
                          in_sig_bt,
@@ -1108,8 +1111,11 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   // If we have to make this method not-entrant we'll overwrite its
   // first instruction with a jump.
-  MacroAssembler::assert_alignment(__ pc());
-  __ nop();
+  {
+    Assembler::IncompressibleRegion ir(masm);  // keep the nop as 4 bytes for patching.
+    MacroAssembler::assert_alignment(__ pc());
+    __ nop();  // 4 bytes
+  }
 
   if (VM_Version::supports_fast_class_init_checks() && method->needs_clinit_barrier()) {
     Label L_skip_barrier;

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -56,6 +56,9 @@
 #include "adfiles/ad_riscv.hpp"
 #include "opto/runtime.hpp"
 #endif
+#if INCLUDE_JVMCI
+#include "jvmci/jvmciJavaClasses.hpp"
+#endif
 
 #define __ masm->
 
@@ -208,6 +211,9 @@ void RegisterSaver::restore_live_registers(MacroAssembler* masm) {
 #ifdef COMPILER2
   __ pop_CPU_state(_save_vectors, Matcher::scalable_vector_reg_size(T_BYTE));
 #else
+#if !INCLUDE_JVMCI
+  assert(!_save_vectors, "vectors are generated only by C2 and JVMCI");
+#endif
   __ pop_CPU_state(_save_vectors);
 #endif
   __ leave();
@@ -492,6 +498,18 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm,
   // Will jump to the compiled code just as if compiled code was doing it.
   // Pre-load the register-jump target early, to schedule it better.
   __ ld(t1, Address(xmethod, in_bytes(Method::from_compiled_offset())));
+
+#if INCLUDE_JVMCI
+  if (EnableJVMCI) {
+    // check if this call should be routed towards a specific entry point
+    __ ld(t0, Address(xthread, in_bytes(JavaThread::jvmci_alternate_call_target_offset())));
+    Label no_alternative_target;
+    __ beqz(t0, no_alternative_target);
+    __ mv(t1, t0);
+    __ sd(zr, Address(xthread, in_bytes(JavaThread::jvmci_alternate_call_target_offset())));
+    __ bind(no_alternative_target);
+  }
+#endif // INCLUDE_JVMCI
 
   // Now generate the shuffle code.
   for (int i = 0; i < total_args_passed; i++) {
@@ -1675,6 +1693,11 @@ void SharedRuntime::generate_deopt_blob() {
   ResourceMark rm;
   // Setup code generation tools
   int pad = 0;
+#if INCLUDE_JVMCI
+  if (EnableJVMCI) {
+    pad += 512; // Increase the buffer size when compiling for JVMCI
+  }
+#endif
   CodeBuffer buffer("deopt_blob", 2048 + pad, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
   int frame_size_in_words = -1;
@@ -1726,6 +1749,12 @@ void SharedRuntime::generate_deopt_blob() {
   __ j(cont);
 
   int reexecute_offset = __ pc() - start;
+#if INCLUDE_JVMCI && !defined(COMPILER1)
+  if (EnableJVMCI && UseJVMCICompiler) {
+    // JVMCI does not use this kind of deoptimization
+    __ should_not_reach_here();
+  }
+#endif
 
   // Reexecute case
   // return address is the pc describes what bci to do re-execute at
@@ -1735,6 +1764,44 @@ void SharedRuntime::generate_deopt_blob() {
 
   __ mvw(xcpool, Deoptimization::Unpack_reexecute); // callee-saved
   __ j(cont);
+
+#if INCLUDE_JVMCI
+  Label after_fetch_unroll_info_call;
+  int implicit_exception_uncommon_trap_offset = 0;
+  int uncommon_trap_offset = 0;
+
+  if (EnableJVMCI) {
+    implicit_exception_uncommon_trap_offset = __ pc() - start;
+
+    __ ld(ra, Address(xthread, in_bytes(JavaThread::jvmci_implicit_exception_pc_offset())));
+    __ sd(zr, Address(xthread, in_bytes(JavaThread::jvmci_implicit_exception_pc_offset())));
+
+    uncommon_trap_offset = __ pc() - start;
+
+    // Save everything in sight.
+    reg_saver.save_live_registers(masm, 0, &frame_size_in_words);
+    // fetch_unroll_info needs to call last_java_frame()
+    Label retaddr;
+    __ set_last_Java_frame(sp, noreg, retaddr, t0);
+
+    __ lw(c_rarg1, Address(xthread, in_bytes(JavaThread::pending_deoptimization_offset())));
+    __ mvw(t0, -1);
+    __ sw(t0, Address(xthread, in_bytes(JavaThread::pending_deoptimization_offset())));
+
+    __ mvw(xcpool, (int32_t)Deoptimization::Unpack_reexecute);
+    __ mv(c_rarg0, xthread);
+    __ orrw(c_rarg2, zr, xcpool); // exec mode
+    int32_t offset = 0;
+    __ la_patchable(t0, RuntimeAddress(CAST_FROM_FN_PTR(address, Deoptimization::uncommon_trap)), offset);
+    __ jalr(x1, t0, offset);
+    __ bind(retaddr);
+    oop_maps->add_gc_map( __ pc()-start, map->deep_copy());
+
+    __ reset_last_Java_frame(false);
+
+    __ j(after_fetch_unroll_info_call);
+  } // EnableJVMCI
+#endif // INCLUDE_JVMCI
 
   int exception_offset = __ pc() - start;
 
@@ -1828,6 +1895,12 @@ void SharedRuntime::generate_deopt_blob() {
   oop_maps->add_gc_map(__ pc() - start, map);
 
   __ reset_last_Java_frame(false);
+
+#if INCLUDE_JVMCI
+  if (EnableJVMCI) {
+    __ bind(after_fetch_unroll_info_call);
+  }
+#endif
 
   // Load UnrollBlock* into x15
   __ mv(x15, x10);
@@ -1984,6 +2057,12 @@ void SharedRuntime::generate_deopt_blob() {
   _deopt_blob = DeoptimizationBlob::create(&buffer, oop_maps, 0, exception_offset, reexecute_offset, frame_size_in_words);
   assert(_deopt_blob != NULL, "create deoptimization blob fail!");
   _deopt_blob->set_unpack_with_exception_in_tls_offset(exception_in_tls_offset);
+#if INCLUDE_JVMCI
+  if (EnableJVMCI) {
+    _deopt_blob->set_uncommon_trap_offset(uncommon_trap_offset);
+    _deopt_blob->set_implicit_exception_uncommon_trap_offset(implicit_exception_uncommon_trap_offset);
+  }
+#endif
 }
 
 // Number of stack slots between incoming argument block and the start of

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1699,7 +1699,6 @@ void os::get_summary_os_info(char* buf, size_t buflen) {
 }
 
 int os::vsnprintf(char* buf, size_t len, const char* fmt, va_list args) {
-#if _MSC_VER >= 1900
   // Starting with Visual Studio 2015, vsnprint is C99 compliant.
   ALLOW_C_FUNCTION(::vsnprintf, int result = ::vsnprintf(buf, len, fmt, args);)
   // If an encoding error occurred (result < 0) then it's not clear
@@ -1708,29 +1707,6 @@ int os::vsnprintf(char* buf, size_t len, const char* fmt, va_list args) {
     buf[len - 1] = '\0';
   }
   return result;
-#else
-  // Before Visual Studio 2015, vsnprintf is not C99 compliant, so use
-  // _vsnprintf, whose behavior seems to be *mostly* consistent across
-  // versions.  However, when len == 0, avoid _vsnprintf too, and just
-  // go straight to _vscprintf.  The output is going to be truncated in
-  // that case, except in the unusual case of empty output.  More
-  // importantly, the documentation for various versions of Visual Studio
-  // are inconsistent about the behavior of _vsnprintf when len == 0,
-  // including it possibly being an error.
-  int result = -1;
-  if (len > 0) {
-    result = _vsnprintf(buf, len, fmt, args);
-    // If output (including NUL terminator) is truncated, the buffer
-    // won't be NUL terminated.  Add the trailing NUL specified by C99.
-    if ((result < 0) || ((size_t)result >= len)) {
-      buf[len - 1] = '\0';
-    }
-  }
-  if (result < 0) {
-    result = _vscprintf(fmt, args);
-  }
-  return result;
-#endif // _MSC_VER dispatch
 }
 
 static inline time_t get_mtime(const char* filename) {

--- a/src/hotspot/share/adlc/adlc.hpp
+++ b/src/hotspot/share/adlc/adlc.hpp
@@ -46,10 +46,6 @@ using namespace std;
 
 #define strdup _strdup
 
-#if _MSC_VER < 1900
-#define snprintf _snprintf
-#endif
-
 #ifndef _INTPTR_T_DEFINED
 #ifdef _WIN64
 typedef __int64 intptr_t;

--- a/src/hotspot/share/c1/c1_CFGPrinter.cpp
+++ b/src/hotspot/share/c1/c1_CFGPrinter.cpp
@@ -65,7 +65,7 @@ CFGPrinterOutput::CFGPrinterOutput(Compilation* compilation)
   char file_name[O_BUFLEN];
   jio_snprintf(file_name, sizeof(file_name), "output_tid" UINTX_FORMAT "_pid%u.cfg",
                os::current_thread_id(), os::current_process_id());
-  _output = new(ResourceObj::C_HEAP, mtCompiler) fileStream(file_name, "at");
+  _output = new(mtCompiler) fileStream(file_name, "at");
 }
 
 void CFGPrinterOutput::inc_indent() {

--- a/src/hotspot/share/cds/classListWriter.cpp
+++ b/src/hotspot/share/cds/classListWriter.cpp
@@ -40,7 +40,7 @@ void ClassListWriter::init() {
   // For -XX:DumpLoadedClassList=<file> option
   if (DumpLoadedClassList != NULL) {
     const char* list_name = make_log_name(DumpLoadedClassList, NULL);
-    _classlist_file = new(ResourceObj::C_HEAP, mtInternal)
+    _classlist_file = new(mtInternal)
                          fileStream(list_name);
     _classlist_file->print_cr("# NOTE: Do not modify this file.");
     _classlist_file->print_cr("#");

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1960,7 +1960,7 @@ void CompileBroker::init_compiler_thread_log() {
         if (LogCompilation && Verbose) {
           tty->print_cr("Opening compilation log %s", file_name);
         }
-        CompileLog* log = new(ResourceObj::C_HEAP, mtCompiler) CompileLog(file_name, fp, thread_id);
+        CompileLog* log = new(mtCompiler) CompileLog(file_name, fp, thread_id);
         if (log == NULL) {
           fclose(fp);
           return;

--- a/src/hotspot/share/compiler/compileLog.cpp
+++ b/src/hotspot/share/compiler/compileLog.cpp
@@ -39,7 +39,7 @@ CompileLog* CompileLog::_first = NULL;
 CompileLog::CompileLog(const char* file_name, FILE* fp, intx thread_id)
   : _context(_context_buffer, sizeof(_context_buffer))
 {
-  initialize(new(ResourceObj::C_HEAP, mtCompiler) fileStream(fp, true));
+  initialize(new(mtCompiler) fileStream(fp, true));
   _file_end = 0;
   _thread_id = thread_id;
 

--- a/src/hotspot/share/compiler/compiler_globals_pd.hpp
+++ b/src/hotspot/share/compiler/compiler_globals_pd.hpp
@@ -70,8 +70,15 @@ define_pd_global(uintx,  NonNMethodCodeHeapSize,     32*M);
 define_pd_global(uintx,  CodeCacheExpansionSize,     32*K);
 define_pd_global(uintx,  CodeCacheMinBlockLength,    1);
 define_pd_global(uintx,  CodeCacheMinimumUseSpace,   200*K);
+#ifndef ZERO
 define_pd_global(bool, NeverActAsServerClassMachine, true);
 define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
+#else
+// Zero runs without compilers. Do not let this code to force
+// the GC mode and default heap settings.
+define_pd_global(bool, NeverActAsServerClassMachine, false);
+define_pd_global(uint64_t,MaxRAM,                    128ULL*G);
+#endif
 #define CI_COMPILER_COUNT 0
 #else
 

--- a/src/hotspot/share/gc/shared/gcLogPrecious.cpp
+++ b/src/hotspot/share/gc/shared/gcLogPrecious.cpp
@@ -33,8 +33,8 @@ stringStream* GCLogPrecious::_temp = NULL;
 Mutex* GCLogPrecious::_lock = NULL;
 
 void GCLogPrecious::initialize() {
-  _lines = new (ResourceObj::C_HEAP, mtGC) stringStream();
-  _temp = new (ResourceObj::C_HEAP, mtGC) stringStream();
+  _lines = new (mtGC) stringStream();
+  _temp = new (mtGC) stringStream();
   _lock = new Mutex(Mutex::event, /* The lowest lock rank I could find */
                     "GCLogPrecious Lock");
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -48,8 +48,8 @@
 
 ShenandoahControlThread::ShenandoahControlThread() :
   ConcurrentGCThread(),
-  _alloc_failure_waiters_lock(Mutex::safepoint-1, "ShenandoahAllocFailureGC_lock", true),
-  _gc_waiters_lock(Mutex::safepoint-1, "ShenandoahRequestedGC_lock", true),
+  _alloc_failure_waiters_lock(Mutex::safepoint-2, "ShenandoahAllocFailureGC_lock", true),
+  _gc_waiters_lock(Mutex::safepoint-2, "ShenandoahRequestedGC_lock", true),
   _periodic_task(this),
   _requested_gc_cause(GCCause::_no_cause_specified),
   _degen_point(ShenandoahGC::_degenerated_outside_cycle),

--- a/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
@@ -277,9 +277,7 @@ JVM_ENTRY_NO_ENV(void, jfr_set_method_sampling_period(JNIEnv* env, jobject jvm, 
   }
   JfrEventId typed_event_id = (JfrEventId)type;
   assert(EventExecutionSample::eventId == typed_event_id || EventNativeMethodSample::eventId == typed_event_id, "invariant");
-  if (periodMillis > 0) {
-    JfrEventSetting::set_enabled(typed_event_id, true); // ensure sampling event is enabled
-  }
+  JfrEventSetting::set_enabled(typed_event_id, periodMillis > 0);
   if (EventExecutionSample::eventId == type) {
     JfrThreadSampling::set_java_sample_period(periodMillis);
   } else {

--- a/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
@@ -299,14 +299,18 @@ static const uint MAX_NR_OF_NATIVE_SAMPLES = 1;
 void JfrThreadSampleClosure::commit_events(JfrSampleType type) {
   if (JAVA_SAMPLE == type) {
     assert(_added_java > 0 && _added_java <= MAX_NR_OF_JAVA_SAMPLES, "invariant");
-    for (uint i = 0; i < _added_java; ++i) {
-      _events[i].commit();
+    if (EventExecutionSample::is_enabled()) {
+      for (uint i = 0; i < _added_java; ++i) {
+        _events[i].commit();
+      }
     }
   } else {
     assert(NATIVE_SAMPLE == type, "invariant");
     assert(_added_native > 0 && _added_native <= MAX_NR_OF_NATIVE_SAMPLES, "invariant");
-    for (uint i = 0; i < _added_native; ++i) {
-      _events_native[i].commit();
+    if (EventNativeMethodSample::is_enabled()) {
+      for (uint i = 0; i < _added_native; ++i) {
+        _events_native[i].commit();
+      }
     }
   }
 }

--- a/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.hpp
@@ -57,9 +57,11 @@ class JfrCheckpointManager : public JfrCHeapObj {
  public:
   typedef JfrCheckpointMspace::Node Buffer;
   typedef JfrCheckpointMspace::NodePtr BufferPtr;
+  typedef const JfrCheckpointMspace::Node* ConstBufferPtr;
  private:
   JfrCheckpointMspace* _global_mspace;
   JfrThreadLocalCheckpointMspace* _thread_local_mspace;
+  JfrThreadLocalCheckpointMspace* _virtual_thread_local_mspace;
   JfrChunkWriter& _chunkwriter;
 
   JfrCheckpointManager(JfrChunkWriter& cw);
@@ -69,14 +71,16 @@ class JfrCheckpointManager : public JfrCHeapObj {
   bool initialize();
   static void destroy();
 
-  static BufferPtr get_thread_local(Thread* thread);
-  static void set_thread_local(Thread* thread, BufferPtr buffer);
-  static BufferPtr acquire_thread_local(size_t size, Thread* thread);
+  static BufferPtr get_virtual_thread_local(Thread* thread);
+  static void set_virtual_thread_local(Thread* thread, BufferPtr buffer);
+  static BufferPtr acquire_virtual_thread_local(Thread* thread, size_t size);
+  static BufferPtr new_virtual_thread_local(Thread* thread, size_t size = 0);
 
-  static BufferPtr lease(Thread* thread, bool previous_epoch = false, size_t size = 0);
-  static BufferPtr lease(BufferPtr old, Thread* thread, size_t size);
   static BufferPtr lease_thread_local(Thread* thread, size_t size = 0);
+  static BufferPtr lease_global(Thread* thread, bool previous_epoch = false, size_t size = 0);
 
+  static BufferPtr acquire(Thread* thread, JfrCheckpointBufferKind kind = JFR_THREADLOCAL, bool previous_epoch = false, size_t size = 0);
+  static BufferPtr renew(ConstBufferPtr old, Thread* thread, size_t size, JfrCheckpointBufferKind kind = JFR_THREADLOCAL);
   static BufferPtr flush(BufferPtr old, size_t used, size_t requested, Thread* thread);
 
   size_t clear();

--- a/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointWriter.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointWriter.cpp
@@ -27,17 +27,18 @@
 #include "jfr/recorder/checkpoint/jfrCheckpointWriter.hpp"
 #include "jfr/utilities/jfrBlob.hpp"
 #include "jfr/writers/jfrBigEndianWriter.hpp"
+#include "runtime/thread.inline.hpp"
 
 JfrCheckpointFlush::JfrCheckpointFlush(Type* old, size_t used, size_t requested, Thread* t) :
   _result(JfrCheckpointManager::flush(old, used, requested, t)) {}
 
-JfrCheckpointWriter::JfrCheckpointWriter(JfrCheckpointType type /* GENERIC */) :
-  JfrCheckpointWriterBase(JfrCheckpointManager::lease(Thread::current()), Thread::current()),
+JfrCheckpointWriter::JfrCheckpointWriter(bool header /* true */, JfrCheckpointType type /* GENERIC */, JfrCheckpointBufferKind kind /* JFR_GLOBAL */) :
+  JfrCheckpointWriterBase(JfrCheckpointManager::acquire(Thread::current(), kind), Thread::current()),
   _time(JfrTicks::now()),
   _offset(0),
   _count(0),
   _type(type),
-  _header(true) {
+  _header(header) {
   assert(this->is_acquired(), "invariant");
   assert(0 == this->current_offset(), "invariant");
   if (_header) {
@@ -45,8 +46,8 @@ JfrCheckpointWriter::JfrCheckpointWriter(JfrCheckpointType type /* GENERIC */) :
   }
 }
 
-JfrCheckpointWriter::JfrCheckpointWriter(Thread* thread, bool header /* true */, JfrCheckpointType type /* GENERIC */, bool global_lease /* true */) :
-  JfrCheckpointWriterBase(global_lease ? JfrCheckpointManager::lease(thread) : JfrCheckpointManager::lease_thread_local(thread), thread),
+JfrCheckpointWriter::JfrCheckpointWriter(Thread* thread, bool header /* true */, JfrCheckpointType type /* GENERIC */, JfrCheckpointBufferKind kind /* JFR_GLOBAL */) :
+  JfrCheckpointWriterBase(JfrCheckpointManager::acquire(thread, kind), thread),
   _time(JfrTicks::now()),
   _offset(0),
   _count(0),
@@ -60,7 +61,7 @@ JfrCheckpointWriter::JfrCheckpointWriter(Thread* thread, bool header /* true */,
 }
 
 JfrCheckpointWriter::JfrCheckpointWriter(bool previous_epoch, Thread* thread, JfrCheckpointType type /* GENERIC */) :
-  JfrCheckpointWriterBase(JfrCheckpointManager::lease(thread, previous_epoch), thread),
+  JfrCheckpointWriterBase(JfrCheckpointManager::lease_global(thread, previous_epoch), thread),
   _time(JfrTicks::now()),
   _offset(0),
   _count(0),

--- a/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointWriter.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointWriter.hpp
@@ -70,9 +70,9 @@ class JfrCheckpointWriter : public JfrCheckpointWriterBase {
   const u1* session_data(size_t* size, bool move = false, const JfrCheckpointContext* ctx = NULL);
   void release();
   JfrCheckpointWriter(bool previous_epoch, Thread* thread, JfrCheckpointType type = GENERIC);
- public:
-  JfrCheckpointWriter(JfrCheckpointType type = GENERIC);
-  JfrCheckpointWriter(Thread* thread, bool header = true, JfrCheckpointType mode = GENERIC, bool global_lease = true);
+public:
+  JfrCheckpointWriter(bool header = true, JfrCheckpointType mode = GENERIC, JfrCheckpointBufferKind kind = JFR_GLOBAL);
+  JfrCheckpointWriter(Thread* thread, bool header = true, JfrCheckpointType mode = GENERIC, JfrCheckpointBufferKind kind = JFR_GLOBAL);
   ~JfrCheckpointWriter();
   void write_type(JfrTypeId type_id);
   void write_count(u4 nof_entries);

--- a/src/hotspot/share/jfr/recorder/service/jfrEvent.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrEvent.hpp
@@ -63,24 +63,20 @@ class JfrEvent {
  private:
   jlong _start_time;
   jlong _end_time;
-  bool _started;
   bool _untimed;
   bool _should_commit;
   bool _evaluated;
 
  protected:
   JfrEvent(EventStartTime timing=TIMED) : _start_time(0), _end_time(0),
-                                          _started(false), _untimed(timing == UNTIMED),
+                                          _untimed(timing == UNTIMED),
                                           _should_commit(false), _evaluated(false)
 #ifdef ASSERT
   , _verifier()
 #endif
   {
-    if (T::is_enabled() && JfrThreadLocal::is_included(Thread::current())) {
-      _started = true;
-      if (TIMED == timing && !T::isInstant) {
-        set_starttime(JfrTicks::now());
-      }
+    if (!T::isInstant && !_untimed && is_enabled()) {
+      set_starttime(JfrTicks::now());
     }
   }
 
@@ -146,19 +142,16 @@ class JfrEvent {
     return T::hasStackTrace;
   }
 
-  bool is_started() const {
-    return _started;
+  bool is_started() {
+    return is_instant() || _start_time != 0 || _untimed;
   }
 
   bool should_commit() {
-    if (!_started) {
+    if (!is_enabled()) {
       return false;
     }
     if (_untimed) {
       return true;
-    }
-    if (_evaluated) {
-      return _should_commit;
     }
     _should_commit = evaluate();
     _evaluated = true;
@@ -167,11 +160,16 @@ class JfrEvent {
 
  private:
   bool should_write() {
-    return _started && (_evaluated ? _should_commit : evaluate());
+    if (_evaluated) {
+      return _should_commit;
+    }
+    if (!is_enabled()) {
+      return false;
+    }
+    return evaluate() && JfrThreadLocal::is_included(Thread::current());
   }
 
   bool evaluate() {
-    assert(_started, "invariant");
     if (_start_time == 0) {
       set_starttime(JfrTicks::now());
     } else if (_end_time == 0) {

--- a/src/hotspot/share/jfr/recorder/storage/jfrBuffer.cpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrBuffer.cpp
@@ -37,7 +37,7 @@ JfrBuffer::JfrBuffer() : _next(NULL),
                          _flags(0),
                          _context(0) {}
 
-bool JfrBuffer::initialize(size_t header_size, size_t size) {
+void JfrBuffer::initialize(size_t header_size, size_t size) {
   assert(_next == NULL, "invariant");
   assert(_identity == NULL, "invariant");
   _header_size = (u2)header_size;
@@ -48,10 +48,9 @@ bool JfrBuffer::initialize(size_t header_size, size_t size) {
   assert(!transient(), "invariant");
   assert(!lease(), "invariant");
   assert(!retired(), "invariant");
-  return true;
 }
 
-void JfrBuffer::reinitialize(bool exclusion /* false */) {
+void JfrBuffer::reinitialize() {
   acquire_critical_section_top();
   set_pos(start());
   release_critical_section_top(start());
@@ -173,8 +172,7 @@ size_t JfrBuffer::unflushed_size() const {
 enum FLAG {
   RETIRED = 1,
   TRANSIENT = 2,
-  LEASE = 4,
-  EXCLUDED = 8
+  LEASE = 4
 };
 
 inline u1 load(const volatile u1* dest) {

--- a/src/hotspot/share/jfr/recorder/storage/jfrBuffer.hpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrBuffer.hpp
@@ -79,8 +79,8 @@ class JfrBuffer {
 
  public:
   JfrBuffer();
-  bool initialize(size_t header_size, size_t size);
-  void reinitialize(bool exclusion = false);
+  void initialize(size_t header_size, size_t size);
+  void reinitialize();
 
   const u1* start() const {
     return ((const u1*)this) + _header_size;

--- a/src/hotspot/share/jfr/recorder/storage/jfrMemorySpace.inline.hpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrMemorySpace.inline.hpp
@@ -218,10 +218,7 @@ inline typename FreeListType::NodePtr JfrMemorySpace<Client, RetrievalPolicy, Fr
   }
   NodePtr node = new (allocation) Node();
   assert(node != NULL, "invariant");
-  if (!node->initialize(sizeof(Node), aligned_size_bytes)) {
-    JfrCHeapObj::free(node, aligned_size_bytes + sizeof(Node));
-    return NULL;
-  }
+  node->initialize(sizeof(Node), aligned_size_bytes);
   return node;
 }
 

--- a/src/hotspot/share/jfr/utilities/jfrTypes.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrTypes.hpp
@@ -57,4 +57,10 @@ enum JfrCheckpointType {
   THREADS = 8
 };
 
+enum JfrCheckpointBufferKind {
+  JFR_GLOBAL,
+  JFR_THREADLOCAL,
+  JFR_VIRTUAL_THREADLOCAL
+};
+
 #endif // SHARE_JFR_UTILITIES_JFRTYPES_HPP

--- a/src/hotspot/share/jvmci/jvmci_globals.cpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.cpp
@@ -152,7 +152,7 @@ bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
 #undef CHECK_NOT_SET
 
   if (JVMCILibDumpJNIConfig != NULL) {
-    _jni_config_file = new(ResourceObj::C_HEAP, mtJVMCI) fileStream(JVMCILibDumpJNIConfig);
+    _jni_config_file = new(mtJVMCI) fileStream(JVMCILibDumpJNIConfig);
     if (_jni_config_file == NULL || !_jni_config_file->is_open()) {
       jio_fprintf(defaultStream::error_stream(),
           "Could not open file for dumping JVMCI shared library JNI config: %s\n", JVMCILibDumpJNIConfig);

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -174,46 +174,105 @@ char* ReallocateHeap(char *old,
 // handles NULL pointers
 void FreeHeap(void* p);
 
-template <MEMFLAGS F> class CHeapObj {
+class CHeapObjBase {
+ public:
+  ALWAYSINLINE void* operator new(size_t size, MEMFLAGS f) throw() {
+    return (void*)AllocateHeap(size, f);
+  }
+
+  ALWAYSINLINE void* operator new(size_t size,
+                                  MEMFLAGS f,
+                                  const NativeCallStack& stack) throw() {
+    return (void*)AllocateHeap(size, f, stack);
+  }
+
+  ALWAYSINLINE void* operator new(size_t size,
+                                  MEMFLAGS f,
+                                  const std::nothrow_t&,
+                                  const NativeCallStack& stack) throw() {
+    return (void*)AllocateHeap(size, f, stack, AllocFailStrategy::RETURN_NULL);
+  }
+
+  ALWAYSINLINE void* operator new(size_t size,
+                                  MEMFLAGS f,
+                                  const std::nothrow_t&) throw() {
+    return (void*)AllocateHeap(size, f, AllocFailStrategy::RETURN_NULL);
+  }
+
+  ALWAYSINLINE void* operator new[](size_t size, MEMFLAGS f) throw() {
+    return (void*)AllocateHeap(size, f);
+  }
+
+  ALWAYSINLINE void* operator new[](size_t size,
+                                    MEMFLAGS f,
+                                    const NativeCallStack& stack) throw() {
+    return (void*)AllocateHeap(size, f, stack);
+  }
+
+  ALWAYSINLINE void* operator new[](size_t size,
+                                    MEMFLAGS f,
+                                    const std::nothrow_t&,
+                                    const NativeCallStack& stack) throw() {
+    return (void*)AllocateHeap(size, f, stack, AllocFailStrategy::RETURN_NULL);
+  }
+
+  ALWAYSINLINE void* operator new[](size_t size,
+                                    MEMFLAGS f,
+                                    const std::nothrow_t&) throw() {
+    return (void*)AllocateHeap(size, f, AllocFailStrategy::RETURN_NULL);
+  }
+
+  void operator delete(void* p)     { FreeHeap(p); }
+  void operator delete [] (void* p) { FreeHeap(p); }
+};
+
+// Uses the implicitly static new and delete operators of CHeapObjBase
+template<MEMFLAGS F>
+class CHeapObj {
  public:
   ALWAYSINLINE void* operator new(size_t size) throw() {
-    return (void*)AllocateHeap(size, F);
+    return CHeapObjBase::operator new(size, F);
   }
 
   ALWAYSINLINE void* operator new(size_t size,
                                   const NativeCallStack& stack) throw() {
-    return (void*)AllocateHeap(size, F, stack);
+    return CHeapObjBase::operator new(size, F, stack);
   }
 
-  ALWAYSINLINE void* operator new(size_t size, const std::nothrow_t&,
+  ALWAYSINLINE void* operator new(size_t size, const std::nothrow_t& nt,
                                   const NativeCallStack& stack) throw() {
-    return (void*)AllocateHeap(size, F, stack, AllocFailStrategy::RETURN_NULL);
+    return CHeapObjBase::operator new(size, F, nt, stack);
   }
 
-  ALWAYSINLINE void* operator new(size_t size, const std::nothrow_t&) throw() {
-    return (void*)AllocateHeap(size, F, AllocFailStrategy::RETURN_NULL);
+  ALWAYSINLINE void* operator new(size_t size, const std::nothrow_t& nt) throw() {
+    return CHeapObjBase::operator new(size, F, nt);
   }
 
   ALWAYSINLINE void* operator new[](size_t size) throw() {
-    return (void*)AllocateHeap(size, F);
+    return CHeapObjBase::operator new[](size, F);
   }
 
   ALWAYSINLINE void* operator new[](size_t size,
-                                  const NativeCallStack& stack) throw() {
-    return (void*)AllocateHeap(size, F, stack);
-  }
-
-  ALWAYSINLINE void* operator new[](size_t size, const std::nothrow_t&,
                                     const NativeCallStack& stack) throw() {
-    return (void*)AllocateHeap(size, F, stack, AllocFailStrategy::RETURN_NULL);
+    return CHeapObjBase::operator new[](size, F, stack);
   }
 
-  ALWAYSINLINE void* operator new[](size_t size, const std::nothrow_t&) throw() {
-    return (void*)AllocateHeap(size, F, AllocFailStrategy::RETURN_NULL);
+  ALWAYSINLINE void* operator new[](size_t size, const std::nothrow_t& nt,
+                                    const NativeCallStack& stack) throw() {
+    return CHeapObjBase::operator new[](size, F, nt, stack);
   }
 
-  void  operator delete(void* p)     { FreeHeap(p); }
-  void  operator delete [] (void* p) { FreeHeap(p); }
+  ALWAYSINLINE void* operator new[](size_t size, const std::nothrow_t& nt) throw() {
+    return CHeapObjBase::operator new[](size, F, nt);
+  }
+
+  void operator delete(void* p)     {
+    CHeapObjBase::operator delete(p);
+  }
+
+  void operator delete [] (void* p) {
+    CHeapObjBase::operator delete[](p);
+  }
 };
 
 // Base class for objects allocated on the stack only.

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -177,49 +177,49 @@ void FreeHeap(void* p);
 class CHeapObjBase {
  public:
   ALWAYSINLINE void* operator new(size_t size, MEMFLAGS f) throw() {
-    return (void*)AllocateHeap(size, f);
+    return AllocateHeap(size, f);
   }
 
   ALWAYSINLINE void* operator new(size_t size,
                                   MEMFLAGS f,
                                   const NativeCallStack& stack) throw() {
-    return (void*)AllocateHeap(size, f, stack);
+    return AllocateHeap(size, f, stack);
   }
 
   ALWAYSINLINE void* operator new(size_t size,
                                   MEMFLAGS f,
                                   const std::nothrow_t&,
                                   const NativeCallStack& stack) throw() {
-    return (void*)AllocateHeap(size, f, stack, AllocFailStrategy::RETURN_NULL);
+    return AllocateHeap(size, f, stack, AllocFailStrategy::RETURN_NULL);
   }
 
   ALWAYSINLINE void* operator new(size_t size,
                                   MEMFLAGS f,
                                   const std::nothrow_t&) throw() {
-    return (void*)AllocateHeap(size, f, AllocFailStrategy::RETURN_NULL);
+    return AllocateHeap(size, f, AllocFailStrategy::RETURN_NULL);
   }
 
   ALWAYSINLINE void* operator new[](size_t size, MEMFLAGS f) throw() {
-    return (void*)AllocateHeap(size, f);
+    return AllocateHeap(size, f);
   }
 
   ALWAYSINLINE void* operator new[](size_t size,
                                     MEMFLAGS f,
                                     const NativeCallStack& stack) throw() {
-    return (void*)AllocateHeap(size, f, stack);
+    return AllocateHeap(size, f, stack);
   }
 
   ALWAYSINLINE void* operator new[](size_t size,
                                     MEMFLAGS f,
                                     const std::nothrow_t&,
                                     const NativeCallStack& stack) throw() {
-    return (void*)AllocateHeap(size, f, stack, AllocFailStrategy::RETURN_NULL);
+    return AllocateHeap(size, f, stack, AllocFailStrategy::RETURN_NULL);
   }
 
   ALWAYSINLINE void* operator new[](size_t size,
                                     MEMFLAGS f,
                                     const std::nothrow_t&) throw() {
-    return (void*)AllocateHeap(size, f, AllocFailStrategy::RETURN_NULL);
+    return AllocateHeap(size, f, AllocFailStrategy::RETURN_NULL);
   }
 
   void operator delete(void* p)     { FreeHeap(p); }

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -36,6 +36,7 @@
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/c2/barrierSetC2.hpp"
 #include "jfr/jfrEvents.hpp"
+#include "memory/allocation.hpp"
 #include "memory/resourceArea.hpp"
 #include "opto/addnode.hpp"
 #include "opto/block.hpp"
@@ -637,7 +638,7 @@ Compile::Compile( ciEnv* ci_env, ciMethod* target, int osr_bci,
                   _vector_reboxing_late_inlines(comp_arena(), 2, 0, NULL),
                   _late_inlines_pos(0),
                   _number_of_mh_late_inlines(0),
-                  _print_inlining_stream(new stringStream()),
+                  _print_inlining_stream(new (mtCompiler) stringStream()),
                   _print_inlining_list(NULL),
                   _print_inlining_idx(0),
                   _print_inlining_output(NULL),
@@ -910,7 +911,7 @@ Compile::Compile( ciEnv* ci_env,
     _initial_gvn(NULL),
     _for_igvn(NULL),
     _number_of_mh_late_inlines(0),
-    _print_inlining_stream(new stringStream()),
+    _print_inlining_stream(new (mtCompiler) stringStream()),
     _print_inlining_list(NULL),
     _print_inlining_idx(0),
     _print_inlining_output(NULL),

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -1058,6 +1058,10 @@ class Compile : public Phase {
           int is_fancy_jump, bool pass_tls,
           bool return_pc, DirectiveSet* directive);
 
+  ~Compile() {
+    delete _print_inlining_stream;
+  };
+
   // Are we compiling a method?
   bool has_method() { return method() != NULL; }
 

--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -149,7 +149,7 @@ void IdealGraphPrinter::init(const char* file_name, bool use_multiple_files, boo
   } else {
     init_network_stream();
   }
-  _xml = new (ResourceObj::C_HEAP, mtCompiler) xmlStream(_output);
+  _xml = new (mtCompiler) xmlStream(_output);
   if (!append) {
     head(TOP_ELEMENT);
   }
@@ -851,9 +851,9 @@ void IdealGraphPrinter::init_file_stream(const char* file_name, bool use_multipl
     } else {
       st.print("%s%d", file_name, _file_count);
     }
-    _output = new (ResourceObj::C_HEAP, mtCompiler) fileStream(st.as_string(), "w");
+    _output = new (mtCompiler) fileStream(st.as_string(), "w");
   } else {
-    _output = new (ResourceObj::C_HEAP, mtCompiler) fileStream(file_name, append ? "a" : "w");
+    _output = new (mtCompiler) fileStream(file_name, append ? "a" : "w");
   }
   if (use_multiple_files) {
     assert(!append, "append should only be used for debugging with a single file");
@@ -862,7 +862,7 @@ void IdealGraphPrinter::init_file_stream(const char* file_name, bool use_multipl
 }
 
 void IdealGraphPrinter::init_network_stream() {
-  _network_stream = new (ResourceObj::C_HEAP, mtCompiler) networkStream();
+  _network_stream = new (mtCompiler) networkStream();
   // Try to connect to visualizer
   if (_network_stream->connect(PrintIdealGraphAddress, PrintIdealGraphPort)) {
     char c = 0;

--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -731,10 +731,9 @@ Node* IdealGraphPrinter::get_load_node(const Node* node) {
 
 void IdealGraphPrinter::walk_nodes(Node* start, bool edges, VectorSet* temp_set) {
   VectorSet visited;
-  GrowableArray<Node *> nodeStack(Thread::current()->resource_area(), 0, 0, NULL);
+  GrowableArray<Node *> nodeStack(Thread::current()->resource_area(), 0, 0, nullptr);
   nodeStack.push(start);
-  visited.test_set(start->_idx);
-  if (C->cfg() != NULL) {
+  if (C->cfg() != nullptr) {
     // once we have a CFG there are some nodes that aren't really
     // reachable but are in the CFG so add them here.
     for (uint i = 0; i < C->cfg()->number_of_blocks(); i++) {
@@ -745,25 +744,23 @@ void IdealGraphPrinter::walk_nodes(Node* start, bool edges, VectorSet* temp_set)
     }
   }
 
-  while(nodeStack.length() > 0) {
+  while (nodeStack.length() > 0) {
+    Node* n = nodeStack.pop();
+    if (visited.test_set(n->_idx)) {
+      continue;
+    }
 
-    Node *n = nodeStack.pop();
     visit_node(n, edges, temp_set);
 
     if (_traverse_outs) {
       for (DUIterator i = n->outs(); n->has_out(i); i++) {
-        Node* p = n->out(i);
-        if (!visited.test_set(p->_idx)) {
-          nodeStack.push(p);
-        }
+        nodeStack.push(n->out(i));
       }
     }
 
-    for ( uint i = 0; i < n->len(); i++ ) {
-      if ( n->in(i) ) {
-        if (!visited.test_set(n->in(i)->_idx)) {
-          nodeStack.push(n->in(i));
-        }
+    for (uint i = 0; i < n->len(); i++) {
+      if (n->in(i) != nullptr) {
+        nodeStack.push(n->in(i));
       }
     }
   }

--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "memory/allocation.hpp"
 #include "opto/loopnode.hpp"
 #include "opto/addnode.hpp"
 #include "opto/callnode.hpp"
@@ -858,7 +859,7 @@ BoolNode* PhaseIdealLoop::rc_predicate(IdealLoopTree *loop, Node* ctrl,
 
   stringStream* predString = NULL;
   if (TraceLoopPredicate) {
-    predString = new stringStream();
+    predString = new (mtCompiler) stringStream();
     predString->print("rc_predicate ");
   }
 
@@ -983,7 +984,7 @@ BoolNode* PhaseIdealLoop::rc_predicate(IdealLoopTree *loop, Node* ctrl,
   if (TraceLoopPredicate) {
     predString->print_cr("<u range");
     tty->print("%s", predString->base());
-    predString->~stringStream();
+    delete predString;
   }
   return bol;
 }

--- a/src/hotspot/share/prims/nativeLookup.cpp
+++ b/src/hotspot/share/prims/nativeLookup.cpp
@@ -355,24 +355,6 @@ address NativeLookup::lookup_entry(const methodHandle& method, TRAPS) {
   return entry; // NULL indicates not found
 }
 
-void* NativeLookup::dll_load(const methodHandle& method) {
-  if (method->has_native_function()) {
-
-    address current_entry = method->native_function();
-
-    char dll_name[JVM_MAXPATHLEN];
-    dll_name[0] = '\0';
-    int offset;
-    bool ret = os::dll_address_to_library_name(current_entry, dll_name, sizeof(dll_name), &offset);
-    if (ret && dll_name[0] != '\0') {
-      char ebuf[32];
-      return os::dll_load(dll_name, ebuf, sizeof(ebuf));
-    }
-  }
-
-  return NULL;
-}
-
 // Check if there are any JVM TI prefixes which have been applied to the native method name.
 // If any are found, remove them before attempting the look up of the
 // native implementation again.

--- a/src/hotspot/share/prims/nativeLookup.hpp
+++ b/src/hotspot/share/prims/nativeLookup.hpp
@@ -39,7 +39,6 @@ class NativeLookup : AllStatic {
   static address lookup_entry(const methodHandle& method, TRAPS);
   static address lookup_entry_prefixed(const methodHandle& method, TRAPS);
 
-  static void* dll_load(const methodHandle& method);
   static const char* compute_complete_jni_name(const char* pure_name, const char* long_name, int args_size, bool os_style);
  public:
   // JNI name computation

--- a/src/hotspot/share/runtime/abstract_vm_version.cpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.cpp
@@ -203,11 +203,7 @@ const char* Abstract_VM_Version::internal_vm_info_string() {
 
   #ifndef HOTSPOT_BUILD_COMPILER
     #ifdef _MSC_VER
-      #if _MSC_VER == 1800
-        #define HOTSPOT_BUILD_COMPILER "MS VC++ 12.0 (VS2013)"
-      #elif _MSC_VER == 1900
-        #define HOTSPOT_BUILD_COMPILER "MS VC++ 14.0 (VS2015)"
-      #elif _MSC_VER == 1911
+      #if _MSC_VER == 1911
         #define HOTSPOT_BUILD_COMPILER "MS VC++ 15.3 (VS2017)"
       #elif _MSC_VER == 1912
         #define HOTSPOT_BUILD_COMPILER "MS VC++ 15.5 (VS2017)"

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3152,12 +3152,6 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
 #ifdef ZERO
   // Zero always runs in interpreted mode
   set_mode_flags(_int);
-
-  // Zero runs without compilers. Do not let compiler selection code
-  // to force it into Serial GC, let the GC ergonomics decide.
-  if (FLAG_IS_DEFAULT(NeverActAsServerClassMachine)) {
-    FLAG_SET_ERGO(NeverActAsServerClassMachine, false);
-  }
 #endif
 
   // eventually fix up InitialTenuringThreshold if only MaxTenuringThreshold is set

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -280,7 +280,7 @@ static jint heap_inspection(AttachOperation* op, outputStream* out) {
   const char* path = op->arg(1);
   if (path != NULL && path[0] != '\0') {
     // create file
-    fs = new (ResourceObj::C_HEAP, mtInternal) fileStream(path);
+    fs = new (mtInternal) fileStream(path);
     if (fs == NULL) {
       out->print_cr("Failed to allocate space for file: %s", path);
     }

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -668,7 +668,7 @@ fileStream* defaultStream::open_file(const char* log_name) {
     return NULL;
   }
 
-  fileStream* file = new(ResourceObj::C_HEAP, mtInternal) fileStream(try_name);
+  fileStream* file = new (mtInternal) fileStream(try_name);
   FREE_C_HEAP_ARRAY(char, try_name);
   if (file->is_open()) {
     return file;
@@ -686,7 +686,7 @@ fileStream* defaultStream::open_file(const char* log_name) {
 
   jio_printf("Warning:  Forcing option -XX:LogFile=%s\n", try_name);
 
-  file = new(ResourceObj::C_HEAP, mtInternal) fileStream(try_name);
+  file = new (mtInternal) fileStream(try_name);
   FREE_C_HEAP_ARRAY(char, try_name);
   if (file->is_open()) {
     return file;
@@ -703,7 +703,7 @@ void defaultStream::init_log() {
 
   if (file != NULL) {
     _log_file = file;
-    _outer_xmlStream = new(ResourceObj::C_HEAP, mtInternal) xmlStream(file);
+    _outer_xmlStream = new(mtInternal) xmlStream(file);
     start_log();
   } else {
     // and leave xtty as NULL
@@ -945,7 +945,7 @@ void ttyLocker::break_tty_lock_for_safepoint(intx holder) {
 
 void ostream_init() {
   if (defaultStream::instance == NULL) {
-    defaultStream::instance = new(ResourceObj::C_HEAP, mtInternal) defaultStream();
+    defaultStream::instance = new(mtInternal) defaultStream();
     tty = defaultStream::instance;
 
     // We want to ensure that time stamps in GC logs consider time 0

--- a/src/hotspot/share/utilities/ostream.hpp
+++ b/src/hotspot/share/utilities/ostream.hpp
@@ -42,7 +42,7 @@ DEBUG_ONLY(class ResourceMark;)
 //     jio_fprintf(defaultStream::output_stream(), "Message");
 // This allows for redirection via -XX:+DisplayVMOutputToStdout and
 // -XX:+DisplayVMOutputToStderr
-class outputStream : public ResourceObj {
+class outputStream : public CHeapObjBase {
  private:
    NONCOPYABLE(outputStream);
 

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -141,7 +141,14 @@ class Direct$Type$Buffer$RW$$BO$
         } else {
             address = base;
         }
-        cleaner = Cleaner.create(this, new Deallocator(base, size, cap));
+        try {
+            cleaner = Cleaner.create(this, new Deallocator(base, size, cap));
+        } catch (Throwable t) {
+            // Prevent leak if the Deallocator or Cleaner fail for any reason
+            UNSAFE.freeMemory(base);
+            Bits.unreserveMemory(size, cap);
+            throw t;
+        }
         att = null;
 #else[rw]
         super(cap);

--- a/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -528,6 +528,10 @@ public abstract class DatagramChannel
      *
      * @throws  NotYetConnectedException
      *          If this channel's socket is not connected
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract int read(ByteBuffer dst) throws IOException;
 
@@ -543,6 +547,10 @@ public abstract class DatagramChannel
      *
      * @throws  NotYetConnectedException
      *          If this channel's socket is not connected
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract long read(ByteBuffer[] dsts, int offset, int length)
         throws IOException;
@@ -559,6 +567,10 @@ public abstract class DatagramChannel
      *
      * @throws  NotYetConnectedException
      *          If this channel's socket is not connected
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public final long read(ByteBuffer[] dsts) throws IOException {
         return read(dsts, 0, dsts.length);
@@ -574,6 +586,10 @@ public abstract class DatagramChannel
      *
      * @throws  NotYetConnectedException
      *          If this channel's socket is not connected
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract int write(ByteBuffer src) throws IOException;
 
@@ -593,6 +609,10 @@ public abstract class DatagramChannel
      *
      * @throws  NotYetConnectedException
      *          If this channel's socket is not connected
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract long write(ByteBuffer[] srcs, int offset, int length)
         throws IOException;
@@ -613,6 +633,10 @@ public abstract class DatagramChannel
      *
      * @throws  NotYetConnectedException
      *          If this channel's socket is not connected
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public final long write(ByteBuffer[] srcs) throws IOException {
         return write(srcs, 0, srcs.length);

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -372,6 +372,10 @@ public abstract class FileChannel
      * then the file position is updated with the number of bytes actually
      * read.  Otherwise this method behaves exactly as specified in the {@link
      * ReadableByteChannel} interface. </p>
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract int read(ByteBuffer dst) throws IOException;
 
@@ -383,6 +387,10 @@ public abstract class FileChannel
      * then the file position is updated with the number of bytes actually
      * read.  Otherwise this method behaves exactly as specified in the {@link
      * ScatteringByteChannel} interface.  </p>
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract long read(ByteBuffer[] dsts, int offset, int length)
         throws IOException;
@@ -394,6 +402,10 @@ public abstract class FileChannel
      * then the file position is updated with the number of bytes actually
      * read.  Otherwise this method behaves exactly as specified in the {@link
      * ScatteringByteChannel} interface.  </p>
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public final long read(ByteBuffer[] dsts) throws IOException {
         return read(dsts, 0, dsts.length);
@@ -412,6 +424,10 @@ public abstract class FileChannel
      *
      * @throws  NonWritableChannelException
      *          If this channel was not opened for writing
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract int write(ByteBuffer src) throws IOException;
 
@@ -429,6 +445,10 @@ public abstract class FileChannel
      *
      * @throws  NonWritableChannelException
      *          If this channel was not opened for writing
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract long write(ByteBuffer[] srcs, int offset, int length)
         throws IOException;
@@ -446,6 +466,10 @@ public abstract class FileChannel
      *
      * @throws  NonWritableChannelException
      *          If this channel was not opened for writing
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public final long write(ByteBuffer[] srcs) throws IOException {
         return write(srcs, 0, srcs.length);

--- a/src/java.base/share/classes/java/nio/channels/SeekableByteChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/SeekableByteChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,10 @@ public interface SeekableByteChannel
      * then the position is updated with the number of bytes actually read.
      * Otherwise this method behaves exactly as specified in the {@link
      * ReadableByteChannel} interface.
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     @Override
     int read(ByteBuffer dst) throws IOException;
@@ -75,6 +79,10 @@ public interface SeekableByteChannel
      * written bytes, and then the position is updated with the number of bytes
      * actually written. Otherwise this method behaves exactly as specified by
      * the {@link WritableByteChannel} interface.
+     *
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     @Override
     int write(ByteBuffer src) throws IOException;

--- a/src/java.base/share/classes/java/nio/channels/SocketChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/SocketChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -603,12 +603,18 @@ public abstract class SocketChannel
     /**
      * @throws  NotYetConnectedException
      *          If this channel is not yet connected
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract int read(ByteBuffer dst) throws IOException;
 
     /**
      * @throws  NotYetConnectedException
      *          If this channel is not yet connected
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract long read(ByteBuffer[] dsts, int offset, int length)
         throws IOException;
@@ -616,6 +622,9 @@ public abstract class SocketChannel
     /**
      * @throws  NotYetConnectedException
      *          If this channel is not yet connected
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public final long read(ByteBuffer[] dsts) throws IOException {
         return read(dsts, 0, dsts.length);
@@ -624,12 +633,18 @@ public abstract class SocketChannel
     /**
      * @throws  NotYetConnectedException
      *          If this channel is not yet connected
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract int write(ByteBuffer src) throws IOException;
 
     /**
      * @throws  NotYetConnectedException
      *          If this channel is not yet connected
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public abstract long write(ByteBuffer[] srcs, int offset, int length)
         throws IOException;
@@ -637,6 +652,9 @@ public abstract class SocketChannel
     /**
      * @throws  NotYetConnectedException
      *          If this channel is not yet connected
+     * @throws  ClosedChannelException      {@inheritDoc}
+     * @throws  AsynchronousCloseException  {@inheritDoc}
+     * @throws  ClosedByInterruptException  {@inheritDoc}
      */
     public final long write(ByteBuffer[] srcs) throws IOException {
         return write(srcs, 0, srcs.length);

--- a/src/java.base/share/classes/java/nio/channels/spi/AbstractSelectableChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/spi/AbstractSelectableChannel.java
@@ -310,6 +310,8 @@ public abstract class AbstractSelectableChannel
      * mode then this method invokes the {@link #implConfigureBlocking
      * implConfigureBlocking} method, while holding the appropriate locks, in
      * order to change the mode.  </p>
+     *
+     * @throws  ClosedChannelException {@inheritDoc}
      */
     public final SelectableChannel configureBlocking(boolean block)
         throws IOException

--- a/src/java.base/share/classes/java/text/DigitList.java
+++ b/src/java.base/share/classes/java/text/DigitList.java
@@ -153,8 +153,8 @@ final class DigitList implements Cloneable {
 
     /**
      * Utility routine to get the value of the digit list
-     * If (count == 0) this throws a NumberFormatException, which
-     * mimics Long.parseLong().
+     * If (count == 0) this returns 0.0,
+     * unlike Double.parseDouble("") which throws NumberFormatException.
      */
     public final double getDouble() {
         if (count == 0) {
@@ -171,7 +171,8 @@ final class DigitList implements Cloneable {
 
     /**
      * Utility routine to get the value of the digit list.
-     * If (count == 0) this returns 0, unlike Long.parseLong().
+     * If (count == 0) this returns 0,
+     * unlike Long.parseLong("") which throws NumberFormatException.
      */
     public final long getLong() {
         // for now, simple implementation; later, do proper IEEE native stuff
@@ -195,6 +196,11 @@ final class DigitList implements Cloneable {
         return Long.parseLong(temp.toString());
     }
 
+    /**
+     * Utility routine to get the value of the digit list.
+     * If (count == 0) this does not throw a NumberFormatException,
+     * unlike BigDecimal("").
+     */
     public final BigDecimal getBigDecimal() {
         if (count == 0) {
             if (decimalAt == 0) {

--- a/src/java.base/share/classes/sun/net/www/ParseUtil.java
+++ b/src/java.base/share/classes/sun/net/www/ParseUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -197,11 +197,14 @@ public final class ParseUtil {
             bb.clear();
             int ui = i;
             for (;;) {
-                assert (n - i >= 2);
+                if (n - i < 2) {
+                    throw new IllegalArgumentException("Malformed escape pair: " + s);
+                }
+
                 try {
                     bb.put(unescape(s, i));
-                } catch (NumberFormatException e) {
-                    throw new IllegalArgumentException();
+                } catch (NumberFormatException | IndexOutOfBoundsException e) {
+                    throw new IllegalArgumentException("Malformed escape pair: " + s);
                 }
                 i += 3;
                 if (i >= n)

--- a/src/java.base/share/classes/sun/net/www/protocol/ftp/Handler.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/ftp/Handler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
 package sun.net.www.protocol.ftp;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.Proxy;
 import java.util.Map;
@@ -58,6 +59,14 @@ public class Handler extends java.net.URLStreamHandler {
 
     protected java.net.URLConnection openConnection(URL u, Proxy p)
         throws IOException {
-        return new FtpURLConnection(u, p);
+        FtpURLConnection connection = null;
+        try {
+            connection = new FtpURLConnection(u, p);
+        } catch (IllegalArgumentException e) {
+            var mfue = new MalformedURLException(e.getMessage());
+            mfue.initCause(e);
+            throw mfue;
+        }
+        return connection;
     }
 }

--- a/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
@@ -1670,17 +1670,6 @@ enum SSLCipher {
             }
 
             @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
-            }
-
-            @Override
             int estimateFragmentSize(int packetSize, int headerSize) {
                 return packetSize - headerSize - recordIvSize - tagSize;
             }
@@ -1791,17 +1780,6 @@ enum SSLCipher {
                 }
 
                 return len + nonce.length;
-            }
-
-            @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
             }
 
             @Override
@@ -1967,17 +1945,6 @@ enum SSLCipher {
             }
 
             @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
-            }
-
-            @Override
             int estimateFragmentSize(int packetSize, int headerSize) {
                 return packetSize - headerSize - tagSize;
             }
@@ -2094,17 +2061,6 @@ enum SSLCipher {
                     keyLimitCountdown -= len;
                 }
                 return len;
-            }
-
-            @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
             }
 
             @Override
@@ -2236,17 +2192,6 @@ enum SSLCipher {
             }
 
             @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
-            }
-
-            @Override
             int estimateFragmentSize(int packetSize, int headerSize) {
                 return packetSize - headerSize - tagSize;
             }
@@ -2362,17 +2307,6 @@ enum SSLCipher {
                 }
 
                 return len;
-            }
-
-            @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
             }
 
             @Override
@@ -2527,17 +2461,6 @@ enum SSLCipher {
             }
 
             @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
-            }
-
-            @Override
             int estimateFragmentSize(int packetSize, int headerSize) {
                 return packetSize - headerSize - tagSize;
             }
@@ -2655,17 +2578,6 @@ enum SSLCipher {
                     keyLimitCountdown -= len;
                 }
                 return len;
-            }
-
-            @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
             }
 
             @Override

--- a/src/java.base/share/classes/sun/security/util/DerOutputStream.java
+++ b/src/java.base/share/classes/sun/security/util/DerOutputStream.java
@@ -26,8 +26,8 @@
 package sun.security.util;
 
 import java.io.ByteArrayOutputStream;
-import java.io.OutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
@@ -79,10 +79,11 @@ extends ByteArrayOutputStream implements DerEncoder {
      *          <em>DerValue.tag_Sequence</em>
      * @param buf buffered data, which must be DER-encoded
      */
-    public void write(byte tag, byte[] buf) throws IOException {
+    public DerOutputStream write(byte tag, byte[] buf) throws IOException {
         write(tag);
         putLength(buf.length);
         write(buf, 0, buf.length);
+        return this;
     }
 
     /**
@@ -94,10 +95,11 @@ extends ByteArrayOutputStream implements DerEncoder {
      *          <em>DerValue.tag_Sequence</em>
      * @param out buffered data
      */
-    public void write(byte tag, DerOutputStream out) throws IOException {
+    public DerOutputStream write(byte tag, DerOutputStream out) throws IOException {
         write(tag);
         putLength(out.count);
         write(out.buf, 0, out.count);
+        return this;
     }
 
     /**
@@ -117,17 +119,19 @@ extends ByteArrayOutputStream implements DerEncoder {
      * explicit tagging the form is always constructed.
      * @param value original value being implicitly tagged
      */
-    public void writeImplicit(byte tag, DerOutputStream value)
+    public DerOutputStream writeImplicit(byte tag, DerOutputStream value)
     throws IOException {
         write(tag);
         write(value.buf, 1, value.count-1);
+        return this;
     }
 
     /**
      * Marshals pre-encoded DER value onto the output stream.
      */
-    public void putDerValue(DerValue val) throws IOException {
+    public DerOutputStream putDerValue(DerValue val) throws IOException {
         val.encode(this);
+        return this;
     }
 
     /*
@@ -141,7 +145,7 @@ extends ByteArrayOutputStream implements DerEncoder {
     /**
      * Marshals a DER boolean on the output stream.
      */
-    public void putBoolean(boolean val) throws IOException {
+    public DerOutputStream putBoolean(boolean val) throws IOException {
         write(DerValue.tag_Boolean);
         putLength(1);
         if (val) {
@@ -149,15 +153,17 @@ extends ByteArrayOutputStream implements DerEncoder {
         } else {
             write(0);
         }
+        return this;
     }
 
     /**
      * Marshals a DER enumerated on the output stream.
      * @param i the enumerated value.
      */
-    public void putEnumerated(int i) throws IOException {
+    public DerOutputStream putEnumerated(int i) throws IOException {
         write(DerValue.tag_Enumerated);
         putIntegerContents(i);
+        return this;
     }
 
     /**
@@ -165,11 +171,12 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * @param i the integer in the form of a BigInteger.
      */
-    public void putInteger(BigInteger i) throws IOException {
+    public DerOutputStream putInteger(BigInteger i) throws IOException {
         write(DerValue.tag_Integer);
         byte[]    buf = i.toByteArray(); // least number  of bytes
         putLength(buf.length);
         write(buf, 0, buf.length);
+        return this;
     }
 
     /**
@@ -177,27 +184,29 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * @param buf the integer in bytes, equivalent to BigInteger::toByteArray.
      */
-    public void putInteger(byte[] buf) throws IOException {
+    public DerOutputStream putInteger(byte[] buf) throws IOException {
         write(DerValue.tag_Integer);
         putLength(buf.length);
         write(buf, 0, buf.length);
+        return this;
     }
 
     /**
      * Marshals a DER integer on the output stream.
      * @param i the integer in the form of an Integer.
      */
-    public void putInteger(Integer i) throws IOException {
-        putInteger(i.intValue());
+    public DerOutputStream putInteger(Integer i) throws IOException {
+        return putInteger(i.intValue());
     }
 
     /**
      * Marshals a DER integer on the output stream.
      * @param i the integer.
      */
-    public void putInteger(int i) throws IOException {
+    public DerOutputStream putInteger(int i) throws IOException {
         write(DerValue.tag_Integer);
         putIntegerContents(i);
+        return this;
     }
 
     private void putIntegerContents(int i) throws IOException {
@@ -250,11 +259,12 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * @param bits the bit string, MSB first
      */
-    public void putBitString(byte[] bits) throws IOException {
+    public DerOutputStream putBitString(byte[] bits) throws IOException {
         write(DerValue.tag_BitString);
         putLength(bits.length + 1);
         write(0);               // all of last octet is used
         write(bits);
+        return this;
     }
 
     /**
@@ -263,13 +273,14 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * @param ba the bit string, MSB first
      */
-    public void putUnalignedBitString(BitArray ba) throws IOException {
+    public DerOutputStream putUnalignedBitString(BitArray ba) throws IOException {
         byte[] bits = ba.toByteArray();
 
         write(DerValue.tag_BitString);
         putLength(bits.length + 1);
         write(bits.length*8 - ba.length()); // excess bits in last octet
         write(bits);
+        return this;
     }
 
     /**
@@ -278,8 +289,8 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * @param ba the bit string, MSB first
      */
-    public void putTruncatedUnalignedBitString(BitArray ba) throws IOException {
-        putUnalignedBitString(ba.truncate());
+    public DerOutputStream putTruncatedUnalignedBitString(BitArray ba) throws IOException {
+        return putUnalignedBitString(ba.truncate());
     }
 
     /**
@@ -287,25 +298,27 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * @param octets the octet string
      */
-    public void putOctetString(byte[] octets) throws IOException {
-        write(DerValue.tag_OctetString, octets);
+    public DerOutputStream putOctetString(byte[] octets) throws IOException {
+        return write(DerValue.tag_OctetString, octets);
     }
 
     /**
      * Marshals a DER "null" value on the output stream.  These are
      * often used to indicate optional values which have been omitted.
      */
-    public void putNull() throws IOException {
+    public DerOutputStream putNull() throws IOException {
         write(DerValue.tag_Null);
         putLength(0);
+        return this;
     }
 
     /**
      * Marshals an object identifier (OID) on the output stream.
      * Corresponds to the ASN.1 "OBJECT IDENTIFIER" construct.
      */
-    public void putOID(ObjectIdentifier oid) throws IOException {
+    public DerOutputStream putOID(ObjectIdentifier oid) throws IOException {
         oid.encode(this);
+        return this;
     }
 
     /**
@@ -313,14 +326,14 @@ extends ByteArrayOutputStream implements DerEncoder {
      * the ASN.1 "SEQUENCE" (zero to N values) and "SEQUENCE OF"
      * (one to N values) constructs.
      */
-    public void putSequence(DerValue[] seq) throws IOException {
+    public DerOutputStream putSequence(DerValue[] seq) throws IOException {
         DerOutputStream bytes = new DerOutputStream();
         int i;
 
         for (i = 0; i < seq.length; i++)
             seq[i].encode(bytes);
 
-        write(DerValue.tag_Sequence, bytes);
+        return write(DerValue.tag_Sequence, bytes);
     }
 
     /**
@@ -330,14 +343,14 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * For DER encoding, use orderedPutSet() or orderedPutSetOf().
      */
-    public void putSet(DerValue[] set) throws IOException {
+    public DerOutputStream putSet(DerValue[] set) throws IOException {
         DerOutputStream bytes = new DerOutputStream();
         int i;
 
         for (i = 0; i < set.length; i++)
             set[i].encode(bytes);
 
-        write(DerValue.tag_Set, bytes);
+        return write(DerValue.tag_Set, bytes);
     }
 
     /**
@@ -350,8 +363,8 @@ extends ByteArrayOutputStream implements DerEncoder {
      * This method supports the ASN.1 "SET OF" construct, but not
      * "SET", which uses a different order.
      */
-    public void putOrderedSetOf(byte tag, DerEncoder[] set) throws IOException {
-        putOrderedSet(tag, set, lexOrder);
+    public DerOutputStream putOrderedSetOf(byte tag, DerEncoder[] set) throws IOException {
+        return putOrderedSet(tag, set, lexOrder);
     }
 
     /**
@@ -364,8 +377,8 @@ extends ByteArrayOutputStream implements DerEncoder {
      * This method supports the ASN.1 "SET" construct, but not
      * "SET OF", which uses a different order.
      */
-    public void putOrderedSet(byte tag, DerEncoder[] set) throws IOException {
-        putOrderedSet(tag, set, tagOrder);
+    public DerOutputStream putOrderedSet(byte tag, DerEncoder[] set) throws IOException {
+        return putOrderedSet(tag, set, tagOrder);
     }
 
     /**
@@ -386,7 +399,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * @param order the order to use when sorting encodings of components.
      */
-    private void putOrderedSet(byte tag, DerEncoder[] set,
+    private DerOutputStream putOrderedSet(byte tag, DerEncoder[] set,
                                Comparator<byte[]> order) throws IOException {
         DerOutputStream[] streams = new DerOutputStream[set.length];
 
@@ -406,54 +419,53 @@ extends ByteArrayOutputStream implements DerEncoder {
         for (int i = 0; i < streams.length; i++) {
             bytes.write(bufs[i]);
         }
-        write(tag, bytes);
-
+        return write(tag, bytes);
     }
 
     /**
      * Marshals a string as a DER encoded UTF8String.
      */
-    public void putUTF8String(String s) throws IOException {
-        writeString(s, DerValue.tag_UTF8String, UTF_8);
+    public DerOutputStream putUTF8String(String s) throws IOException {
+        return writeString(s, DerValue.tag_UTF8String, UTF_8);
     }
 
     /**
      * Marshals a string as a DER encoded PrintableString.
      */
-    public void putPrintableString(String s) throws IOException {
-        writeString(s, DerValue.tag_PrintableString, US_ASCII);
+    public DerOutputStream putPrintableString(String s) throws IOException {
+        return writeString(s, DerValue.tag_PrintableString, US_ASCII);
     }
 
     /**
      * Marshals a string as a DER encoded T61String.
      */
-    public void putT61String(String s) throws IOException {
+    public DerOutputStream putT61String(String s) throws IOException {
         /*
          * Works for characters that are defined in both ASCII and
          * T61.
          */
-        writeString(s, DerValue.tag_T61String, ISO_8859_1);
+        return writeString(s, DerValue.tag_T61String, ISO_8859_1);
     }
 
     /**
      * Marshals a string as a DER encoded IA5String.
      */
-    public void putIA5String(String s) throws IOException {
-        writeString(s, DerValue.tag_IA5String, US_ASCII);
+    public DerOutputStream putIA5String(String s) throws IOException {
+        return writeString(s, DerValue.tag_IA5String, US_ASCII);
     }
 
     /**
      * Marshals a string as a DER encoded BMPString.
      */
-    public void putBMPString(String s) throws IOException {
-        writeString(s, DerValue.tag_BMPString, UTF_16BE);
+    public DerOutputStream putBMPString(String s) throws IOException {
+        return writeString(s, DerValue.tag_BMPString, UTF_16BE);
     }
 
     /**
      * Marshals a string as a DER encoded GeneralString.
      */
-    public void putGeneralString(String s) throws IOException {
-        writeString(s, DerValue.tag_GeneralString, US_ASCII);
+    public DerOutputStream putGeneralString(String s) throws IOException {
+        return writeString(s, DerValue.tag_GeneralString, US_ASCII);
     }
 
     /**
@@ -464,13 +476,14 @@ extends ByteArrayOutputStream implements DerEncoder {
      * @param charset the charset that should be used corresponding to
      * the above tag.
      */
-    private void writeString(String s, byte stringTag, Charset charset)
+    private DerOutputStream writeString(String s, byte stringTag, Charset charset)
         throws IOException {
 
         byte[] data = s.getBytes(charset);
         write(stringTag);
         putLength(data.length);
         write(data);
+        return this;
     }
 
     /**
@@ -479,8 +492,8 @@ extends ByteArrayOutputStream implements DerEncoder {
      * <P>YYMMDDhhmmss{Z|+hhmm|-hhmm} ... emits only using Zulu time
      * and with seconds (even if seconds=0) as per RFC 5280.
      */
-    public void putUTCTime(Date d) throws IOException {
-        putTime(d, DerValue.tag_UtcTime);
+    public DerOutputStream putUTCTime(Date d) throws IOException {
+        return putTime(d, DerValue.tag_UtcTime);
     }
 
     /**
@@ -489,8 +502,8 @@ extends ByteArrayOutputStream implements DerEncoder {
      * <P>YYYYMMDDhhmmss{Z|+hhmm|-hhmm} ... emits only using Zulu time
      * and with seconds (even if seconds=0) as per RFC 5280.
      */
-    public void putGeneralizedTime(Date d) throws IOException {
-        putTime(d, DerValue.tag_GeneralizedTime);
+    public DerOutputStream putGeneralizedTime(Date d) throws IOException {
+        return putTime(d, DerValue.tag_GeneralizedTime);
     }
 
     /**
@@ -500,7 +513,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      * @param d the date to be marshalled
      * @param tag the tag for UTC Time or Generalized Time
      */
-    private void putTime(Date d, byte tag) throws IOException {
+    private DerOutputStream putTime(Date d, byte tag) throws IOException {
 
         /*
          * Format the date.
@@ -527,6 +540,7 @@ extends ByteArrayOutputStream implements DerEncoder {
         write(tag);
         putLength(time.length);
         write(time);
+        return this;
     }
 
     /**
@@ -564,23 +578,6 @@ extends ByteArrayOutputStream implements DerEncoder {
     }
 
     /**
-     * Put the tag of the attribute in the stream.
-     *
-     * @param tagClass the tag class type, one of UNIVERSAL, CONTEXT,
-     *        APPLICATION or PRIVATE
-     * @param form if true, the value is constructed, otherwise it is
-     * primitive.
-     * @param val the tag value
-     */
-    public void putTag(byte tagClass, boolean form, byte val) {
-        byte tag = (byte)(tagClass | val);
-        if (form) {
-            tag |= (byte)0x20;
-        }
-        write(tag);
-    }
-
-    /**
      *  Write the current contents of this <code>DerOutputStream</code>
      *  to an <code>OutputStream</code>.
      *
@@ -588,6 +585,16 @@ extends ByteArrayOutputStream implements DerEncoder {
      */
     public void derEncode(OutputStream out) throws IOException {
         out.write(toByteArray());
+    }
+
+    /**
+     * Write a DerEncoder onto the output stream.
+     * @param encoder the DerEncoder
+     * @throws IOException on output error
+     */
+    public DerOutputStream write(DerEncoder encoder) throws IOException {
+        encoder.derEncode(this);
+        return this;
     }
 
     byte[] buf() {

--- a/src/java.desktop/share/classes/com/sun/beans/introspect/ClassInfo.java
+++ b/src/java.desktop/share/classes/com/sun/beans/introspect/ClassInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,44 +65,53 @@ public final class ClassInfo {
 
     private final Object mutex = new Object();
     private final Class<?> type;
-    private List<Method> methods;
-    private Map<String,PropertyInfo> properties;
-    private Map<String,EventSetInfo> eventSets;
+    private volatile List<Method> methods;
+    private volatile Map<String,PropertyInfo> properties;
+    private volatile Map<String,EventSetInfo> eventSets;
 
     private ClassInfo(Class<?> type) {
         this.type = type;
     }
 
     public List<Method> getMethods() {
-        if (this.methods == null) {
+        List<Method> methods = this.methods;
+        if (methods == null) {
             synchronized (this.mutex) {
-                if (this.methods == null) {
-                    this.methods = MethodInfo.get(this.type);
+                methods = this.methods;
+                if (methods == null) {
+                    methods = MethodInfo.get(this.type);
+                    this.methods = methods;
                 }
             }
         }
-        return this.methods;
+        return methods;
     }
 
     public Map<String,PropertyInfo> getProperties() {
-        if (this.properties == null) {
+        Map<String, PropertyInfo> properties = this.properties;
+        if (properties == null) {
             synchronized (this.mutex) {
-                if (this.properties == null) {
-                    this.properties = PropertyInfo.get(this.type);
+                properties = this.properties;
+                if (properties == null) {
+                    properties = PropertyInfo.get(this.type);
+                    this.properties = properties;
                 }
             }
         }
-        return this.properties;
+        return properties;
     }
 
     public Map<String,EventSetInfo> getEventSets() {
-        if (this.eventSets == null) {
+        Map<String, EventSetInfo> eventSets = this.eventSets;
+        if (eventSets == null) {
             synchronized (this.mutex) {
-                if (this.eventSets == null) {
-                    this.eventSets = EventSetInfo.get(this.type);
+                eventSets = this.eventSets;
+                if (eventSets == null) {
+                    eventSets = EventSetInfo.get(this.type);
+                    this.eventSets = eventSets;
                 }
             }
         }
-        return this.eventSets;
+        return eventSets;
     }
 }

--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKFileChooserUI.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKFileChooserUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -979,6 +979,26 @@ class GTKFileChooserUI extends SynthFileChooserUI {
             } else {
                 v.sort(Comparator.comparing(fsv::getSystemDisplayName));
             }
+        }
+
+        @Override
+        public Vector<File> getDirectories() {
+            Vector<File> files = super.getDirectories();
+
+            /*
+             * Delete the "/.." file entry from file chooser directory list in
+             * GTK LAF if current directory is root and files vector contains
+             * "/.." entry.
+             *
+             * It is not possible to go beyond root directory.
+             */
+            File crntDir = getFileChooser().getCurrentDirectory();
+            FileSystemView fsv = getFileChooser().getFileSystemView();
+            if (crntDir != null && fsv.isFileSystemRoot(crntDir) &&
+                files.contains(new File("/.."))) {
+                    files.removeElementAt(0);
+            }
+            return files;
         }
     }
 

--- a/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
@@ -71,10 +71,10 @@ import sun.java2d.cmm.PCMM;
  * color space (e.g. {@code TYPE_RGB}, {@code TYPE_CMYK}, etc.), but the
  * specific color values of the output data will be undefined.
  * <p>
- * The details of this class are not important for simple applets, which draw in
- * a default color space or manipulate and display imported images with a known
- * color space. At most, such applets would need to get one of the default color
- * spaces via {@link ColorSpace#getInstance}.
+ * The details of this class are not important for simple applications, which
+ * draw in a default color space or manipulate and display imported images with
+ * a known color space. At most, such applications would need to get one of the
+ * default color spaces via {@link ColorSpace#getInstance}.
  *
  * @see ColorSpace
  * @see ICC_Profile

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1073,8 +1073,8 @@ public sealed class ICC_Profile implements Serializable
      * Returns a particular tagged data element from the profile as a byte
      * array. Elements are identified by signatures as defined in the ICC
      * specification. The signature icSigHead can be used to get the header.
-     * This method is useful for advanced applets or applications which need to
-     * access profile data directly.
+     * This method is useful for advanced applications which need to access
+     * profile data directly.
      *
      * @param  tagSignature the ICC tag signature for the data element you want
      *         to get
@@ -1099,8 +1099,8 @@ public sealed class ICC_Profile implements Serializable
      * Sets a particular tagged data element in the profile from a byte array.
      * The array should contain data in a format, corresponded to the
      * {@code tagSignature} as defined in the ICC specification, section 10.
-     * This method is useful for advanced applets or applications which need to
-     * access profile data directly.
+     * This method is useful for advanced applications which need to access
+     * profile data directly.
      *
      * @param  tagSignature the ICC tag signature for the data element you want
      *         to set

--- a/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStreamImpl.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStreamImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -200,6 +200,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         buf.setLength(len);
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public boolean readBoolean() throws IOException {
         int ch = this.read();
         if (ch < 0) {
@@ -208,6 +211,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         return (ch != 0);
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public byte readByte() throws IOException {
         int ch = this.read();
         if (ch < 0) {
@@ -216,6 +222,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         return (byte)ch;
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public int readUnsignedByte() throws IOException {
         int ch = this.read();
         if (ch < 0) {
@@ -224,6 +233,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         return ch;
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public short readShort() throws IOException {
         if (read(byteBuf, 0, 2) != 2) {
             throw new EOFException();
@@ -238,14 +250,23 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         }
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public int readUnsignedShort() throws IOException {
         return ((int)readShort()) & 0xffff;
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public char readChar() throws IOException {
         return (char)readShort();
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public int readInt() throws IOException {
         if (read(byteBuf, 0, 4) !=  4) {
             throw new EOFException();
@@ -262,10 +283,16 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         }
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public long readUnsignedInt() throws IOException {
         return ((long)readInt()) & 0xffffffffL;
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public long readLong() throws IOException {
         // REMIND: Once 6277756 is fixed, we should do a bulk read of all 8
         // bytes here as we do in readShort() and readInt() for even better
@@ -280,10 +307,16 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         }
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public float readFloat() throws IOException {
         return Float.intBitsToFloat(readInt());
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public double readDouble() throws IOException {
         return Double.longBitsToDouble(readLong());
     }
@@ -318,6 +351,10 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         return input.toString();
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     * @throws java.io.UTFDataFormatException {@inheritDoc}
+     */
     public String readUTF() throws IOException {
         this.bitOffset = 0;
 
@@ -340,6 +377,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         return ret;
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public void readFully(byte[] b, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > b.length || off + len < 0) {
@@ -357,10 +397,16 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         }
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public void readFully(byte[] b) throws IOException {
         readFully(b, 0, b.length);
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public void readFully(short[] s, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > s.length || off + len < 0) {
@@ -377,6 +423,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         }
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public void readFully(char[] c, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > c.length || off + len < 0) {
@@ -393,6 +442,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         }
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public void readFully(int[] i, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > i.length || off + len < 0) {
@@ -409,6 +461,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         }
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public void readFully(long[] l, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > l.length || off + len < 0) {
@@ -425,6 +480,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         }
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public void readFully(float[] f, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > f.length || off + len < 0) {
@@ -441,6 +499,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         }
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public void readFully(double[] d, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > d.length || off + len < 0) {
@@ -641,6 +702,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         this.bitOffset = bitOffset;
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public int readBit() throws IOException {
         checkClosed();
 
@@ -663,6 +727,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         return val & 0x1;
     }
 
+    /**
+     * @throws EOFException {@inheritDoc}
+     */
     public long readBits(int numBits) throws IOException {
         checkClosed();
 

--- a/src/java.desktop/share/classes/javax/imageio/stream/ImageOutputStreamImpl.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/ImageOutputStreamImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -156,6 +156,9 @@ public abstract class ImageOutputStreamImpl
         write(b, 0, len*2);
     }
 
+    /**
+     * @throws UTFDataFormatException {@inheritDoc}
+     */
     public void writeUTF(String s) throws IOException {
         int strlen = s.length();
         int utflen = 0;

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalFileChooserUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalFileChooserUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1266,9 +1266,7 @@ public class MetalFileChooserUI extends BasicFileChooserUI {
         public void actionPerformed(ActionEvent e) {
             directoryComboBox.hidePopup();
             File f = (File)directoryComboBox.getSelectedItem();
-            if (!getFileChooser().getCurrentDirectory().equals(f)) {
-                getFileChooser().setCurrentDirectory(f);
-            }
+            getFileChooser().setCurrentDirectory(f);
         }
     }
 

--- a/src/java.naming/share/classes/javax/naming/InitialContext.java
+++ b/src/java.naming/share/classes/javax/naming/InitialContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -413,34 +413,60 @@ public class InitialContext implements Context {
         return getURLOrDefaultInitCtx(name).lookup(name);
     }
 
+    /**
+     * @throws  NameAlreadyBoundException {@inheritDoc}
+     * @throws  javax.naming.directory.InvalidAttributesException {@inheritDoc}
+     */
     public void bind(String name, Object obj) throws NamingException {
         getURLOrDefaultInitCtx(name).bind(name, obj);
     }
 
+    /**
+     * @throws  NameAlreadyBoundException {@inheritDoc}
+     * @throws  javax.naming.directory.InvalidAttributesException {@inheritDoc}
+     */
     public void bind(Name name, Object obj) throws NamingException {
         getURLOrDefaultInitCtx(name).bind(name, obj);
     }
 
+    /**
+     * @throws  javax.naming.directory.InvalidAttributesException {@inheritDoc}
+     */
     public void rebind(String name, Object obj) throws NamingException {
         getURLOrDefaultInitCtx(name).rebind(name, obj);
     }
 
+    /**
+     * @throws  javax.naming.directory.InvalidAttributesException {@inheritDoc}
+     */
     public void rebind(Name name, Object obj) throws NamingException {
         getURLOrDefaultInitCtx(name).rebind(name, obj);
     }
 
+    /**
+     * @throws  NameNotFoundException {@inheritDoc}
+     */
     public void unbind(String name) throws NamingException  {
         getURLOrDefaultInitCtx(name).unbind(name);
     }
 
+    /**
+     * @throws  NameNotFoundException {@inheritDoc}
+     */
     public void unbind(Name name) throws NamingException  {
         getURLOrDefaultInitCtx(name).unbind(name);
     }
 
+    /**
+     * @throws  NameAlreadyBoundException {@inheritDoc}
+     */
     public void rename(String oldName, String newName) throws NamingException {
         getURLOrDefaultInitCtx(oldName).rename(oldName, newName);
     }
 
+    /**
+     * @throws  NameAlreadyBoundException {@inheritDoc}
+     */
     public void rename(Name oldName, Name newName)
         throws NamingException
     {
@@ -469,18 +495,36 @@ public class InitialContext implements Context {
         return getURLOrDefaultInitCtx(name).listBindings(name);
     }
 
+    /**
+     * @throws  NameNotFoundException {@inheritDoc}
+     * @throws  NotContextException {@inheritDoc}
+     * @throws  ContextNotEmptyException {@inheritDoc}
+     */
     public void destroySubcontext(String name) throws NamingException  {
         getURLOrDefaultInitCtx(name).destroySubcontext(name);
     }
 
+    /**
+     * @throws  NameNotFoundException {@inheritDoc}
+     * @throws  NotContextException {@inheritDoc}
+     * @throws  ContextNotEmptyException {@inheritDoc}
+     */
     public void destroySubcontext(Name name) throws NamingException  {
         getURLOrDefaultInitCtx(name).destroySubcontext(name);
     }
 
+    /**
+     * @throws  NameAlreadyBoundException {@inheritDoc}
+     * @throws  javax.naming.directory.InvalidAttributesException {@inheritDoc}
+     */
     public Context createSubcontext(String name) throws NamingException  {
         return getURLOrDefaultInitCtx(name).createSubcontext(name);
     }
 
+    /**
+     * @throws  NameAlreadyBoundException {@inheritDoc}
+     * @throws  javax.naming.directory.InvalidAttributesException {@inheritDoc}
+     */
     public Context createSubcontext(Name name) throws NamingException  {
         return getURLOrDefaultInitCtx(name).createSubcontext(name);
     }
@@ -551,6 +595,9 @@ public class InitialContext implements Context {
         gotDefault = false;
     }
 
+    /**
+     * @throws OperationNotSupportedException {@inheritDoc}
+     */
     public String getNameInNamespace() throws NamingException {
         return getDefaultInitCtx().getNameInNamespace();
     }

--- a/src/java.naming/share/classes/javax/naming/directory/BasicAttribute.java
+++ b/src/java.naming/share/classes/javax/naming/directory/BasicAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -474,6 +474,8 @@ public class BasicAttribute implements Attribute {
       *<p>
       * This method by default throws OperationNotSupportedException. A subclass
       * should override this method if it supports schema.
+      *
+      * @throws OperationNotSupportedException {@inheritDoc}
       */
     public DirContext getAttributeSyntaxDefinition() throws NamingException {
             throw new OperationNotSupportedException("attribute syntax");
@@ -484,6 +486,8 @@ public class BasicAttribute implements Attribute {
       *<p>
       * This method by default throws OperationNotSupportedException. A subclass
       * should override this method if it supports schema.
+      *
+      * @throws OperationNotSupportedException {@inheritDoc}
       */
     public DirContext getAttributeDefinition() throws NamingException {
         throw new OperationNotSupportedException("attribute definition");

--- a/src/java.naming/share/classes/javax/naming/directory/InitialDirContext.java
+++ b/src/java.naming/share/classes/javax/naming/directory/InitialDirContext.java
@@ -181,69 +181,115 @@ public class InitialDirContext extends InitialContext implements DirContext {
         return getURLOrDefaultInitDirCtx(name).getAttributes(name, attrIds);
     }
 
+    /**
+     * @throws  AttributeModificationException {@inheritDoc}
+     */
     public void modifyAttributes(String name, int mod_op, Attributes attrs)
             throws NamingException {
         getURLOrDefaultInitDirCtx(name).modifyAttributes(name, mod_op, attrs);
     }
 
+    /**
+     * @throws  AttributeModificationException {@inheritDoc}
+     */
     public void modifyAttributes(Name name, int mod_op, Attributes attrs)
             throws NamingException  {
         getURLOrDefaultInitDirCtx(name).modifyAttributes(name, mod_op, attrs);
     }
 
+    /**
+     * @throws  AttributeModificationException {@inheritDoc}
+     */
     public void modifyAttributes(String name, ModificationItem[] mods)
             throws NamingException  {
         getURLOrDefaultInitDirCtx(name).modifyAttributes(name, mods);
     }
 
+    /**
+     * @throws  AttributeModificationException {@inheritDoc}
+     */
     public void modifyAttributes(Name name, ModificationItem[] mods)
             throws NamingException  {
         getURLOrDefaultInitDirCtx(name).modifyAttributes(name, mods);
     }
 
+    /**
+     * @throws  NameAlreadyBoundException {@inheritDoc}
+     * @throws  InvalidAttributesException {@inheritDoc}
+     */
     public void bind(String name, Object obj, Attributes attrs)
             throws NamingException  {
         getURLOrDefaultInitDirCtx(name).bind(name, obj, attrs);
     }
 
+    /**
+     * @throws  NameAlreadyBoundException {@inheritDoc}
+     * @throws  InvalidAttributesException {@inheritDoc}
+     */
     public void bind(Name name, Object obj, Attributes attrs)
             throws NamingException  {
         getURLOrDefaultInitDirCtx(name).bind(name, obj, attrs);
     }
 
+    /**
+     * @throws  InvalidAttributesException {@inheritDoc}
+     */
     public void rebind(String name, Object obj, Attributes attrs)
             throws NamingException  {
         getURLOrDefaultInitDirCtx(name).rebind(name, obj, attrs);
     }
 
+    /**
+     * @throws  InvalidAttributesException {@inheritDoc}
+     */
     public void rebind(Name name, Object obj, Attributes attrs)
             throws NamingException  {
         getURLOrDefaultInitDirCtx(name).rebind(name, obj, attrs);
     }
 
+    /**
+     * @throws  NameAlreadyBoundException {@inheritDoc}
+     * @throws  InvalidAttributesException {@inheritDoc}
+     */
     public DirContext createSubcontext(String name, Attributes attrs)
             throws NamingException  {
         return getURLOrDefaultInitDirCtx(name).createSubcontext(name, attrs);
     }
 
+    /**
+     * @throws  NameAlreadyBoundException {@inheritDoc}
+     * @throws  InvalidAttributesException {@inheritDoc}
+     */
     public DirContext createSubcontext(Name name, Attributes attrs)
             throws NamingException  {
         return getURLOrDefaultInitDirCtx(name).createSubcontext(name, attrs);
     }
 
+    /**
+     * @throws  OperationNotSupportedException {@inheritDoc}
+     */
     public DirContext getSchema(String name) throws NamingException {
         return getURLOrDefaultInitDirCtx(name).getSchema(name);
     }
 
+    /**
+     * @throws  OperationNotSupportedException {@inheritDoc}
+     */
     public DirContext getSchema(Name name) throws NamingException {
         return getURLOrDefaultInitDirCtx(name).getSchema(name);
     }
 
+    /**
+     * @throws  OperationNotSupportedException {@inheritDoc}
+     */
     public DirContext getSchemaClassDefinition(String name)
             throws NamingException {
         return getURLOrDefaultInitDirCtx(name).getSchemaClassDefinition(name);
     }
 
+    /**
+     * @throws  OperationNotSupportedException {@inheritDoc}
+     */
     public DirContext getSchemaClassDefinition(Name name)
             throws NamingException {
         return getURLOrDefaultInitDirCtx(name).getSchemaClassDefinition(name);
@@ -287,6 +333,10 @@ public class InitialDirContext extends InitialContext implements DirContext {
                                             attributesToReturn);
     }
 
+    /**
+     * @throws  InvalidSearchFilterException {@inheritDoc}
+     * @throws  InvalidSearchControlsException {@inheritDoc}
+     */
     public NamingEnumeration<SearchResult>
         search(String name,
                String filter,
@@ -296,6 +346,10 @@ public class InitialDirContext extends InitialContext implements DirContext {
         return getURLOrDefaultInitDirCtx(name).search(name, filter, cons);
     }
 
+    /**
+     * @throws  InvalidSearchFilterException {@inheritDoc}
+     * @throws  InvalidSearchControlsException {@inheritDoc}
+     */
     public NamingEnumeration<SearchResult>
         search(Name name,
                String filter,
@@ -305,6 +359,10 @@ public class InitialDirContext extends InitialContext implements DirContext {
         return getURLOrDefaultInitDirCtx(name).search(name, filter, cons);
     }
 
+    /**
+     * @throws  InvalidSearchControlsException {@inheritDoc}
+     * @throws  InvalidSearchFilterException {@inheritDoc}
+     */
     public NamingEnumeration<SearchResult>
         search(String name,
                String filterExpr,
@@ -316,6 +374,10 @@ public class InitialDirContext extends InitialContext implements DirContext {
                                                       filterArgs, cons);
     }
 
+    /**
+     * @throws  InvalidSearchControlsException {@inheritDoc}
+     * @throws  InvalidSearchFilterException {@inheritDoc}
+     */
     public NamingEnumeration<SearchResult>
         search(Name name,
                String filterExpr,

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/linux_x86/LinuxX86JavaThreadPDAccess.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/linux_x86/LinuxX86JavaThreadPDAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,7 +116,7 @@ public class LinuxX86JavaThreadPDAccess implements JavaThreadPDAccess {
   public    Address getLastSP(Address addr) {
     ThreadProxy t = getThreadProxy(addr);
     X86ThreadContext context = (X86ThreadContext) t.getContext();
-    return context.getRegisterAsAddress(X86ThreadContext.ESP);
+    return context.getRegisterAsAddress(X86ThreadContext.SP);
   }
 
   public    ThreadProxy getThreadProxy(Address addr) {

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.riscv64/src/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotJVMCIBackendFactory.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.riscv64/src/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotJVMCIBackendFactory.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.vm.ci.hotspot.riscv64;
+
+import static java.util.Collections.emptyMap;
+import static jdk.vm.ci.common.InitTimer.timer;
+
+import java.util.EnumSet;
+import java.util.Map;
+
+import jdk.vm.ci.riscv64.RISCV64;
+import jdk.vm.ci.riscv64.RISCV64.CPUFeature;
+import jdk.vm.ci.code.Architecture;
+import jdk.vm.ci.code.RegisterConfig;
+import jdk.vm.ci.code.TargetDescription;
+import jdk.vm.ci.code.stack.StackIntrospection;
+import jdk.vm.ci.common.InitTimer;
+import jdk.vm.ci.hotspot.HotSpotCodeCacheProvider;
+import jdk.vm.ci.hotspot.HotSpotConstantReflectionProvider;
+import jdk.vm.ci.hotspot.HotSpotJVMCIBackendFactory;
+import jdk.vm.ci.hotspot.HotSpotJVMCIRuntime;
+import jdk.vm.ci.hotspot.HotSpotMetaAccessProvider;
+import jdk.vm.ci.hotspot.HotSpotStackIntrospection;
+import jdk.vm.ci.meta.ConstantReflectionProvider;
+import jdk.vm.ci.runtime.JVMCIBackend;
+
+public class RISCV64HotSpotJVMCIBackendFactory implements HotSpotJVMCIBackendFactory {
+
+    private static EnumSet<RISCV64.CPUFeature> computeFeatures(RISCV64HotSpotVMConfig config) {
+        // Configure the feature set using the HotSpot flag settings.
+        Map<String, Long> constants = config.getStore().getConstants();
+        return HotSpotJVMCIBackendFactory.convertFeatures(CPUFeature.class, constants, config.vmVersionFeatures, emptyMap());
+    }
+
+    private static EnumSet<RISCV64.Flag> computeFlags(RISCV64HotSpotVMConfig config) {
+        EnumSet<RISCV64.Flag> flags = EnumSet.noneOf(RISCV64.Flag.class);
+
+        if (config.useConservativeFence) {
+            flags.add(RISCV64.Flag.UseConservativeFence);
+        }
+        if (config.avoidUnalignedAccesses) {
+            flags.add(RISCV64.Flag.AvoidUnalignedAccesses);
+        }
+        if (config.nearCpool) {
+            flags.add(RISCV64.Flag.NearCpool);
+        }
+        if (config.traceTraps) {
+            flags.add(RISCV64.Flag.TraceTraps);
+        }
+        if (config.useRVV) {
+            flags.add(RISCV64.Flag.UseRVV);
+        }
+        if (config.useRVC) {
+            flags.add(RISCV64.Flag.UseRVC);
+        }
+        if (config.useZba) {
+            flags.add(RISCV64.Flag.UseZba);
+        }
+        if (config.useZbb) {
+            flags.add(RISCV64.Flag.UseZbb);
+        }
+        if (config.useRVVForBigIntegerShiftIntrinsics) {
+            flags.add(RISCV64.Flag.UseRVVForBigIntegerShiftIntrinsics);
+        }
+
+        return flags;
+    }
+
+    private static TargetDescription createTarget(RISCV64HotSpotVMConfig config) {
+        final int stackFrameAlignment = 16;
+        final int implicitNullCheckLimit = 4096;
+        final boolean inlineObjects = true;
+        Architecture arch = new RISCV64(computeFeatures(config), computeFlags(config));
+        return new TargetDescription(arch, true, stackFrameAlignment, implicitNullCheckLimit, inlineObjects);
+    }
+
+    protected HotSpotConstantReflectionProvider createConstantReflection(HotSpotJVMCIRuntime runtime) {
+        return new HotSpotConstantReflectionProvider(runtime);
+    }
+
+    private static RegisterConfig createRegisterConfig(RISCV64HotSpotVMConfig config, TargetDescription target) {
+        return new RISCV64HotSpotRegisterConfig(target, config.useCompressedOops, config.linuxOs);
+    }
+
+    protected HotSpotCodeCacheProvider createCodeCache(HotSpotJVMCIRuntime runtime, TargetDescription target, RegisterConfig regConfig) {
+        return new HotSpotCodeCacheProvider(runtime, target, regConfig);
+    }
+
+    protected HotSpotMetaAccessProvider createMetaAccess(HotSpotJVMCIRuntime runtime) {
+        return new HotSpotMetaAccessProvider(runtime);
+    }
+
+    @Override
+    public String getArchitecture() {
+        return "riscv64";
+    }
+
+    @Override
+    public String toString() {
+        return "JVMCIBackend:" + getArchitecture();
+    }
+
+    @Override
+    @SuppressWarnings("try")
+    public JVMCIBackend createJVMCIBackend(HotSpotJVMCIRuntime runtime, JVMCIBackend host) {
+        assert host == null;
+        RISCV64HotSpotVMConfig config = new RISCV64HotSpotVMConfig(runtime.getConfigStore());
+        TargetDescription target = createTarget(config);
+
+        RegisterConfig regConfig;
+        HotSpotCodeCacheProvider codeCache;
+        ConstantReflectionProvider constantReflection;
+        HotSpotMetaAccessProvider metaAccess;
+        StackIntrospection stackIntrospection;
+        try (InitTimer t = timer("create providers")) {
+            try (InitTimer rt = timer("create MetaAccess provider")) {
+                metaAccess = createMetaAccess(runtime);
+            }
+            try (InitTimer rt = timer("create RegisterConfig")) {
+                regConfig = createRegisterConfig(config, target);
+            }
+            try (InitTimer rt = timer("create CodeCache provider")) {
+                codeCache = createCodeCache(runtime, target, regConfig);
+            }
+            try (InitTimer rt = timer("create ConstantReflection provider")) {
+                constantReflection = createConstantReflection(runtime);
+            }
+            try (InitTimer rt = timer("create StackIntrospection provider")) {
+                stackIntrospection = new HotSpotStackIntrospection(runtime);
+            }
+        }
+        try (InitTimer rt = timer("instantiate backend")) {
+            return createBackend(metaAccess, codeCache, constantReflection, stackIntrospection);
+        }
+    }
+
+    protected JVMCIBackend createBackend(HotSpotMetaAccessProvider metaAccess, HotSpotCodeCacheProvider codeCache, ConstantReflectionProvider constantReflection,
+                    StackIntrospection stackIntrospection) {
+        return new JVMCIBackend(metaAccess, codeCache, constantReflection, stackIntrospection);
+    }
+}

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.riscv64/src/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotRegisterConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.riscv64/src/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotRegisterConfig.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.vm.ci.hotspot.riscv64;
+
+import static jdk.vm.ci.riscv64.RISCV64.x0;
+import static jdk.vm.ci.riscv64.RISCV64.x1;
+import static jdk.vm.ci.riscv64.RISCV64.x2;
+import static jdk.vm.ci.riscv64.RISCV64.x3;
+import static jdk.vm.ci.riscv64.RISCV64.x4;
+import static jdk.vm.ci.riscv64.RISCV64.x5;
+import static jdk.vm.ci.riscv64.RISCV64.x6;
+import static jdk.vm.ci.riscv64.RISCV64.x7;
+import static jdk.vm.ci.riscv64.RISCV64.x8;
+import static jdk.vm.ci.riscv64.RISCV64.x10;
+import static jdk.vm.ci.riscv64.RISCV64.x11;
+import static jdk.vm.ci.riscv64.RISCV64.x12;
+import static jdk.vm.ci.riscv64.RISCV64.x13;
+import static jdk.vm.ci.riscv64.RISCV64.x14;
+import static jdk.vm.ci.riscv64.RISCV64.x15;
+import static jdk.vm.ci.riscv64.RISCV64.x16;
+import static jdk.vm.ci.riscv64.RISCV64.x17;
+import static jdk.vm.ci.riscv64.RISCV64.x23;
+import static jdk.vm.ci.riscv64.RISCV64.x27;
+import static jdk.vm.ci.riscv64.RISCV64.f10;
+import static jdk.vm.ci.riscv64.RISCV64.f11;
+import static jdk.vm.ci.riscv64.RISCV64.f12;
+import static jdk.vm.ci.riscv64.RISCV64.f13;
+import static jdk.vm.ci.riscv64.RISCV64.f14;
+import static jdk.vm.ci.riscv64.RISCV64.f15;
+import static jdk.vm.ci.riscv64.RISCV64.f16;
+import static jdk.vm.ci.riscv64.RISCV64.f17;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import jdk.vm.ci.riscv64.RISCV64;
+import jdk.vm.ci.code.Architecture;
+import jdk.vm.ci.code.CallingConvention;
+import jdk.vm.ci.code.CallingConvention.Type;
+import jdk.vm.ci.code.Register;
+import jdk.vm.ci.code.RegisterArray;
+import jdk.vm.ci.code.RegisterAttributes;
+import jdk.vm.ci.code.RegisterConfig;
+import jdk.vm.ci.code.StackSlot;
+import jdk.vm.ci.code.TargetDescription;
+import jdk.vm.ci.code.ValueKindFactory;
+import jdk.vm.ci.common.JVMCIError;
+import jdk.vm.ci.hotspot.HotSpotCallingConventionType;
+import jdk.vm.ci.meta.AllocatableValue;
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.JavaType;
+import jdk.vm.ci.meta.PlatformKind;
+import jdk.vm.ci.meta.Value;
+import jdk.vm.ci.meta.ValueKind;
+
+public class RISCV64HotSpotRegisterConfig implements RegisterConfig {
+
+    private final TargetDescription target;
+
+    private final RegisterArray allocatable;
+
+    /**
+     * The caller saved registers always include all parameter registers.
+     */
+    private final RegisterArray callerSaved;
+
+    private final boolean allAllocatableAreCallerSaved;
+
+    private final RegisterAttributes[] attributesMap;
+
+    @Override
+    public RegisterArray getAllocatableRegisters() {
+        return allocatable;
+    }
+
+    @Override
+    public RegisterArray filterAllocatableRegisters(PlatformKind kind, RegisterArray registers) {
+        ArrayList<Register> list = new ArrayList<>();
+        for (Register reg : registers) {
+            if (target.arch.canStoreValue(reg.getRegisterCategory(), kind)) {
+                list.add(reg);
+            }
+        }
+
+        return new RegisterArray(list);
+    }
+
+    @Override
+    public RegisterAttributes[] getAttributesMap() {
+        return attributesMap.clone();
+    }
+
+    private final RegisterArray javaGeneralParameterRegisters = new RegisterArray(x11, x12, x13, x14, x15, x16, x17, x10);
+    private final RegisterArray nativeGeneralParameterRegisters = new RegisterArray(x10, x11, x12, x13, x14, x15, x16, x17);
+    private final RegisterArray fpParameterRegisters = new RegisterArray(f10, f11, f12, f13, f14, f15, f16, f17);
+
+    public static final Register zero = x0;
+    public static final Register ra = x1;
+    public static final Register sp = x2;
+    public static final Register gp = x3;
+    public static final Register tp = x4;
+    public static final Register t0 = x5;
+    public static final Register t1 = x6;
+    public static final Register t2 = x7;
+    public static final Register fp = x8;
+    public static final Register threadRegister = x23;
+    public static final Register heapBaseRegister = x27;
+
+    private static final RegisterArray reservedRegisters = new RegisterArray(zero, ra, sp, gp, tp, t0, t1, t2, fp);
+
+    private static RegisterArray initAllocatable(Architecture arch, boolean reserveForHeapBase) {
+        RegisterArray allRegisters = arch.getAvailableValueRegisters();
+        Register[] registers = new Register[allRegisters.size() - reservedRegisters.size() - (reserveForHeapBase ? 1 : 0)];
+        List<Register> reservedRegistersList = reservedRegisters.asList();
+
+        int idx = 0;
+        for (Register reg : allRegisters) {
+            if (reservedRegistersList.contains(reg)) {
+                // skip reserved registers
+                continue;
+            }
+            assert !(reg.equals(zero) || reg.equals(ra) || reg.equals(sp) || reg.equals(gp) || reg.equals(tp) ||
+                     reg.equals(t0) || reg.equals(t1) || reg.equals(t2) || reg.equals(fp));
+            if (reserveForHeapBase && reg.equals(heapBaseRegister)) {
+                // skip heap base register
+                continue;
+            }
+
+            registers[idx++] = reg;
+        }
+
+        assert idx == registers.length;
+        return new RegisterArray(registers);
+    }
+
+    public RISCV64HotSpotRegisterConfig(TargetDescription target, boolean useCompressedOops, boolean linuxOs) {
+        this(target, initAllocatable(target.arch, useCompressedOops));
+        assert callerSaved.size() >= allocatable.size();
+    }
+
+    public RISCV64HotSpotRegisterConfig(TargetDescription target, RegisterArray allocatable) {
+        this.target = target;
+        this.allocatable = allocatable;
+
+        Set<Register> callerSaveSet = new HashSet<>();
+        allocatable.addTo(callerSaveSet);
+        fpParameterRegisters.addTo(callerSaveSet);
+        javaGeneralParameterRegisters.addTo(callerSaveSet);
+        nativeGeneralParameterRegisters.addTo(callerSaveSet);
+        callerSaved = new RegisterArray(callerSaveSet);
+
+        allAllocatableAreCallerSaved = true;
+        attributesMap = RegisterAttributes.createMap(this, RISCV64.allRegisters);
+    }
+
+    @Override
+    public RegisterArray getCallerSaveRegisters() {
+        return callerSaved;
+    }
+
+    @Override
+    public RegisterArray getCalleeSaveRegisters() {
+        return null;
+    }
+
+    @Override
+    public boolean areAllAllocatableRegistersCallerSaved() {
+        return allAllocatableAreCallerSaved;
+    }
+
+    @Override
+    public CallingConvention getCallingConvention(Type type, JavaType returnType, JavaType[] parameterTypes, ValueKindFactory<?> valueKindFactory) {
+        HotSpotCallingConventionType hotspotType = (HotSpotCallingConventionType) type;
+        if (type == HotSpotCallingConventionType.NativeCall) {
+            return callingConvention(nativeGeneralParameterRegisters, returnType, parameterTypes, hotspotType, valueKindFactory);
+        }
+        return callingConvention(javaGeneralParameterRegisters, returnType, parameterTypes, hotspotType, valueKindFactory);
+    }
+
+    @Override
+    public RegisterArray getCallingConventionRegisters(Type type, JavaKind kind) {
+        HotSpotCallingConventionType hotspotType = (HotSpotCallingConventionType) type;
+        switch (kind) {
+            case Boolean:
+            case Byte:
+            case Short:
+            case Char:
+            case Int:
+            case Long:
+            case Object:
+                return hotspotType == HotSpotCallingConventionType.NativeCall ? nativeGeneralParameterRegisters : javaGeneralParameterRegisters;
+            case Float:
+            case Double:
+                return fpParameterRegisters;
+            default:
+                throw JVMCIError.shouldNotReachHere();
+        }
+    }
+
+    private CallingConvention callingConvention(RegisterArray generalParameterRegisters, JavaType returnType, JavaType[] parameterTypes, HotSpotCallingConventionType type,
+                    ValueKindFactory<?> valueKindFactory) {
+        AllocatableValue[] locations = new AllocatableValue[parameterTypes.length];
+
+        int currentGeneral = 0;
+        int currentFP = 0;
+        int currentStackOffset = 0;
+
+        for (int i = 0; i < parameterTypes.length; i++) {
+            final JavaKind kind = parameterTypes[i].getJavaKind().getStackKind();
+
+            switch (kind) {
+                case Byte:
+                case Boolean:
+                case Short:
+                case Char:
+                case Int:
+                case Long:
+                case Object:
+                    if (currentGeneral < generalParameterRegisters.size()) {
+                        Register register = generalParameterRegisters.get(currentGeneral++);
+                        locations[i] = register.asValue(valueKindFactory.getValueKind(kind));
+                    }
+                    break;
+                case Float:
+                case Double:
+                    if (currentFP < fpParameterRegisters.size()) {
+                        Register register = fpParameterRegisters.get(currentFP++);
+                        locations[i] = register.asValue(valueKindFactory.getValueKind(kind));
+                    } else if (currentGeneral < generalParameterRegisters.size()) {
+                        Register register = generalParameterRegisters.get(currentGeneral++);
+                        locations[i] = register.asValue(valueKindFactory.getValueKind(kind));
+                    }
+                    break;
+                default:
+                    throw JVMCIError.shouldNotReachHere();
+            }
+
+            if (locations[i] == null) {
+                ValueKind<?> valueKind = valueKindFactory.getValueKind(kind);
+                locations[i] = StackSlot.get(valueKind, currentStackOffset, !type.out);
+                currentStackOffset += Math.max(valueKind.getPlatformKind().getSizeInBytes(), target.wordSize);
+            }
+        }
+
+        JavaKind returnKind = returnType == null ? JavaKind.Void : returnType.getJavaKind();
+        AllocatableValue returnLocation = returnKind == JavaKind.Void ? Value.ILLEGAL : getReturnRegister(returnKind).asValue(valueKindFactory.getValueKind(returnKind.getStackKind()));
+        return new CallingConvention(currentStackOffset, returnLocation, locations);
+    }
+
+    @Override
+    public Register getReturnRegister(JavaKind kind) {
+        switch (kind) {
+            case Boolean:
+            case Byte:
+            case Char:
+            case Short:
+            case Int:
+            case Long:
+            case Object:
+                return x10;
+            case Float:
+            case Double:
+                return f10;
+            case Void:
+            case Illegal:
+                return null;
+            default:
+                throw new UnsupportedOperationException("no return register for type " + kind);
+        }
+    }
+
+    @Override
+    public Register getFrameRegister() {
+        return x2;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Allocatable: " + getAllocatableRegisters() + "%n" + "CallerSave:  " + getCallerSaveRegisters() + "%n");
+    }
+}

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.riscv64/src/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.riscv64/src/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotVMConfig.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.vm.ci.hotspot.riscv64;
+
+import jdk.vm.ci.hotspot.HotSpotVMConfigAccess;
+import jdk.vm.ci.hotspot.HotSpotVMConfigStore;
+import jdk.vm.ci.services.Services;
+
+/**
+ * Used to access native configuration details.
+ *
+ * All non-static, public fields in this class are so that they can be compiled as constants.
+ */
+class RISCV64HotSpotVMConfig extends HotSpotVMConfigAccess {
+
+    RISCV64HotSpotVMConfig(HotSpotVMConfigStore config) {
+        super(config);
+    }
+
+    final boolean linuxOs = Services.getSavedProperty("os.name", "").startsWith("Linux");
+
+    final boolean useCompressedOops = getFlag("UseCompressedOops", Boolean.class);
+
+    // CPU Capabilities
+
+    /*
+     * These flags are set based on the corresponding command line flags.
+     */
+    final boolean useConservativeFence = getFlag("UseConservativeFence", Boolean.class);
+    final boolean avoidUnalignedAccesses = getFlag("AvoidUnalignedAccesses", Boolean.class);
+    final boolean nearCpool = getFlag("NearCpool", Boolean.class);
+    final boolean traceTraps = getFlag("TraceTraps", Boolean.class);
+    final boolean useRVV = getFlag("UseRVV", Boolean.class);
+    final boolean useRVC = getFlag("UseRVC", Boolean.class);
+    final boolean useZba = getFlag("UseZba", Boolean.class);
+    final boolean useZbb = getFlag("UseZbb", Boolean.class);
+    final boolean useRVVForBigIntegerShiftIntrinsics = getFlag("UseRVVForBigIntegerShiftIntrinsics", Boolean.class);
+
+    final long vmVersionFeatures = getFieldValue("Abstract_VM_Version::_features", Long.class, "uint64_t");
+
+    /*
+     * These flags are set if the corresponding support is in the hardware.
+     */
+    // Checkstyle: stop
+    // CPU feature flags are currently not available in VM_Version
+    // Checkstyle: resume
+
+}

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.riscv64/src/jdk/vm/ci/hotspot/riscv64/package-info.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.riscv64/src/jdk/vm/ci/hotspot/riscv64/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * The RISCV64 HotSpot specific portions of the JVMCI API.
+ */
+package jdk.vm.ci.hotspot.riscv64;

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.riscv64/src/jdk/vm/ci/riscv64/RISCV64.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.riscv64/src/jdk/vm/ci/riscv64/RISCV64.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.vm.ci.riscv64;
+
+import java.nio.ByteOrder;
+import java.util.EnumSet;
+
+import jdk.vm.ci.code.Architecture;
+import jdk.vm.ci.code.CPUFeatureName;
+import jdk.vm.ci.code.Register;
+import jdk.vm.ci.code.Register.RegisterCategory;
+import jdk.vm.ci.code.RegisterArray;
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.PlatformKind;
+
+/**
+ * Represents the RISCV64 architecture.
+ */
+public class RISCV64 extends Architecture {
+
+    public static final RegisterCategory CPU = new RegisterCategory("CPU");
+
+    // General purpose CPU registers
+    public static final Register x0 = new Register(0, 0, "x0", CPU);
+    public static final Register x1 = new Register(1, 1, "x1", CPU);
+    public static final Register x2 = new Register(2, 2, "x2", CPU);
+    public static final Register x3 = new Register(3, 3, "x3", CPU);
+    public static final Register x4 = new Register(4, 4, "x4", CPU);
+    public static final Register x5 = new Register(5, 5, "x5", CPU);
+    public static final Register x6 = new Register(6, 6, "x6", CPU);
+    public static final Register x7 = new Register(7, 7, "x7", CPU);
+    public static final Register x8 = new Register(8, 8, "x8", CPU);
+    public static final Register x9 = new Register(9, 9, "x9", CPU);
+    public static final Register x10 = new Register(10, 10, "x10", CPU);
+    public static final Register x11 = new Register(11, 11, "x11", CPU);
+    public static final Register x12 = new Register(12, 12, "x12", CPU);
+    public static final Register x13 = new Register(13, 13, "x13", CPU);
+    public static final Register x14 = new Register(14, 14, "x14", CPU);
+    public static final Register x15 = new Register(15, 15, "x15", CPU);
+    public static final Register x16 = new Register(16, 16, "x16", CPU);
+    public static final Register x17 = new Register(17, 17, "x17", CPU);
+    public static final Register x18 = new Register(18, 18, "x18", CPU);
+    public static final Register x19 = new Register(19, 19, "x19", CPU);
+    public static final Register x20 = new Register(20, 20, "x20", CPU);
+    public static final Register x21 = new Register(21, 21, "x21", CPU);
+    public static final Register x22 = new Register(22, 22, "x22", CPU);
+    public static final Register x23 = new Register(23, 23, "x23", CPU);
+    public static final Register x24 = new Register(24, 24, "x24", CPU);
+    public static final Register x25 = new Register(25, 25, "x25", CPU);
+    public static final Register x26 = new Register(26, 26, "x26", CPU);
+    public static final Register x27 = new Register(27, 27, "x27", CPU);
+    public static final Register x28 = new Register(28, 28, "x28", CPU);
+    public static final Register x29 = new Register(29, 29, "x29", CPU);
+    public static final Register x30 = new Register(30, 30, "x30", CPU);
+    public static final Register x31 = new Register(31, 31, "x31", CPU);
+
+    // @formatter:off
+    public static final RegisterArray cpuRegisters = new RegisterArray(
+        x0,  x1,  x2,  x3,  x4,  x5,  x6,  x7,
+        x8,  x9,  x10, x11, x12, x13, x14, x15,
+        x16, x17, x18, x19, x20, x21, x22, x23,
+        x24, x25, x26, x27, x28, x29, x30, x31
+    );
+    // @formatter:on
+
+    public static final RegisterCategory FP = new RegisterCategory("FP");
+
+    // Simd registers
+    public static final Register f0 = new Register(32, 0, "f0", FP);
+    public static final Register f1 = new Register(33, 1, "f1", FP);
+    public static final Register f2 = new Register(34, 2, "f2", FP);
+    public static final Register f3 = new Register(35, 3, "f3", FP);
+    public static final Register f4 = new Register(36, 4, "f4", FP);
+    public static final Register f5 = new Register(37, 5, "f5", FP);
+    public static final Register f6 = new Register(38, 6, "f6", FP);
+    public static final Register f7 = new Register(39, 7, "f7", FP);
+    public static final Register f8 = new Register(40, 8, "f8", FP);
+    public static final Register f9 = new Register(41, 9, "f9", FP);
+    public static final Register f10 = new Register(42, 10, "f10", FP);
+    public static final Register f11 = new Register(43, 11, "f11", FP);
+    public static final Register f12 = new Register(44, 12, "f12", FP);
+    public static final Register f13 = new Register(45, 13, "f13", FP);
+    public static final Register f14 = new Register(46, 14, "f14", FP);
+    public static final Register f15 = new Register(47, 15, "f15", FP);
+    public static final Register f16 = new Register(48, 16, "f16", FP);
+    public static final Register f17 = new Register(49, 17, "f17", FP);
+    public static final Register f18 = new Register(50, 18, "f18", FP);
+    public static final Register f19 = new Register(51, 19, "f19", FP);
+    public static final Register f20 = new Register(52, 20, "f20", FP);
+    public static final Register f21 = new Register(53, 21, "f21", FP);
+    public static final Register f22 = new Register(54, 22, "f22", FP);
+    public static final Register f23 = new Register(55, 23, "f23", FP);
+    public static final Register f24 = new Register(56, 24, "f24", FP);
+    public static final Register f25 = new Register(57, 25, "f25", FP);
+    public static final Register f26 = new Register(58, 26, "f26", FP);
+    public static final Register f27 = new Register(59, 27, "f27", FP);
+    public static final Register f28 = new Register(60, 28, "f28", FP);
+    public static final Register f29 = new Register(61, 29, "f29", FP);
+    public static final Register f30 = new Register(62, 30, "f30", FP);
+    public static final Register f31 = new Register(63, 31, "f31", FP);
+
+    // @formatter:off
+    public static final RegisterArray fpRegisters = new RegisterArray(
+        f0,  f1,  f2,  f3,  f4,  f5,  f6,  f7,
+        f8,  f9,  f10, f11, f12, f13, f14, f15,
+        f16, f17, f18, f19, f20, f21, f22, f23,
+        f24, f25, f26, f27, f28, f29, f30, f31
+    );
+    // @formatter:on
+
+    // @formatter:off
+    public static final RegisterArray allRegisters = new RegisterArray(
+        x0,  x1,  x2,  x3,  x4,  x5,  x6,  x7,
+        x8,  x9,  x10, x11, x12, x13, x14, x15,
+        x16, x17, x18, x19, x20, x21, x22, x23,
+        x24, x25, x26, x27, x28, x29, x30, x31,
+
+        f0,  f1,  f2,  f3,  f4,  f5,  f6,  f7,
+        f8,  f9,  f10, f11, f12, f13, f14, f15,
+        f16, f17, f18, f19, f20, f21, f22, f23,
+        f24, f25, f26, f27, f28, f29, f30, f31
+    );
+    // @formatter:on
+
+    /**
+     * Basic set of CPU features mirroring what is returned from the mcpuid register. See:
+     * {@code VM_Version::cpuFeatureFlags}.
+     */
+    public enum CPUFeature implements CPUFeatureName {
+        I,
+        M,
+        A,
+        F,
+        D,
+        C,
+        V
+    }
+
+    private final EnumSet<CPUFeature> features;
+
+    /**
+     * Set of flags to control code emission.
+     */
+    public enum Flag {
+        UseConservativeFence,
+        AvoidUnalignedAccesses,
+        NearCpool,
+        TraceTraps,
+        UseRVV,
+        UseRVC,
+        UseZba,
+        UseZbb,
+        UseRVVForBigIntegerShiftIntrinsics
+    }
+
+    private final EnumSet<Flag> flags;
+
+    public RISCV64(EnumSet<CPUFeature> features, EnumSet<Flag> flags) {
+        super("riscv64", RISCV64Kind.QWORD, ByteOrder.LITTLE_ENDIAN, true, allRegisters, 0, 0, 8);
+        this.features = features;
+        this.flags = flags;
+    }
+
+    @Override
+    public EnumSet<CPUFeature> getFeatures() {
+        return features;
+    }
+
+    public EnumSet<Flag> getFlags() {
+        return flags;
+    }
+
+    @Override
+    public PlatformKind getPlatformKind(JavaKind javaKind) {
+        switch (javaKind) {
+            case Boolean:
+            case Byte:
+                return RISCV64Kind.BYTE;
+            case Short:
+            case Char:
+                return RISCV64Kind.WORD;
+            case Int:
+                return RISCV64Kind.DWORD;
+            case Long:
+            case Object:
+                return RISCV64Kind.QWORD;
+            case Float:
+                return RISCV64Kind.SINGLE;
+            case Double:
+                return RISCV64Kind.DOUBLE;
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public boolean canStoreValue(RegisterCategory category, PlatformKind platformKind) {
+        RISCV64Kind kind = (RISCV64Kind) platformKind;
+        if (kind.isInteger()) {
+            return category.equals(CPU);
+        } else if (kind.isFP()) {
+            return category.equals(FP);
+        }
+        return false;
+    }
+
+    @Override
+    public RISCV64Kind getLargestStorableKind(RegisterCategory category) {
+        if (category.equals(CPU)) {
+            return RISCV64Kind.QWORD;
+        } else if (category.equals(FP)) {
+            return RISCV64Kind.DOUBLE;
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.riscv64/src/jdk/vm/ci/riscv64/RISCV64Kind.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.riscv64/src/jdk/vm/ci/riscv64/RISCV64Kind.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.vm.ci.riscv64;
+
+import jdk.vm.ci.meta.PlatformKind;
+
+public enum RISCV64Kind implements PlatformKind {
+
+    // scalar
+    BYTE(1),
+    WORD(2),
+    DWORD(4),
+    QWORD(8),
+    SINGLE(4),
+    DOUBLE(8);
+
+    private final int size;
+    private final int vectorLength;
+
+    private final RISCV64Kind scalar;
+    private final EnumKey<RISCV64Kind> key = new EnumKey<>(this);
+
+    RISCV64Kind(int size) {
+        this.size = size;
+        this.scalar = this;
+        this.vectorLength = 1;
+    }
+
+    RISCV64Kind(int size, RISCV64Kind scalar) {
+        this.size = size;
+        this.scalar = scalar;
+
+        assert size % scalar.size == 0;
+        this.vectorLength = size / scalar.size;
+    }
+
+    public RISCV64Kind getScalar() {
+        return scalar;
+    }
+
+    @Override
+    public int getSizeInBytes() {
+        return size;
+    }
+
+    @Override
+    public int getVectorLength() {
+        return vectorLength;
+    }
+
+    @Override
+    public Key getKey() {
+        return key;
+    }
+
+    public boolean isInteger() {
+        switch (this) {
+            case BYTE:
+            case WORD:
+            case DWORD:
+            case QWORD:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public boolean isFP() {
+        switch (this) {
+            case SINGLE:
+            case DOUBLE:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    public char getTypeChar() {
+        switch (this) {
+            case BYTE:
+                return 'b';
+            case WORD:
+                return 'w';
+            case DWORD:
+                return 'd';
+            case QWORD:
+                return 'q';
+            case SINGLE:
+                return 'S';
+            case DOUBLE:
+                return 'D';
+            default:
+                return '-';
+        }
+    }
+
+}

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.riscv64/src/jdk/vm/ci/riscv64/package-info.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.riscv64/src/jdk/vm/ci/riscv64/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * The RISCV64 platform independent portions of the JVMCI API.
+ */
+package jdk.vm.ci.riscv64;

--- a/src/jdk.internal.vm.ci/share/classes/module-info.java
+++ b/src/jdk.internal.vm.ci/share/classes/module-info.java
@@ -39,5 +39,6 @@ module jdk.internal.vm.ci {
 
     provides jdk.vm.ci.hotspot.HotSpotJVMCIBackendFactory with
         jdk.vm.ci.hotspot.aarch64.AArch64HotSpotJVMCIBackendFactory,
-        jdk.vm.ci.hotspot.amd64.AMD64HotSpotJVMCIBackendFactory;
+        jdk.vm.ci.hotspot.amd64.AMD64HotSpotJVMCIBackendFactory,
+        jdk.vm.ci.hotspot.riscv64.RISCV64HotSpotJVMCIBackendFactory;
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventControl.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventControl.java
@@ -44,7 +44,6 @@ import jdk.jfr.SettingDefinition;
 import jdk.jfr.StackTrace;
 import jdk.jfr.Threshold;
 import jdk.jfr.events.ActiveSettingEvent;
-import jdk.jfr.internal.EventInstrumentation.SettingInfo;
 import jdk.jfr.internal.settings.CutoffSetting;
 import jdk.jfr.internal.settings.EnabledSetting;
 import jdk.jfr.internal.settings.PeriodSetting;
@@ -66,7 +65,7 @@ public final class EventControl {
     private static final Type TYPE_CUTOFF = TypeLibrary.createType(CutoffSetting.class);
     private static final Type TYPE_THROTTLE = TypeLibrary.createType(ThrottleSetting.class);
 
-    private final ArrayList<SettingInfo> settingInfos = new ArrayList<>();
+    private final ArrayList<SettingControl> settingControls = new ArrayList<>();
     private final ArrayList<NamedControl> namedControls = new ArrayList<>(5);
     private final PlatformEventType type;
     private final String idName;
@@ -163,7 +162,6 @@ public final class EventControl {
         try {
             Module settingModule = settingsClass.getModule();
             Modules.addReads(settingModule, EventControl.class.getModule());
-            int index = settingInfos.size();
             SettingControl settingControl = instantiateSettingControl(settingsClass);
             Control c = new Control(settingControl, null);
             c.setDefault();
@@ -180,7 +178,7 @@ public final class EventControl {
                 aes.trimToSize();
                 addControl(settingName, c);
                 eventType.add(PrivateAccess.getInstance().newSettingDescriptor(settingType, settingName, defaultValue, aes));
-                settingInfos.add(new SettingInfo(FIELD_SETTING_PREFIX + index, index, null, null, settingControl));
+                settingControls.add(settingControl);
             }
         } catch (InstantiationException e) {
             // Programming error by user, fail fast
@@ -308,7 +306,14 @@ public final class EventControl {
         return idName;
     }
 
-    public List<SettingInfo> getSettingInfos() {
-        return settingInfos;
+    /**
+     * A malicious user must never be able to run a callback in the wrong
+     * context. Methods on SettingControl must therefore never be invoked directly
+     * by JFR, instead use jdk.jfr.internal.Control.
+     *
+     * The returned list is only to be used inside EventConfiguration
+     */
+    public List<SettingControl> getSettingControls() {
+        return settingControls;
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventInstrumentation.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventInstrumentation.java
@@ -60,18 +60,10 @@ import jdk.jfr.internal.event.EventWriter;
  */
 public final class EventInstrumentation {
 
-    record SettingInfo(String fieldName, int index, Type paramType, String methodName, SettingControl settingControl) {
-        /**
-         * A malicious user must never be able to run a callback in the wrong
-         * context. Methods on SettingControl must therefore never be invoked directly
-         * by JFR, instead use jdk.jfr.internal.Control.
-         */
-        public SettingControl settingControl() {
-            return this.settingControl;
-        }
+    record SettingInfo(Type paramType, String methodName) {
     }
 
-    record FieldInfo(String fieldName, String fieldDescriptor, String internalClassName) {
+    record FieldInfo(String name, String descriptor) {
     }
 
     public static final String FIELD_EVENT_THREAD = "eventThread";
@@ -136,8 +128,8 @@ public final class EventInstrumentation {
     public static Method findStaticCommitMethod(ClassNode classNode, List<FieldInfo> fields) {
         StringBuilder sb = new StringBuilder();
         sb.append("(");
-        for (FieldInfo v : fields) {
-            sb.append(v.fieldDescriptor);
+        for (FieldInfo field : fields) {
+            sb.append(field.descriptor);
         }
         sb.append(")V");
         Method m = new Method("commit", sb.toString());
@@ -244,10 +236,8 @@ public final class EventInstrumentation {
                             Type[] args = Type.getArgumentTypes(m.desc);
                             if (args.length == 1) {
                                 Type paramType = args[0];
-                                String fieldName = EventControl.FIELD_SETTING_PREFIX + settingInfos.size();
-                                int index = settingInfos.size();
                                 methodSet.add(m.name);
-                                settingInfos.add(new SettingInfo(fieldName, index, paramType, m.name, null));
+                                settingInfos.add(new SettingInfo(paramType, m.name));
                             }
                         }
                     }
@@ -263,10 +253,8 @@ public final class EventInstrumentation {
                             if (method.getParameterCount() == 1) {
                                 Parameter param = method.getParameters()[0];
                                 Type paramType = Type.getType(param.getType());
-                                String fieldName = EventControl.FIELD_SETTING_PREFIX + settingInfos.size();
-                                int index = settingInfos.size();
                                 methodSet.add(method.getName());
-                                settingInfos.add(new SettingInfo(fieldName, index, paramType, method.getName(), null));
+                                settingInfos.add(new SettingInfo(paramType, method.getName()));
                             }
                         }
                     }
@@ -285,11 +273,11 @@ public final class EventInstrumentation {
         // control in which order they occur and we can add @Name, @Description
         // in Java, instead of in native. It also means code for adding implicit
         // fields for native can be reused by Java.
-        fieldInfos.add(new FieldInfo("startTime", Type.LONG_TYPE.getDescriptor(), classNode.name));
-        fieldInfos.add(new FieldInfo("duration", Type.LONG_TYPE.getDescriptor(), classNode.name));
+        fieldInfos.add(new FieldInfo("startTime", Type.LONG_TYPE.getDescriptor()));
+        fieldInfos.add(new FieldInfo("duration", Type.LONG_TYPE.getDescriptor()));
         for (FieldNode field : classNode.fields) {
             if (!fieldSet.contains(field.name) && isValidField(field.access, Type.getType(field.desc).getClassName())) {
-                FieldInfo fi = new FieldInfo(field.name, field.desc, classNode.name);
+                FieldInfo fi = new FieldInfo(field.name, field.desc);
                 fieldInfos.add(fi);
                 fieldSet.add(field.name);
             }
@@ -303,7 +291,7 @@ public final class EventInstrumentation {
                         if (!fieldSet.contains(fieldName)) {
                             Type fieldType = Type.getType(field.getType());
                             String internalClassName = ASMToolkit.getInternalName(c.getName());
-                            fieldInfos.add(new FieldInfo(fieldName, fieldType.getDescriptor(), internalClassName));
+                            fieldInfos.add(new FieldInfo(fieldName, fieldType.getDescriptor()));
                             fieldSet.add(fieldName);
                         }
                     }
@@ -574,7 +562,7 @@ public final class EventInstrumentation {
                     // stack: [EW] [EW]
                     methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
                     // stack: [EW] [EW] [this]
-                    methodVisitor.visitFieldInsn(Opcodes.GETFIELD, getInternalClassName(), field.fieldName, field.fieldDescriptor);
+                    methodVisitor.visitFieldInsn(Opcodes.GETFIELD, getInternalClassName(), field.name, field.descriptor);
                     // stack: [EW] [EW] <T>
                     EventWriterMethod eventMethod = EventWriterMethod.lookupMethod(field);
                     invokeVirtual(methodVisitor, TYPE_EVENT_WRITER, eventMethod.asmMethod);
@@ -633,8 +621,8 @@ public final class EventInstrumentation {
             methodVisitor.visitFieldInsn(Opcodes.GETFIELD, getInternalClassName(), FIELD_DURATION, "J");
             invokeVirtual(methodVisitor, TYPE_EVENT_CONFIGURATION, METHOD_EVENT_CONFIGURATION_SHOULD_COMMIT);
             methodVisitor.visitJumpInsn(Opcodes.IFEQ, fail);
-            int index = 0;
-            for (SettingInfo si : settingInfos) {
+            for (int index = 0; index < settingInfos.size(); index++) {
+                SettingInfo si = settingInfos.get(index);
                 // if (!settingsMethod(eventConfiguration.settingX)) goto fail;
                 methodVisitor.visitIntInsn(Opcodes.ALOAD, 0);
                 if (untypedEventConfiguration) {
@@ -648,7 +636,6 @@ public final class EventInstrumentation {
                 methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, si.paramType().getInternalName());
                 methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, getInternalClassName(), si.methodName, "(" + si.paramType().getDescriptor() + ")Z", false);
                 methodVisitor.visitJumpInsn(Opcodes.IFEQ, fail);
-                index++;
             }
             // return true
             methodVisitor.visitInsn(Opcodes.ICONST_1);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriterMethod.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriterMethod.java
@@ -67,16 +67,16 @@ public enum EventWriterMethod {
      *
      * @return the method
      */
-    public static EventWriterMethod lookupMethod(FieldInfo v) {
+    public static EventWriterMethod lookupMethod(FieldInfo field) {
         // event thread
-        if (v.fieldName().equals(EventInstrumentation.FIELD_EVENT_THREAD)) {
+        if (field.name().equals(EventInstrumentation.FIELD_EVENT_THREAD)) {
             return EventWriterMethod.PUT_EVENT_THREAD;
         }
         for (EventWriterMethod m : EventWriterMethod.values()) {
-            if (v.fieldDescriptor().equals(m.typeDescriptor)) {
+            if (field.descriptor().equals(m.typeDescriptor)) {
                 return m;
             }
         }
-        throw new Error("Unknown type " + v.fieldDescriptor());
+        throw new Error("Unknown type " + field.descriptor());
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -188,15 +188,15 @@ public final class MetadataRepository {
         return Utils.getConfiguration(eventClass);
     }
 
-    private EventConfiguration newEventConfiguration(EventType eventType, EventControl ec, SettingControl[] settings) {
+    private EventConfiguration newEventConfiguration(EventType eventType, EventControl ec) {
         try {
             if (cachedEventConfigurationConstructor == null) {
-                var argClasses = new Class<?>[] { EventType.class, EventControl.class, SettingControl[].class };
+                var argClasses = new Class<?>[] { EventType.class, EventControl.class};
                 Constructor<EventConfiguration> c = EventConfiguration.class.getDeclaredConstructor(argClasses);
                 SecuritySupport.setAccessible(c);
                 cachedEventConfigurationConstructor = c;
             }
-            return cachedEventConfigurationConstructor.newInstance(eventType, ec, settings);
+            return cachedEventConfigurationConstructor.newInstance(eventType, ec);
         } catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
             throw new InternalError(e);
         }
@@ -209,13 +209,7 @@ public final class MetadataRepository {
         }
         EventType eventType = PrivateAccess.getInstance().newEventType(pEventType);
         EventControl ec = new EventControl(pEventType, eventClass);
-        List<SettingInfo> settingInfos = ec.getSettingInfos();
-        SettingControl[] settings = new SettingControl[settingInfos.size()];
-        int index = 0;
-        for (var settingInfo : settingInfos) {
-            settings[index++] = settingInfo.settingControl();
-        }
-        EventConfiguration configuration = newEventConfiguration(eventType, ec, settings);
+        EventConfiguration configuration = newEventConfiguration(eventType, ec);
         PlatformEventType pe = configuration.getPlatformEventType();
         pe.setRegistered(true);
         // If class is instrumented or should not be instrumented, mark as instrumented.

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/event/EventConfiguration.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/event/EventConfiguration.java
@@ -40,11 +40,11 @@ public final class EventConfiguration {
     private final SettingControl[] settings;
 
     // Private constructor so user code can't instantiate
-    private EventConfiguration(EventType eventType, EventControl eventControl, SettingControl[] settings) {
+    private EventConfiguration(EventType eventType, EventControl eventControl) {
         this.eventType = eventType;
         this.platformEventType = PrivateAccess.getInstance().getPlatformEventType(eventType);
         this.eventControl = eventControl;
-        this.settings = settings;
+        this.settings = eventControl.getSettingControls().toArray(new SettingControl[0]);
     }
 
     // Class jdk.jfr.internal.PlatformEventType is not

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/DirectExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/DirectExecutionControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,6 +103,11 @@ public class DirectExecutionControl implements ExecutionControl {
         loaderDelegate.classesRedefined(cbcs);
     }
 
+    /**
+     * @throws ExecutionControl.UserException {@inheritDoc}
+     * @throws ExecutionControl.ResolutionException {@inheritDoc}
+     * @throws ExecutionControl.StoppedException {@inheritDoc}
+     */
     @Override
     public String invoke(String className, String methodName)
             throws RunException, InternalException, EngineTerminationException {
@@ -133,6 +138,11 @@ public class DirectExecutionControl implements ExecutionControl {
         }
     }
 
+    /**
+     * @throws ExecutionControl.UserException {@inheritDoc}
+     * @throws ExecutionControl.ResolutionException {@inheritDoc}
+     * @throws ExecutionControl.StoppedException {@inheritDoc}
+     */
     @Override
     public String varValue(String className, String varName)
             throws RunException, EngineTerminationException, InternalException {
@@ -173,6 +183,13 @@ public class DirectExecutionControl implements ExecutionControl {
         throw new NotImplementedException("stop: Not supported.");
     }
 
+    /**
+     * @throws ExecutionControl.UserException {@inheritDoc}
+     * @throws ExecutionControl.ResolutionException {@inheritDoc}
+     * @throws ExecutionControl.StoppedException {@inheritDoc}
+     * @throws ExecutionControl.EngineTerminationException {@inheritDoc}
+     * @throws ExecutionControl.NotImplementedException {@inheritDoc}
+     */
     @Override
     public Object extensionCommand(String command, Object arg)
             throws RunException, EngineTerminationException, InternalException {

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/JdiDefaultExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/JdiDefaultExecutionControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,6 +148,11 @@ public class JdiDefaultExecutionControl extends JdiExecutionControl {
         deathListeners.add(s -> disposeVM());
      }
 
+    /**
+     * @throws ExecutionControl.UserException {@inheritDoc}
+     * @throws ExecutionControl.ResolutionException {@inheritDoc}
+     * @throws ExecutionControl.StoppedException {@inheritDoc}
+     */
     @Override
     public String invoke(String classname, String methodname)
             throws RunException,

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/RemoteExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/RemoteExecutionControl.java
@@ -110,12 +110,24 @@ public class RemoteExecutionControl extends DirectExecutionControl implements Ex
         // handled by JDI
     }
 
+    /**
+     * @throws ExecutionControl.UserException {@inheritDoc}
+     * @throws ExecutionControl.ResolutionException {@inheritDoc}
+     * @throws ExecutionControl.StoppedException {@inheritDoc}
+     * @throws ExecutionControl.EngineTerminationException {@inheritDoc}
+     * @throws ExecutionControl.NotImplementedException {@inheritDoc}
+     */
     // Overridden only so this stack frame is seen
     @Override
     protected String invoke(Method doitMethod) throws Exception {
         return super.invoke(doitMethod);
     }
 
+    /**
+     * @throws ExecutionControl.UserException {@inheritDoc}
+     * @throws ExecutionControl.ResolutionException {@inheritDoc}
+     * @throws ExecutionControl.StoppedException {@inheritDoc}
+     */
     // Overridden only so this stack frame is seen
     @Override
     public String varValue(String className, String varName) throws RunException, EngineTerminationException, InternalException {

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/StreamingExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/StreamingExecutionControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,6 +87,11 @@ public class StreamingExecutionControl implements ExecutionControl {
         }
     }
 
+    /**
+     * @throws ExecutionControl.UserException {@inheritDoc}
+     * @throws ExecutionControl.ResolutionException {@inheritDoc}
+     * @throws ExecutionControl.StoppedException {@inheritDoc}
+     */
     @Override
     public String invoke(String classname, String methodname)
             throws RunException, EngineTerminationException, InternalException {
@@ -105,6 +110,11 @@ public class StreamingExecutionControl implements ExecutionControl {
         }
     }
 
+    /**
+     * @throws ExecutionControl.UserException {@inheritDoc}
+     * @throws ExecutionControl.ResolutionException {@inheritDoc}
+     * @throws ExecutionControl.StoppedException {@inheritDoc}
+     */
     @Override
     public String varValue(String classname, String varname)
             throws RunException, EngineTerminationException, InternalException {
@@ -151,6 +161,13 @@ public class StreamingExecutionControl implements ExecutionControl {
         }
     }
 
+    /**
+     * @throws ExecutionControl.UserException {@inheritDoc}
+     * @throws ExecutionControl.ResolutionException {@inheritDoc}
+     * @throws ExecutionControl.StoppedException {@inheritDoc}
+     * @throws ExecutionControl.EngineTerminationException {@inheritDoc}
+     * @throws ExecutionControl.NotImplementedException {@inheritDoc}
+     */
     @Override
     public Object extensionCommand(String command, Object arg)
             throws RunException, EngineTerminationException, InternalException {

--- a/src/jdk.naming.dns/share/classes/com/sun/jndi/dns/DnsClient.java
+++ b/src/jdk.naming.dns/share/classes/com/sun/jndi/dns/DnsClient.java
@@ -730,7 +730,7 @@ class Tcp {
             return reader.read();
         }
         finally {
-            timeoutLeft -= System.currentTimeMillis() - start;
+            timeoutLeft -= (int) (System.currentTimeMillis() - start);
         }
     }
 

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/CodeInstallationTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/CodeInstallationTest.java
@@ -24,12 +24,14 @@ package jdk.vm.ci.code.test;
 
 import jdk.vm.ci.aarch64.AArch64;
 import jdk.vm.ci.amd64.AMD64;
+import jdk.vm.ci.riscv64.RISCV64;
 import jdk.vm.ci.code.Architecture;
 import jdk.vm.ci.code.CodeCacheProvider;
 import jdk.vm.ci.code.InstalledCode;
 import jdk.vm.ci.code.TargetDescription;
 import jdk.vm.ci.code.test.aarch64.AArch64TestAssembler;
 import jdk.vm.ci.code.test.amd64.AMD64TestAssembler;
+import jdk.vm.ci.code.test.riscv64.RISCV64TestAssembler;
 import jdk.vm.ci.hotspot.HotSpotCodeCacheProvider;
 import jdk.vm.ci.hotspot.HotSpotCompiledCode;
 import jdk.vm.ci.hotspot.HotSpotJVMCIRuntime;
@@ -76,6 +78,8 @@ public class CodeInstallationTest {
             return new AMD64TestAssembler(codeCache, config);
         } else if (arch instanceof AArch64) {
             return new AArch64TestAssembler(codeCache, config);
+        } else if (arch instanceof RISCV64) {
+            return new RISCV64TestAssembler(codeCache, config);
         } else {
             Assert.fail("unsupported architecture");
             return null;

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/DataPatchTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/DataPatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @requires vm.jvmci
- * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64"
+ * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64" | vm.simpleArch == "riscv64"
  * @library /
  * @modules jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.meta
@@ -33,7 +33,8 @@
  *          jdk.internal.vm.ci/jdk.vm.ci.runtime
  *          jdk.internal.vm.ci/jdk.vm.ci.aarch64
  *          jdk.internal.vm.ci/jdk.vm.ci.amd64
- * @compile CodeInstallationTest.java DebugInfoTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java
+ *          jdk.internal.vm.ci/jdk.vm.ci.riscv64
+ * @compile CodeInstallationTest.java DebugInfoTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java riscv64/RISCV64TestAssembler.java
  * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseJVMCICompiler jdk.vm.ci.code.test.DataPatchTest
  */
 

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/InterpreterFrameSizeTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/InterpreterFrameSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @requires vm.jvmci
- * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64"
+ * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64" | vm.simpleArch == "riscv64"
  * @modules jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.code
  *          jdk.internal.vm.ci/jdk.vm.ci.code.site
@@ -33,7 +33,8 @@
  *          jdk.internal.vm.ci/jdk.vm.ci.common
  *          jdk.internal.vm.ci/jdk.vm.ci.aarch64
  *          jdk.internal.vm.ci/jdk.vm.ci.amd64
- * @compile CodeInstallationTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java
+ *          jdk.internal.vm.ci/jdk.vm.ci.riscv64
+ * @compile CodeInstallationTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java riscv64/RISCV64TestAssembler.java
  * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseJVMCICompiler jdk.vm.ci.code.test.InterpreterFrameSizeTest
  */
 

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/MaxOopMapStackOffsetTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/MaxOopMapStackOffsetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @requires vm.jvmci
- * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64"
+ * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64" | vm.simpleArch == "riscv64"
  * @library /
  * @modules jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.meta
@@ -34,7 +34,8 @@
  *          jdk.internal.vm.ci/jdk.vm.ci.runtime
  *          jdk.internal.vm.ci/jdk.vm.ci.aarch64
  *          jdk.internal.vm.ci/jdk.vm.ci.amd64
- * @compile CodeInstallationTest.java DebugInfoTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java
+ *          jdk.internal.vm.ci/jdk.vm.ci.riscv64
+ * @compile CodeInstallationTest.java DebugInfoTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java riscv64/RISCV64TestAssembler.java
  * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseJVMCICompiler jdk.vm.ci.code.test.MaxOopMapStackOffsetTest
  */
 

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @requires vm.jvmci
- * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64"
+ * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64" | vm.simpleArch == "riscv64"
  * @library /test/lib /
  * @modules jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.code
@@ -34,7 +34,8 @@
  *          jdk.internal.vm.ci/jdk.vm.ci.common
  *          jdk.internal.vm.ci/jdk.vm.ci.aarch64
  *          jdk.internal.vm.ci/jdk.vm.ci.amd64
- * @compile CodeInstallationTest.java TestHotSpotVMConfig.java NativeCallTest.java TestAssembler.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java
+ *          jdk.internal.vm.ci/jdk.vm.ci.riscv64
+ * @compile CodeInstallationTest.java TestHotSpotVMConfig.java NativeCallTest.java TestAssembler.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java riscv64/RISCV64TestAssembler.java
  * @run junit/othervm/native -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI  -Xbootclasspath/a:. jdk.vm.ci.code.test.NativeCallTest
  */
 package jdk.vm.ci.code.test;

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/SimpleCodeInstallationTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/SimpleCodeInstallationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @requires vm.jvmci
- * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64"
+ * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64" | vm.simpleArch == "riscv64"
  * @library /
  * @modules jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.meta
@@ -33,7 +33,8 @@
  *          jdk.internal.vm.ci/jdk.vm.ci.runtime
  *          jdk.internal.vm.ci/jdk.vm.ci.aarch64
  *          jdk.internal.vm.ci/jdk.vm.ci.amd64
- * @compile CodeInstallationTest.java DebugInfoTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java
+ *          jdk.internal.vm.ci/jdk.vm.ci.riscv64
+ * @compile CodeInstallationTest.java DebugInfoTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java riscv64/RISCV64TestAssembler.java
  * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseJVMCICompiler jdk.vm.ci.code.test.SimpleCodeInstallationTest
  */
 

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/SimpleDebugInfoTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/SimpleDebugInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @requires vm.jvmci
- * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64"
+ * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64" | vm.simpleArch == "riscv64"
  * @library /
  * @modules jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.meta
@@ -33,7 +33,8 @@
  *          jdk.internal.vm.ci/jdk.vm.ci.runtime
  *          jdk.internal.vm.ci/jdk.vm.ci.aarch64
  *          jdk.internal.vm.ci/jdk.vm.ci.amd64
- * @compile CodeInstallationTest.java DebugInfoTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java
+ *          jdk.internal.vm.ci/jdk.vm.ci.riscv64
+ * @compile CodeInstallationTest.java DebugInfoTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java riscv64/RISCV64TestAssembler.java
  * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseJVMCICompiler jdk.vm.ci.code.test.SimpleDebugInfoTest
  */
 

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/VirtualObjectDebugInfoTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/VirtualObjectDebugInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @requires vm.jvmci
- * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64"
+ * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64" | vm.simpleArch == "riscv64"
  * @library /
  * @modules jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.meta
@@ -33,7 +33,8 @@
  *          jdk.internal.vm.ci/jdk.vm.ci.runtime
  *          jdk.internal.vm.ci/jdk.vm.ci.aarch64
  *          jdk.internal.vm.ci/jdk.vm.ci.amd64
- * @compile CodeInstallationTest.java DebugInfoTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java
+ *          jdk.internal.vm.ci/jdk.vm.ci.riscv64
+ * @compile CodeInstallationTest.java DebugInfoTest.java TestAssembler.java TestHotSpotVMConfig.java amd64/AMD64TestAssembler.java aarch64/AArch64TestAssembler.java riscv64/RISCV64TestAssembler.java
  * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseJVMCICompiler jdk.vm.ci.code.test.VirtualObjectDebugInfoTest
  */
 

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/riscv64/RISCV64TestAssembler.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/riscv64/RISCV64TestAssembler.java
@@ -1,0 +1,542 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.vm.ci.code.test.riscv64;
+
+import jdk.vm.ci.code.CallingConvention;
+import jdk.vm.ci.code.CodeCacheProvider;
+import jdk.vm.ci.code.DebugInfo;
+import jdk.vm.ci.code.Register;
+import jdk.vm.ci.code.RegisterValue;
+import jdk.vm.ci.code.StackSlot;
+import jdk.vm.ci.code.site.ConstantReference;
+import jdk.vm.ci.code.site.DataSectionReference;
+import jdk.vm.ci.code.test.TestAssembler;
+import jdk.vm.ci.code.test.TestHotSpotVMConfig;
+import jdk.vm.ci.hotspot.HotSpotCallingConventionType;
+import jdk.vm.ci.hotspot.HotSpotConstant;
+import jdk.vm.ci.hotspot.HotSpotForeignCallTarget;
+import jdk.vm.ci.meta.AllocatableValue;
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.VMConstant;
+import jdk.vm.ci.riscv64.RISCV64;
+import jdk.vm.ci.riscv64.RISCV64Kind;
+
+public class RISCV64TestAssembler extends TestAssembler {
+
+    private static final Register scratchRegister = RISCV64.x5;
+    private static final Register doubleScratch = RISCV64.f5;
+
+    public RISCV64TestAssembler(CodeCacheProvider codeCache, TestHotSpotVMConfig config) {
+        super(codeCache, config,
+              16 /* initialFrameSize */, 16 /* stackAlignment */,
+              RISCV64Kind.DWORD /* narrowOopKind */,
+              /* registers */
+              RISCV64.x10, RISCV64.x11, RISCV64.x12, RISCV64.x13,
+              RISCV64.x14, RISCV64.x15, RISCV64.x16, RISCV64.x17);
+    }
+
+    private static int f(int val, int msb, int lsb) {
+        int nbits = msb - lsb + 1;
+        assert val >= 0;
+        assert val < (1 << nbits);
+        assert msb >= lsb;
+        return val << lsb;
+    }
+
+    private static int f(Register r, int msb, int lsb) {
+        assert msb - lsb == 4;
+        return f(r.encoding, msb, lsb);
+    }
+
+    private static int instructionImmediate(int imm, int rs1, int funct, int rd, int opcode) {
+        return f(imm, 31, 20) | f(rs1, 19, 15) | f(funct, 14, 12) | f(rd, 11, 7) | f(opcode, 6, 0);
+    }
+
+    private static int instructionRegister(int funct7, int rs2, int rs1, int funct3, int rd, int opcode) {
+        return f(funct7, 31, 25) | f(rs2, 24, 20) | f(rs1, 19, 15) | f(funct3, 14, 12) | f(rd, 11, 7) | f(opcode, 6, 0);
+    }
+
+    private void emitNop() {
+        code.emitInt(instructionImmediate(0, 0, 0b000, 0, 0b0010011));
+    }
+
+    private void emitAdd(Register Rd, Register Rm, Register Rn) {
+        // ADD
+        code.emitInt(instructionRegister(0b0000000, Rn.encoding, Rm.encoding, 0b000, Rd.encoding, 0b0110011));
+    }
+
+    private void emitAdd(Register Rd, Register Rn, int imm12) {
+        // ADDI
+        code.emitInt(instructionImmediate(imm12 & 0xfff, Rn.encoding, 0b000, Rd.encoding, 0b0010011));
+    }
+
+    private void emitAddW(Register Rd, Register Rn, int imm12) {
+        // ADDIW
+        code.emitInt(instructionImmediate(imm12 & 0xfff, Rn.encoding, 0b000, Rd.encoding, 0b0011011));
+    }
+
+    private void emitSub(Register Rd, Register Rn, int imm12) {
+        // SUBI
+        emitAdd(Rd, Rn, -imm12);;
+    }
+
+    private void emitSub(Register Rd, Register Rm, Register Rn) {
+        // SUB
+        code.emitInt(instructionRegister(0b0100000, Rn.encoding, Rm.encoding, 0b000, Rd.encoding, 0b0110011));
+    }
+
+    private void emitMv(Register Rd, Register Rn) {
+        // MV
+        code.emitInt(instructionRegister(0b0000000, 0, Rn.encoding, 0b000, Rd.encoding, 0b0110011));
+    }
+
+    private void emitShiftLeft(Register Rd, Register Rn, int shift) {
+        // SLLI
+        code.emitInt(instructionImmediate(shift & 0x3f, Rn.encoding, 0b001, Rd.encoding, 0b0010011));
+    }
+
+    private void emitShiftRight(Register Rd, Register Rn, int shift) {
+        // SRLI
+        code.emitInt(instructionImmediate(shift & 0x3f, Rn.encoding, 0b101, Rd.encoding, 0b0010011));
+    }
+
+    private void emitLui(Register Rd, int imm20) {
+        // LUI
+        code.emitInt(f(imm20, 31, 12) | f(Rd, 11, 7) | f(0b0110111, 6, 0));
+    }
+
+    private void emitAuipc(Register Rd, int imm20) {
+        // AUIPC
+        code.emitInt(f(imm20, 31, 12) | f(Rd, 11, 7) | f(0b0010111, 6, 0));
+    }
+
+    private void emitLoadImmediate(Register Rd, int imm32) {
+        long upper = imm32, lower = imm32;
+        lower = (lower << 52) >> 52;
+        upper -= lower;
+        upper = (int) upper;
+        emitLui(Rd, ((int) (upper >> 12)) & 0xfffff);
+        emitAddW(Rd, Rd, (int) lower);
+    }
+
+    private void emitLoadRegister(Register Rd, RISCV64Kind kind, Register Rn, int offset) {
+        // LB/LH/LW/LD (immediate)
+        assert offset >= 0;
+        int size = 0;
+        int opc = 0;
+        switch (kind) {
+            case BYTE: size = 0b000; opc = 0b0000011; break;
+            case WORD: size = 0b001; opc = 0b0000011; break;
+            case DWORD: size = 0b010; opc = 0b0000011; break;
+            case QWORD: size = 0b011; opc = 0b0000011; break;
+            case SINGLE: size = 0b010; opc = 0b0000111; break;
+            case DOUBLE: size = 0b011; opc = 0b0000111; break;
+            default: throw new IllegalArgumentException();
+        }
+        code.emitInt(f(offset, 31, 20) | f(Rn, 19, 15) | f(size, 14, 12) | f(Rd, 11, 7) | f(opc, 6, 0));
+    }
+
+    private void emitStoreRegister(Register Rd, RISCV64Kind kind, Register Rn, int offset) {
+        // SB/SH/SW/SD (immediate)
+        assert offset >= 0;
+        int size = 0;
+        int opc = 0;
+        switch (kind) {
+            case BYTE: size = 0b000; opc = 0b0100011; break;
+            case WORD: size = 0b001; opc = 0b0100011; break;
+            case DWORD: size = 0b010; opc = 0b0100011; break;
+            case QWORD: size = 0b011; opc = 0b0100011; break;
+            case SINGLE: size = 0b010; opc = 0b0100111; break;
+            case DOUBLE: size = 0b011; opc = 0b0100111; break;
+            default: throw new IllegalArgumentException();
+        }
+        code.emitInt(f((offset >> 5), 31, 25) | f(Rd, 24, 20) | f(Rn, 19, 15) | f(size, 14, 12) | f((offset & 0x1f), 11, 7) | f(opc, 6, 0));
+    }
+
+    private void emitJalr(Register Rd, Register Rn, int imm) {
+        code.emitInt(instructionImmediate(imm & 0xfff, Rn.encoding, 0b000, Rd.encoding, 0b1100111));
+    }
+
+    private void emitFmv(Register Rd, RISCV64Kind kind, Register Rn) {
+        int funct = 0;
+        switch (kind) {
+            case SINGLE: funct = 0b1111000; break;
+            case DOUBLE: funct = 0b1111001; break;
+            default: throw new IllegalArgumentException();
+        }
+        code.emitInt(instructionRegister(funct, 0b00000, Rn.encoding, 0b000, Rd.encoding, 0b1010011));
+    }
+
+    @Override
+    public void emitGrowStack(int size) {
+        assert size % 16 == 0;
+        if (size > -2048 && size < 0) {
+            emitAdd(RISCV64.x2, RISCV64.x2, -size);
+        } else if (size == 0) {
+            // No-op
+        } else if (size < 2048) {
+            emitSub(RISCV64.x2, RISCV64.x2, size);
+        } else if (size < 65535) {
+            emitLoadImmediate(scratchRegister, size);
+            emitSub(RISCV64.x2, RISCV64.x2, scratchRegister);
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    public void emitPrologue() {
+        // Must be patchable by NativeJump::patch_verified_entry
+        emitNop();
+        emitAdd(RISCV64.x2, RISCV64.x2, -32); // addi sp sp -32
+        emitStoreRegister(RISCV64.x8, RISCV64Kind.QWORD, RISCV64.x2, 0); // sd x8 sp(0)
+        emitStoreRegister(RISCV64.x1, RISCV64Kind.QWORD, RISCV64.x2, 8); // sd x1 sp(8)
+        emitMv(RISCV64.x8, RISCV64.x2); // mv x8, x2
+
+        setDeoptRescueSlot(newStackSlot(RISCV64Kind.QWORD));
+    }
+
+    @Override
+    public void emitEpilogue() {
+        recordMark(config.MARKID_DEOPT_HANDLER_ENTRY);
+        recordCall(new HotSpotForeignCallTarget(config.handleDeoptStub), 6*4, true, null);
+        emitCall(0xdeaddeaddeadL);
+    }
+
+    @Override
+    public void emitCallPrologue(CallingConvention cc, Object... prim) {
+        emitGrowStack(cc.getStackSize());
+        frameSize += cc.getStackSize();
+        AllocatableValue[] args = cc.getArguments();
+        for (int i = 0; i < args.length; i++) {
+            emitLoad(args[i], prim[i]);
+        }
+    }
+
+    @Override
+    public void emitCallEpilogue(CallingConvention cc) {
+        emitGrowStack(-cc.getStackSize());
+        frameSize -= cc.getStackSize();
+    }
+
+    @Override
+    public void emitCall(long addr) {
+        emitMovPtrHelper(scratchRegister, addr);
+        emitJalr(RISCV64.x1, scratchRegister, (int) (addr & 0x3f));
+    }
+
+    @Override
+    public void emitLoad(AllocatableValue av, Object prim) {
+        if (av instanceof RegisterValue) {
+            Register reg = ((RegisterValue) av).getRegister();
+            if (prim instanceof Float) {
+                emitLoadFloat(reg, (Float) prim);
+            } else if (prim instanceof Double) {
+                emitLoadDouble(reg, (Double) prim);
+            } else if (prim instanceof Integer) {
+                emitLoadInt(reg, (Integer) prim);
+            } else if (prim instanceof Long) {
+                emitLoadLong(reg, (Long) prim);
+            }
+        } else if (av instanceof StackSlot) {
+            StackSlot slot = (StackSlot) av;
+            if (prim instanceof Float) {
+                emitFloatToStack(slot, emitLoadFloat(doubleScratch, (Float) prim));
+            } else if (prim instanceof Double) {
+                emitDoubleToStack(slot, emitLoadDouble(doubleScratch, (Double) prim));
+            } else if (prim instanceof Integer) {
+                emitIntToStack(slot, emitLoadInt(scratchRegister, (Integer) prim));
+            } else if (prim instanceof Long) {
+                emitLongToStack(slot, emitLoadLong(scratchRegister, (Long) prim));
+            } else {
+                assert false : "Unimplemented";
+            }
+        } else {
+            throw new IllegalArgumentException("Unknown value " + av);
+        }
+    }
+
+    private void emitLoad32(Register ret, int addr) {
+        long upper = addr, lower = addr;
+        lower = (lower << 52) >> 52;
+        upper -= lower;
+        upper = (int) upper;
+        emitLui(ret, ((int) (upper >> 12)) & 0xfffff);
+        emitAdd(ret, ret, (int) lower);
+    }
+
+    private void emitMovPtrHelper(Register ret, long addr) {
+        // 48-bit VA
+        assert (addr >> 48) == 0 : "invalid pointer" + Long.toHexString(addr);
+        emitLoad32(ret, (int) (addr >> 17));
+        emitShiftLeft(ret, ret, 11);
+        emitAdd(ret, ret, (int) ((addr >> 6) & 0x7ff));
+        emitShiftLeft(ret, ret, 6);
+    }
+
+    private void emitLoadPointer32(Register ret, int addr) {
+        emitLoadImmediate(ret, addr);
+        // Lui sign-extends the value, which we do not want
+        emitShiftLeft(ret, ret, 32);
+        emitShiftRight(ret, ret, 32);
+    }
+
+    private void emitLoadPointer48(Register ret, long addr) {
+        emitMovPtrHelper(ret, addr);
+        emitAdd(ret, ret, (int) (addr & 0x3f));
+    }
+
+    @Override
+    public Register emitLoadPointer(HotSpotConstant c) {
+        recordDataPatchInCode(new ConstantReference((VMConstant) c));
+
+        Register ret = newRegister();
+        if (c.isCompressed()) {
+            emitLoadPointer32(ret, 0xdeaddead);
+        } else {
+            emitLoadPointer48(ret, 0xdeaddeaddeadL);
+        }
+        return ret;
+    }
+
+    @Override
+    public Register emitLoadPointer(Register b, int offset) {
+        Register ret = newRegister();
+        emitLoadRegister(ret, RISCV64Kind.QWORD, b, offset & 0xfff);
+        return ret;
+    }
+
+    @Override
+    public Register emitLoadNarrowPointer(DataSectionReference ref) {
+        recordDataPatchInCode(ref);
+
+        Register ret = newRegister();
+        emitAuipc(ret, 0xdead >> 11);
+        emitLoadRegister(ret, RISCV64Kind.DWORD, ret, 0xdead & 0x7ff);
+        // The value is sign-extendsed, which we do not want
+        emitShiftLeft(ret, ret, 32);
+        emitShiftRight(ret, ret, 32);
+        return ret;
+    }
+
+    @Override
+    public Register emitLoadPointer(DataSectionReference ref) {
+        recordDataPatchInCode(ref);
+
+        Register ret = newRegister();
+        emitAuipc(ret, 0xdead >> 11);
+        emitLoadRegister(ret, RISCV64Kind.QWORD, ret, 0xdead & 0x7ff);
+        return ret;
+    }
+
+    private Register emitLoadDouble(Register reg, double c) {
+        DataSectionReference ref = new DataSectionReference();
+        ref.setOffset(data.position());
+        data.emitDouble(c);
+
+        recordDataPatchInCode(ref);
+        emitAuipc(scratchRegister, 0xdead >> 11);
+        emitLoadRegister(scratchRegister, RISCV64Kind.QWORD, scratchRegister, 0xdead & 0x7ff);
+        if (reg.getRegisterCategory().equals(RISCV64.FP)) {
+            emitFmv(reg, RISCV64Kind.DOUBLE, scratchRegister);
+        } else {
+            emitMv(reg, scratchRegister);
+        }
+        return reg;
+    }
+
+    private Register emitLoadFloat(Register reg, float c) {
+        DataSectionReference ref = new DataSectionReference();
+        ref.setOffset(data.position());
+        data.emitFloat(c);
+
+        recordDataPatchInCode(ref);
+        emitAuipc(scratchRegister, 0xdead >> 11);
+        emitLoadRegister(scratchRegister, RISCV64Kind.DWORD, scratchRegister, 0xdead & 0x7ff);
+        if (reg.getRegisterCategory().equals(RISCV64.FP)) {
+            emitFmv(reg, RISCV64Kind.SINGLE, scratchRegister);
+        } else {
+            emitMv(reg, scratchRegister);
+        }
+        return reg;
+    }
+
+    @Override
+    public Register emitLoadFloat(float c) {
+        Register ret = RISCV64.f10;
+        return emitLoadFloat(ret, c);
+    }
+
+    private Register emitLoadLong(Register reg, long c) {
+        long lower = c & 0xffffffff;
+        lower = lower - ((lower << 44) >> 44);
+        emitLoad32(reg, (int) ((c >> 32) & 0xffffffff));
+        emitShiftLeft(reg, reg, 12);
+        emitAdd(reg, reg, (int) ((lower >> 20) & 0xfff));
+        emitShiftLeft(reg, reg, 12);
+        emitAdd(reg, reg, (int) ((c << 44) >> 52));
+        emitShiftLeft(reg, reg, 8);
+        emitAdd(reg, reg, (int) (c & 0xff));
+        return reg;
+    }
+
+    @Override
+    public Register emitLoadLong(long c) {
+        Register ret = newRegister();
+        return emitLoadLong(ret, c);
+    }
+
+    private Register emitLoadInt(Register reg, int c) {
+        emitLoadImmediate(reg, c);
+        return reg;
+    }
+
+    @Override
+    public Register emitLoadInt(int c) {
+        Register ret = newRegister();
+        return emitLoadInt(ret, c);
+    }
+
+    @Override
+    public Register emitIntArg0() {
+        return codeCache.getRegisterConfig()
+            .getCallingConventionRegisters(HotSpotCallingConventionType.JavaCall, JavaKind.Int)
+            .get(0);
+    }
+
+    @Override
+    public Register emitIntArg1() {
+        return codeCache.getRegisterConfig()
+            .getCallingConventionRegisters(HotSpotCallingConventionType.JavaCall, JavaKind.Int)
+            .get(1);
+    }
+
+    @Override
+    public Register emitIntAdd(Register a, Register b) {
+        emitAdd(a, a, b);
+        return a;
+    }
+
+    @Override
+    public void emitTrap(DebugInfo info) {
+        // Dereference null pointer
+        emitAdd(scratchRegister, RISCV64.x0, 0);
+        recordImplicitException(info);
+        emitLoadRegister(RISCV64.x0, RISCV64Kind.QWORD, scratchRegister, 0);
+    }
+
+    @Override
+    public void emitIntRet(Register a) {
+        emitMv(RISCV64.x10, a);
+        emitMv(RISCV64.x2, RISCV64.x8);  // mv sp, x8
+        emitLoadRegister(RISCV64.x8, RISCV64Kind.QWORD, RISCV64.x2, 0);  // ld x8 0(sp)
+        emitLoadRegister(RISCV64.x1, RISCV64Kind.QWORD, RISCV64.x2, 8);  // ld x1 8(sp)
+        emitAdd(RISCV64.x2, RISCV64.x2, 32);  // addi sp sp 32
+        emitJalr(RISCV64.x0, RISCV64.x1, 0);  // ret
+    }
+
+    @Override
+    public void emitFloatRet(Register a) {
+        assert a == RISCV64.f10 : "Unimplemented move " + a;
+        emitMv(RISCV64.x2, RISCV64.x8);  // mv sp, x8
+        emitLoadRegister(RISCV64.x8, RISCV64Kind.QWORD, RISCV64.x2, 0);  // ld x8 0(sp)
+        emitLoadRegister(RISCV64.x1, RISCV64Kind.QWORD, RISCV64.x2, 8);  // ld x1 8(sp)
+        emitAdd(RISCV64.x2, RISCV64.x2, 32);  // addi sp sp 32
+        emitJalr(RISCV64.x0, RISCV64.x1, 0);  // ret
+    }
+
+    @Override
+    public void emitPointerRet(Register a) {
+        emitIntRet(a);
+    }
+
+    @Override
+    public StackSlot emitPointerToStack(Register a) {
+        return emitLongToStack(a);
+    }
+
+    @Override
+    public StackSlot emitNarrowPointerToStack(Register a) {
+        return emitIntToStack(a);
+    }
+
+    @Override
+    public Register emitUncompressPointer(Register compressed, long base, int shift) {
+        if (shift > 0) {
+            emitShiftLeft(compressed, compressed, shift);
+        }
+
+        if (base != 0) {
+            emitLoadLong(scratchRegister, base);
+            emitAdd(compressed, compressed, scratchRegister);
+        }
+
+        return compressed;
+    }
+
+    private StackSlot emitDoubleToStack(StackSlot slot, Register a) {
+        emitStoreRegister(a, RISCV64Kind.DOUBLE, RISCV64.x2, slot.getOffset(frameSize) & 0xfff);
+        return slot;
+    }
+
+    @Override
+    public StackSlot emitDoubleToStack(Register a) {
+        StackSlot ret = newStackSlot(RISCV64Kind.DOUBLE);
+        return emitDoubleToStack(ret, a);
+    }
+
+    private StackSlot emitFloatToStack(StackSlot slot, Register a) {
+        emitStoreRegister(a, RISCV64Kind.SINGLE, RISCV64.x2, slot.getOffset(frameSize) & 0xfff);
+        return slot;
+    }
+
+    @Override
+    public StackSlot emitFloatToStack(Register a) {
+        StackSlot ret = newStackSlot(RISCV64Kind.SINGLE);
+        return emitFloatToStack(ret, a);
+    }
+
+    private StackSlot emitIntToStack(StackSlot slot, Register a) {
+        emitStoreRegister(a, RISCV64Kind.DWORD, RISCV64.x2, slot.getOffset(frameSize) & 0xfff);
+        return slot;
+    }
+
+    @Override
+    public StackSlot emitIntToStack(Register a) {
+        StackSlot ret = newStackSlot(RISCV64Kind.DWORD);
+        return emitIntToStack(ret, a);
+    }
+
+    private StackSlot emitLongToStack(StackSlot slot, Register a) {
+        emitStoreRegister(a, RISCV64Kind.QWORD, RISCV64.x2, slot.getOffset(frameSize) & 0xfff);
+        return slot;
+    }
+
+    @Override
+    public StackSlot emitLongToStack(Register a) {
+        StackSlot ret = newStackSlot(RISCV64Kind.QWORD);
+        return emitLongToStack(ret, a);
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyLoop.java
@@ -28,7 +28,7 @@
  * @summary Unexpected test result caused by C2 IdealLoopTree::do_remove_empty_loop
  *
  * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation
- *      -XX:StressLongCountedLoop=0
+ *      -XX:+IgnoreUnrecognizedVMOptions -XX:StressLongCountedLoop=0
  *      compiler.loopopts.TestRemoveEmptyLoop
  */
 

--- a/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransforms.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransforms.java
@@ -37,8 +37,12 @@ import jdk.test.lib.Utils;
 /*
  * @test
  * @bug 8287794
- * @summary Test various reverse bytes ideal transforms on X86(AVX2, AVX512) and AARCH64(NEON)
+ * @summary Test various reverse bytes ideal transforms on X86(AVX2, AVX512) and AArch64(NEON).
+ *          For AArch64(SVE), we have a specific optimization,
+ *          ReverseBytesV (ReverseBytesV X MASK) MASK => X, which eliminates both ReverseBytesV
+ *          nodes. The test cases for AArch64(SVE) are in TestReverseByteTransformsSVE.java.
  * @requires vm.compiler2.enabled
+ * @requires !(vm.cpu.features ~= ".*sve.*")
  * @modules jdk.incubator.vector
  * @library /test/lib /
  * @run driver compiler.vectorapi.TestReverseByteTransforms

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/RelativePath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/RelativePath.java
@@ -39,7 +39,7 @@ import java.io.File;
 public class RelativePath extends DynamicArchiveTestBase {
 
     public static void main(String[] args) throws Exception {
-        runTest(AppendClasspath::testDefaultBase);
+        runTest(RelativePath::testDefaultBase);
     }
 
     static void testDefaultBase() throws Exception {
@@ -54,6 +54,16 @@ public class RelativePath extends DynamicArchiveTestBase {
         int idx = appJar.lastIndexOf(File.separator);
         String jarName = appJar.substring(idx + 1);
         String jarDir = appJar.substring(0, idx);
+
+        // Create CDS Archive
+        dump(topArchiveName, "-Xlog:cds",
+            "-Xlog:cds+dynamic=debug",
+            "-cp", appJar + File.pathSeparator + appJar2,
+            "HelloMore")
+            .assertNormalExit(output-> {
+                    output.shouldContain("Written dynamic archive 0x");
+            });
+
         // relative path starting with "."
         runWithRelativePath(null, topArchiveName, jarDir,
             "-Xlog:class+load",

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/RedefineRetransform.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/RedefineRetransform.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ *
+ * @bug 7124710
+ *
+ * @requires vm.jvmti
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ * @library /test/lib
+ *
+ * @comment main/othervm/native -Xlog:redefine*=trace -agentlib:RedefineRetransform RedefineRetransform
+ * @run main/othervm/native -agentlib:RedefineRetransform RedefineRetransform 1
+ * @run main/othervm/native -agentlib:RedefineRetransform RedefineRetransform 2
+ * @run main/othervm/native -agentlib:RedefineRetransform RedefineRetransform 3
+ * @run main/othervm/native -agentlib:RedefineRetransform RedefineRetransform 4
+ * @run main/othervm/native -agentlib:RedefineRetransform RedefineRetransform 5
+ * @run main/othervm/native -agentlib:RedefineRetransform RedefineRetransform 6
+ */
+
+import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import jdk.internal.org.objectweb.asm.AnnotationVisitor;
+import jdk.internal.org.objectweb.asm.ClassReader;
+import jdk.internal.org.objectweb.asm.ClassVisitor;
+import jdk.internal.org.objectweb.asm.ClassWriter;
+import jdk.internal.org.objectweb.asm.Opcodes;
+import jdk.internal.org.objectweb.asm.Type;
+
+/*
+ * The test verifies that after interleaved RedefineClasses/RetransformClasses calls
+ * JVMTI passes correct class bytes to ClassFileLoadHook (as per JVMTI spec).
+ * To distinguish class version the test instruments test class overriding runtime-visible annotation.
+ */
+public class RedefineRetransform {
+    static {
+        System.loadLibrary("RedefineRetransform");
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface ClassVersion {
+        int value();
+    }
+
+    // Use runtime-visible annotation to specify class version.
+    @ClassVersion(0)
+    static class TestClass {
+        public TestClass() { }
+    }
+
+    // Redefines testClass with classBytes, instruments with classLoadHookBytes (if != null).
+    // Returns class bytes passed to ClassFileLoadHook or null on error.
+    private static native byte[] nRedefine(Class testClass, byte[] classBytes, byte[] classLoadHookBytes);
+    // Retransforms testClass, instruments with classBytes (if != null).
+    // Returns class bytes passed to ClassFileLoadHook or null on error.
+    private static native byte[] nRetransform(Class testClass, byte[] classBytes);
+
+    // Class bytes for initial TestClass (ClassVersion == 0).
+    private static byte[] initialClassBytes;
+
+    private static class VersionScanner extends ClassVisitor {
+        private Integer detectedVersion;
+        private Integer versionToSet;
+        // to get version
+        public VersionScanner() {
+            super(Opcodes.ASM7);
+        }
+        // to set version
+        public VersionScanner(int verToSet, ClassVisitor classVisitor) {
+            super(Opcodes.ASM7, classVisitor);
+            versionToSet = verToSet;
+        }
+
+        public int detectedVersion() {
+            if (detectedVersion == null) {
+                throw new RuntimeException("Version not detected");
+            }
+            return detectedVersion;
+        }
+
+        @Override
+        public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+            //log("visitAnnotation: descr = '" + descriptor + "', visible = " + visible);
+            if (Type.getDescriptor(ClassVersion.class).equals(descriptor)) {
+                return new AnnotationVisitor(Opcodes.ASM7, super.visitAnnotation(descriptor, visible)) {
+                    @Override
+                    public void visit(String name, Object value) {
+                        //log("visit: name = '" + name + "', value = " + value
+                        //        + " (" + (value == null ? "N/A" : value.getClass()) + ")");
+                        if ("value".equals(name) && value instanceof Integer intValue) {
+                            detectedVersion = intValue;
+                            if (versionToSet != null) {
+                                //log("replace with " + versionToSet);
+                                value = versionToSet;
+                            }
+                        }
+                        super.visit(name, value);
+                    }
+                };
+            }
+            return super.visitAnnotation(descriptor, visible);
+        }
+    }
+
+    // Generates TestClass class bytes with the specified ClassVersion value.
+    private static byte[] getClassBytes(int ver) {
+        if (ver < 0) {
+            return null;
+        }
+        ClassWriter cw = new ClassWriter(0);
+        ClassReader cr = new ClassReader(initialClassBytes);
+        cr.accept(new VersionScanner(ver, cw), 0);
+        return cw.toByteArray();
+    }
+
+    // Extracts ClassVersion values from the provided class bytes.
+    private static int getClassBytesVersion(byte[] classBytes) {
+        ClassReader cr = new ClassReader(classBytes);
+        VersionScanner scanner = new VersionScanner();
+        cr.accept(scanner, 0);
+        return scanner.detectedVersion();
+    }
+
+    static void init() {
+        try {
+            initialClassBytes = TestClass.class.getClassLoader()
+                    .getResourceAsStream("RedefineRetransform$TestClass.class")
+                    .readAllBytes();
+            log("Read TestClass bytes: " + initialClassBytes.length);
+        } catch (IOException ex) {
+            throw new RuntimeException("Failed to read class bytes", ex);
+        }
+    }
+
+    // Redefines TestClass to the version specified.
+    static void redefine(int ver) {
+        redefine(ver, -1);
+    }
+
+    // Redefines TestClass to the version specified
+    // instrumenting (from ClassFileLoadHook) with 'classLoadHookVer' class bytes (if >= 0).
+    // Also verifies that class bytes passed to ClassFileLoadHook have correct version (ver).
+    static void redefine(int ver, int classLoadHookVer) {
+        byte[] classBytes = getClassBytes(ver);
+        byte[] classLoadHookBytes = getClassBytes(classLoadHookVer);
+
+        byte[] hookClassBytes = nRedefine(TestClass.class, classBytes, classLoadHookBytes);
+        if (hookClassBytes == null) {
+            throw new RuntimeException("Redefine error (ver = " + ver + ")");
+        }
+        // verify ClassFileLoadHook gets the expected class bytes
+        int hookVer = getClassBytesVersion(hookClassBytes);
+        if (hookVer != ver) {
+            throw new RuntimeException("CLFH got unexpected version: "  + hookVer
+                    + " (expected " + ver + ")");
+        }
+    }
+
+    // Retransforms TestClass instrumenting (from ClassFileLoadHook) with 'ver' class bytes (if >= 0).
+    // Verifies that class bytes passed to ClassFileLoadHook have correct version (expectedVer).
+    static void retransform(int ver, int expectedVer) {
+        byte[] classBytes = getClassBytes(ver);
+        byte[] hookClassBytes = nRetransform(TestClass.class, classBytes);
+        int hookVer = getClassBytesVersion(hookClassBytes);
+        if (hookVer != expectedVer) {
+            throw new RuntimeException("CLFH got unexpected version: "  + hookVer
+                    + " (expected " + expectedVer + ")");
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        int testCase;
+        try {
+            testCase = Integer.valueOf(args[0]);
+        } catch (Exception ex) {
+            throw new RuntimeException("Single numeric argument expected", ex);
+        }
+        init();
+        switch (testCase) {
+        case 1:
+            test("Redefine-Retransform-Retransform", () -> {
+                redefine(1);        // cached class bytes are not set
+                retransform(2, 1);  // sets cached class bytes to ver 1
+                retransform(3, 1);  // uses existing cache
+            });
+            break;
+
+        case 2:
+            test("Redefine-Retransform-Redefine-Redefine", () -> {
+                redefine(1);        // cached class bytes are not set
+                retransform(2, 1);  // sets cached class bytes to ver 1
+                redefine(3);        // resets cached class bytes to nullptr
+                redefine(4);        // cached class bytes are not set
+            });
+            break;
+
+        case 3:
+            test("Redefine-Retransform-Redefine-Retransform", () -> {
+                redefine(1);        // cached class bytes are not set
+                retransform(2, 1);  // sets cached class bytes to ver 1
+                redefine(3);        // resets cached class bytes to nullptr
+                retransform(4, 3);  // sets cached class bytes to ver 3
+            });
+            break;
+
+        case 4:
+            test("Retransform-Redefine-Retransform-Retransform", () -> {
+                retransform(1, 0);  // sets cached class bytes to ver 0 (initially loaded)
+                redefine(2);        // resets cached class bytes to nullptr
+                retransform(3, 2);  // sets cached class bytes to ver 2
+                retransform(4, 2);  // uses existing cache
+            });
+            break;
+
+        case 5:
+            test("Redefine-Retransform-Redefine-Retransform with CFLH", () -> {
+                redefine(1, 5);     // CFLH sets cached class bytes to ver 1
+                retransform(2, 1);  // uses existing cache
+                redefine(3, 6);     // resets cached class bytes to nullptr,
+                                    // CFLH sets cached class bytes to ver 3
+                retransform(4, 3);  // uses existing cache
+            });
+            break;
+
+        case 6:
+            test("Retransform-Redefine-Retransform-Retransform with CFLH", () -> {
+                retransform(1, 0);  // sets cached class bytes to ver 0 (initially loaded)
+                redefine(2, 5);     // resets cached class bytes to nullptr,
+                                    // CFLH sets cached class bytes to ver 2
+                retransform(3, 2);  // uses existing cache
+                retransform(4, 2);  // uses existing cache
+            });
+            break;
+        }
+    }
+
+    private static void log(Object msg) {
+        System.out.println(msg);
+    }
+
+    private interface Test {
+        void test();
+    }
+
+    private static void test(String name, Test theTest) {
+        log(">>Test: " + name);
+        theTest.test();
+        log("<<Test: " + name + " - OK");
+        log("");
+    }
+}

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/libRedefineRetransform.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/libRedefineRetransform.cpp
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <jni.h>
+#include <jvmti.h>
+#include <stdio.h>
+#include <string.h>
+
+// set by Agent_OnLoad
+static jvmtiEnv* jvmti = nullptr;
+
+static const char testClassName[] = "RedefineRetransform$TestClass";
+
+static void _log(const char* format, ...) {
+    va_list args;
+    va_start(args, format);
+    vprintf(format, args);
+    va_end(args);
+    fflush(0);
+}
+
+static bool isTestClass(const char* name) {
+    return name != nullptr && strcmp(name, testClassName) == 0;
+}
+
+/*
+ * Helper class for data exchange between RedefineClasses/RetransformClasses and
+ * ClassFileLoadHook callback (saves class bytes to be passed to CFLH,
+ * allows setting new class bytes to return from CFLH).
+ * Callers create an instance on the stack, ClassFileLoadHook handler uses getInstance().
+ */
+class ClassFileLoadHookHelper {
+    const char* mode;   // for logging only
+    bool eventEnabled;
+    JNIEnv* env;
+    jbyteArray classBytes = nullptr;
+
+    unsigned char* savedClassBytes = nullptr;
+    jint savedClassBytesLen = 0;
+
+    // single instance
+    static ClassFileLoadHookHelper *instance;
+public:
+    ClassFileLoadHookHelper(const char* mode, JNIEnv* jni_env, jbyteArray hookClassBytes)
+        : mode(mode), eventEnabled(false), env(jni_env), classBytes(nullptr),
+        savedClassBytes(nullptr), savedClassBytesLen(0)
+    {
+        _log(">>%s\n", mode);
+        if (hookClassBytes != nullptr) {
+            classBytes = (jbyteArray)env->NewGlobalRef(hookClassBytes);
+        }
+    }
+
+    ~ClassFileLoadHookHelper() {
+        // cleanup on error
+        stop();
+        if (classBytes != nullptr) {
+            env->DeleteGlobalRef(classBytes);
+        }
+        if (savedClassBytes != nullptr) {
+            jvmti->Deallocate(savedClassBytes);
+        }
+        _log("<<%s\n", mode);
+    }
+
+    bool start() {
+        instance = this;
+        jvmtiError err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, nullptr);
+        if (err != JVMTI_ERROR_NONE) {
+            _log("%s: SetEventNotificationMode(JVMTI_ENABLE) error %d\n", mode, err);
+            eventEnabled = true;
+            return false;
+        }
+        return true;
+    }
+
+    void stop() {
+        instance = nullptr;
+        if (eventEnabled) {
+            jvmtiError err = jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, nullptr);
+            if (err != JVMTI_ERROR_NONE) {
+                _log("%s: SetEventNotificationMode(JVMTI_DISABLE) error %d\n", mode, err);
+                return;
+            }
+            eventEnabled = false;
+        }
+    }
+
+    // valid only between start() and stop()
+    static ClassFileLoadHookHelper* getInstance() {
+        return instance;
+    }
+
+    bool getHookClassBytes(unsigned char** newClassBytes, jint* newLen) {
+        if (classBytes != nullptr) {
+            jsize len = env->GetArrayLength(classBytes);
+            unsigned char* buf = nullptr;
+            jvmtiError err = jvmti->Allocate(len, &buf);
+            if (err != JVMTI_ERROR_NONE) {
+                _log("ClassFileLoadHook: failed to allocate %ld bytes for new class bytes: %d", len, err);
+                return false;
+            }
+
+            jbyte* arrayPtr = env->GetByteArrayElements(classBytes, nullptr);
+            if (arrayPtr == nullptr) {
+                _log("ClassFileLoadHook: failed to get array elements\n");
+                jvmti->Deallocate(buf);
+                return false;
+            }
+
+            memcpy(buf, arrayPtr, len);
+
+            env->ReleaseByteArrayElements(classBytes, arrayPtr, JNI_ABORT);
+
+            *newClassBytes = buf;
+            *newLen = len;
+
+            _log("  ClassFileLoadHook: set new class bytes\n");
+        }
+        return true;
+    }
+
+    void setSavedHookClassBytes(const unsigned char* bytes, jint len) {
+        jvmtiError err = jvmti->Allocate(len, &savedClassBytes);
+        if (err != JVMTI_ERROR_NONE) {
+            _log("ClassFileLoadHook: failed to allocate %ld bytes for saved class bytes: %d", len, err);
+            return;
+        }
+        memcpy(savedClassBytes, bytes, len);
+        savedClassBytesLen = len;
+    }
+
+    jbyteArray getSavedHookClassBytes() {
+        if (savedClassBytes == nullptr) {
+            _log("%s: savedClassBytes is NULL\n", mode);
+            return nullptr;
+        }
+
+        jbyteArray result = env->NewByteArray(savedClassBytesLen);
+        if (result == nullptr) {
+            _log("%s: NewByteArray(%ld) failed\n", mode, savedClassBytesLen);
+        } else {
+            jbyte* arrayPtr = env->GetByteArrayElements(result, nullptr);
+            if (arrayPtr == nullptr) {
+                _log("%s: Failed to get array elements\n", mode);
+                result = nullptr;
+            } else {
+                memcpy(arrayPtr, savedClassBytes, savedClassBytesLen);
+                env->ReleaseByteArrayElements(result, arrayPtr, JNI_COMMIT);
+            }
+        }
+        return result;
+    }
+};
+
+ClassFileLoadHookHelper* ClassFileLoadHookHelper::instance = nullptr;
+
+
+extern "C" {
+
+JNIEXPORT void JNICALL
+callbackClassFileLoadHook(jvmtiEnv *jvmti_env,
+        JNIEnv* jni_env,
+        jclass class_being_redefined,
+        jobject loader,
+        const char* name,
+        jobject protection_domain,
+        jint class_data_len,
+        const unsigned char* class_data,
+        jint* new_class_data_len,
+        unsigned char** new_class_data) {
+    if (isTestClass(name)) {
+        _log(">>ClassFileLoadHook: %s, %ld bytes, ptr = %p\n", name, class_data_len, class_data);
+
+        ClassFileLoadHookHelper* helper = ClassFileLoadHookHelper::getInstance();
+        if (helper == nullptr) {
+            _log("ClassFileLoadHook ERROR: helper instance is not initialized\n");
+            return;
+        }
+        // save class bytes
+        helper->setSavedHookClassBytes(class_data, class_data_len);
+        // set new class bytes
+        helper->getHookClassBytes(new_class_data, new_class_data_len);
+
+        _log("<<ClassFileLoadHook\n");
+    }
+}
+
+JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM* jvm, char* options, void* reserved) {
+    jint res = jvm->GetEnv((void **)&jvmti, JVMTI_VERSION_1_1);
+    if (res != JNI_OK) {
+        _log("Failed to get JVMTI interface: %ld\n", res);
+        return JNI_ERR;
+    }
+
+    jvmtiCapabilities caps;
+    memset(&caps, 0, sizeof(caps));
+
+    caps.can_redefine_classes = 1;
+    caps.can_retransform_classes = 1;
+    jvmtiError err = jvmti->AddCapabilities(&caps);
+    if (err != JVMTI_ERROR_NONE) {
+        _log("Failed to add capabilities: %d\n", err);
+        return JNI_ERR;
+    }
+
+    jvmtiEventCallbacks eventCallbacks;
+    memset(&eventCallbacks, 0, sizeof(eventCallbacks));
+    eventCallbacks.ClassFileLoadHook = callbackClassFileLoadHook;
+    err = jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks));
+    if (err != JVMTI_ERROR_NONE) {
+        _log("Error setting event callbacks: %d\n", err);
+        return JNI_ERR;
+    }
+
+    return JNI_OK;
+}
+
+JNIEXPORT void JNICALL
+Agent_OnUnload(JavaVM* jvm) {
+    return;
+}
+
+
+JNIEXPORT jbyteArray JNICALL
+Java_RedefineRetransform_nRedefine(JNIEnv* env, jclass klass,
+                                   jclass testClass, jbyteArray classBytes, jbyteArray classLoadHookBytes) {
+
+    ClassFileLoadHookHelper helper("nRedefine", env, classLoadHookBytes);
+
+    jsize len = env->GetArrayLength(classBytes);
+    jbyte* arrayPtr = env->GetByteArrayElements(classBytes, nullptr);
+    if (arrayPtr == nullptr) {
+        _log("nRedefine: Failed to get array elements\n");
+        return nullptr;
+    }
+
+    if (helper.start()) {
+        jvmtiClassDefinition classDef;
+        memset(&classDef, 0, sizeof(classDef));
+        classDef.klass = testClass;
+        classDef.class_byte_count = len;
+        classDef.class_bytes = (unsigned char*)arrayPtr;
+
+        jvmtiError err = jvmti->RedefineClasses(1, &classDef);
+
+        if (err != JVMTI_ERROR_NONE) {
+            _log("nRedefine: RedefineClasses error %d", err);
+            // don't exit here, need to cleanup
+        }
+        helper.stop();
+    }
+
+    env->ReleaseByteArrayElements(classBytes, arrayPtr, JNI_ABORT);
+
+    return helper.getSavedHookClassBytes();
+}
+
+JNIEXPORT jbyteArray JNICALL
+Java_RedefineRetransform_nRetransform(JNIEnv* env, jclass klass, jclass testClass, jbyteArray classBytes) {
+
+    ClassFileLoadHookHelper helper("nRetransform", env, classBytes);
+    if (helper.start()) {
+        jvmtiError err = jvmti->RetransformClasses(1, &testClass);
+        if (err != JVMTI_ERROR_NONE) {
+            _log("nRetransform: RetransformClasses error %d\n", err);
+            // don't exit here, disable CFLH event
+        }
+        helper.stop();
+    }
+    return helper.getSavedHookClassBytes();
+}
+
+}

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -507,7 +507,6 @@ java/lang/instrument/RetransformBigClass.sh                     8065756 generic-
 # jdk_io
 
 java/io/pathNames/GeneralWin32.java                             8180264 windows-all
-java/io/BufferedInputStream/TransferTo.java                     8294541 generic-all
 java/io/File/createTempFile/SpecialTempFile.java                8274122 windows11
 java/io/File/GetXSpace.java                                     8291911 windows-all
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -664,6 +664,7 @@ javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all
 javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 javax/swing/plaf/aqua/CustomComboBoxFocusTest.java 8294254 macosx-all
+javax/swing/JRadioButton/4314194/bug4314194.java 8295006 linux-all
 
 # Several tests which fail on some hidpi systems/macosx12-aarch64 system
 java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -749,7 +749,6 @@ jdk/jfr/startupargs/TestStartName.java                          8214685 windows-
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
 jdk/jfr/api/consumer/recordingstream/TestOnEvent.java           8255404 linux-x64
-jdk/jfr/event/runtime/TestActiveSettingEvent.java               8287832 generic-all
 jdk/jfr/api/consumer/TestRecordingFileWrite.java                8287699 linux-x64,macosx-x64
 
 ############################################################################

--- a/test/jdk/com/sun/java/swing/plaf/gtk/TestFileChooserDirectorySelection.java
+++ b/test/jdk/com/sun/java/swing/plaf/gtk/TestFileChooserDirectorySelection.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6777156
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @requires (os.family == "linux")
+ * @summary Verifies if user is not able to select "../" beyond
+ * root file system.
+ * @run main/manual TestFileChooserDirectorySelection
+ */
+
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class TestFileChooserDirectorySelection {
+    private static JFrame frame;
+    private static final String INSTRUCTIONS =
+            "Double click on the \"../\" entry from directory list.\n\n" +
+            "Repeat the same process till the current directory is root " +
+            "i.e \" / \" .\n\n" +
+            "If \" ../ \" option is not available at root directory" +
+            ", press Pass else Fail.";
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
+        PassFailJFrame passFailJFrame = new PassFailJFrame(
+                "JFileChooser Test Instructions", INSTRUCTIONS, 5, 8, 35);
+        try {
+            SwingUtilities.invokeAndWait(
+                    TestFileChooserDirectorySelection::createAndShowUI);
+            passFailJFrame.awaitAndCheck();
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+    private static void createAndShowUI() {
+        frame = new JFrame("Test File Chooser Directory Selection");
+        JFileChooser fileChooser = new JFileChooser();
+        fileChooser.setControlButtonsAreShown(false);
+        PassFailJFrame.addTestWindow(frame);
+        PassFailJFrame.positionTestWindow(
+                frame, PassFailJFrame.Position.HORIZONTAL);
+        frame.add(fileChooser);
+        frame.setSize(500, 500);
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setVisible(true);
+    }
+}

--- a/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
+++ b/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
@@ -105,11 +105,20 @@ public class ClassUnloadEventTest {
             }
         }
         loader = null;
+
+        // Do a short delay to make sure that the debug agent is done processing all
+        // ClassPrepare events. Otherwise the debug agent might still be holding on to
+        // a reference to a class, which will prevent it from unloading during the GC.
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+        }
+
         // Trigger class unloading
         ClassUnloadCommon.triggerUnloading();
 
-        // Short delay to make sure all ClassUnloadEvents have been sent
-        // before VMDeathEvent is genareated.
+        // Do a short delay to make sure all ClassUnloadEvents have been sent
+        // before VMDeathEvent is generated.
         try {
             Thread.sleep(5000);
         } catch (InterruptedException e) {

--- a/test/jdk/java/io/BufferedInputStream/TransferTo.java
+++ b/test/jdk/java/io/BufferedInputStream/TransferTo.java
@@ -61,8 +61,8 @@ import static org.testng.Assert.assertTrue;
  * @test
  * @library /test/lib
  * @build jdk.test.lib.RandomFactory
- * @run testng/othervm/timeout=180 TransferTo
- * @bug 8279283
+ * @run testng/othervm/timeout=180 -Xmx1280m TransferTo
+ * @bug 8279283 8294541
  * @summary Tests whether java.io.BufferedInputStream.transferTo conforms to the
  *          InputStream.transferTo specification
  * @key randomness

--- a/test/jdk/java/lang/Thread/virtual/ThreadAPI.java
+++ b/test/jdk/java/lang/Thread/virtual/ThreadAPI.java
@@ -754,7 +754,7 @@ public class ThreadAPI {
 
     /**
      * Test platform thread invoking timed-Thread.join on a thread that is parking
-     * and unparking.
+     * and unparking while pinned.
      */
     @Test
     public void testJoin33() throws Exception {
@@ -775,11 +775,18 @@ public class ThreadAPI {
 
     /**
      * Test virtual thread invoking timed-Thread.join on a thread that is parking
-     * and unparking.
+     * and unparking while pinned.
      */
     @Test
     public void testJoin34() throws Exception {
-        VThreadRunner.run(this::testJoin33);
+        // need at least two carrier threads due to pinning
+        int previousParallelism = VThreadRunner.ensureParallelism(2);
+        try {
+            VThreadRunner.run(this::testJoin33);
+        } finally {
+            // restore
+            VThreadRunner.setParallelism(previousParallelism);
+        }
     }
 
     /**

--- a/test/jdk/java/lang/instrument/NativeMethodPrefixAgent.java
+++ b/test/jdk/java/lang/instrument/NativeMethodPrefixAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,13 @@ class NativeMethodPrefixAgent {
 
     static ClassFileTransformer t0, t1, t2;
     static Instrumentation inst;
+    private static Throwable agentError;
+
+    public static void checkErrors() {
+        if (agentError != null) {
+            throw new RuntimeException("Agent error", agentError);
+        }
+    }
 
     static class Tr implements ClassFileTransformer {
         final String trname;
@@ -87,10 +94,12 @@ class NativeMethodPrefixAgent {
 
                     return redef? null : newcf;
                 } catch (Throwable ex) {
+                    if (agentError == null) {
+                        agentError = ex;
+                    }
                     System.err.println("ERROR: Injection failure: " + ex);
                     ex.printStackTrace();
-                    System.err.println("Returning bad class file, to cause test failure");
-                    return new byte[0];
+                    return null;
                 }
             }
             return null;

--- a/test/jdk/java/lang/instrument/NativeMethodPrefixApp.java
+++ b/test/jdk/java/lang/instrument/NativeMethodPrefixApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,8 @@ public class NativeMethodPrefixApp implements StringIdCallback {
         java.lang.reflect.Array.getLength(new short[5]);
         RuntimeMXBean mxbean = ManagementFactory.getRuntimeMXBean();
         System.err.println(mxbean.getVmVendor());
+
+        NativeMethodPrefixAgent.checkErrors();
 
         for (int i = 0; i < gotIt.length; ++i) {
             if (!gotIt[i]) {

--- a/test/jdk/java/lang/instrument/asmlib/Instrumentor.java
+++ b/test/jdk/java/lang/instrument/asmlib/Instrumentor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -124,7 +124,7 @@ public class Instrumentor {
     }
 
     public synchronized Instrumentor addNativeMethodTrackingInjection(String prefix, Consumer<InstrHelper> injector) {
-        instrumentingVisitor = new ClassVisitor(Opcodes.ASM7, instrumentingVisitor) {
+        instrumentingVisitor = new ClassVisitor(Opcodes.ASM9, instrumentingVisitor) {
             private final Set<Consumer<ClassVisitor>> wmGenerators = new HashSet<>();
             private String className;
 

--- a/test/jdk/java/lang/management/ThreadMXBean/VirtualThreadDeadlocks.java
+++ b/test/jdk/java/lang/management/ThreadMXBean/VirtualThreadDeadlocks.java
@@ -22,22 +22,24 @@
  */
 
 /**
- * @test
+ * @test id=default
  * @bug 8284161 8287103
  * @summary Test ThredMXBean.findMonitorDeadlockedThreads with cycles of
  *   platform and virtual threads in deadlock
  * @enablePreview
- * @modules java.management
+ * @modules java.base/java.lang:+open java.management
+ * @library /test/lib
  * @run main/othervm VirtualThreadDeadlocks PP
  * @run main/othervm VirtualThreadDeadlocks PV
  * @run main/othervm VirtualThreadDeadlocks VV
  */
 
 /**
- * @test
+ * @test id=no-vmcontinuations
  * @requires vm.continuations
  * @enablePreview
- * @modules java.management
+ * @modules java.base/java.lang:+open java.management
+ * @library /test/lib
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations VirtualThreadDeadlocks PP
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations VirtualThreadDeadlocks PV
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations VirtualThreadDeadlocks VV
@@ -48,6 +50,7 @@ import java.lang.management.ThreadMXBean;
 import java.util.Arrays;
 import java.util.concurrent.CyclicBarrier;
 import java.util.stream.Stream;
+import jdk.test.lib.thread.VThreadRunner;
 
 public class VirtualThreadDeadlocks {
     private static final Object LOCK1 = new Object();
@@ -61,6 +64,8 @@ public class VirtualThreadDeadlocks {
      * VV = test deadlock with two virtual threads
      */
     public static void main(String[] args) throws Exception {
+        // need at least two carrier threads due to pinning
+        VThreadRunner.ensureParallelism(2);
 
         // start thread1
         Thread.Builder builder1 = (args[0].charAt(0) == 'P')

--- a/test/jdk/java/lang/management/ThreadMXBean/VirtualThreads.java
+++ b/test/jdk/java/lang/management/ThreadMXBean/VirtualThreads.java
@@ -22,7 +22,7 @@
  */
 
 /**
- * @test
+ * @test id=default
  * @bug 8284161 8290562
  * @summary Test java.lang.management.ThreadMXBean with virtual threads
  * @enablePreview
@@ -31,7 +31,7 @@
  */
 
 /**
- * @test
+ * @test id=no-vmcontinuations
  * @requires vm.continuations
  * @enablePreview
  * @modules java.base/java.lang:+open java.management

--- a/test/jdk/java/net/URL/B8282395.java
+++ b/test/jdk/java/net/URL/B8282395.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/* @test
+ * @summary URL.openConnection can throw IOOBE
+ * @bug 8282395
+ */
+
+import java.net.MalformedURLException;
+import java.net.Proxy;
+import java.net.URL;
+
+public class B8282395 {
+    public static void main(String[] args) throws Exception {
+        boolean res = false;
+        URL url = new URL("ftp://.:%@");
+        try {
+            // Will throw IndexOutOfBoundsException if not fixed
+            url.openConnection();
+        } catch (MalformedURLException e) {
+            res = true;
+        }
+        if (!res) {
+            throw new RuntimeException("MalformedURLException should be thrown");
+        }
+        res = false;
+        try {
+            // Will throw IndexOutOfBoundsException if not fixed
+            url.openConnection(Proxy.NO_PROXY);
+        } catch (MalformedURLException e) {
+            res = true;
+        }
+        if (!res) {
+            throw new RuntimeException("MalformedURLException should be thrown");
+        }
+    }
+
+}

--- a/test/jdk/java/net/httpclient/AbstractConnectTimeout.java
+++ b/test/jdk/java/net/httpclient/AbstractConnectTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,19 +54,13 @@ public abstract class AbstractConnectTimeout {
 
     static List<List<Duration>> TIMEOUTS = List.of(
                     // connectTimeout   HttpRequest timeout
-            Arrays.asList( NO_DURATION,   ofSeconds(1)  ),
             Arrays.asList( NO_DURATION,   ofMillis(100) ),
-            Arrays.asList( NO_DURATION,   ofNanos(99)   ),
             Arrays.asList( NO_DURATION,   ofNanos(1)    ),
 
-            Arrays.asList( ofSeconds(1),  NO_DURATION   ),
             Arrays.asList( ofMillis(100), NO_DURATION   ),
-            Arrays.asList( ofNanos(99),   NO_DURATION   ),
             Arrays.asList( ofNanos(1),    NO_DURATION   ),
 
-            Arrays.asList( ofSeconds(1),  ofMinutes(1)  ),
             Arrays.asList( ofMillis(100), ofMinutes(1)  ),
-            Arrays.asList( ofNanos(99),   ofMinutes(1)  ),
             Arrays.asList( ofNanos(1),    ofMinutes(1)  )
     );
 

--- a/test/jdk/java/net/httpclient/AbstractConnectTimeoutHandshake.java
+++ b/test/jdk/java/net/httpclient/AbstractConnectTimeoutHandshake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,17 +68,11 @@ public abstract class AbstractConnectTimeoutHandshake {
 
     static List<List<Duration>> TIMEOUTS = List.of(
                     // connectTimeout   HttpRequest timeout
-            Arrays.asList( NO_DURATION,   ofSeconds(1)  ),
-            Arrays.asList( NO_DURATION,   ofSeconds(2)  ),
-            Arrays.asList( NO_DURATION,   ofMillis(500) ),
+            Arrays.asList( NO_DURATION,   ofMillis(100) ),
 
-            Arrays.asList( ofSeconds(1),  NO_DURATION   ),
-            Arrays.asList( ofSeconds(2),  NO_DURATION   ),
-            Arrays.asList( ofMillis(500), NO_DURATION   ),
+            Arrays.asList( ofMillis(100), NO_DURATION   ),
 
-            Arrays.asList( ofSeconds(1),  ofMinutes(1)  ),
-            Arrays.asList( ofSeconds(2),  ofMinutes(1)  ),
-            Arrays.asList( ofMillis(500), ofMinutes(1)  )
+            Arrays.asList( ofMillis(100), ofMinutes(1)  )
     );
 
     static final List<String> METHODS = List.of("GET" , "POST");

--- a/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JFrame;
+import javax.swing.JFileChooser;
+import javax.swing.SwingUtilities;
+import javax.swing.WindowConstants;
+
+import javax.swing.filechooser.FileView;
+
+/*
+ * @test
+ * @bug 6616245
+ * @key headful
+ * @requires (os.family == "windows" | os.family == "linux")
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Test to check if NPE occurs when using custom FileView.
+ * @run main/manual FileViewNPETest
+ */
+public class FileViewNPETest {
+    static PassFailJFrame passFailJFrame;
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(new Runnable() {
+            public void run() {
+                try {
+                    initialize();
+                } catch (InterruptedException | InvocationTargetException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        passFailJFrame.awaitAndCheck();
+    }
+
+    static void initialize() throws InterruptedException, InvocationTargetException {
+        JFrame frame;
+        JFileChooser jfc;
+
+        //Initialize the components
+        final String INSTRUCTIONS = """
+                Instructions to Test:
+                1. The traversable folder is set to the Documents folder,
+                 if it exists, in the user's home folder, otherwise
+                 it's the user's home. Other folders are non-traversable.
+                2. When the file chooser appears on the screen, select any
+                 non-traversable folder from "Look-In" combo box,
+                 for example the user's folder or a folder above it.
+                 (The folder will not be opened since it's non-traversable).
+                3. Select the Documents folder again.
+                4. If NullPointerException does not occur in the step 3,
+                 click Pass, otherwise the test fails automatically.
+                """;
+        frame = new JFrame("JFileChooser File View NPE test");
+        passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS,
+                5L, 13, 40);
+        jfc = new JFileChooser();
+
+        String userHome = System.getProperty("user.home");
+        String docs = userHome + File.separator + "Documents";
+        String path = (new File(docs).exists()) ? docs : userHome;
+
+        jfc.setCurrentDirectory(new File(path));
+        jfc.setFileView(new CustomFileView(path));
+        jfc.setControlButtonsAreShown(false);
+
+        PassFailJFrame.addTestWindow(frame);
+        PassFailJFrame.positionTestWindow(frame, PassFailJFrame.Position.HORIZONTAL);
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+
+        frame.add(jfc, BorderLayout.CENTER);
+        frame.pack();
+        frame.setVisible(true);
+    }
+}
+
+class CustomFileView extends FileView {
+    private final String basePath;
+
+    public CustomFileView(String path) {
+        basePath = path;
+    }
+
+    public Boolean isTraversable(File filePath) {
+        return ((filePath != null) && (filePath.isDirectory()))
+                && filePath.getAbsolutePath().startsWith(basePath);
+    }
+}

--- a/test/jdk/javax/swing/JRadioButton/4314194/bug4314194.java
+++ b/test/jdk/javax/swing/JRadioButton/4314194/bug4314194.java
@@ -72,6 +72,7 @@ public class bug4314194 {
             totalPixels++;
         }
 
+        System.out.println("correctColoredPixels " + correctColoredPixels + " totalPixels " + totalPixels);
         return ((double)correctColoredPixels/totalPixels*100) >= tolerance;
     }
 
@@ -90,8 +91,8 @@ public class bug4314194 {
         UIManager.getDefaults().put("CheckBox.disabledText", checkboxColor);
         UIManager.getDefaults().put("RadioButton.disabledText", radioButtonColor);
 
-        checkBox = new JCheckBox("WWWWW");
-        radioButton = new JRadioButton("WWWWW");
+        checkBox = new JCheckBox("\u2588".repeat(5));
+        radioButton = new JRadioButton("\u2588".repeat(5));
         checkBox.setFont(checkBox.getFont().deriveFont(50.0f));
         radioButton.setFont(radioButton.getFont().deriveFont(50.0f));
         checkBox.setEnabled(false);

--- a/test/jdk/jdk/jfr/api/event/TestShouldCommit.java
+++ b/test/jdk/jdk/jfr/api/event/TestShouldCommit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,171 +23,172 @@
 
 package jdk.jfr.api.event;
 
+import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Set;
 
 import jdk.jfr.Event;
 import jdk.jfr.Recording;
-import jdk.test.lib.Asserts;
+import jdk.jfr.SettingControl;
+import jdk.jfr.SettingDefinition;
+import jdk.jfr.consumer.RecordingFile;
+
+import static jdk.test.lib.Asserts.assertTrue;
+import static jdk.test.lib.Asserts.assertFalse;
 
 /**
  * @test
- * @summary Test enable/disable event and verify recording has expected events.
+ * @summary Test jdk.jfr.Event::shouldCommit()
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib
- * @run main/othervm -Xlog:jfr+event+setting=trace jdk.jfr.api.event.TestShouldCommit
+ * @run main/othervm jdk.jfr.api.event.TestShouldCommit
  */
-
 public class TestShouldCommit {
 
-    public static void main(String[] args) throws Exception {
-        Recording rA = new Recording();
-
-        verifyShouldCommitFalse(); // No active recordings
-
-        rA.start();
-        rA.enable(MyEvent.class).withoutThreshold(); // recA=all
-        verifyShouldCommitTrue();
-
-        setThreshold(rA, 100); // recA=100
-        verifyThreshold(100);
-
-        setThreshold(rA, 200); // recA=200
-        verifyThreshold(200);
-
-        Recording rB = new Recording();
-        verifyThreshold(200);  // recA=200, recB=not started
-
-        rB.start();
-        verifyThreshold(200);  // recA=200, recB=not specified, settings from recA is used.
-
-        setThreshold(rB, 100); // recA=200, recB=100
-        verifyThreshold(100);
-
-        setThreshold(rB, 300); // recA=200, recB=300
-        verifyThreshold(200);
-
-        rA.disable(MyEvent.class); // recA=disabled, recB=300
-
-        verifyThreshold(300);
-
-        rB.disable(MyEvent.class); // recA=disabled, recB=disabled
-        verifyShouldCommitFalse();
-
-        setThreshold(rA, 200); // recA=200, recB=disabled
-        verifyThreshold(200);
-
-        rB.enable(MyEvent.class).withoutThreshold(); // recA=200, recB=all
-        verifyShouldCommitTrue();
-
-        setThreshold(rB, 100); // recA=200, recB=100
-        verifyThreshold(100);
-
-        rB.stop(); // recA=200, recB=stopped
-        verifyThreshold(200);
-
-        rA.stop(); // recA=stopped, recB=stopped
-        verifyShouldCommitFalse();
-
-        rA.close();
-        rB.close();
-
-        verifyShouldCommitFalse();
+    private static class CatEvent extends Event {
     }
 
-    private static void setThreshold(Recording r, long millis) {
-        r.enable(MyEvent.class).withThreshold(Duration.ofMillis(millis));
+    private static class DogEvent extends Event {
     }
 
-    private static void verifyThreshold(long threshold) throws Exception {
-        // Create 2 events, with different sleep time between begin() and end()
-        // First event ends just before threshold, the other just after.
-        verifyThreshold(threshold-5, threshold);
-        verifyThreshold(threshold+5, threshold);
-    }
+    private static class BirdEvent extends Event {
+        public boolean isFlying;
 
-    private static void verifyThreshold(long sleepMs, long thresholdMs) throws Exception {
-        MyEvent event = new MyEvent();
-
-        long beforeStartNanos = System.nanoTime();
-        event.begin();
-        long afterStartNanos = System.nanoTime();
-
-        Thread.sleep(sleepMs);
-
-        long beforeStopNanos = System.nanoTime();
-        event.end();
-        long afterStopNanos = System.nanoTime();
-
-        boolean actualShouldCommit = event.shouldCommit();
-
-        final long safetyMarginNanos = 2000000; // Allow an error of 2 ms. May have to be tuned.
-
-        //Duration of event has been at least minDurationMicros
-        long minDurationMicros = (beforeStopNanos - afterStartNanos - safetyMarginNanos) / 1000;
-        //Duration of event has been at most maxDurationMicros
-        long maxDurationMicros = (afterStopNanos - beforeStartNanos + safetyMarginNanos) / 1000;
-        Asserts.assertLessThanOrEqual(minDurationMicros, maxDurationMicros, "Wrong min/max duration. Test error.");
-
-        long thresholdMicros = thresholdMs * 1000;
-        Boolean shouldCommit = null;
-        if (minDurationMicros > thresholdMicros) {
-            shouldCommit = new Boolean(true);  // shouldCommit() must be true
-        } else if (maxDurationMicros < thresholdMicros) {
-            shouldCommit = new Boolean(false); // shouldCommit() must be false
-        } else {
-            // Too close to call. No checks are done since we are not sure of expected shouldCommit().
+        @SettingDefinition
+        public boolean fly(FlySetting control) {
+            return control.shouldFly() == isFlying;
         }
+    }
 
-        System.out.printf(
-            "threshold=%d, duration=[%d-%d], shouldCommit()=%b, expected=%s%n",
-            thresholdMicros, minDurationMicros, maxDurationMicros, actualShouldCommit,
-            (shouldCommit!=null ? shouldCommit : "too close to call"));
+    private static class FlySetting extends SettingControl {
+        private boolean shouldFly;
 
-        try {
-            if (shouldCommit != null) {
-                Asserts.assertEquals(shouldCommit.booleanValue(), actualShouldCommit, "Wrong shouldCommit()");
+        @Override
+        public String combine(Set<String> settingValues) {
+            for (String s : settingValues) {
+                if ("true".equals(s)) {
+                    return "true";
+                }
             }
-        } catch (Exception e) {
-            System.out.println("Unexpected value of shouldCommit(). Searching for active threshold...");
-            searchThreshold(thresholdMs, 2000+thresholdMs);
-            throw e;
+            return "false";
+        }
+
+        public boolean shouldFly() {
+            return shouldFly;
+        }
+
+        @Override
+        public void setValue(String settingValue) {
+            shouldFly = "true".equals(settingValue);
+        }
+
+        @Override
+        public String getValue() {
+            return String.valueOf(shouldFly);
         }
     }
 
-    // Sleeps until shouldCommit() is true, or give up. Used for logging.
-    private static void searchThreshold(long expectedMs, long maxMs) throws Exception {
-        long start = System.nanoTime();
-        long stop = start + maxMs * 1000000;
+    public static void main(String[] args) throws Exception {
+        testEnablement();
+        testThreshold();
+        testCustomSetting();
+        testWithoutEnd();
+        testCommit();
+    }
 
-        MyEvent event = new MyEvent();
-        event.begin();
-        event.end();
+    private static void testEnablement() throws Exception {
+        DogEvent b = new DogEvent();
+        assertFalse(b.shouldCommit(), "Expected false before recording is started");
 
-        while (!event.shouldCommit() && System.nanoTime() < stop) {
+        try (Recording r = new Recording()) {
+            r.enable(CatEvent.class);
+            r.disable(DogEvent.class);
+            r.start();
+
+            CatEvent c = new CatEvent();
+            assertTrue(c.shouldCommit(), "Expected true for enabled event");
+
+            DogEvent d = new DogEvent();
+            assertFalse(d.shouldCommit(), "Expected false for disabled event");
+        }
+
+        CatEvent c = new CatEvent();
+        assertFalse(c.shouldCommit(), "Expected false after recording is stopped");
+    }
+
+    private static void testThreshold() throws Exception {
+        try (Recording r = new Recording()) {
+            r.enable(CatEvent.class).withThreshold(Duration.ofNanos(0));
+            r.enable(DogEvent.class).withThreshold(Duration.ofDays(1));
+            r.start();
+
+            CatEvent c = new CatEvent();
+            c.begin();
             Thread.sleep(1);
-            event.end();
+            c.end();
+            assertTrue(c.shouldCommit(), "Expected true if above threshold");
+
+            DogEvent d = new DogEvent();
+            d.begin();
+            Thread.sleep(1);
+            d.end();
+            assertFalse(d.shouldCommit(), "Expected false if below threshold");
         }
-        long durationMicros = (System.nanoTime() - start) / 1000;
-        long expectedMicros = expectedMs * 1000;
-        System.out.printf("shouldCommit()=%b after %,d ms, expected %,d%n", event.shouldCommit(), durationMicros, expectedMicros);
     }
 
-    private static void verifyShouldCommitFalse() {
-        MyEvent event = new MyEvent();
-        event.begin();
-        event.end();
-        Asserts.assertFalse(event.shouldCommit(), "shouldCommit() expected false");
+    private static void testCustomSetting() throws Exception {
+        try (Recording r = new Recording()) {
+            r.enable(BirdEvent.class).with("fly", "true");
+            r.start();
+            BirdEvent b1 = new BirdEvent();
+            b1.isFlying = false;
+            b1.begin();
+            b1.end();
+            assertFalse(b1.shouldCommit(), "Expected false if rejected by custom setting");
+
+            BirdEvent b2 = new BirdEvent();
+            b2.isFlying = true;
+            b2.begin();
+            b2.end();
+            assertTrue(b2.shouldCommit(), "Expected true if accepted by custom setting");
+        }
     }
 
-    private static void verifyShouldCommitTrue() {
-        MyEvent event = new MyEvent();
-        event.begin();
-        event.end();
-        Asserts.assertTrue(event.shouldCommit(), "shouldCommit() expected true");
+    private static void testWithoutEnd() throws Exception {
+        try (Recording r = new Recording()) {
+            r.enable(CatEvent.class).withThreshold(Duration.ofDays(0));
+            r.enable(DogEvent.class).withThreshold(Duration.ofDays(1));
+            r.start();
+
+            CatEvent c = new CatEvent();
+            c.begin();
+            Thread.sleep(1);
+            assertTrue(c.shouldCommit(), "Expected true when above threshold and end() not invoked");
+
+            DogEvent d = new DogEvent();
+            d.begin();
+            Thread.sleep(1);
+            assertFalse(d.shouldCommit(), "Expected false when below threshold and end() not invoked");
+        }
     }
 
-    private static class MyEvent extends Event {
+    private static void testCommit() throws Exception {
+        try (Recording r = new Recording()) {
+            r.enable(CatEvent.class);
+            r.start();
+            CatEvent c = new CatEvent();
+            c.begin();
+            Thread.sleep(1);
+            c.end();
+            if (c.shouldCommit()) {
+                c.commit();
+            }
+            r.stop();
+            Path file = Path.of("dump.jfr");
+            r.dump(file);
+            boolean hasEvent = RecordingFile.readAllEvents(file).size() > 0;
+            assertTrue(hasEvent, "Expected event when using commit() after shouldCommit()");
+        }
     }
-
 }


### PR DESCRIPTION
java/awt/PopupMenu/PopupMenuLocation.java seems to be unstable in MacOS machines, especially in MacOSX 12 & 13 machines. It seems to be a testbug as adding some stability improvements fixes the issue. It intermittently fails in CI causing some noise. This test was already problem listed in windows due to an umbrella bug JDK-8238720. This fix doesn't cover the Windows issue, so the problem listing in windows will remain same.

Fix:
Some stability improvements have been done and the test has been run 100 times per platform in mach5 and got full PASS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288415](https://bugs.openjdk.org/browse/JDK-8288415): java/awt/PopupMenu/PopupMenuLocation.java is unstable in MacOS machines


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10606/head:pull/10606` \
`$ git checkout pull/10606`

Update a local copy of the PR: \
`$ git checkout pull/10606` \
`$ git pull https://git.openjdk.org/jdk pull/10606/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10606`

View PR using the GUI difftool: \
`$ git pr show -t 10606`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10606.diff">https://git.openjdk.org/jdk/pull/10606.diff</a>

</details>
