### PR TITLE
8282463: javax/sound/sampled/Clip/DataPusherThreadCheck.java fails

### DIFF
--- a/test/jdk/javax/sound/sampled/Clip/DataPusherThreadCheck.java
+++ b/test/jdk/javax/sound/sampled/Clip/DataPusherThreadCheck.java
@@ -28,6 +28,8 @@ import javax.sound.sampled.AudioFileFormat;
 import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.Clip;
+import javax.sound.sampled.DataLine;
 import java.applet.AudioClip;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -49,6 +51,10 @@ public class DataPusherThreadCheck {
         try {
             AudioFormat format =
                     new AudioFormat(PCM_SIGNED, 44100, 8, 1, 1, 44100, false);
+            DataLine.Info info = new DataLine.Info(Clip.class, format);
+            if (!(AudioSystem.isLineSupported(info)) ) {
+                return; // the test is not applicable
+            }
             int dataSize = 6000*1000 * format.getFrameSize();
             InputStream in = new ByteArrayInputStream(new byte[dataSize]);
             AudioInputStream audioStream = new AudioInputStream(in, format, NOT_SPECIFIED);


### PR DESCRIPTION
Test failed on Ubuntu, because both implementations of `MixerProvider` have no devices:
1. com.sun.media.sound.DirectAudioDeviceProvider#nGetNumDevices returns `0`
 ![DirectAudioDeviceProvider init](https://user-images.githubusercontent.com/741251/195988216-aa86da0f-739b-433f-87e2-86c2d6904a0d.png)
2. com.sun.media.sound.PortMixerProvider#nGetNumDevices returns `0`
 ![PortMixerProvider init](https://user-images.githubusercontent.com/741251/195988239-59678e0c-be7b-43ff-b02a-9abb2392e8f9.png)


It leads to `javax.sound.sampled.spi.MixerProvider#getMixerInfo` returns empty array.
![AudioSystem getMixedInfoList](https://user-images.githubusercontent.com/741251/195988266-1656e6d3-de4a-4e53-a613-415f60075726.png)

And DataPusher thread is not created, because of AudioSystem.isLineSupported returns false in the method `com.sun.media.sound.JavaSoundAudioClip#createSourceDataLine`.
I propose to perform the same check in test code and skip it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282463](https://bugs.openjdk.org/browse/JDK-8282463): javax/sound/sampled/Clip/DataPusherThreadCheck.java fails


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10717/head:pull/10717` \
`$ git checkout pull/10717`

Update a local copy of the PR: \
`$ git checkout pull/10717` \
`$ git pull https://git.openjdk.org/jdk pull/10717/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10717`

View PR using the GUI difftool: \
`$ git pr show -t 10717`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10717.diff">https://git.openjdk.org/jdk/pull/10717.diff</a>

</details>
