### PR TITLE
8295717: Minimize disabled warnings in accessibility native code

### DIFF
--- a/make/modules/jdk.accessibility/Launcher.gmk
+++ b/make/modules/jdk.accessibility/Launcher.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ ifeq ($(call isTargetOs, windows), true)
       CFLAGS := $(filter-out -Zc:wchar_t-, $(CFLAGS_JDKEXE)) -Zc:wchar_t \
           -analyze- -Od -Gd -D_WINDOWS \
           -D_UNICODE -DUNICODE -RTC1 -EHsc, \
-      DISABLED_WARNINGS_microsoft := 4267 4996, \
+      DISABLED_WARNINGS_microsoft_jabswitch.cpp := 4267 4996, \
       LDFLAGS := $(LDFLAGS_JDKEXE), \
       LIBS := advapi32.lib version.lib user32.lib, \
       VERSIONINFO_RESOURCE := $(ACCESSIBILITY_SRCDIR)/common/AccessBridgeStatusWindow.rc, \

--- a/make/modules/jdk.accessibility/Lib.gmk
+++ b/make/modules/jdk.accessibility/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ ifeq ($(call isTargetOs, windows), true)
         SRC := libwindowsaccessbridge, \
         EXTRA_SRC := common, \
         OPTIMIZATION := LOW, \
-        DISABLED_WARNINGS_microsoft := 4311 4302 4312, \
+        DISABLED_WARNINGS_microsoft_WinAccessBridge.cpp := 4302 4311, \
         CFLAGS := $(CFLAGS_JDKLIB) \
             -DACCESSBRIDGE_ARCH_$2, \
         EXTRA_HEADER_DIRS := \


### PR DESCRIPTION
After JDK-8294281, it is now possible to disable warnings for individual files instead for whole libraries. I used this opportunity to go through all disabled warnings in the accessibility native code.

Any warnings that were only triggered in a few files were removed from the library as a whole, and changed to be only disabled for those files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295717](https://bugs.openjdk.org/browse/JDK-8295717): Minimize disabled warnings in accessibility native code


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10788/head:pull/10788` \
`$ git checkout pull/10788`

Update a local copy of the PR: \
`$ git checkout pull/10788` \
`$ git pull https://git.openjdk.org/jdk pull/10788/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10788`

View PR using the GUI difftool: \
`$ git pr show -t 10788`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10788.diff">https://git.openjdk.org/jdk/pull/10788.diff</a>

</details>
