### PR TITLE
8295646: Ignore zero pairs in address descriptors read by dwarf parser

### DIFF
--- a/src/hotspot/share/utilities/elfFile.cpp
+++ b/src/hotspot/share/utilities/elfFile.cpp
@@ -763,6 +763,8 @@ bool DwarfFile::DebugAranges::read_set_header(DebugArangesSetHeader& header) {
     return false;
   }
 
+  _entry_end = _reader.get_position() + header._unit_length;
+
   if (!_reader.read_word(&header._version) || header._version != 2) {
     // DWARF 4 uses version 2 as specified in Appendix F of the DWARF 4 spec.
     DWARF_LOG_ERROR(".debug_aranges in unsupported DWARF version %" PRIu16, header._version)
@@ -803,7 +805,7 @@ bool DwarfFile::DebugAranges::read_address_descriptors(const DwarfFile::DebugAra
       found_matching_set = true;
       return true;
     }
-  } while (!is_terminating_entry(descriptor) && _reader.has_bytes_left());
+  } while (!is_terminating_entry(header) && _reader.has_bytes_left());
 
   // Set does not match offset_in_library. Continue with next.
   return true;
@@ -819,8 +821,8 @@ bool DwarfFile::DebugAranges::does_match_offset(const uint32_t offset_in_library
          && offset_in_library < descriptor.beginning_address + descriptor.range_length;
 }
 
-bool DwarfFile::DebugAranges::is_terminating_entry(const AddressDescriptor& descriptor) {
-  return descriptor.beginning_address == 0 && descriptor.range_length == 0;
+bool DwarfFile::DebugAranges::is_terminating_entry(const DwarfFile::DebugAranges::DebugArangesSetHeader& header) {
+  return _reader.get_position() >= _entry_end;
 }
 
 // Find the .debug_line offset for the line number program by reading from the .debug_abbrev and .debug_info section.

--- a/src/hotspot/share/utilities/elfFile.cpp
+++ b/src/hotspot/share/utilities/elfFile.cpp
@@ -805,7 +805,7 @@ bool DwarfFile::DebugAranges::read_address_descriptors(const DwarfFile::DebugAra
       found_matching_set = true;
       return true;
     }
-  } while (!is_terminating_entry(header) && _reader.has_bytes_left());
+  } while (!is_terminating_entry(header, descriptor) && _reader.has_bytes_left());
 
   // Set does not match offset_in_library. Continue with next.
   return true;
@@ -821,8 +821,12 @@ bool DwarfFile::DebugAranges::does_match_offset(const uint32_t offset_in_library
          && offset_in_library < descriptor.beginning_address + descriptor.range_length;
 }
 
