### PR TITLE
6924219: (fc spec) FileChannel.write(ByteBuffer, position) behavior when file opened for append not specified

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -146,7 +146,9 @@ import jdk.internal.javac.PreviewFeature;
  * operation first advances the position to the end of the file and then writes
  * the requested data.  Whether the advancement of the position and the writing
  * of the data are done in a single atomic operation is system-dependent and
- * therefore unspecified.
+ * therefore unspecified.  In this mode an invocation of the {@linkplain
+ * #write(ByteBuffer,long) absolute write} operation leads to unspecified
+ * behavior.
  *
  * @see java.io.FileInputStream#getChannel()
  * @see java.io.FileOutputStream#getChannel()
@@ -193,7 +195,9 @@ public abstract class FileChannel
      *     the position to the end of the file and then writes the requested
      *     data. Whether the advancement of the position and the writing of the
      *     data are done in a single atomic operation is system-dependent and
-     *     therefore unspecified. This option may not be used in conjunction
+     *     therefore unspecified. The effect of performing an
+     *     {@linkplain #write(ByteBuffer,long) absolute write} with this option
+     *     present is unspecified. This option may not be used in conjunction
      *     with the {@code READ} or {@code TRUNCATE_EXISTING} options. </td>
      * </tr>
      * <tr>
@@ -808,6 +812,9 @@ public abstract class FileChannel
      * position is greater than the file's current size then the file will be
      * grown to accommodate the new bytes; the values of any bytes between the
      * previous end-of-file and the newly-written bytes are unspecified.  </p>
+     *
+     * <p> If the file is open in <a href="#append-mode">append mode</a>, then
+     * the effect of invoking this method is unspecified.
      *
      * @param  src
      *         The buffer from which bytes are to be transferred

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -146,9 +146,9 @@ import jdk.internal.javac.PreviewFeature;
  * operation first advances the position to the end of the file and then writes
  * the requested data.  Whether the advancement of the position and the writing
  * of the data are done in a single atomic operation is system-dependent and
- * therefore unspecified.  In this mode an invocation of the {@linkplain
- * #write(ByteBuffer,long) absolute write} operation leads to unspecified
- * behavior.
+ * therefore unspecified.  In this mode the behavior of the method to
+ * {@linkplain #write(ByteBuffer,long) write at a given position} is also
+ * system-dependent.
  *
  * @see java.io.FileInputStream#getChannel()
  * @see java.io.FileOutputStream#getChannel()
@@ -195,8 +195,8 @@ public abstract class FileChannel
      *     the position to the end of the file and then writes the requested
      *     data. Whether the advancement of the position and the writing of the
      *     data are done in a single atomic operation is system-dependent and
-     *     therefore unspecified. The effect of performing an
-     *     {@linkplain #write(ByteBuffer,long) absolute write} with this option
+     *     therefore unspecified. The effect of {@linkplain
+     *     #write(ByteBuffer,long) writing at a given position} with this option
      *     present is unspecified. This option may not be used in conjunction
      *     with the {@code READ} or {@code TRUNCATE_EXISTING} options. </td>
      * </tr>


### PR DESCRIPTION
Add some verbiage stating that the outcome of invoking the absolute write method `java.nio.channels.write(ByteBuffer,long)` is unspecified when the channel was opened with the `APPEND` option present.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-6924219](https://bugs.openjdk.org/browse/JDK-6924219): (fc spec) FileChannel.write(ByteBuffer, position) behavior when file opened for append not specified
 * [JDK-8295312](https://bugs.openjdk.org/browse/JDK-8295312): (fc spec) FileChannel.write(ByteBuffer, position) behavior when file opened for append not specified (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10707/head:pull/10707` \
`$ git checkout pull/10707`

Update a local copy of the PR: \
`$ git checkout pull/10707` \
`$ git pull https://git.openjdk.org/jdk pull/10707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10707`

View PR using the GUI difftool: \
`$ git pr show -t 10707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10707.diff">https://git.openjdk.org/jdk/pull/10707.diff</a>

</details>
