### PR TITLE
JDK-8294994: Update Jarsigner and Keytool i18n tests to validate i18n compliance

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -610,12 +610,12 @@ jdk_core_manual_no_input_security = \
     sun/security/smartcardio/TestMultiplePresent.java \
     sun/security/smartcardio/TestPresent.java \
     sun/security/smartcardio/TestTransmit.java \
-    sun/security/tools/jarsigner/compatibility/Compatibility.java \
-    sun/security/tools/keytool/i18n.java
+    sun/security/tools/jarsigner/compatibility/Compatibility.java
 
 jdk_core_manual_requires_human_input = \
     com/sun/jndi/dns/Test6991580.java \
-    java/util/TimeZone/DefaultTimeZoneTest.java
+    java/util/TimeZone/DefaultTimeZoneTest.java \
+    sun/security/tools/keytool/i18n.java
 
 
 # Test sets for running inside container environment

--- a/test/jdk/sun/security/tools/keytool/i18n.java
+++ b/test/jdk/sun/security/tools/keytool/i18n.java
@@ -61,7 +61,7 @@
  * @run main/manual/othervm -Duser.language=zh -Duser.country=CN i18n
  */
 
-import jdk.test.lib.TestUI;
+import jdk.test.lib.UIBuilder;
 
 import javax.swing.*;
 import java.io.ByteArrayOutputStream;
