### PR TITLE
8295007: javax/swing/JRadioButton/4314194/bug4314194.java fails in mach5 for WIndowLookAndFeel

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -665,6 +665,7 @@ javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all
 javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 javax/swing/plaf/aqua/CustomComboBoxFocusTest.java 8294254 macosx-all
+javax/swing/JRadioButton/4314194/bug4314194.java 8295006 linux-all
 
 # Several tests which fail on some hidpi systems/macosx12-aarch64 system
 java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64

--- a/test/jdk/javax/swing/JRadioButton/4314194/bug4314194.java
+++ b/test/jdk/javax/swing/JRadioButton/4314194/bug4314194.java
@@ -50,7 +50,7 @@ public class bug4314194 {
     private static Robot robot;
     private static final Color radioButtonColor = Color.RED;
     private static final Color checkboxColor = Color.GREEN;
-    private static final int tolerance = 20;
+    private static final int tolerance = 10;
 
     private static boolean checkComponent(Component comp, Color c) throws Exception {
         int correctColoredPixels = 0;
@@ -72,6 +72,7 @@ public class bug4314194 {
             totalPixels++;
         }
 
+        System.out.println("correctColoredPixels " + correctColoredPixels + " totalPixels " + totalPixels);
         return ((double)correctColoredPixels/totalPixels*100) >= tolerance;
     }
 

--- a/test/jdk/javax/swing/JRadioButton/4314194/bug4314194.java
+++ b/test/jdk/javax/swing/JRadioButton/4314194/bug4314194.java
@@ -50,7 +50,7 @@ public class bug4314194 {
     private static Robot robot;
     private static final Color radioButtonColor = Color.RED;
     private static final Color checkboxColor = Color.GREEN;
-    private static final int tolerance = 10;
+    private static final int tolerance = 20;
 
     private static boolean checkComponent(Component comp, Color c) throws Exception {
         int correctColoredPixels = 0;
@@ -91,8 +91,8 @@ public class bug4314194 {
         UIManager.getDefaults().put("CheckBox.disabledText", checkboxColor);
         UIManager.getDefaults().put("RadioButton.disabledText", radioButtonColor);
 
-        checkBox = new JCheckBox("WWWWW");
-        radioButton = new JRadioButton("WWWWW");
+        checkBox = new JCheckBox("\u2588".repeat(5));
+        radioButton = new JRadioButton("\u2588".repeat(5));
         checkBox.setFont(checkBox.getFont().deriveFont(50.0f));
         radioButton.setFont(radioButton.getFont().deriveFont(50.0f));
         checkBox.setEnabled(false);


### PR DESCRIPTION
javax/swing/JRadioButton/4314194/bug4314194.java correct color pixels pixel % varies between 30% for Metal to about 20% for Nimbus to about 19% for Windows L&F. But Nimbus in linux correct color pixel % falls to about 14%
so adjusted % tolerance check to 10
Also, JDK-8075916 is fixed for NimbusL&F but same issue is present for GTK L&F which is to be addressed separately as JDK-8295006 so problemlisted for now

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295007](https://bugs.openjdk.org/browse/JDK-8295007): javax/swing/JRadioButton/4314194/bug4314194.java fails in mach5 for WIndowLookAndFeel


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Author) ⚠️ Review applies to [a50ad3eb](https://git.openjdk.org/jdk/pull/10618/files/a50ad3ebf31377579d02aeebda693485a89b0ac2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10618/head:pull/10618` \
`$ git checkout pull/10618`

Update a local copy of the PR: \
`$ git checkout pull/10618` \
`$ git pull https://git.openjdk.org/jdk pull/10618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10618`

View PR using the GUI difftool: \
`$ git pr show -t 10618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10618.diff">https://git.openjdk.org/jdk/pull/10618.diff</a>

</details>
