### PR TITLE
8263044: jdk/jfr/jvm/TestDumpOnCrash.java timed out

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkHeader.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkHeader.java
@@ -164,8 +164,18 @@ public final class ChunkHeader {
                     Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Chunk: finalChunk=" + finalChunk);
                     absoluteChunkEnd = absoluteChunkStart + chunkSize;
                     return;
-                } else if (finished) {
-                    throw new IOException("No metadata event found in finished chunk.");
+                } else {
+                    if (finished) {
+                        throw new IOException("No metadata event found in finished chunk.");
+                    }
+                    if (chunkSize == HEADER_SIZE) {
+                        // This ensures that a non-streaming parser is able
+                        // to break out of the loop in case the file is
+                        // ended before the first metadata event has
+                        // been written. This can happen during a failed crash
+                        // dump.
+                        input.pollWait();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Hi,

When a crash/emergency dump is created, it is sometimes not complete.

This is OK as there is no guarantee that a dump will succeed when the JVM crashes. Problem occurs if this happens before the first metadata event has been written (metadataPosition == 0) in which case the parser will loop indefinitely.

This is expected behavior in the streaming case (EventStream), but if the recording was opened with RecordingFile it is usually able to finish or throw an exception. The fix is to invoke pollWait() if a valid recording only consists of the header (68 bytes). This will result in similar behaviour as if the recording was terminated prematurely, but the metadata event had been written. 

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8263044](https://bugs.openjdk.org/browse/JDK-8263044): jdk/jfr/jvm/TestDumpOnCrash.java timed out


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10629/head:pull/10629` \
`$ git checkout pull/10629`

Update a local copy of the PR: \
`$ git checkout pull/10629` \
`$ git pull https://git.openjdk.org/jdk pull/10629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10629`

View PR using the GUI difftool: \
`$ git pr show -t 10629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10629.diff">https://git.openjdk.org/jdk/pull/10629.diff</a>

</details>
