### PR TITLE
8294987: Streamline DerOutputStream write

### DIFF
--- a/src/java.base/share/classes/sun/security/util/DerOutputStream.java
+++ b/src/java.base/share/classes/sun/security/util/DerOutputStream.java
@@ -26,8 +26,8 @@
 package sun.security.util;
 
 import java.io.ByteArrayOutputStream;
-import java.io.OutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
@@ -79,10 +79,11 @@ extends ByteArrayOutputStream implements DerEncoder {
      *          <em>DerValue.tag_Sequence</em>
      * @param buf buffered data, which must be DER-encoded
      */
-    public void write(byte tag, byte[] buf) throws IOException {
+    public DerOutputStream write(byte tag, byte[] buf) throws IOException {
         write(tag);
         putLength(buf.length);
         write(buf, 0, buf.length);
+        return this;
     }
 
     /**
@@ -94,10 +95,11 @@ extends ByteArrayOutputStream implements DerEncoder {
      *          <em>DerValue.tag_Sequence</em>
      * @param out buffered data
      */
-    public void write(byte tag, DerOutputStream out) throws IOException {
+    public DerOutputStream write(byte tag, DerOutputStream out) throws IOException {
         write(tag);
         putLength(out.count);
         write(out.buf, 0, out.count);
+        return this;
     }
 
     /**
@@ -117,17 +119,19 @@ extends ByteArrayOutputStream implements DerEncoder {
      * explicit tagging the form is always constructed.
      * @param value original value being implicitly tagged
      */
-    public void writeImplicit(byte tag, DerOutputStream value)
+    public DerOutputStream writeImplicit(byte tag, DerOutputStream value)
     throws IOException {
         write(tag);
         write(value.buf, 1, value.count-1);
+        return this;
     }
 
     /**
      * Marshals pre-encoded DER value onto the output stream.
      */
-    public void putDerValue(DerValue val) throws IOException {
+    public DerOutputStream putDerValue(DerValue val) throws IOException {
         val.encode(this);
+        return this;
     }
 
     /*
@@ -141,7 +145,7 @@ extends ByteArrayOutputStream implements DerEncoder {
     /**
      * Marshals a DER boolean on the output stream.
      */
-    public void putBoolean(boolean val) throws IOException {
+    public DerOutputStream putBoolean(boolean val) throws IOException {
         write(DerValue.tag_Boolean);
         putLength(1);
         if (val) {
@@ -149,15 +153,17 @@ extends ByteArrayOutputStream implements DerEncoder {
         } else {
             write(0);
         }
+        return this;
     }
 
     /**
      * Marshals a DER enumerated on the output stream.
      * @param i the enumerated value.
      */
-    public void putEnumerated(int i) throws IOException {
+    public DerOutputStream putEnumerated(int i) throws IOException {
         write(DerValue.tag_Enumerated);
         putIntegerContents(i);
+        return this;
     }
 
     /**
@@ -165,11 +171,12 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * @param i the integer in the form of a BigInteger.
      */
-    public void putInteger(BigInteger i) throws IOException {
+    public DerOutputStream putInteger(BigInteger i) throws IOException {
         write(DerValue.tag_Integer);
         byte[]    buf = i.toByteArray(); // least number  of bytes
         putLength(buf.length);
         write(buf, 0, buf.length);
+        return this;
     }
 
     /**
@@ -177,27 +184,29 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * @param buf the integer in bytes, equivalent to BigInteger::toByteArray.
      */
-    public void putInteger(byte[] buf) throws IOException {
+    public DerOutputStream putInteger(byte[] buf) throws IOException {
         write(DerValue.tag_Integer);
         putLength(buf.length);
         write(buf, 0, buf.length);
+        return this;
     }
 
     /**
      * Marshals a DER integer on the output stream.
      * @param i the integer in the form of an Integer.
      */
-    public void putInteger(Integer i) throws IOException {
-        putInteger(i.intValue());
+    public DerOutputStream putInteger(Integer i) throws IOException {
+        return putInteger(i.intValue());
     }
 
     /**
      * Marshals a DER integer on the output stream.
      * @param i the integer.
      */
-    public void putInteger(int i) throws IOException {
+    public DerOutputStream putInteger(int i) throws IOException {
         write(DerValue.tag_Integer);
         putIntegerContents(i);
+        return this;
     }
 
     private void putIntegerContents(int i) throws IOException {
@@ -250,11 +259,12 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * @param bits the bit string, MSB first
      */
-    public void putBitString(byte[] bits) throws IOException {
+    public DerOutputStream putBitString(byte[] bits) throws IOException {
         write(DerValue.tag_BitString);
         putLength(bits.length + 1);
         write(0);               // all of last octet is used
         write(bits);
+        return this;
     }
 
     /**
@@ -263,13 +273,14 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * @param ba the bit string, MSB first
      */
-    public void putUnalignedBitString(BitArray ba) throws IOException {
+    public DerOutputStream putUnalignedBitString(BitArray ba) throws IOException {
         byte[] bits = ba.toByteArray();
 
         write(DerValue.tag_BitString);
         putLength(bits.length + 1);
         write(bits.length*8 - ba.length()); // excess bits in last octet
         write(bits);
+        return this;
     }
 
     /**
@@ -278,8 +289,9 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * @param ba the bit string, MSB first
      */
-    public void putTruncatedUnalignedBitString(BitArray ba) throws IOException {
+    public DerOutputStream putTruncatedUnalignedBitString(BitArray ba) throws IOException {
         putUnalignedBitString(ba.truncate());
+        return this;
     }
 
     /**
@@ -287,25 +299,28 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * @param octets the octet string
      */
-    public void putOctetString(byte[] octets) throws IOException {
+    public DerOutputStream putOctetString(byte[] octets) throws IOException {
         write(DerValue.tag_OctetString, octets);
+        return this;
     }
 
     /**
      * Marshals a DER "null" value on the output stream.  These are
      * often used to indicate optional values which have been omitted.
      */
-    public void putNull() throws IOException {
+    public DerOutputStream putNull() throws IOException {
         write(DerValue.tag_Null);
         putLength(0);
+        return this;
     }
 
     /**
      * Marshals an object identifier (OID) on the output stream.
      * Corresponds to the ASN.1 "OBJECT IDENTIFIER" construct.
      */
-    public void putOID(ObjectIdentifier oid) throws IOException {
+    public DerOutputStream putOID(ObjectIdentifier oid) throws IOException {
         oid.encode(this);
+        return this;
     }
 
     /**
@@ -313,7 +328,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      * the ASN.1 "SEQUENCE" (zero to N values) and "SEQUENCE OF"
      * (one to N values) constructs.
      */
-    public void putSequence(DerValue[] seq) throws IOException {
+    public DerOutputStream putSequence(DerValue[] seq) throws IOException {
         DerOutputStream bytes = new DerOutputStream();
         int i;
 
@@ -321,6 +336,7 @@ extends ByteArrayOutputStream implements DerEncoder {
             seq[i].encode(bytes);
 
         write(DerValue.tag_Sequence, bytes);
+        return this;
     }
 
     /**
@@ -330,7 +346,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * For DER encoding, use orderedPutSet() or orderedPutSetOf().
      */
-    public void putSet(DerValue[] set) throws IOException {
+    public DerOutputStream putSet(DerValue[] set) throws IOException {
         DerOutputStream bytes = new DerOutputStream();
         int i;
 
@@ -338,6 +354,7 @@ extends ByteArrayOutputStream implements DerEncoder {
             set[i].encode(bytes);
 
         write(DerValue.tag_Set, bytes);
+        return this;
     }
 
     /**
@@ -350,8 +367,8 @@ extends ByteArrayOutputStream implements DerEncoder {
      * This method supports the ASN.1 "SET OF" construct, but not
      * "SET", which uses a different order.
      */
-    public void putOrderedSetOf(byte tag, DerEncoder[] set) throws IOException {
-        putOrderedSet(tag, set, lexOrder);
+    public DerOutputStream putOrderedSetOf(byte tag, DerEncoder[] set) throws IOException {
+        return putOrderedSet(tag, set, lexOrder);
     }
 
     /**
@@ -364,8 +381,8 @@ extends ByteArrayOutputStream implements DerEncoder {
      * This method supports the ASN.1 "SET" construct, but not
      * "SET OF", which uses a different order.
      */
-    public void putOrderedSet(byte tag, DerEncoder[] set) throws IOException {
-        putOrderedSet(tag, set, tagOrder);
+    public DerOutputStream putOrderedSet(byte tag, DerEncoder[] set) throws IOException {
+        return putOrderedSet(tag, set, tagOrder);
     }
 
     /**
@@ -386,7 +403,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * @param order the order to use when sorting encodings of components.
      */
-    private void putOrderedSet(byte tag, DerEncoder[] set,
+    private DerOutputStream putOrderedSet(byte tag, DerEncoder[] set,
                                Comparator<byte[]> order) throws IOException {
         DerOutputStream[] streams = new DerOutputStream[set.length];
 
@@ -407,53 +424,53 @@ extends ByteArrayOutputStream implements DerEncoder {
             bytes.write(bufs[i]);
         }
         write(tag, bytes);
-
+        return this;
     }
 
     /**
      * Marshals a string as a DER encoded UTF8String.
      */
-    public void putUTF8String(String s) throws IOException {
-        writeString(s, DerValue.tag_UTF8String, UTF_8);
+    public DerOutputStream putUTF8String(String s) throws IOException {
+        return writeString(s, DerValue.tag_UTF8String, UTF_8);
     }
 
     /**
      * Marshals a string as a DER encoded PrintableString.
      */
-    public void putPrintableString(String s) throws IOException {
-        writeString(s, DerValue.tag_PrintableString, US_ASCII);
+    public DerOutputStream putPrintableString(String s) throws IOException {
+        return writeString(s, DerValue.tag_PrintableString, US_ASCII);
     }
 
     /**
      * Marshals a string as a DER encoded T61String.
      */
-    public void putT61String(String s) throws IOException {
+    public DerOutputStream putT61String(String s) throws IOException {
         /*
          * Works for characters that are defined in both ASCII and
          * T61.
          */
-        writeString(s, DerValue.tag_T61String, ISO_8859_1);
+        return writeString(s, DerValue.tag_T61String, ISO_8859_1);
     }
 
     /**
      * Marshals a string as a DER encoded IA5String.
      */
-    public void putIA5String(String s) throws IOException {
-        writeString(s, DerValue.tag_IA5String, US_ASCII);
+    public DerOutputStream putIA5String(String s) throws IOException {
+        return writeString(s, DerValue.tag_IA5String, US_ASCII);
     }
 
     /**
      * Marshals a string as a DER encoded BMPString.
      */
-    public void putBMPString(String s) throws IOException {
-        writeString(s, DerValue.tag_BMPString, UTF_16BE);
+    public DerOutputStream putBMPString(String s) throws IOException {
+        return writeString(s, DerValue.tag_BMPString, UTF_16BE);
     }
 
     /**
      * Marshals a string as a DER encoded GeneralString.
      */
-    public void putGeneralString(String s) throws IOException {
-        writeString(s, DerValue.tag_GeneralString, US_ASCII);
+    public DerOutputStream putGeneralString(String s) throws IOException {
+        return writeString(s, DerValue.tag_GeneralString, US_ASCII);
     }
 
     /**
@@ -464,13 +481,14 @@ extends ByteArrayOutputStream implements DerEncoder {
      * @param charset the charset that should be used corresponding to
      * the above tag.
      */
-    private void writeString(String s, byte stringTag, Charset charset)
+    private DerOutputStream writeString(String s, byte stringTag, Charset charset)
         throws IOException {
 
         byte[] data = s.getBytes(charset);
         write(stringTag);
         putLength(data.length);
         write(data);
+        return this;
     }
 
     /**
@@ -479,8 +497,8 @@ extends ByteArrayOutputStream implements DerEncoder {
      * <P>YYMMDDhhmmss{Z|+hhmm|-hhmm} ... emits only using Zulu time
      * and with seconds (even if seconds=0) as per RFC 5280.
      */
-    public void putUTCTime(Date d) throws IOException {
-        putTime(d, DerValue.tag_UtcTime);
+    public DerOutputStream putUTCTime(Date d) throws IOException {
+        return putTime(d, DerValue.tag_UtcTime);
     }
 
     /**
@@ -489,8 +507,8 @@ extends ByteArrayOutputStream implements DerEncoder {
      * <P>YYYYMMDDhhmmss{Z|+hhmm|-hhmm} ... emits only using Zulu time
      * and with seconds (even if seconds=0) as per RFC 5280.
      */
-    public void putGeneralizedTime(Date d) throws IOException {
-        putTime(d, DerValue.tag_GeneralizedTime);
+    public DerOutputStream putGeneralizedTime(Date d) throws IOException {
+        return putTime(d, DerValue.tag_GeneralizedTime);
     }
 
     /**
@@ -500,7 +518,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      * @param d the date to be marshalled
      * @param tag the tag for UTC Time or Generalized Time
      */
-    private void putTime(Date d, byte tag) throws IOException {
+    private DerOutputStream putTime(Date d, byte tag) throws IOException {
 
         /*
          * Format the date.
@@ -527,6 +545,7 @@ extends ByteArrayOutputStream implements DerEncoder {
         write(tag);
         putLength(time.length);
         write(time);
+        return this;
     }
 
     /**
@@ -564,23 +583,6 @@ extends ByteArrayOutputStream implements DerEncoder {
     }
 
     /**
-     * Put the tag of the attribute in the stream.
-     *
-     * @param tagClass the tag class type, one of UNIVERSAL, CONTEXT,
-     *        APPLICATION or PRIVATE
-     * @param form if true, the value is constructed, otherwise it is
-     * primitive.
-     * @param val the tag value
-     */
-    public void putTag(byte tagClass, boolean form, byte val) {
-        byte tag = (byte)(tagClass | val);
-        if (form) {
-            tag |= (byte)0x20;
-        }
-        write(tag);
-    }
-
-    /**
      *  Write the current contents of this <code>DerOutputStream</code>
      *  to an <code>OutputStream</code>.
      *
@@ -588,6 +590,16 @@ extends ByteArrayOutputStream implements DerEncoder {
      */
     public void derEncode(OutputStream out) throws IOException {
         out.write(toByteArray());
+    }
+
+    /**
+     * Write a DerEncoder onto the output stream.
+     * @param encoder the DerEncoder
+     * @throws IOException on output error
+     */
+    public DerOutputStream write(DerEncoder encoder) throws IOException {
+        encoder.derEncode(this);
+        return this;
     }
 
     byte[] buf() {

--- a/src/java.base/share/classes/sun/security/util/DerOutputStream.java
+++ b/src/java.base/share/classes/sun/security/util/DerOutputStream.java
@@ -290,8 +290,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      * @param ba the bit string, MSB first
      */
     public DerOutputStream putTruncatedUnalignedBitString(BitArray ba) throws IOException {
-        putUnalignedBitString(ba.truncate());
-        return this;
+        return putUnalignedBitString(ba.truncate());
     }
 
     /**
@@ -300,8 +299,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      * @param octets the octet string
      */
     public DerOutputStream putOctetString(byte[] octets) throws IOException {
-        write(DerValue.tag_OctetString, octets);
-        return this;
+        return write(DerValue.tag_OctetString, octets);
     }
 
     /**
@@ -335,8 +333,7 @@ extends ByteArrayOutputStream implements DerEncoder {
         for (i = 0; i < seq.length; i++)
             seq[i].encode(bytes);
 
-        write(DerValue.tag_Sequence, bytes);
-        return this;
+        return write(DerValue.tag_Sequence, bytes);
     }
 
     /**
@@ -353,8 +350,7 @@ extends ByteArrayOutputStream implements DerEncoder {
         for (i = 0; i < set.length; i++)
             set[i].encode(bytes);
 
-        write(DerValue.tag_Set, bytes);
-        return this;
+        return write(DerValue.tag_Set, bytes);
     }
 
     /**
@@ -423,8 +419,7 @@ extends ByteArrayOutputStream implements DerEncoder {
         for (int i = 0; i < streams.length; i++) {
             bytes.write(bufs[i]);
         }
-        write(tag, bytes);
-        return this;
+        return write(tag, bytes);
     }
 
     /**


### PR DESCRIPTION
Return `this` in various output methods so you can write something like
```
        new DerOutputStream().putInteger(1)
                .putOctetString("12345".getBytes(StandardCharsets.UTF_8))
                .write(AlgorithmId.get("ed25519"))
                .writeImplicit((byte)0x80, new DerOutputStream().putUnalignedBitString(ba)).toByteArray();
```
No regression test. Trivial pure enhancement.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294987](https://bugs.openjdk.org/browse/JDK-8294987): Streamline DerOutputStream write


### Reviewers
 * [Jamil Nimeh](https://openjdk.org/census#jnimeh) (@jnimeh - **Reviewer**) ⚠️ Review applies to [298f5f20](https://git.openjdk.org/jdk/pull/10608/files/298f5f20745c4c869b7c53eef1ada06b8296403c)
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10608/head:pull/10608` \
`$ git checkout pull/10608`

Update a local copy of the PR: \
`$ git checkout pull/10608` \
`$ git pull https://git.openjdk.org/jdk pull/10608/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10608`

View PR using the GUI difftool: \
`$ git pr show -t 10608`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10608.diff">https://git.openjdk.org/jdk/pull/10608.diff</a>

</details>
