### PR TITLE
8295156: G1: Improve constant other time calculation

### DIFF
--- a/src/hotspot/share/gc/g1/g1Analytics.cpp
+++ b/src/hotspot/share/gc/g1/g1Analytics.cpp
@@ -241,13 +241,9 @@ double G1Analytics::predict_dirtied_cards_rate_ms() const {
   return predict_zero_bounded(_dirtied_cards_rate_ms_seq);
 }
 
-double G1Analytics::predict_young_card_merge_to_scan_ratio() const {
-  return predict_in_unit_interval(_young_card_merge_to_scan_ratio_seq);
-}
-
 size_t G1Analytics::predict_scan_card_num(size_t rs_length, bool for_young_gc) const {
   if (for_young_gc || !enough_samples_available(_mixed_card_merge_to_scan_ratio_seq)) {
-    return (size_t)(rs_length * predict_young_card_merge_to_scan_ratio());
+    return (size_t)(rs_length * predict_in_unit_interval(_young_card_merge_to_scan_ratio_seq));
   } else {
     return (size_t)(rs_length * predict_in_unit_interval(_mixed_card_merge_to_scan_ratio_seq));
   }

--- a/src/hotspot/share/gc/g1/g1Analytics.cpp
+++ b/src/hotspot/share/gc/g1/g1Analytics.cpp
@@ -172,32 +172,32 @@ void G1Analytics::report_dirtied_cards_rate_ms(double cards_per_ms) {
   _dirtied_cards_rate_ms_seq->add(cards_per_ms);
 }
 
-void G1Analytics::report_cost_per_card_scan_ms(double cost_per_card_ms, bool for_young_gc) {
-  if (for_young_gc) {
+void G1Analytics::report_cost_per_card_scan_ms(double cost_per_card_ms, bool for_young_only_phase) {
+  if  (for_young_only_phase) {
     _young_cost_per_card_scan_ms_seq->add(cost_per_card_ms);
   } else {
     _mixed_cost_per_card_scan_ms_seq->add(cost_per_card_ms);
   }
 }
 
-void G1Analytics::report_cost_per_card_merge_ms(double cost_per_card_ms, bool for_young_gc) {
-  if (for_young_gc) {
+void G1Analytics::report_cost_per_card_merge_ms(double cost_per_card_ms, bool for_young_only_phase) {
+  if  (for_young_only_phase) {
     _young_cost_per_card_merge_ms_seq->add(cost_per_card_ms);
   } else {
     _mixed_cost_per_card_merge_ms_seq->add(cost_per_card_ms);
   }
 }
 
-void G1Analytics::report_card_merge_to_scan_ratio(double merge_to_scan_ratio, bool for_young_gc) {
-  if (for_young_gc) {
+void G1Analytics::report_card_merge_to_scan_ratio(double merge_to_scan_ratio, bool for_young_only_phase) {
+  if  (for_young_only_phase) {
     _young_card_merge_to_scan_ratio_seq->add(merge_to_scan_ratio);
   } else {
     _mixed_card_merge_to_scan_ratio_seq->add(merge_to_scan_ratio);
   }
 }
 
-void G1Analytics::report_rs_length_diff(double rs_length_diff, bool for_young_gc) {
-  if (for_young_gc) {
+void G1Analytics::report_rs_length_diff(double rs_length_diff, bool for_young_only_phase) {
+  if  (for_young_only_phase) {
     _young_rs_length_diff_seq->add(rs_length_diff);
   } else {
     _mixed_rs_length_diff_seq->add(rs_length_diff);
@@ -224,16 +224,16 @@ void G1Analytics::report_constant_other_time_ms(double constant_other_time_ms) {
   _constant_other_time_ms_seq->add(constant_other_time_ms);
 }
 
-void G1Analytics::report_pending_cards(double pending_cards, bool for_young_gc) {
-  if (for_young_gc) {
+void G1Analytics::report_pending_cards(double pending_cards, bool for_young_only_phase) {
+  if  (for_young_only_phase) {
     _young_pending_cards_seq->add(pending_cards);
   } else {
     _mixed_pending_cards_seq->add(pending_cards);
   }
 }
 
-void G1Analytics::report_rs_length(double rs_length, bool for_young_gc) {
-  if (for_young_gc) {
+void G1Analytics::report_rs_length(double rs_length, bool for_young_only_phase) {
+  if  (for_young_only_phase) {
     _young_rs_length_seq->add(rs_length);
   } else {
     _mixed_rs_length_seq->add(rs_length);
@@ -256,24 +256,24 @@ double G1Analytics::predict_dirtied_cards_rate_ms() const {
   return predict_zero_bounded(_dirtied_cards_rate_ms_seq);
 }
 
-size_t G1Analytics::predict_scan_card_num(size_t rs_length, bool for_young_gc) const {
-  if (for_young_gc || !enough_samples_available(_mixed_card_merge_to_scan_ratio_seq)) {
+size_t G1Analytics::predict_scan_card_num(size_t rs_length, bool for_young_only_phase) const {
+  if  (for_young_only_phase || !enough_samples_available(_mixed_card_merge_to_scan_ratio_seq)) {
     return (size_t)(rs_length * predict_in_unit_interval(_young_card_merge_to_scan_ratio_seq));
   } else {
     return (size_t)(rs_length * predict_in_unit_interval(_mixed_card_merge_to_scan_ratio_seq));
   }
 }
 
-double G1Analytics::predict_card_merge_time_ms(size_t card_num, bool for_young_gc) const {
-  if (for_young_gc || !enough_samples_available(_mixed_cost_per_card_merge_ms_seq)) {
+double G1Analytics::predict_card_merge_time_ms(size_t card_num, bool for_young_only_phase) const {
+  if  (for_young_only_phase || !enough_samples_available(_mixed_cost_per_card_merge_ms_seq)) {
     return card_num * predict_zero_bounded(_young_cost_per_card_merge_ms_seq);
   } else {
     return card_num * predict_zero_bounded(_mixed_cost_per_card_merge_ms_seq);
   }
 }
 
-double G1Analytics::predict_card_scan_time_ms(size_t card_num, bool for_young_gc) const {
-  if (for_young_gc || !enough_samples_available(_mixed_cost_per_card_scan_ms_seq)) {
+double G1Analytics::predict_card_scan_time_ms(size_t card_num, bool for_young_only_phase) const {
+  if  (for_young_only_phase || !enough_samples_available(_mixed_cost_per_card_scan_ms_seq)) {
     return card_num * predict_zero_bounded(_young_cost_per_card_scan_ms_seq);
   } else {
     return card_num * predict_zero_bounded(_mixed_cost_per_card_scan_ms_seq);
@@ -316,16 +316,16 @@ double G1Analytics::predict_cleanup_time_ms() const {
   return predict_zero_bounded(_concurrent_mark_cleanup_times_ms);
 }
 
-size_t G1Analytics::predict_rs_length(bool for_young_gc) const {
-  if (for_young_gc || !enough_samples_available(_mixed_rs_length_seq)) {
+size_t G1Analytics::predict_rs_length(bool for_young_only_phase) const {
+  if  (for_young_only_phase || !enough_samples_available(_mixed_rs_length_seq)) {
     return predict_size(_young_rs_length_seq) + predict_size(_young_rs_length_diff_seq);
   } else {
     return predict_size(_mixed_rs_length_seq) + predict_size(_mixed_rs_length_diff_seq);
   }
 }
 
-size_t G1Analytics::predict_pending_cards(bool for_young_gc) const {
-  if (for_young_gc || !enough_samples_available(_young_pending_cards_seq)) {
+size_t G1Analytics::predict_pending_cards(bool for_young_only_phase) const {
+  if  (for_young_only_phase || !enough_samples_available(_young_pending_cards_seq)) {
     return predict_size(_young_pending_cards_seq);
   } else {
     return predict_size(_mixed_pending_cards_seq);

--- a/src/hotspot/share/gc/g1/g1Analytics.cpp
+++ b/src/hotspot/share/gc/g1/g1Analytics.cpp
@@ -78,7 +78,8 @@ G1Analytics::G1Analytics(const G1Predictions* predictor) :
     _concurrent_mark_cleanup_times_ms(new TruncatedSeq(NumPrevPausesForHeuristics)),
     _alloc_rate_ms_seq(new TruncatedSeq(TruncatedSeqLength)),
     _prev_collection_pause_end_ms(0.0),
-    _rs_length_diff_seq(new TruncatedSeq(TruncatedSeqLength)),
+    _young_rs_length_diff_seq(new TruncatedSeq(TruncatedSeqLength)),
+    _mixed_rs_length_diff_seq(new TruncatedSeq(TruncatedSeqLength)),
     _concurrent_refine_rate_ms_seq(new TruncatedSeq(TruncatedSeqLength)),
     _dirtied_cards_rate_ms_seq(new TruncatedSeq(TruncatedSeqLength)),
     _young_card_merge_to_scan_ratio_seq(new TruncatedSeq(TruncatedSeqLength)),
@@ -91,8 +92,10 @@ G1Analytics::G1Analytics(const G1Predictions* predictor) :
     _constant_other_time_ms_seq(new TruncatedSeq(TruncatedSeqLength)),
     _young_other_cost_per_region_ms_seq(new TruncatedSeq(TruncatedSeqLength)),
     _non_young_other_cost_per_region_ms_seq(new TruncatedSeq(TruncatedSeqLength)),
-    _pending_cards_seq(new TruncatedSeq(TruncatedSeqLength)),
-    _rs_length_seq(new TruncatedSeq(TruncatedSeqLength)),
+    _young_pending_cards_seq(new TruncatedSeq(TruncatedSeqLength)),
+    _mixed_pending_cards_seq(new TruncatedSeq(TruncatedSeqLength)),
+    _young_rs_length_seq(new TruncatedSeq(TruncatedSeqLength)),
+    _mixed_rs_length_seq(new TruncatedSeq(TruncatedSeqLength)),
     _cost_per_byte_ms_during_cm_seq(new TruncatedSeq(TruncatedSeqLength)),
     _recent_prev_end_times_for_all_gcs_sec(new TruncatedSeq(NumPrevPausesForHeuristics)),
     _long_term_pause_time_ratio(0.0),
@@ -104,7 +107,7 @@ G1Analytics::G1Analytics(const G1Predictions* predictor) :
 
   int index = MIN2(ParallelGCThreads - 1, 7u);
 
-  _rs_length_diff_seq->add(rs_length_diff_defaults[index]);
+  _young_rs_length_diff_seq->add(rs_length_diff_defaults[index]);
   // Start with inverse of maximum STW cost.
   _concurrent_refine_rate_ms_seq->add(1/cost_per_logged_card_ms_defaults[0]);
   // Some applications have very low rates for logging cards.
@@ -193,8 +196,12 @@ void G1Analytics::report_card_merge_to_scan_ratio(double merge_to_scan_ratio, bo
   }
 }
 
-void G1Analytics::report_rs_length_diff(double rs_length_diff) {
-  _rs_length_diff_seq->add(rs_length_diff);
+void G1Analytics::report_rs_length_diff(double rs_length_diff, bool for_young_gc) {
+  if (for_young_gc) {
+    _young_rs_length_diff_seq->add(rs_length_diff);
+  } else {
+    _mixed_rs_length_diff_seq->add(rs_length_diff);
+  }
 }
 
 void G1Analytics::report_cost_per_byte_ms(double cost_per_byte_ms, bool mark_or_rebuild_in_progress) {
@@ -217,12 +224,20 @@ void G1Analytics::report_constant_other_time_ms(double constant_other_time_ms) {
   _constant_other_time_ms_seq->add(constant_other_time_ms);
 }
 
-void G1Analytics::report_pending_cards(double pending_cards) {
-  _pending_cards_seq->add(pending_cards);
+void G1Analytics::report_pending_cards(double pending_cards, bool for_young_gc) {
+  if (for_young_gc) {
+    _young_pending_cards_seq->add(pending_cards);
+  } else {
+    _mixed_pending_cards_seq->add(pending_cards);
+  }
 }
 
-void G1Analytics::report_rs_length(double rs_length) {
-  _rs_length_seq->add(rs_length);
+void G1Analytics::report_rs_length(double rs_length, bool for_young_gc) {
+  if (for_young_gc) {
+    _young_rs_length_seq->add(rs_length);
+  } else {
+    _mixed_rs_length_seq->add(rs_length);
+  }
 }
 
 double G1Analytics::predict_alloc_rate_ms() const {
@@ -301,12 +316,20 @@ double G1Analytics::predict_cleanup_time_ms() const {
   return predict_zero_bounded(_concurrent_mark_cleanup_times_ms);
 }
 
-size_t G1Analytics::predict_rs_length() const {
-  return predict_size(_rs_length_seq) + predict_size(_rs_length_diff_seq);
+size_t G1Analytics::predict_rs_length(bool for_young_gc) const {
+  if (for_young_gc || !enough_samples_available(_mixed_rs_length_seq)) {
+    return predict_size(_young_rs_length_seq) + predict_size(_young_rs_length_diff_seq);
+  } else {
+    return predict_size(_mixed_rs_length_seq) + predict_size(_mixed_rs_length_diff_seq);
+  }
 }
 
-size_t G1Analytics::predict_pending_cards() const {
-  return predict_size(_pending_cards_seq);
+size_t G1Analytics::predict_pending_cards(bool for_young_gc) const {
+  if (for_young_gc || !enough_samples_available(_young_pending_cards_seq)) {
+    return predict_size(_young_pending_cards_seq);
+  } else {
+    return predict_size(_mixed_pending_cards_seq);
+  }
 }
 
 double G1Analytics::oldest_known_gc_end_time_sec() const {

--- a/src/hotspot/share/gc/g1/g1Analytics.hpp
+++ b/src/hotspot/share/gc/g1/g1Analytics.hpp
@@ -45,7 +45,8 @@ class G1Analytics: public CHeapObj<mtGC> {
   TruncatedSeq* _alloc_rate_ms_seq;
   double        _prev_collection_pause_end_ms;
 
-  TruncatedSeq* _rs_length_diff_seq;
+  TruncatedSeq* _young_rs_length_diff_seq;
+  TruncatedSeq* _mixed_rs_length_diff_seq;
   TruncatedSeq* _concurrent_refine_rate_ms_seq;
   TruncatedSeq* _dirtied_cards_rate_ms_seq;
   // The ratio between the number of merged cards and actually scanned cards, for
@@ -67,8 +68,10 @@ class G1Analytics: public CHeapObj<mtGC> {
   TruncatedSeq* _young_other_cost_per_region_ms_seq;
   TruncatedSeq* _non_young_other_cost_per_region_ms_seq;
 
-  TruncatedSeq* _pending_cards_seq;
-  TruncatedSeq* _rs_length_seq;
+  TruncatedSeq* _young_pending_cards_seq;
+  TruncatedSeq* _mixed_pending_cards_seq;
+  TruncatedSeq* _young_rs_length_seq;
+  TruncatedSeq* _mixed_rs_length_seq;
 
   TruncatedSeq* _cost_per_byte_ms_during_cm_seq;
 
@@ -126,13 +129,13 @@ public:
   void report_cost_per_card_scan_ms(double cost_per_remset_card_ms, bool for_young_gc);
   void report_cost_per_card_merge_ms(double cost_per_card_ms, bool for_young_gc);
   void report_card_merge_to_scan_ratio(double cards_per_entry_ratio, bool for_young_gc);
-  void report_rs_length_diff(double rs_length_diff);
+  void report_rs_length_diff(double rs_length_diff, bool for_young_gc);
   void report_cost_per_byte_ms(double cost_per_byte_ms, bool mark_or_rebuild_in_progress);
   void report_young_other_cost_per_region_ms(double other_cost_per_region_ms);
   void report_non_young_other_cost_per_region_ms(double other_cost_per_region_ms);
   void report_constant_other_time_ms(double constant_other_time_ms);
-  void report_pending_cards(double pending_cards);
-  void report_rs_length(double rs_length);
+  void report_pending_cards(double pending_cards, bool for_young_gc);
+  void report_rs_length(double rs_length, bool for_young_gc);
 
   double predict_alloc_rate_ms() const;
   int num_alloc_rate_ms() const;
@@ -161,8 +164,8 @@ public:
 
   double predict_cleanup_time_ms() const;
 
-  size_t predict_rs_length() const;
-  size_t predict_pending_cards() const;
+  size_t predict_rs_length(bool for_young_gc) const;
+  size_t predict_pending_cards(bool for_young_gc) const;
 
   // Add a new GC of the given duration and end time to the record.
   void update_recent_gc_times(double end_time_sec, double elapsed_ms);

--- a/src/hotspot/share/gc/g1/g1Analytics.hpp
+++ b/src/hotspot/share/gc/g1/g1Analytics.hpp
@@ -139,10 +139,9 @@ public:
 
   double predict_concurrent_refine_rate_ms() const;
   double predict_dirtied_cards_rate_ms() const;
-  double predict_young_card_merge_to_scan_ratio() const;
 
-  double predict_mixed_card_merge_to_scan_ratio() const;
-
+  // Predict how many of the given remembered set of length rs_length will add to
+  // the number of total cards scanned.
   size_t predict_scan_card_num(size_t rs_length, bool for_young_gc) const;
 
   double predict_card_merge_time_ms(size_t card_num, bool for_young_gc) const;

--- a/src/hotspot/share/gc/g1/g1Analytics.hpp
+++ b/src/hotspot/share/gc/g1/g1Analytics.hpp
@@ -126,16 +126,16 @@ public:
   void report_alloc_rate_ms(double alloc_rate);
   void report_concurrent_refine_rate_ms(double cards_per_ms);
   void report_dirtied_cards_rate_ms(double cards_per_ms);
-  void report_cost_per_card_scan_ms(double cost_per_remset_card_ms, bool for_young_gc);
-  void report_cost_per_card_merge_ms(double cost_per_card_ms, bool for_young_gc);
-  void report_card_merge_to_scan_ratio(double cards_per_entry_ratio, bool for_young_gc);
-  void report_rs_length_diff(double rs_length_diff, bool for_young_gc);
+  void report_cost_per_card_scan_ms(double cost_per_remset_card_ms, bool for_young_only_phase);
+  void report_cost_per_card_merge_ms(double cost_per_card_ms, bool for_young_only_phase);
+  void report_card_merge_to_scan_ratio(double cards_per_entry_ratio, bool for_young_only_phase);
+  void report_rs_length_diff(double rs_length_diff, bool for_young_only_phase);
   void report_cost_per_byte_ms(double cost_per_byte_ms, bool mark_or_rebuild_in_progress);
   void report_young_other_cost_per_region_ms(double other_cost_per_region_ms);
   void report_non_young_other_cost_per_region_ms(double other_cost_per_region_ms);
   void report_constant_other_time_ms(double constant_other_time_ms);
-  void report_pending_cards(double pending_cards, bool for_young_gc);
-  void report_rs_length(double rs_length, bool for_young_gc);
+  void report_pending_cards(double pending_cards, bool for_young_only_phase);
+  void report_rs_length(double rs_length, bool for_young_only_phase);
 
   double predict_alloc_rate_ms() const;
   int num_alloc_rate_ms() const;
@@ -145,10 +145,10 @@ public:
 
   // Predict how many of the given remembered set of length rs_length will add to
   // the number of total cards scanned.
-  size_t predict_scan_card_num(size_t rs_length, bool for_young_gc) const;
+  size_t predict_scan_card_num(size_t rs_length, bool for_young_only_phase) const;
 
-  double predict_card_merge_time_ms(size_t card_num, bool for_young_gc) const;
-  double predict_card_scan_time_ms(size_t card_num, bool for_young_gc) const;
+  double predict_card_merge_time_ms(size_t card_num, bool for_young_only_phase) const;
+  double predict_card_scan_time_ms(size_t card_num, bool for_young_only_phase) const;
 
   double predict_object_copy_time_ms_during_cm(size_t bytes_to_copy) const;
 
@@ -164,8 +164,8 @@ public:
 
   double predict_cleanup_time_ms() const;
 
-  size_t predict_rs_length(bool for_young_gc) const;
-  size_t predict_pending_cards(bool for_young_gc) const;
+  size_t predict_rs_length(bool for_young_only_phase) const;
+  size_t predict_pending_cards(bool for_young_only_phase) const;
 
   // Add a new GC of the given duration and end time to the record.
   void update_recent_gc_times(double end_time_sec, double elapsed_ms);

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -421,7 +421,7 @@ double G1CollectionSet::finalize_young_part(double target_pause_time_ms, G1Survi
   // collection set's current size
   set_recorded_rs_length(_inc_recorded_rs_length);
 
-  double predicted_base_time_ms = _policy->predict_base_elapsed_time_ms(pending_cards);
+  double predicted_base_time_ms = _policy->predict_base_time_ms(pending_cards);
   double predicted_eden_time = _inc_predicted_non_copy_time_ms + _policy->predict_eden_copy_time_ms(eden_region_length);
   double remaining_time_ms = MAX2(target_pause_time_ms - (predicted_base_time_ms + predicted_eden_time), 0.0);
 

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
@@ -390,7 +390,10 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
   }
 
   double cur_collection_par_time_ms() {
-    return _cur_collection_initial_evac_time_ms + _cur_optional_evac_time_ms;
+    return _cur_collection_initial_evac_time_ms +
+           _cur_optional_evac_time_ms +
+           _cur_merge_heap_roots_time_ms +
+           _cur_optional_merge_heap_roots_time_ms;
   }
 
   double cur_expand_heap_time_ms() {

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -257,10 +257,10 @@ uint G1Policy::calculate_young_desired_length(size_t rs_length) const {
     desired_eden_length_by_mmu = calculate_desired_eden_length_by_mmu();
 
     const size_t pending_cards = _analytics->predict_pending_cards();
-    double survivor_base_time_ms = predict_base_elapsed_time_ms(pending_cards, rs_length);
+    double base_time_ms = predict_base_time_ms(pending_cards, rs_length);
 
     desired_eden_length_by_pause =
-      calculate_desired_eden_length_by_pause(survivor_base_time_ms,
+      calculate_desired_eden_length_by_pause(base_time_ms,
                                              absolute_min_young_length - survivor_length,
                                              absolute_max_young_length - survivor_length);
 
@@ -476,17 +476,17 @@ uint G1Policy::calculate_desired_eden_length_before_young_only(double base_time_
   return min_eden_length;
 }
 
-uint G1Policy::calculate_desired_eden_length_before_mixed(double survivor_base_time_ms,
+uint G1Policy::calculate_desired_eden_length_before_mixed(double base_time_ms,
                                                           uint min_eden_length,
                                                           uint max_eden_length) const {
   G1CollectionSetCandidates* candidates = _collection_set->candidates();
 
   uint min_old_regions_end = MIN2(candidates->cur_idx() + calc_min_old_cset_length(candidates),
                                   candidates->num_regions());
-  double predicted_region_evac_time_ms = survivor_base_time_ms;
+  double predicted_region_evac_time_ms = base_time_ms;
   for (uint i = candidates->cur_idx(); i < min_old_regions_end; i++) {
     HeapRegion* r = candidates->at(i);
-    predicted_region_evac_time_ms += predict_region_total_time_ms(r, false);
+    predicted_region_evac_time_ms += predict_region_total_time_ms(r, false /* for_young_gc */);
   }
   uint desired_eden_length_by_min_cset_length =
      calculate_desired_eden_length_before_young_only(predicted_region_evac_time_ms,
@@ -1008,19 +1008,25 @@ void G1Policy::record_young_gc_pause_end(bool evacuation_failed) {
   phase_times()->print(evacuation_failed);
 }
 
-double G1Policy::predict_base_elapsed_time_ms(size_t pending_cards,
-                                              size_t rs_length) const {
+double G1Policy::predict_base_time_ms(size_t pending_cards,
+                                      size_t rs_length) const {
   size_t effective_scanned_cards = _analytics->predict_scan_card_num(rs_length, collector_state()->in_young_only_phase());
-  return
-    _analytics->predict_card_merge_time_ms(pending_cards + rs_length, collector_state()->in_young_only_phase()) +
-    _analytics->predict_card_scan_time_ms(effective_scanned_cards, collector_state()->in_young_only_phase()) +
-    _analytics->predict_constant_other_time_ms() +
-    predict_survivor_regions_evac_time();
+
+  double card_merge_time = _analytics->predict_card_merge_time_ms(pending_cards + rs_length, collector_state()->in_young_only_phase());
+  double card_scan_time = _analytics->predict_card_scan_time_ms(effective_scanned_cards, collector_state()->in_young_only_phase());
+  double constant_other_time = _analytics->predict_constant_other_time_ms();
+  double survivor_evac_time = predict_survivor_regions_evac_time();
+
+  double total_time = card_merge_time + card_scan_time + constant_other_time + survivor_evac_time;
+
+  log_trace(gc, ergo, heap)("Predicted base time: total %f lb_cards %zu rs_length %zu effective_scanned_cards %zu card_merge_time %f card_scan_time %f constant_other_time %f survivor_evac_time %f",
+                            total_time, pending_cards, rs_length, effective_scanned_cards, card_merge_time, card_scan_time, constant_other_time, survivor_evac_time);
+  return total_time;
 }
 
-double G1Policy::predict_base_elapsed_time_ms(size_t pending_cards) const {
+double G1Policy::predict_base_time_ms(size_t pending_cards) const {
   size_t rs_length = _analytics->predict_rs_length();
-  return predict_base_elapsed_time_ms(pending_cards, rs_length);
+  return predict_base_time_ms(pending_cards, rs_length);
 }
 
 size_t G1Policy::predict_bytes_to_copy(HeapRegion* hr) const {

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -73,7 +73,6 @@ G1Policy::G1Policy(STWGCTimer* gc_timer) :
   _predicted_surviving_bytes_from_survivor(0),
   _predicted_surviving_bytes_from_old(0),
   _rs_length(0),
-  _rs_length_prediction(0),
   _pending_cards_at_gc_start(0),
   _concurrent_start_to_mixed(),
   _collection_set(NULL),
@@ -202,11 +201,16 @@ void G1Policy::update_young_length_bounds() {
 }
 
 void G1Policy::update_young_length_bounds(size_t pending_cards, size_t rs_length) {
+  uint old_young_list_target_length = _young_list_target_length;
+
   _young_list_desired_length = calculate_young_desired_length(pending_cards, rs_length);
   _young_list_target_length = calculate_young_target_length(_young_list_desired_length);
   _young_list_max_length = calculate_young_max_length(_young_list_target_length);
 
-  log_debug(gc, ergo, heap)("Young list lengths: desired: %u, target: %u, max: %u",
+  log_trace(gc, ergo, heap)("Young list length update: pending cards %zu rs_length %zu old target %u desired: %u target: %u max: %u",
+                            pending_cards,
+                            rs_length,
+                            old_young_list_target_length,
                             _young_list_desired_length,
                             _young_list_target_length,
                             _young_list_max_length);
@@ -519,30 +523,13 @@ G1GCPhaseTimes* G1Policy::phase_times() const {
   return _phase_times;
 }
 
-void G1Policy::revise_young_list_target_length_if_necessary(size_t rs_length) {
+void G1Policy::revise_young_list_target_length(size_t rs_length) {
   guarantee(use_adaptive_young_list_length(), "should not call this otherwise" );
 
-  if (rs_length > _rs_length_prediction) {
-    // add 10% to avoid having to recalculate often
-    size_t rs_length_prediction = rs_length * 1100 / 1000;
-    update_rs_length_prediction(rs_length_prediction);
-
-    G1DirtyCardQueueSet& dcqs = G1BarrierSet::dirty_card_queue_set();
-    // We have no measure of the number of cards in the thread buffers, assume
-    // these are very few compared to the ones in the DCQS.
-    update_young_length_bounds(dcqs.num_cards(), rs_length_prediction);
-  }
-}
-
-void G1Policy::update_rs_length_prediction() {
-  bool for_young_only_phase = collector_state()->in_young_only_phase();
-  update_rs_length_prediction(_analytics->predict_rs_length(for_young_only_phase));
-}
-
-void G1Policy::update_rs_length_prediction(size_t prediction) {
-  if (collector_state()->in_young_only_phase() && use_adaptive_young_list_length()) {
-    _rs_length_prediction = prediction;
-  }
+  G1DirtyCardQueueSet& dcqs = G1BarrierSet::dirty_card_queue_set();
+  // We have no measure of the number of cards in the thread buffers, assume
+  // these are very few compared to the ones in the DCQS.
+  update_young_length_bounds(dcqs.num_cards(), rs_length);
 }
 
 void G1Policy::record_full_collection_start() {
@@ -577,7 +564,6 @@ void G1Policy::record_full_collection_end() {
   update_survival_estimates_for_next_collection();
   _survivor_surv_rate_group->reset();
   update_young_length_bounds();
-  update_rs_length_prediction();
 
   _old_gen_alloc_tracker.reset_after_gc(_g1h->humongous_regions_count() * HeapRegion::GrainBytes);
 
@@ -901,7 +887,6 @@ void G1Policy::record_young_collection_end(bool concurrent_operation_is_full_mar
 
   _free_regions_at_end_of_collection = _g1h->num_free_regions();
 
-  update_rs_length_prediction();
   update_survival_estimates_for_next_collection();
 
   // Do not update dynamic IHOP due to G1 periodic collection as it is highly likely

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1010,7 +1010,9 @@ void G1Policy::record_young_gc_pause_end(bool evacuation_failed) {
 
 double G1Policy::predict_base_time_ms(size_t pending_cards,
                                       size_t rs_length) const {
-  size_t effective_scanned_cards = _analytics->predict_scan_card_num(rs_length, collector_state()->in_young_only_phase());
+  // Assume that all cards from the log buffers will be scanned, i.e. there are no
+  // duplicates in that set.
+  size_t effective_scanned_cards = _analytics->predict_scan_card_num(rs_length, collector_state()->in_young_only_phase()) + pending_cards;
 
   double card_merge_time = _analytics->predict_card_merge_time_ms(pending_cards + rs_length, collector_state()->in_young_only_phase());
   double card_scan_time = _analytics->predict_card_scan_time_ms(effective_scanned_cards, collector_state()->in_young_only_phase());

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -194,11 +194,14 @@ uint G1Policy::calculate_desired_eden_length_by_mmu() const {
 }
 
 void G1Policy::update_young_length_bounds() {
-  update_young_length_bounds(_analytics->predict_rs_length());
+  // We have no measure of the number of pending cards in the thread buffers,
+  // assume these are very few.
+  update_young_length_bounds(_analytics->predict_pending_cards(),
+                             _analytics->predict_rs_length());
 }
 
-void G1Policy::update_young_length_bounds(size_t rs_length) {
-  _young_list_desired_length = calculate_young_desired_length(rs_length);
+void G1Policy::update_young_length_bounds(size_t pending_cards, size_t rs_length) {
+  _young_list_desired_length = calculate_young_desired_length(pending_cards, rs_length);
   _young_list_target_length = calculate_young_target_length(_young_list_desired_length);
   _young_list_max_length = calculate_young_max_length(_young_list_target_length);
 
@@ -221,7 +224,7 @@ void G1Policy::update_young_length_bounds(size_t rs_length) {
 // The main reason is revising young length, with or without the GCLocker being
 // active.
 //
-uint G1Policy::calculate_young_desired_length(size_t rs_length) const {
+uint G1Policy::calculate_young_desired_length(size_t pending_cards, size_t rs_length) const {
   uint min_young_length_by_sizer = _young_gen_sizer.min_desired_young_length();
   uint max_young_length_by_sizer = _young_gen_sizer.max_desired_young_length();
 
@@ -256,7 +259,6 @@ uint G1Policy::calculate_young_desired_length(size_t rs_length) const {
   if (use_adaptive_young_list_length()) {
     desired_eden_length_by_mmu = calculate_desired_eden_length_by_mmu();
 
-    const size_t pending_cards = _analytics->predict_pending_cards();
     double base_time_ms = predict_base_time_ms(pending_cards, rs_length);
 
     desired_eden_length_by_pause =
@@ -523,7 +525,11 @@ void G1Policy::revise_young_list_target_length_if_necessary(size_t rs_length) {
     // add 10% to avoid having to recalculate often
     size_t rs_length_prediction = rs_length * 1100 / 1000;
     update_rs_length_prediction(rs_length_prediction);
-    update_young_length_bounds(rs_length_prediction);
+
+    G1DirtyCardQueueSet& dcqs = G1BarrierSet::dirty_card_queue_set();
+    // We have no measure of the number of cards in the thread buffers, assume
+    // these are very few compared to the ones in the DCQS.
+    update_young_length_bounds(dcqs.num_cards(), rs_length_prediction);
   }
 }
 
@@ -914,7 +920,7 @@ void G1Policy::record_young_collection_end(bool concurrent_operation_is_full_mar
   } else {
     // Any garbage collection triggered as periodic collection resets the time-to-mixed
     // measurement. Periodic collection typically means that the application is "inactive", i.e.
-    // the marking threads may have received an uncharacterisic amount of cpu time
+    // the marking threads may have received an uncharacteristic amount of cpu time
     // for completing the marking, i.e. are faster than expected.
     // This skews the predicted marking length towards smaller values which might cause
     // the mark start being too late.

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -687,7 +687,7 @@ double G1Policy::other_time_ms(double pause_time_ms) const {
 }
 
 double G1Policy::constant_other_time_ms(double pause_time_ms) const {
-  return other_time_ms(pause_time_ms) - phase_times()->total_rebuild_freelist_time_ms();
+  return other_time_ms(pause_time_ms) - (young_other_time_ms() + non_young_other_time_ms());
 }
 
 bool G1Policy::about_to_start_mixed_phase() const {

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -196,9 +196,9 @@ uint G1Policy::calculate_desired_eden_length_by_mmu() const {
 void G1Policy::update_young_length_bounds() {
   // We have no measure of the number of pending cards in the thread buffers,
   // assume these are very few.
-  bool for_young_gc = collector_state()->in_young_only_phase();
-  update_young_length_bounds(_analytics->predict_pending_cards(for_young_gc),
-                             _analytics->predict_rs_length(for_young_gc));
+  bool for_young_only_phase = collector_state()->in_young_only_phase();
+  update_young_length_bounds(_analytics->predict_pending_cards(for_young_only_phase),
+                             _analytics->predict_rs_length(for_young_only_phase));
 }
 
 void G1Policy::update_young_length_bounds(size_t pending_cards, size_t rs_length) {
@@ -489,7 +489,7 @@ uint G1Policy::calculate_desired_eden_length_before_mixed(double base_time_ms,
   double predicted_region_evac_time_ms = base_time_ms;
   for (uint i = candidates->cur_idx(); i < min_old_regions_end; i++) {
     HeapRegion* r = candidates->at(i);
-    predicted_region_evac_time_ms += predict_region_total_time_ms(r, false /* for_young_gc */);
+    predicted_region_evac_time_ms += predict_region_total_time_ms(r, false /* for_young_only_phase */);
   }
   uint desired_eden_length_by_min_cset_length =
      calculate_desired_eden_length_before_young_only(predicted_region_evac_time_ms,
@@ -535,8 +535,8 @@ void G1Policy::revise_young_list_target_length_if_necessary(size_t rs_length) {
 }
 
 void G1Policy::update_rs_length_prediction() {
-  bool for_young_gc = collector_state()->in_young_only_phase();
-  update_rs_length_prediction(_analytics->predict_rs_length(for_young_gc));
+  bool for_young_only_phase = collector_state()->in_young_only_phase();
+  update_rs_length_prediction(_analytics->predict_rs_length(for_young_only_phase));
 }
 
 void G1Policy::update_rs_length_prediction(size_t prediction) {
@@ -1030,8 +1030,8 @@ double G1Policy::predict_base_time_ms(size_t pending_cards,
 }
 
 double G1Policy::predict_base_time_ms(size_t pending_cards) const {
-  bool for_young_gc = collector_state()->in_young_only_phase();
-  size_t rs_length = _analytics->predict_rs_length(for_young_gc);
+  bool for_young_only_phase = collector_state()->in_young_only_phase();
+  size_t rs_length = _analytics->predict_rs_length(for_young_only_phase);
   return predict_base_time_ms(pending_cards, rs_length);
 }
 
@@ -1062,9 +1062,9 @@ double G1Policy::predict_region_copy_time_ms(HeapRegion* hr) const {
 }
 
 double G1Policy::predict_region_non_copy_time_ms(HeapRegion* hr,
-                                                 bool for_young_gc) const {
+                                                 bool for_young_only_phase) const {
   size_t rs_length = hr->rem_set()->occupied();
-  size_t scan_card_num = _analytics->predict_scan_card_num(rs_length, for_young_gc);
+  size_t scan_card_num = _analytics->predict_scan_card_num(rs_length, for_young_only_phase);
 
   double region_elapsed_time_ms =
     _analytics->predict_card_merge_time_ms(rs_length, collector_state()->in_young_only_phase()) +
@@ -1080,8 +1080,8 @@ double G1Policy::predict_region_non_copy_time_ms(HeapRegion* hr,
   return region_elapsed_time_ms;
 }
 
-double G1Policy::predict_region_total_time_ms(HeapRegion* hr, bool for_young_gc) const {
-  return predict_region_non_copy_time_ms(hr, for_young_gc) + predict_region_copy_time_ms(hr);
+double G1Policy::predict_region_total_time_ms(HeapRegion* hr, bool for_young_only_phase) const {
+  return predict_region_non_copy_time_ms(hr, for_young_only_phase) + predict_region_copy_time_ms(hr);
 }
 
 bool G1Policy::should_allocate_mutator_region() const {

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -137,10 +137,10 @@ public:
     _rs_length = rs_length;
   }
 
-  double predict_base_elapsed_time_ms(size_t num_pending_cards) const;
+  double predict_base_time_ms(size_t pending_cards) const;
 
 private:
-  double predict_base_elapsed_time_ms(size_t num_pending_cards, size_t rs_length) const;
+  double predict_base_time_ms(size_t pending_cards, size_t rs_length) const;
 
   double predict_region_copy_time_ms(HeapRegion* hr) const;
 
@@ -219,7 +219,7 @@ private:
   // Calculates the desired eden length before mixed gc so that after adding the
   // minimum amount of old gen regions from the collection set, the eden fits into
   // the pause time goal.
-  uint calculate_desired_eden_length_before_mixed(double survivor_base_time_ms,
+  uint calculate_desired_eden_length_before_mixed(double base_time_ms,
                                                   uint min_eden_length,
                                                   uint max_eden_length) const;
 

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -147,8 +147,8 @@ private:
 public:
 
   double predict_eden_copy_time_ms(uint count, size_t* bytes_to_copy = NULL) const;
-  double predict_region_non_copy_time_ms(HeapRegion* hr, bool for_young_gc) const;
-  double predict_region_total_time_ms(HeapRegion* hr, bool for_young_gc) const;
+  double predict_region_non_copy_time_ms(HeapRegion* hr, bool for_young_only_phase) const;
+  double predict_region_total_time_ms(HeapRegion* hr, bool for_young_only_phase) const;
 
   void cset_regions_freed() {
     bool update = should_update_surv_rate_group_predictors();

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -104,8 +104,6 @@ class G1Policy: public CHeapObj<mtGC> {
 
   size_t _rs_length;
 
-  size_t _rs_length_prediction;
-
   size_t _pending_cards_at_gc_start;
 
   G1ConcurrentStartToMixedTimeTracker _concurrent_start_to_mixed;
@@ -232,9 +230,6 @@ private:
   // the maximum number of regions to use in that case.
   uint calculate_young_max_length(uint target_young_length) const;
 
-  void update_rs_length_prediction();
-  void update_rs_length_prediction(size_t prediction);
-
   size_t predict_bytes_to_copy(HeapRegion* hr) const;
   double predict_survivor_regions_evac_time() const;
 
@@ -295,7 +290,7 @@ public:
   // Check the current value of the young list RSet length and
   // compare it against the last prediction. If the current value is
   // higher, recalculate the young list target length prediction.
-  void revise_young_list_target_length_if_necessary(size_t rs_length);
+  void revise_young_list_target_length(size_t rs_length);
 
   // This should be called after the heap is resized.
   void record_new_heap_size(uint new_number_of_regions);

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -194,10 +194,10 @@ private:
   double _mark_cleanup_start_sec;
 
   // Updates the internal young gen maximum and target and desired lengths.
-  // If no rs_length parameter is passed, predict the RS length using the
-  // prediction model, otherwise use the given rs_length as the prediction.
+  // If no parameters are passed, predict pending cards and the RS length using
+  // the prediction model.
   void update_young_length_bounds();
-  void update_young_length_bounds(size_t rs_length);
+  void update_young_length_bounds(size_t pending_cards, size_t rs_length);
 
   // Calculate and return the minimum desired eden length based on the MMU target.
   uint calculate_desired_eden_length_by_mmu() const;
@@ -225,7 +225,7 @@ private:
 
   // Calculate desired young length based on current situation without taking actually
   // available free regions into account.
-  uint calculate_young_desired_length(size_t rs_length) const;
+  uint calculate_young_desired_length(size_t pending_cards, size_t rs_length) const;
   // Limit the given desired young length to available free regions.
   uint calculate_young_target_length(uint desired_young_length) const;
   // The GCLocker might cause us to need more regions than the target. Calculate

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -538,7 +538,7 @@ class G1RemSetSamplingTask : public G1ServiceTask {
       g1cs->iterate(&cl);
 
       if (cl.is_complete()) {
-        policy->revise_young_list_target_length_if_necessary(cl.sampled_rs_length());
+        policy->revise_young_list_target_length(cl.sampled_rs_length());
       }
     }
     update_vtime_accum(vtime.duration());

--- a/src/hotspot/share/gc/g1/g1YoungGCEvacFailureInjector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCEvacFailureInjector.cpp
@@ -57,7 +57,7 @@ void G1YoungGCEvacFailureInjector::select_evac_failure_regions() {
   g1h->collection_set_iterate_all(&closure);
 }
 
-bool G1YoungGCEvacFailureInjector::arm_if_needed_for_gc_type(bool for_young_gc,
+bool G1YoungGCEvacFailureInjector::arm_if_needed_for_gc_type(bool for_young_only_phase,
                                                              bool during_concurrent_start,
                                                              bool mark_or_rebuild_in_progress) {
   bool res = false;
@@ -67,7 +67,7 @@ bool G1YoungGCEvacFailureInjector::arm_if_needed_for_gc_type(bool for_young_gc,
   if (during_concurrent_start) {
     res |= G1EvacuationFailureALotDuringConcurrentStart;
   }
-  if (for_young_gc) {
+  if (for_young_only_phase) {
     res |= G1EvacuationFailureALotDuringYoungGC;
   } else {
     // GCs are mixed

--- a/src/hotspot/share/gc/g1/g1YoungGCEvacFailureInjector.hpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCEvacFailureInjector.hpp
@@ -61,7 +61,7 @@ class G1YoungGCEvacFailureInjector {
   CHeapBitMap _evac_failure_regions;
 #endif
 
-  bool arm_if_needed_for_gc_type(bool for_young_gc,
+  bool arm_if_needed_for_gc_type(bool for_young_only_phase,
                                  bool during_concurrent_start,
                                  bool mark_or_rebuild_in_progress) EVAC_FAILURE_INJECTOR_RETURN_( return false; );
 

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -147,7 +147,7 @@ void HeapRegion::calc_gc_efficiency() {
   // Retrieve a prediction of the elapsed time for this region for
   // a mixed gc because the region will only be evacuated during a
   // mixed gc.
-  double region_elapsed_time_ms = policy->predict_region_total_time_ms(this, false /* for_young_gc */);
+  double region_elapsed_time_ms = policy->predict_region_total_time_ms(this, false /* for_young_only_phase */);
   _gc_efficiency = (double) reclaimable_bytes() / region_elapsed_time_ms;
 }
 


### PR DESCRIPTION
Hi all,

  can I have reviews for this change from Ivan that improves current constant other time calculation, allowing for better predictions?

After many years of changes to the garbage collection algorithm, moving around phases, the current calculation of constant other time became just wrong. This change fixes this.

Depends on PR#10652, please review that one first if not done yet.

Testing: Testing: gha, local testing, tier1-5 with other changes in this patch series, perf testing with other changes in this patch series

Thanks,
  Thomas

/contributor add @walulyai
/contributor remove @tschatzl 