### PR TITLE
8295953: Use enhanced-for cycle instead of Enumeration in sun.security

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/JavaKeyStore.java
+++ b/src/java.base/share/classes/sun/security/provider/JavaKeyStore.java
@@ -483,9 +483,9 @@ public abstract sealed class JavaKeyStore extends KeyStoreSpi {
     public String engineGetCertificateAlias(Certificate cert) {
         Certificate certElem;
 
-        for (Enumeration<String> e = entries.keys(); e.hasMoreElements(); ) {
-            String alias = e.nextElement();
-            Object entry = entries.get(alias);
+        for (Map.Entry<String, Object> e : entries.entrySet()) {
+            String alias = e.getKey();
+            Object entry = e.getValue();
             if (entry instanceof TrustedCertEntry) {
                 certElem = ((TrustedCertEntry)entry).cert;
             } else if (((KeyEntry)entry).chain != null) {
@@ -566,10 +566,9 @@ public abstract sealed class JavaKeyStore extends KeyStoreSpi {
 
             dos.writeInt(entries.size());
 
-            for (Enumeration<String> e = entries.keys(); e.hasMoreElements();) {
-
-                String alias = e.nextElement();
-                Object entry = entries.get(alias);
+            for (Map.Entry<String, Object> e : entries.entrySet()) {
+                String alias = e.getKey();
+                Object entry = e.getValue();
 
                 if (entry instanceof KeyEntry) {
 

--- a/src/java.base/share/classes/sun/security/provider/PolicyParser.java
+++ b/src/java.base/share/classes/sun/security/provider/PolicyParser.java
@@ -316,8 +316,6 @@ public class PolicyParser {
     {
         PrintWriter out = new PrintWriter(new BufferedWriter(policy));
 
-        Enumeration<GrantEntry> enum_ = grantElements();
-
         out.println("/* AUTOMATICALLY GENERATED ON "+
                     (new java.util.Date()) + "*/");
         out.println("/* DO NOT EDIT */");
@@ -333,8 +331,7 @@ public class PolicyParser {
         }
 
         // write "grant" entries
-        while (enum_.hasMoreElements()) {
-            GrantEntry ge = enum_.nextElement();
+        for (GrantEntry ge : grantEntries) {
             ge.write(out);
             out.println();
         }
@@ -938,9 +935,7 @@ public class PolicyParser {
                 }
             }
             out.println(" {");
-            Enumeration<PermissionEntry> enum_ = permissionEntries.elements();
-            while (enum_.hasMoreElements()) {
-                PermissionEntry pe = enum_.nextElement();
+            for (PermissionEntry pe : permissionEntries) {
                 out.write("  ");
                 pe.write(out);
             }

--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
@@ -1311,9 +1311,7 @@ final class SSLSessionImpl extends ExtendedSSLSession {
     public String[] getValueNames() {
         ArrayList<Object> v = new ArrayList<>();
         Object securityCtx = SecureKey.getCurrentSecurityContext();
-        for (Enumeration<SecureKey> e = boundValues.keys();
-                e.hasMoreElements(); ) {
-            SecureKey key = e.nextElement();
+        for (SecureKey key : boundValues.keySet()) {
             if (securityCtx.equals(key.getSecurityContext())) {
                 v.add(key.getAppKey());
             }

--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -4177,9 +4177,7 @@ public final class Main {
         // Try out each certificate in the vector, until we find one
         // whose public key verifies the signature of the certificate
         // in question.
-        for (Enumeration<Pair<String,X509Certificate>> issuerCerts = vec.elements();
-                issuerCerts.hasMoreElements(); ) {
-            Pair<String,X509Certificate> issuerCert = issuerCerts.nextElement();
+        for (Pair<String, X509Certificate> issuerCert : vec) {
             PublicKey issuerPubKey = issuerCert.snd.getPublicKey();
             try {
                 certToVerify.snd.verify(issuerPubKey);

--- a/src/java.base/share/classes/sun/security/x509/X509CRLEntryImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CRLEntryImpl.java
@@ -408,12 +408,8 @@ public class X509CRLEntryImpl extends X509CRLEntry
 
             if (extAlias == null) { // may be unknown
                 ObjectIdentifier findOID = ObjectIdentifier.of(oid);
-                Extension ex;
-                ObjectIdentifier inCertOID;
-                for (Enumeration<Extension> e = extensions.getElements();
-                                                 e.hasMoreElements();) {
-                    ex = e.nextElement();
-                    inCertOID = ex.getExtensionId();
+                for (Extension ex : extensions.getAllExtensions()) {
+                    ObjectIdentifier inCertOID = ex.getExtensionId();
                     if (inCertOID.equals(findOID)) {
                         crlExt = ex;
                         break;

--- a/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
@@ -1014,12 +1014,8 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
 
             if (extAlias == null) { // may be unknown
                 ObjectIdentifier findOID = ObjectIdentifier.of(oid);
-                Extension ex;
-                ObjectIdentifier inCertOID;
-                for (Enumeration<Extension> e = extensions.getElements();
-                                                 e.hasMoreElements();) {
-                    ex = e.nextElement();
-                    inCertOID = ex.getExtensionId();
+                for (Extension ex : extensions.getAllExtensions()) {
+                    ObjectIdentifier inCertOID = ex.getExtensionId();
                     if (inCertOID.equals(findOID)) {
                         crlExt = ex;
                         break;


### PR DESCRIPTION
java.util.Enumeration is a legacy interface from java 1.0.
There are a few places with cycles which use it to iterate over collections. We can replace this manual cycle with enchanced-for, which is shorter and easier to read.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295953](https://bugs.openjdk.org/browse/JDK-8295953): Use enhanced-for cycle instead of Enumeration in sun.security


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10734/head:pull/10734` \
`$ git checkout pull/10734`

Update a local copy of the PR: \
`$ git checkout pull/10734` \
`$ git pull https://git.openjdk.org/jdk pull/10734/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10734`

View PR using the GUI difftool: \
`$ git pr show -t 10734`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10734.diff">https://git.openjdk.org/jdk/pull/10734.diff</a>

</details>
