### PR TITLE
8295268: Optimized builds are broken due to incorrect assert_is_rfp shortcuts

### DIFF
--- a/src/hotspot/cpu/arm/smallRegisterMap_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/smallRegisterMap_arm.inline.hpp
@@ -33,7 +33,7 @@ class SmallRegisterMap {
 public:
   static constexpr SmallRegisterMap* instance = nullptr;
 private:
-  static void assert_is_rfp(VMReg r) PRODUCT_RETURN
+  static void assert_is_rfp(VMReg r) NOT_DEBUG_RETURN
                                      DEBUG_ONLY({ Unimplemented(); })
 public:
   // as_RegisterMap is used when we didn't want to templatize and abstract over RegisterMap type to support SmallRegisterMap

--- a/src/hotspot/cpu/ppc/smallRegisterMap_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/smallRegisterMap_ppc.inline.hpp
@@ -33,7 +33,7 @@ class SmallRegisterMap {
 public:
   static constexpr SmallRegisterMap* instance = nullptr;
 private:
-  static void assert_is_rfp(VMReg r) PRODUCT_RETURN
+  static void assert_is_rfp(VMReg r) NOT_DEBUG_RETURN
                                      DEBUG_ONLY({ Unimplemented(); })
 public:
   // as_RegisterMap is used when we didn't want to templatize and abstract over RegisterMap type to support SmallRegisterMap

--- a/src/hotspot/cpu/riscv/smallRegisterMap_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/smallRegisterMap_riscv.inline.hpp
@@ -33,7 +33,7 @@ class SmallRegisterMap {
 public:
   static constexpr SmallRegisterMap* instance = nullptr;
 private:
-  static void assert_is_rfp(VMReg r) PRODUCT_RETURN
+  static void assert_is_rfp(VMReg r) NOT_DEBUG_RETURN
                                      DEBUG_ONLY({ Unimplemented(); })
 public:
   // as_RegisterMap is used when we didn't want to templatize and abstract over RegisterMap type to support SmallRegisterMap

--- a/src/hotspot/cpu/s390/smallRegisterMap_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/smallRegisterMap_s390.inline.hpp
@@ -33,7 +33,7 @@ class SmallRegisterMap {
 public:
   static constexpr SmallRegisterMap* instance = nullptr;
 private:
-  static void assert_is_rfp(VMReg r) PRODUCT_RETURN
+  static void assert_is_rfp(VMReg r) NOT_DEBUG_RETURN
                                      DEBUG_ONLY({ Unimplemented(); })
 public:
   // as_RegisterMap is used when we didn't want to templatize and abstract over RegisterMap type to support SmallRegisterMap

--- a/src/hotspot/cpu/zero/smallRegisterMap_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/smallRegisterMap_zero.inline.hpp
@@ -33,7 +33,7 @@ class SmallRegisterMap {
 public:
   static constexpr SmallRegisterMap* instance = nullptr;
 private:
-  static void assert_is_rfp(VMReg r) PRODUCT_RETURN
+  static void assert_is_rfp(VMReg r) NOT_DEBUG_RETURN
                                      DEBUG_ONLY({ Unimplemented(); })
 public:
   // as_RegisterMap is used when we didn't want to templatize and abstract over RegisterMap type to support SmallRegisterMap


### PR DESCRIPTION
Fails on many platforms, for example arm32:

```
/home/shade/trunks/jdk/src/hotspot/cpu/arm/smallRegisterMap_arm.inline.hpp:36:36: error: expected ';' at end of member declaration
   36 | static void assert_is_rfp(VMReg r) PRODUCT_RETURN
      | ^
```

The reason is that `PRODUCT_RETURN` + `DEBUG_ONLY` are not unity: in "optimized" builds, we have `!PRODUCT` and `!DEBUG`.

```
  static void assert_is_rfp(VMReg r) PRODUCT_RETURN
                                     DEBUG_ONLY({ Unimplemented(); })
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295268](https://bugs.openjdk.org/browse/JDK-8295268): Optimized builds are broken due to incorrect assert_is_rfp shortcuts


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10696/head:pull/10696` \
`$ git checkout pull/10696`

Update a local copy of the PR: \
`$ git checkout pull/10696` \
`$ git pull https://git.openjdk.org/jdk pull/10696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10696`

View PR using the GUI difftool: \
`$ git pr show -t 10696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10696.diff">https://git.openjdk.org/jdk/pull/10696.diff</a>

</details>