@@ -305,7 +305,7 @@ public class i18n {
     public boolean validate(String command, String instruction, String message) {
         failed = false;
         currentThread = Thread.currentThread();
-        JDialog dialog = new TestUI.DialogBuilder()
+        JDialog dialog = new UIBuilder.DialogBuilder()
                 .setTitle("keytool " + command)
                 .setInstruction(instruction)
                 .setMessage(message)

--- a/test/jdk/sun/security/tools/keytool/i18n.java
+++ b/test/jdk/sun/security/tools/keytool/i18n.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,17 +23,410 @@
 
 /*
  * @test
- * @bug 4348369 8076069
- * @summary keytool not i18n compliant
+ * @bug 4348369 8076069 8294994
+ * @summary keytool i18n compliant
  * @author charlie lai
- * @run main/manual i18n
+ * @modules java.base/sun.security.tools.keytool
+ * @library /test/lib
+ * @run main/manual/othervm i18n en
  */
 
-import java.nio.file.Path;
+/*
+ * @test
+ * @bug 4348369 8076069 8294994
+ * @summary keytool i18n compliant
+ * @author charlie lai
+ * @modules java.base/sun.security.tools.keytool
+ * @library /test/lib
+ * @run main/manual/othervm i18n de
+ */
 
-public class i18n{
-    public static void main(String[] args) throws Exception {
-        System.out.println("see i18n.html");
-        System.out.println(Path.of(System.getProperty("test.jdk"), "bin", "keytool"));
+/*
+ * @test
+ * @bug 4348369 8076069 8294994
+ * @summary keytool i18n compliant
+ * @author charlie lai
+ * @modules java.base/sun.security.tools.keytool
+ * @library /test/lib
+ * @run main/manual/othervm i18n ja
+ */
+
+/*
+ * @test
+ * @bug 4348369 8076069 8294994
+ * @summary keytool i18n compliant
+ * @author charlie lai
+ * @modules java.base/sun.security.tools.keytool
+ * @library /test/lib
+ * @run main/manual/othervm i18n zh CN
+ */
+
+import javax.swing.*;
+import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Locale;
+
+public class i18n {
+    private static final String[][] TABLE = new String[][]{
+            {"-help", "All the output in this test should be in ${LANG}. "
+                    + "Otherwise, the test failed."},
+
+            {"-genkeypair -keyalg DSA -v -keysize 512 "
+                    + "-dname cn=Name,ou=Java,o=Oracle,l=City,s=State,c=Country "
+                    + "-storepass a "
+                    + "-keypass a "
+                    + "-keystore ./i18n.keystore",
+                    "Output in ${LANG}. Check keytool error: java.lang.Exception: "
+                            + "Keystore password must be at least 6 characters."},
+
+            {"-genkeypair -keyalg DSA -v -keysize 512 "
+                    + "-dname cn=Name,ou=Java,o=Oracle,l=City,s=State,c=Country "
+                    + "-storepass password "
+                    + "-keypass password "
+                    + "-keystore ./i18n.keystore",
+                    "Output in ${LANG}. Check: generated a 512 bit DSA key pair "
+                            + "for CN=Name, OU=Java, O=Oracle, L=City, ST=State "
+                            + "C=Country."},
+
+            {"-list -v -storepass password -keystore ./i18n.keystore",
+                    "Output in ${LANG}. Check: contains 1 keystore entry with "
+                            + "512-bit DSA key algorithm for CN=Name, OU=Java, "
+                            + "O=Oracle, L=City, ST=State C=Country."},
+
+            {"-list -v -storepass a -keystore ./i18n.keystore",
+                    "Output in ${LANG}. Check keytool error:java.io.IOException: "
+                            + "keystore password was incorrect."},
+
+            {"-genkey -keyalg DSA -v -keysize 512 "
+                    + "-storepass password "
+                    + "-keypass password "
+                    + "-keystore ./i18n.keystore",
+                    "Output in ${LANG}. Check keytool error: java.lang.Exception: "
+                            + "alias 'mykey' already exists."},
+
+            {"-genkeypair -keyalg DSA -v -keysize 512 "
+                    + "-dname cn=Name,ou=Java,o=Oracle,l=City,s=State,c=Country "
+                    + "-alias mykey2 "
+                    + "-storepass password "
+                    + "-keypass password "
+                    + "-keystore ./i18n.keystore",
+                    "Output in ${LANG}. Check: generated a 512 bit DSA key pair "
+                            + "for CN=Name, OU=Java, O=Oracle, L=City, ST=State "
+                            + "C=Country."},
+
+            {"-list -v -storepass password -keystore ./i18n.keystore",
+                    "Output in ${LANG}. Check: contains 2 keystore entries "
+                            + "(alias name mykey & mykey2), both with 512-bit DSA"
+                            + " key algorithm for CN=Name, OU=Java, O=Oracle, "
+                            + "L=City, ST=State C=Country."},
+
+            {"-keypasswd -v "
+                    + "-alias mykey2 "
+                    + "-storepass password "
+                    + "-keypass password "
+                    + "-new a "
+                    + "-keystore ./i18n.keystore",
+                    "Output in ${LANG}. Check keytool error: java.lang.Exception: "
+                            + "New password must be at least 6 characters."},
+
+            {"-keypasswd -v "
+                    + "-alias mykey2 "
+                    + "-storepass password "
+                    + "-keypass password "
+                    + "-new aaaaaa "
+                    + "-keystore ./i18n.keystore",
+                    "Output in ${LANG}. Check keytool error: -keypasswd "
+                            + "commands not supported if -storetype is PKCS12."},
+
+            {"-genkeypair -keyalg DSA -v -keysize 512 "
+                    + "-dname cn=Name,ou=Java,o=Oracle,l=City,s=State,c=Country "
+                    + "-storepass password "
+                    + "-keypass password "
+                    + "-keystore ./i18n.jks "
+                    + "-storetype JKS",
+                    "Output in ${LANG}. Check: generated a 512 bit DSA key pair "
+                            + "with a JKS warning."},
+
+            {"-keypasswd -v "
+                    + "-storepass password "
+                    + "-keypass password "
+                    + "-new aaaaaa "
+                    + "-keystore ./i18n.jks",
+                    "Output in ${LANG}. Check: storing i18n.jks with a JKS warning."},
+
+            {"-selfcert -v -alias mykey "
+                    + "-storepass password "
+                    + "-keypass password "
+                    + "-keystore ./i18n.keystore",
+                    "Output in ${LANG}. Check: generated a new certificate "
+                            + "(self-signed)."},
+
+            {"-list -v -storepass password -keystore ./i18n.keystore",
+                    "Output in ${LANG}. Check: contains 2 keystore entries "
+                            + "(alias name mykey & mykey2), both with 512-bit DSA"
+                            + " key algorithm for CN=Name, OU=Java, O=Oracle, "
+                            + "L=City, ST=State C=Country."},
+
+            {"-export -v -alias mykey "
+                    + "-file backup.keystore "
+                    + "-storepass password "
+                    + "-keystore ./i18n.keystore",
+                    "Output in ${LANG}. Check: certificate stored in file <backup"
+                            + ".keystore>."},
+
+            {"-import -v "
+                    + "-file backup.keystore "
+                    + "-storepass password "
+                    + "-keystore ./i18n.keystore",
+                    "Output in ${LANG}. Check keytool error: reply and certificate "
+                            + "in keystore are identical."},
+
+            {"-printcert -file backup.keystore",
+                    "Output in ${LANG}. Check: 512 bit DSA key pair for CN=Name,"
+                            + " OU=Java, O=Oracle, L=City, ST=State C=Country."},
+
+            {"-list -storepass password -keystore ./i18n.keystore "
+                    + "-addprovider SUN",
+                    "Output in ${LANG}. Check: contains 2 keystore entries "
+                            + "(alias name mykey & mykey2)."},
+
+            {"-storepasswd "
+                    + "-storepass password "
+                    + "-new a "
+                    + "-keystore ./i18n.keystore",
+                    "Output in ${LANG}. Check keytool error: java.lang.Exception: "
+                            + "New password must be at least 6 characters."},
+
+            {"-storepasswd "
+                    + "-storetype PKCS11 "
+                    + "-keystore NONE",
+                    "Output in ${LANG}. Check keytool error: java.lang"
+                            + ".UnsupportedOperationException: -storepasswd and "
+                            + "-keypasswd commands not supported if -storetype is"
+                            + " PKCS11."},
+
+            {"-keypasswd "
+                    + "-storetype PKCS11 "
+                    + "-keystore NONE",
+                    "Output in ${LANG}. Check keytool error: java.lang"
+                            + ".UnsupportedOperationException: -storepasswd and "
+                            + "-keypasswd commands not supported if -storetype is"
+                            + " PKCS11."},
+
+            {"-list -protected "
+                    + "-storepass password "
+                    + "-keystore ./i18n.keystore",
+                    "Output in ${LANG}. Check keytool error: java.lang"
+                            + ".IllegalArgumentException: if -protected is "
+                            + "specified, then -storepass, -keypass, and -new "
+                            + "must not be specified."},
+
+            {"-keypasswd -protected "
+                    + "-storepass password "
+                    + "-keystore ./i18n.keystore",
+                    "Output in ${LANG}. Check keytool error: java.lang"
+                            + ".IllegalArgumentException: if -protected is "
+                            + "specified, then -storepass, -keypass, and -new "
+                            + "must not be specified."},
+
+            {"-keypasswd -protected "
+                    + "-storepass password "
+                    + "-new aaaaaa "
+                    + "-keystore ./i18n.keystore",
+                    "Output in ${LANG}. Check keytool error: java.lang"
+                            + ".IllegalArgumentException: if -protected is "
+                            + "specified, then -storepass, -keypass, and -new "
+                            + "must not be specified."},
+    };
+    private static String TEST_SRC = System.getProperty("test.src");
+    private static int TIMEOUT_MS = 120000;
+    private volatile boolean failed = false;
+    private volatile boolean aborted = false;
+    private Thread currentThread = null;
+
+    public static class DialogBuilder {
+        private JDialog dialog;
+        private JTextArea instructionsText;
+        private JTextArea messageText;
+        private JButton pass;
+        private JButton fail;
+
+        public DialogBuilder() {
+            dialog = new JDialog(new JFrame());
+            dialog.setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
+            instructionsText = new JTextArea("", 5, 100);
+
+            dialog.add("North", new JScrollPane(instructionsText,
+                    JScrollPane.VERTICAL_SCROLLBAR_ALWAYS,
+                    JScrollPane.HORIZONTAL_SCROLLBAR_ALWAYS));
+
+            messageText = new JTextArea("", 20, 100);
+            dialog.add("Center", new JScrollPane(messageText,
+                    JScrollPane.VERTICAL_SCROLLBAR_ALWAYS,
+                    JScrollPane.HORIZONTAL_SCROLLBAR_ALWAYS));
+
+            JPanel buttons = new JPanel();
+            pass = new JButton("pass");
+            pass.setActionCommand("pass");
+            buttons.add("East", pass);
+
+            fail = new JButton("fail");
+            fail.setActionCommand("fail");
+            buttons.add("West", fail);
+
+            dialog.add("South", buttons);
+        }
+
+        public DialogBuilder setTitle(String title) {
+            dialog.setTitle(title);
+            return this;
+        }
+
+        public DialogBuilder setInstruction(String instruction) {
+            instructionsText.setText("Test instructions:\n" + instruction);
+            return this;
+        }
+
+        public DialogBuilder setMessage(String message) {
+            messageText.setText(message);
+            return this;
+        }
+
+        public DialogBuilder setPassAction(ActionListener action) {
+            pass.addActionListener(action);
+            return this;
+        }
+
+        public DialogBuilder setFailAction(ActionListener action) {
+            fail.addActionListener(action);
+            return this;
+        }
+
+        public DialogBuilder setAbortAction(Runnable action) {
+            dialog.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    super.windowClosing(e);
+                    action.run();
+                }
+            });
+            return this;
+        }
+
+        public JDialog build() {
+            dialog.pack();
+            return dialog;
+        }
+    }
+
+    public static void executeKeytool(String command) throws Exception {
+        sun.security.tools.keytool.Main.main(command.split("\\s+"));
+    }
+
+    public static void main(String[] args) {
+        if (args.length == 1) {
+            Locale.setDefault(Locale.of(args[0]));
+        } else if (args.length == 2) {
+            Locale.setDefault(Locale.of(args[0], args[1]));
+        }
+        final String LANG = Locale.getDefault().getDisplayLanguage();
+
+        boolean testFailed = false;
+        i18n i18nTest = new i18n();
+
+        for (String[] entry : TABLE) {
+            String command = entry[0].replaceAll("\\$\\{TEST_SRC\\}", TEST_SRC);
+            String instruction = entry[1].replaceAll("\\$\\{LANG\\}", LANG);
+
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+            doKeytool(command, new PrintStream(buffer, true));
+
+            testFailed |= i18nTest.validate(command, instruction, buffer.toString());
+        }
+
+        if (testFailed) {
+            throw new RuntimeException("One or more tests failed.");
+        }
+    }
+
+    public static void doKeytool(String command, PrintStream dest) {
+        // Backups stdout and stderr.
+        PrintStream origStdOut = System.out;
+        PrintStream origErrOut = System.err;
+
+        // Redirects the system output to a custom one.
+        System.setOut(dest);
+        System.setErr(dest);
+
+        try {
+            executeKeytool("-debug " + command);
+        } catch (Exception e) {
+            // Do nothing.
+        } finally {
+            System.setOut(origStdOut);
+            System.setErr(origErrOut);
+        }
+    }
+
+    public boolean validate(String command, String instruction, String message) {
+        failed = false;
+        currentThread = Thread.currentThread();
+        JDialog dialog = new DialogBuilder()
+                .setTitle("keytool " + command)
+                .setInstruction(instruction)
+                .setMessage(message)
+                .setPassAction(e -> pass())
+                .setFailAction(e -> fail())
+                .setAbortAction(() -> abort())
+                .build();
+
+        SwingUtilities.invokeLater(() -> {
+            try {
+                dialog.setVisible(true);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        try {
+            Thread.sleep(TIMEOUT_MS);
+            //Timed out, so fail the test
+            throw new RuntimeException(
+                    "Timed out after " + TIMEOUT_MS / 1000 + " seconds");
+        } catch (InterruptedException e) {
+            if (aborted) {
+                throw new RuntimeException("TEST ABORTED");
+            }
+
+            if (failed) {
+                System.out.println(command + ": TEST FAILED");
+                System.out.println(message);
+            } else {
+                System.out.println(command + ": TEST PASSED");
+            }
+        } finally {
+            dialog.dispose();
+        }
+
+        return failed;
+    }
+
+    public void pass() {
+        failed = false;
+        currentThread.interrupt();
+    }
+
+    public void fail() {
+        failed = true;
+        currentThread.interrupt();
+    }
+
+    public void abort() {
+        aborted = true;
+        currentThread.interrupt();
     }
 }

--- a/test/lib/jdk/test/lib/TestUI.java
+++ b/test/lib/jdk/test/lib/TestUI.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.test.lib;
+
+import javax.swing.*;
+import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+
+public class TestUI {
+    public static class DialogBuilder {
+        private JDialog dialog;
+        private JTextArea instructionsText;
+        private JTextArea messageText;
+        private JButton pass;
+        private JButton fail;
+
+        public DialogBuilder() {
+            dialog = new JDialog(new JFrame());
+            dialog.setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
+            instructionsText = new JTextArea("", 5, 100);
+
+            dialog.add("North", new JScrollPane(instructionsText,
+                    JScrollPane.VERTICAL_SCROLLBAR_ALWAYS,
+                    JScrollPane.HORIZONTAL_SCROLLBAR_ALWAYS));
+
+            messageText = new JTextArea("", 20, 100);
+            dialog.add("Center", new JScrollPane(messageText,
+                    JScrollPane.VERTICAL_SCROLLBAR_ALWAYS,
+                    JScrollPane.HORIZONTAL_SCROLLBAR_ALWAYS));
+
+            JPanel buttons = new JPanel();
+            pass = new JButton("pass");
+            pass.setActionCommand("pass");
+            buttons.add("East", pass);
+
+            fail = new JButton("fail");
+            fail.setActionCommand("fail");
+            buttons.add("West", fail);
+
+            dialog.add("South", buttons);
+        }
+
+        public DialogBuilder setTitle(String title) {
+            dialog.setTitle(title);
+            return this;
+        }
+
+        public DialogBuilder setInstruction(String instruction) {
+            instructionsText.setText("Test instructions:\n" + instruction);
+            return this;
+        }
+
+        public DialogBuilder setMessage(String message) {
+            messageText.setText(message);
+            return this;
+        }
+
+        public DialogBuilder setPassAction(ActionListener action) {
+            pass.addActionListener(action);
+            return this;
+        }
+
+        public DialogBuilder setFailAction(ActionListener action) {
+            fail.addActionListener(action);
+            return this;
+        }
+
+        public DialogBuilder setCloseAction(Runnable action) {
+            dialog.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    super.windowClosing(e);
+                    action.run();
+                }
+            });
+            return this;
+        }
+
+        public JDialog build() {
+            dialog.pack();
+            return dialog;
+        }
+    }
+}

--- a/test/lib/jdk/test/lib/UIBuilder.java
+++ b/test/lib/jdk/test/lib/UIBuilder.java
@@ -50,7 +50,7 @@ public class UIBuilder {
         private JButton fail;
 
         /**
-         * Contruct a new DialogBuilder object.
+         * Construct a new DialogBuilder object.
          */
         public DialogBuilder() {
             dialog = new JDialog(new JFrame());

--- a/test/lib/jdk/test/lib/UIBuilder.java
+++ b/test/lib/jdk/test/lib/UIBuilder.java
@@ -27,7 +27,21 @@ import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 
-public class TestUI {
+/**
+ * This is a common library for building UI for testing purposes.
+ */
+public class UIBuilder {
+
+    /**
+     * Creates a {@link javax.swing.JDialog} object with a fixed layout that contains
+     * an instructions {@link javax.swing.JTextArea} and a message
+     * {@link javax.swing.JTextArea} for displaying text contents. Text contents can
+     * be set by using {@code setInstruction} method and {@code setMessage} method.
+     *
+     * The {@link javax.swing.JDialog} object also a pass {@link javax.swing.JButton}
+     * and a fail {@link javax.swing.JButton} to indicate test result. Buttons' action
+     * can be bound by using {@code setPassAction} and {@code setFailAction}.
+     */
     public static class DialogBuilder {
         private JDialog dialog;
         private JTextArea instructionsText;
@@ -35,6 +49,9 @@ public class TestUI {
         private JButton pass;
         private JButton fail;
 
+        /**
+         * Contruct a new DialogBuilder object.
+         */
         public DialogBuilder() {
             dialog = new JDialog(new JFrame());
             dialog.setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
@@ -61,31 +78,65 @@ public class TestUI {
             dialog.add("South", buttons);
         }
 
+        /**
+         * Returns this {@code DialogBuilder} setting the dialog's title to a new value.
+         * @param title a string value
+         * @returns this DialogBuilder
+         */
         public DialogBuilder setTitle(String title) {
             dialog.setTitle(title);
             return this;
         }
 
+        /**
+         * Returns this {@code DialogBuilder} setting the instruction text to a new
+         * value.
+         * @param instruction a string value
+         * @returns this DialogBuilder
+         */
         public DialogBuilder setInstruction(String instruction) {
             instructionsText.setText("Test instructions:\n" + instruction);
             return this;
         }
 
+        /**
+         * Returns this {@code DialogBuilder} setting the message text to a new value.
+         * @param message a string value
+         * @returns this DialogBuilder
+         */
         public DialogBuilder setMessage(String message) {
             messageText.setText(message);
             return this;
         }
 
+        /**
+         * Returns this {@code DialogBuilder} setting pass button action to
+         * {@link java.awt.event.ActionListener}.
+         * @param action an action to perform on button click
+         * @returns this DialogBuilder
+         */
         public DialogBuilder setPassAction(ActionListener action) {
             pass.addActionListener(action);
             return this;
         }
 
+        /**
+         * Returns this {@code DialogBuilder} setting fail button action to
+         * {@link java.awt.event.ActionListener}.
+         * @param action an action to perform on button click
+         * @returns this DialogBuilder
+         */
         public DialogBuilder setFailAction(ActionListener action) {
             fail.addActionListener(action);
             return this;
         }
 
+        /**
+         * Returns this {@code DialogBuilder} setting window-closing action to
+         * {@link java.lang.Runnable}.
+         * @param action a runnerable action to perform on window close
+         * @returns this DialogBuilder
+         */
         public DialogBuilder setCloseAction(Runnable action) {
             dialog.addWindowListener(new WindowAdapter() {
                 @Override
@@ -97,6 +148,10 @@ public class TestUI {
             return this;
         }
 
+        /**
+         * Returns a {@link javax.swing.JDialog} window.
+         * @returns a JDialog
+         */
         public JDialog build() {
             dialog.pack();
             return dialog;


### PR DESCRIPTION
The jarsigner and keytool are localized into English, German, Japanese and Simplified Chinese. This task is to modify the existing i18n tests to validate i18n compliance in these tools. 

In addition, this task also contains changes for manual test enhancement and simplification which originated from [JDK-8292663](https://bugs.openjdk.org/browse/JDK-8292663).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294994](https://bugs.openjdk.org/browse/JDK-8294994): Update Jarsigner and Keytool i18n tests to validate i18n compliance


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10635/head:pull/10635` \
`$ git checkout pull/10635`

Update a local copy of the PR: \
`$ git checkout pull/10635` \
`$ git pull https://git.openjdk.org/jdk pull/10635/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10635`

View PR using the GUI difftool: \
`$ git pr show -t 10635`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10635.diff">https://git.openjdk.org/jdk/pull/10635.diff</a>

</details>
