### PR TITLE
8295413: com/sun/jdi/EATests.java fails with compiler flag -XX:+StressReflectiveCode

### DIFF
--- a/test/jdk/com/sun/jdi/EATests.java
+++ b/test/jdk/com/sun/jdi/EATests.java
@@ -764,6 +764,7 @@ abstract class EATestCaseBaseTarget extends EATestCaseBaseShared implements Runn
     public static final boolean EliminateAllocations = unbox(WB.getBooleanVMFlag("EliminateAllocations"), UseJVMCICompiler);
     public static final boolean DeoptimizeObjectsALot = WB.getBooleanVMFlag("DeoptimizeObjectsALot");
     public static final boolean ZGCIsSelected = GC.Z.isSelected();
+    public static final boolean StressReflectiveCode = unbox(WB.getBooleanVMFlag("StressReflectiveCode"), false);
 
     public String testMethodName;
     public int testMethodDepth;
@@ -885,7 +886,7 @@ abstract class EATestCaseBaseTarget extends EATestCaseBaseShared implements Runn
             Asserts.assertEQ(testMethodName, frames[stackTraceDepth].getMethodName(),
                     testCaseName + ": test method not found at depth " + testMethodDepth);
             // check if the frame is (not) deoptimized as expected
-            if (!DeoptimizeObjectsALot) {
+            if (!DeoptimizeObjectsALot && !StressReflectiveCode) {
                 if (testFrameShouldBeDeoptimized()) {
                     Asserts.assertTrue(WB.isFrameDeoptimized(testMethodDepth+1),
                             testCaseName + ": expected test method frame at depth " + testMethodDepth + " to be deoptimized");


### PR DESCRIPTION
With `StressReflectiveCode` C2 has inexact type information which can prevent ea
based optimizations (see `ConnectionGraph::add_call_node()`)

This pr changes the test jdk/com/sun/jdi/EATests.java to read the flag
`StressReflectiveCode`. If enabled it shall neither expect ea based optimizations
of allocations nor deoptimization of corresponding frames upon debugger access.

Tested on the standard platforms with fastdebug and release builds.

```
make test TEST=test/jdk/com/sun/jdi/EATests.java TEST_VM_OPTS="-XX:+IgnoreUnrecognizedVMOptions -XX:+StressReflectiveCode"
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295413](https://bugs.openjdk.org/browse/JDK-8295413): com/sun/jdi/EATests.java fails with compiler flag -XX:+StressReflectiveCode


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) ⚠️ Review applies to [9071e5b4](https://git.openjdk.org/jdk/pull/10769/files/9071e5b45aa797d5cbfd489e4df32157a1a8f027)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10769/head:pull/10769` \
`$ git checkout pull/10769`

Update a local copy of the PR: \
`$ git checkout pull/10769` \
`$ git pull https://git.openjdk.org/jdk pull/10769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10769`

View PR using the GUI difftool: \
`$ git pr show -t 10769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10769.diff">https://git.openjdk.org/jdk/pull/10769.diff</a>

</details>
