### PR TITLE
8295205: Add jcheck whitespace checking for markdown files

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -15,7 +15,7 @@ version=0
 domain=openjdk.org
 
 [checks "whitespace"]
-files=.*\.cpp|.*\.hpp|.*\.c|.*\.h|.*\.java|.*\.cc|.*\.hh|.*\.m|.*\.mm|.*\.gmk|.*\.m4|.*\.ac|Makefile
+files=.*\.cpp|.*\.hpp|.*\.c|.*\.h|.*\.java|.*\.cc|.*\.hh|.*\.m|.*\.mm|.*\.md|.*\.gmk|.*\.m4|.*\.ac|Makefile
 ignore-tabs=.*\.gmk|Makefile
 
 [checks "merge"]

--- a/doc/hotspot-unit-tests.md
+++ b/doc/hotspot-unit-tests.md
@@ -100,7 +100,7 @@ Generally speaking to write a good test, one should create a model of
 the system under tests, a model of possible bugs (or bugs which one
 wants to find) and design tests using those models.
 
-### Nearness 
+### Nearness
 
 Prefer having checks inside test code.
 
@@ -156,7 +156,7 @@ that the distance between compared values is not more than 4 ULPs,
 there is also `EXPECT_NEAR(v1, v2, eps)` which checks that the absolute
 value of the difference between `v1` and `v2` is not greater than `eps`.
 
-### C string comparison 
+### C string comparison
 
 Use string special macros for C strings comparisons.
 
@@ -229,7 +229,7 @@ test failure analysis. For example, class `Foo` - test group `Foo`,
 compiler logging subsystem - test group `CompilerLogging`, G1 GC — test
 group `G1GC`, and so forth.
 
-### Filename 
+### Filename
 
 A test file must have `test_` prefix and `.cpp` suffix.
 
