### PR TITLE
8295102: Always load @lambda-form-invoker lines from default classlist

### DIFF
--- a/src/hotspot/share/cds/classListParser.cpp
+++ b/src/hotspot/share/cds/classListParser.cpp
@@ -54,7 +54,9 @@
 volatile Thread* ClassListParser::_parsing_thread = NULL;
 ClassListParser* ClassListParser::_instance = NULL;
 
-ClassListParser::ClassListParser(const char* file) : _id2klass_table(INITIAL_TABLE_SIZE, MAX_TABLE_SIZE) {
+ClassListParser::ClassListParser(const char* file, ParseMode parse_mode) : _id2klass_table(INITIAL_TABLE_SIZE, MAX_TABLE_SIZE) {
+  log_info(cds)("Parsing %s%s", file,
+                (parse_mode == _parse_lambda_forms_invokers_only) ? " (lambda form invokers only" : "");
   _classlist_file = file;
   _file = NULL;
   // Use os::open() because neither fopen() nor os::fopen()
@@ -73,6 +75,7 @@ ClassListParser::ClassListParser(const char* file) : _id2klass_table(INITIAL_TAB
   _line_no = 0;
   _interfaces = new (ResourceObj::C_HEAP, mtClass) GrowableArray<int>(10, mtClass);
   _indy_items = new (ResourceObj::C_HEAP, mtClass) GrowableArray<const char*>(9, mtClass);
+  _parse_mode = parse_mode;
 
   // _instance should only be accessed by the thread that created _instance.
   assert(_instance == NULL, "must be singleton");
@@ -101,6 +104,10 @@ int ClassListParser::parse(TRAPS) {
     if (lambda_form_line()) {
       // The current line is "@lambda-form-invoker ...". It has been recorded in LambdaFormInvokers,
       // and will be processed later.
+      continue;
+    }
+
+    if (_parse_mode == _parse_lambda_forms_invokers_only) {
       continue;
     }
 

--- a/src/hotspot/share/cds/classListParser.cpp
+++ b/src/hotspot/share/cds/classListParser.cpp
@@ -56,7 +56,7 @@ ClassListParser* ClassListParser::_instance = NULL;
 
 ClassListParser::ClassListParser(const char* file, ParseMode parse_mode) : _id2klass_table(INITIAL_TABLE_SIZE, MAX_TABLE_SIZE) {
   log_info(cds)("Parsing %s%s", file,
-                (parse_mode == _parse_lambda_forms_invokers_only) ? " (lambda form invokers only" : "");
+                (parse_mode == _parse_lambda_forms_invokers_only) ? " (lambda form invokers only)" : "");
   _classlist_file = file;
   _file = NULL;
   // Use os::open() because neither fopen() nor os::fopen()

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -737,7 +737,7 @@ void MetaspaceShared::get_default_classlist(char* default_classlist, const size_
   // Construct the path to the class list (in jre/lib)
   // Walk up two directories from the location of the VM and
   // optionally tack on "lib" (depending on platform)
-  os::jvm_path(default_classlist, buf_size);
+  os::jvm_path(default_classlist, (jint)(buf_size));
   for (int i = 0; i < 3; i++) {
     char *end = strrchr(default_classlist, *os::file_separator());
     if (end != NULL) *end = '\0';
@@ -780,8 +780,12 @@ void MetaspaceShared::preload_classes(TRAPS) {
                                                     ClassListParser::_parse_all, CHECK);
   }
   if (classlist_path != default_classlist) {
-    class_count += ClassListParser::parse_classlist(default_classlist,
-                                                    ClassListParser::_parse_lambda_forms_invokers_only, CHECK);
+    struct stat statbuf;
+    if (os::stat(default_classlist, &statbuf) == 0) {
+      // File exists, let's use it.
+      class_count += ClassListParser::parse_classlist(default_classlist,
+                                                      ClassListParser::_parse_lambda_forms_invokers_only, CHECK);
+    }
   }
 
   // Exercise the manifest processing code to ensure classes used by CDS at runtime

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -733,35 +733,39 @@ void MetaspaceShared::adjust_heap_sizes_for_dumping() {
 }
 #endif // INCLUDE_CDS_JAVA_HEAP && _LP64
 
+void MetaspaceShared::get_default_classlist(char* default_classlist, const size_t buf_size) {
+  // Construct the path to the class list (in jre/lib)
+  // Walk up two directories from the location of the VM and
+  // optionally tack on "lib" (depending on platform)
+  os::jvm_path(default_classlist, buf_size);
+  for (int i = 0; i < 3; i++) {
+    char *end = strrchr(default_classlist, *os::file_separator());
+    if (end != NULL) *end = '\0';
+  }
+  size_t classlist_path_len = strlen(default_classlist);
+  if (classlist_path_len >= 3) {
+    if (strcmp(default_classlist + classlist_path_len - 3, "lib") != 0) {
+      if (classlist_path_len < buf_size - 4) {
+        jio_snprintf(default_classlist + classlist_path_len,
+                     buf_size - classlist_path_len,
+                     "%slib", os::file_separator());
+        classlist_path_len += 4;
+      }
+    }
+  }
+  if (classlist_path_len < buf_size - 10) {
+    jio_snprintf(default_classlist + classlist_path_len,
+                 buf_size - classlist_path_len,
+                 "%sclasslist", os::file_separator());
+  }
+}
+
 void MetaspaceShared::preload_classes(TRAPS) {
   char default_classlist[JVM_MAXPATHLEN];
   const char* classlist_path;
 
+  get_default_classlist(default_classlist, sizeof(default_classlist));
   if (SharedClassListFile == NULL) {
-    // Construct the path to the class list (in jre/lib)
-    // Walk up two directories from the location of the VM and
-    // optionally tack on "lib" (depending on platform)
-    os::jvm_path(default_classlist, sizeof(default_classlist));
-    for (int i = 0; i < 3; i++) {
-      char *end = strrchr(default_classlist, *os::file_separator());
-      if (end != NULL) *end = '\0';
-    }
-    int classlist_path_len = (int)strlen(default_classlist);
-    if (classlist_path_len >= 3) {
-      if (strcmp(default_classlist + classlist_path_len - 3, "lib") != 0) {
-        if (classlist_path_len < JVM_MAXPATHLEN - 4) {
-          jio_snprintf(default_classlist + classlist_path_len,
-                       sizeof(default_classlist) - classlist_path_len,
-                       "%slib", os::file_separator());
-          classlist_path_len += 4;
-        }
-      }
-    }
-    if (classlist_path_len < JVM_MAXPATHLEN - 10) {
-      jio_snprintf(default_classlist + classlist_path_len,
-                   sizeof(default_classlist) - classlist_path_len,
-                   "%sclasslist", os::file_separator());
-    }
     classlist_path = default_classlist;
   } else {
     classlist_path = SharedClassListFile;
@@ -769,9 +773,15 @@ void MetaspaceShared::preload_classes(TRAPS) {
 
   log_info(cds)("Loading classes to share ...");
   _has_error_classes = false;
-  int class_count = parse_classlist(classlist_path, CHECK);
+  int class_count = ClassListParser::parse_classlist(classlist_path,
+                                                     ClassListParser::_parse_all, CHECK);
   if (ExtraSharedClassListFile) {
-    class_count += parse_classlist(ExtraSharedClassListFile, CHECK);
+    class_count += ClassListParser::parse_classlist(ExtraSharedClassListFile,
+                                                    ClassListParser::_parse_all, CHECK);
+  }
+  if (classlist_path != default_classlist) {
+    class_count += ClassListParser::parse_classlist(default_classlist,
+                                                    ClassListParser::_parse_lambda_forms_invokers_only, CHECK);
   }
 
   // Exercise the manifest processing code to ensure classes used by CDS at runtime
@@ -812,12 +822,6 @@ void MetaspaceShared::preload_and_dump_impl(TRAPS) {
 
   VM_PopulateDumpSharedSpace op;
   VMThread::execute(&op);
-}
-
-
-int MetaspaceShared::parse_classlist(const char* classlist_path, TRAPS) {
-  ClassListParser parser(classlist_path);
-  return parser.parse(THREAD); // returns the number of classes loaded.
 }
 
 // Returns true if the class's status has changed.

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -88,9 +88,6 @@ class MetaspaceShared : AllStatic {
 private:
   static void preload_and_dump_impl(TRAPS) NOT_CDS_RETURN;
   static void preload_classes(TRAPS) NOT_CDS_RETURN;
-  static int parse_classlist(const char * classlist_path,
-                              TRAPS) NOT_CDS_RETURN_(0);
-
 
 public:
   static Symbol* symbol_rs_base() {
@@ -202,5 +199,6 @@ private:
                                      ReservedSpace& class_space_rs);
   static MapArchiveResult map_archive(FileMapInfo* mapinfo, char* mapped_base_address, ReservedSpace rs);
   static void unmap_archive(FileMapInfo* mapinfo);
+  static void get_default_classlist(char* default_classlist, const size_t buf_size);
 };
 #endif // SHARE_CDS_METASPACESHARED_HPP

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -423,6 +423,7 @@ hotspot_appcds_dynamic = \
  -runtime/cds/appcds/jcmd/JCmdTestStaticDump.java \
  -runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java \
  -runtime/cds/appcds/jcmd/JCmdTestFileSafety.java \
+ -runtime/cds/appcds/lambdaForm/DefaultClassListLFInvokers.java \
  -runtime/cds/appcds/methodHandles \
  -runtime/cds/appcds/sharedStrings \
  -runtime/cds/appcds/ArchiveRelocationTest.java \

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
@@ -745,4 +745,33 @@ public class TestCommon extends CDSTestUtils {
         }
         return sb.toString();
     }
+
+    public static void stdoutMustMatch(OutputAnalyzer a, OutputAnalyzer b) {
+        linesMustMatch(a.getStdout().split("\n"),
+                             b.getStdout().split("\n"));
+    }
+
+    public static void linesMustMatch(String a[], String b[]) {
+        int max = Math.max(a.length, b.length);
+        for (int i = 0; i < max; i++) {
+            if (!a[i].equals(b[i])) {
+                System.out.println("a:" + i + " " + a[i]);
+                System.out.println("b:" + i + " " + b[i]);
+                throw new RuntimeException("Output mismatch on line :" + i
+                                           + ", a=" + a[i]
+                                           + ", b=" + b[i]);
+            }
+        }
+        if (a.length > b.length) {
+            throw new RuntimeException("Output mismatch on line :" + max
+                                       + ", a=" + a[max]
+                                       + ", b=<none>");
+
+        }
+        if (a.length < b.length) {
+            throw new RuntimeException("Output mismatch on line :" + max
+                                       + ", a=<none>"
+                                       + ", b=" + b[max]);
+        }
+    }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -746,9 +747,9 @@ public class TestCommon extends CDSTestUtils {
         return sb.toString();
     }
 
-    public static void stdoutMustMatch(OutputAnalyzer a, OutputAnalyzer b) {
-        linesMustMatch(a.getStdout().split("\n"),
-                             b.getStdout().split("\n"));
+    public static void filesMustMatch(Path a, Path b) throws IOException {
+        linesMustMatch(Files.readString(a).split("\n"),
+                       Files.readString(b).split("\n"));
     }
 
     public static void linesMustMatch(String a[], String b[]) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
@@ -752,26 +752,30 @@ public class TestCommon extends CDSTestUtils {
     }
 
     public static void linesMustMatch(String a[], String b[]) {
-        int max = Math.max(a.length, b.length);
-        for (int i = 0; i < max; i++) {
+        int limit = Math.min(a.length, b.length);
+
+        // Check the lines that are in both a[] and b[]
+        for (int i = 0; i < limit; i++) {
             if (!a[i].equals(b[i])) {
                 System.out.println("a:" + i + " " + a[i]);
                 System.out.println("b:" + i + " " + b[i]);
-                throw new RuntimeException("Output mismatch on line :" + i
-                                           + ", a=" + a[i]
+                throw new RuntimeException("Output mismatch on line " + i
+                                           + ": a=" + a[i]
                                            + ", b=" + b[i]);
             }
         }
+
+        // Report the first line that is in one array but not in the other
         if (a.length > b.length) {
-            throw new RuntimeException("Output mismatch on line :" + max
-                                       + ", a=" + a[max]
+            throw new RuntimeException("Output mismatch on line " + limit
+                                       + ": a=" + a[limit]
                                        + ", b=<none>");
 
         }
         if (a.length < b.length) {
-            throw new RuntimeException("Output mismatch on line :" + max
-                                       + ", a=<none>"
-                                       + ", b=" + b[max]);
+            throw new RuntimeException("Output mismatch on line " + limit
+                                       + ": a=<none>"
+                                       + ", b=" + b[limit]);
         }
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/lambdaForm/DefaultClassListLFInvokers.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/lambdaForm/DefaultClassListLFInvokers.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8295102
+ * @summary Always load the lambda-form-invoker lines from default classlist
+ * @requires vm.cds
+ * @library /test/jdk/lib/testlibrary /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ * @build DefaultClassListLFInvokers
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar
+ *             DefaultClassListLFInvokersApp DefaultClassListLFInvokersApp$CompMethods
+ * @run driver DefaultClassListLFInvokers
+ */
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Comparator;
+
+import jdk.test.lib.cds.CDSOptions;
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.helpers.ClassFileInstaller;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class DefaultClassListLFInvokers {
+    static final String appClass = DefaultClassListLFInvokersApp.class.getName();
+    static final String appJar = ClassFileInstaller.getJarPath("app.jar");
+
+    static final String[] classlist = {
+        appClass,
+        // If we have at least one line of @lambda-form-invoker in the classlist, it triggers
+        // the regeneration of the 4 XXX$Holder during -Xshare:dump.
+        "@lambda-form-invoker [LF_RESOLVE] java.lang.invoke.DirectMethodHandle$Holder invokeStatic L_V"
+    };
+
+    public static void main(String[] args) throws Exception {
+        File classListFile = CDSTestUtils.makeClassList(classlist);
+
+        OutputAnalyzer dump =
+            CDSTestUtils.createArchive("-XX:SharedClassListFile=" + classListFile.getPath(),
+                                       "-cp", appJar);
+        CDSTestUtils.checkDump(dump);
+
+        CDSOptions opts = (new CDSOptions())
+            .addSuffix("-showversion", "-Xlog:cds:stderr", "-cp", appJar, appClass)
+            .setUseVersion(false);
+
+        opts.setXShareMode("auto");
+        opts.setUseSystemArchive(false);
+        OutputAnalyzer withcds = CDSTestUtils.run(opts).getOutput();
+        withcds.shouldContain(DefaultClassListLFInvokersApp.FLAG);
+        withcds.shouldHaveExitValue(0);
+
+        opts.setXShareMode("off");
+        opts.setUseSystemArchive(true);
+        OutputAnalyzer nocds = CDSTestUtils.run(opts).getOutput();
+        nocds.shouldContain(DefaultClassListLFInvokersApp.FLAG);
+        withcds.shouldHaveExitValue(0);
+
+        // Make sure we still have all the LF invoker methods as when CDS is disabled,
+        // in which case the XXX$Holder classes are loaded from $JAVA_HOME/lib/modules
+
+        System.out.println("\n\n============================== Checking output: withcds vs nocds");
+        TestCommon.stdoutMustMatch(withcds, nocds);
+
+        opts.setXShareMode("auto");
+        opts.setUseSystemArchive(true);
+        OutputAnalyzer defcds = CDSTestUtils.run(opts).getOutput();
+        defcds.shouldContain(DefaultClassListLFInvokersApp.FLAG);
+        withcds.shouldHaveExitValue(0);
+
+        // We should also have all the LF invoker methods as when the default CDS archive is used
+        // in which case the XXX$Holder classes are loaded from the default archive,
+        // e.g., $JAVA_HOME/lib/server/classes.jsa
+
+        System.out.println("\n\n============================== Checking output: withcds vs defcds");
+        TestCommon.stdoutMustMatch(withcds, defcds);
+    }
+}
+
+class DefaultClassListLFInvokersApp {
+    public static final String FLAG = "Test Success!";
+
+    static class CompMethods implements Comparator<Method> {
+        public int compare(Method a, Method b) {
+            return a.toString().compareTo(b.toString());
+        }
+    }
+    static final CompMethods compMethods = new CompMethods();
+
+    public static void main(String[] args) throws Exception {
+        test("java.lang.invoke.Invokers$Holder");
+        test("java.lang.invoke.DirectMethodHandle$Holder");
+        test("java.lang.invoke.DelegatingMethodHandle$Holder");
+        test("java.lang.invoke.LambdaForm$Holder");
+        System.out.println(FLAG);
+    }
+
+    static void test(String className) throws Exception {
+        Class c = Class.forName(className);
+        Method[] methods = c.getDeclaredMethods();
+        System.out.println("Dumping all methods in " + c);
+        Arrays.sort(methods, 0, methods.length, compMethods);
+        for (Method m : methods) {
+            System.out.println(m);
+        }
+        System.out.println("Found " + methods.length + " methods\n\n");
+    }
+}

--- a/test/lib/jdk/test/lib/cds/CDSTestUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSTestUtils.java
@@ -204,6 +204,10 @@ public class CDSTestUtils {
             output.shouldNotHaveExitValue(0);
             return this;
         }
+
+        public OutputAnalyzer getOutput() {
+            return output;
+        }
     }
 
     // A number to be included in the filename of the stdout and the stderr output file.

--- a/test/lib/jdk/test/lib/cds/CDSTestUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSTestUtils.java
@@ -204,10 +204,6 @@ public class CDSTestUtils {
             output.shouldNotHaveExitValue(0);
             return this;
         }
-
-        public OutputAnalyzer getOutput() {
-            return output;
-        }
     }
 
     // A number to be included in the filename of the stdout and the stderr output file.


### PR DESCRIPTION
The `@lambda-form-invoker` lines in the default classlist (`$JAVA_HOME/lib/classlist`) control what lambda-form invoker methods are added to these classes that are generated during a CDS dump ([see here](https://github.com/iklam/jdk/blob/5aa997b001367141a6a2d2e69649d41b46199ab4/src/hotspot/share/cds/lambdaFormInvokers.cpp#L230)):

- `java.lang.invoke.Invokers$Holder`
- `java.lang.invoke.DirectMethodHandle$Holder`
- `java.lang.invoke.DelegatingMethodHandle$Holder`
- `java.lang.invoke.LambdaForm$Holder`

The list of these invoker methods is generated as part of the [JDK build process](https://github.com/iklam/jdk/blob/1996f649a3a30b7ac4b547a762417f807f5fa414/make/GenerateLinkOptData.gmk#L64). They are used for invoking MethodHandles of commonly-used types, so that we can avoid generating custom LambdaForm classes.

When a CDS archive is created with a non-default classlist, (e.g., `-XX:SharedClassListFile=foo.classlist`), such a classlist may not contain all the `@lambda-form-invoker` lines as in the default classlist. As a result, at runtime, more custom LambdaForm classes may be generated than necessary.

The solution is to always load the `@lambda-form-invoker` lines from the default classlist, to make sure the CDS image has all the commonly-used invoker methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295102](https://bugs.openjdk.org/browse/JDK-8295102): Always load @lambda-form-invoker lines from default classlist


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to [2e6af772](https://git.openjdk.org/jdk/pull/10639/files/2e6af772766dff3432a11b436924185e1b270626)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10639/head:pull/10639` \
`$ git checkout pull/10639`

Update a local copy of the PR: \
`$ git checkout pull/10639` \
`$ git pull https://git.openjdk.org/jdk pull/10639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10639`

View PR using the GUI difftool: \
`$ git pr show -t 10639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10639.diff">https://git.openjdk.org/jdk/pull/10639.diff</a>

</details>
