### PR TITLE
8294956: GHA: qemu-debootstrap is deprecated, use the regular one

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: 'Create sysroot'
         run: >
-          sudo qemu-debootstrap
+          sudo debootstrap
           --arch=${{ matrix.debian-arch }}
           --verbose
           --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev


### PR DESCRIPTION
On current Ubuntu systems, qemu-debootstrap is deprecated. It prints the warning messages like:

```
$ sudo qemu-debootstrap --arch=arm64 --verbose --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev --resolve-deps bullseye aarch64-sysroot https://httpredir.debian.org/debian/
...
W: qemu-debootstrap is deprecated. Please use regular debootstrap directly
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294956](https://bugs.openjdk.org/browse/JDK-8294956): GHA: qemu-debootstrap is deprecated, use the regular one


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10610/head:pull/10610` \
`$ git checkout pull/10610`

Update a local copy of the PR: \
`$ git checkout pull/10610` \
`$ git pull https://git.openjdk.org/jdk pull/10610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10610`

View PR using the GUI difftool: \
`$ git pr show -t 10610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10610.diff">https://git.openjdk.org/jdk/pull/10610.diff</a>

</details>
