### PR TITLE
8295469: S390X: Optimized builds are broken

### DIFF
--- a/src/hotspot/cpu/s390/assembler_s390.cpp
+++ b/src/hotspot/cpu/s390/assembler_s390.cpp
@@ -138,7 +138,7 @@ Assembler::branch_condition Assembler::inverse_float_condition(Assembler::branch
   return inverse_cc;
 }
 
-#ifdef ASSERT
+#ifndef PRODUCT
 void Assembler::print_dbg_msg(outputStream* out, unsigned long inst, const char* msg, int ilen) {
   out->flush();
   switch (ilen) {

--- a/src/hotspot/cpu/s390/interp_masm_s390.hpp
+++ b/src/hotspot/cpu/s390/interp_masm_s390.hpp
@@ -166,7 +166,7 @@ class InterpreterMacroAssembler: public MacroAssembler {
 
   // Accessors to the template interpreter state.
 
-  void asm_assert_ijava_state_magic(Register tmp) PRODUCT_RETURN;
+  void asm_assert_ijava_state_magic(Register tmp) NOT_DEBUG_RETURN;
 
   void save_bcp();
 


### PR DESCRIPTION
```
* For target hotspot_variant-server_libjvm_objs_BUILD_LIBJVM_link:
/usr/lib/gcc-cross/s390x-linux-gnu/10/../../../../s390x-linux-gnu/bin/ld: /home/shade/trunks/jdk/build/build-all-server-optimized-s390x-linux-gnu-10/hotspot/variant-server/libjvm/objs/interp_masm_s390.o: in function `InterpreterMacroAssembler::get_monitors(RegisterImpl*)':
make/hotspot/src/hotspot/cpu/s390/interp_masm_s390.cpp:673: undefined reference to `InterpreterMacroAssembler::asm_assert_ijava_state_magic(RegisterImpl*)'
/usr/lib/gcc-cross/s390x-linux-gnu/10/../../../../s390x-linux-gnu/bin/ld: /home/shade/trunks/jdk/build/build-all-server-optimized-s390x-linux-gnu-10/hotspot/variant-server/libjvm/objs/interp_masm_s390.o: in function `InterpreterMacroAssembler::save_bcp()':
make/hotspot/src/hotspot/cpu/s390/interp_masm_s390.cpp:654: undefined reference to `InterpreterMacroAssembler::asm_assert_ijava_state_magic(RegisterImpl*)'
``` 

The fix is to enable assert-like methods only in "debug" builds, and allow diag-like printing methods in "optimized" builds.

Additional testing:
 - [x] Linux S390X {server, client, minimal, zero} x {release, fastdebug, slowdebug, optimized} `make hotspot`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295469](https://bugs.openjdk.org/browse/JDK-8295469): S390X: Optimized builds are broken


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10743/head:pull/10743` \
`$ git checkout pull/10743`

Update a local copy of the PR: \
`$ git checkout pull/10743` \
`$ git pull https://git.openjdk.org/jdk pull/10743/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10743`

View PR using the GUI difftool: \
`$ git pr show -t 10743`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10743.diff">https://git.openjdk.org/jdk/pull/10743.diff</a>

</details>
