### PR TITLE
8295447: NullPointerException with invalid pattern matching construct in constructor call

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4119,6 +4119,10 @@ public class Attr extends JCTree.Visitor {
                                          Type exprType,
                                          Type pattType) {
         Warner warner = new Warner();
+        // if any type is erroneous, the problem is reported elsewhere
+        if (exprType.isErroneous() || pattType.isErroneous()) {
+            return false;
+        }
         if (!types.isCastable(exprType, pattType, warner)) {
             chk.basicHandler.report(pos,
                     diags.fragment(Fragments.InconvertibleTypes(exprType, pattType)));
@@ -4180,7 +4184,7 @@ public class Attr extends JCTree.Visitor {
             tree.record = record;
         } else {
             log.error(tree.pos(), Errors.DeconstructionPatternOnlyRecords(site.tsym));
-            expectedRecordTypes = Stream.generate(() -> Type.noType)
+            expectedRecordTypes = Stream.generate(() -> types.createErrorType(tree.type))
                                 .limit(tree.nested.size())
                                 .collect(List.collector());
         }

--- a/test/langtools/tools/javac/T8295447.java
+++ b/test/langtools/tools/javac/T8295447.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/**
+ * @test
+ * @bug 8295447
+ * @summary NullPointerException with invalid pattern matching construct in constructor call
+ * @modules jdk.compiler
+ * @compile/fail/ref=T8295447.out -XDrawDiagnostics --enable-preview -source ${jdk.version} T8295447.java
+ */
+public class T8295447 {
+    class Foo {
+        void m(Object o) {
+            if(o instanceof Foo(int x)) {}
+        }
+
+        Foo(Object o) {
+            m((o instanceof Foo(int x))? 0 : 1);
+        }
+        void m(int i) { }
+    }
+
+    class Base { int i; Base(int j) { i = j; } }
+    class Sub extends Base {
+        Sub(Object o) { super(o instanceof java.awt.Point(int x, int y)? x + y: 0); }
+    }
+}

--- a/test/langtools/tools/javac/T8295447.out
+++ b/test/langtools/tools/javac/T8295447.out
@@ -1,0 +1,6 @@
+T8295447.java:33:29: compiler.err.deconstruction.pattern.only.records: T8295447.Foo
+T8295447.java:37:29: compiler.err.deconstruction.pattern.only.records: T8295447.Foo
+T8295447.java:44:44: compiler.err.deconstruction.pattern.only.records: java.awt.Point
+- compiler.note.preview.filename: T8295447.java, DEFAULT
+- compiler.note.preview.recompile
+3 errors


### PR DESCRIPTION
In the examples below:

```
int i = (o instanceof Bar(int x))? 0 : 1;
meth(i);
```

```
meth((o instanceof Bar(int x))? 0 : 1);
```

the error `DeconstructionPatternOnlyRecords` was reported only on the first case but the compiler was still crashing in both occasions. `NoType` was passed and `checkCastablePattern` was letting an erroneous type to pass through the subtyping checks. The proposed fix addresses that in `checkCastablePattern`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295447](https://bugs.openjdk.org/browse/JDK-8295447): NullPointerException with invalid pattern matching construct in constructor call


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10791/head:pull/10791` \
`$ git checkout pull/10791`

Update a local copy of the PR: \
`$ git checkout pull/10791` \
`$ git pull https://git.openjdk.org/jdk pull/10791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10791`

View PR using the GUI difftool: \
`$ git pr show -t 10791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10791.diff">https://git.openjdk.org/jdk/pull/10791.diff</a>

</details>
