### PR TITLE
8295414: [Aarch64] C2: assert(false) failed: bad AD file

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -4904,7 +4904,7 @@ operand iRegP()
   match(iRegP_R0);
   //match(iRegP_R2);
   //match(iRegP_R4);
-  //match(iRegP_R5);
+  match(iRegP_R5);
   match(thread_RegP);
   op_cost(0);
   format %{ %}

--- a/test/hotspot/jtreg/compiler/types/TestSubTypeCheckMacroTrichotomy.java
+++ b/test/hotspot/jtreg/compiler/types/TestSubTypeCheckMacroTrichotomy.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,10 +25,13 @@
 /**
  * @test
  * @bug 8253566
+ * @bug 8295414
  * @summary clazz.isAssignableFrom will return false for interface implementors
  * @requires vm.compiler2.enabled
  *
  * @run main/othervm -XX:-BackgroundCompilation TestSubTypeCheckMacroTrichotomy
+ * @run main/othervm -XX:-BackgroundCompilation -XX:+StressReflectiveCode -XX:+ExpandSubTypeCheckAtParseTime
+ *     -XX:-TieredCompilation -XX:CompileThreshold=100 TestSubTypeCheckMacroTrichotomy
  *
  */
 

--- a/test/hotspot/jtreg/compiler/types/TestSubTypeCheckMacroTrichotomy.java
+++ b/test/hotspot/jtreg/compiler/types/TestSubTypeCheckMacroTrichotomy.java
@@ -30,7 +30,9 @@
  * @requires vm.compiler2.enabled
  *
  * @run main/othervm -XX:-BackgroundCompilation TestSubTypeCheckMacroTrichotomy
- * @run main/othervm -XX:-BackgroundCompilation -XX:+StressReflectiveCode -XX:+ExpandSubTypeCheckAtParseTime
+ * @run main/othervm -XX:-BackgroundCompilation
+ *     -XX:+IgnoreUnrecognizedVMOptions -XX:+StressReflectiveCode
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+ExpandSubTypeCheckAtParseTime
  *     -XX:-TieredCompilation -XX:CompileThreshold=100 TestSubTypeCheckMacroTrichotomy
  *
  */


### PR DESCRIPTION
The "bad AD file" error is because PartialSubtypeCheck produces an iRegP_R5 result, which cannot be matched as an input where iRegP is expected.
Update the test to reproduce the crash and updated iRegP rule to match iRegP_R5.
The fact that this went so long without being noticed makes me wonder how much test coverage PartialSubtypeCheck has received on aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295414](https://bugs.openjdk.org/browse/JDK-8295414): [Aarch64] C2: assert(false) failed: bad AD file


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [87445222](https://git.openjdk.org/jdk/pull/10749/files/87445222ec40bf4f445979566aa8459ff894a66e)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10749/head:pull/10749` \
`$ git checkout pull/10749`

Update a local copy of the PR: \
`$ git checkout pull/10749` \
`$ git pull https://git.openjdk.org/jdk pull/10749/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10749`

View PR using the GUI difftool: \
`$ git pr show -t 10749`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10749.diff">https://git.openjdk.org/jdk/pull/10749.diff</a>

</details>
