### PR TITLE
8291456: com/sun/jdi/ClassUnloadEventTest.java failed with: Wrong number of class unload events: expected 10 got 4

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -719,6 +719,8 @@ void JvmtiExport::post_vm_initialized() {
 void JvmtiExport::post_vm_death() {
   EVT_TRIG_TRACE(JVMTI_EVENT_VM_DEATH, ("Trg VM death event triggered" ));
 
+  JvmtiTagMap::flush_all_object_free_events();
+
   JvmtiEnvIterator it;
   for (JvmtiEnv* env = it.first(); env != NULL; env = it.next(env)) {
     if (env->is_enabled(JVMTI_EVENT_VM_DEATH)) {

--- a/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
+++ b/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
@@ -117,13 +117,8 @@ public class ClassUnloadEventTest {
         // Trigger class unloading
         ClassUnloadCommon.triggerUnloading();
 
-        // Do a short delay to make sure all ClassUnloadEvents have been sent
-        // before VMDeathEvent is generated.
-        try {
-            Thread.sleep(5000);
-        } catch (InterruptedException e) {
-        }
-
+        // We rely on JVMTI to post all pending ObjectFree events at VM shutdown.
+        // It will trigger the JDWP agent to synthesize expected ClassUnloadEvents events.
         System.out.println("Exiting debuggee");
     }
 


### PR DESCRIPTION
The JDI ClassUnloadEvent events are synthesized by the JDWP agent from the JVM TI ObjectFree events.
The JVM TI ObjectFree events are flushed when the JVM TI SetEvenNotificationMode is used to disable the ObjectFree events. It is not very helpful for JDWP agent as the ObjectFree events are always enabled.
The fix is to flush all pending ObjectFree events at the VM shutdown.

Testing:

All mach5 jobs with JVMTI/JDI tests and tiers 1-6 were successfully passed on 3 debug platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291456](https://bugs.openjdk.org/browse/JDK-8291456): com/sun/jdi/ClassUnloadEventTest.java failed with: Wrong number of class unload events: expected 10 got 4


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10736/head:pull/10736` \
`$ git checkout pull/10736`

Update a local copy of the PR: \
`$ git checkout pull/10736` \
`$ git pull https://git.openjdk.org/jdk pull/10736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10736`

View PR using the GUI difftool: \
`$ git pr show -t 10736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10736.diff">https://git.openjdk.org/jdk/pull/10736.diff</a>

</details>
