### PR TITLE
8295232: "java.locale.useOldISOCodes" property is read lazily

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
+++ b/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
@@ -55,6 +55,7 @@ public final class StaticProperty {
     private static final String JAVA_PROPERTIES_DATE;
     private static final String SUN_JNU_ENCODING;
     private static final Charset jnuCharset;
+    private static final String JAVA_LOCALE_USE_OLD_ISO_CODES;
 
     private StaticProperty() {}
 
@@ -74,6 +75,7 @@ public final class StaticProperty {
         JAVA_PROPERTIES_DATE = getProperty(props, "java.properties.date", null);
         SUN_JNU_ENCODING = getProperty(props, "sun.jnu.encoding");
         jnuCharset = Charset.forName(SUN_JNU_ENCODING, Charset.defaultCharset());
+        JAVA_LOCALE_USE_OLD_ISO_CODES = getProperty(props, "java.locale.useOldISOCodes", "");
     }
 
     private static String getProperty(Properties props, String key) {
@@ -242,5 +244,16 @@ public final class StaticProperty {
      */
     public static Charset jnuCharset() {
         return jnuCharset;
+    }
+
+    /**
+     * {@return the {@code java.locale.useOldISOCodes} system property}
+     *
+     * <strong>{@link SecurityManager#checkPropertyAccess} is NOT checked
+     * in this method. The caller of this method should take care to ensure
+     * that the returned property is not made accessible to untrusted code.</strong>
+     */
+    public static String javaLocaleUseOldISOCodes() {
+        return JAVA_LOCALE_USE_OLD_ISO_CODES;
     }
 }

--- a/src/java.base/share/classes/sun/util/locale/BaseLocale.java
+++ b/src/java.base/share/classes/sun/util/locale/BaseLocale.java
@@ -33,6 +33,7 @@
 package sun.util.locale;
 
 import jdk.internal.misc.CDS;
+import jdk.internal.util.StaticProperty;
 import jdk.internal.vm.annotation.Stable;
 import sun.security.action.GetPropertyAction;
 
@@ -101,9 +102,10 @@ public final class BaseLocale {
 
     /**
      * Boolean for the old ISO language code compatibility.
+     * The system property "java.locale.useOldISOCodes" is not security sensitive,
+     * so no need to ensure privileged access here.
      */
-    private static final boolean OLD_ISO_CODES = GetPropertyAction.privilegedGetProperties()
-            .getProperty("java.locale.useOldISOCodes", "false")
+    private static final boolean OLD_ISO_CODES = StaticProperty.javaLocaleUseOldISOCodes()
             .equalsIgnoreCase("true");
 
     // This method must be called with normalize = false only when creating the

--- a/src/java.base/share/classes/sun/util/locale/BaseLocale.java
+++ b/src/java.base/share/classes/sun/util/locale/BaseLocale.java
@@ -35,7 +35,6 @@ package sun.util.locale;
 import jdk.internal.misc.CDS;
 import jdk.internal.util.StaticProperty;
 import jdk.internal.vm.annotation.Stable;
-import sun.security.action.GetPropertyAction;
 
 import java.lang.ref.SoftReference;
 import java.util.StringJoiner;

--- a/test/jdk/java/util/Locale/UseOldISOCodesTest.java
+++ b/test/jdk/java/util/Locale/UseOldISOCodesTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/**
+ * @test
+ * @bug 8295232
+ * @summary Ensures java.locale.useOldISOCodes is statically initialized
+ * @library /test/lib
+ * @run main UseOldISOCodesTest
+ */
+import java.util.Locale;
+import jdk.test.lib.process.ProcessTools;
+
+public class UseOldISOCodesTest {
+    public static void main(String[] args) throws Exception {
+        ProcessTools.executeTestJvm("-Djava.locale.useOldISOCodes=true", "UseOldISOCodesTest$Runner")
+                .outputTo(System.out)
+                .errorTo(System.err)
+                .shouldHaveExitValue(0);
+    }
+
+    static class Runner {
+        private static final String obsoleteCode = "iw";
+        private static final String newCode = "he";
+
+        public static void main(String[] args) {
+            System.setProperty("java.locale.useOldISOCodes", "false");
+            Locale locale = Locale.of(newCode);
+            if(!obsoleteCode.equals(locale.getLanguage())){
+                throw new RuntimeException("Expected that newcode mapped to old ");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixed to utilize `StaticProperty` so that the system property value for `java.locale.useOldISOCodes` set on the command line is honored even with lazy `Locale` initialization.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295232](https://bugs.openjdk.org/browse/JDK-8295232): "java.locale.useOldISOCodes" property is read lazily


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to [20bc893d](https://git.openjdk.org/jdk/pull/10683/files/20bc893d8139066af497ea610975d466fdf26988)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to [20bc893d](https://git.openjdk.org/jdk/pull/10683/files/20bc893d8139066af497ea610975d466fdf26988)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [20bc893d](https://git.openjdk.org/jdk/pull/10683/files/20bc893d8139066af497ea610975d466fdf26988)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to [20bc893d](https://git.openjdk.org/jdk/pull/10683/files/20bc893d8139066af497ea610975d466fdf26988)
 * [Sean Coffey](https://openjdk.org/census#coffeys) (@coffeys - **Reviewer**) ⚠️ Review applies to [20bc893d](https://git.openjdk.org/jdk/pull/10683/files/20bc893d8139066af497ea610975d466fdf26988)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10683/head:pull/10683` \
`$ git checkout pull/10683`

Update a local copy of the PR: \
`$ git checkout pull/10683` \
`$ git pull https://git.openjdk.org/jdk pull/10683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10683`

View PR using the GUI difftool: \
`$ git pr show -t 10683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10683.diff">https://git.openjdk.org/jdk/pull/10683.diff</a>

</details>
