### PR TITLE
6201035: Document NPE for passing null insets to constructors and methods of several javax.swing.border.* classes

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/border/AbstractBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/AbstractBorder.java
@@ -85,7 +85,7 @@ public abstract class AbstractBorder implements Border, Serializable
      * @param c the component for which this border insets value applies
      * @param insets the object to be reinitialized
      * @return the <code>insets</code> object
-     * @throws {@code NullPointerException} if {@code insets}
+     * @throws NullPointerException if the specified {@code insets}
      *         is {@code null}
      */
     public Insets getBorderInsets(Component c, Insets insets) {

--- a/src/java.desktop/share/classes/javax/swing/border/AbstractBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/AbstractBorder.java
@@ -84,7 +84,7 @@ public abstract class AbstractBorder implements Border, Serializable
      * Reinitializes the insets parameter with this Border's current Insets.
      * @param c the component for which this border insets value applies
      * @param insets the object to be reinitialized
-     * @return the <code>insets</code> object
+     * @return the {@code insets} object
      * @throws NullPointerException if the specified {@code insets}
      *         is {@code null}
      */

--- a/src/java.desktop/share/classes/javax/swing/border/AbstractBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/AbstractBorder.java
@@ -85,6 +85,8 @@ public abstract class AbstractBorder implements Border, Serializable
      * @param c the component for which this border insets value applies
      * @param insets the object to be reinitialized
      * @return the <code>insets</code> object
+     * @throws {@code NullPointerException} if {@code insets}
+     *         is {@code null}
      */
     public Insets getBorderInsets(Component c, Insets insets) {
         insets.left = insets.top = insets.right = insets.bottom = 0;

--- a/src/java.desktop/share/classes/javax/swing/border/BevelBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/BevelBorder.java
@@ -142,6 +142,8 @@ public class BevelBorder extends AbstractBorder
      * Reinitialize the insets parameter with this Border's current Insets.
      * @param c the component for which this border insets value applies
      * @param insets the object to be reinitialized
+     * @throws NullPointerException if the specified {@code insets}
+     *         is {@code null}
      */
     public Insets getBorderInsets(Component c, Insets insets) {
         insets.set(2, 2, 2, 2);

--- a/src/java.desktop/share/classes/javax/swing/border/CompoundBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/CompoundBorder.java
@@ -137,6 +137,8 @@ public class CompoundBorder extends AbstractBorder {
      * Reinitialize the insets parameter with this Border's current Insets.
      * @param c the component for which this border insets value applies
      * @param insets the object to be reinitialized
+     * @throws NullPointerException if the specified {@code insets}
+     *         is {@code null}
      */
     public Insets getBorderInsets(Component c, Insets insets) {
         Insets  nextInsets;

--- a/src/java.desktop/share/classes/javax/swing/border/EmptyBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/EmptyBorder.java
@@ -83,8 +83,8 @@ public class EmptyBorder extends AbstractBorder implements Serializable
     /**
      * Creates an empty border with the specified insets.
      * @param borderInsets the insets of the border
-     * @throws {@code NullPointerException} if {@code borderInsets}
-     *          is {@code null}
+     * @throws NullPointerException if the specified {@code borderInsets}
+     *         is {@code null}
      */
     @ConstructorProperties({"borderInsets"})
     public EmptyBorder(Insets borderInsets)   {
@@ -104,8 +104,8 @@ public class EmptyBorder extends AbstractBorder implements Serializable
      * Reinitialize the insets parameter with this Border's current Insets.
      * @param c the component for which this border insets value applies
      * @param insets the object to be reinitialized
-     * @throws {@code NullPointerException} if {@code insets}
-     *          is {@code null}
+     * @throws NullPointerException if the specified {@code insets}
+     *         is {@code null}
      */
     public Insets getBorderInsets(Component c, Insets insets) {
         insets.left = left;

--- a/src/java.desktop/share/classes/javax/swing/border/EmptyBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/EmptyBorder.java
@@ -104,6 +104,8 @@ public class EmptyBorder extends AbstractBorder implements Serializable
      * Reinitialize the insets parameter with this Border's current Insets.
      * @param c the component for which this border insets value applies
      * @param insets the object to be reinitialized
+     * @throws {@code NullPointerException} if {@code insets}
+     *          is {@code null}
      */
     public Insets getBorderInsets(Component c, Insets insets) {
         insets.left = left;

--- a/src/java.desktop/share/classes/javax/swing/border/EmptyBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/EmptyBorder.java
@@ -83,6 +83,8 @@ public class EmptyBorder extends AbstractBorder implements Serializable
     /**
      * Creates an empty border with the specified insets.
      * @param borderInsets the insets of the border
+     * @throws {@code NullPointerException} if {@code borderInsets}
+     *          is {@code null}
      */
     @ConstructorProperties({"borderInsets"})
     public EmptyBorder(Insets borderInsets)   {

--- a/src/java.desktop/share/classes/javax/swing/border/EtchedBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/EtchedBorder.java
@@ -210,6 +210,8 @@ public class EtchedBorder extends AbstractBorder
      *
      * @param c the component for which this border insets value applies
      * @param insets the object to be reinitialized
+     * @throws NullPointerException if the specified {@code insets}
+     *         is {@code null}
      */
     public Insets getBorderInsets(Component c, Insets insets) {
         insets.set(2, 2, 2, 2);

--- a/src/java.desktop/share/classes/javax/swing/border/LineBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/LineBorder.java
@@ -174,6 +174,8 @@ public class LineBorder extends AbstractBorder
      *
      * @param c the component for which this border insets value applies
      * @param insets the object to be reinitialized
+     * @throws NullPointerException if the specified {@code insets}
+     *         is {@code null}
      */
     public Insets getBorderInsets(Component c, Insets insets) {
         insets.set(thickness, thickness, thickness, thickness);

--- a/src/java.desktop/share/classes/javax/swing/border/MatteBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/MatteBorder.java
@@ -75,6 +75,8 @@ public class MatteBorder extends EmptyBorder
      * Creates a matte border with the specified insets and color.
      * @param borderInsets the insets of the border
      * @param matteColor the color rendered for the border
+     * @throws {@code NullPointerException} if {@code borderInsets}
+     *          is {@code null}
      * @since 1.3
      */
     public MatteBorder(Insets borderInsets, Color matteColor)   {
@@ -99,6 +101,8 @@ public class MatteBorder extends EmptyBorder
      * Creates a matte border with the specified insets and tile icon.
      * @param borderInsets the insets of the border
      * @param tileIcon the icon to be used for tiling the border
+     * @throws {@code NullPointerException} if {@code borderInsets}
+     *      *   is {@code null}
      * @since 1.3
      */
     public MatteBorder(Insets borderInsets, Icon tileIcon)   {

--- a/src/java.desktop/share/classes/javax/swing/border/MatteBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/MatteBorder.java
@@ -102,7 +102,7 @@ public class MatteBorder extends EmptyBorder
      * @param borderInsets the insets of the border
      * @param tileIcon the icon to be used for tiling the border
      * @throws {@code NullPointerException} if {@code borderInsets}
-     *      *   is {@code null}
+     *          is {@code null}
      * @since 1.3
      */
     public MatteBorder(Insets borderInsets, Icon tileIcon)   {
@@ -169,7 +169,9 @@ public class MatteBorder extends EmptyBorder
     /**
      * Reinitialize the insets parameter with this Border's current Insets.
      * @param c the component for which this border insets value applies
-     * @param insets the object to be reinitialized
+     * @param insets the object to be
+     * @throws {@code NullPointerException} if {@code insets}
+     *         is {@code null}
      * @since 1.3
      */
     public Insets getBorderInsets(Component c, Insets insets) {

--- a/src/java.desktop/share/classes/javax/swing/border/MatteBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/MatteBorder.java
@@ -169,7 +169,7 @@ public class MatteBorder extends EmptyBorder
     /**
      * Reinitialize the insets parameter with this Border's current Insets.
      * @param c the component for which this border insets value applies
-     * @param insets the object to be
+     * @param insets the object to be reinitialized
      * @throws {@code NullPointerException} if {@code insets}
      *         is {@code null}
      * @since 1.3

--- a/src/java.desktop/share/classes/javax/swing/border/MatteBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/MatteBorder.java
@@ -75,8 +75,8 @@ public class MatteBorder extends EmptyBorder
      * Creates a matte border with the specified insets and color.
      * @param borderInsets the insets of the border
      * @param matteColor the color rendered for the border
-     * @throws {@code NullPointerException} if {@code borderInsets}
-     *          is {@code null}
+     * @throws NullPointerException if the specified {@code borderInsets}
+     *         is {@code null}
      * @since 1.3
      */
     public MatteBorder(Insets borderInsets, Color matteColor)   {
@@ -101,8 +101,8 @@ public class MatteBorder extends EmptyBorder
      * Creates a matte border with the specified insets and tile icon.
      * @param borderInsets the insets of the border
      * @param tileIcon the icon to be used for tiling the border
-     * @throws {@code NullPointerException} if {@code borderInsets}
-     *          is {@code null}
+     * @throws NullPointerException if the specified {@code borderInsets}
+     *         is {@code null}
      * @since 1.3
      */
     public MatteBorder(Insets borderInsets, Icon tileIcon)   {
@@ -170,7 +170,7 @@ public class MatteBorder extends EmptyBorder
      * Reinitialize the insets parameter with this Border's current Insets.
      * @param c the component for which this border insets value applies
      * @param insets the object to be reinitialized
-     * @throws {@code NullPointerException} if {@code insets}
+     * @throws NullPointerException if the specified {@code insets}
      *         is {@code null}
      * @since 1.3
      */

--- a/src/java.desktop/share/classes/javax/swing/border/SoftBevelBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/SoftBevelBorder.java
@@ -152,6 +152,8 @@ public class SoftBevelBorder extends BevelBorder
      * Reinitialize the insets parameter with this Border's current Insets.
      * @param c the component for which this border insets value applies
      * @param insets the object to be reinitialized
+     * @throws NullPointerException if the specified {@code insets}
+     *         is {@code null}
      */
     public Insets getBorderInsets(Component c, Insets insets)       {
         insets.set(3, 3, 3, 3);

--- a/src/java.desktop/share/classes/javax/swing/border/TitledBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/TitledBorder.java
@@ -374,6 +374,8 @@ public class TitledBorder extends AbstractBorder
      * Reinitialize the insets parameter with this Border's current Insets.
      * @param c the component for which this border insets value applies
      * @param insets the object to be reinitialized
+     * @throws NullPointerException if the specified {@code insets}
+     *         is {@code null}
      */
     public Insets getBorderInsets(Component c, Insets insets) {
         Border border = getBorder();

--- a/src/java.desktop/share/classes/javax/swing/plaf/BorderUIResource.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/BorderUIResource.java
@@ -172,6 +172,8 @@ public class BorderUIResource implements Border, UIResource, Serializable
         /**
          * Constructs an {@code EmptyBorderUIResource}.
          * @param insets the insets of the border
+         * @throws NullPointerException if the spcecified {@code insets}
+         *         is {@code null}
          */
         @ConstructorProperties({"borderInsets"})
         public EmptyBorderUIResource(Insets insets) {


### PR DESCRIPTION
The behavior of MatteBorder constructors taking Insets object as a parameter is undocumented. It would throw NPE if null object is passed to it, which should be documented in the spec.
<!-- csr: 'update' -->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-6201035](https://bugs.openjdk.org/browse/JDK-6201035): Document NPE for passing null insets to constructors and methods of several javax.swing.border.* classes
 * [JDK-8295454](https://bugs.openjdk.org/browse/JDK-8295454): Document NPE for passing null insets to constructors and methods of several javax.swing.border.* classes (**CSR**)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer) ⚠️ Review applies to [389c7c4c](https://git.openjdk.org/jdk/pull/10740/files/389c7c4c69c7a5e5b016a82b9dc552a85f4ed3a5)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [389c7c4c](https://git.openjdk.org/jdk/pull/10740/files/389c7c4c69c7a5e5b016a82b9dc552a85f4ed3a5)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10740/head:pull/10740` \
`$ git checkout pull/10740`

Update a local copy of the PR: \
`$ git checkout pull/10740` \
`$ git pull https://git.openjdk.org/jdk pull/10740/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10740`

View PR using the GUI difftool: \
`$ git pr show -t 10740`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10740.diff">https://git.openjdk.org/jdk/pull/10740.diff</a>

</details>
