### PR TITLE
8295024: Cyclic constructor error is non-deterministic and inconsistent

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5349,7 +5349,7 @@ public class Attr extends JCTree.Visitor {
                     if (permittedTypes.contains(subTypeSym)) {
                         DiagnosticPosition pos =
                                 env.enclClass.permitting.stream()
-                                        .filter(permittedExpr -> TreeInfo.diagnosticPositionFor(subTypeSym, permittedExpr, true) != null)
+                                        .filter(permittedExpr -> TreeInfo.diagnosticPositionFor(subTypeSym, permittedExpr, null, true) != null)
                                         .limit(2).collect(List.collector()).get(1);
                         log.error(pos, Errors.InvalidPermitsClause(Fragments.IsDuplicated(subTypeSym.type)));
                     } else {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5349,7 +5349,7 @@ public class Attr extends JCTree.Visitor {
                     if (permittedTypes.contains(subTypeSym)) {
                         DiagnosticPosition pos =
                                 env.enclClass.permitting.stream()
-                                        .filter(permittedExpr -> TreeInfo.diagnosticPositionFor(subTypeSym, permittedExpr, null, true) != null)
+                                        .filter(permittedExpr -> TreeInfo.diagnosticPositionFor(subTypeSym, permittedExpr, true) != null)
                                         .limit(2).collect(List.collector()).get(1);
                         log.error(pos, Errors.InvalidPermitsClause(Fragments.IsDuplicated(subTypeSym.type)));
                     } else {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -3719,7 +3719,7 @@ public class Check {
                                         Map<Symbol,Symbol> callMap) {
         if (ctor != null && (ctor.flags_field & ACYCLIC) == 0) {
             if ((ctor.flags_field & LOCKED) != 0) {
-                log.error(TreeInfo.diagnosticPositionFor(ctor, tree, JCIdent.class::isInstance, false),
+                log.error(TreeInfo.diagnosticPositionFor(ctor, tree, false, t -> t.hasTag(IDENT)),
                           Errors.RecursiveCtorInvocation);
             } else {
                 ctor.flags_field |= LOCKED;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -3689,7 +3689,8 @@ public class Check {
      *  constructors.
      */
     void checkCyclicConstructors(JCClassDecl tree) {
-        Map<Symbol,Symbol> callMap = new HashMap<>();
+        // use LinkedHashMap so we generate errors deterministically
+        Map<Symbol,Symbol> callMap = new LinkedHashMap<>();
 
         // enter each constructor this-call into the map
         for (List<JCTree> l = tree.defs; l.nonEmpty(); l = l.tail) {
@@ -3718,7 +3719,7 @@ public class Check {
                                         Map<Symbol,Symbol> callMap) {
         if (ctor != null && (ctor.flags_field & ACYCLIC) == 0) {
             if ((ctor.flags_field & LOCKED) != 0) {
-                log.error(TreeInfo.diagnosticPositionFor(ctor, tree),
+                log.error(TreeInfo.diagnosticPositionFor(ctor, tree, JCIdent.class::isInstance, false),
                           Errors.RecursiveCtorInvocation);
             } else {
                 ctor.flags_field |= LOCKED;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
@@ -707,11 +707,15 @@ public class TreeInfo {
     /** Find the position for reporting an error about a symbol, where
      *  that symbol is defined somewhere in the given tree. */
     public static DiagnosticPosition diagnosticPositionFor(final Symbol sym, final JCTree tree) {
-        return diagnosticPositionFor(sym, tree, null, false);
+        return diagnosticPositionFor(sym, tree, false);
     }
 
-    public static DiagnosticPosition diagnosticPositionFor(final Symbol sym, final JCTree tree,
-            Predicate<? super JCTree> filter, boolean returnNullIfNotFound) {
+    public static DiagnosticPosition diagnosticPositionFor(final Symbol sym, final JCTree tree, boolean returnNullIfNotFound) {
+        return diagnosticPositionFor(sym, tree, returnNullIfNotFound, null);
+    }
+
+    public static DiagnosticPosition diagnosticPositionFor(final Symbol sym, final JCTree tree, boolean returnNullIfNotFound,
+            Predicate<? super JCTree> filter) {
         class DiagScanner extends DeclScanner {
             DiagScanner(Symbol sym, Predicate<? super JCTree> filter) {
                 super(sym, filter);
@@ -741,6 +745,9 @@ public class TreeInfo {
         final Symbol sym;
         final Predicate<? super JCTree> filter;
 
+        DeclScanner(final Symbol sym) {
+            this(sym, null);
+        }
         DeclScanner(final Symbol sym, Predicate<? super JCTree> filter) {
             this.sym = sym;
             this.filter = filter;
@@ -792,7 +799,7 @@ public class TreeInfo {
     /** Find the declaration for a symbol, where
      *  that symbol is defined somewhere in the given tree. */
     public static JCTree declarationFor(final Symbol sym, final JCTree tree) {
-        DeclScanner s = new DeclScanner(sym, null);
+        DeclScanner s = new DeclScanner(sym);
         tree.accept(s);
         return s.result;
     }

--- a/test/langtools/tools/javac/Diagnostics/8295024/T8295024.java
+++ b/test/langtools/tools/javac/Diagnostics/8295024/T8295024.java
@@ -1,0 +1,63 @@
+/**
+ * @test /nodynamiccopyright/
+ * @bug     8295024
+ * @summary Cyclic constructor error is non-deterministic and inconsistent
+ * @compile T8295024.java
+ * @run main T8295024
+ */
+import java.io.*;
+import java.net.*;
+import java.util.*;
+import java.util.stream.*;
+import javax.tools.*;
+public class T8295024 {
+
+    private static final int NUM_RUNS = 10;
+    private static final String EXPECTED_ERROR = """
+        Cyclic.java:12:9: compiler.err.recursive.ctor.invocation
+        1 error
+        """;
+    private static final String SOURCE = """
+        public class Cyclic {
+            public Cyclic(int x) {
+                this((float)x);
+            }
+            public Cyclic(float x) {
+                this((long)x);
+            }
+            public Cyclic(long x) {
+                this((double)x);
+            }
+            public Cyclic(double x) {
+                this((int)x);
+            //  ^ error should be reported here every time
+            }
+        }
+        """;
+
+    private static final SimpleJavaFileObject FILE = new SimpleJavaFileObject(
+      URI.create("string:///Cyclic.java"), JavaFileObject.Kind.SOURCE) {
+        @Override
+        public String getCharContent(boolean ignoreEncodingErrors) {
+            return  SOURCE;
+        }
+    };
+
+    public static void main(String[] args) throws Exception {
+
+        // Compile program NUM_RUNS times
+        final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        final StringWriter output = new StringWriter();
+        final Iterable<String> options = Collections.singleton("-XDrawDiagnostics");
+        final Iterable<SimpleJavaFileObject> files = Collections.singleton(FILE);
+        for (int i = 0; i < NUM_RUNS; i++)
+            compiler.getTask(output, null, null, options, null, files).call();
+
+        // Verify consistent error report each time
+        final String expected = IntStream.range(0, NUM_RUNS)
+          .mapToObj(i -> EXPECTED_ERROR)
+          .collect(Collectors.joining(""));
+        final String actual = output.toString().replaceAll("\\r", "");
+        assert expected.equals(actual) : "EXPECTED:\n" + expected + "ACTUAL:\n" + actual;
+    }
+}

--- a/test/langtools/tools/javac/Diagnostics/8295024/T8295024.java
+++ b/test/langtools/tools/javac/Diagnostics/8295024/T8295024.java
@@ -2,8 +2,6 @@
  * @test /nodynamiccopyright/
  * @bug     8295024
  * @summary Cyclic constructor error is non-deterministic and inconsistent
- * @compile T8295024.java
- * @run main T8295024
  */
 import java.io.*;
 import java.net.*;


### PR DESCRIPTION
This patch addresses two related issues that cause javac's reporting of recursive constructor errors to be non-deterministic.

The first issue is caused by the use of a `HashMap` when finding cycles in the graph of constructor invocations. This causes non-determinism in which constructor is identified as the "culprit" for the purposes of error reporting. The obvious fix here is to use a `LinkedHashMap` instead.

The second problem is caused by how the error's source code location is found via `TreeInfo.diagnosticPositionFor()`. That method searches the AST for a node matching the constructor's `Symbol`, but both the constructor declaration and all of its invocations will match that `Symbol`, and so whichever of those happens first in the source code wins.

The fix adds an optional filter parameter to `TreeInfo.diagnosticPositionFor()`, and then uses it to match only the constructor invocation. Reporting the invocation instead of the declaration is preferred because it provides more specific information about exactly how the recursion occurs. Put another way, when identifying a cycle in a graph, reporting an edge is more helpful than reporting a node.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295024](https://bugs.openjdk.org/browse/JDK-8295024): Cyclic constructor error is non-deterministic and inconsistent


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10679/head:pull/10679` \
`$ git checkout pull/10679`

Update a local copy of the PR: \
`$ git checkout pull/10679` \
`$ git pull https://git.openjdk.org/jdk pull/10679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10679`

View PR using the GUI difftool: \
`$ git pr show -t 10679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10679.diff">https://git.openjdk.org/jdk/pull/10679.diff</a>

</details>