@@ -283,7 +283,7 @@ Fixture classes should be named after tested classes, subsystems, etc
 (follow [Test group names rule](#test-group-names)) and have
 `Test` suffix to prevent class name conflicts.
 
-### Friend classes 
+### Friend classes
 
 All test purpose friends should have either `Test` or `Testable` suffix.
 
@@ -303,7 +303,7 @@ the same way it is done in hotspot.
 
 ## Miscellaneous
 
-### Hotspot style 
+### Hotspot style
 
 Abide the norms and rules accepted in Hotspot style guide.
 
@@ -392,7 +392,7 @@ In long-term, we expect jtreg to support GoogleTest tests as first
 class citizens, that is to say, jtreg will parse @requires comments
 and filter out inapplicable tests.
 
-### Flag restoring 
+### Flag restoring
 
 Restore changed flags.
 
@@ -404,7 +404,7 @@ require to use a test fixture class, which sometimes is too wordy. The
 simpler facilities like `FLAG_GUARD` macro or `*FlagSetting` classes could
 be used in such cases to restore/set values.
 
-Caveats: 
+Caveats:
 
 * Changing a flag’s value could break the invariants between flags' values and hence could lead to unexpected/unsupported JVM state.
 

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -138,7 +138,7 @@ apply.
 ### JTReg
 
 JTReg tests can be selected either by picking a JTReg test group, or a selection
-of files or directories containing JTReg tests. Documentation can be found at 
+of files or directories containing JTReg tests. Documentation can be found at
 [https://openjdk.org/jtreg/](https://openjdk.org/jtreg/), note especially the
 extensive [FAQ](https://openjdk.org/jtreg/faq.html).
 
@@ -607,8 +607,8 @@ Note: restart is required to make the settings take effect.
 
 ## Editing this document
 
-If you want to contribute changes to this document, edit `doc/testing.md` and 
-then run `make update-build-docs` to generate the same changes in 
+If you want to contribute changes to this document, edit `doc/testing.md` and
+then run `make update-build-docs` to generate the same changes in
 `doc/testing.html`.
 
 ---

--- a/src/java.base/share/legal/public_suffix.md
+++ b/src/java.base/share/legal/public_suffix.md
@@ -17,7 +17,7 @@ at https://mozilla.org/MPL/2.0/.
 
 Software distributed under the License is distributed on an "AS IS" basis,
 WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
-for the specific language governing rights and limitations under the License. 
+for the specific language governing rights and limitations under the License.
 ```
 
 ### MPL v2.0
@@ -59,7 +59,7 @@ Mozilla Public License Version 2.0
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in 
+    means a work that combines Covered Software with other material, in
     a separate file or files, that is not Covered Software.
 
 1.8. "License"

--- a/src/java.desktop/share/legal/harfbuzz.md
+++ b/src/java.desktop/share/legal/harfbuzz.md
@@ -12,7 +12,7 @@ files names COPYING in subdirectories where applicable.
 
 Copyright © 2010,2011,2012,2013,2014,2015,2016,2017,2018,2019,2020  Google, Inc.
 Copyright © 2018,2019,2020  Ebrahim Byagowi
-Copyright © 2019,2020  Facebook, Inc. 
+Copyright © 2019,2020  Facebook, Inc.
 Copyright © 2012  Mozilla Foundation
 Copyright © 2011  Codethink Limited
 Copyright © 2008,2010  Nokia Corporation and/or its subsidiary(-ies)

--- a/src/java.desktop/share/legal/jpeg.md
+++ b/src/java.desktop/share/legal/jpeg.md
@@ -12,7 +12,7 @@ Lee Crocker, Julian Minguillon, Luis Ortiz, George Phillips, Davide Rossi,
 Guido Vollbeding, Ge' Weijers, and other members of the Independent JPEG
 Group.
 
-IJG is not affiliated with the official ISO JPEG standards committee. 
+IJG is not affiliated with the official ISO JPEG standards committee.
 
 The authors make NO WARRANTY or representation, either express or implied,
 with respect to this software, its quality, accuracy, merchantability, or

--- a/src/java.xml/share/legal/xalan.md
+++ b/src/java.xml/share/legal/xalan.md
@@ -11,8 +11,8 @@
    This product includes software developed by
    The Apache Software Foundation (http://www.apache.org/).
 
-   Specifically, we only include the XSLTC portion of the source from the Xalan distribution. 
-   The Xalan project has two processors: an interpretive one (Xalan Interpretive) and a 
+   Specifically, we only include the XSLTC portion of the source from the Xalan distribution.
+   The Xalan project has two processors: an interpretive one (Xalan Interpretive) and a
    compiled one (The XSLT Compiler (XSLTC)). We *only* use the XSLTC part of Xalan; We use
    the source from the packages that are part of the XSLTC sources.
 
@@ -234,22 +234,22 @@ limitations under the License.
 
 JLEX COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
 Copyright 1996-2003 by Elliot Joel Berk and C. Scott Ananian
-Permission to use, copy, modify, and distribute this software and 
-its documentation for any purpose and without fee is hereby granted, 
-provided that the above copyright notice appear in all copies and that 
-both the copyright notice and this permission notice and warranty 
-disclaimer appear in supporting documentation, and that the name of 
-the authors or their employers not be used in advertising or publicity 
-pertaining to distribution of the software without specific, written 
+Permission to use, copy, modify, and distribute this software and
+its documentation for any purpose and without fee is hereby granted,
+provided that the above copyright notice appear in all copies and that
+both the copyright notice and this permission notice and warranty
+disclaimer appear in supporting documentation, and that the name of
+the authors or their employers not be used in advertising or publicity
+pertaining to distribution of the software without specific, written
 prior permission.
-The authors and their employers disclaim all warranties with regard to 
-this software, including all implied warranties of merchantability and 
-fitness. In no event shall the authors or their employers be liable for 
-any special, indirect or consequential damages or any damages whatsoever 
-resulting from loss of use, data or profits, whether in an action of 
-contract, negligence or other tortious action, arising out of or in 
-connection with the use or performance of this software.The portions of 
-JLex output which are hard-coded into the JLex source code are (naturally) 
+The authors and their employers disclaim all warranties with regard to
+this software, including all implied warranties of merchantability and
+fitness. In no event shall the authors or their employers be liable for
+any special, indirect or consequential damages or any damages whatsoever
+resulting from loss of use, data or profits, whether in an action of
+contract, negligence or other tortious action, arising out of or in
+connection with the use or performance of this software.The portions of
+JLex output which are hard-coded into the JLex source code are (naturally)
 covered by this same license.
 
 </pre>

--- a/src/java.xml/share/legal/xerces.md
+++ b/src/java.xml/share/legal/xerces.md
@@ -6,7 +6,7 @@
     == NOTICE file corresponding to section 4(d) of the Apache License,    ==
     == Version 2.0, in this case for the Apache Xerces Java distribution.  ==
     =========================================================================
-    
+
     Apache Xerces Java
     Copyright 1999-2022 The Apache Software Foundation
 

--- a/test/jdk/javax/accessibility/manual/README.md
+++ b/test/jdk/javax/accessibility/manual/README.md
@@ -73,7 +73,7 @@ frame will contain a name of the test in the title and detailed instructions.
    5. Push "Fail" button again
    6. Screenshot and the description are saved for further analysis
    7. Test UI closes
-   
+
 **Wasning: Do not close any window directly, all windows will be closed once the test is finished as passed or failed.**
 
 **Note: Keyboard navigation is supported throughout the test framework UI.**


### PR DESCRIPTION
Markdown files are basically source code for documentation. It should have the same whitespace checks as all other source code, so we don't get spurious trailing whitespace changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295205](https://bugs.openjdk.org/browse/JDK-8295205): Add jcheck whitespace checking for markdown files


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10671/head:pull/10671` \
`$ git checkout pull/10671`

Update a local copy of the PR: \
`$ git checkout pull/10671` \
`$ git pull https://git.openjdk.org/jdk pull/10671/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10671`

View PR using the GUI difftool: \
`$ git pr show -t 10671`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10671.diff">https://git.openjdk.org/jdk/pull/10671.diff</a>

</details>
