### PR TITLE
8295435: Build failure with GCC7 after JDK-8294314 due to strict-overflow warnings

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -94,6 +94,8 @@ DISABLED_WARNINGS_clang := ignored-qualifiers sometimes-uninitialized \
 ifneq ($(DEBUG_LEVEL), release)
   # Assert macro gives warning
   DISABLED_WARNINGS_clang += tautological-constant-out-of-range-compare
+  # Some reasonable asserts produce warnings on GCC <= 7
+  DISABLED_WARNINGS_gcc += strict-overflow
 endif
 
 DISABLED_WARNINGS_xlc := tautological-compare shift-negative-value
@@ -154,15 +156,12 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_gcc := $(DISABLED_WARNINGS_gcc), \
     DISABLED_WARNINGS_gcc_ad_$(HOTSPOT_TARGET_CPU_ARCH).cpp := nonnull, \
     DISABLED_WARNINGS_gcc_assembler_aarch64.cpp := misleading-indentation, \
-    DISABLED_WARNINGS_gcc_bytecodeAssembler.cpp := strict-overflow, \
     DISABLED_WARNINGS_gcc_c1_LIR.cpp := misleading-indentation, \
     DISABLED_WARNINGS_gcc_cgroupV1Subsystem_linux.cpp := address, \
     DISABLED_WARNINGS_gcc_cgroupV2Subsystem_linux.cpp := address, \
     DISABLED_WARNINGS_gcc_dict.cpp := char-subscripts, \
-    DISABLED_WARNINGS_gcc_instanceKlass.cpp := strict-overflow, \
     DISABLED_WARNINGS_gcc_interp_masm_x86.cpp := uninitialized, \
     DISABLED_WARNINGS_gcc_javaClasses.cpp := misleading-indentation, \
-    DISABLED_WARNINGS_gcc_klassVtable.cpp := strict-overflow, \
     DISABLED_WARNINGS_gcc_loopnode.cpp := sequence-point, \
     DISABLED_WARNINGS_gcc_postaloc.cpp := address, \
     DISABLED_WARNINGS_gcc_sharedRuntimeTrig.cpp := misleading-indentation, \

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -154,12 +154,15 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_gcc := $(DISABLED_WARNINGS_gcc), \
     DISABLED_WARNINGS_gcc_ad_$(HOTSPOT_TARGET_CPU_ARCH).cpp := nonnull, \
     DISABLED_WARNINGS_gcc_assembler_aarch64.cpp := misleading-indentation, \
+    DISABLED_WARNINGS_gcc_bytecodeAssembler.cpp := strict-overflow, \
     DISABLED_WARNINGS_gcc_c1_LIR.cpp := misleading-indentation, \
     DISABLED_WARNINGS_gcc_cgroupV1Subsystem_linux.cpp := address, \
     DISABLED_WARNINGS_gcc_cgroupV2Subsystem_linux.cpp := address, \
     DISABLED_WARNINGS_gcc_dict.cpp := char-subscripts, \
+    DISABLED_WARNINGS_gcc_instanceKlass.cpp := strict-overflow, \
     DISABLED_WARNINGS_gcc_interp_masm_x86.cpp := uninitialized, \
     DISABLED_WARNINGS_gcc_javaClasses.cpp := misleading-indentation, \
+    DISABLED_WARNINGS_gcc_klassVtable.cpp := strict-overflow, \
     DISABLED_WARNINGS_gcc_loopnode.cpp := sequence-point, \
     DISABLED_WARNINGS_gcc_postaloc.cpp := address, \
     DISABLED_WARNINGS_gcc_sharedRuntimeTrig.cpp := misleading-indentation, \


### PR DESCRIPTION
Hi all,

Let's disable `-Werror=strict-overflow` to get it build with gcc7 on Linux/x86.
```
bytecodeAssembler.cpp
instanceKlass.cpp
klassVtable.cpp
```

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295435](https://bugs.openjdk.org/browse/JDK-8295435): Build failure with GCC7 after JDK-8294314 due to strict-overflow warnings


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Contributors
 * Aleksey Shipilev `<shade@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10738/head:pull/10738` \
`$ git checkout pull/10738`

Update a local copy of the PR: \
`$ git checkout pull/10738` \
`$ git pull https://git.openjdk.org/jdk pull/10738/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10738`

View PR using the GUI difftool: \
`$ git pr show -t 10738`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10738.diff">https://git.openjdk.org/jdk/pull/10738.diff</a>

</details>
