### PR TITLE
8295333: G1: Remove unnecessary check in G1Policy::calculate_desired_eden_length_by_mmu

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -180,17 +180,11 @@ void G1Policy::record_new_heap_size(uint new_number_of_regions) {
 }
 
 uint G1Policy::calculate_desired_eden_length_by_mmu() const {
-  // One could argue that any useful eden length to keep any MMU wouldn't be zero, but
-  // in theory this is possible. Other constraints enforce a minimum eden size of one
-  // region anyway.
-  uint desired_min_length = 0;
-  if (use_adaptive_young_list_length()) {
-    double now_sec = os::elapsedTime();
-    double when_ms = _mmu_tracker->when_max_gc_sec(now_sec) * 1000.0;
-    double alloc_rate_ms = _analytics->predict_alloc_rate_ms();
-    desired_min_length = (uint) ceil(alloc_rate_ms * when_ms);
-  }
-  return desired_min_length;
+  assert(use_adaptive_young_list_length(), "precondition");
+  double now_sec = os::elapsedTime();
+  double when_ms = _mmu_tracker->when_max_gc_sec(now_sec) * 1000.0;
+  double alloc_rate_ms = _analytics->predict_alloc_rate_ms();
+  return (uint) ceil(alloc_rate_ms * when_ms);
 }
 
 void G1Policy::update_young_length_bounds() {


### PR DESCRIPTION
Simple change of removing an `if` check.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295333](https://bugs.openjdk.org/browse/JDK-8295333): G1: Remove unnecessary check in G1Policy::calculate_desired_eden_length_by_mmu


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10712/head:pull/10712` \
`$ git checkout pull/10712`

Update a local copy of the PR: \
`$ git checkout pull/10712` \
`$ git pull https://git.openjdk.org/jdk pull/10712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10712`

View PR using the GUI difftool: \
`$ git pr show -t 10712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10712.diff">https://git.openjdk.org/jdk/pull/10712.diff</a>

</details>
