### PR TITLE
8295070: Introduce more target combinations for compiler flags

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -345,7 +345,7 @@ define SetupCompileNativeFileBody
 
     ifneq ($(DISABLE_WARNING_PREFIX), )
       $1_WARNINGS_FLAGS := $$(addprefix $(DISABLE_WARNING_PREFIX), \
-        $$($$($1_BASE)_DISABLED_WARNINGS_$(TOOLCHAIN_TYPE)_$$($1_FILENAME)))
+        $$($$($1_BASE)_DISABLED_WARNINGS_$(TOOLCHAIN_TYPE)_$$($1_FILENAME)) \
         $$($$($1_BASE)_DISABLED_WARNINGS_$(TOOLCHAIN_TYPE)_$(OPENJDK_TARGET_OS)_$$($1_FILENAME)))
     endif
 

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -346,6 +346,7 @@ define SetupCompileNativeFileBody
     ifneq ($(DISABLE_WARNING_PREFIX), )
       $1_WARNINGS_FLAGS := $$(addprefix $(DISABLE_WARNING_PREFIX), \
         $$($$($1_BASE)_DISABLED_WARNINGS_$(TOOLCHAIN_TYPE)_$$($1_FILENAME)))
+        $$($$($1_BASE)_DISABLED_WARNINGS_$(TOOLCHAIN_TYPE)_$(OPENJDK_TARGET_OS)_$$($1_FILENAME)))
     endif
 
     $1_BASE_CFLAGS :=  $$($$($1_BASE)_CFLAGS) $$($$($1_BASE)_EXTRA_CFLAGS) \
@@ -687,10 +688,12 @@ define SetupNativeCompilationBody
   # Sort to remove duplicates and provide a reproducible order on the input files to the linker.
   $1_ALL_OBJS := $$(sort $$($1_EXPECTED_OBJS) $$($1_EXTRA_OBJECT_FILES))
 
-  # Pickup extra OPENJDK_TARGET_OS_TYPE, OPENJDK_TARGET_OS, and/or OPENJDK_TARGET_OS plus
-  # OPENJDK_TARGET_CPU pair dependent variables for CFLAGS.
+  # Pickup extra OPENJDK_TARGET_OS_TYPE, OPENJDK_TARGET_OS, TOOLCHAIN_TYPE and
+  # OPENJDK_TARGET_OS plus OPENJDK_TARGET_CPU pair dependent variables for CFLAGS.
   $1_EXTRA_CFLAGS := $$($1_CFLAGS_$(OPENJDK_TARGET_OS_TYPE)) $$($1_CFLAGS_$(OPENJDK_TARGET_OS)) \
+      $$($1_CFLAGS_$(TOOLCHAIN_TYPE)) \
       $$($1_CFLAGS_$(OPENJDK_TARGET_OS)_$(OPENJDK_TARGET_CPU))
+
   ifneq ($(DEBUG_LEVEL), release)
     # Pickup extra debug dependent variables for CFLAGS
     $1_EXTRA_CFLAGS += $$($1_CFLAGS_debug)
@@ -707,8 +710,11 @@ define SetupNativeCompilationBody
     $1_EXTRA_CFLAGS += $$(STATIC_LIBS_CFLAGS)
   endif
 
-  # Pickup extra OPENJDK_TARGET_OS_TYPE and/or OPENJDK_TARGET_OS dependent variables for CXXFLAGS.
-  $1_EXTRA_CXXFLAGS := $$($1_CXXFLAGS_$(OPENJDK_TARGET_OS_TYPE)) $$($1_CXXFLAGS_$(OPENJDK_TARGET_OS))
+  # Pickup extra OPENJDK_TARGET_OS_TYPE, OPENJDK_TARGET_OS and/or TOOLCHAIN_TYPE
+  # dependent variables for CXXFLAGS.
+  $1_EXTRA_CXXFLAGS := $$($1_CXXFLAGS_$(OPENJDK_TARGET_OS_TYPE)) $$($1_CXXFLAGS_$(OPENJDK_TARGET_OS)) \
+      $$($1_CXXFLAGS_$(TOOLCHAIN_TYPE))
+
   ifneq ($(DEBUG_LEVEL), release)
     # Pickup extra debug dependent variables for CXXFLAGS
     $1_EXTRA_CXXFLAGS += $$($1_CXXFLAGS_debug)
