### PR TITLE
8291914: generated constructors are considered compact when they shouldn't

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -2302,7 +2302,8 @@ public class Flow {
                     // leave caught unchanged.
                     scan(tree.body);
 
-                    boolean isCompactConstructor = (tree.sym.flags() & Flags.COMPACT_RECORD_CONSTRUCTOR) != 0;
+                    boolean isCompactOrGeneratedRecordConstructor = (tree.sym.flags() & Flags.COMPACT_RECORD_CONSTRUCTOR) != 0 ||
+                            (tree.sym.flags() & (GENERATEDCONSTR | RECORD)) == (GENERATEDCONSTR | RECORD);
                     if (isInitialConstructor) {
                         boolean isSynthesized = (tree.sym.flags() &
                                                  GENERATEDCONSTR) != 0;
@@ -2312,10 +2313,10 @@ public class Flow {
                             if (var.owner == classDef.sym) {
                                 // choose the diagnostic position based on whether
                                 // the ctor is default(synthesized) or not
-                                if (isSynthesized && !isCompactConstructor) {
+                                if (isSynthesized && !isCompactOrGeneratedRecordConstructor) {
                                     checkInit(TreeInfo.diagnosticPositionFor(var, vardecl),
                                             var, Errors.VarNotInitializedInDefaultConstructor(var));
-                                } else if (isCompactConstructor) {
+                                } else if (isCompactOrGeneratedRecordConstructor) {
                                     boolean isInstanceRecordField = var.enclClass().isRecord() &&
                                             (var.flags_field & (Flags.PRIVATE | Flags.FINAL | Flags.GENERATED_MEMBER | Flags.RECORD)) != 0 &&
                                             !var.isStatic() &&

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -2770,7 +2770,8 @@ public class Lower extends TreeTranslator {
                 lambdaTranslationMap = prevLambdaTranslationMap;
             }
         }
-        if (tree.name == names.init && (tree.sym.flags_field & Flags.COMPACT_RECORD_CONSTRUCTOR) != 0) {
+        if (tree.name == names.init && ((tree.sym.flags_field & Flags.COMPACT_RECORD_CONSTRUCTOR) != 0 ||
+                (tree.sym.flags_field & (GENERATEDCONSTR | RECORD)) == (GENERATEDCONSTR | RECORD))) {
             // lets find out if there is any field waiting to be initialized
             ListBuffer<VarSymbol> fields = new ListBuffer<>();
             for (Symbol sym : currentClass.getEnclosedElements()) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
@@ -1417,7 +1417,7 @@ public class TypeEnter implements Completer {
             /* if we have to generate a default constructor for records we will treat it as the compact one
              * to trigger field initialization later on
              */
-            csym.flags_field |= Flags.COMPACT_RECORD_CONSTRUCTOR | GENERATEDCONSTR;
+            csym.flags_field |= GENERATEDCONSTR;
             ListBuffer<VarSymbol> params = new ListBuffer<>();
             JCVariableDecl lastField = recordFieldDecls.last();
             for (JCVariableDecl field : recordFieldDecls) {

--- a/test/langtools/tools/javac/processing/model/util/elements/TestRecordPredicates.java
+++ b/test/langtools/tools/javac/processing/model/util/elements/TestRecordPredicates.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8289249
+ * @bug 8289249 8291914
  * @summary Test Elements.{isCompactConstructor, isCanonicalConstructor}
  * @library /tools/javac/lib
  * @build   JavacTestingAbstractProcessor TestRecordPredicates
@@ -107,7 +107,7 @@ public class TestRecordPredicates extends JavacTestingAbstractProcessor {
         boolean isCanonical() default false;
     }
 
-    @ExpectedPredicates(isCompact=true, isCanonical=true)
+    @ExpectedPredicates(isCompact=false, isCanonical=true)
     record RecordCompactCtor(int foo, double bar) {}
 
     // Example from JLS 8.10.4.2


### PR DESCRIPTION
javac is considering all record generated constructors as compact constructors. According to the spec compact constructors should be declared explicitly. This constructor is compact:
```
record R1(int i) {
    R1 {}
}
```
here there is no explicit constructor so the compiler is providing one but it shouldn't be considered a compact constructor:
```
record R2(int i) {}
```
this PR is fixing the current compiler bug so that for declarations like record R2 the compiler generated constructor is not considered a compact one.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291914](https://bugs.openjdk.org/browse/JDK-8291914): generated constructors are considered compact when they shouldn't


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10756/head:pull/10756` \
`$ git checkout pull/10756`

Update a local copy of the PR: \
`$ git checkout pull/10756` \
`$ git pull https://git.openjdk.org/jdk pull/10756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10756`

View PR using the GUI difftool: \
`$ git pr show -t 10756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10756.diff">https://git.openjdk.org/jdk/pull/10756.diff</a>

</details>
