### PR TITLE
8295767: Remove unused fields in sun.awt.geom.Edge

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/geom/Edge.java
+++ b/src/java.desktop/share/classes/sun/awt/geom/Edge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,6 @@
 package sun.awt.geom;
 
 final class Edge {
-    static final int INIT_PARTS = 4;
-    static final int GROW_PARTS = 10;
 
     Curve curve;
     int ctag;


### PR DESCRIPTION
Remove couple of unused `static` fields in `sun.awt.geom.Edge` class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295767](https://bugs.openjdk.org/browse/JDK-8295767): Remove unused fields in sun.awt.geom.Edge


### Reviewers
 * @SWinxy (no known github.com user name / role)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10720/head:pull/10720` \
`$ git checkout pull/10720`

Update a local copy of the PR: \
`$ git checkout pull/10720` \
`$ git pull https://git.openjdk.org/jdk pull/10720/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10720`

View PR using the GUI difftool: \
`$ git pr show -t 10720`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10720.diff">https://git.openjdk.org/jdk/pull/10720.diff</a>

</details>
