### PR TITLE
8284614: on macOS "spindump" should be run from failure_handler as root

### DIFF
--- a/test/failure_handler/src/share/conf/mac.properties
+++ b/test/failure_handler/src/share/conf/mac.properties
@@ -41,8 +41,8 @@ native.DevToolsSecurity.app=DevToolsSecurity
 native.DevToolsSecurity.args=--status
 
 # spindump requires root privileges
-native.spindump.app=spindump
-native.spindump.args=%p -stdout
+native.spindump.app=sudo
+native.spindump.args=spindump %p -stdout
 
 native.vmmap.app=bash
 native.vmmap.delimiter=\0


### PR DESCRIPTION
The fix is contributed by @plummercj actually.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284614](https://bugs.openjdk.org/browse/JDK-8284614): on macOS "spindump" should be run from failure_handler as root


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - Committer)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Contributors
 * Chris Plummer `<cjplummer@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10730/head:pull/10730` \
`$ git checkout pull/10730`

Update a local copy of the PR: \
`$ git checkout pull/10730` \
`$ git pull https://git.openjdk.org/jdk pull/10730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10730`

View PR using the GUI difftool: \
`$ git pr show -t 10730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10730.diff">https://git.openjdk.org/jdk/pull/10730.diff</a>

</details>
