### PR TITLE
JDK-8295517: Fix stutter typo in JDK-8294539

### DIFF
--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -172,8 +172,8 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * <dd>The two floating-point values represent the same IEEE 754
  * <i>datum</i>. In particular, for {@linkplain #isFinite(double)
  * finite} values, the sign, {@linkplain Math#getExponent(double)
- * exponent}, and significand components of the
- * floating-point values are the same. Under this relation:
+ * exponent}, and significand components of the floating-point values
+ * are the same. Under this relation:
  * <ul>
  * <li> {@code +0.0} and {@code -0.0} are distinguished from each other.
  * <li> every bit pattern encoding a NaN is considered equivalent to each other

--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -169,7 +169,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * </dd>
  *
  * <dt><i><a id=repEquivalence>representation equivalence</a></i>:</dt>
- * <dd>The two floating-point values represent the the same IEEE 754
+ * <dd>The two floating-point values represent the same IEEE 754
  * <i>datum</i>. In particular, for {@linkplain #isFinite(double)
  * finite} values, the sign, {@linkplain Math#getExponent(double)
  * exponent}, and significand components of the


### PR DESCRIPTION
"the the" -> "the"

I'll reflow the paragraph before pushing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295517](https://bugs.openjdk.org/browse/JDK-8295517): Fix stutter typo in JDK-8294539


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [da960757](https://git.openjdk.org/jdk/pull/10750/files/da960757de3974a9a4f493bccd14996cc1f49afd)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to [da960757](https://git.openjdk.org/jdk/pull/10750/files/da960757de3974a9a4f493bccd14996cc1f49afd)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10750/head:pull/10750` \
`$ git checkout pull/10750`

Update a local copy of the PR: \
`$ git checkout pull/10750` \
`$ git pull https://git.openjdk.org/jdk pull/10750/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10750`

View PR using the GUI difftool: \
`$ git pr show -t 10750`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10750.diff">https://git.openjdk.org/jdk/pull/10750.diff</a>

</details>
