### PR TITLE
8294841: G1: Refactor predict_base_elapsed_time_ms

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -421,7 +421,7 @@ double G1CollectionSet::finalize_young_part(double target_pause_time_ms, G1Survi
   // collection set's current size
   set_recorded_rs_length(_inc_recorded_rs_length);
 
-  double predicted_base_time_ms = _policy->predict_base_elapsed_time_ms(pending_cards);
+  double predicted_base_time_ms = _policy->predict_base_time_ms(pending_cards);
   double predicted_eden_time = _inc_predicted_non_copy_time_ms + _policy->predict_eden_copy_time_ms(eden_region_length);
   double remaining_time_ms = MAX2(target_pause_time_ms - (predicted_base_time_ms + predicted_eden_time), 0.0);
 

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -257,10 +257,10 @@ uint G1Policy::calculate_young_desired_length(size_t rs_length) const {
     desired_eden_length_by_mmu = calculate_desired_eden_length_by_mmu();
 
     const size_t pending_cards = _analytics->predict_pending_cards();
-    double survivor_base_time_ms = predict_base_elapsed_time_ms(pending_cards, rs_length);
+    double base_time_ms = predict_base_time_ms(pending_cards, rs_length);
 
     desired_eden_length_by_pause =
-      calculate_desired_eden_length_by_pause(survivor_base_time_ms,
+      calculate_desired_eden_length_by_pause(base_time_ms,
                                              absolute_min_young_length - survivor_length,
                                              absolute_max_young_length - survivor_length);
 
@@ -476,17 +476,17 @@ uint G1Policy::calculate_desired_eden_length_before_young_only(double base_time_
   return min_eden_length;
 }
 
-uint G1Policy::calculate_desired_eden_length_before_mixed(double survivor_base_time_ms,
+uint G1Policy::calculate_desired_eden_length_before_mixed(double base_time_ms,
                                                           uint min_eden_length,
                                                           uint max_eden_length) const {
   G1CollectionSetCandidates* candidates = _collection_set->candidates();
 
   uint min_old_regions_end = MIN2(candidates->cur_idx() + calc_min_old_cset_length(candidates),
                                   candidates->num_regions());
-  double predicted_region_evac_time_ms = survivor_base_time_ms;
+  double predicted_region_evac_time_ms = base_time_ms;
   for (uint i = candidates->cur_idx(); i < min_old_regions_end; i++) {
     HeapRegion* r = candidates->at(i);
-    predicted_region_evac_time_ms += predict_region_total_time_ms(r, false);
+    predicted_region_evac_time_ms += predict_region_total_time_ms(r, false /* for_young_gc */);
   }
   uint desired_eden_length_by_min_cset_length =
      calculate_desired_eden_length_before_young_only(predicted_region_evac_time_ms,
@@ -1008,19 +1008,25 @@ void G1Policy::record_young_gc_pause_end(bool evacuation_failed) {
   phase_times()->print(evacuation_failed);
 }
 
-double G1Policy::predict_base_elapsed_time_ms(size_t pending_cards,
-                                              size_t rs_length) const {
+double G1Policy::predict_base_time_ms(size_t pending_cards,
+                                      size_t rs_length) const {
   size_t effective_scanned_cards = _analytics->predict_scan_card_num(rs_length, collector_state()->in_young_only_phase());
-  return
-    _analytics->predict_card_merge_time_ms(pending_cards + rs_length, collector_state()->in_young_only_phase()) +
-    _analytics->predict_card_scan_time_ms(effective_scanned_cards, collector_state()->in_young_only_phase()) +
-    _analytics->predict_constant_other_time_ms() +
-    predict_survivor_regions_evac_time();
+
+  double card_merge_time = _analytics->predict_card_merge_time_ms(pending_cards + rs_length, collector_state()->in_young_only_phase());
+  double card_scan_time = _analytics->predict_card_scan_time_ms(effective_scanned_cards, collector_state()->in_young_only_phase());
+  double constant_other_time = _analytics->predict_constant_other_time_ms();
+  double survivor_evac_time = predict_survivor_regions_evac_time();
+
+  double total_time = card_merge_time + card_scan_time + constant_other_time + survivor_evac_time;
+
+  log_trace(gc, ergo, heap)("Predicted base time: total %f lb_cards %zu rs_length %zu effective_scanned_cards %zu card_merge_time %f card_scan_time %f constant_other_time %f survivor_evac_time %f",
+                            total_time, pending_cards, rs_length, effective_scanned_cards, card_merge_time, card_scan_time, constant_other_time, survivor_evac_time);
+  return total_time;
 }
 
-double G1Policy::predict_base_elapsed_time_ms(size_t pending_cards) const {
+double G1Policy::predict_base_time_ms(size_t pending_cards) const {
   size_t rs_length = _analytics->predict_rs_length();
-  return predict_base_elapsed_time_ms(pending_cards, rs_length);
+  return predict_base_time_ms(pending_cards, rs_length);
 }
 
 size_t G1Policy::predict_bytes_to_copy(HeapRegion* hr) const {

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -137,10 +137,10 @@ public:
     _rs_length = rs_length;
   }
 
-  double predict_base_elapsed_time_ms(size_t num_pending_cards) const;
+  double predict_base_time_ms(size_t pending_cards) const;
 
 private:
-  double predict_base_elapsed_time_ms(size_t num_pending_cards, size_t rs_length) const;
+  double predict_base_time_ms(size_t pending_cards, size_t rs_length) const;
 
   double predict_region_copy_time_ms(HeapRegion* hr) const;
 
@@ -219,7 +219,7 @@ private:
   // Calculates the desired eden length before mixed gc so that after adding the
   // minimum amount of old gen regions from the collection set, the eden fits into
   // the pause time goal.
-  uint calculate_desired_eden_length_before_mixed(double survivor_base_time_ms,
+  uint calculate_desired_eden_length_before_mixed(double base_time_ms,
                                                   uint min_eden_length,
                                                   uint max_eden_length) const;
 


### PR DESCRIPTION
Hi,

  can I have reviews for this change that does some minor renaming?

Testing: local compilation, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294841](https://bugs.openjdk.org/browse/JDK-8294841): G1: Refactor predict_base_elapsed_time_ms


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10644/head:pull/10644` \
`$ git checkout pull/10644`

Update a local copy of the PR: \
`$ git checkout pull/10644` \
`$ git pull https://git.openjdk.org/jdk pull/10644/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10644`

View PR using the GUI difftool: \
`$ git pr show -t 10644`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10644.diff">https://git.openjdk.org/jdk/pull/10644.diff</a>

</details>
