### PR TITLE
8295375: debug agent class tracking should not piggy back on the cbClassPrepare() callback

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/classTrack.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/classTrack.c
@@ -46,20 +46,35 @@
  */
 static jvmtiEnv* trackingEnv;
 
+static void addPreparedClass(JNIEnv *env, jclass klass);
+
 /*
  * Invoke the callback when classes are freed.
  */
 void JNICALL
 cbTrackingObjectFree(jvmtiEnv* jvmti_env, jlong tag)
 {
+    JDI_ASSERT(jvmti_env == trackingEnv);
     eventHandler_synthesizeUnloadEvent((char*)jlong_to_ptr(tag), getEnv());
 }
 
-void
-classTrack_addPreparedClass(JNIEnv *env_unused, jclass klass)
+/*
+ * Invoke the callback when classes are prepared.
+ */
+void JNICALL
+cbTrackingClassPrepare(jvmtiEnv* jvmti_env, JNIEnv *env, jthread thread, jclass klass)
+{
+    JDI_ASSERT(jvmti_env == trackingEnv);
+    addPreparedClass(env, klass);
+}
+
+/*
+ * Add a class to the prepared class hash table.
+ */
+static void
+addPreparedClass(JNIEnv *env, jclass klass)
 {
     jvmtiError error;
-    jvmtiEnv* env = trackingEnv;
 
     char* signature;
     error = classSignature(klass, &signature, NULL);
@@ -70,7 +85,7 @@ classTrack_addPreparedClass(JNIEnv *env_unused, jclass klass)
     if (gdata && gdata->assertOn) {
         // Check if already tagged.
         jlong tag;
-        error = JVMTI_FUNC_PTR(trackingEnv, GetTag)(env, klass, &tag);
+        error = JVMTI_FUNC_PTR(trackingEnv, GetTag)(trackingEnv, klass, &tag);
         if (error != JVMTI_ERROR_NONE) {
             EXIT_ERROR(error, "Unable to GetTag with class trackingEnv");
         }
@@ -83,7 +98,7 @@ classTrack_addPreparedClass(JNIEnv *env_unused, jclass klass)
         }
     }
 
-    error = JVMTI_FUNC_PTR(trackingEnv, SetTag)(env, klass, ptr_to_jlong(signature));
+    error = JVMTI_FUNC_PTR(trackingEnv, SetTag)(trackingEnv, klass, ptr_to_jlong(signature));
     if (error != JVMTI_ERROR_NONE) {
         jvmtiDeallocate(signature);
         EXIT_ERROR(error,"SetTag");
@@ -102,15 +117,27 @@ setupEvents()
     }
     jvmtiEventCallbacks cb;
     memset(&cb, 0, sizeof(cb));
+
+    // Setup JVMTI callbacks
     cb.ObjectFree = cbTrackingObjectFree;
+    cb.ClassPrepare = cbTrackingClassPrepare;
     error = JVMTI_FUNC_PTR(trackingEnv, SetEventCallbacks)(trackingEnv, &cb, sizeof(cb));
     if (error != JVMTI_ERROR_NONE) {
         return JNI_FALSE;
     }
+
+    // Enable OBJECT_FREE events
     error = JVMTI_FUNC_PTR(trackingEnv, SetEventNotificationMode)(trackingEnv, JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, NULL);
     if (error != JVMTI_ERROR_NONE) {
         return JNI_FALSE;
     }
+
+    // Enable CLASS_PREPARE events
+    error = JVMTI_FUNC_PTR(trackingEnv, SetEventNotificationMode)(trackingEnv, JVMTI_ENABLE, JVMTI_EVENT_CLASS_PREPARE, NULL);
+    if (error != JVMTI_ERROR_NONE) {
+        return JNI_FALSE;
+    }
+
     return JNI_TRUE;
 }
 
@@ -143,7 +170,7 @@ classTrack_initialize(JNIEnv *env)
             jint wanted = JVMTI_CLASS_STATUS_PREPARED | JVMTI_CLASS_STATUS_ARRAY;
             status = classStatus(klass);
             if ((status & wanted) != 0) {
-                classTrack_addPreparedClass(env, klass);
+                addPreparedClass(env, klass);
             }
         }
         jvmtiDeallocate(classes);

