### PR TITLE
8293531: C2: some vectorapi tests fail assert "Not monotonic" with flag -XX:TypeProfileLevel=222

### DIFF
--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1748,7 +1748,7 @@ PhaseCCP::~PhaseCCP() {
 
 #ifdef ASSERT
 static bool ccp_type_widens(const Type* t, const Type* t0) {
-  assert(t->meet(t0) == t, "Not monotonic");
+  assert(t->meet(t0) == t->remove_speculative(), "Not monotonic");
   switch (t->base() == t0->base() ? t->base() : Type::Top) {
   case Type::Int:
     assert(t0->isa_int()->_widen <= t->isa_int()->_widen, "widen increases");


### PR DESCRIPTION
Problem occurs in iterative DF analysis during CCP optimization, meet operations drops the speculative types before converging participating lattice values since [include_speculative argument it receives is always set to false ](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/type.hpp#L231)where as [equality check ](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/phaseX.cpp#L1751) in the failing assertion is performed against original type still carrying the speculative type.

To fix this, type comparison in the assertion should also be done after stripping the speculative type, with this change intermittent assertion failures in several vector API tests reported in the bug report  are no longer seen.

Kindly review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293531](https://bugs.openjdk.org/browse/JDK-8293531): C2: some vectorapi tests fail assert "Not monotonic" with flag -XX:TypeProfileLevel=222


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10648/head:pull/10648` \
`$ git checkout pull/10648`

Update a local copy of the PR: \
`$ git checkout pull/10648` \
`$ git pull https://git.openjdk.org/jdk pull/10648/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10648`

View PR using the GUI difftool: \
`$ git pr show -t 10648`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10648.diff">https://git.openjdk.org/jdk/pull/10648.diff</a>

</details>
