### PR TITLE
8295025: (bf) ByteBuffer "Access to binary data" section suggests putFloat is void

### DIFF
--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -150,10 +150,11 @@ import jdk.internal.util.ArraysSupport;
  * values, for example, this class defines:
  *
  * <blockquote><pre>
- * float  {@link #getFloat()}
- * float  {@link #getFloat(int) getFloat(int index)}
- *  void  {@link #putFloat(float) putFloat(float f)}
- *  void  {@link #putFloat(int,float) putFloat(int index, float f)}</pre></blockquote>
+ * float      {@link #getFloat()}
+ * float      {@link #getFloat(int) getFloat(int index)}
+ * ByteBuffer {@link #putFloat(float) putFloat(float f)}
+ * ByteBuffer {@link #putFloat(int,float) putFloat(int index, float f)}
+ * </pre></blockquote>
  *
  * <p> Corresponding methods are defined for the types {@code char,
  * short, int, long}, and {@code double}.  The index


### PR DESCRIPTION
In the "Access to binary data" section of the class specification of `java.nio.ByteBuffer`, change `void putFloat` to `ByteBuffer putFloat`.
<!-- csr: 'update' -->

<!-- csr: 'update' -->

<!-- csr: 'update' -->

<!-- csr: 'update' -->

<!-- csr: 'update' -->

<!-- csr: 'update' -->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8295025](https://bugs.openjdk.org/browse/JDK-8295025): (bf) ByteBuffer "Access to binary data" section suggests putFloat is void
 * [JDK-8295101](https://bugs.openjdk.org/browse/JDK-8295101): (bf) ByteBuffer "Access to binary data" section suggests putFloat is void (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10638/head:pull/10638` \
`$ git checkout pull/10638`

Update a local copy of the PR: \
`$ git checkout pull/10638` \
`$ git pull https://git.openjdk.org/jdk pull/10638/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10638`

View PR using the GUI difftool: \
`$ git pr show -t 10638`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10638.diff">https://git.openjdk.org/jdk/pull/10638.diff</a>

</details>

<!-- csr: 'update' -->
