### PR TITLE
8295703: RISC-V: Remove implicit noreg temp register arguments in MacroAssembler

### DIFF
--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -287,7 +287,7 @@ void InterpreterMacroAssembler::load_resolved_reference_at_index(
   // Add in the index
   addi(index, index, arrayOopDesc::base_offset_in_bytes(T_OBJECT) >> LogBytesPerHeapOop);
   shadd(result, index, result, index, LogBytesPerHeapOop);
-  load_heap_oop(result, Address(result, 0));
+  load_heap_oop(result, Address(result, 0), tmp, t1);
 }
 
 void InterpreterMacroAssembler::load_resolved_klass_at_offset(

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -206,12 +206,12 @@ class MacroAssembler: public Assembler {
   void decode_heap_oop(Register r) { decode_heap_oop(r, r); }
   void encode_heap_oop(Register d, Register s);
   void encode_heap_oop(Register r) { encode_heap_oop(r, r); };
-  void load_heap_oop(Register dst, Address src, Register tmp1 = noreg,
-                     Register tmp2 = noreg, DecoratorSet decorators = 0);
-  void load_heap_oop_not_null(Register dst, Address src, Register tmp1 = noreg,
-                              Register tmp2 = noreg, DecoratorSet decorators = 0);
-  void store_heap_oop(Address dst, Register val, Register tmp1 = noreg,
-                      Register tmp2 = noreg, Register tmp3 = noreg, DecoratorSet decorators = 0);
+  void load_heap_oop(Register dst, Address src, Register tmp1,
+                     Register tmp2, DecoratorSet decorators = 0);
+  void load_heap_oop_not_null(Register dst, Address src, Register tmp1,
+                              Register tmp2, DecoratorSet decorators = 0);
+  void store_heap_oop(Address dst, Register val, Register tmp1,
+                      Register tmp2, Register tmp3, DecoratorSet decorators = 0);
 
   void store_klass_gap(Register dst, Register src);
 

--- a/src/hotspot/cpu/riscv/methodHandles_riscv.cpp
+++ b/src/hotspot/cpu/riscv/methodHandles_riscv.cpp
@@ -136,11 +136,11 @@ void MethodHandles::jump_to_lambda_form(MacroAssembler* _masm,
 
   // Load the invoker, as MH -> MH.form -> LF.vmentry
   __ verify_oop(recv);
-  __ load_heap_oop(method_temp, Address(recv, NONZERO(java_lang_invoke_MethodHandle::form_offset())), temp2);
+  __ load_heap_oop(method_temp, Address(recv, NONZERO(java_lang_invoke_MethodHandle::form_offset())), temp2, t1);
   __ verify_oop(method_temp);
-  __ load_heap_oop(method_temp, Address(method_temp, NONZERO(java_lang_invoke_LambdaForm::vmentry_offset())), temp2);
+  __ load_heap_oop(method_temp, Address(method_temp, NONZERO(java_lang_invoke_LambdaForm::vmentry_offset())), temp2, t1);
   __ verify_oop(method_temp);
-  __ load_heap_oop(method_temp, Address(method_temp, NONZERO(java_lang_invoke_MemberName::method_offset())), temp2);
+  __ load_heap_oop(method_temp, Address(method_temp, NONZERO(java_lang_invoke_MemberName::method_offset())), temp2, t1);
   __ verify_oop(method_temp);
   __ access_load_at(T_ADDRESS, IN_HEAP, method_temp, Address(method_temp, NONZERO(java_lang_invoke_ResolvedMethodName::vmtarget_offset())), noreg, noreg);
 
@@ -321,7 +321,7 @@ void MethodHandles::generate_method_handle_dispatch(MacroAssembler* _masm,
       if (VerifyMethodHandles && iid != vmIntrinsics::_linkToInterface) {
         Label L_ok;
         Register temp2_defc = temp2;
-        __ load_heap_oop(temp2_defc, member_clazz, temp3);
+        __ load_heap_oop(temp2_defc, member_clazz, temp3, t1);
         load_klass_from_Class(_masm, temp2_defc);
         __ verify_klass_ptr(temp2_defc);
         __ check_klass_subtype(temp1_recv_klass, temp2_defc, temp3, L_ok);
@@ -348,7 +348,7 @@ void MethodHandles::generate_method_handle_dispatch(MacroAssembler* _masm,
         if (VerifyMethodHandles) {
           verify_ref_kind(_masm, JVM_REF_invokeSpecial, member_reg, temp3);
         }
-        __ load_heap_oop(xmethod, member_vmtarget);
+        __ load_heap_oop(xmethod, member_vmtarget, temp3, t1);
         __ access_load_at(T_ADDRESS, IN_HEAP, xmethod, vmtarget_method, noreg, noreg);
         break;
 
@@ -356,7 +356,7 @@ void MethodHandles::generate_method_handle_dispatch(MacroAssembler* _masm,
         if (VerifyMethodHandles) {
           verify_ref_kind(_masm, JVM_REF_invokeStatic, member_reg, temp3);
         }
-        __ load_heap_oop(xmethod, member_vmtarget);
+        __ load_heap_oop(xmethod, member_vmtarget, temp3, t1);
         __ access_load_at(T_ADDRESS, IN_HEAP, xmethod, vmtarget_method, noreg, noreg);
         break;
 
@@ -397,7 +397,7 @@ void MethodHandles::generate_method_handle_dispatch(MacroAssembler* _masm,
         }
 
         Register temp3_intf = temp3;
-        __ load_heap_oop(temp3_intf, member_clazz);
+        __ load_heap_oop(temp3_intf, member_clazz, temp2, t1);
         load_klass_from_Class(_masm, temp3_intf);
         __ verify_klass_ptr(temp3_intf);
 


### PR DESCRIPTION
This is similar to: https://bugs.openjdk.org/browse/JDK-8295257

Remove implicit `= noreg` temporary register arguments for the three methods that still have them.
  * `load_heap_oop`
  * `store_heap_oop`
  * `load_heap_oop_not_null`

Only `load_heap_oop` is used with the implicit `= noreg` arguments.
After [JDK-8293769](https://bugs.openjdk.org/browse/JDK-8293769), the GCs only use explicitly passed in registers. This will also be the case for generational ZGC. Where it currently requires `load_heap_oop` to provide a second temporary register.

Testing: Tier1 hotspot with fastdebug build on HiFive Unmatched board.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295703](https://bugs.openjdk.org/browse/JDK-8295703): RISC-V: Remove implicit noreg temp register arguments in MacroAssembler


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10778/head:pull/10778` \
`$ git checkout pull/10778`

Update a local copy of the PR: \
`$ git checkout pull/10778` \
`$ git pull https://git.openjdk.org/jdk pull/10778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10778`

View PR using the GUI difftool: \
`$ git pr show -t 10778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10778.diff">https://git.openjdk.org/jdk/pull/10778.diff</a>

</details>
