### PR TITLE
8288415: java/awt/PopupMenu/PopupMenuLocation.java is unstable in MacOS machines

### DIFF
--- a/test/jdk/java/awt/PopupMenu/PopupMenuLocation.java
+++ b/test/jdk/java/awt/PopupMenu/PopupMenuLocation.java
@@ -33,8 +33,14 @@ import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.Toolkit;
 import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.awt.event.*;
+import java.io.File;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+import javax.imageio.ImageIO;
+import javax.swing.SwingUtilities;
+
 
 /**
  * @test
@@ -48,35 +54,44 @@ public final class PopupMenuLocation {
     public static final String TEXT =
             "Long-long-long-long-long-long-long text in the item-";
     private static volatile boolean action = false;
+    private static Robot robot;
+    private static Frame frame;
+    private static Rectangle currentScreenBounds;
+
 
     public static void main(final String[] args) throws Exception {
+        robot = new Robot();
+        robot.setAutoDelay(200);
         GraphicsEnvironment ge =
                 GraphicsEnvironment.getLocalGraphicsEnvironment();
         GraphicsDevice[] sds = ge.getScreenDevices();
         for (GraphicsDevice sd : sds) {
             GraphicsConfiguration gc = sd.getDefaultConfiguration();
-            Rectangle bounds = gc.getBounds();
-            Point point = new Point(bounds.x, bounds.y);
+            currentScreenBounds = gc.getBounds();
+            Point point = new Point(currentScreenBounds.x, currentScreenBounds.y);
             Insets insets = Toolkit.getDefaultToolkit().getScreenInsets(gc);
-            while (point.y < bounds.y + bounds.height - insets.bottom - SIZE) {
-                while (point.x
-                        < bounds.x + bounds.width - insets.right - SIZE) {
+            while (point.y < currentScreenBounds.y + currentScreenBounds.height - insets.bottom - SIZE) {
+                while (point.x <
+                           currentScreenBounds.x + currentScreenBounds.width - insets.right - SIZE) {
                     test(point);
-                    point.translate(bounds.width / 5, 0);
+                    point.translate(currentScreenBounds.width / 5, 0);
+                   }
+                   point.setLocation(currentScreenBounds.x, point.y + currentScreenBounds.height / 5);
                 }
-                point.setLocation(bounds.x, point.y + bounds.height / 5);
             }
         }
-    }
 
     private static void test(final Point tmp) throws Exception {
+        frame = new Frame();
         PopupMenu pm = new PopupMenu();
-        for (int i = 1; i < 7; i++) {
-            pm.add(TEXT + i);
-        }
-        pm.addActionListener(e -> action = true);
-        Frame frame = new Frame();
+        IntStream.rangeClosed(1, 6).forEach(i -> pm.add(TEXT + i));
+        pm.addActionListener(e -> {
+            action = true;
+            System.out.println(" Got action event " + e);
+        });
+
         try {
+            frame.setUndecorated(true);
             frame.setAlwaysOnTop(true);
             frame.setLayout(new FlowLayout());
             frame.add(pm);
@@ -84,6 +99,7 @@ public final class PopupMenuLocation {
             frame.setSize(SIZE, SIZE);
             frame.setVisible(true);
             frame.setLocation(tmp.x, tmp.y);
+
             frame.addMouseListener(new MouseAdapter() {
                 public void mousePressed(MouseEvent e) {
                     show(e);
@@ -95,6 +111,7 @@ public final class PopupMenuLocation {
 
                 private void show(MouseEvent e) {
                     if (e.isPopupTrigger()) {
+                        System.out.println("Going to show popup "+pm+" on "+frame);
                         pm.show(frame, 0, 50);
                     }
                 }
@@ -106,22 +123,36 @@ public final class PopupMenuLocation {
     }
 
     private static void openPopup(final Frame frame) throws Exception {
-        Robot robot = new Robot();
-        robot.setAutoDelay(200);
         robot.waitForIdle();
         Point pt = frame.getLocationOnScreen();
-        robot.mouseMove(pt.x + frame.getWidth() / 2, pt.y + 50);
+        int x = pt.x + frame.getWidth() / 2;
+        int y = pt.y + 50;
+        robot.mouseMove(x, y);
         robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
-        int x = pt.x + frame.getWidth() / 2;
-        int y = pt.y + 130;
+        robot.waitForIdle();
+         y = y+50;
         robot.mouseMove(x, y);
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
         if (!action) {
-            throw new RuntimeException();
+            captureScreen();
+            throw new RuntimeException(
+                    "Failed, Not received the PopupMenu ActionEvent yet on " +
+                    "frame= "+frame+", isFocused = "+frame.isFocused());
         }
         action = false;
     }
+
+    private static void captureScreen() {
+        try {
+            ImageIO.write(robot.createScreenCapture(currentScreenBounds), "png",
+                          new File("screen1.png"));
+        } catch (Exception exception) {
+            exception.printStackTrace();
+        }
+        action = false;
+    }
+
 }


### PR DESCRIPTION
java/awt/PopupMenu/PopupMenuLocation.java seems to be unstable in MacOS machines, especially in MacOSX 12 & 13 machines. It seems to be a testbug as adding some stability improvements fixes the issue. It intermittently fails in CI causing some noise. This test was already problem listed in windows due to an umbrella bug JDK-8238720. This fix doesn't cover the Windows issue, so the problem listing in windows will remain same.

Fix:
Some stability improvements have been done and the test has been run 100 times per platform in mach5 and got full PASS.
Also updated the screen capture code, made frame undecorated, added some prints for better debugging.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288415](https://bugs.openjdk.org/browse/JDK-8288415): java/awt/PopupMenu/PopupMenuLocation.java is unstable in MacOS machines


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10655/head:pull/10655` \
`$ git checkout pull/10655`

Update a local copy of the PR: \
`$ git checkout pull/10655` \
`$ git pull https://git.openjdk.org/jdk pull/10655/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10655`

View PR using the GUI difftool: \
`$ git pr show -t 10655`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10655.diff">https://git.openjdk.org/jdk/pull/10655.diff</a>

</details>
