### PR TITLE
8233697: CHT: Iteration parallelization

### DIFF
--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -407,8 +407,6 @@ class ConcurrentHashTable : public CHeapObj<F> {
 
   ~ConcurrentHashTable();
 
-  class BucketsClaimer;
-
   size_t get_mem_size(Thread* thread);
 
   size_t get_size_log2(Thread* thread);
@@ -486,6 +484,8 @@ class ConcurrentHashTable : public CHeapObj<F> {
   template <typename SCAN_FUNC>
   void do_scan(Thread* thread, SCAN_FUNC& scan_f);
 
+
+  class BucketsClaimer;
   // Visit all items with SCAN_FUNC without any protection.
   // It will assume there is no other thread accessing this
   // table during the safepoint. Must be called with VM thread.

--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -346,10 +346,6 @@ class ConcurrentHashTable : public CHeapObj<F> {
   template <typename FUNC>
   void do_scan_locked(Thread* thread, FUNC& scan_f);
 
-  // Visits nodes for buckets in range [start_idx, stop_id) with FUNC.
-  template <typename FUNC>
-  static bool do_scan_for_range(FUNC& scan_f, size_t start_idx, size_t stop_idx, InternalTable *table);
-
   // Check for dead items in a bucket.
   template <typename EVALUATE_FUNC>
   size_t delete_check_nodes(Bucket* bucket, EVALUATE_FUNC& eval_f,
@@ -484,18 +480,15 @@ class ConcurrentHashTable : public CHeapObj<F> {
   template <typename SCAN_FUNC>
   void do_scan(Thread* thread, SCAN_FUNC& scan_f);
 
+  // Visits nodes for buckets in range [start_idx, stop_id) with FUNC.
+  template <typename FUNC>
+  static bool do_scan_for_range(FUNC& scan_f, size_t start_idx, size_t stop_idx, InternalTable *table);
 
   // Visit all items with SCAN_FUNC without any protection.
   // It will assume there is no other thread accessing this
   // table during the safepoint. Must be called with VM thread.
   template <typename SCAN_FUNC>
   void do_safepoint_scan(SCAN_FUNC& scan_f);
-
-  class BucketsClaimer;
-  // Visit all items with SCAN_FUNC without any protection.
-  // Thread-safe, but must be called at safepoint.
-  template <typename SCAN_FUNC>
-  void do_safepoint_scan(SCAN_FUNC& scan_f, BucketsClaimer* bucket_claimer);
 
   // Destroying items matching EVALUATE_FUNC, before destroying items
   // DELETE_FUNC is called, if resize lock is obtained. Else returns false.
@@ -540,6 +533,7 @@ class ConcurrentHashTable : public CHeapObj<F> {
  public:
   class BulkDeleteTask;
   class GrowTask;
+  class ScanTask;
 };
 
 #endif // SHARE_UTILITIES_CONCURRENTHASHTABLE_HPP

--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -485,13 +485,13 @@ class ConcurrentHashTable : public CHeapObj<F> {
   void do_scan(Thread* thread, SCAN_FUNC& scan_f);
 
 
-  class BucketsClaimer;
   // Visit all items with SCAN_FUNC without any protection.
   // It will assume there is no other thread accessing this
   // table during the safepoint. Must be called with VM thread.
   template <typename SCAN_FUNC>
   void do_safepoint_scan(SCAN_FUNC& scan_f);
 
+  class BucketsClaimer;
   // Visit all items with SCAN_FUNC without any protection.
   // Thread-safe, but must be called at safepoint.
   template <typename SCAN_FUNC>

--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -978,7 +978,6 @@ inline void ConcurrentHashTable<CONFIG, F>::
   } /* ends critical section */
 }
 
-
 template <typename CONFIG, MEMFLAGS F>
 template <typename EVALUATE_FUNC>
 inline size_t ConcurrentHashTable<CONFIG, F>::
@@ -1181,46 +1180,6 @@ inline void ConcurrentHashTable<CONFIG, F>::
 }
 
 template <typename CONFIG, MEMFLAGS F>
-template <typename FUNC>
-inline bool ConcurrentHashTable<CONFIG, F>::
-  do_scan_for_range(FUNC& scan_f, size_t start_idx, size_t stop_idx, InternalTable* table)
-{
-  assert(start_idx < stop_idx, "Must be");
-  assert(stop_idx <= table->_size, "Must be");
-
-  for (size_t bucket_it = start_idx; bucket_it < stop_idx; ++bucket_it) {
-    Bucket* bucket = table->get_bucket(bucket_it);
-    // If bucket has a redirect, the items will be in the new table.
-    if (!bucket->have_redirect()) {
-      if(!visit_nodes(bucket, scan_f)) {
-        return false;
-      }
-    } else {
-      assert(bucket->is_locked(), "Bucket must be locked.");
-    }
-  }
-  return true;
-}
-
-template <typename CONFIG, MEMFLAGS F>
-template <typename SCAN_FUNC>
-inline void ConcurrentHashTable<CONFIG, F>::
-  do_safepoint_scan(SCAN_FUNC& scan_f, BucketsClaimer* bucket_claimer)
-{
-  assert(SafepointSynchronize::is_at_safepoint(),
-         "must only be called in a safepoint");
-  size_t start_idx = 0, stop_idx = 0;
-  InternalTable* table = nullptr;
-  while (bucket_claimer->claim(&start_idx, &stop_idx, &table)) {
-    assert(table != nullptr, "precondition");
-    if (!do_scan_for_range(scan_f, start_idx, stop_idx, table)) {
-      return;
-    }
-    table = nullptr;
-  }
-}
-
-template <typename CONFIG, MEMFLAGS F>
 template <typename EVALUATE_FUNC, typename DELETE_FUNC>
 inline bool ConcurrentHashTable<CONFIG, F>::
   try_bulk_delete(Thread* thread, EVALUATE_FUNC& eval_f, DELETE_FUNC& del_f)
@@ -1341,73 +1300,116 @@ inline bool ConcurrentHashTable<CONFIG, F>::
 
 template <typename CONFIG, MEMFLAGS F>
 class ConcurrentHashTable<CONFIG, F>::BucketsClaimer {
-  // Default size of _claim_size_log2
-  static const size_t DEFAULT_CLAIM_SIZE_LOG2 = 7;
+  using InternalTable = ConcurrentHashTable<CONFIG, F>::InternalTable;
 
   ConcurrentHashTable<CONFIG, F>* _cht;
-  // The table is split into ranges, every increment is one range.
-  volatile size_t _next_to_claim;
-  size_t _claim_size_log2; // Log number of buckets in claimed range.
-  size_t _limit;      // Limit to number of claims
 
+  struct InternalTableClaimer {
+    volatile size_t _next;
+    size_t _limit;
+    size_t _size;
+    InternalTable* _table;
+
+    InternalTableClaimer() : _next(0), _limit(0), _size(0), _table(nullptr) { }
+
+    InternalTableClaimer(size_t claim_size, InternalTable* table) :
+      InternalTableClaimer()
+    {
+      set(claim_size, table);
+    }
+
+    void set(size_t claim_size, InternalTable* table) {
+      assert(table != nullptr, "precondition");
+      _limit = table->_size;
+      _size  = MIN2(claim_size, _limit);
+      _table = table;
+    }
+  };
+
+  InternalTableClaimer _claimer;
   // If there is a paused resize, we also need to operate on the already resized items.
-  volatile size_t _next_to_claim_new_table;
-  size_t _claim_size_log2_new_table;
-  size_t _limit_new_table;
-
+  InternalTableClaimer _new_table_claimer;
 public:
-  BucketsClaimer(ConcurrentHashTable<CONFIG, F>* cht) :
+  BucketsClaimer(ConcurrentHashTable<CONFIG, F>* cht, size_t claim_size) :
     _cht(cht),
-    _next_to_claim(0),
-    _claim_size_log2(DEFAULT_CLAIM_SIZE_LOG2),
-    _limit(0),
-    _next_to_claim_new_table(0),
-    _claim_size_log2_new_table(0),
-    _limit_new_table(0)
+    _claimer(claim_size, _cht->_table),
+    _new_table_claimer()
   {
-    size_t size_log2 = _cht->_table->_log2_size;
-    _claim_size_log2 = MIN2(_claim_size_log2, size_log2);
-    _limit = (size_t)1 << (size_log2 - _claim_size_log2);
-
-    ConcurrentHashTable<CONFIG, F>::InternalTable* new_table = _cht->get_new_table();
+    InternalTable* new_table = _cht->get_new_table();
 
     if (new_table == nullptr) { return; }
 
     DEBUG_ONLY(if (new_table == POISON_PTR) { return; })
 
-    size_t size_log2_new_table = new_table->_log2_size;
-    _claim_size_log2_new_table = MIN2(DEFAULT_CLAIM_SIZE_LOG2, size_log2_new_table);
-    _limit_new_table = (size_t)1 << (size_log2_new_table - _claim_size_log2_new_table);
+    _new_table_claimer.set(claim_size, new_table);
   }
 
-  // Returns true if you succeeded to claim the range [start, stop).
-  bool claim(size_t* start, size_t* stop, ConcurrentHashTable<CONFIG, F>::InternalTable** table) {
-    if (Atomic::load(&_next_to_claim) < _limit) {
-      size_t claimed = Atomic::fetch_and_add(&_next_to_claim, 1u);
-      if (claimed < _limit) {
-        *start = claimed << _claim_size_log2;
-        *stop  = (*start) + ((size_t)1 << _claim_size_log2);
-        *table = _cht->get_table();
+  bool claim(InternalTableClaimer* claimer, size_t* start, size_t* stop, InternalTable** table) {
+    if (Atomic::load(&claimer->_next) < claimer->_limit) {
+      size_t claimed = Atomic::fetch_and_add(&claimer->_next, claimer->_size);
+      if (claimed < claimer->_limit) {
+        *start = claimed;
+        *stop  = MIN2(claimed + claimer->_size, claimer->_limit);
+        *table = claimer->_table;
         return true;
       }
     }
+    return false;
+  }
 
-    if (_limit_new_table == 0) {
+  // Returns true if you succeeded to claim the range [start, stop).
+  bool claim(size_t* start, size_t* stop, InternalTable** table) {
+    if (claim(&_claimer, start, stop, table)) {
+      return true;
+    }
+
+    // If there is a paused resize, we also need to operate on the already resized items.
+    if (_new_table_claimer._limit == 0) {
       assert(_cht->get_new_table() == nullptr || _cht->get_new_table() == POISON_PTR, "Precondition");
       return false;
     }
 
-    ConcurrentHashTable<CONFIG, F>::InternalTable* new_table = _cht->get_new_table();
-    assert(new_table != nullptr, "Precondition");
-    size_t claimed = Atomic::fetch_and_add(&_next_to_claim_new_table, 1u);
-    if (claimed < _limit_new_table) {
-      *start = claimed << _claim_size_log2_new_table;
-      *stop  = (*start) + ((size_t)1 << _claim_size_log2_new_table);
-      *table = new_table;
-      return true;
-    }
-    return false;
+    return claim(&_new_table_claimer, start, stop, table);
   }
 };
+
+template <typename CONFIG, MEMFLAGS F>
+template <typename SCAN_FUNC>
+inline void ConcurrentHashTable<CONFIG, F>::
+  do_safepoint_scan(SCAN_FUNC& scan_f, BucketsClaimer* bucket_claimer)
+{
+  assert(SafepointSynchronize::is_at_safepoint(),
+         "must only be called in a safepoint");
+  size_t start_idx = 0, stop_idx = 0;
+  InternalTable* table = nullptr;
+  while (bucket_claimer->claim(&start_idx, &stop_idx, &table)) {
+    assert(table != nullptr, "precondition");
+    if (!do_scan_for_range(scan_f, start_idx, stop_idx, table)) {
+      return;
+    }
+    table = nullptr;
+  }
+}
+
+template <typename CONFIG, MEMFLAGS F>
+template <typename FUNC>
+inline bool ConcurrentHashTable<CONFIG, F>::
+  do_scan_for_range(FUNC& scan_f, size_t start_idx, size_t stop_idx, InternalTable* table)
+{
+  assert(start_idx < stop_idx, "Must be");
+  assert(stop_idx <= table->_size, "Must be");
+  for (size_t bucket_it = start_idx; bucket_it < stop_idx; ++bucket_it) {
+    Bucket* bucket = table->get_bucket(bucket_it);
+    // If bucket has a redirect, the items will be in the new table.
+    if (!bucket->have_redirect()) {
+      if(!visit_nodes(bucket, scan_f)) {
+        return false;
+      }
+    } else {
+      assert(bucket->is_locked(), "Bucket must be locked.");
+    }
+  }
+  return true;
+}
 
 #endif // SHARE_UTILITIES_CONCURRENTHASHTABLE_INLINE_HPP

--- a/test/hotspot/gtest/utilities/test_concurrentHashtable.cpp
+++ b/test/hotspot/gtest/utilities/test_concurrentHashtable.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "precompiled.hpp"
+#include "gc/shared/workerThread.hpp"
 #include "runtime/mutex.hpp"
 #include "runtime/os.hpp" // malloc
 #include "runtime/semaphore.hpp"
@@ -1144,4 +1145,80 @@ public:
 
 TEST_VM(ConcurrentHashTable, concurrent_mt_bulk_delete) {
   mt_test_doer<Driver_BD_Thread>();
+}
+
+class CHTParallelScanTask: public WorkerTask {
+  TestTable* _cht;
+  TestTable::BucketsClaimer* _bucket_claimer;
+  size_t *_total_scanned;
+
+public:
+  CHTParallelScanTask(TestTable* cht,
+                      TestTable::BucketsClaimer* bc,
+                      size_t *total_scanned) :
+    WorkerTask("CHT Parallel Scan"),
+    _cht(cht),
+    _bucket_claimer(bc),
+    _total_scanned(total_scanned)
+  { }
+
+  void work(uint worker_id) {
+    ChtCountScan par_scan;
+    _cht->do_safepoint_scan(par_scan, _bucket_claimer);
+    Atomic::add(_total_scanned, par_scan._count);
+  }
+};
+
+class CHTWorkers : AllStatic {
+  static WorkerThreads* _workers;
+  static WorkerThreads* workers() {
+    if (_workers == nullptr) {
+      _workers = new WorkerThreads("CHT Workers", MaxWorkers);
+      _workers->initialize_workers();
+      _workers->set_active_workers(MaxWorkers);
+    }
+    return _workers;
+  }
+
+public:
+  static const uint MaxWorkers = 8;
+  static void run_task(WorkerTask* task) {
+    workers()->run_task(task);
+  }
+};
+
+WorkerThreads* CHTWorkers::_workers = nullptr;
+
+class CHTParallelScan: public VM_GTestExecuteAtSafepoint {
+  TestTable* _cht;
+  uintptr_t _num_items;
+public:
+  CHTParallelScan(TestTable* cht, uintptr_t num_items) :
+    _cht(cht), _num_items(num_items)
+  {}
+
+  void doit() {
+    size_t total_scanned = 0;
+    TestTable::BucketsClaimer bucket_claimer(_cht);
+
+    CHTParallelScanTask task(_cht, &bucket_claimer, &total_scanned);
+    CHTWorkers::run_task(&task);
+
+     EXPECT_TRUE(total_scanned == (size_t)_num_items) << " Should scan all inserted items: " << total_scanned;
+  }
+};
+
+TEST_VM(ConcurrentHashTable, concurrent_par_scan) {
+  TestTable* cht = new TestTable(16, 16, 2);
+
+  uintptr_t num_items = 999999;
+  for (uintptr_t v = 1; v <= num_items; v++ ) {
+    TestLookup tl(v);
+    EXPECT_TRUE(cht->insert(JavaThread::current(), tl, v)) << "Inserting an unique value should work.";
+  }
+
+  // Run the test at a safepoint.
+  CHTParallelScan op(cht, num_items);
+  ThreadInVMfromNative invm(JavaThread::current());
+  VMThread::execute(&op);
 }

--- a/test/hotspot/gtest/utilities/test_concurrentHashtable.cpp
+++ b/test/hotspot/gtest/utilities/test_concurrentHashtable.cpp
@@ -1199,7 +1199,7 @@ public:
 
   void doit() {
     size_t total_scanned = 0;
-    TestTable::BucketsClaimer bucket_claimer(_cht);
+    TestTable::BucketsClaimer bucket_claimer(_cht, 64);
 
     CHTParallelScanTask task(_cht, &bucket_claimer, &total_scanned);
     CHTWorkers::run_task(&task);


### PR DESCRIPTION
Hi,

Please review this change to add parallel iteration of the ConcurrentHashTable. The iteration should be done during a safepoint without concurrent modifications to the ConcurrentHashTable.

Usecase is in parallelizing the merging of large remsets for G1.

Some background: The problem is that particularly during (G1) mixed gc it happens that the distribution of contents in the CHT is very unbalanced - young gen regions have a very small remembered set (little work), and old gen regions very large ones (much work).

Since the current work distribution is based on whole remembered sets (i.e. CHTs), this makes for a very unbalanced merge remsets phase in G1 when you have quite a bit more than the number of old gen regions threads at your disposal.
This negatively impacts pause time predictions (and obviously pause times are longer than necessary as many threads are idling to wait for the phase to complete).

This change only adds the infrastructure code in the CHT, there will be a follow-up with G1 changes.

Testing: tier 1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233697](https://bugs.openjdk.org/browse/JDK-8233697): CHT: Iteration parallelization


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10759/head:pull/10759` \
`$ git checkout pull/10759`

Update a local copy of the PR: \
`$ git checkout pull/10759` \
`$ git pull https://git.openjdk.org/jdk pull/10759/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10759`

View PR using the GUI difftool: \
`$ git pr show -t 10759`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10759.diff">https://git.openjdk.org/jdk/pull/10759.diff</a>

</details>