@@ -751,12 +757,16 @@ define SetupNativeCompilationBody
         $$(DISABLED_WARNINGS) \
         $$(DISABLED_WARNINGS_C) \
         $$($1_DISABLED_WARNINGS_$(TOOLCHAIN_TYPE)) \
-        $$($1_DISABLED_WARNINGS_C_$(TOOLCHAIN_TYPE)))
+        $$($1_DISABLED_WARNINGS_C_$(TOOLCHAIN_TYPE)) \
+        $$($1_DISABLED_WARNINGS_$(TOOLCHAIN_TYPE)_$(OPENJDK_TARGET_OS)) \
+        $$($1_DISABLED_WARNINGS_C_$(TOOLCHAIN_TYPE)_$(OPENJDK_TARGET_OS)))
     $1_EXTRA_CXXFLAGS += $$(addprefix $(DISABLE_WARNING_PREFIX), \
         $$(DISABLED_WARNINGS) \
         $$(DISABLED_WARNINGS_CXX) \
         $$($1_DISABLED_WARNINGS_$(TOOLCHAIN_TYPE)) \
-        $$($1_DISABLED_WARNINGS_CXX_$(TOOLCHAIN_TYPE)))
+        $$($1_DISABLED_WARNINGS_CXX_$(TOOLCHAIN_TYPE)) \
+        $$($1_DISABLED_WARNINGS_$(TOOLCHAIN_TYPE)_$(OPENJDK_TARGET_OS)) \
+        $$($1_DISABLED_WARNINGS_CXX_$(TOOLCHAIN_TYPE)_$(OPENJDK_TARGET_OS)))
   endif
 
   # Check if warnings should be considered errors.
@@ -967,10 +977,15 @@ define SetupNativeCompilationBody
     $1_REAL_MAPFILE := $$($1_MAPFILE)
   endif
 
-  # Pickup extra OPENJDK_TARGET_OS_TYPE and/or OPENJDK_TARGET_OS dependent variables
-  # for LDFLAGS and LIBS
-  $1_EXTRA_LDFLAGS += $$($1_LDFLAGS_$(OPENJDK_TARGET_OS_TYPE)) $$($1_LDFLAGS_$(OPENJDK_TARGET_OS))
-  $1_EXTRA_LIBS += $$($1_LIBS_$(OPENJDK_TARGET_OS_TYPE)) $$($1_LIBS_$(OPENJDK_TARGET_OS))
+  # Pickup extra OPENJDK_TARGET_OS_TYPE, OPENJDK_TARGET_OS and TOOLCHAIN_TYPE
+  # dependent variables for LDFLAGS and LIBS, and additionally the pair dependent
+  # TOOLCHAIN_TYPE plus OPENJDK_TARGET_OS for LDFLAGS, or OPENJDK_TARGET_OS plus
+  # TOOLCHAIN_TYPE for LIBS
+  $1_EXTRA_LDFLAGS += $$($1_LDFLAGS_$(OPENJDK_TARGET_OS_TYPE)) $$($1_LDFLAGS_$(OPENJDK_TARGET_OS)) \
+      $$($1_LDFLAGS_$(TOOLCHAIN_TYPE)) $$($1_LDFLAGS_$(TOOLCHAIN_TYPE)_$(OPENJDK_TARGET_OS))
+  $1_EXTRA_LIBS += $$($1_LIBS_$(OPENJDK_TARGET_OS_TYPE)) $$($1_LIBS_$(OPENJDK_TARGET_OS)) \
+      $$($1_LIBS_$(OPENJDK_TARGET_OS)_$(TOOLCHAIN_TYPE)) $$($1_LIBS_$(TOOLCHAIN_TYPE))
+
   ifneq ($$($1_REAL_MAPFILE), )
     $1_EXTRA_LDFLAGS += $(call SET_SHARED_LIBRARY_MAPFILE,$$($1_REAL_MAPFILE))
   endif

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -486,7 +486,19 @@ endef
 #   CFLAGS the compiler flags to be used, used both for C and C++.
 #   CXXFLAGS the compiler flags to be used for c++, if set overrides CFLAGS.
 #   LDFLAGS the linker flags to be used, used both for C and C++.
