### PR TITLE
8295666: Linux x86 build fails after 8292591

### DIFF
--- a/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
+++ b/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
@@ -35,6 +35,8 @@
 #ifndef SYS_membarrier
   #if defined(AMD64)
   #define SYS_membarrier 324
+  #elif defined(X86)
+  #define SYS_membarrier 375
   #elif defined(PPC64)
   #define SYS_membarrier 365
   #elif defined(AARCH64)


### PR DESCRIPTION
I have got build failure similar to recent [Linux aarch64](https://github.com/openjdk/jdk/pull/10265) and [Linux Alpha Zero](https://github.com/openjdk/jdk/pull/10721) failures:

```
src/hotspot/os/linux/systemMemoryBarrier_linux.cpp:65:18: error: 'SYS_membarrier' was not declared in this scope
   return syscall(SYS_membarrier, cmd, flags, cpu_id); // cpu_id only on >= 5.10
                  ^~~~~~~~~~~~~~ 
```

The failure is known to be fixed by adding missing ` SYS_membarrier` definition. The raw constant 375 is taken from the `linux-libc-dev_6.0.2-1_i386.deb' cross-compilation headers:
```
/usr/include/i386-linux-gnu/asm/unistd_32.h:#define __NR_membarrier 375
/usr/include/i386-linux-gnu/bits/syscall.h:# define SYS_membarrier __NR_membarrier

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295666](https://bugs.openjdk.org/browse/JDK-8295666): Linux x86 build fails after 8292591


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10771/head:pull/10771` \
`$ git checkout pull/10771`

Update a local copy of the PR: \
`$ git checkout pull/10771` \
`$ git pull https://git.openjdk.org/jdk pull/10771/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10771`

View PR using the GUI difftool: \
`$ git pr show -t 10771`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10771.diff">https://git.openjdk.org/jdk/pull/10771.diff</a>

</details>