--- a/src/jdk.jdwp.agent/share/native/libjdwp/classTrack.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/classTrack.h
@@ -34,12 +34,6 @@ struct bag *
 classTrack_processUnloads(JNIEnv *env);
 
 /*
- * Add a class to the prepared class hash table.
- */
-void
-classTrack_addPreparedClass(JNIEnv *env, jclass klass);
-
-/*
  * Initialize class tracking.
  */
 void

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.c
@@ -1265,7 +1265,6 @@ enableEvents(HandlerNode *node)
         case EI_THREAD_END:
         case EI_VM_INIT:
         case EI_VM_DEATH:
-        case EI_CLASS_PREPARE:
         case EI_GC_FINISH:
         case EI_VIRTUAL_THREAD_START:
         case EI_VIRTUAL_THREAD_END:
@@ -1326,7 +1325,6 @@ disableEvents(HandlerNode *node)
         case EI_THREAD_END:
         case EI_VM_INIT:
         case EI_VM_DEATH:
-        case EI_CLASS_PREPARE:
         case EI_GC_FINISH:
         case EI_VIRTUAL_THREAD_START:
         case EI_VIRTUAL_THREAD_END:

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
@@ -546,11 +546,6 @@ filterAndHandleEvent(JNIEnv *env, EventInfo *evinfo, EventIndex ei,
         HandlerNode *node;
         char        *classname;
 
-        /* We must keep track of all classes prepared to know what's unloaded */
-        if (evinfo->ei == EI_CLASS_PREPARE) {
-            classTrack_addPreparedClass(env, evinfo->clazz);
-        }
-
         node = getHandlerChain(ei)->first;
         classname = getClassname(evinfo->clazz);
 
@@ -1508,11 +1503,6 @@ eventHandler_initialize(jbyte sessionID)
                                        EI_THREAD_END, NULL);
     if (error != JVMTI_ERROR_NONE) {
         EXIT_ERROR(error,"Can't enable thread end events");
-    }
-    error = threadControl_setEventMode(JVMTI_ENABLE,
-                                       EI_CLASS_PREPARE, NULL);
-    if (error != JVMTI_ERROR_NONE) {
-        EXIT_ERROR(error,"Can't enable class prepare events");
     }
     error = threadControl_setEventMode(JVMTI_ENABLE,
                                        EI_GC_FINISH, NULL);


### PR DESCRIPTION
The debug agent needs to keep track of all loaded classes, and also be notified when they are unloaded. It tracks classes loading by getting CLASS_PREPARE events and it tracks their unloading by tagging them, which triggers OBJECT_FREE events when they are unloaded. The tagging and OBJECT_FREE events are handled by a separate JVMTIEnv from the one that does main event handling, mostly in support of the attached debugger. However, the CLASS_PREPARE events are piggy backed on the main event handler. As a result, we have this special check in filterAndHandleEvent():

        /* We must keep track of all classes prepared to know what's unloaded */
        if (evinfo->ei == EI_CLASS_PREPARE) {
            classTrack_addPreparedClass(env, evinfo->clazz);
        }

We also have to always keep CLASS_PREPARE events enabled on the main event handler, even if the debugger is not requesting them. The main event handler has a lot of overhead that isn't necessary when simply wanting to use the CLASS_PREPARE event for class tracking.

Another downside of this piggy backing is it causes problems for addressing [JDK-8295376](https://bugs.openjdk.org/browse/JDK-8295376), which is attempting to not track virtual threads when the debugger is not attached (no VIRTUAL_THREAD_START and VIRTUAL_THREAD_END events). The problem is when the debugger is not attached and a CLASS_PREPARE event comes in on a virtual thread, the debug agent unnecessarily creates a ThreadNode for it. Since there won't be a corresponding VIRTUAL_THREAD_END event when the virtual thread is destroyed (as long as the debugger is not attached), the debug agent ends up keeping this ThreadNode around even after the thread is gone. This usually eventually leads to an assert.

The fix for this is pretty simple. We already have the separate JVMTIEnv that the class tracker uses to handle OBJECT_FREE. This is easily purposed to also handle CLASS_PREPARE events. By doing so we can get rid of the special CLASS_PREPARE code above in filterAndHandleEvent(), and we also only need to enable CLASS_PREPARE events for the main event handler when a debugger is attached and is requesting them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295375](https://bugs.openjdk.org/browse/JDK-8295375): debug agent class tracking should not piggy back on the cbClassPrepare() callback


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10776/head:pull/10776` \
`$ git checkout pull/10776`

Update a local copy of the PR: \
`$ git checkout pull/10776` \
`$ git pull https://git.openjdk.org/jdk pull/10776/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10776`

View PR using the GUI difftool: \
`$ git pr show -t 10776`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10776.diff">https://git.openjdk.org/jdk/pull/10776.diff</a>

</details>
