### PR TITLE
8295033: hsdis configure error when cross-compiling with --with-binutils-src

### DIFF
--- a/make/autoconf/lib-hsdis.m4
+++ b/make/autoconf/lib-hsdis.m4
@@ -175,10 +175,10 @@ AC_DEFUN([LIB_BUILD_BINUTILS],
       fi
     else
       binutils_cc="$CC $SYSROOT_CFLAGS"
-      if test "x$host" = "x$build"; then
-        binutils_target=""
+      if test "x$COMPILE_TYPE" = xcross; then
+        binutils_target="--host=$OPENJDK_TARGET_AUTOCONF_NAME"
       else
-        binutils_target="--host=$host"
+        binutils_target=""
       fi
     fi
     binutils_cflags="$binutils_cflags $MACHINE_FLAG $JVM_PICFLAG $C_O_FLAG_NORM"

--- a/make/autoconf/lib-hsdis.m4
+++ b/make/autoconf/lib-hsdis.m4
@@ -175,7 +175,11 @@ AC_DEFUN([LIB_BUILD_BINUTILS],
       fi
     else
       binutils_cc="$CC $SYSROOT_CFLAGS"
-      binutils_target=""
+      if test "x$host" = "x$build"; then
+        binutils_target=""
+      else
+        binutils_target="--host=$host"
+      fi
     fi
     binutils_cflags="$binutils_cflags $MACHINE_FLAG $JVM_PICFLAG $C_O_FLAG_NORM"
 


### PR DESCRIPTION
I built hsdis with the following parameters from source code of binutils while cross-compiling:
```
--with-hsdis=binutils \
--with-binutils-src=/home/dingli/jdk-tools/binutils-2.38
```

But configure will exit with the following error:
```
checking whether we are cross compiling... configure: error: in `/home/dingli/jdk-tools/binutils-2.38-src':
configure: error: cannot run C compiled programs.
If you meant to cross compile, use `--host'.
See `config.log' for more details
configure: Automatic building of binutils failed on configure. Try building it manually
configure: error: Cannot continue
configure exiting with result code 1
```

The reason for the error is that binutils wants to be configured with --host during cross-compilation. So we can determine if we are currently cross-compiling and add the --host parameter to binutils_target:
```diff
diff --git a/make/autoconf/lib-hsdis.m4 b/make/autoconf/lib-hsdis.m4
index d72bbf6df32..dddc1cf6a4d 100644
--- a/make/autoconf/lib-hsdis.m4
+++ b/make/autoconf/lib-hsdis.m4
@@ -175,7 +175,11 @@ AC_DEFUN([LIB_BUILD_BINUTILS],
       fi
     else
       binutils_cc="$CC $SYSROOT_CFLAGS"
-      binutils_target=""
+      if test "x$host" = "x$build"; then
+        binutils_target=""
+      else
+        binutils_target="--host=$host"
+      fi
     fi
     binutils_cflags="$binutils_cflags $MACHINE_FLAG $JVM_PICFLAG $C_O_FLAG_NORM"
 
```

In the meantime, I removed some useless code about hsdis-demo because hsdis-demo.c was removed in [JDK-8275128](https://bugs.openjdk.org/browse/JDK-8275128) .

## Testing:

- cross compile for RISC-V on x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295033](https://bugs.openjdk.org/browse/JDK-8295033): hsdis configure error when cross-compiling with --with-binutils-src


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [21cc4d06](https://git.openjdk.org/jdk/pull/10628/files/21cc4d06749719e0c41f3e86ee6e0575f327a5d8)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10628/head:pull/10628` \
`$ git checkout pull/10628`

Update a local copy of the PR: \
`$ git checkout pull/10628` \
`$ git pull https://git.openjdk.org/jdk pull/10628/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10628`

View PR using the GUI difftool: \
`$ git pr show -t 10628`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10628.diff">https://git.openjdk.org/jdk/pull/10628.diff</a>

</details>
