### PR TITLE
8295711: Rename ZBarrierSetAssembler::load_at parameter name from "tmp_thread" to "tmp2"

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
@@ -57,10 +57,10 @@ void ZBarrierSetAssembler::load_at(MacroAssembler* masm,
                                    Register dst,
                                    Address src,
                                    Register tmp1,
-                                   Register tmp_thread) {
+                                   Register tmp2) {
   if (!ZBarrierSet::barrier_needed(decorators, type)) {
     // Barrier not needed
-    BarrierSetAssembler::load_at(masm, decorators, type, dst, src, tmp1, tmp_thread);
+    BarrierSetAssembler::load_at(masm, decorators, type, dst, src, tmp1, tmp2);
     return;
   }
 

--- a/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.hpp
@@ -50,7 +50,7 @@ public:
                        Register dst,
                        Address src,
                        Register tmp1,
-                       Register tmp_thread);
+                       Register tmp2);
 
 #ifdef ASSERT
   virtual void store_at(MacroAssembler* masm,

--- a/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.cpp
@@ -59,10 +59,10 @@ void ZBarrierSetAssembler::load_at(MacroAssembler* masm,
                                    Register dst,
                                    Address src,
                                    Register tmp1,
-                                   Register tmp_thread) {
+                                   Register tmp2) {
   if (!ZBarrierSet::barrier_needed(decorators, type)) {
     // Barrier not needed
-    BarrierSetAssembler::load_at(masm, decorators, type, dst, src, tmp1, tmp_thread);
+    BarrierSetAssembler::load_at(masm, decorators, type, dst, src, tmp1, tmp2);
     return;
   }
 

--- a/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.hpp
@@ -52,7 +52,7 @@ public:
                        Register dst,
                        Address src,
                        Register tmp1,
-                       Register tmp_thread);
+                       Register tmp2);
 
 #ifdef ASSERT
   virtual void store_at(MacroAssembler* masm,


### PR DESCRIPTION
This is a trivial change renaming a formal parameter for ZBarrierSetAssembler::load_at.

On AArch64 and RISC-V, the last formal parameter for ZBarrierSetAssembler::load_at
is named "tmp_thread". But the callers will pass an ordinary temporary register for
this parameter which has no relation with the thread register. We should rename this
formal parameter from "tmp_thread" to "tmp2".

Testing: fastdebug builds on linux-aarch64 & linux-riscv64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295711](https://bugs.openjdk.org/browse/JDK-8295711): Rename ZBarrierSetAssembler::load_at parameter name from "tmp_thread" to "tmp2"


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author)
 * [Hao Sun](https://openjdk.org/census#haosun) (@shqking - Author)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10783/head:pull/10783` \
`$ git checkout pull/10783`

Update a local copy of the PR: \
`$ git checkout pull/10783` \
`$ git pull https://git.openjdk.org/jdk pull/10783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10783`

View PR using the GUI difftool: \
`$ git pr show -t 10783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10783.diff">https://git.openjdk.org/jdk/pull/10783.diff</a>

</details>
