### PR TITLE
8295370: Update java.io.ObjectStreamField to use Class.descriptorString

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectStreamClass.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamClass.java
@@ -62,7 +62,6 @@ import jdk.internal.reflect.ReflectionFactory;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.access.JavaSecurityAccess;
 import sun.reflect.misc.ReflectUtil;
-import static java.io.ObjectStreamField.*;
 
 /**
  * Serialization's descriptor for classes.  It contains the name and
@@ -1564,10 +1563,10 @@ public final class ObjectStreamClass implements Serializable {
         StringBuilder sb = new StringBuilder();
         sb.append('(');
         for (int i = 0; i < paramTypes.length; i++) {
-            appendClassSignature(sb, paramTypes[i]);
+            sb.append(paramTypes[i].descriptorString());
         }
         sb.append(')');
-        appendClassSignature(sb, retType);
+        sb.append(retType.descriptorString());
         return sb.toString();
     }
 
@@ -1881,7 +1880,7 @@ public final class ObjectStreamClass implements Serializable {
         public MemberSignature(Field field) {
             member = field;
             name = field.getName();
-            signature = getClassSignature(field.getType());
+            signature = field.getType().descriptorString();
         }
 
         public MemberSignature(Constructor<?> cons) {

--- a/src/java.base/share/classes/java/io/ObjectStreamField.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -125,58 +125,6 @@ public class ObjectStreamField
     }
 
     /**
-     * Returns JVM type signature for given primitive.
-     */
-    private static String getPrimitiveSignature(Class<?> cl) {
-        if (cl == Integer.TYPE)
-            return "I";
-        else if (cl == Byte.TYPE)
-            return "B";
-        else if (cl == Long.TYPE)
-            return "J";
-        else if (cl == Float.TYPE)
-            return "F";
-        else if (cl == Double.TYPE)
-            return "D";
-        else if (cl == Short.TYPE)
-            return "S";
-        else if (cl == Character.TYPE)
-            return "C";
-        else if (cl == Boolean.TYPE)
-            return "Z";
-        else if (cl == Void.TYPE)
-            return "V";
-        else
-            throw new InternalError();
-    }
-
-    /**
-     * Returns JVM type signature for given class.
-     */
-    static String getClassSignature(Class<?> cl) {
-        if (cl.isPrimitive()) {
-            return getPrimitiveSignature(cl);
-        } else {
-            return appendClassSignature(new StringBuilder(), cl).toString();
-        }
-    }
-
-    static StringBuilder appendClassSignature(StringBuilder sbuf, Class<?> cl) {
-        while (cl.isArray()) {
-            sbuf.append('[');
-            cl = cl.getComponentType();
-        }
-
-        if (cl.isPrimitive()) {
-            sbuf.append(getPrimitiveSignature(cl));
-        } else {
-            sbuf.append('L').append(cl.getName().replace('.', '/')).append(';');
-        }
-
-        return sbuf;
-    }
-
-    /**
      * Creates an ObjectStreamField representing the given field with the
      * specified unshared setting.  For compatibility with the behavior of
      * earlier serialization implementations, a "showType" parameter is
@@ -190,7 +138,7 @@ public class ObjectStreamField
         name = field.getName();
         Class<?> ftype = field.getType();
         type = (showType || ftype.isPrimitive()) ? ftype : Object.class;
-        signature = getClassSignature(ftype).intern();
+        signature = ftype.descriptorString().intern();
     }
 
     /**
@@ -347,7 +295,7 @@ public class ObjectStreamField
         // of the public constructors are used, in which case type is always
         // initialized to the exact type we want the signature to represent.
         if (sig == null) {
-            typeSignature = sig = getClassSignature(type).intern();
+            typeSignature = sig = type.descriptorString().intern();
         }
         return sig;
     }


### PR DESCRIPTION
The code in ObjectStreamField for constructing type signatures should be replaced by Class.descriptorString(). 
The corresponding change is made in ObjectStreamClass.
There is no change to the contents of the type strings and the existing tests will cover it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295370](https://bugs.openjdk.org/browse/JDK-8295370): Update java.io.ObjectStreamField to use Class.descriptorString


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10714/head:pull/10714` \
`$ git checkout pull/10714`

Update a local copy of the PR: \
`$ git checkout pull/10714` \
`$ git pull https://git.openjdk.org/jdk pull/10714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10714`

View PR using the GUI difftool: \
`$ git pr show -t 10714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10714.diff">https://git.openjdk.org/jdk/pull/10714.diff</a>

</details>
