### PR TITLE
8295225: [JVMCI] codeStart should be cleared when entryPoint is cleared

### DIFF
--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -1616,6 +1616,7 @@ CodeBlob* JVMCIEnv::get_code_blob(JVMCIObject obj) {
       // nmethod in the code cache.
       set_InstalledCode_address(obj, 0);
       set_InstalledCode_entryPoint(obj, 0);
+      set_HotSpotInstalledCode_codeStart(obj, 0);
     }
     return nm;
   }

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -820,11 +820,13 @@ void JVMCINMethodData::invalidate_nmethod_mirror(nmethod* nm) {
       // an InvalidInstalledCodeException.
       HotSpotJVMCI::InstalledCode::set_address(jvmciEnv, nmethod_mirror, 0);
       HotSpotJVMCI::InstalledCode::set_entryPoint(jvmciEnv, nmethod_mirror, 0);
+      HotSpotJVMCI::HotSpotInstalledCode::set_codeStart(jvmciEnv, nmethod_mirror, 0);
     } else if (nm->is_not_entrant()) {
       // Zero the entry point so any new invocation will fail but keep
       // the address link around that so that existing activations can
       // be deoptimized via the mirror (i.e. JVMCIEnv::invalidate_installed_code).
       HotSpotJVMCI::InstalledCode::set_entryPoint(jvmciEnv, nmethod_mirror, 0);
+      HotSpotJVMCI::HotSpotInstalledCode::set_codeStart(jvmciEnv, nmethod_mirror, 0);
     }
   }
 

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/InvalidateInstalledCodeTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/InvalidateInstalledCodeTest.java
@@ -91,15 +91,18 @@ public class InvalidateInstalledCodeTest extends CodeInstallerTest {
 
         Asserts.assertTrue(nmethod.isValid(), testCase + " : code is not valid, i = " + nmethod);
         Asserts.assertTrue(nmethod.isAlive(), testCase + " : code is not alive, i = " + nmethod);
+        Asserts.assertNotEquals(nmethod.getStart(), 0L);
 
         // Make nmethod non-entrant but still alive
         CompilerToVMHelper.invalidateHotSpotNmethod(nmethod, false);
         Asserts.assertFalse(nmethod.isValid(), testCase + " : code is valid, i = " + nmethod);
         Asserts.assertTrue(nmethod.isAlive(), testCase + " : code is not alive, i = " + nmethod);
+        Asserts.assertEquals(nmethod.getStart(), 0L);
 
         // Deoptimize the nmethod and cut the link to it from the HotSpotNmethod
         CompilerToVMHelper.invalidateHotSpotNmethod(nmethod, true);
         Asserts.assertFalse(nmethod.isValid(), testCase + " : code is valid, i = " + nmethod);
         Asserts.assertFalse(nmethod.isAlive(), testCase + " : code is alive, i = " + nmethod);
+        Asserts.assertEquals(nmethod.getStart(), 0L);
     }
 }


### PR DESCRIPTION
When the `InstalledCode.entryPoint` field is [cleared](https://github.com/openjdk/jdk/search?q=set_InstalledCode_entryPoint), the `HotSpotInstalledCode.codeStart` field should also be cleared. That is, when making an nmethod non-entrant, all Java fields pointing to code in the nmethod should be cleared. This avoids an inconsistent view of the code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295225](https://bugs.openjdk.org/browse/JDK-8295225): [JVMCI] codeStart should be cleared when entryPoint is cleared


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10682/head:pull/10682` \
`$ git checkout pull/10682`

Update a local copy of the PR: \
`$ git checkout pull/10682` \
`$ git pull https://git.openjdk.org/jdk pull/10682/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10682`

View PR using the GUI difftool: \
`$ git pr show -t 10682`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10682.diff">https://git.openjdk.org/jdk/pull/10682.diff</a>

</details>
