### PR TITLE
8294460: CodeSection::alignment checks for CodeBuffer::SECT_STUBS incorrectly

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -452,6 +452,10 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
     _shared_stub_to_interp_requests = NULL;
     _shared_trampoline_requests = NULL;
 
+    _consts.initialize_outer(this, SECT_CONSTS);
+    _insts.initialize_outer(this,  SECT_INSTS);
+    _stubs.initialize_outer(this,  SECT_STUBS);
+
 #ifndef PRODUCT
     _decode_begin    = NULL;
     // Collect block comments, but restrict collection to cases where a disassembly is output.
@@ -466,9 +470,6 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
   }
 
   void initialize(address code_start, csize_t code_size) {
-    _consts.initialize_outer(this,  SECT_CONSTS);
-    _insts.initialize_outer(this,   SECT_INSTS);
-    _stubs.initialize_outer(this,   SECT_STUBS);
     _total_start = code_start;
     _total_size  = code_size;
     // Initialize the main section:
@@ -752,7 +753,7 @@ inline int CodeSection::alignment(int section) {
   if (section == CodeBuffer::SECT_INSTS) {
     return (int) CodeEntryAlignment;
   }
-  if (CodeBuffer::SECT_STUBS) {
+  if (section == CodeBuffer::SECT_STUBS) {
     // CodeBuffer installer expects sections to be HeapWordSize aligned
     return HeapWordSize;
   }


### PR DESCRIPTION
This is a fix for an apparent code bug:

```
inline int CodeSection::alignment(int section) {
  if (section == CodeBuffer::SECT_CONSTS) {
    return (int) sizeof(jdouble);
  }
  if (section == CodeBuffer::SECT_INSTS) {
    return (int) CodeEntryAlignment;
  }
  if (CodeBuffer::SECT_STUBS) {   <--- here must be (section == CodeBuffer::SECT_STUBS) condition!
    // CodeBuffer installer expects sections to be HeapWordSize aligned
    return HeapWordSize;
  }
  ShouldNotReachHere();
  return 0;
}
```

Also, the section size initializer code is moved to initialize_misc() to fix the code path that works with uninitialized data.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294460](https://bugs.openjdk.org/browse/JDK-8294460): CodeSection::alignment checks for CodeBuffer::SECT_STUBS incorrectly


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10699/head:pull/10699` \
`$ git checkout pull/10699`

Update a local copy of the PR: \
`$ git checkout pull/10699` \
`$ git pull https://git.openjdk.org/jdk pull/10699/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10699`

View PR using the GUI difftool: \
`$ git pr show -t 10699`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10699.diff">https://git.openjdk.org/jdk/pull/10699.diff</a>

</details>
