### PR TITLE
8295067: Remove virtual from ResourceObj::print_on

### DIFF
--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -488,7 +488,7 @@ protected:
 #ifndef PRODUCT
   // Printing support
   void print() const;
-  virtual void print_on(outputStream* st) const;
+  void print_on(outputStream* st) const;
 #endif // PRODUCT
 };
 


### PR DESCRIPTION
We never use this method in any virtual manner. For example, we never iterate over `ResourceObj*` where the underlying types are different subclasses of `ResourceObj`. Removing `virtual` removes 8 bytes from each allocation (24 bytes -> 16 bytes) and also allows subclasses `print_on` to be non-`const`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295067](https://bugs.openjdk.org/browse/JDK-8295067): Remove virtual from ResourceObj::print_on


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10630/head:pull/10630` \
`$ git checkout pull/10630`

Update a local copy of the PR: \
`$ git checkout pull/10630` \
`$ git pull https://git.openjdk.org/jdk pull/10630/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10630`

View PR using the GUI difftool: \
`$ git pr show -t 10630`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10630.diff">https://git.openjdk.org/jdk/pull/10630.diff</a>

</details>