+#   LDFLAGS_<toolchain> the linker flags to be used for the specified toolchain,
+#       used both for C and C++.
+#   LDFLAGS_<OS> the linker flags to be used for the specified target OS,
+#       used both for C and C++.
+#   LDFLAGS_<toolchain>_<OS> the linker flags to be used for the specified
+#       toolchain and target OS, used both for C and C++.
 #   LIBS the libraries to link to
+#   LIBS_<OS> the libraries to link to for the specified target OS,
+#       used both for C and C++.
+#   LIBS_<toolchain> the libraries to link to for the specified toolchain,
+#       used both for C and C++.
+#   LIBS_<OS>_<toolchain> the libraries to link to for the specified target
+#       OS and toolchain, used both for C and C++.
 #   ARFLAGS the archiver flags to be used
 #   OBJECT_DIR the directory where we store the object files
 #   OUTPUT_DIR the directory where the resulting binary is put
@@ -509,10 +521,20 @@ endef
 #   LD the linker to use, default is $(LD)
 #   OPTIMIZATION sets optimization level to NONE, LOW, HIGH, HIGHEST, HIGHEST_JVM, SIZE
 #   DISABLED_WARNINGS_<toolchain> Disable the given warnings for the specified toolchain
+#   DISABLED_WARNINGS_<toolchain>_<OS> Disable the given warnings for the specified
+#       toolchain and target OS
 #   DISABLED_WARNINGS_C_<toolchain> Disable the given warnings for the specified toolchain
 #       when compiling C code
+#   DISABLED_WARNINGS_C_<toolchain>_<OS> Disable the given warnings for the specified
+#       toolchain and target OS when compiling C code
 #   DISABLED_WARNINGS_CXX_<toolchain> Disable the given warnings for the specified
 #       toolchain when compiling C++ code
+#   DISABLED_WARNINGS_CXX_<toolchain>_<OS> Disable the given warnings for the specified
+#       toolchain and target OS  when compiling C++ code
+#   DISABLED_WARNINGS_<toolchain>_<filename> Disable the given warnings for the specified
+#       toolchain when compiling the file specified by filename
+#   DISABLED_WARNINGS_<toolchain>_<OS>_<filename> Disable the given warnings for the specified
+#       toolchain and target OS when compiling the file specified by filename
 #   STRIP_SYMBOLS Set to false to override global strip policy and always leave
 #       symbols in the binary, if the toolchain allows for it
 #   DEBUG_SYMBOLS Set to false to disable generation of debug symbols

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -530,7 +530,7 @@ endef
 #   DISABLED_WARNINGS_CXX_<toolchain> Disable the given warnings for the specified
 #       toolchain when compiling C++ code
 #   DISABLED_WARNINGS_CXX_<toolchain>_<OS> Disable the given warnings for the specified
-#       toolchain and target OS  when compiling C++ code
+#       toolchain and target OS when compiling C++ code
 #   DISABLED_WARNINGS_<toolchain>_<filename> Disable the given warnings for the specified
 #       toolchain when compiling the file specified by filename
 #   DISABLED_WARNINGS_<toolchain>_<OS>_<filename> Disable the given warnings for the specified


### PR DESCRIPTION
Several parts of the make system in the JDK has large parts of cluttered if branches dedicated to setting flags for the specific compiler used in the build. This could be more neatly accomplished by instead adding more target combinations in SetupNativeCompilation so the callsite can more cleanly specify which OS and compiler it desires to set these flags for. The change currently includes:

DISABLED_WARNINGS (including per file warnings), CFLAGS/CXXFLAGS and LDFLAGS: Compiler-then-OS (The priority shown reflects how the flags depend more so on the compiler)
LIBS: OS-then-Compiler, as libraries typically vary based on the system being compiled for

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295070](https://bugs.openjdk.org/browse/JDK-8295070): Introduce more target combinations for compiler flags


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10634/head:pull/10634` \
`$ git checkout pull/10634`

Update a local copy of the PR: \
`$ git checkout pull/10634` \
`$ git pull https://git.openjdk.org/jdk pull/10634/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10634`

View PR using the GUI difftool: \
`$ git pr show -t 10634`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10634.diff">https://git.openjdk.org/jdk/pull/10634.diff</a>

</details>
