### PR TITLE
8295154: Documentation for RemoteExecutionControl.invoke(Method) inherits non-existent documentation

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/RemoteExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/RemoteExecutionControl.java
@@ -110,13 +110,6 @@ public class RemoteExecutionControl extends DirectExecutionControl implements Ex
         // handled by JDI
     }
 
-    /**
-     * @throws ExecutionControl.UserException {@inheritDoc}
-     * @throws ExecutionControl.ResolutionException {@inheritDoc}
-     * @throws ExecutionControl.StoppedException {@inheritDoc}
-     * @throws ExecutionControl.EngineTerminationException {@inheritDoc}
-     * @throws ExecutionControl.NotImplementedException {@inheritDoc}
-     */
     // Overridden only so this stack frame is seen
     @Override
     protected String invoke(Method doitMethod) throws Exception {


### PR DESCRIPTION
Please review this trivial fix that partially reverts changes from JDK-8294377.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295154](https://bugs.openjdk.org/browse/JDK-8295154): Documentation for RemoteExecutionControl.invoke(Method) inherits non-existent documentation


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10653/head:pull/10653` \
`$ git checkout pull/10653`

Update a local copy of the PR: \
`$ git checkout pull/10653` \
`$ git pull https://git.openjdk.org/jdk pull/10653/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10653`

View PR using the GUI difftool: \
`$ git pr show -t 10653`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10653.diff">https://git.openjdk.org/jdk/pull/10653.diff</a>

</details>
