### PR TITLE
8294997: Improve ECC math operations

### DIFF
--- a/make/jdk/src/classes/build/tools/intpoly/FieldGen.java
+++ b/make/jdk/src/classes/build/tools/intpoly/FieldGen.java
@@ -246,8 +246,7 @@ public class FieldGen {
         }
 
         public BigInteger getValue() {
-            return BigInteger.valueOf(2).pow(power)
-                    .multiply(BigInteger.valueOf(coefficient));
+            return BigInteger.valueOf(coefficient).shiftLeft(power);
         }
 
         public String toString() {
@@ -663,14 +662,12 @@ public class FieldGen {
                 subtract = true;
             }
             String coefExpr = "BigInteger.valueOf(" + coefValue + ")";
-            String powExpr = "BigInteger.valueOf(2).pow(" + t.getPower() + ")";
+            String powExpr = ".shiftLeft(" + t.getPower() + ")";
             String termExpr = "ERROR";
             if (t.getPower() == 0) {
                 termExpr = coefExpr;
-            } else if (coefValue == 1) {
-                termExpr = powExpr;
             } else {
-                termExpr = powExpr + ".multiply(" + coefExpr + ")";
+                termExpr = coefExpr + powExpr;
             }
             if (subtract) {
                 result.appendLine("result = result.subtract(" + termExpr + ");");

--- a/src/java.base/share/classes/sun/security/provider/DSAParameterGenerator.java
+++ b/src/java.base/share/classes/sun/security/provider/DSAParameterGenerator.java
@@ -235,15 +235,15 @@ public class DSAParameterGenerator extends AlgorithmParameterGeneratorSpi {
                 /* Step 11.2 */
                 BigInteger W = V[0];
                 for (int i = 1; i < n; i++) {
-                    W = W.add(V[i].multiply(BigInteger.TWO.pow(i * outLen)));
+                    W = W.add(V[i].shiftLeft(i * outLen));
                 }
                 W = W.add((V[n].mod(BigInteger.TWO.pow(b)))
-                               .multiply(BigInteger.TWO.pow(n * outLen)));
+                               .shiftLeft(n * outLen));
                 /* Step 11.3 */
                 BigInteger twoLm1 = BigInteger.TWO.pow(valueL - 1);
                 BigInteger X = W.add(twoLm1);
                 /* Step 11.4, 11.5 */
-                BigInteger c = X.mod(resultQ.multiply(BigInteger.TWO));
+                BigInteger c = X.mod(resultQ.shiftLeft(1));
                 resultP = X.subtract(c.subtract(BigInteger.ONE));
                 /* Step 11.6, 11.7 */
                 if (resultP.compareTo(twoLm1) > -1

--- a/src/java.base/share/classes/sun/security/provider/DSAParameterGenerator.java
+++ b/src/java.base/share/classes/sun/security/provider/DSAParameterGenerator.java
@@ -235,15 +235,15 @@ public class DSAParameterGenerator extends AlgorithmParameterGeneratorSpi {
                 /* Step 11.2 */
                 BigInteger W = V[0];
                 for (int i = 1; i < n; i++) {
-                    W = W.add(V[i].shiftLeft(i * outLen));
+                    W = W.add(V[i].multiply(BigInteger.TWO.pow(i * outLen)));
                 }
                 W = W.add((V[n].mod(BigInteger.TWO.pow(b)))
-                               .shiftLeft(n * outLen));
+                               .multiply(BigInteger.TWO.pow(n * outLen)));
                 /* Step 11.3 */
                 BigInteger twoLm1 = BigInteger.TWO.pow(valueL - 1);
                 BigInteger X = W.add(twoLm1);
                 /* Step 11.4, 11.5 */
-                BigInteger c = X.mod(resultQ.shiftLeft(1));
+                BigInteger c = X.mod(resultQ.multiply(BigInteger.TWO));
                 resultP = X.subtract(c.subtract(BigInteger.ONE));
                 /* Step 11.6, 11.7 */
                 if (resultP.compareTo(twoLm1) > -1

--- a/src/java.base/share/classes/sun/security/util/math/intpoly/IntegerPolynomial.java
+++ b/src/java.base/share/classes/sun/security/util/math/intpoly/IntegerPolynomial.java
@@ -329,9 +329,10 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
     }
 
     protected void setLimbsValuePositive(BigInteger v, long[] limbs) {
-        BigInteger mod = BigInteger.valueOf(1 << bitsPerLimb);
+        assert bitsPerLimb < 32;
+        long limbMask = (1L << bitsPerLimb) - 1;
         for (int i = 0; i < limbs.length; i++) {
-            limbs[i] = v.mod(mod).longValue();
+            limbs[i] = v.intValue() & limbMask;
             v = v.shiftRight(bitsPerLimb);
         }
     }

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECOperations.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECOperations.java
@@ -304,25 +304,28 @@ public class ECOperations {
         p.getY().setValue(t2).setProduct(b);
         p.getY().setDifference(p.getZ());
 
-        p.getX().setValue(p.getY()).setProduct(two);
-        p.getY().setSum(p.getX());
-        p.getY().setReduced();
+//        p.getX().setValue(p.getY()).setProduct(two);
+//        p.getY().setSum(p.getX());
+//        p.getY().setReduced();
+        p.getY().setProduct(three);
         p.getX().setValue(t1).setDifference(p.getY());
 
         p.getY().setSum(t1);
         p.getY().setProduct(p.getX());
         p.getX().setProduct(t3);
 
-        t3.setValue(t2).setProduct(two);
-        t2.setSum(t3);
+//        t3.setValue(t2).setProduct(two);
+//        t2.setSum(t3);
+//        t2.setReduced();
+        t2.setProduct(three);
         p.getZ().setProduct(b);
 
-        t2.setReduced();
         p.getZ().setDifference(t2);
         p.getZ().setDifference(t0);
-        t3.setValue(p.getZ()).setProduct(two);
-        p.getZ().setReduced();
-        p.getZ().setSum(t3);
+//        t3.setValue(p.getZ()).setProduct(two);
+//        p.getZ().setReduced();
+//        p.getZ().setSum(t3);
+        p.getZ().setProduct(three);
         t0.setProduct(three);
 
         t0.setDifference(t2);
@@ -382,26 +385,30 @@ public class ECOperations {
         p.getZ().setProduct(b);
 
         p.getX().setValue(p.getY()).setDifference(p.getZ());
-        p.getX().setReduced();
-        p.getZ().setValue(p.getX()).setProduct(two);
-        p.getX().setSum(p.getZ());
+//        p.getX().setReduced();
+//        p.getZ().setValue(p.getX()).setProduct(two);
+//        p.getX().setSum(p.getZ());
+        p.getX().setProduct(three);
 
         p.getZ().setValue(t1).setDifference(p.getX());
         p.getX().setSum(t1);
         p.getY().setProduct(b);
 
-        t1.setValue(t2).setProduct(two);
-        t2.setSum(t1);
-        t2.setReduced();
+//        t1.setValue(t2).setProduct(two);
+//        t2.setSum(t1);
+//        t2.setReduced();
+        t2.setProduct(three);
         p.getY().setDifference(t2);
 
         p.getY().setDifference(t0);
-        p.getY().setReduced();
-        t1.setValue(p.getY()).setProduct(two);
-        p.getY().setSum(t1);
+//        p.getY().setReduced();
+//        t1.setValue(p.getY()).setProduct(two);
+//        p.getY().setSum(t1);
+        p.getY().setProduct(three);
 
-        t1.setValue(t0).setProduct(two);
-        t0.setSum(t1);
+//        t1.setValue(t0).setProduct(two);
+//        t0.setSum(t1);
+        t0.setProduct(three);
         t0.setDifference(t2);
 
         t1.setValue(t4).setProduct(p.getY());
@@ -413,8 +420,10 @@ public class ECOperations {
         p.getX().setDifference(t1);
 
         p.getZ().setProduct(t4);
-        t1.setValue(t3).setProduct(t0);
-        p.getZ().setSum(t1);
+//        t1.setValue(t3).setProduct(t0);
+//        p.getZ().setSum(t1);
+        t3.setProduct(t0);
+        p.getZ().setSum(t3);
 
     }
 
@@ -453,26 +462,31 @@ public class ECOperations {
 
         p.getZ().setValue(t2).setProduct(b);
         p.getX().setValue(p.getY()).setDifference(p.getZ());
-        p.getZ().setValue(p.getX()).setProduct(two);
 
-        p.getX().setSum(p.getZ());
-        p.getX().setReduced();
+//        p.getZ().setValue(p.getX()).setProduct(two);
+//        p.getX().setSum(p.getZ());
+//        p.getX().setReduced();
+        p.getX().setProduct(three);
+
         p.getZ().setValue(t1).setDifference(p.getX());
         p.getX().setSum(t1);
 
         p.getY().setProduct(b);
-        t1.setValue(t2).setSum(t2);
-        t2.setSum(t1);
-        t2.setReduced();
+//        t1.setValue(t2).setSum(t2);
+//        t2.setSum(t1);
+//        t2.setReduced();
+        t2.setProduct(three);
 
         p.getY().setDifference(t2);
         p.getY().setDifference(t0);
-        p.getY().setReduced();
-        t1.setValue(p.getY()).setSum(p.getY());
+//        p.getY().setReduced();
+//        t1.setValue(p.getY()).setSum(p.getY());
+//        p.getY().setSum(t1);
+        p.getY().setProduct(three);
 
-        p.getY().setSum(t1);
-        t1.setValue(t0).setProduct(two);
-        t0.setSum(t1);
+//        t1.setValue(t0).setProduct(two);
+//        t0.setSum(t1);
+        t0.setProduct(three);
 
         t0.setDifference(t2);
         t1.setValue(t4).setProduct(p.getY());
@@ -484,9 +498,11 @@ public class ECOperations {
 
         p.getX().setDifference(t1);
         p.getZ().setProduct(t4);
-        t1.setValue(t3).setProduct(t0);
 
-        p.getZ().setSum(t1);
+//        t1.setValue(t3).setProduct(t0);
+//        p.getZ().setSum(t1);
+        t3.setProduct(t0);
+        p.getZ().setSum(t3);
 
     }
 }

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECOperations.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECOperations.java
@@ -304,9 +304,6 @@ public class ECOperations {
         p.getY().setValue(t2).setProduct(b);
         p.getY().setDifference(p.getZ());
 
-//        p.getX().setValue(p.getY()).setProduct(two);
-//        p.getY().setSum(p.getX());
-//        p.getY().setReduced();
         p.getY().setProduct(three);
         p.getX().setValue(t1).setDifference(p.getY());
 
@@ -314,17 +311,11 @@ public class ECOperations {
         p.getY().setProduct(p.getX());
         p.getX().setProduct(t3);
 
-//        t3.setValue(t2).setProduct(two);
-//        t2.setSum(t3);
-//        t2.setReduced();
         t2.setProduct(three);
         p.getZ().setProduct(b);
 
         p.getZ().setDifference(t2);
         p.getZ().setDifference(t0);
-//        t3.setValue(p.getZ()).setProduct(two);
-//        p.getZ().setReduced();
-//        p.getZ().setSum(t3);
         p.getZ().setProduct(three);
         t0.setProduct(three);
 
@@ -385,29 +376,18 @@ public class ECOperations {
         p.getZ().setProduct(b);
 
         p.getX().setValue(p.getY()).setDifference(p.getZ());
-//        p.getX().setReduced();
-//        p.getZ().setValue(p.getX()).setProduct(two);
-//        p.getX().setSum(p.getZ());
         p.getX().setProduct(three);
 
         p.getZ().setValue(t1).setDifference(p.getX());
         p.getX().setSum(t1);
         p.getY().setProduct(b);
 
-//        t1.setValue(t2).setProduct(two);
-//        t2.setSum(t1);
-//        t2.setReduced();
         t2.setProduct(three);
         p.getY().setDifference(t2);
 
         p.getY().setDifference(t0);
-//        p.getY().setReduced();
-//        t1.setValue(p.getY()).setProduct(two);
-//        p.getY().setSum(t1);
         p.getY().setProduct(three);
 
-//        t1.setValue(t0).setProduct(two);
-//        t0.setSum(t1);
         t0.setProduct(three);
         t0.setDifference(t2);
 
@@ -420,8 +400,6 @@ public class ECOperations {
         p.getX().setDifference(t1);
 
         p.getZ().setProduct(t4);
-//        t1.setValue(t3).setProduct(t0);
-//        p.getZ().setSum(t1);
         t3.setProduct(t0);
         p.getZ().setSum(t3);
 
@@ -463,29 +441,18 @@ public class ECOperations {
         p.getZ().setValue(t2).setProduct(b);
         p.getX().setValue(p.getY()).setDifference(p.getZ());
 
-//        p.getZ().setValue(p.getX()).setProduct(two);
-//        p.getX().setSum(p.getZ());
-//        p.getX().setReduced();
         p.getX().setProduct(three);
 
         p.getZ().setValue(t1).setDifference(p.getX());
         p.getX().setSum(t1);
 
         p.getY().setProduct(b);
-//        t1.setValue(t2).setSum(t2);
-//        t2.setSum(t1);
-//        t2.setReduced();
         t2.setProduct(three);
 
         p.getY().setDifference(t2);
         p.getY().setDifference(t0);
-//        p.getY().setReduced();
-//        t1.setValue(p.getY()).setSum(p.getY());
-//        p.getY().setSum(t1);
         p.getY().setProduct(three);
 
-//        t1.setValue(t0).setProduct(two);
-//        t0.setSum(t1);
         t0.setProduct(three);
 
         t0.setDifference(t2);
@@ -499,8 +466,6 @@ public class ECOperations {
         p.getX().setDifference(t1);
         p.getZ().setProduct(t4);
 
-//        t1.setValue(t3).setProduct(t0);
-//        p.getZ().setSum(t1);
         t3.setProduct(t0);
         p.getZ().setSum(t3);
 

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/Ed25519Operations.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/Ed25519Operations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/Ed25519Operations.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/Ed25519Operations.java
@@ -137,7 +137,7 @@ public class Ed25519Operations extends EdECOperations {
             throw exception.apply("Invalid point");
         }
 
-        if (xLSB != x.asBigInteger().mod(BigInteger.valueOf(2)).intValue()) {
+        if (xLSB != (x.asBigInteger().intValue() & 1)) {
             x.setAdditiveInverse();
         }
 

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/Ed448Operations.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/Ed448Operations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/Ed448Operations.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/Ed448Operations.java
@@ -127,7 +127,7 @@ public class Ed448Operations extends EdECOperations {
             throw exception.apply("Invalid point");
         }
 
-        if (xLSB != x.asBigInteger().mod(TWO).intValue()) {
+        if (xLSB != (x.asBigInteger().intValue() & 1)) {
             x.setAdditiveInverse();
         }
 


### PR DESCRIPTION
This patch rewrites some BigInteger and curve point operations used in EC calculations:
- coefficient * 2^power is equivalent to coefficient << power
- number mod 2^n is equivalent to number & (2^n-1)
- pair of IntegerModuloP operations:
t2 = t1+t1
t1 = t1+t2
is equivalent to t1=t1*3, which is now implemented more efficiently.

Benchmarked the code using not-yet-merged benchmark from #10544. Results on x64 before:
```
Benchmark        (messageLength)   Mode  Cnt     Score   Error  Units
Signatures.sign               64  thrpt   15  1578.907 ± 1.522  ops/s
```
After:
```
Benchmark        (messageLength)   Mode  Cnt     Score   Error  Units
Signatures.sign               64  thrpt   15  1679.495 ± 3.883  ops/s
```
Greatest part of the improvement is related to ECOperations changes; BigInteger modifications provide only marginal gains (1584 ops/s without ECOperations changes).

Tier1-3 tests continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294997](https://bugs.openjdk.org/browse/JDK-8294997): Improve ECC math operations


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10614/head:pull/10614` \
`$ git checkout pull/10614`

Update a local copy of the PR: \
`$ git checkout pull/10614` \
`$ git pull https://git.openjdk.org/jdk pull/10614/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10614`

View PR using the GUI difftool: \
`$ git pr show -t 10614`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10614.diff">https://git.openjdk.org/jdk/pull/10614.diff</a>

</details>
