### PR TITLE
8295719: Remove unneeded disabled warnings in jdk.sctp

### DIFF
--- a/make/modules/jdk.sctp/Lib.gmk
+++ b/make/modules/jdk.sctp/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -34,8 +34,6 @@ ifeq ($(call isTargetOsType, unix), true)
         NAME := sctp, \
         OPTIMIZATION := LOW, \
         CFLAGS := $(CFLAGS_JDKLIB), \
-        DISABLED_WARNINGS_gcc := undef, \
-        DISABLED_WARNINGS_clang := undef, \
         EXTRA_HEADER_DIRS := \
             $(call GetJavaHeaderDir, java.base) \
             java.base:libnet \


### PR DESCRIPTION
In `libsctp`, there are a couple of `DISABLED_WARNINGS` that are no longer needed to build successfully. These should be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295719](https://bugs.openjdk.org/browse/JDK-8295719): Remove unneeded disabled warnings in jdk.sctp


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10789/head:pull/10789` \
`$ git checkout pull/10789`

Update a local copy of the PR: \
`$ git checkout pull/10789` \
`$ git pull https://git.openjdk.org/jdk pull/10789/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10789`

View PR using the GUI difftool: \
`$ git pr show -t 10789`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10789.diff">https://git.openjdk.org/jdk/pull/10789.diff</a>

</details>
