### PR TITLE
8295218: New KeepAliveTest.java has invalid copyright notice

### DIFF
--- a/test/jdk/sun/net/www/http/HttpClient/KeepAliveTest.java
+++ b/test/jdk/sun/net/www/http/HttpClient/KeepAliveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Hi, 

This is a copyright update to the PR just integrated to fix the incorrect copyright notice in the new test

Thanks,
Michael

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295218](https://bugs.openjdk.org/browse/JDK-8295218): New KeepAliveTest.java has invalid copyright notice


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10674/head:pull/10674` \
`$ git checkout pull/10674`

Update a local copy of the PR: \
`$ git checkout pull/10674` \
`$ git pull https://git.openjdk.org/jdk pull/10674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10674`

View PR using the GUI difftool: \
`$ git pr show -t 10674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10674.diff">https://git.openjdk.org/jdk/pull/10674.diff</a>

</details>
