### PR TITLE
8295468: RISC-V: Minimal builds are broken

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -32,6 +32,7 @@
 #include "gc/shared/barrierSetAssembler.hpp"
 #include "gc/shared/cardTable.hpp"
 #include "gc/shared/cardTableBarrierSet.hpp"
+#include "gc/shared/collectedHeap.hpp"
 #include "interpreter/bytecodeHistogram.hpp"
 #include "interpreter/interpreter.hpp"
 #include "memory/resourceArea.hpp"

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -32,6 +32,7 @@
 #include "oops/oop.inline.hpp"
 #include "runtime/handles.hpp"
 #include "runtime/orderAccess.hpp"
+#include "runtime/safepoint.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
 #include "utilities/ostream.hpp"


### PR DESCRIPTION
Attempting to build RISC-V "minimal" variant fails with:

```
* For target hotspot_variant-minimal_libjvm_objs_macroAssembler_riscv.o:
In file included from /home/shade/trunks/jdk/src/hotspot/share/utilities/globalDefinitions.hpp:29,
                 from /home/shade/trunks/jdk/src/hotspot/share/memory/allocation.hpp:29,
                 from /home/shade/trunks/jdk/src/hotspot/share/memory/arena.hpp:28,
                 from /home/shade/trunks/jdk/src/hotspot/share/runtime/handles.hpp:28,
                 from /home/shade/trunks/jdk/src/hotspot/share/code/oopRecorder.hpp:28,
                 from /home/shade/trunks/jdk/src/hotspot/share/asm/codeBuffer.hpp:28,
                 from /home/shade/trunks/jdk/src/hotspot/share/asm/assembler.hpp:28,
                 from /home/shade/trunks/jdk/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp:28:
/home/shade/trunks/jdk/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp: In member function 'void MacroAssembler::movoop(Register, jobject)':
/home/shade/trunks/jdk/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp:1966:30: error: invalid use of incomplete type 'class CollectedHeap'
 1966 | assert(Universe::heap()->is_in(JNIHandles::resolve(obj)), "should be real oop");
      | ^~
``` 

Additional testing: 
 - [x] Linux RISC-V minimal builds {release, fastdebug, slowdebug, optimized}

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295468](https://bugs.openjdk.org/browse/JDK-8295468): RISC-V: Minimal builds are broken


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Author)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10742/head:pull/10742` \
`$ git checkout pull/10742`

Update a local copy of the PR: \
`$ git checkout pull/10742` \
`$ git pull https://git.openjdk.org/jdk pull/10742/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10742`

View PR using the GUI difftool: \
`$ git pr show -t 10742`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10742.diff">https://git.openjdk.org/jdk/pull/10742.diff</a>

</details>
