### PR TITLE
8295379: ProblemList java/lang/Float/Binary16Conversion.java in Xcomp mode on x64

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -37,4 +37,4 @@ serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
 
 serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java 8288430 generic-all
 
-gc/cslocker/TestCSLocker.java 8293289 linux-x64,macosx-x64
+gc/cslocker/TestCSLocker.java 8293289 generic-x64

--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -32,3 +32,4 @@ java/lang/ref/ReferenceEnqueue.java 8284236 generic-all
 
 com/sun/jdi/JdbLastErrorTest.java 8293829 windows-x64
 
+java/lang/Float/Binary16Conversion.java 8295351 generic-x64


### PR DESCRIPTION
A trivial fix to ProblemList a couple of tests in -Xcomp mode on generic-x64:

[JDK-8295379](https://bugs.openjdk.org/browse/JDK-8295379) ProblemList java/lang/Float/Binary16Conversion.java in Xcomp mode on x64
[JDK-8295380](https://bugs.openjdk.org/browse/JDK-8295380) ProblemList gc/cslocker/TestCSLocker.java in Xcomp mode on x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8295379](https://bugs.openjdk.org/browse/JDK-8295379): ProblemList java/lang/Float/Binary16Conversion.java in Xcomp mode on x64
 * [JDK-8295380](https://bugs.openjdk.org/browse/JDK-8295380): ProblemList gc/cslocker/TestCSLocker.java in Xcomp mode on x64


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10719/head:pull/10719` \
`$ git checkout pull/10719`

Update a local copy of the PR: \
`$ git checkout pull/10719` \
`$ git pull https://git.openjdk.org/jdk pull/10719/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10719`

View PR using the GUI difftool: \
`$ git pr show -t 10719`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10719.diff">https://git.openjdk.org/jdk/pull/10719.diff</a>

</details>
