### PR TITLE
8295295: CDS ArchivedEnumTest fails with StaticProperty::JAVA_LOCALE_USE_OLD_ISO_CODES

### DIFF
--- a/src/hotspot/share/cds/cdsHeapVerifier.cpp
+++ b/src/hotspot/share/cds/cdsHeapVerifier.cpp
@@ -128,7 +128,8 @@ CDSHeapVerifier::CDSHeapVerifier() : _archived_objs(0), _problems(0)
 
   // This just points to an empty Map
   ADD_EXCL("jdk/internal/reflect/Reflection",            "methodFilterMap");       // E
-  ADD_EXCL("jdk/internal/util/StaticProperty",           "FILE_ENCODING");         // C
+  ADD_EXCL("jdk/internal/util/StaticProperty",           "FILE_ENCODING",          // C
+                                                 "JAVA_LOCALE_USE_OLD_ISO_CODES"); // C
 
   // Integer for 0 and 1 are in java/lang/Integer$IntegerCache and are archived
   ADD_EXCL("sun/invoke/util/ValueConversions",           "ONE_INT",                // E


### PR DESCRIPTION
Please review this trivial change to fix a tier2 failure:

The field `jdk.internal.util.StaticProperty::JAVA_LOCALE_USE_OLD_ISO_CODES` was added recently in [JDK-8295232](https://bugs.openjdk.org/browse/JDK-8295232). We need to add this field to the exception rules in cdsHeapVerifier.cpp, similar to the existing entry for `StaticProperty::FILE_ENCODING`

For more information about the exception rules, please see 
https://github.com/openjdk/jdk/blob/4224d45132b98e4f7bb7a96b696692d2f0bf645e/src/hotspot/share/cds/cdsHeapVerifier.cpp#L40-L83

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295295](https://bugs.openjdk.org/browse/JDK-8295295): CDS ArchivedEnumTest fails with StaticProperty::JAVA_LOCALE_USE_OLD_ISO_CODES


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10702/head:pull/10702` \
`$ git checkout pull/10702`

Update a local copy of the PR: \
`$ git checkout pull/10702` \
`$ git pull https://git.openjdk.org/jdk pull/10702/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10702`

View PR using the GUI difftool: \
`$ git pr show -t 10702`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10702.diff">https://git.openjdk.org/jdk/pull/10702.diff</a>

</details>
