### PR TITLE
8295707: Create a regression test for JDK-7184401

### DIFF
--- a/test/jdk/java/awt/EventDispatchThread/InterruptEDTTest.java
+++ b/test/jdk/java/awt/EventDispatchThread/InterruptEDTTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+/*
+ * @test
+ * @key headful
+ * @bug 7184401
+ * @summary Verify that events are not lost when EDT is interrupted.
+ * @modules java.desktop/sun.awt
+ * @run main InterruptEDTTest
+ */
+
+public class InterruptEDTTest {
+
+    static Frame frame = null;
+    static Thread edt = null;
+    static volatile Robot robot = null;
+
+    public static void main(String args[]) throws Exception {
+        try {
+            robot = new Robot();
+            EventQueue.invokeAndWait(() -> {
+                edt = Thread.currentThread();
+                frame = new Frame("Frame");
+                frame.addMouseListener(new MouseAdapter() {
+                    public void mouseClicked(MouseEvent me) {
+                        System.out.println("Mouse clicked Event: " + me);
+                    }
+                });
+                frame.setBounds(350, 50, 300, 300);
+                frame.setVisible(true);
+            });
+        } catch (InterruptedException iex) {
+        } catch (Exception exx) {
+            exx.printStackTrace();
+        }
+        ((sun.awt.SunToolkit) (Toolkit.getDefaultToolkit())).realSync();
+        try {
+            EventQueue.invokeLater(() -> {
+                robot.mouseMove(frame.getX() + frame.getWidth() / 2,
+                    frame.getY() + frame.getHeight() / 2);
+                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            });
+        } catch (Exception exx) {
+            exx.printStackTrace();
+        }
+        edt.interrupt();
+        ((sun.awt.SunToolkit) (Toolkit.getDefaultToolkit())).realSync();
+        try {
+            EventQueue.invokeLater(() -> {
+                robot.mouseMove(frame.getX() + frame.getWidth() / 3,
+                    frame.getY() + frame.getHeight() / 3);
+            });
+        } catch (Exception exx) {
+            exx.printStackTrace();
+        }
+        System.out.println("Test passed.");
+        EventQueue.invokeAndWait(() -> disposeFrame());
+    }
+
+    private static void disposeFrame() {
+        if (frame != null) {
+            frame.dispose();
+            frame = null;
+        }
+    }
+}
+

--- a/test/jdk/java/awt/EventDispatchThread/InterruptEDTTest.java
+++ b/test/jdk/java/awt/EventDispatchThread/InterruptEDTTest.java
@@ -83,12 +83,6 @@ public class InterruptEDTTest {
         edt.interrupt();
         ((sun.awt.SunToolkit) (Toolkit.getDefaultToolkit())).realSync();
         try {
-            EventQueue.invokeAndWait(() -> {
-                xLocation = frame.getX();
-                yLocation = frame.getY();
-                width = frame.getWidth();
-                height = frame.getHeight();
-            });
             robot.mouseMove(xLocation + width / 3, yLocation + height / 3);
         } catch (Exception exx) {
             exx.printStackTrace();

--- a/test/jdk/java/awt/EventDispatchThread/InterruptEDTTest.java
+++ b/test/jdk/java/awt/EventDispatchThread/InterruptEDTTest.java
@@ -40,9 +40,13 @@ import java.awt.event.MouseEvent;
 
 public class InterruptEDTTest {
 
-    static Frame frame = null;
-    static Thread edt = null;
-    static volatile Robot robot = null;
+    private static Frame frame = null;
+    private static volatile Thread edt = null;
+    private static volatile Robot robot = null;
+    private static volatile int xLocation;
+    private static volatile int yLocation;
+    private static volatile int width;
+    private static volatile int height;
 
     public static void main(String args[]) throws Exception {
         try {
@@ -55,31 +59,37 @@ public class InterruptEDTTest {
                         System.out.println("Mouse clicked Event: " + me);
                     }
                 });
-                frame.setBounds(350, 50, 300, 300);
+                frame.setBounds(350, 50, 400, 400);
+                frame.setLocationRelativeTo(null);
                 frame.setVisible(true);
             });
-        } catch (InterruptedException iex) {
-        } catch (Exception exx) {
-            exx.printStackTrace();
-        }
-        ((sun.awt.SunToolkit) (Toolkit.getDefaultToolkit())).realSync();
-        try {
+            ((sun.awt.SunToolkit) (Toolkit.getDefaultToolkit())).realSync();
+            EventQueue.invokeAndWait(() -> {
+                xLocation = frame.getX();
+                yLocation = frame.getY();
+                width = frame.getWidth();
+                height = frame.getHeight();
+            });
+            ((sun.awt.SunToolkit) (Toolkit.getDefaultToolkit())).realSync();
             EventQueue.invokeLater(() -> {
-                robot.mouseMove(frame.getX() + frame.getWidth() / 2,
-                    frame.getY() + frame.getHeight() / 2);
+                robot.mouseMove(xLocation + width / 2, yLocation + height / 2);
                 robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
                 robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             });
-        } catch (Exception exx) {
-            exx.printStackTrace();
+        } catch (Exception e) {
+            e.printStackTrace();
         }
+
         edt.interrupt();
         ((sun.awt.SunToolkit) (Toolkit.getDefaultToolkit())).realSync();
         try {
-            EventQueue.invokeLater(() -> {
-                robot.mouseMove(frame.getX() + frame.getWidth() / 3,
-                    frame.getY() + frame.getHeight() / 3);
+            EventQueue.invokeAndWait(() -> {
+                xLocation = frame.getX();
+                yLocation = frame.getY();
+                width = frame.getWidth();
+                height = frame.getHeight();
             });
+            robot.mouseMove(xLocation + width / 3, yLocation + height / 3);
         } catch (Exception exx) {
             exx.printStackTrace();
         }


### PR DESCRIPTION
8295707: Create a regression test for JDK-7184401

JDK-7184401 - JDk7u6 : Missing main menu bar in Netbeans after fix for 7162144
Above bug got introduced due to a fix for [JDK-7162144](https://bugs.openjdk.java.net/browse/JDK-7162144). 
The issue was observed on the netbeans UI. 
The test below recreates a standalone test to mimic the failure reported in Netbeans in [JDK-7184401](https://bugs.openjdk.java.net/browse/JDK-7184401) and verifies that it is working as expected after it got fixed via [JDK-7189350](https://bugs.openjdk.java.net/browse/JDK-7189350))

The Test attempts to reproduce specific behavior of NetBeans at the certain toolbar creation stage. Widgets are created on EDT; Another code posts some events to them on EDT; From another thread some code calls explicitly edt.interrupt().
Before this got fixed, events from a second code got lost.

This review is for migrating tests from a closed test suite to open.
Testing:
1.Tested the code on jdk7u6 to reproduce the issue - the UI hangs when run on this build.
2. Tested the code on jdk7u361 b01 to validate the fix - the test passed.
3.Mach5 Testing(40 times per platform) in macos x64, linux x64 and windows x64 - the .results are clean


<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295707](https://bugs.openjdk.org/browse/JDK-8295707): Create a regression test for JDK-7184401


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10784/head:pull/10784` \
`$ git checkout pull/10784`

Update a local copy of the PR: \
`$ git checkout pull/10784` \
`$ git pull https://git.openjdk.org/jdk pull/10784/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10784`

View PR using the GUI difftool: \
`$ git pr show -t 10784`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10784.diff">https://git.openjdk.org/jdk/pull/10784.diff</a>

</details>
