### PR TITLE
8295288: Some vm_flags tests associate with a wrong BugID

### DIFF
--- a/test/lib-test/jdk/test/whitebox/vm_flags/BooleanTest.java
+++ b/test/lib-test/jdk/test/whitebox/vm_flags/BooleanTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test BooleanTest
- * @bug 8028756
+ * @bug 8038756
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.compiler

--- a/test/lib-test/jdk/test/whitebox/vm_flags/DoubleTest.java
+++ b/test/lib-test/jdk/test/whitebox/vm_flags/DoubleTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test DoubleTest
- * @bug 8028756
+ * @bug 8038756
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @modules java.management/sun.management

--- a/test/lib-test/jdk/test/whitebox/vm_flags/StringTest.java
+++ b/test/lib-test/jdk/test/whitebox/vm_flags/StringTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test StringTest
- * @bug 8028756
+ * @bug 8038756
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @modules java.management/sun.management

--- a/test/lib-test/jdk/test/whitebox/vm_flags/Uint64Test.java
+++ b/test/lib-test/jdk/test/whitebox/vm_flags/Uint64Test.java
@@ -23,7 +23,7 @@
 
 /*
  * @test Uint64Test
- * @bug 8028756
+ * @bug 8038756
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @modules java.management/sun.management

--- a/test/lib-test/jdk/test/whitebox/vm_flags/UintxTest.java
+++ b/test/lib-test/jdk/test/whitebox/vm_flags/UintxTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test UintxTest
- * @bug 8028756
+ * @bug 8038756
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management/sun.management


### PR DESCRIPTION
Fixing incorrect bug IDs. IntxTest.java already has the correct bug ID, and SizeTTest has a different bug ID that is correct.

All changed tests passing locally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295288](https://bugs.openjdk.org/browse/JDK-8295288): Some vm_flags tests associate with a wrong BugID


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10703/head:pull/10703` \
`$ git checkout pull/10703`

Update a local copy of the PR: \
`$ git checkout pull/10703` \
`$ git pull https://git.openjdk.org/jdk pull/10703/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10703`

View PR using the GUI difftool: \
`$ git pr show -t 10703`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10703.diff">https://git.openjdk.org/jdk/pull/10703.diff</a>

</details>
