### PR TITLE
8295005: compiler/loopopts/TestRemoveEmptyLoop.java fails with release VMs after JDK-8294839

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyLoop.java
@@ -27,6 +27,7 @@
  * @bug 8231988 8293996
  * @summary Unexpected test result caused by C2 IdealLoopTree::do_remove_empty_loop
  *
+ * @requires vm.debug == true
  * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation
  *      -XX:StressLongCountedLoop=0
  *      compiler.loopopts.TestRemoveEmptyLoop

--- a/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyLoop.java
@@ -27,9 +27,8 @@
  * @bug 8231988 8293996
  * @summary Unexpected test result caused by C2 IdealLoopTree::do_remove_empty_loop
  *
- * @requires vm.debug == true
  * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation
- *      -XX:StressLongCountedLoop=0
+ *      -XX:+IgnoreUnrecognizedVMOptions -XX:StressLongCountedLoop=0
  *      compiler.loopopts.TestRemoveEmptyLoop
  */
 


### PR DESCRIPTION
Since we need to set `-XX:StressLongCountedLoop=0` to avoid timeout of the test.
So only run it with debug VMs.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295005](https://bugs.openjdk.org/browse/JDK-8295005): compiler/loopopts/TestRemoveEmptyLoop.java fails with release VMs after JDK-8294839


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10617/head:pull/10617` \
`$ git checkout pull/10617`

Update a local copy of the PR: \
`$ git checkout pull/10617` \
`$ git pull https://git.openjdk.org/jdk pull/10617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10617`

View PR using the GUI difftool: \
`$ git pr show -t 10617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10617.diff">https://git.openjdk.org/jdk/pull/10617.diff</a>

</details>
