### PR TITLE
8295016: Make the arraycopy_epilogue signature consistent with its usage

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.hpp
@@ -47,7 +47,7 @@ public:
   virtual void arraycopy_prologue(MacroAssembler* masm, DecoratorSet decorators, bool is_oop,
                                   Register src, Register dst, Register count, RegSet saved_regs) {}
   virtual void arraycopy_epilogue(MacroAssembler* masm, DecoratorSet decorators, bool is_oop,
-                                  Register start, Register end, Register tmp, RegSet saved_regs) {}
+                                  Register start, Register count, Register tmp, RegSet saved_regs) {}
   virtual void load_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                        Register dst, Address src, Register tmp1, Register tmp2);
   virtual void store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.hpp
@@ -48,7 +48,7 @@ public:
   virtual void arraycopy_prologue(MacroAssembler* masm, DecoratorSet decorators, bool is_oop,
                                   Register src, Register dst, Register count, RegSet saved_regs) {}
   virtual void arraycopy_epilogue(MacroAssembler* masm, DecoratorSet decorators, bool is_oop,
-                                  Register start, Register end, Register tmp, RegSet saved_regs) {}
+                                  Register start, Register count, Register tmp, RegSet saved_regs) {}
   virtual void load_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                        Register dst, Address src, Register tmp1, Register tmp2);
   virtual void store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,


### PR DESCRIPTION
The second register argument should be named `count`. Please see the following usage.

https://github.com/openjdk/jdk/blob/495c043533d68106e07721b2e971006e9eba97e3/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp#L1138

https://github.com/openjdk/jdk/blob/495c043533d68106e07721b2e971006e9eba97e3/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp#L1210

https://github.com/openjdk/jdk/blob/495c043533d68106e07721b2e971006e9eba97e3/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp#L1584

Update: also fix for AArch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295016](https://bugs.openjdk.org/browse/JDK-8295016): Make the arraycopy_epilogue signature consistent with its usage


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10620/head:pull/10620` \
`$ git checkout pull/10620`

Update a local copy of the PR: \
`$ git checkout pull/10620` \
`$ git pull https://git.openjdk.org/jdk pull/10620/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10620`

View PR using the GUI difftool: \
`$ git pr show -t 10620`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10620.diff">https://git.openjdk.org/jdk/pull/10620.diff</a>

</details>
