### PR TITLE
8295003: Do not mention applets in the "java.awt.color" package

### DIFF
--- a/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
@@ -71,10 +71,10 @@ import sun.java2d.cmm.PCMM;
  * color space (e.g. {@code TYPE_RGB}, {@code TYPE_CMYK}, etc.), but the
  * specific color values of the output data will be undefined.
  * <p>
- * The details of this class are not important for simple applets, which draw in
- * a default color space or manipulate and display imported images with a known
- * color space. At most, such applets would need to get one of the default color
- * spaces via {@link ColorSpace#getInstance}.
+ * The details of this class are not important for simple applications, which
+ * draw in a default color space or manipulate and display imported images with
+ * a known color space. At most, such applications would need to get one of the
+ * default color spaces via {@link ColorSpace#getInstance}.
  *
  * @see ColorSpace
  * @see ICC_Profile

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1073,8 +1073,8 @@ public sealed class ICC_Profile implements Serializable
      * Returns a particular tagged data element from the profile as a byte
      * array. Elements are identified by signatures as defined in the ICC
      * specification. The signature icSigHead can be used to get the header.
-     * This method is useful for advanced applets or applications which need to
-     * access profile data directly.
+     * This method is useful for advanced applications which need to access
+     * profile data directly.
      *
      * @param  tagSignature the ICC tag signature for the data element you want
      *         to get
@@ -1099,8 +1099,8 @@ public sealed class ICC_Profile implements Serializable
      * Sets a particular tagged data element in the profile from a byte array.
      * The array should contain data in a format, corresponded to the
      * {@code tagSignature} as defined in the ICC specification, section 10.
-     * This method is useful for advanced applets or applications which need to
-     * access profile data directly.
+     * This method is useful for advanced applications which need to access
+     * profile data directly.
      *
      * @param  tagSignature the ICC tag signature for the data element you want
      *         to set


### PR DESCRIPTION
The usage of "applets" are replaced by the "applications" in the "java.awt.color" package.
If there are no objections I'll skip the CSR for this small cleanup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295003](https://bugs.openjdk.org/browse/JDK-8295003): Do not mention applets in the "java.awt.color" package


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10616/head:pull/10616` \
`$ git checkout pull/10616`

Update a local copy of the PR: \
`$ git checkout pull/10616` \
`$ git pull https://git.openjdk.org/jdk pull/10616/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10616`

View PR using the GUI difftool: \
`$ git pr show -t 10616`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10616.diff">https://git.openjdk.org/jdk/pull/10616.diff</a>

</details>
