### PR TITLE
8295714: GHA ::set-output is deprecated and will be removed

### DIFF
--- a/.github/actions/config/action.yml
+++ b/.github/actions/config/action.yml
@@ -42,5 +42,5 @@ runs:
       run: |
         # Extract value from configuration file
         value="$(grep -h ${{ inputs.var }}= make/conf/github-actions.conf | cut -d '=' -f 2-)"
-        echo "::set-output name=value::$value"
+        echo "value=$value" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/do-build/action.yml
+++ b/.github/actions/do-build/action.yml
@@ -61,7 +61,7 @@ runs:
               $build_dir/make-support/failure-summary.log \
               $build_dir/make-support/failure-logs/* \
               failure-logs/ 2> /dev/null || true
-          echo '::set-output name=failure::true'
+          echo 'failure=true' >> $GITHUB_OUTPUT
         fi
       shell: bash
 

--- a/.github/actions/get-bootjdk/action.yml
+++ b/.github/actions/get-bootjdk/action.yml
@@ -42,7 +42,7 @@ runs:
       run: |
         # Convert platform name to upper case
         platform_prefix="$(echo ${{ inputs.platform }} | tr [a-z-] [A-Z_])"
-        echo "::set-output name=value::$platform_prefix"
+        echo "value=$platform_prefix" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: 'Get URL configuration'
@@ -105,5 +105,5 @@ runs:
       id: path-name
       run: |
         # Export the path
-        echo '::set-output name=path::bootjdk/jdk'
+        echo 'path=bootjdk/jdk' >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/get-bundles/action.yml
+++ b/.github/actions/get-bundles/action.yml
@@ -103,7 +103,7 @@ runs:
           tests_dir="$(cygpath $tests_dir)"
         fi
 
-        echo "::set-output name=jdk::$jdk_dir"
-        echo "::set-output name=symbols::$symbols_dir"
-        echo "::set-output name=tests::$tests_dir"
+        echo "jdk=$jdk_dir" >> $GITHUB_OUTPUT
+        echo "symbols=$symbols_dir" >> $GITHUB_OUTPUT
+        echo "tests=$tests_dir" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/get-bundles/action.yml
+++ b/.github/actions/get-bundles/action.yml
@@ -48,14 +48,14 @@ runs:
   steps:
     - name: 'Download bundles artifact'
       id: download-bundles
-      uses: actions/download-artifact@v3.0.1
+      uses: actions/download-artifact@v3
       with:
         name: bundles-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: bundles
       continue-on-error: true
 
     - name: 'Download bundles artifact (retry)'
-      uses: actions/download-artifact@v3.0.1
+      uses: actions/download-artifact@v3
       with:
         name: bundles-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: bundles

--- a/.github/actions/get-bundles/action.yml
+++ b/.github/actions/get-bundles/action.yml
@@ -48,14 +48,14 @@ runs:
   steps:
     - name: 'Download bundles artifact'
       id: download-bundles
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v3.0.1
       with:
         name: bundles-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: bundles
       continue-on-error: true
 
     - name: 'Download bundles artifact (retry)'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v3.0.1
       with:
         name: bundles-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: bundles

--- a/.github/actions/get-gtest/action.yml
+++ b/.github/actions/get-gtest/action.yml
@@ -50,5 +50,5 @@ runs:
       id: path-name
       run: |
         # Export the path
-        echo '::set-output name=path::gtest'
+        echo 'path=gtest' >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/get-jtreg/action.yml
+++ b/.github/actions/get-jtreg/action.yml
@@ -68,5 +68,5 @@ runs:
       id: path-name
       run: |
         # Export the path
-        echo '::set-output name=path::jtreg/installed'
+        echo 'path=jtreg/installed' >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/upload-bundles/action.yml
+++ b/.github/actions/upload-bundles/action.yml
@@ -62,9 +62,9 @@ runs:
         fi
 
         if [[ "$jdk_bundle_zip$jdk_bundle_tar_gz$symbols_bundle$tests_bundle" != "" ]]; then
-          echo '::set-output name=bundles-found::true'
+          echo 'bundles-found=true' >> $GITHUB_OUTPUT
         else
-          echo '::set-output name=bundles-found::false'
+          echo 'bundles-found=false' >> $GITHUB_OUTPUT
         fi
       shell: bash
 

--- a/.github/scripts/gen-test-summary.sh
+++ b/.github/scripts/gen-test-summary.sh
@@ -25,6 +25,7 @@
 #
 
 GITHUB_STEP_SUMMARY="$1"
+GITHUB_OUTPUT="$2"
 
 test_suite_name=$(cat build/run-test-prebuilt/test-support/test-last-ids.txt)
 results_dir=build/run-test-prebuilt/test-results/$test_suite_name/text
@@ -41,12 +42,12 @@ error_count=$(echo $errors | wc -w || true)
 
 if [[ "$failures" = "" && "$errors" = "" ]]; then
   # We know something went wrong, but not what
-  echo '::set-output name=error-message::Unspecified test suite failure. Please see log for job for details.'
+  echo 'error-message=Unspecified test suite failure. Please see log for job for details.' >> $GITHUB_OUTPUT
   exit 0
 fi
 
-echo '::set-output name=failure::true'
-echo "::set-output name=error-message::Test run reported $failure_count test failure(s) and $error_count error(s). See summary for details."
+echo 'failure=true' >> $GITHUB_OUTPUT
+echo "error-message=Test run reported $failure_count test failure(s) and $error_count error(s). See summary for details." >> $GITHUB_OUTPUT
 
 echo '### :boom: Test failures summary' >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           # Set a proper suffix for packages if using a different architecture
           if [[ '${{ inputs.apt-architecture }}' != '' ]]; then
-            echo '::set-output name=suffix:::${{ inputs.apt-architecture }}'
+            echo 'suffix=:${{ inputs.apt-architecture }}' >> $GITHUB_OUTPUT
           fi
 
       # Upgrading apt to solve libc6 installation bugs, see JDK-8260460.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,14 +110,14 @@ jobs:
             echo 'false'
           }
 
-          echo "::set-output name=linux-x64::$(check_platform linux-x64 linux x64)"
-          echo "::set-output name=linux-x86::$(check_platform linux-x86 linux x86)"
-          echo "::set-output name=linux-x64-variants::$(check_platform linux-x64-variants variants)"
-          echo "::set-output name=linux-cross-compile::$(check_platform linux-cross-compile cross-compile)"
-          echo "::set-output name=macos-x64::$(check_platform macos-x64 macos x64)"
-          echo "::set-output name=macos-aarch64::$(check_platform macos-aarch64 macos aarch64)"
-          echo "::set-output name=windows-x64::$(check_platform windows-x64 windows x64)"
-          echo "::set-output name=windows-aarch64::$(check_platform windows-aarch64 windows aarch64)"
+          echo "linux-x64=$(check_platform linux-x64 linux x64)" >> $GITHUB_OUTPUT
+          echo "linux-x86=$(check_platform linux-x86 linux x86)" >> $GITHUB_OUTPUT
+          echo "linux-x64-variants=$(check_platform linux-x64-variants variants)" >> $GITHUB_OUTPUT
+          echo "linux-cross-compile=$(check_platform linux-cross-compile cross-compile)" >> $GITHUB_OUTPUT
+          echo "macos-x64=$(check_platform macos-x64 macos x64)" >> $GITHUB_OUTPUT
+          echo "macos-aarch64=$(check_platform macos-aarch64 macos aarch64)" >> $GITHUB_OUTPUT
+          echo "windows-x64=$(check_platform windows-x64 windows x64)" >> $GITHUB_OUTPUT
+          echo "windows-aarch64=$(check_platform windows-aarch64 windows aarch64)" >> $GITHUB_OUTPUT
 
   ###
   ### Build jobs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,9 +138,9 @@ jobs:
           # We need a minimal PATH on Windows
           # Set PATH to "", so just GITHUB_PATH is included
           if [[ '${{ runner.os }}' == 'Windows' ]]; then
-            echo "::set-output name=value::"
+            echo "value=" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=value::$PATH"
+            echo "value=$PATH" >> $GITHUB_OUTPUT
           fi
 
       - name: 'Run tests'
@@ -154,7 +154,7 @@ jobs:
           SYMBOLS_IMAGE_DIR=${{ steps.bundles.outputs.symbols-path }}
           TEST_IMAGE_DIR=${{ steps.bundles.outputs.tests-path }}
           JTREG='JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash;VERBOSE=fail,error,time;KEYWORDS=!headful'
-          && bash ./.github/scripts/gen-test-summary.sh "$GITHUB_STEP_SUMMARY"
+          && bash ./.github/scripts/gen-test-summary.sh "$GITHUB_STEP_SUMMARY" "$GITHUB_OUTPUT"
         env:
           PATH: ${{ steps.path.outputs.value }}
 
@@ -187,7 +187,7 @@ jobs:
           fi
 
           artifact_name="results-${{ inputs.platform }}-$(echo ${{ matrix.test-name }} | tr '/ ' '__')"
-          echo "::set-output name=artifact-name::$artifact_name"
+          echo "artifact-name=$artifact_name" >> $GITHUB_OUTPUT
         if: always()
 
       - name: 'Upload test results'


### PR DESCRIPTION
We need to transition to use the new `$GITHUB_OUTPUT` method instead. 

This needs to be fixed since it is currently spamming the summary with warnings, and will stop working soon.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295714](https://bugs.openjdk.org/browse/JDK-8295714): GHA ::set-output is deprecated and will be removed


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [9d51fadf](https://git.openjdk.org/jdk/pull/10785/files/9d51fadf2f3f4f4d1346ce703dafd59acf128849)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10785/head:pull/10785` \
`$ git checkout pull/10785`

Update a local copy of the PR: \
`$ git checkout pull/10785` \
`$ git pull https://git.openjdk.org/jdk pull/10785/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10785`

View PR using the GUI difftool: \
`$ git pr show -t 10785`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10785.diff">https://git.openjdk.org/jdk/pull/10785.diff</a>

</details>
