### PR TITLE
8286394: Address possibly lossy conversions in jdk.naming.dns

### DIFF
--- a/make/modules/jdk.naming.dns/Java.gmk
+++ b/make/modules/jdk.naming.dns/Java.gmk
@@ -1,1 +1,0 @@
-DISABLED_WARNINGS_java += lossy-conversions

--- a/src/jdk.naming.dns/share/classes/com/sun/jndi/dns/DnsClient.java
+++ b/src/jdk.naming.dns/share/classes/com/sun/jndi/dns/DnsClient.java
@@ -730,7 +730,7 @@ class Tcp {
             return reader.read();
         }
         finally {
-            timeoutLeft -= System.currentTimeMillis() - start;
+            timeoutLeft -= (int) (System.currentTimeMillis() - start);
         }
     }
 


### PR DESCRIPTION
Added an int cast for the `timeoutLeft` assignment, looking through the code and other uses of the variable it seems to show no issues with lossy conversion. As part of this I removed the file to disable the conversion warning

I tested this build and it doesn't give any warnings on this file

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286394](https://bugs.openjdk.org/browse/JDK-8286394): Address possibly lossy conversions in jdk.naming.dns


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Aleksei Efimov](https://openjdk.org/census#aefimov) (@AlekseiEfimov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10607/head:pull/10607` \
`$ git checkout pull/10607`

Update a local copy of the PR: \
`$ git checkout pull/10607` \
`$ git pull https://git.openjdk.org/jdk pull/10607/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10607`

View PR using the GUI difftool: \
`$ git pr show -t 10607`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10607.diff">https://git.openjdk.org/jdk/pull/10607.diff</a>

</details>
