### PR TITLE
8295029: runtime/cds/appcds/LotsOfClasses.java fail with jfx

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -598,23 +598,16 @@ const int _default_loader_dictionary_size = 107;
 Dictionary* ClassLoaderData::create_dictionary() {
   assert(!has_class_mirror_holder(), "class mirror holder cld does not have a dictionary");
   int size;
-  bool resizable = false;
   if (_the_null_class_loader_data == NULL) {
     size = _boot_loader_dictionary_size;
-    resizable = true;
   } else if (class_loader()->is_a(vmClasses::reflect_DelegatingClassLoader_klass())) {
     size = 1;  // there's only one class in relection class loader and no initiated classes
   } else if (is_system_class_loader_data()) {
     size = _boot_loader_dictionary_size;
-    resizable = true;
   } else {
     size = _default_loader_dictionary_size;
-    resizable = true;
   }
-  if (!DynamicallyResizeSystemDictionaries || DumpSharedSpaces) {
-    resizable = false;
-  }
-  return new Dictionary(this, size, resizable);
+  return new Dictionary(this, size);
 }
 
 // Tell the GC to keep this klass alive. Needed while iterating ClassLoaderDataGraph,

--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -53,8 +53,8 @@ const size_t END_SIZE = 24;
 // If a chain gets to 100 something might be wrong
 const size_t REHASH_LEN = 100;
 
-Dictionary::Dictionary(ClassLoaderData* loader_data, size_t table_size, bool resizable)
-  : _resizable(resizable), _number_of_entries(0), _loader_data(loader_data) {
+Dictionary::Dictionary(ClassLoaderData* loader_data, size_t table_size)
+  : _number_of_entries(0), _loader_data(loader_data) {
 
   size_t start_size_log_2 = MAX2(ceil_log2(table_size), (size_t)2); // 2 is minimum size even though some dictionaries only have one entry
   size_t current_size = ((size_t)1) << start_size_log_2;
@@ -104,8 +104,7 @@ int Dictionary::table_size() const {
 }
 
 bool Dictionary::check_if_needs_resize() {
-  return (_resizable &&
-         (_number_of_entries > (_resize_load_trigger * table_size())) &&
+  return ((_number_of_entries > (_resize_load_trigger * table_size())) &&
          !_table->is_max_size_reached());
 }
 
@@ -480,8 +479,8 @@ void DictionaryEntry::print_count(outputStream *st) {
 // ----------------------------------------------------------------------------
 
 void Dictionary::print_size(outputStream* st) const {
-  st->print_cr("Java dictionary (table_size=%d, classes=%d, resizable=%s)",
-               table_size(), _number_of_entries, BOOL_TO_STR(_resizable));
+  st->print_cr("Java dictionary (table_size=%d, classes=%d)",
+               table_size(), _number_of_entries);
 }
 
 void Dictionary::print_on(outputStream* st) const {

--- a/src/hotspot/share/classfile/dictionary.hpp
+++ b/src/hotspot/share/classfile/dictionary.hpp
@@ -41,7 +41,6 @@ template <typename T> class GrowableArray;
 class DictionaryEntry;
 
 class Dictionary : public CHeapObj<mtClass> {
-  bool _resizable;
   int _number_of_entries;
 
   class Config {
@@ -63,7 +62,7 @@ class Dictionary : public CHeapObj<mtClass> {
   int table_size() const;
 
 public:
-  Dictionary(ClassLoaderData* loader_data, size_t table_size, bool resizable = false);
+  Dictionary(ClassLoaderData* loader_data, size_t table_size);
   ~Dictionary();
 
   void add_klass(JavaThread* current, Symbol* class_name, InstanceKlass* obj);

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -676,9 +676,6 @@ const int ObjectAlignmentInBytes = 8;
   notproduct(bool, PrintClassLoaderDataGraphAtExit, false,                  \
           "Print the class loader data graph at exit")                      \
                                                                             \
-  product(bool, DynamicallyResizeSystemDictionaries, true, DIAGNOSTIC,      \
-          "Dynamically resize system dictionaries as needed")               \
-                                                                            \
   product(bool, AllowParallelDefineClass, false,                            \
           "Allow parallel defineClass requests for class loaders "          \
           "registering as parallel capable")                                \


### PR DESCRIPTION
This removes the can-resize parameter for ClassLoaderData dictionaries. They can all resize now that the shared dictionaries are moved to the CompactHashtable. This also removes an unused/untested development option to disallow resizing.
Tested with tiers1-4 and tested with the failing test case. It can't be added because it requires outside code or simulated because it would be an expensive test to generate all those class files.  There's an existing test for resizing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295029](https://bugs.openjdk.org/browse/JDK-8295029): runtime/cds/appcds/LotsOfClasses.java fail with jfx


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Gerard Ziemski](https://openjdk.org/census#gziemski) (@gerard-ziemski - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10708/head:pull/10708` \
`$ git checkout pull/10708`

Update a local copy of the PR: \
`$ git checkout pull/10708` \
`$ git pull https://git.openjdk.org/jdk pull/10708/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10708`

View PR using the GUI difftool: \
`$ git pr show -t 10708`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10708.diff">https://git.openjdk.org/jdk/pull/10708.diff</a>

</details>
