### PR TITLE
8295433: EpsilonHeap doesn't need to override post_initialize()

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2022, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,10 +72,6 @@ jint EpsilonHeap::initialize() {
   EpsilonInitLogger::print();
 
   return JNI_OK;
-}
-
-void EpsilonHeap::post_initialize() {
-  CollectedHeap::post_initialize();
 }
 
 void EpsilonHeap::initialize_serviceability() {

--- a/src/hotspot/share/gc/epsilon/epsilonHeap.hpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.hpp
@@ -69,7 +69,6 @@ public:
   }
 
   virtual jint initialize();
-  virtual void post_initialize();
   virtual void initialize_serviceability();
 
   virtual GrowableArray<GCMemoryManager*> memory_managers();


### PR DESCRIPTION
post_initialize() is a virtual function of CollectedHeap. EpsilonGC doesn't have a particular reason to override it.
Its implementation just calls the base's post_initialize(). 

```cpp
void EpsilonHeap::post_initialize() {
  CollectedHeap::post_initialize();
  }
``` 

In universe_post_init(), HotSpot invokes post_initialize() via vtable.
Universe::heap()->post_initialize(); 

By deleting it, HotSpot still needs a call via vtable, but it will jump to CollectedHeap::post_initialize() directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295433](https://bugs.openjdk.org/browse/JDK-8295433): EpsilonHeap doesn't need to override post_initialize()


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10737/head:pull/10737` \
`$ git checkout pull/10737`

Update a local copy of the PR: \
`$ git checkout pull/10737` \
`$ git pull https://git.openjdk.org/jdk pull/10737/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10737`

View PR using the GUI difftool: \
`$ git pr show -t 10737`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10737.diff">https://git.openjdk.org/jdk/pull/10737.diff</a>

</details>
