### PR TITLE
8295456: (ch) sun.nio.ch.Util::checkBufferPositionAligned gives misleading/incorrect error

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/Util.java
+++ b/src/java.base/share/classes/sun/nio/ch/Util.java
@@ -502,19 +502,18 @@ public class Util {
         return dbb;
     }
 
-    static void checkBufferPositionAligned(ByteBuffer bb,
-                                                     int pos, int alignment)
+    static void checkBufferPositionAligned(ByteBuffer bb, int pos, int alignment)
         throws IOException
     {
-        if (bb.alignmentOffset(pos, alignment) != 0) {
-            throw new IOException("Current location of the bytebuffer ("
+        final int alignmentOffset = bb.alignmentOffset(pos, alignment);
+        if (alignmentOffset != 0) {
+            throw new IOException("Current position of the bytebuffer ("
                 + pos + ") is not a multiple of the block size ("
-                + alignment + ")");
+                + alignment + "): alignment offset = " + alignmentOffset);
         }
     }
 
-    static void checkRemainingBufferSizeAligned(int rem,
-                                                          int alignment)
+    static void checkRemainingBufferSizeAligned(int rem, int alignment)
         throws IOException
     {
         if (rem % alignment != 0) {
@@ -524,8 +523,7 @@ public class Util {
         }
     }
 
-    static void checkChannelPositionAligned(long position,
-                                                      int alignment)
+    static void checkChannelPositionAligned(long position, int alignment)
         throws IOException
     {
         if (position % alignment != 0) {

--- a/test/jdk/java/nio/channels/FileChannel/directio/ReadDirect.java
+++ b/test/jdk/java/nio/channels/FileChannel/directio/ReadDirect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -144,7 +144,7 @@ public class ReadDirect {
                 fc.read(block);
                 throw new RuntimeException("Expected exception not thrown");
             } catch (IOException e) {
-                if (!e.getMessage().contains("Current location of the bytebuffer "
+                if (!e.getMessage().contains("Current position of the bytebuffer "
                     +  "(" + pos + ") is not a multiple of the block size ("
                     + alignment + ")"))
                     throw new Exception("Read test failed");

--- a/test/jdk/java/nio/channels/FileChannel/directio/WriteDirect.java
+++ b/test/jdk/java/nio/channels/FileChannel/directio/WriteDirect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,7 +101,7 @@ public class WriteDirect {
                 fc.write(block);
                 throw new RuntimeException("Expected exception not thrown");
             } catch (IOException e) {
-                if (!e.getMessage().contains("Current location of the bytebuffer "
+                if (!e.getMessage().contains("Current position of the bytebuffer "
                     +  "(" + pos + ") is not a multiple of the block size ("
                     + alignment + ")"))
                     throw new Exception("Write test failed");


### PR DESCRIPTION
Improve `IOException` message in `sun.nio.ch.Util::checkBufferPositionAligned`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295456](https://bugs.openjdk.org/browse/JDK-8295456): (ch) sun.nio.ch.Util::checkBufferPositionAligned gives misleading/incorrect error


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10753/head:pull/10753` \
`$ git checkout pull/10753`

Update a local copy of the PR: \
`$ git checkout pull/10753` \
`$ git pull https://git.openjdk.org/jdk pull/10753/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10753`

View PR using the GUI difftool: \
`$ git pr show -t 10753`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10753.diff">https://git.openjdk.org/jdk/pull/10753.diff</a>

</details>
