### PR TITLE
8295168: Remove superfluous period in @throws tag description

### DIFF
--- a/src/java.prefs/share/classes/java/util/prefs/AbstractPreferences.java
+++ b/src/java.prefs/share/classes/java/util/prefs/AbstractPreferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -318,7 +318,7 @@ public abstract class AbstractPreferences extends Preferences {
      *         removed with the {@link #removeNode()} method.
      * @throws IllegalArgumentException if key contains the null control
      *         character, code point U+0000.
-     * @throws NullPointerException {@inheritDoc}.
+     * @throws NullPointerException {@inheritDoc}
      */
     public void remove(String key) {
         Objects.requireNonNull(key, "Specified key cannot be null");


### PR DESCRIPTION
Please review this utmost trivial fix for an issue discovered while working on something else in jdk.javadoc. As far as I can see, this is the only case of `{@inheritDoc}` not being the sole content of a `@throws` description in JDK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295168](https://bugs.openjdk.org/browse/JDK-8295168): Remove superfluous period in @throws tag description


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10664/head:pull/10664` \
`$ git checkout pull/10664`

Update a local copy of the PR: \
`$ git checkout pull/10664` \
`$ git pull https://git.openjdk.org/jdk pull/10664/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10664`

View PR using the GUI difftool: \
`$ git pr show -t 10664`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10664.diff">https://git.openjdk.org/jdk/pull/10664.diff</a>

</details>
