### PR TITLE
8295294: Misc cleanups in runtime/InvocationTests

### DIFF
--- a/test/hotspot/jtreg/runtime/InvocationTests/shared/AbstractGenerator.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/shared/AbstractGenerator.java
@@ -121,48 +121,44 @@ public abstract class AbstractGenerator {
         Class targetClass;
         Checker checker;
 
+        System.out.printf(caseDescription);
+
         try {
             paramClass = loader.loadClass(calleeClassName);
             targetClass = loader.loadClass(classNameC);
 
             checker = getChecker(paramClass, targetClass);
+
+            if (executeTests) {
+                // Check runtime behavior
+                Caller caller = new Caller(loader, checker, paramClass, targetClass);
+                for (String site : callSites) {
+                    String callResult = caller.call(site);
+                    System.out.printf(" %7s", callResult);
+
+                    if (!caller.isPassed()) {
+                        String result = checker.check(loader.loadClass(site));
+                        System.out.printf("/%s", Checker.abbreviateResult(result));
+                        isPassed = false;
+                    }
+                }
+                if (!caller.isPassed()) {
+                    System.out.print(" |   FAILED");
+                }
+            } else {
+                for (String site : callSites) {
+                    String result = checker.check(loader.loadClass(site));
+                    System.out.printf(" %7s", Checker.abbreviateResult(result));
+                }
+            }
         } catch (Throwable e) {
             String result = Checker.abbreviateResult(e.getClass().getName());
-
-            System.out.printf(caseDescription);
 
             for (String site : callSites) {
                 System.out.printf(" %7s", result);
             }
-
-            System.out.println("");
-
-            return true;
         }
-
-        if (executeTests) {
-            // Check runtime behavior
-            System.out.printf(caseDescription);
-
-            Caller caller = new Caller(loader, checker, paramClass, targetClass);
-            for (String site : callSites) {
-                String callResult = caller.call(site);
-                System.out.printf(" %7s", callResult);
-
-                if (!caller.isPassed()) {
-                    isPassed = false;
-                }
-            }
-            if (!caller.isPassed()) {
-                System.out.print(" |   FAILED");
-            }
-            System.out.println();
-        } else {
-            for (String site : callSites) {
-                String result = checker.check(loader.loadClass(site));
-                System.out.printf(" %7s", Checker.abbreviateResult(result));
-            }
-        }
+        System.out.println();
 
         return isPassed;
     }

--- a/test/hotspot/jtreg/runtime/InvocationTests/shared/AbstractGenerator.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/shared/AbstractGenerator.java
@@ -142,23 +142,21 @@ public abstract class AbstractGenerator {
 
         if (executeTests) {
             // Check runtime behavior
+            System.out.printf(caseDescription);
+
             Caller caller = new Caller(loader, checker, paramClass, targetClass);
-            boolean printedCaseDes = false;
             for (String site : callSites) {
                 String callResult = caller.call(site);
+                System.out.printf(" %7s", callResult);
 
                 if (!caller.isPassed()) {
                     isPassed = false;
-                    if (!printedCaseDes) {
-                        System.out.printf(caseDescription);
-                        printedCaseDes = true;
-                    }
-                    System.out.printf(" %7s", callResult);
                 }
             }
             if (!caller.isPassed()) {
-                System.out.println(" |   FAILED");
+                System.out.print(" |   FAILED");
             }
+            System.out.println();
         } else {
             for (String site : callSites) {
                 String result = checker.check(loader.loadClass(site));

--- a/test/hotspot/jtreg/runtime/InvocationTests/shared/ExecutorGenerator.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/shared/ExecutorGenerator.java
@@ -49,7 +49,7 @@ public class ExecutorGenerator {
     }
 
     public byte[] generateExecutor(String[] callSites) {
-        ClassWriter cw = new ClassWriter(COMPUTE_MAXS);
+        ClassWriter cw = new ClassWriter(COMPUTE_FRAMES | COMPUTE_MAXS);
 
         cw.visit(Utils.version, ACC_PUBLIC | (Utils.isACC_SUPER ? ACC_SUPER : 0), className, null, "java/lang/Object", null);
 


### PR DESCRIPTION
Address the following problems in runtime/InvocationTests:
  - Test case tracing output is omitted;
  - Stand-alone test case executors are broken.

Testing: manual

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295294](https://bugs.openjdk.org/browse/JDK-8295294): Misc cleanups in runtime/InvocationTests


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10701/head:pull/10701` \
`$ git checkout pull/10701`

Update a local copy of the PR: \
`$ git checkout pull/10701` \
`$ git pull https://git.openjdk.org/jdk pull/10701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10701`

View PR using the GUI difftool: \
`$ git pr show -t 10701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10701.diff">https://git.openjdk.org/jdk/pull/10701.diff</a>

</details>
