### PR TITLE
8294899: Process.waitFor() throws IllegalThreadStateException

### DIFF
--- a/src/java.base/windows/classes/java/lang/ProcessImpl.java
+++ b/src/java.base/windows/classes/java/lang/ProcessImpl.java
@@ -572,7 +572,7 @@ final class ProcessImpl extends Process {
         }
         if (Thread.interrupted())
             throw new InterruptedException();
-        return exitValue();
+        return getExitCodeProcess(handle);
     }
 
     private static native void waitForInterruptibly(long handle);

--- a/test/jdk/java/lang/ProcessBuilder/WindowsExitValue.java
+++ b/test/jdk/java/lang/ProcessBuilder/WindowsExitValue.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Verify that when a child returns exit value 259, Process.waitFor does not throw
+ * @bug 8294899
+ * @requires (os.family == "windows")
+ * @run junit WindowsExitValue
+ */
+
+import java.io.IOException;
+
+import org.junit.*;
+import static org.junit.Assert.*;
+
+public class WindowsExitValue {
+
+    @Test
+    public void checkExit259() throws IOException {
+        try {
+            Process process = new ProcessBuilder("cmd", "/c", "exit /b 259").start();
+            long exitValue = process.waitFor();
+            assertEquals(exitValue, 259);
+        } catch (InterruptedException ie) {
+            org.junit.Assert.fail("InterruptedException not expected");
+        }
+    }
+}


### PR DESCRIPTION
Process.waitFor() throws IllegalThreadStateException when a process returns an exit code of 259.
As described in the bug report, `waitFor()` should be sensitive to the exit value.
Previously, it erroneously threw IllegalStateException.
Added a test to verify. 
