### PR TITLE
8295176: some langtools test pollutes source tree

### DIFF
--- a/test/langtools/tools/javac/options/release/ReleaseOption.java
+++ b/test/langtools/tools/javac/options/release/ReleaseOption.java
@@ -1,9 +1,10 @@
 /**
  * @test /nodynamiccopyright/
  * @bug 8072480
- * @summary Verify that javac rejects Java 8 program with --release 7
+ * @summary Verify that javac rejects Java 17 program with --release 11
  * @compile ReleaseOption.java
+ * @compile/fail/ref=ReleaseOption.out -XDrawDiagnostics --release 11 ReleaseOption.java
  */
 
-interface ReleaseOption extends java.util.stream.Stream {
+interface ReleaseOption extends java.util.random.RandomGenerator {
 }

--- a/test/langtools/tools/javac/options/release/ReleaseOption.out
+++ b/test/langtools/tools/javac/options/release/ReleaseOption.out
@@ -1,0 +1,2 @@
+ReleaseOption.java:9:49: compiler.err.doesnt.exist: java.util.random
+1 error

--- a/test/langtools/tools/javac/options/release/ReleaseOptionThroughAPI.java
+++ b/test/langtools/tools/javac/options/release/ReleaseOptionThroughAPI.java
@@ -50,7 +50,7 @@ public class ReleaseOptionThroughAPI {
              PrintWriter outWriter = new PrintWriter(out)) {
             Iterable<? extends JavaFileObject> input =
                     fm.getJavaFileObjects(System.getProperty("test.src") + "/ReleaseOption.java");
-            List<String> options = Arrays.asList("--release", "8", "-XDrawDiagnostics", "-Xlint:-options");
+            List<String> options = Arrays.asList("--release", "8", "-XDrawDiagnostics", "-Xlint:-options", "-d", ".");
 
             compiler.getTask(outWriter, fm, null, options, null, input).call();
             String expected ="";

--- a/test/langtools/tools/javac/options/release/ReleaseOptionThroughAPI.java
+++ b/test/langtools/tools/javac/options/release/ReleaseOptionThroughAPI.java
@@ -50,10 +50,12 @@ public class ReleaseOptionThroughAPI {
              PrintWriter outWriter = new PrintWriter(out)) {
             Iterable<? extends JavaFileObject> input =
                     fm.getJavaFileObjects(System.getProperty("test.src") + "/ReleaseOption.java");
-            List<String> options = Arrays.asList("--release", "8", "-XDrawDiagnostics", "-Xlint:-options", "-d", ".");
+            List<String> options = Arrays.asList("--release", "11", "-XDrawDiagnostics", "-d", ".");
 
             compiler.getTask(outWriter, fm, null, options, null, input).call();
-            String expected ="";
+            String expected =
+                    "ReleaseOption.java:9:49: compiler.err.doesnt.exist: java.util.random" + lineSep +
+                    "1 error" + lineSep;
             if (!expected.equals(out.toString())) {
                 throw new AssertionError("Unexpected output: " + out.toString());
             }


### PR DESCRIPTION
The `ReleaseOptionThroughAPI.java` test compiles another test source, `ReleaseOption.java`. But it does not specify the output directory, so javac generates the classfile next to the source files into the source directory, causing trouble.

The proposed fix is to add `-d .` to the test, so that the classfile is not generated into the working directory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295176](https://bugs.openjdk.org/browse/JDK-8295176): some langtools test pollutes source tree


### Reviewers
 * [Srikanth Adayapalam](https://openjdk.org/census#sadayapalam) (@sadayapalam - **Reviewer**) ⚠️ Review applies to [8d452c71](https://git.openjdk.org/jdk/pull/10724/files/8d452c71edabbe43f40942977ec2bf7ccdb6844c)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10724/head:pull/10724` \
`$ git checkout pull/10724`

Update a local copy of the PR: \
`$ git checkout pull/10724` \
`$ git pull https://git.openjdk.org/jdk pull/10724/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10724`

View PR using the GUI difftool: \
`$ git pr show -t 10724`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10724.diff">https://git.openjdk.org/jdk/pull/10724.diff</a>

</details>
