### PR TITLE
8295009: RISC-V: Interpreter intrinsify Thread.currentThread()

### DIFF
--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -1442,6 +1442,17 @@ address TemplateInterpreterGenerator::generate_normal_entry(bool synchronized) {
   return entry_point;
 }
 
+// Method entry for java.lang.Thread.currentThread
+address TemplateInterpreterGenerator::generate_currentThread() {
+  address entry_point = __ pc();
+
+  __ ld(x10, Address(xthread, JavaThread::vthread_offset()));
+  __ resolve_oop_handle(x10, t0, t1);
+  __ ret();
+
+  return entry_point;
+}
+
 //-----------------------------------------------------------------------------
 // Exceptions
 

--- a/src/hotspot/share/interpreter/abstractInterpreter.cpp
+++ b/src/hotspot/share/interpreter/abstractInterpreter.cpp
@@ -133,7 +133,7 @@ AbstractInterpreter::MethodKind AbstractInterpreter::method_kind(const methodHan
       case vmIntrinsics::_floatToRawIntBits: return java_lang_Float_floatToRawIntBits;
       case vmIntrinsics::_longBitsToDouble:  return java_lang_Double_longBitsToDouble;
       case vmIntrinsics::_doubleToRawLongBits: return java_lang_Double_doubleToRawLongBits;
-#if defined(AMD64) || defined(AARCH64)
+#if defined(AMD64) || defined(AARCH64) || defined(RISCV64)
       case vmIntrinsics::_currentThread:     return java_lang_Thread_currentThread;
 #endif
 #endif // ZERO

--- a/src/hotspot/share/interpreter/templateInterpreterGenerator.cpp
+++ b/src/hotspot/share/interpreter/templateInterpreterGenerator.cpp
@@ -201,7 +201,7 @@ void TemplateInterpreterGenerator::generate_all() {
   method_entry(java_lang_math_fmaF )
   method_entry(java_lang_math_fmaD )
   method_entry(java_lang_ref_reference_get)
-#if defined(AMD64) || defined(AARCH64)
+#if defined(AMD64) || defined(AARCH64) || defined(RISCV64)
   method_entry(java_lang_Thread_currentThread)
 #endif
   AbstractInterpreter::initialize_method_handle_entries();
@@ -433,7 +433,7 @@ address TemplateInterpreterGenerator::generate_method_entry(
                                            : // fall thru
   case Interpreter::java_util_zip_CRC32C_updateDirectByteBuffer
                                            : entry_point = generate_CRC32C_updateBytes_entry(kind); break;
-#if defined(AMD64) || defined(AARCH64)
+#if defined(AMD64) || defined(AARCH64) || defined(RISCV64)
   case Interpreter::java_lang_Thread_currentThread
                                            : entry_point = generate_currentThread(); break;
 #endif

--- a/src/hotspot/share/interpreter/templateInterpreterGenerator.hpp
+++ b/src/hotspot/share/interpreter/templateInterpreterGenerator.hpp
@@ -94,7 +94,7 @@ class TemplateInterpreterGenerator: public AbstractInterpreterGenerator {
   address generate_CRC32_update_entry();
   address generate_CRC32_updateBytes_entry(AbstractInterpreter::MethodKind kind);
   address generate_CRC32C_updateBytes_entry(AbstractInterpreter::MethodKind kind);
-#if defined(AMD64) || defined(AARCH64)
+#if defined(AMD64) || defined(AARCH64) || defined(RISCV64)
   address generate_currentThread();
 #endif
 #ifdef IA32


### PR DESCRIPTION
Calling intrinsic version of Thread.currentThread() in interpreter is ~30% faster on the Unmatched board:
Before:
Benchmark Mode Cnt Score Error Units
MyBenchmark.testCurrentThread avgt 5 4665.765 ± 212.906 ns/op
After:
Benchmark Mode Cnt Score Error Units
MyBenchmark.testCurrentThread avgt 5 3381.415 ± 223.005 ns/op

Tier1 and jdk_loom have been tested on unmatched.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295009](https://bugs.openjdk.org/browse/JDK-8295009): RISC-V: Interpreter intrinsify Thread.currentThread()


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10709/head:pull/10709` \
`$ git checkout pull/10709`

Update a local copy of the PR: \
`$ git checkout pull/10709` \
`$ git pull https://git.openjdk.org/jdk pull/10709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10709`

View PR using the GUI difftool: \
`$ git pr show -t 10709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10709.diff">https://git.openjdk.org/jdk/pull/10709.diff</a>

</details>
