### PR TITLE
8295014: Remove unnecessary explicit casts to void* in CHeapObjBase

### DIFF
--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -177,49 +177,49 @@ void FreeHeap(void* p);
 class CHeapObjBase {
  public:
   ALWAYSINLINE void* operator new(size_t size, MEMFLAGS f) throw() {
-    return (void*)AllocateHeap(size, f);
+    return AllocateHeap(size, f);
   }
 
   ALWAYSINLINE void* operator new(size_t size,
                                   MEMFLAGS f,
                                   const NativeCallStack& stack) throw() {
-    return (void*)AllocateHeap(size, f, stack);
+    return AllocateHeap(size, f, stack);
   }
 
   ALWAYSINLINE void* operator new(size_t size,
                                   MEMFLAGS f,
                                   const std::nothrow_t&,
                                   const NativeCallStack& stack) throw() {
-    return (void*)AllocateHeap(size, f, stack, AllocFailStrategy::RETURN_NULL);
+    return AllocateHeap(size, f, stack, AllocFailStrategy::RETURN_NULL);
   }
 
   ALWAYSINLINE void* operator new(size_t size,
                                   MEMFLAGS f,
                                   const std::nothrow_t&) throw() {
-    return (void*)AllocateHeap(size, f, AllocFailStrategy::RETURN_NULL);
+    return AllocateHeap(size, f, AllocFailStrategy::RETURN_NULL);
   }
 
   ALWAYSINLINE void* operator new[](size_t size, MEMFLAGS f) throw() {
-    return (void*)AllocateHeap(size, f);
+    return AllocateHeap(size, f);
   }
 
   ALWAYSINLINE void* operator new[](size_t size,
                                     MEMFLAGS f,
                                     const NativeCallStack& stack) throw() {
-    return (void*)AllocateHeap(size, f, stack);
+    return AllocateHeap(size, f, stack);
   }
 
   ALWAYSINLINE void* operator new[](size_t size,
                                     MEMFLAGS f,
                                     const std::nothrow_t&,
                                     const NativeCallStack& stack) throw() {
-    return (void*)AllocateHeap(size, f, stack, AllocFailStrategy::RETURN_NULL);
+    return AllocateHeap(size, f, stack, AllocFailStrategy::RETURN_NULL);
   }
 
   ALWAYSINLINE void* operator new[](size_t size,
                                     MEMFLAGS f,
                                     const std::nothrow_t&) throw() {
-    return (void*)AllocateHeap(size, f, AllocFailStrategy::RETURN_NULL);
+    return AllocateHeap(size, f, AllocFailStrategy::RETURN_NULL);
   }
 
   void operator delete(void* p)     { FreeHeap(p); }


### PR DESCRIPTION
Please review this change to CHeapObjBase that removes unnecessary explicit
casts from char* to void*.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295014](https://bugs.openjdk.org/browse/JDK-8295014): Remove unnecessary explicit casts to void* in CHeapObjBase


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - Author)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10623/head:pull/10623` \
`$ git checkout pull/10623`

Update a local copy of the PR: \
`$ git checkout pull/10623` \
`$ git pull https://git.openjdk.org/jdk pull/10623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10623`

View PR using the GUI difftool: \
`$ git pr show -t 10623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10623.diff">https://git.openjdk.org/jdk/pull/10623.diff</a>

</details>
