### PR TITLE
8277970: Test jdk/sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java fails with "tag mismatch"

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketInputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketInputRecord.java
@@ -255,7 +255,11 @@ final class SSLSocketInputRecord extends InputRecord implements SSLRecord {
         // Decrypt the fragment
         //
         ByteBuffer fragment;
+        recordLock.lock();
         try {
+            if (isClosed) {
+                return null;
+            }
             Plaintext plaintext =
                     readCipher.decrypt(contentType, recordBody, null);
             fragment = plaintext.fragment;
@@ -264,6 +268,8 @@ final class SSLSocketInputRecord extends InputRecord implements SSLRecord {
             throw bpe;
         } catch (GeneralSecurityException gse) {
             throw new SSLProtocolException("Unexpected exception", gse);
+        } finally {
+            recordLock.unlock();
         }
 
         if (contentType != ContentType.HANDSHAKE.id &&

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -616,7 +616,6 @@ com/sun/security/sasl/gsskerb/NoSecurityLayer.java              8039280 generic-
 sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
 sun/security/provider/PolicyParser/ExtDirsChange.java           8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
-sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java 8277970 linux-all,macosx-x64
 
 ############################################################################
 

--- a/test/jdk/sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
 
 /*
  * @test
- * @bug 8274736
+ * @bug 8274736 8277970
  * @summary Concurrent read/close of SSLSockets causes SSLSessions to be
  *          invalidated unnecessarily
  * @library /javax/net/ssl/templates


### PR DESCRIPTION
This patch fixes the issue where a thread doing SSLSocket.close() could destroy the read cipher while it was used by another thread doing SSLSocket.read().

The reported issue was triggered by SSLSocket.close() calling inputRecord.close() -> readCipher.dispose() -> cipher.doFinal() on an AES/GCM cipher between `updateAAD` and `doFinal`; this changed the cipher state and caused the doFinal call to fail.

The issue for AES/GCM (and all other AEAD ciphers) was fixed by JDK-8294848; this patch addresses the non-AEAD ciphers.

Tier1-3 clean. Also, no failures after 1200 repetitions of NoInvalidateSocketException.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277970](https://bugs.openjdk.org/browse/JDK-8277970): Test jdk/sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java fails with "tag mismatch"


### Reviewers
 * [Jamil Nimeh](https://openjdk.org/census#jnimeh) (@jnimeh - **Reviewer**)
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10657/head:pull/10657` \
`$ git checkout pull/10657`

Update a local copy of the PR: \
`$ git checkout pull/10657` \
`$ git pull https://git.openjdk.org/jdk pull/10657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10657`

View PR using the GUI difftool: \
`$ git pr show -t 10657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10657.diff">https://git.openjdk.org/jdk/pull/10657.diff</a>

</details>
