### PR TITLE
8295662: jdk/incubator/vector tests fail "assert(VM_Version::supports_avx512vlbw()) failed"

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -1698,18 +1698,7 @@ void C2_MacroAssembler::load_iota_indices(XMMRegister dst, int vlen_in_bytes, Ba
     offset += 128;
   }
   ExternalAddress addr(StubRoutines::x86::vector_iota_indices() + offset);
-  if (vlen_in_bytes <= 4) {
-    movdl(dst, addr);
-  } else if (vlen_in_bytes == 8) {
-    movq(dst, addr);
-  } else if (vlen_in_bytes == 16) {
-    movdqu(dst, addr, noreg);
-  } else if (vlen_in_bytes == 32) {
-    vmovdqu(dst, addr, noreg);
-  } else {
-    assert(vlen_in_bytes == 64, "%d", vlen_in_bytes);
-    evmovdqub(dst, k0, addr, false /*merge*/, Assembler::AVX_512bit, noreg);
-  }
+  load_vector(dst, addr, vlen_in_bytes);
 }
 
 // Reductions for vectors of bytes, shorts, ints, longs, floats, and doubles.


### PR DESCRIPTION
This patch removes the incorrectly used `evmovdqub` and uses `evmovdqul` because the former requires AVX512BW, which is unavailable on KNL settings. We have `C2_MacroAssembler::load_vector` already so we can use it here instead.

Thanks a lot.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295662](https://bugs.openjdk.org/browse/JDK-8295662): jdk/incubator/vector tests fail "assert(VM_Version::supports_avx512vlbw()) failed"


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10764/head:pull/10764` \
`$ git checkout pull/10764`

Update a local copy of the PR: \
`$ git checkout pull/10764` \
`$ git pull https://git.openjdk.org/jdk pull/10764/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10764`

View PR using the GUI difftool: \
`$ git pr show -t 10764`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10764.diff">https://git.openjdk.org/jdk/pull/10764.diff</a>

</details>
