### PR TITLE
8295320: [BACKOUT] 8276687 Remove support for JDK 1.4.1 PerfData shared memory files

### DIFF
--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/PerfDataBuffer.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/PerfDataBuffer.java
@@ -61,8 +61,33 @@ public class PerfDataBuffer extends AbstractPerfDataBuffer {
      */
     public PerfDataBuffer(VmIdentifier vmid) throws MonitorException {
         try {
+            // Try 1.4.2 and later first
             ByteBuffer bb = perf.attach(vmid.getLocalVmId());
             createPerfDataBuffer(bb, vmid.getLocalVmId());
+
+        } catch (IllegalArgumentException e) {
+            // now try 1.4.1 by attempting to directly map the files.
+            try {
+                String filename = PerfDataFile.getTempDirectory()
+                                  + PerfDataFile.dirNamePrefix
+                                  + Integer.toString(vmid.getLocalVmId());
+
+                File f = new File(filename);
+
+                FileChannel fc = new RandomAccessFile(f, "r").getChannel();
+                ByteBuffer bb = fc.map(FileChannel.MapMode.READ_ONLY, 0L,
+                                       (int)fc.size());
+                fc.close();
+                createPerfDataBuffer(bb, vmid.getLocalVmId());
+
+            } catch (FileNotFoundException e2) {
+                // re-throw the exception from the 1.4.2 attach method
+                throw new MonitorException(vmid.getLocalVmId() + " not found",
+                                           e);
+            } catch (IOException e2) {
+                throw new MonitorException("Could not map 1.4.1 file for "
+                                           + vmid.getLocalVmId(), e2);
+            }
         } catch (IOException e) {
             throw new MonitorException("Could not attach to "
                                        + vmid.getLocalVmId(), e);


### PR DESCRIPTION
This PR reverts JDK-8276687, which has caused tier1 test failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295320](https://bugs.openjdk.org/browse/JDK-8295320): [BACKOUT] 8276687 Remove support for JDK 1.4.1 PerfData shared memory files


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10711/head:pull/10711` \
`$ git checkout pull/10711`

Update a local copy of the PR: \
`$ git checkout pull/10711` \
`$ git pull https://git.openjdk.org/jdk pull/10711/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10711`

View PR using the GUI difftool: \
`$ git pr show -t 10711`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10711.diff">https://git.openjdk.org/jdk/pull/10711.diff</a>

</details>
