### PR TITLE
JDK-8295325: tools/jlink/plugins/SaveJlinkArgfilesPluginTest.java fails on Linux ppc64le

### DIFF
--- a/test/jdk/tools/jlink/plugins/SaveJlinkArgfilesPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/SaveJlinkArgfilesPluginTest.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @summary Test --save-jlink-argfiles plugin
+ * @requires vm.jvmci
  * @library ../../lib
  * @library /test/lib
  * @modules java.base/jdk.internal.jimage


### PR DESCRIPTION
The test tools/jlink/plugins/SaveJlinkArgfilesPluginTest.java fails on Linux ppc64le because it assumes that vm.jvmci is
available on all platforms but this is currently not the case on Linux ppc64le.
Error is :

Error: Module jdk.internal.vm.ci not found
java.lang.module.FindException: Module jdk.internal.vm.ci not found
at java.base/java.lang.module.Resolver.findFail(Resolver.java:892)
at java.base/java.lang.module.Resolver.resolve(Resolver.java:129)
at java.base/java.lang.module.Configuration.resolve(Configuration.java:420)
at java.base/java.lang.module.Configuration.resolve(Configuration.java:254)
at jdk.jlink/jdk.tools.jlink.internal.Jlink$JlinkConfiguration.resolve(Jlink.java:217)
at jdk.jlink/jdk.tools.jlink.internal.JlinkTask.createImageProvider(JlinkTask.java:551)
at jdk.jlink/jdk.tools.jlink.internal.JlinkTask.createImage(JlinkTask.java:439)
at jdk.jlink/jdk.tools.jlink.internal.JlinkTask.run(JlinkTask.java:291)
at jdk.jlink/jdk.tools.jlink.internal.Main.run(Main.java:56)
at jdk.jlink/jdk.tools.jlink.internal.Main$JlinkToolProvider.run(Main.java:73)
at tests.JImageGenerator$JLinkTask.call(JImageGenerator.java:715)
at tests.Helper.generateDefaultImage(Helper.java:257)
at SaveJlinkArgfilesPluginTest.main(SaveJlinkArgfilesPluginTest.java:66)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:578)
at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:312)
at java.base/java.lang.Thread.run(Thread.java:1591)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295325](https://bugs.openjdk.org/browse/JDK-8295325): tools/jlink/plugins/SaveJlinkArgfilesPluginTest.java fails on Linux ppc64le


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10713/head:pull/10713` \
`$ git checkout pull/10713`

Update a local copy of the PR: \
`$ git checkout pull/10713` \
`$ git pull https://git.openjdk.org/jdk pull/10713/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10713`

View PR using the GUI difftool: \
`$ git pr show -t 10713`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10713.diff">https://git.openjdk.org/jdk/pull/10713.diff</a>

</details>
