### PR TITLE
JDK-8295412 : support latest VS2022 MSC_VER in abstract_vm_version.cpp

### DIFF
--- a/src/hotspot/share/runtime/abstract_vm_version.cpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.cpp
@@ -239,6 +239,10 @@ const char* Abstract_VM_Version::internal_vm_info_string() {
         #define HOTSPOT_BUILD_COMPILER "MS VC++ 17.0 (VS2022)"
       #elif _MSC_VER == 1931
         #define HOTSPOT_BUILD_COMPILER "MS VC++ 17.1 (VS2022)"
+      #elif _MSC_VER == 1932
+        #define HOTSPOT_BUILD_COMPILER "MS VC++ 17.2 (VS2022)"
+      #elif _MSC_VER == 1933
+        #define HOTSPOT_BUILD_COMPILER "MS VC++ 17.3 (VS2022)"
       #else
         #define HOTSPOT_BUILD_COMPILER "unknown MS VC++:" XSTR(_MSC_VER)
       #endif


### PR DESCRIPTION
Currently the latest VS2022 versions are not supported when checking _MSC_VER in abstract_vm_version.cpp, that should be improved.
See
https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170
https://learn.microsoft.com/de-de/visualstudio/install/visual-studio-build-numbers-and-release-dates?view=vs-2022
Visual Studio 2022 version 17.3 1933
Visual Studio 2022 version 17.2 1932

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295412](https://bugs.openjdk.org/browse/JDK-8295412): support latest VS2022 MSC_VER in abstract_vm_version.cpp


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10727/head:pull/10727` \
`$ git checkout pull/10727`

Update a local copy of the PR: \
`$ git checkout pull/10727` \
`$ git pull https://git.openjdk.org/jdk pull/10727/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10727`

View PR using the GUI difftool: \
`$ git pr show -t 10727`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10727.diff">https://git.openjdk.org/jdk/pull/10727.diff</a>

</details>