-bool DwarfFile::DebugAranges::is_terminating_entry(const DwarfFile::DebugAranges::DebugArangesSetHeader& header) {
-  return _reader.get_position() >= _entry_end;
+bool DwarfFile::DebugAranges::is_terminating_entry(const DwarfFile::DebugAranges::DebugArangesSetHeader& header,
+                                                   const AddressDescriptor& descriptor) {
+  bool is_terminating = _reader.get_position() >= _entry_end;
+  assert(!is_terminating || (descriptor.beginning_address == 0 && descriptor.range_length == 0),
+         "a terminating entry needs a pair of zero");
+  return is_terminating;
 }
 
 // Find the .debug_line offset for the line number program by reading from the .debug_abbrev and .debug_info section.

--- a/src/hotspot/share/utilities/elfFile.hpp
+++ b/src/hotspot/share/utilities/elfFile.hpp
@@ -494,7 +494,8 @@ class DwarfFile : public ElfFile {
                                   uint32_t offset_in_library, bool& found_matching_set);
     bool read_address_descriptor(AddressDescriptor& descriptor);
     static bool does_match_offset(uint32_t offset_in_library, const AddressDescriptor& descriptor) ;
-    bool is_terminating_entry(const DwarfFile::DebugAranges::DebugArangesSetHeader& header);
+    bool is_terminating_entry(const DwarfFile::DebugAranges::DebugArangesSetHeader& header,
+                              const AddressDescriptor& descriptor);
    public:
     DebugAranges(DwarfFile* dwarf_file) : _dwarf_file(dwarf_file), _reader(dwarf_file->fd()),
                                           _section_start_address(0), _entry_end(0) {}

--- a/src/hotspot/share/utilities/elfFile.hpp
+++ b/src/hotspot/share/utilities/elfFile.hpp
@@ -485,15 +485,19 @@ class DwarfFile : public ElfFile {
     MarkedDwarfFileReader _reader;
     uint32_t _section_start_address;
 
+    // a calculated end position
+    long _entry_end;
+
     bool read_section_header();
     bool read_set_header(DebugArangesSetHeader& header);
     bool read_address_descriptors(const DwarfFile::DebugAranges::DebugArangesSetHeader& header,
                                   uint32_t offset_in_library, bool& found_matching_set);
     bool read_address_descriptor(AddressDescriptor& descriptor);
     static bool does_match_offset(uint32_t offset_in_library, const AddressDescriptor& descriptor) ;
-    static bool is_terminating_entry(const AddressDescriptor& descriptor);
+    bool is_terminating_entry(const DwarfFile::DebugAranges::DebugArangesSetHeader& header);
    public:
-    DebugAranges(DwarfFile* dwarf_file) : _dwarf_file(dwarf_file), _reader(dwarf_file->fd()), _section_start_address(0) {}
+    DebugAranges(DwarfFile* dwarf_file) : _dwarf_file(dwarf_file), _reader(dwarf_file->fd()),
+                                          _section_start_address(0), _entry_end(0) {}
     bool find_compilation_unit_offset(uint32_t offset_in_library, uint32_t* compilation_unit_offset);
 
   };


### PR DESCRIPTION
RISC-V generates debuginfo like

```
> readelf --debug-dump=aranges build/linux-riscv64-server-fastdebug/images/test/hotspot/gtest/server/libjvm.so

... 
Length:                   1756
  Version:                  2
  Offset into .debug_info:  0x4bc5e9
  Pointer Size:             8
  Segment Size:             0

    Address            Length
    0000000000344ece 0000000000004a2c
    0000000000000000 0000000000000000     <=
    0000000000000000 0000000000000000     <=
    0000000000000000 0000000000000000     <=
    00000000003498fa 0000000000000016
    0000000000349910 0000000000000016
    ....
    000000000026d5b8 0000000000000b9a
    000000000034a532 0000000000000628
    000000000034ab5a 00000000000002ac
    0000000000000000 0000000000000000     <=
    0000000000000000 0000000000000000
    0000000000000000 0000000000000000
    000000000034ae06 0000000000000bee
    000000000034b9f4 0000000000000660
    000000000034c054 00000000000005aa
    0000000000000000 0000000000000000
    0000000000000000 0000000000000000     <=
    000000000034c5fe 0000000000000af2
    000000000034d0f0 0000000000000f16
    000000000034e006 0000000000000b4a
    0000000000000000 0000000000000000
    0000000000000000 0000000000000000
    000000000026e152 000000000000000e
    0000000000000000 0000000000000000
```

Our dwarf parser (gdb's dwarf parser before this April is as well [1], which encountered the same issue on RISC-V) uses `address == 0 && size == 0` in `is_terminating_entry()` to detect terminations of an arange section, which will early terminate parsing RISC-V's debuginfo at an "apparent terminator" described in [1] so that the result would not look correct with tests failures. The `_header._unit_length` is read but not used and it is the real length that can determine the section's end, so we can use it to get the end position of a section instead of `address == 0 && size == 0` checks to fix this issue.

Also, the reason why `readelf` has no such issue is it also uses the same approach to determine the end position. [2]

Tests added along with the dwarf parser patch are all tested and passed on x86_64, aarch64, and riscv64.
Running a tier1 sanity test now.

Thanks,
Xiaolin

[1] https://github.com/bminor/binutils-gdb/commit/1a7c41d5ece7d0d1aa77d8019ee46f03181854fa
[2] https://github.com/bminor/binutils-gdb/blob/fd320c4c29c9a1915d24a68a167a5fd6d2c27e60/binutils/dwarf.c#L7594

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295646](https://bugs.openjdk.org/browse/JDK-8295646): Ignore zero pairs in address descriptors read by dwarf parser


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10758/head:pull/10758` \
`$ git checkout pull/10758`

Update a local copy of the PR: \
`$ git checkout pull/10758` \
`$ git pull https://git.openjdk.org/jdk pull/10758/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10758`

View PR using the GUI difftool: \
`$ git pr show -t 10758`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10758.diff">https://git.openjdk.org/jdk/pull/10758.diff</a>

</details>
