### PR TITLE
8295716: Minimize disabled warnings in security libs

### DIFF
--- a/make/modules/java.security.jgss/Lib.gmk
+++ b/make/modules/java.security.jgss/Lib.gmk
@@ -32,7 +32,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJ2GSS, \
     OPTIMIZATION := LOW, \
     CFLAGS := $(CFLAGS_JDKLIB), \
     DISABLED_WARNINGS_gcc := undef, \
-    DISABLED_WARNINGS_clang := undef, \
     LDFLAGS := $(LDFLAGS_JDKLIB) \
         $(call SET_SHARED_LIBRARY_ORIGIN), \
     LIBS := $(LIBDL), \
@@ -80,7 +79,7 @@ ifneq ($(BUILD_CRYPTO), false)
         NAME := osxkrb5, \
         OPTIMIZATION := LOW, \
         CFLAGS := $(CFLAGS_JDKLIB), \
-        DISABLED_WARNINGS_clang := deprecated-declarations, \
+        DISABLED_WARNINGS_clang_nativeccache.c := deprecated-declarations, \
         LDFLAGS := $(LDFLAGS_JDKLIB) \
             $(call SET_SHARED_LIBRARY_ORIGIN), \
         LIBS := -framework Cocoa -framework SystemConfiguration \

--- a/make/modules/jdk.crypto.cryptoki/Lib.gmk
+++ b/make/modules/jdk.crypto.cryptoki/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJ2PKCS11, \
     NAME := j2pkcs11, \
     OPTIMIZATION := LOW, \
     CFLAGS := $(CFLAGS_JDKLIB), \
-    DISABLED_WARNINGS_clang := format-nonliteral, \
+    DISABLED_WARNINGS_clang_p11_util.c := format-nonliteral, \
     LDFLAGS := $(LDFLAGS_JDKLIB) \
         $(call SET_SHARED_LIBRARY_ORIGIN), \
     LIBS_unix := $(LIBDL), \


### PR DESCRIPTION
After JDK-8294281, it is now possible to disable warnings for individual files instead for whole libraries. I used this opportunity to go through all disabled warnings in the security native libraries.

Any warnings that were only triggered in a few files were removed from the library as a whole, and changed to be only disabled for those files.

Some warnings didn't trigger in any file anymore, and could just be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295716](https://bugs.openjdk.org/browse/JDK-8295716): Minimize disabled warnings in security libs


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10787/head:pull/10787` \
`$ git checkout pull/10787`

Update a local copy of the PR: \
`$ git checkout pull/10787` \
`$ git pull https://git.openjdk.org/jdk pull/10787/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10787`

View PR using the GUI difftool: \
`$ git pr show -t 10787`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10787.diff">https://git.openjdk.org/jdk/pull/10787.diff</a>

</details>
