### PR TITLE
8295779: Xcode 14.0 fails to build jdk on m1 macos

### DIFF
--- a/src/java.desktop/share/native/liblcms/cmstypes.c
+++ b/src/java.desktop/share/native/liblcms/cmstypes.c
@@ -3444,6 +3444,8 @@ void *Type_ProfileSequenceId_Read(struct _cms_typehandler_struct* self, cmsIOHAN
     cmsUInt32Number Count;
     cmsUInt32Number BaseOffset;
 
+    cmsUNUSED_PARAMETER(SizeOfTag);
+
     *nItems = 0;
 
     // Get actual position as a basis for element offsets
@@ -5143,6 +5145,8 @@ void *Type_Dictionary_Read(struct _cms_typehandler_struct* self, cmsIOHANDLER* i
    wchar_t *NameWCS = NULL, *ValueWCS = NULL;
    cmsMLU *DisplayNameMLU = NULL, *DisplayValueMLU=NULL;
    cmsBool rc;
+
+    cmsUNUSED_PARAMETER(SizeOfTag);
 
     *nItems = 0;
 


### PR DESCRIPTION
Building on MacOS 12.6 M1 with Xcode 14.0 fails due to C compiler unused parameter warnings:
```
Creating support/modules_libs/java.desktop/libosx.dylib from 1 file(s)
/Users/archie/proj/jdk/src/java.desktop/share/native/liblcms/cmstypes.c:3441:132: error: parameter 'SizeOfTag' set but not used [-Werror,-Wunused-but-set-parameter]
void *Type_ProfileSequenceId_Read(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, cmsUInt32Number* nItems, cmsUInt32Number SizeOfTag)
                                                                                                                                   ^
/Users/archie/proj/jdk/src/java.desktop/share/native/liblcms/cmstypes.c:5137:125: error: parameter 'SizeOfTag' set but not used [-Werror,-Wunused-but-set-parameter]
void *Type_Dictionary_Read(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, cmsUInt32Number* nItems, cmsUInt32Number SizeOfTag)
                                                                                                                            ^
2 errors generated.
make[3]: *** [/Users/archie/proj/jdk/build/macosx-aarch64-server-release/support/native/java.desktop/liblcms/cmstypes.o] Error 1
make[3]: *** Waiting for unfinished jobs....
make[2]: *** [java.desktop-libs] Error 2
```

This patch adds `cmsUNUSED_PARAMETER()` macros to suppress the warnings and fix the build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295779](https://bugs.openjdk.org/browse/JDK-8295779): Xcode 14.0 fails to build jdk on m1 macos


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10768/head:pull/10768` \
`$ git checkout pull/10768`

Update a local copy of the PR: \
`$ git checkout pull/10768` \
`$ git pull https://git.openjdk.org/jdk pull/10768/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10768`

View PR using the GUI difftool: \
`$ git pr show -t 10768`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10768.diff">https://git.openjdk.org/jdk/pull/10768.diff</a>

</details>
