### PR TITLE
8293833: Error mixing types with -XX:+UseCMoveUnconditionally -XX:+UseVectorCmov

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -1845,7 +1845,7 @@ void SuperWord::filter_packs() {
 }
 
 //------------------------------merge_packs_to_cmovd---------------------------
-// Merge CMoveD into new vector-nodes
+// Merge qualified CMoveD into new vector-nodes
 // We want to catch this pattern and subsume CmpD and Bool into CMoveD
 //
 //                   SubD             ConD
@@ -1867,11 +1867,28 @@ void SuperWord::filter_packs() {
 //                   \ v /
 //                   CMoveD
 //
+// Also clear unqualified CMove pack from the packset.
 
 void SuperWord::merge_packs_to_cmovd() {
   for (int i = _packset.length() - 1; i >= 0; i--) {
-    _cmovev_kit.make_cmovevd_pack(_packset.at(i));
+    Node_List* unused_cmove_pk = _cmovev_kit.make_cmovevd_pack(_packset.at(i));
+
+    // Clear the unused cmove pack and its related packs from superword candidate packset.
+    if (unused_cmove_pk != NULL) {
+      Node* cmove = unused_cmove_pk->at(0);
+      Node* bol = cmove->as_CMove()->in(CMoveNode::Condition);
+      if (my_pack(bol)) {
+        remove_pack(my_pack(bol));
+      }
+      Node* cmp = bol->in(1);
+      if (my_pack(cmp)) {
+        remove_pack(my_pack(cmp));
+      }
+      remove_pack(unused_cmove_pk);
+    }
+
   }
+
   #ifndef PRODUCT
     if (TraceSuperWord) {
       tty->print_cr("\nSuperWord::merge_packs_to_cmovd(): After merge");
@@ -1909,20 +1926,23 @@ Node* CMoveKit::is_CmpD_candidate(Node* def) const {
   return use;
 }
 
+// Determine if the current pack is an ideal cmove pack, and if its related packs,
+// i.e. bool node pack and cmp node pack, can be successfully merged for vectorization.
+// If yes, create a new cmove pack to substitute the old one, map all info to the
+// new pack and delete the old cmove pack and related packs from the packset.
+// If no, return immediately with the unqualified cmove pack, delete related packs from
+// the packset and clear all info as well.
 Node_List* CMoveKit::make_cmovevd_pack(Node_List* cmovd_pk) {
   Node *cmovd = cmovd_pk->at(0);
-  if (!cmovd->is_CMove()) {
+
+  if ((cmovd->Opcode() != Op_CMoveF && cmovd->Opcode() != Op_CMoveD) ||
+      pack(cmovd) != NULL /* already in the cmov pack */) {
     return NULL;
   }
-  if (cmovd->Opcode() != Op_CMoveF && cmovd->Opcode() != Op_CMoveD) {
-    return NULL;
-  }
-  if (pack(cmovd) != NULL) { // already in the cmov pack
-    return NULL;
-  }
+
   if (cmovd->in(0) != NULL) {
     NOT_PRODUCT(if(_sw->is_trace_cmov()) {tty->print("CMoveKit::make_cmovevd_pack: CMoveD %d has control flow, escaping...", cmovd->_idx); cmovd->dump();})
-    return NULL;
+    return cmovd_pk;
   }
 
   Node* bol = cmovd->as_CMove()->in(CMoveNode::Condition);
@@ -1932,11 +1952,11 @@ Node_List* CMoveKit::make_cmovevd_pack(Node_List* cmovd_pk) {
       || bol->in(0) != NULL  // BoolNode has control flow!!
       || _sw->my_pack(bol) == NULL) {
       NOT_PRODUCT(if(_sw->is_trace_cmov()) {tty->print("CMoveKit::make_cmovevd_pack: Bool %d does not fit CMoveD %d for building vector, escaping...", bol->_idx, cmovd->_idx); bol->dump();})
-      return NULL;
+    return cmovd_pk;
   }
   Node_List* bool_pk = _sw->my_pack(bol);
   if (bool_pk->size() != cmovd_pk->size() ) {
-    return NULL;
+    return cmovd_pk;
   }
 
   Node* cmpd = bol->in(1);
@@ -1946,16 +1966,16 @@ Node_List* CMoveKit::make_cmovevd_pack(Node_List* cmovd_pk) {
       || cmpd->in(0) != NULL  // CmpDNode has control flow!!
       || _sw->my_pack(cmpd) == NULL) {
       NOT_PRODUCT(if(_sw->is_trace_cmov()) {tty->print("CMoveKit::make_cmovevd_pack: CmpD %d does not fit CMoveD %d for building vector, escaping...", cmpd->_idx, cmovd->_idx); cmpd->dump();})
-      return NULL;
+    return cmovd_pk;
   }
   Node_List* cmpd_pk = _sw->my_pack(cmpd);
   if (cmpd_pk->size() != cmovd_pk->size() ) {
-    return NULL;
+    return cmovd_pk;
   }
 
   if (!test_cmpd_pack(cmpd_pk, cmovd_pk)) {
     NOT_PRODUCT(if(_sw->is_trace_cmov()) {tty->print("CMoveKit::make_cmovevd_pack: cmpd pack for CmpD %d failed vectorization test", cmpd->_idx); cmpd->dump();})
-    return NULL;
+    return cmovd_pk;
   }
 
   Node_List* new_cmpd_pk = new Node_List();
@@ -1970,7 +1990,6 @@ Node_List* CMoveKit::make_cmovevd_pack(Node_List* cmovd_pk) {
     map(cmov, new_cmpd_pk);
     map(bol, new_cmpd_pk);
     map(cmp, new_cmpd_pk);
-
     _sw->set_my_pack(cmov, new_cmpd_pk); // and keep old packs for cmp and bool
   }
   _sw->_packset.remove(cmovd_pk);
@@ -1978,7 +1997,7 @@ Node_List* CMoveKit::make_cmovevd_pack(Node_List* cmovd_pk) {
   _sw->_packset.remove(cmpd_pk);
   _sw->_packset.append(new_cmpd_pk);
   NOT_PRODUCT(if(_sw->is_trace_cmov()) {tty->print_cr("CMoveKit::make_cmovevd_pack: added syntactic CMoveD pack"); _sw->print_pack(new_cmpd_pk);})
-  return new_cmpd_pk;
+  return NULL;
 }
 
 bool CMoveKit::test_cmpd_pack(Node_List* cmpd_pk, Node_List* cmovd_pk) {
@@ -3673,6 +3692,16 @@ void SuperWord::remove_pack_at(int pos) {
     set_my_pack(s, NULL);
   }
   _packset.remove_at(pos);
+}
+
+//------------------------------remove_pack------------------------------
+// Remove the pack in the packset
+void SuperWord::remove_pack(Node_List* p) {
+  for (uint i = 0; i < p->size(); i++) {
+    Node* s = p->at(i);
+    set_my_pack(s, NULL);
+  }
+  _packset.remove(p);
 }
 
 void SuperWord::packset_sort(int n) {

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -1933,7 +1933,7 @@ Node* CMoveKit::is_CmpD_candidate(Node* def) const {
 }
 
 bool CMoveKit::is_cmove_pack_candidate(Node_List* cmove_pk) {
-  Node *cmove = cmove_pk->at(0);
+  Node* cmove = cmove_pk->at(0);
   if ((cmove->Opcode() != Op_CMoveF && cmove->Opcode() != Op_CMoveD) ||
       pack(cmove) != NULL /* already in the cmove pack */) {
     return false;
@@ -1944,7 +1944,7 @@ bool CMoveKit::is_cmove_pack_candidate(Node_List* cmove_pk) {
 // Determine if the current pack is an ideal cmove pack, and if its related packs,
 // i.e. bool node pack and cmp node pack, can be successfully merged for vectorization.
 bool CMoveKit::can_merge_cmove_pack(Node_List* cmove_pk) {
-  Node *cmove = cmove_pk->at(0);
+  Node* cmove = cmove_pk->at(0);
 
   if (cmove->in(0) != NULL) {
     NOT_PRODUCT(if(_sw->is_trace_cmov()) {tty->print("CMoveKit::make_cmove_pack: CMove %d has control flow, escaping...", cmove->_idx); cmove->dump();})
@@ -1990,7 +1990,7 @@ bool CMoveKit::can_merge_cmove_pack(Node_List* cmove_pk) {
 // Create a new cmove pack to substitute the old one, map all info to the
 // new pack and delete the old cmove pack and related packs from the packset.
 void CMoveKit::make_cmove_pack(Node_List* cmove_pk) {
-  Node *cmove = cmove_pk->at(0);
+  Node* cmove = cmove_pk->at(0);
   Node* bol = cmove->as_CMove()->in(CMoveNode::Condition);
   Node_List* bool_pk = _sw->my_pack(bol);
   Node* cmp = bol->in(1);

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -215,7 +215,11 @@ class CMoveKit {
   Node_List* pack(Node* key)      const  { return (Node_List*)_dict->operator[](_2p(key)); }
   Node* is_Bool_candidate(Node* nd) const; // if it is the right candidate return corresponding CMove* ,
   Node* is_CmpD_candidate(Node* nd) const; // otherwise return NULL
-  Node_List* make_cmovevd_pack(Node_List* cmovd_pk);
+  // If the input pack is a cmove candidate, return true, otherwise return false.
+  bool is_cmove_pack_candidate(Node_List* cmove_pk);
+  // Determine if the current cmove pack can be vectorized.
+  bool can_merge_cmove_pack(Node_List* cmove_pk);
+  void make_cmove_pack(Node_List* cmovd_pk);
   bool test_cmpd_pack(Node_List* cmpd_pk, Node_List* cmovd_pk);
 };//class CMoveKit
 
@@ -536,6 +540,8 @@ class SuperWord : public ResourceObj {
   void construct_my_pack_map();
   // Remove packs that are not implemented or not profitable.
   void filter_packs();
+  // Clear the unused cmove pack and its related packs from superword candidate packset.
+  void remove_cmove_and_related_packs(Node_List* cmove_pk);
   // Merge CMoveD into new vector-nodes
   void merge_packs_to_cmovd();
   // Adjust the memory graph for the packed operations

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -584,6 +584,8 @@ class SuperWord : public ResourceObj {
   Node_List* in_pack(Node* s, Node_List* p);
   // Remove the pack at position pos in the packset
   void remove_pack_at(int pos);
+  // Remove the pack in the packset
+  void remove_pack(Node_List* p);
   // Return the node executed first in pack p.
   Node* executed_first(Node_List* p);
   // Return the node executed last in pack p.

--- a/test/hotspot/jtreg/compiler/c2/TestCondAddDeadBranch.java
+++ b/test/hotspot/jtreg/compiler/c2/TestCondAddDeadBranch.java
@@ -26,7 +26,7 @@
  * @bug 8268883 8293833
  * @summary C2: assert(false) failed: unscheduable graph
  *          Error mixing types with -XX:+UseCMoveUnconditionally -XX:+UseVectorCmov
- *
+ * @requires vm.compiler2.enabled
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestCondAddDeadBranch TestCondAddDeadBranch
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestCondAddDeadBranch
  *                   -XX:+UseCMoveUnconditionally -XX:+UseVectorCmov -XX:MaxVectorSize=32  TestCondAddDeadBranch

--- a/test/hotspot/jtreg/compiler/c2/TestCondAddDeadBranch.java
+++ b/test/hotspot/jtreg/compiler/c2/TestCondAddDeadBranch.java
@@ -23,10 +23,13 @@
 
 /**
  * @test
- * @bug 8268883
+ * @bug 8268883 8293833
  * @summary C2: assert(false) failed: unscheduable graph
+ *          Error mixing types with -XX:+UseCMoveUnconditionally -XX:+UseVectorCmov
  *
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestCondAddDeadBranch TestCondAddDeadBranch
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestCondAddDeadBranch
+ *                   -XX:+UseCMoveUnconditionally -XX:+UseVectorCmov -XX:MaxVectorSize=32  TestCondAddDeadBranch
  *
  */
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorConditionalMove.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorConditionalMove.java
@@ -174,6 +174,15 @@ public class TestVectorConditionalMove {
         }
     }
 
+    @Test
+    @IR(failOn = {IRNode.CMOVEVD})
+    private static void testCMoveVDUnsupported() {
+        int seed = 1001;
+        for (int i = 0; i < doublec.length; i++) {
+            doublec[i] = (i % 2 == 0) ? seed + i : seed - i;
+        }
+    }
+
     @Run(test = {"testCMoveVFGT", "testCMoveVFLT","testCMoveVDLE", "testCMoveVDGE", "testCMoveVFEQ", "testCMoveVDNE",
                  "testCMoveVFGTSwap", "testCMoveVFLTSwap","testCMoveVDLESwap", "testCMoveVDGESwap"})
     private void testCMove_runner() {

--- a/test/hotspot/jtreg/compiler/loopopts/TestCastFFAtPhi.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestCastFFAtPhi.java
@@ -23,10 +23,13 @@
 
 /**
  * @test
- * @bug 8268017
+ * @bug 8268017 8293833
  * @summary C2: assert(phi_type->isa_int() || phi_type->isa_ptr() || phi_type->isa_long()) failed: bad phi type
+ *          Error mixing types with -XX:+UseCMoveUnconditionally -XX:+UseVectorCmov
  *
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestCastFFAtPhi TestCastFFAtPhi
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestCastFFAtPhi -XX:+UseCMoveUnconditionally
+ *                   -XX:+UseVectorCmov -XX:MaxVectorSize=32 TestCastFFAtPhi
  *
  */
 

--- a/test/hotspot/jtreg/compiler/loopopts/TestCastFFAtPhi.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestCastFFAtPhi.java
@@ -26,7 +26,7 @@
  * @bug 8268017 8293833
  * @summary C2: assert(phi_type->isa_int() || phi_type->isa_ptr() || phi_type->isa_long()) failed: bad phi type
  *          Error mixing types with -XX:+UseCMoveUnconditionally -XX:+UseVectorCmov
- *
+ * @requires vm.compiler2.enabled
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestCastFFAtPhi TestCastFFAtPhi
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestCastFFAtPhi -XX:+UseCMoveUnconditionally
  *                   -XX:+UseVectorCmov -XX:MaxVectorSize=32 TestCastFFAtPhi


### PR DESCRIPTION
After JDK-8139340, JDK-8192846 and JDK-8289422, we can vectorize
the case below by enabling -XX:+UseCMoveUnconditionally and
-XX:+UseVectorCmov:
```
// double[] a, double[] b, double[] c;
for (int i = 0; i < a.length; i++) {
    c[i] = (a[i] > b[i]) ? a[i] : b[i];
}
```

But we don't support the case like:
```
// double[] a;
// int seed;
for (int i = 0; i < a.length; i++) {
    a[i] = (i % 2 == 0) ? seed + i : seed - i;
}
```
because the IR nodes for the CMoveD in the loop is:
```
  AddI  AndI     AddD   SubD
     \  /         /     /
     CmpI        /    /
       \        /   /
      Bool     /  /
          \   / /
          CMoveD
```

and it is not our target pattern, which requires that the inputs
of Cmp node must be the same as the inputs of CMove node
as commented in CMoveKit::make_cmovevd_pack(). Because
we can't vectorize the CMoveD pack, we shouldn't vectorize
its inputs, AddD and SubD. But the current function
CMoveKit::make_cmovevd_pack() doesn't clear the unqualified
CMoveD pack from the packset. In this way, superword wrongly
vectorizes AddD and SubD. Finally, we get a scalar CMoveD
node with two vector inputs, AddVD and SubVD, which has
wrong mixing types, then the assertion fails.

To fix it, we need to remove the unvectorized CMoveD pack
from the packset and clear related map info.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293833](https://bugs.openjdk.org/browse/JDK-8293833): Error mixing types with -XX:+UseCMoveUnconditionally -XX:+UseVectorCmov


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [47ca7341](https://git.openjdk.org/jdk/pull/10627/files/47ca7341d91061ca6e1b86c2308ff046c9ac410e)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10627/head:pull/10627` \
`$ git checkout pull/10627`

Update a local copy of the PR: \
`$ git checkout pull/10627` \
`$ git pull https://git.openjdk.org/jdk pull/10627/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10627`

View PR using the GUI difftool: \
`$ git pr show -t 10627`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10627.diff">https://git.openjdk.org/jdk/pull/10627.diff</a>

</details>
