### PR TITLE
8295069: [PPC64] Performance regression after JDK-8290025

### DIFF
--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
@@ -162,7 +162,8 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Register t
   // Actual patching is done in (platform-specific part of) BarrierSetNMethod.
   __ load_const32(tmp, 0 /* Value is patched */); // 2 instructions
 
-  __ lwz(R0, in_bytes(bs_nm->thread_disarmed_offset()), R16_thread);
+  // Low order half of 64 bit value is currently used.
+  __ ld(R0, in_bytes(bs_nm->thread_disarmed_offset()), R16_thread);
   __ cmpw(CCR0, R0, tmp);
 
   __ bnectrl(CCR0);

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
@@ -23,7 +23,6 @@
  *
  */
 
-#include "nativeInst_ppc.hpp"
 #include "precompiled.hpp"
 #include "asm/macroAssembler.inline.hpp"
 #include "classfile/classLoaderData.hpp"
@@ -169,7 +168,10 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Register t
   __ bnectrl(CCR0);
 
   // Oops may have been changed; exploiting isync semantics (used as acquire) to make those updates observable.
-  __ isync();
+  // But, many GCs don't modify nmethods during a concurrent phase.
+  if (!UseSerialGC && !UseG1GC && !UseParallelGC && !UseEpsilonGC) {
+    __ isync();
+  }
 
   __ block_comment("} nmethod_entry_barrier (nmethod_entry_barrier)");
 }

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
@@ -167,9 +167,10 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Register t
 
   __ bnectrl(CCR0);
 
-  // Oops may have been changed; exploiting isync semantics (used as acquire) to make those updates observable.
+  // Oops may have been changed. Make those updates observable.
+  // "isync" can serve both, data and instruction patching.
   // But, many GCs don't modify nmethods during a concurrent phase.
-  if (!UseSerialGC && !UseG1GC && !UseParallelGC && !UseEpsilonGC) {
+  if (nmethod_patching_type() != NMethodPatchingType::stw_instruction_and_data_patch) {
     __ isync();
   }
 

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.hpp
@@ -30,7 +30,11 @@
 #include "memory/allocation.hpp"
 #include "oops/access.hpp"
 
-class InterpreterMacroAssembler;
+enum class NMethodPatchingType {
+  stw_instruction_and_data_patch,
+  conc_instruction_and_data_patch,
+  conc_data_patch
+};
 
 class BarrierSetAssembler: public CHeapObj<mtGC> {
 public:
@@ -57,6 +61,8 @@ public:
                                              Register obj, Register tmp, Label& slowpath);
 
   virtual void barrier_stubs_init() {}
+
+  virtual NMethodPatchingType nmethod_patching_type() { return NMethodPatchingType::stw_instruction_and_data_patch; }
 
   virtual void nmethod_entry_barrier(MacroAssembler* masm, Register tmp);
   virtual void c2i_entry_barrier(MacroAssembler* masm, Register tmp1, Register tmp2, Register tmp3);

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetNMethod_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetNMethod_ppc.cpp
@@ -82,7 +82,7 @@ public:
     // bnectrl (mnemonic) (weak check; not checking the exact type)
     verify_op_code(current_instruction, Assembler::BCCTR_OPCODE);
 
-    verify_op_code(current_instruction, Assembler::ISYNC_OPCODE);
+    // isync is optional
   }
 
 private:
@@ -100,7 +100,10 @@ private:
 };
 
 static NativeNMethodBarrier* get_nmethod_barrier(nmethod* nm) {
-  address barrier_address = nm->code_begin() + nm->frame_complete_offset() + (-9 * 4);
+  address barrier_address = nm->code_begin() + nm->frame_complete_offset() + (-8 * 4);
+  if (!UseSerialGC && !UseG1GC && !UseParallelGC && !UseEpsilonGC) {
+    barrier_address -= 4; // isync (see nmethod_entry_barrier)
+  }
 
   auto barrier = reinterpret_cast<NativeNMethodBarrier*>(barrier_address);
   debug_only(barrier->verify());

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetNMethod_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetNMethod_ppc.cpp
@@ -76,7 +76,7 @@ public:
     get_patchable_instruction_handle()->verify();
     current_instruction += 2;
 
-    verify_op_code(current_instruction, Assembler::LWZ_OPCODE);
+    verify_op_code(current_instruction, Assembler::LD_OPCODE);
 
     // cmpw (mnemonic)
     verify_op_code(current_instruction, Assembler::CMP_OPCODE);

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetNMethod_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetNMethod_ppc.cpp
@@ -26,6 +26,8 @@
 #include "code/codeBlob.hpp"
 #include "code/nmethod.hpp"
 #include "code/nativeInst.hpp"
+#include "gc/shared/barrierSet.hpp"
+#include "gc/shared/barrierSetAssembler.hpp"
 #include "gc/shared/barrierSetNMethod.hpp"
 #include "utilities/debug.hpp"
 
@@ -100,8 +102,9 @@ private:
 };
 
 static NativeNMethodBarrier* get_nmethod_barrier(nmethod* nm) {
+  BarrierSetAssembler* bs_asm = BarrierSet::barrier_set()->barrier_set_assembler();
   address barrier_address = nm->code_begin() + nm->frame_complete_offset() + (-8 * 4);
-  if (!UseSerialGC && !UseG1GC && !UseParallelGC && !UseEpsilonGC) {
+  if (bs_asm->nmethod_patching_type() != NMethodPatchingType::stw_instruction_and_data_patch) {
     barrier_address -= 4; // isync (see nmethod_entry_barrier)
   }
 

--- a/src/hotspot/cpu/ppc/gc/shenandoah/shenandoahBarrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/shenandoah/shenandoahBarrierSetAssembler_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, 2021, Red Hat, Inc. All rights reserved.
- * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2018, 2022, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/gc/shenandoah/shenandoahBarrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/shenandoah/shenandoahBarrierSetAssembler_ppc.hpp
@@ -61,6 +61,7 @@ private:
   void resolve_forward_pointer_not_null(MacroAssembler* masm, Register dst, Register tmp);
 
 public:
+  virtual NMethodPatchingType nmethod_patching_type() { return NMethodPatchingType::conc_data_patch; }
 
   /* ==== C1 stubs ==== */
 #ifdef COMPILER1

--- a/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.hpp
@@ -64,6 +64,8 @@ public:
   virtual void try_resolve_jobject_in_native(MacroAssembler* masm, Register dst, Register jni_env,
                                              Register obj, Register tmp, Label& slowpath);
 
+  virtual NMethodPatchingType nmethod_patching_type() { return NMethodPatchingType::conc_data_patch; }
+
 #ifdef COMPILER1
   void generate_c1_load_barrier_test(LIR_Assembler* ce,
                                      LIR_Opr ref) const;

--- a/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
I have a proposal to mitigate the performance regression (see JBS issue) on PPC64 significantly. We get most of the performance back. Please review. Implemented like on aarch64, now. Also use 64 bit load for `uint64_t _nmethod_disarm_value` (not relevant for Little Endian).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295069](https://bugs.openjdk.org/browse/JDK-8295069): [PPC64] Performance regression after JDK-8290025


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10632/head:pull/10632` \
`$ git checkout pull/10632`

Update a local copy of the PR: \
`$ git checkout pull/10632` \
`$ git pull https://git.openjdk.org/jdk pull/10632/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10632`

View PR using the GUI difftool: \
`$ git pr show -t 10632`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10632.diff">https://git.openjdk.org/jdk/pull/10632.diff</a>

</details>
