### PR TITLE
8294993: LingeredApp test update

### DIFF
--- a/test/lib/jdk/test/lib/apps/LingeredApp.java
+++ b/test/lib/jdk/test/lib/apps/LingeredApp.java
@@ -450,13 +450,16 @@ public class LingeredApp {
             theApp.runAppExactJvmOpts(jvmOpts);
             theApp.waitAppReadyOrCrashed();
         } catch (Exception ex) {
-            boolean alive = theApp.getProcess().isAlive();
+            boolean alive = theApp.getProcess() != null && theApp.getProcess().isAlive();
             System.out.println("LingeredApp failed to start or failed to crash. isAlive=" + alive + ": " + ex);
             // stopApp in case it is still alive, may be able to get output:
-            theApp.stopApp();
-            //if (!alive) {
-            //    theApp.finishApp(); // Cannot call getOutput() if still alive
-            //}
+            if (alive) {
+                theApp.stopApp();
+            }
+            alive = theApp.getProcess() != null && theApp.getProcess().isAlive();
+            if (!alive) {
+                theApp.finishApp(); // Calls getOutput(), fails if still alive
+            }
             theApp.deleteLock();
             throw ex;
         } finally {

--- a/test/lib/jdk/test/lib/apps/LingeredApp.java
+++ b/test/lib/jdk/test/lib/apps/LingeredApp.java
@@ -475,7 +475,7 @@ public class LingeredApp {
         int count = 0;
         FilenameFilter filter = (dir, file) -> (file.startsWith("hs_err_pid") || file.startsWith("core") || file.endsWith("mdmp"));
         for (File f : new File(".").listFiles(filter)) {
-            System.out.println(f);
+            System.out.println(f + " " + f.length() + " bytes");
             count++;
         }
         if (count == 0) {

--- a/test/lib/jdk/test/lib/apps/LingeredApp.java
+++ b/test/lib/jdk/test/lib/apps/LingeredApp.java
@@ -280,9 +280,9 @@ public class LingeredApp {
                 }
             }
 
-            long epoch = epoch();
-            if (epoch - here > timeout) {
-                throw new IOException("Timeout: app not started or crashed in " + timeout + "ms");
+            long timeTaken = epoch() - here;
+            if (timeTaken > timeout) {
+                throw new IOException("Timeout: app not started or crashed in " + timeTaken + "ms");
             }
 
             // Live process should touch lock file every second
@@ -461,7 +461,7 @@ public class LingeredApp {
             throw ex;
         } finally {
             long t2 = System.currentTimeMillis();
-            System.out.println("Starting LingeredApp took " + (t2 - t1) + "ms");
+            System.out.println("LingeredApp startup took " + (t2 - t1) + "ms");
             checkForDumps();
         }
     }

--- a/test/lib/jdk/test/lib/apps/LingeredApp.java
+++ b/test/lib/jdk/test/lib/apps/LingeredApp.java
@@ -270,8 +270,7 @@ public class LingeredApp {
         timeout = Utils.adjustTimeout(timeout) * 1000;
         long here = epoch();
         while (true) {
-            // Make sure process didn't already exit:
-            // check this now, and immediately after sleeping for spinDelay each loop.
+            // Check for crash or lock modification now, and immediately after sleeping for spinDelay each loop.
             if (!appProcess.isAlive()) {
                 if (forceCrash) {
                     return; // This is expected. Just return.
@@ -280,17 +279,16 @@ public class LingeredApp {
                 }
             }
 
-            long timeTaken = epoch() - here;
-            if (timeTaken > timeout) {
-                throw new IOException("Timeout: app not started or crashed in " + timeTaken + "ms");
-            }
-
             // Live process should touch lock file every second
             long lm = lastModified(lockFileName);
             if (lm > lockCreationTime) {
                 break;
             }
 
+            long timeTaken = epoch() - here;
+            if (timeTaken > timeout) {
+                throw new IOException("Timeout: app not started or crashed in " + timeTaken + "ms");
+            }
             try {
                 Thread.sleep(spinDelay);
             } catch (InterruptedException ex) {

--- a/test/lib/jdk/test/lib/apps/LingeredApp.java
+++ b/test/lib/jdk/test/lib/apps/LingeredApp.java
@@ -475,7 +475,8 @@ public class LingeredApp {
         int count = 0;
         FilenameFilter filter = (dir, file) -> (file.startsWith("hs_err_pid") || file.startsWith("core") || file.endsWith("mdmp"));
         for (File f : new File(".").listFiles(filter)) {
-            System.out.println(f + " " + f.length() + " bytes");
+            long fileSize = f.length();
+            System.out.println(f + " " + (fileSize / 1024 / 1024) + "mb (" + fileSize + " bytes)");
             count++;
         }
         if (count == 0) {

--- a/test/lib/jdk/test/lib/util/CoreUtils.java
+++ b/test/lib/jdk/test/lib/util/CoreUtils.java
@@ -113,8 +113,11 @@ public class CoreUtils {
             Asserts.assertGT(coreFileSize, 0L, "Unexpected core size");
 
             // Make sure the core file is moved into the cwd if not already there.
+            // Core/minidump usually created in current directory (Linux and Windows).
             Path corePath = Paths.get(coreFileLocation);
-            if (corePath.getParent() != null) {
+            File parent = new File(coreFileLocation).getParentFile();
+            File cwdParent = new File(".").getAbsoluteFile().getParentFile();
+            if (parent != null && !parent.equals(cwdParent)) {
                 Path coreFileName = corePath.getFileName();
                 System.out.println("Moving core file to cwd: " +  coreFileName);
                 long startTime = System.currentTimeMillis();


### PR DESCRIPTION
There are a few changes we can make to better understand the LingeredApp test when it goes wrong:

startAppExactJvmOpts() should not try and call finishApp unless the process isAlive, that just creates a misleading exception.

waitAppReady() is really waitAppReadyOrCrashed(), and should not timeout immediately after the 1 second sleep, or we lose a second of our timeout value (not critical with a long timeout, but seems more honest).

Show how long we waited when startup/crashing times out.

Show how long a good startup takes, so we have a basic for comparison when it fails.

Show if there are hs_err/core/mdmp files in the working directory after startup/crash attempt.

Also, in open/test/lib/jdk/test/lib/util/CoreUtils.java:

"Move core file" often seems unnecessary, core/mdmp usually being created in the current directory. But getCoreFileLocation() performs Files.move() which takes enough time to not be a no-op.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294993](https://bugs.openjdk.org/browse/JDK-8294993): LingeredApp test update


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10613/head:pull/10613` \
`$ git checkout pull/10613`

Update a local copy of the PR: \
`$ git checkout pull/10613` \
`$ git pull https://git.openjdk.org/jdk pull/10613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10613`

View PR using the GUI difftool: \
`$ git pr show -t 10613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10613.diff">https://git.openjdk.org/jdk/pull/10613.diff</a>

</details>
