### PR TITLE
8295709: Linux AArch64 builds broken after JDK-8294438

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -137,7 +137,7 @@ void Address::lea(MacroAssembler *as, Register r) const {
       __ add(r, _base, _offset);
     else
       __ sub(r, _base, -_offset);
-      break;
+    break;
   }
   case base_plus_offset_reg: {
     __ add(r, _base, _index, _ext.op(), MAX2(_ext.shift(), 0));


### PR DESCRIPTION
Currently fails with:

 ```
* For target hotspot_variant-server_libjvm_objs_assembler_aarch64.o:
/home/shade/trunks/jdk/src/hotspot/cpu/aarch64/assembler_aarch64.cpp: In member function 'void Address::lea(MacroAssembler*, Register) const':
/home/shade/trunks/jdk/src/hotspot/cpu/aarch64/assembler_aarch64.cpp:138:5: error: this 'else' clause does not guard... [-Werror=misleading-indentation]
  138 | else
      | ^~~~
/home/shade/trunks/jdk/src/hotspot/cpu/aarch64/assembler_aarch64.cpp:140:7: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'else'
  140 | break;
      | ^~~~~
cc1plus: all warnings being treated as errors
``` 