### PR TITLE
8295276: AArch64: Add backend support for half float conversion intrinsics

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -14578,6 +14578,32 @@ instruct convF2L_reg_reg(iRegLNoSp dst, vRegF src) %{
   ins_pipe(fp_f2l);
 %}
 
+instruct convF2HF_reg_reg(iRegINoSp dst, vRegF src, vRegF tmp) %{
+  match(Set dst (ConvF2HF src));
+  format %{ "fcvt $tmp, $src\t# convert single to half precision\n\t"
+            "smov $dst, $tmp\t# move result from $tmp to $dst"
+  %}
+  effect(TEMP tmp);
+  ins_encode %{
+      __ fcvtsh($tmp$$FloatRegister, $src$$FloatRegister);
+      __ smov($dst$$Register, $tmp$$FloatRegister, __ H, 0);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct convHF2F_reg_reg(vRegF dst, iRegINoSp src, vRegF tmp) %{
+  match(Set dst (ConvHF2F src));
+  format %{ "mov $tmp, $src\t# move source from $src to $tmp\n\t"
+            "fcvt $dst, $tmp\t# convert half to single precision"
+  %}
+  effect(TEMP tmp);
+  ins_encode %{
+      __ mov($tmp$$FloatRegister, __ H, 0, $src$$Register);
+      __ fcvths($dst$$FloatRegister, $tmp$$FloatRegister);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 instruct convI2F_reg_reg(vRegF dst, iRegIorL2I src) %{
   match(Set dst (ConvI2F src));
 

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -1907,31 +1907,33 @@ void mvnw(Register Rd, Register Rm,
 #undef INSN
 
   // Floating-point data-processing (1 source)
-  void data_processing(unsigned op31, unsigned type, unsigned opcode,
+  void data_processing(unsigned type, unsigned opcode,
                        FloatRegister Vd, FloatRegister Vn) {
     starti;
-    f(op31, 31, 29);
+    f(0b000, 31, 29);
     f(0b11110, 28, 24);
     f(type, 23, 22), f(1, 21), f(opcode, 20, 15), f(0b10000, 14, 10);
     rf(Vn, 5), rf(Vd, 0);
   }
 
-#define INSN(NAME, op31, type, opcode)                  \
+#define INSN(NAME, type, opcode)                        \
   void NAME(FloatRegister Vd, FloatRegister Vn) {       \
-    data_processing(op31, type, opcode, Vd, Vn);        \
+    data_processing(type, opcode, Vd, Vn);              \
   }
 
-  INSN(fmovs,  0b000, 0b00, 0b000000);
-  INSN(fabss,  0b000, 0b00, 0b000001);
-  INSN(fnegs,  0b000, 0b00, 0b000010);
-  INSN(fsqrts, 0b000, 0b00, 0b000011);
-  INSN(fcvts,  0b000, 0b00, 0b000101);   // Single-precision to double-precision
+  INSN(fmovs,  0b00, 0b000000);
+  INSN(fabss,  0b00, 0b000001);
+  INSN(fnegs,  0b00, 0b000010);
+  INSN(fsqrts, 0b00, 0b000011);
+  INSN(fcvts,  0b00, 0b000101);   // Single-precision to double-precision
+  INSN(fcvths, 0b11, 0b000100);   // Half-precision to single-precision
+  INSN(fcvtsh, 0b00, 0b000111);   // Single-precision to half-precision
 
-  INSN(fmovd,  0b000, 0b01, 0b000000);
-  INSN(fabsd,  0b000, 0b01, 0b000001);
-  INSN(fnegd,  0b000, 0b01, 0b000010);
-  INSN(fsqrtd, 0b000, 0b01, 0b000011);
-  INSN(fcvtd,  0b000, 0b01, 0b000100);   // Double-precision to single-precision
+  INSN(fmovd,  0b01, 0b000000);
+  INSN(fabsd,  0b01, 0b000001);
+  INSN(fnegd,  0b01, 0b000010);
+  INSN(fsqrtd, 0b01, 0b000011);
+  INSN(fcvtd,  0b01, 0b000100);   // Double-precision to single-precision
 
 private:
   void _fcvt_narrow_extend(FloatRegister Vd, SIMD_Arrangement Ta,

--- a/test/hotspot/gtest/aarch64/aarch64-asmtest.py
+++ b/test/hotspot/gtest/aarch64/aarch64-asmtest.py
@@ -957,7 +957,9 @@ class LoadStorePairOp(InstructionWithModes):
 class FloatInstruction(Instruction):
 
     def aname(self):
-        if (self._name.endswith("s") | self._name.endswith("d")):
+        if (self._name in ["fcvtsh", "fcvths"]):
+            return self._name[:len(self._name)-2]
+        elif (self._name.endswith("s") | self._name.endswith("d")):
             return self._name[:len(self._name)-1]
         else:
             return self._name
@@ -1012,6 +1014,8 @@ class SVEVectorOp(Instruction):
         elif not self._isPredicated and (name in ["and", "eor", "orr", "bic"]):
             self._width = RegVariant(3, 3)
             self._bitwiseop = True
+        elif name == "revb":
+            self._width = RegVariant(1, 3)
         else:
             self._width = RegVariant(0, 3)
 
@@ -1458,7 +1462,7 @@ generate(FourRegFloatOp,
 
 generate(TwoRegFloatOp,
          [["fmovs", "ss"], ["fabss", "ss"], ["fnegs", "ss"], ["fsqrts", "ss"],
-          ["fcvts", "ds"],
+          ["fcvts", "ds"], ["fcvtsh", "hs"], ["fcvths", "sh"],
           ["fmovd", "dd"], ["fabsd", "dd"], ["fnegd", "dd"], ["fsqrtd", "dd"],
           ["fcvtd", "sd"],
           ])

--- a/test/hotspot/gtest/aarch64/asmtest.out.h
+++ b/test/hotspot/gtest/aarch64/asmtest.out.h
@@ -493,276 +493,278 @@
     __ fnegs(v21, v19);                                //       fneg    s21, s19
     __ fsqrts(v20, v11);                               //       fsqrt   s20, s11
     __ fcvts(v17, v20);                                //       fcvt    d17, s20
-    __ fmovd(v6, v15);                                 //       fmov    d6, d15
-    __ fabsd(v3, v3);                                  //       fabs    d3, d3
-    __ fnegd(v28, v3);                                 //       fneg    d28, d3
-    __ fsqrtd(v27, v14);                               //       fsqrt   d27, d14
-    __ fcvtd(v14, v10);                                //       fcvt    s14, d10
+    __ fcvtsh(v6, v15);                                //       fcvt    h6, s15
+    __ fcvths(v3, v3);                                 //       fcvt    s3, h3
+    __ fmovd(v28, v3);                                 //       fmov    d28, d3
+    __ fabsd(v27, v14);                                //       fabs    d27, d14
+    __ fnegd(v14, v10);                                //       fneg    d14, d10
+    __ fsqrtd(v12, v11);                               //       fsqrt   d12, d11
+    __ fcvtd(v17, v10);                                //       fcvt    s17, d10
 
 // FloatConvertOp
-    __ fcvtzsw(r12, v11);                              //       fcvtzs  w12, s11
-    __ fcvtzs(r17, v10);                               //       fcvtzs  x17, s10
-    __ fcvtzdw(r25, v7);                               //       fcvtzs  w25, d7
-    __ fcvtzd(r7, v14);                                //       fcvtzs  x7, d14
-    __ scvtfws(v28, r0);                               //       scvtf   s28, w0
-    __ scvtfs(v22, r0);                                //       scvtf   s22, x0
-    __ scvtfwd(v12, r23);                              //       scvtf   d12, w23
-    __ scvtfd(v13, r13);                               //       scvtf   d13, x13
-    __ fcvtassw(r7, v14);                              //       fcvtas  w7, s14
-    __ fcvtasd(r7, v8);                                //       fcvtas  x7, d8
-    __ fcvtmssw(r20, v17);                             //       fcvtms  w20, s17
-    __ fcvtmsd(r28, v30);                              //       fcvtms  x28, d30
-    __ fmovs(r16, v2);                                 //       fmov    w16, s2
-    __ fmovd(r9, v16);                                 //       fmov    x9, d16
-    __ fmovs(v20, r29);                                //       fmov    s20, w29
-    __ fmovd(v4, r1);                                  //       fmov    d4, x1
+    __ fcvtzsw(r25, v7);                               //       fcvtzs  w25, s7
+    __ fcvtzs(r7, v14);                                //       fcvtzs  x7, s14
+    __ fcvtzdw(r28, v0);                               //       fcvtzs  w28, d0
+    __ fcvtzd(r22, v0);                                //       fcvtzs  x22, d0
+    __ scvtfws(v12, r23);                              //       scvtf   s12, w23
+    __ scvtfs(v13, r13);                               //       scvtf   s13, x13
+    __ scvtfwd(v7, r14);                               //       scvtf   d7, w14
+    __ scvtfd(v7, r8);                                 //       scvtf   d7, x8
+    __ fcvtassw(r20, v17);                             //       fcvtas  w20, s17
+    __ fcvtasd(r28, v30);                              //       fcvtas  x28, d30
+    __ fcvtmssw(r16, v2);                              //       fcvtms  w16, s2
+    __ fcvtmsd(r9, v16);                               //       fcvtms  x9, d16
+    __ fmovs(r20, v29);                                //       fmov    w20, s29
+    __ fmovd(r4, v1);                                  //       fmov    x4, d1
+    __ fmovs(v26, r24);                                //       fmov    s26, w24
+    __ fmovd(v23, r14);                                //       fmov    d23, x14
 
 // TwoRegFloatOp
-    __ fcmps(v26, v24);                                //       fcmp    s26, s24
-    __ fcmpd(v23, v14);                                //       fcmp    d23, d14
-    __ fcmps(v21, 0.0);                                //       fcmp    s21, #0.0
-    __ fcmpd(v12, 0.0);                                //       fcmp    d12, #0.0
+    __ fcmps(v21, v12);                                //       fcmp    s21, s12
+    __ fcmpd(v5, v12);                                 //       fcmp    d5, d12
+    __ fcmps(v24, 0.0);                                //       fcmp    s24, #0.0
+    __ fcmpd(v24, 0.0);                                //       fcmp    d24, #0.0
 
 // LoadStorePairOp
-    __ stpw(r12, r24, Address(r24, -192));             //       stp     w12, w24, [x24, #-192]
-    __ ldpw(r22, r5, Address(r16, 128));               //       ldp     w22, w5, [x16, #128]
-    __ ldpsw(r20, r19, Address(r13, 112));             //       ldpsw   x20, x19, [x13, #112]
-    __ stp(r17, r6, Address(r13, 96));                 //       stp     x17, x6, [x13, #96]
-    __ ldp(r5, r1, Address(r17, -160));                //       ldp     x5, x1, [x17, #-160]
+    __ stpw(r27, r21, Address(r16, 128));              //       stp     w27, w21, [x16, #128]
+    __ ldpw(r17, r13, Address(r22, 32));               //       ldp     w17, w13, [x22, #32]
+    __ ldpsw(r6, r13, Address(r17, -16));              //       ldpsw   x6, x13, [x17, #-16]
+    __ stp(r28, r26, Address(r17, -160));              //       stp     x28, x26, [x17, #-160]
+    __ ldp(r21, r6, Address(r13, -192));               //       ldp     x21, x6, [x13, #-192]
 
 // LoadStorePairOp
-    __ stpw(r13, r20, Address(__ pre(r22, -208)));     //       stp     w13, w20, [x22, #-208]!
-    __ ldpw(r30, r27, Address(__ pre(r10, 80)));       //       ldp     w30, w27, [x10, #80]!
-    __ ldpsw(r13, r20, Address(__ pre(r26, 16)));      //       ldpsw   x13, x20, [x26, #16]!
-    __ stp(r4, r23, Address(__ pre(r29, -80)));        //       stp     x4, x23, [x29, #-80]!
-    __ ldp(r22, r0, Address(__ pre(r6, -112)));        //       ldp     x22, x0, [x6, #-112]!
+    __ stpw(r26, r23, Address(__ pre(r19, 16)));       //       stp     w26, w23, [x19, #16]!
+    __ ldpw(r4, r16, Address(__ pre(r10, 128)));       //       ldp     w4, w16, [x10, #128]!
+    __ ldpsw(r14, r4, Address(__ pre(r23, -96)));      //       ldpsw   x14, x4, [x23, #-96]!
+    __ stp(r29, r12, Address(__ pre(r16, 32)));        //       stp     x29, x12, [x16, #32]!
+    __ ldp(r26, r17, Address(__ pre(r27, 96)));        //       ldp     x26, x17, [x27, #96]!
 
 // LoadStorePairOp
-    __ stpw(r17, r27, Address(__ post(r5, 80)));       //       stp     w17, w27, [x5], #80
-    __ ldpw(r14, r11, Address(__ post(r16, -256)));    //       ldp     w14, w11, [x16], #-256
-    __ ldpsw(r12, r23, Address(__ post(r9, -240)));    //       ldpsw   x12, x23, [x9], #-240
-    __ stp(r23, r7, Address(__ post(r0, 32)));         //       stp     x23, x7, [x0], #32
-    __ ldp(r17, r8, Address(__ post(r26, 80)));        //       ldp     x17, x8, [x26], #80
+    __ stpw(r6, r0, Address(__ post(r4, -96)));        //       stp     w6, w0, [x4], #-96
+    __ ldpw(r2, r30, Address(__ post(r14, 0)));        //       ldp     w2, w30, [x14], #0
+    __ ldpsw(r23, r24, Address(__ post(r7, -256)));    //       ldpsw   x23, x24, [x7], #-256
+    __ stp(r0, r26, Address(__ post(r5, 128)));        //       stp     x0, x26, [x5], #128
+    __ ldp(r6, r11, Address(__ post(r15, -160)));      //       ldp     x6, x11, [x15], #-160
 
 // LoadStorePairOp
-    __ stnpw(r11, r15, Address(r10, -176));            //       stnp    w11, w15, [x10, #-176]
-    __ ldnpw(r19, r16, Address(r4, 64));               //       ldnp    w19, w16, [x4, #64]
-    __ stnp(r30, r14, Address(r9, -240));              //       stnp    x30, x14, [x9, #-240]
-    __ ldnp(r29, r23, Address(r20, 32));               //       ldnp    x29, x23, [x20, #32]
+    __ stnpw(r25, r8, Address(r2, -128));              //       stnp    w25, w8, [x2, #-128]
+    __ ldnpw(r30, r14, Address(r1, -208));             //       ldnp    w30, w14, [x1, #-208]
+    __ stnp(r22, r0, Address(r13, -144));              //       stnp    x22, x0, [x13, #-144]
+    __ ldnp(r3, r12, Address(r27, 0));                 //       ldnp    x3, x12, [x27, #0]
 
 // LdStNEONOp
-    __ ld1(v5, __ T8B, Address(r27));                  //       ld1     {v5.8B}, [x27]
-    __ ld1(v10, v11, __ T16B, Address(__ post(r25, 32))); //    ld1     {v10.16B, v11.16B}, [x25], 32
-    __ ld1(v15, v16, v17, __ T1D, Address(__ post(r30, r19))); //       ld1     {v15.1D, v16.1D, v17.1D}, [x30], x19
-    __ ld1(v17, v18, v19, v20, __ T8H, Address(__ post(r16, 64))); //   ld1     {v17.8H, v18.8H, v19.8H, v20.8H}, [x16], 64
-    __ ld1r(v30, __ T8B, Address(r23));                //       ld1r    {v30.8B}, [x23]
-    __ ld1r(v17, __ T4S, Address(__ post(r8, 4)));     //       ld1r    {v17.4S}, [x8], 4
-    __ ld1r(v12, __ T1D, Address(__ post(r9, r3)));    //       ld1r    {v12.1D}, [x9], x3
-    __ ld2(v19, v20, __ T2D, Address(r2));             //       ld2     {v19.2D, v20.2D}, [x2]
-    __ ld2(v21, v22, __ T4H, Address(__ post(r8, 16))); //      ld2     {v21.4H, v22.4H}, [x8], 16
-    __ ld2r(v13, v14, __ T16B, Address(r4));           //       ld2r    {v13.16B, v14.16B}, [x4]
-    __ ld2r(v28, v29, __ T2S, Address(__ post(r3, 8))); //      ld2r    {v28.2S, v29.2S}, [x3], 8
-    __ ld2r(v29, v30, __ T2D, Address(__ post(r29, r0))); //    ld2r    {v29.2D, v30.2D}, [x29], x0
-    __ ld3(v7, v8, v9, __ T4S, Address(__ post(r1, r21))); //   ld3     {v7.4S, v8.4S, v9.4S}, [x1], x21
-    __ ld3(v17, v18, v19, __ T2S, Address(r0));        //       ld3     {v17.2S, v18.2S, v19.2S}, [x0]
-    __ ld3r(v26, v27, v28, __ T8H, Address(r5));       //       ld3r    {v26.8H, v27.8H, v28.8H}, [x5]
-    __ ld3r(v25, v26, v27, __ T4S, Address(__ post(r1, 12))); //        ld3r    {v25.4S, v26.4S, v27.4S}, [x1], 12
-    __ ld3r(v22, v23, v24, __ T1D, Address(__ post(r2, r29))); //       ld3r    {v22.1D, v23.1D, v24.1D}, [x2], x29
-    __ ld4(v13, v14, v15, v16, __ T8H, Address(__ post(r27, 64))); //   ld4     {v13.8H, v14.8H, v15.8H, v16.8H}, [x27], 64
-    __ ld4(v29, v30, v31, v0, __ T8B, Address(__ post(r24, r23))); //   ld4     {v29.8B, v30.8B, v31.8B, v0.8B}, [x24], x23
-    __ ld4r(v13, v14, v15, v16, __ T8B, Address(r15)); //       ld4r    {v13.8B, v14.8B, v15.8B, v16.8B}, [x15]
-    __ ld4r(v15, v16, v17, v18, __ T4H, Address(__ post(r14, 8))); //   ld4r    {v15.4H, v16.4H, v17.4H, v18.4H}, [x14], 8
-    __ ld4r(v27, v28, v29, v30, __ T2S, Address(__ post(r20, r23))); // ld4r    {v27.2S, v28.2S, v29.2S, v30.2S}, [x20], x23
+    __ ld1(v10, __ T8B, Address(r0));                  //       ld1     {v10.8B}, [x0]
+    __ ld1(v12, v13, __ T16B, Address(__ post(r17, 32))); //    ld1     {v12.16B, v13.16B}, [x17], 32
+    __ ld1(v10, v11, v12, __ T1D, Address(__ post(r24, r2))); //        ld1     {v10.1D, v11.1D, v12.1D}, [x24], x2
+    __ ld1(v8, v9, v10, v11, __ T8H, Address(__ post(r17, 64))); //     ld1     {v8.8H, v9.8H, v10.8H, v11.8H}, [x17], 64
+    __ ld1r(v23, __ T8B, Address(r30));                //       ld1r    {v23.8B}, [x30]
+    __ ld1r(v22, __ T4S, Address(__ post(r2, 4)));     //       ld1r    {v22.4S}, [x2], 4
+    __ ld1r(v30, __ T1D, Address(__ post(r30, r15)));  //       ld1r    {v30.1D}, [x30], x15
+    __ ld2(v20, v21, __ T2D, Address(r5));             //       ld2     {v20.2D, v21.2D}, [x5]
+    __ ld2(v24, v25, __ T4H, Address(__ post(r9, 16))); //      ld2     {v24.4H, v25.4H}, [x9], 16
+    __ ld2r(v16, v17, __ T16B, Address(r12));          //       ld2r    {v16.16B, v17.16B}, [x12]
+    __ ld2r(v23, v24, __ T2S, Address(__ post(r7, 8))); //      ld2r    {v23.2S, v24.2S}, [x7], 8
+    __ ld2r(v26, v27, __ T2D, Address(__ post(r16, r3))); //    ld2r    {v26.2D, v27.2D}, [x16], x3
+    __ ld3(v25, v26, v27, __ T4S, Address(__ post(r11, r7))); //        ld3     {v25.4S, v26.4S, v27.4S}, [x11], x7
+    __ ld3(v30, v31, v0, __ T2S, Address(r12));        //       ld3     {v30.2S, v31.2S, v0.2S}, [x12]
+    __ ld3r(v15, v16, v17, __ T8H, Address(r9));       //       ld3r    {v15.8H, v16.8H, v17.8H}, [x9]
+    __ ld3r(v30, v31, v0, __ T4S, Address(__ post(r6, 12))); // ld3r    {v30.4S, v31.4S, v0.4S}, [x6], 12
+    __ ld3r(v7, v8, v9, __ T1D, Address(__ post(r23, r13))); // ld3r    {v7.1D, v8.1D, v9.1D}, [x23], x13
+    __ ld4(v4, v5, v6, v7, __ T8H, Address(__ post(r6, 64))); //        ld4     {v4.8H, v5.8H, v6.8H, v7.8H}, [x6], 64
+    __ ld4(v4, v5, v6, v7, __ T8B, Address(__ post(r19, r15))); //      ld4     {v4.8B, v5.8B, v6.8B, v7.8B}, [x19], x15
+    __ ld4r(v25, v26, v27, v28, __ T8B, Address(r14)); //       ld4r    {v25.8B, v26.8B, v27.8B, v28.8B}, [x14]
+    __ ld4r(v26, v27, v28, v29, __ T4H, Address(__ post(r28, 8))); //   ld4r    {v26.4H, v27.4H, v28.4H, v29.4H}, [x28], 8
+    __ ld4r(v25, v26, v27, v28, __ T2S, Address(__ post(r5, r6))); //   ld4r    {v25.2S, v26.2S, v27.2S, v28.2S}, [x5], x6
 
 // NEONReduceInstruction
-    __ addv(v24, __ T8B, v25);                         //       addv    b24, v25.8B
-    __ addv(v15, __ T16B, v16);                        //       addv    b15, v16.16B
-    __ addv(v25, __ T4H, v26);                         //       addv    h25, v26.4H
+    __ addv(v14, __ T8B, v15);                         //       addv    b14, v15.8B
+    __ addv(v10, __ T16B, v11);                        //       addv    b10, v11.16B
+    __ addv(v13, __ T4H, v14);                         //       addv    h13, v14.4H
     __ addv(v14, __ T8H, v15);                         //       addv    h14, v15.8H
-    __ addv(v10, __ T4S, v11);                         //       addv    s10, v11.4S
-    __ smaxv(v13, __ T8B, v14);                        //       smaxv   b13, v14.8B
-    __ smaxv(v14, __ T16B, v15);                       //       smaxv   b14, v15.16B
-    __ smaxv(v20, __ T4H, v21);                        //       smaxv   h20, v21.4H
-    __ smaxv(v1, __ T8H, v2);                          //       smaxv   h1, v2.8H
-    __ smaxv(v22, __ T4S, v23);                        //       smaxv   s22, v23.4S
-    __ fmaxv(v30, __ T4S, v31);                        //       fmaxv   s30, v31.4S
-    __ sminv(v14, __ T8B, v15);                        //       sminv   b14, v15.8B
-    __ uminv(v2, __ T8B, v3);                          //       uminv   b2, v3.8B
-    __ sminv(v6, __ T16B, v7);                         //       sminv   b6, v7.16B
-    __ uminv(v3, __ T16B, v4);                         //       uminv   b3, v4.16B
-    __ sminv(v7, __ T4H, v8);                          //       sminv   h7, v8.4H
-    __ uminv(v24, __ T4H, v25);                        //       uminv   h24, v25.4H
-    __ sminv(v0, __ T8H, v1);                          //       sminv   h0, v1.8H
-    __ uminv(v27, __ T8H, v28);                        //       uminv   h27, v28.8H
+    __ addv(v20, __ T4S, v21);                         //       addv    s20, v21.4S
+    __ smaxv(v1, __ T8B, v2);                          //       smaxv   b1, v2.8B
+    __ smaxv(v22, __ T16B, v23);                       //       smaxv   b22, v23.16B
+    __ smaxv(v30, __ T4H, v31);                        //       smaxv   h30, v31.4H
+    __ smaxv(v14, __ T8H, v15);                        //       smaxv   h14, v15.8H
+    __ smaxv(v2, __ T4S, v3);                          //       smaxv   s2, v3.4S
+    __ fmaxv(v6, __ T4S, v7);                          //       fmaxv   s6, v7.4S
+    __ sminv(v3, __ T8B, v4);                          //       sminv   b3, v4.8B
+    __ uminv(v7, __ T8B, v8);                          //       uminv   b7, v8.8B
+    __ sminv(v24, __ T16B, v25);                       //       sminv   b24, v25.16B
+    __ uminv(v0, __ T16B, v1);                         //       uminv   b0, v1.16B
+    __ sminv(v27, __ T4H, v28);                        //       sminv   h27, v28.4H
+    __ uminv(v29, __ T4H, v30);                        //       uminv   h29, v30.4H
+    __ sminv(v5, __ T8H, v6);                          //       sminv   h5, v6.8H
+    __ uminv(v5, __ T8H, v6);                          //       uminv   h5, v6.8H
     __ sminv(v29, __ T4S, v30);                        //       sminv   s29, v30.4S
-    __ uminv(v5, __ T4S, v6);                          //       uminv   s5, v6.4S
-    __ fminv(v5, __ T4S, v6);                          //       fminv   s5, v6.4S
-    __ fmaxp(v29, v30, __ S);                          //       fmaxp   s29, v30.2S
-    __ fmaxp(v11, v12, __ D);                          //       fmaxp   d11, v12.2D
-    __ fminp(v25, v26, __ S);                          //       fminp   s25, v26.2S
-    __ fminp(v0, v1, __ D);                            //       fminp   d0, v1.2D
+    __ uminv(v11, __ T4S, v12);                        //       uminv   s11, v12.4S
+    __ fminv(v25, __ T4S, v26);                        //       fminv   s25, v26.4S
+    __ fmaxp(v0, v1, __ S);                            //       fmaxp   s0, v1.2S
+    __ fmaxp(v30, v31, __ D);                          //       fmaxp   d30, v31.2D
+    __ fminp(v0, v1, __ S);                            //       fminp   s0, v1.2S
+    __ fminp(v17, v18, __ D);                          //       fminp   d17, v18.2D
 
 // TwoRegNEONOp
-    __ absr(v30, __ T8B, v31);                         //       abs     v30.8B, v31.8B
-    __ absr(v0, __ T16B, v1);                          //       abs     v0.16B, v1.16B
-    __ absr(v17, __ T4H, v18);                         //       abs     v17.4H, v18.4H
-    __ absr(v28, __ T8H, v29);                         //       abs     v28.8H, v29.8H
-    __ absr(v25, __ T2S, v26);                         //       abs     v25.2S, v26.2S
-    __ absr(v9, __ T4S, v10);                          //       abs     v9.4S, v10.4S
-    __ absr(v25, __ T2D, v26);                         //       abs     v25.2D, v26.2D
-    __ fabs(v12, __ T2S, v13);                         //       fabs    v12.2S, v13.2S
-    __ fabs(v15, __ T4S, v16);                         //       fabs    v15.4S, v16.4S
-    __ fabs(v11, __ T2D, v12);                         //       fabs    v11.2D, v12.2D
-    __ fneg(v10, __ T2S, v11);                         //       fneg    v10.2S, v11.2S
-    __ fneg(v17, __ T4S, v18);                         //       fneg    v17.4S, v18.4S
-    __ fneg(v24, __ T2D, v25);                         //       fneg    v24.2D, v25.2D
-    __ fsqrt(v21, __ T2S, v22);                        //       fsqrt   v21.2S, v22.2S
-    __ fsqrt(v23, __ T4S, v24);                        //       fsqrt   v23.4S, v24.4S
-    __ fsqrt(v0, __ T2D, v1);                          //       fsqrt   v0.2D, v1.2D
-    __ notr(v16, __ T8B, v17);                         //       not     v16.8B, v17.8B
-    __ notr(v10, __ T16B, v11);                        //       not     v10.16B, v11.16B
+    __ absr(v28, __ T8B, v29);                         //       abs     v28.8B, v29.8B
+    __ absr(v25, __ T16B, v26);                        //       abs     v25.16B, v26.16B
+    __ absr(v9, __ T4H, v10);                          //       abs     v9.4H, v10.4H
+    __ absr(v25, __ T8H, v26);                         //       abs     v25.8H, v26.8H
+    __ absr(v12, __ T2S, v13);                         //       abs     v12.2S, v13.2S
+    __ absr(v15, __ T4S, v16);                         //       abs     v15.4S, v16.4S
+    __ absr(v11, __ T2D, v12);                         //       abs     v11.2D, v12.2D
+    __ fabs(v10, __ T2S, v11);                         //       fabs    v10.2S, v11.2S
+    __ fabs(v17, __ T4S, v18);                         //       fabs    v17.4S, v18.4S
+    __ fabs(v24, __ T2D, v25);                         //       fabs    v24.2D, v25.2D
+    __ fneg(v21, __ T2S, v22);                         //       fneg    v21.2S, v22.2S
+    __ fneg(v23, __ T4S, v24);                         //       fneg    v23.4S, v24.4S
+    __ fneg(v0, __ T2D, v1);                           //       fneg    v0.2D, v1.2D
+    __ fsqrt(v16, __ T2S, v17);                        //       fsqrt   v16.2S, v17.2S
+    __ fsqrt(v10, __ T4S, v11);                        //       fsqrt   v10.4S, v11.4S
+    __ fsqrt(v6, __ T2D, v7);                          //       fsqrt   v6.2D, v7.2D
+    __ notr(v28, __ T8B, v29);                         //       not     v28.8B, v29.8B
+    __ notr(v6, __ T16B, v7);                          //       not     v6.16B, v7.16B
 
 // ThreeRegNEONOp
-    __ andr(v6, __ T8B, v7, v8);                       //       and     v6.8B, v7.8B, v8.8B
-    __ andr(v28, __ T16B, v29, v30);                   //       and     v28.16B, v29.16B, v30.16B
-    __ orr(v6, __ T8B, v7, v8);                        //       orr     v6.8B, v7.8B, v8.8B
-    __ orr(v5, __ T16B, v6, v7);                       //       orr     v5.16B, v6.16B, v7.16B
-    __ eor(v5, __ T8B, v6, v7);                        //       eor     v5.8B, v6.8B, v7.8B
-    __ eor(v20, __ T16B, v21, v22);                    //       eor     v20.16B, v21.16B, v22.16B
-    __ addv(v17, __ T8B, v18, v19);                    //       add     v17.8B, v18.8B, v19.8B
-    __ addv(v15, __ T16B, v16, v17);                   //       add     v15.16B, v16.16B, v17.16B
-    __ addv(v17, __ T4H, v18, v19);                    //       add     v17.4H, v18.4H, v19.4H
-    __ addv(v29, __ T8H, v30, v31);                    //       add     v29.8H, v30.8H, v31.8H
-    __ addv(v26, __ T2S, v27, v28);                    //       add     v26.2S, v27.2S, v28.2S
-    __ addv(v28, __ T4S, v29, v30);                    //       add     v28.4S, v29.4S, v30.4S
-    __ addv(v1, __ T2D, v2, v3);                       //       add     v1.2D, v2.2D, v3.2D
-    __ fadd(v27, __ T2S, v28, v29);                    //       fadd    v27.2S, v28.2S, v29.2S
-    __ fadd(v0, __ T4S, v1, v2);                       //       fadd    v0.4S, v1.4S, v2.4S
-    __ fadd(v20, __ T2D, v21, v22);                    //       fadd    v20.2D, v21.2D, v22.2D
-    __ subv(v28, __ T8B, v29, v30);                    //       sub     v28.8B, v29.8B, v30.8B
-    __ subv(v15, __ T16B, v16, v17);                   //       sub     v15.16B, v16.16B, v17.16B
-    __ subv(v12, __ T4H, v13, v14);                    //       sub     v12.4H, v13.4H, v14.4H
-    __ subv(v10, __ T8H, v11, v12);                    //       sub     v10.8H, v11.8H, v12.8H
-    __ subv(v28, __ T2S, v29, v30);                    //       sub     v28.2S, v29.2S, v30.2S
-    __ subv(v28, __ T4S, v29, v30);                    //       sub     v28.4S, v29.4S, v30.4S
-    __ subv(v19, __ T2D, v20, v21);                    //       sub     v19.2D, v20.2D, v21.2D
-    __ fsub(v22, __ T2S, v23, v24);                    //       fsub    v22.2S, v23.2S, v24.2S
-    __ fsub(v10, __ T4S, v11, v12);                    //       fsub    v10.4S, v11.4S, v12.4S
-    __ fsub(v4, __ T2D, v5, v6);                       //       fsub    v4.2D, v5.2D, v6.2D
+    __ andr(v5, __ T8B, v6, v7);                       //       and     v5.8B, v6.8B, v7.8B
+    __ andr(v5, __ T16B, v6, v7);                      //       and     v5.16B, v6.16B, v7.16B
+    __ orr(v20, __ T8B, v21, v22);                     //       orr     v20.8B, v21.8B, v22.8B
+    __ orr(v17, __ T16B, v18, v19);                    //       orr     v17.16B, v18.16B, v19.16B
+    __ eor(v15, __ T8B, v16, v17);                     //       eor     v15.8B, v16.8B, v17.8B
+    __ eor(v17, __ T16B, v18, v19);                    //       eor     v17.16B, v18.16B, v19.16B
+    __ addv(v29, __ T8B, v30, v31);                    //       add     v29.8B, v30.8B, v31.8B
+    __ addv(v26, __ T16B, v27, v28);                   //       add     v26.16B, v27.16B, v28.16B
+    __ addv(v28, __ T4H, v29, v30);                    //       add     v28.4H, v29.4H, v30.4H
+    __ addv(v1, __ T8H, v2, v3);                       //       add     v1.8H, v2.8H, v3.8H
+    __ addv(v27, __ T2S, v28, v29);                    //       add     v27.2S, v28.2S, v29.2S
+    __ addv(v0, __ T4S, v1, v2);                       //       add     v0.4S, v1.4S, v2.4S
+    __ addv(v20, __ T2D, v21, v22);                    //       add     v20.2D, v21.2D, v22.2D
+    __ fadd(v28, __ T2S, v29, v30);                    //       fadd    v28.2S, v29.2S, v30.2S
+    __ fadd(v15, __ T4S, v16, v17);                    //       fadd    v15.4S, v16.4S, v17.4S
+    __ fadd(v12, __ T2D, v13, v14);                    //       fadd    v12.2D, v13.2D, v14.2D
+    __ subv(v10, __ T8B, v11, v12);                    //       sub     v10.8B, v11.8B, v12.8B
+    __ subv(v28, __ T16B, v29, v30);                   //       sub     v28.16B, v29.16B, v30.16B
+    __ subv(v28, __ T4H, v29, v30);                    //       sub     v28.4H, v29.4H, v30.4H
+    __ subv(v19, __ T8H, v20, v21);                    //       sub     v19.8H, v20.8H, v21.8H
+    __ subv(v22, __ T2S, v23, v24);                    //       sub     v22.2S, v23.2S, v24.2S
+    __ subv(v10, __ T4S, v11, v12);                    //       sub     v10.4S, v11.4S, v12.4S
+    __ subv(v4, __ T2D, v5, v6);                       //       sub     v4.2D, v5.2D, v6.2D
+    __ fsub(v30, __ T2S, v31, v0);                     //       fsub    v30.2S, v31.2S, v0.2S
+    __ fsub(v20, __ T4S, v21, v22);                    //       fsub    v20.4S, v21.4S, v22.4S
+    __ fsub(v8, __ T2D, v9, v10);                      //       fsub    v8.2D, v9.2D, v10.2D
     __ mulv(v30, __ T8B, v31, v0);                     //       mul     v30.8B, v31.8B, v0.8B
-    __ mulv(v20, __ T16B, v21, v22);                   //       mul     v20.16B, v21.16B, v22.16B
-    __ mulv(v8, __ T4H, v9, v10);                      //       mul     v8.4H, v9.4H, v10.4H
-    __ mulv(v30, __ T8H, v31, v0);                     //       mul     v30.8H, v31.8H, v0.8H
-    __ mulv(v17, __ T2S, v18, v19);                    //       mul     v17.2S, v18.2S, v19.2S
-    __ mulv(v10, __ T4S, v11, v12);                    //       mul     v10.4S, v11.4S, v12.4S
-    __ fabd(v27, __ T2S, v28, v29);                    //       fabd    v27.2S, v28.2S, v29.2S
-    __ fabd(v2, __ T4S, v3, v4);                       //       fabd    v2.4S, v3.4S, v4.4S
-    __ fabd(v24, __ T2D, v25, v26);                    //       fabd    v24.2D, v25.2D, v26.2D
-    __ fmul(v4, __ T2S, v5, v6);                       //       fmul    v4.2S, v5.2S, v6.2S
-    __ fmul(v3, __ T4S, v4, v5);                       //       fmul    v3.4S, v4.4S, v5.4S
-    __ fmul(v8, __ T2D, v9, v10);                      //       fmul    v8.2D, v9.2D, v10.2D
-    __ mlav(v22, __ T4H, v23, v24);                    //       mla     v22.4H, v23.4H, v24.4H
-    __ mlav(v17, __ T8H, v18, v19);                    //       mla     v17.8H, v18.8H, v19.8H
-    __ mlav(v13, __ T2S, v14, v15);                    //       mla     v13.2S, v14.2S, v15.2S
-    __ mlav(v4, __ T4S, v5, v6);                       //       mla     v4.4S, v5.4S, v6.4S
-    __ fmla(v28, __ T2S, v29, v30);                    //       fmla    v28.2S, v29.2S, v30.2S
-    __ fmla(v23, __ T4S, v24, v25);                    //       fmla    v23.4S, v24.4S, v25.4S
-    __ fmla(v21, __ T2D, v22, v23);                    //       fmla    v21.2D, v22.2D, v23.2D
-    __ mlsv(v25, __ T4H, v26, v27);                    //       mls     v25.4H, v26.4H, v27.4H
-    __ mlsv(v24, __ T8H, v25, v26);                    //       mls     v24.8H, v25.8H, v26.8H
-    __ mlsv(v3, __ T2S, v4, v5);                       //       mls     v3.2S, v4.2S, v5.2S
-    __ mlsv(v23, __ T4S, v24, v25);                    //       mls     v23.4S, v24.4S, v25.4S
-    __ fmls(v26, __ T2S, v27, v28);                    //       fmls    v26.2S, v27.2S, v28.2S
-    __ fmls(v23, __ T4S, v24, v25);                    //       fmls    v23.4S, v24.4S, v25.4S
-    __ fmls(v14, __ T2D, v15, v16);                    //       fmls    v14.2D, v15.2D, v16.2D
-    __ fdiv(v21, __ T2S, v22, v23);                    //       fdiv    v21.2S, v22.2S, v23.2S
-    __ fdiv(v3, __ T4S, v4, v5);                       //       fdiv    v3.4S, v4.4S, v5.4S
-    __ fdiv(v23, __ T2D, v24, v25);                    //       fdiv    v23.2D, v24.2D, v25.2D
-    __ maxv(v8, __ T8B, v9, v10);                      //       smax    v8.8B, v9.8B, v10.8B
-    __ maxv(v24, __ T16B, v25, v26);                   //       smax    v24.16B, v25.16B, v26.16B
-    __ maxv(v19, __ T4H, v20, v21);                    //       smax    v19.4H, v20.4H, v21.4H
-    __ maxv(v15, __ T8H, v16, v17);                    //       smax    v15.8H, v16.8H, v17.8H
-    __ maxv(v16, __ T2S, v17, v18);                    //       smax    v16.2S, v17.2S, v18.2S
-    __ maxv(v2, __ T4S, v3, v4);                       //       smax    v2.4S, v3.4S, v4.4S
-    __ smaxp(v1, __ T8B, v2, v3);                      //       smaxp   v1.8B, v2.8B, v3.8B
-    __ smaxp(v0, __ T16B, v1, v2);                     //       smaxp   v0.16B, v1.16B, v2.16B
-    __ smaxp(v24, __ T4H, v25, v26);                   //       smaxp   v24.4H, v25.4H, v26.4H
-    __ smaxp(v4, __ T8H, v5, v6);                      //       smaxp   v4.8H, v5.8H, v6.8H
-    __ smaxp(v3, __ T2S, v4, v5);                      //       smaxp   v3.2S, v4.2S, v5.2S
-    __ smaxp(v11, __ T4S, v12, v13);                   //       smaxp   v11.4S, v12.4S, v13.4S
-    __ fmax(v30, __ T2S, v31, v0);                     //       fmax    v30.2S, v31.2S, v0.2S
-    __ fmax(v27, __ T4S, v28, v29);                    //       fmax    v27.4S, v28.4S, v29.4S
-    __ fmax(v9, __ T2D, v10, v11);                     //       fmax    v9.2D, v10.2D, v11.2D
-    __ minv(v25, __ T8B, v26, v27);                    //       smin    v25.8B, v26.8B, v27.8B
-    __ minv(v2, __ T16B, v3, v4);                      //       smin    v2.16B, v3.16B, v4.16B
-    __ minv(v12, __ T4H, v13, v14);                    //       smin    v12.4H, v13.4H, v14.4H
-    __ minv(v17, __ T8H, v18, v19);                    //       smin    v17.8H, v18.8H, v19.8H
-    __ minv(v30, __ T2S, v31, v0);                     //       smin    v30.2S, v31.2S, v0.2S
-    __ minv(v1, __ T4S, v2, v3);                       //       smin    v1.4S, v2.4S, v3.4S
-    __ sminp(v12, __ T8B, v13, v14);                   //       sminp   v12.8B, v13.8B, v14.8B
-    __ sminp(v28, __ T16B, v29, v30);                  //       sminp   v28.16B, v29.16B, v30.16B
-    __ sminp(v0, __ T4H, v1, v2);                      //       sminp   v0.4H, v1.4H, v2.4H
-    __ sminp(v17, __ T8H, v18, v19);                   //       sminp   v17.8H, v18.8H, v19.8H
+    __ mulv(v17, __ T16B, v18, v19);                   //       mul     v17.16B, v18.16B, v19.16B
+    __ mulv(v10, __ T4H, v11, v12);                    //       mul     v10.4H, v11.4H, v12.4H
+    __ mulv(v27, __ T8H, v28, v29);                    //       mul     v27.8H, v28.8H, v29.8H
+    __ mulv(v2, __ T2S, v3, v4);                       //       mul     v2.2S, v3.2S, v4.2S
+    __ mulv(v24, __ T4S, v25, v26);                    //       mul     v24.4S, v25.4S, v26.4S
+    __ fabd(v4, __ T2S, v5, v6);                       //       fabd    v4.2S, v5.2S, v6.2S
+    __ fabd(v3, __ T4S, v4, v5);                       //       fabd    v3.4S, v4.4S, v5.4S
+    __ fabd(v8, __ T2D, v9, v10);                      //       fabd    v8.2D, v9.2D, v10.2D
+    __ fmul(v22, __ T2S, v23, v24);                    //       fmul    v22.2S, v23.2S, v24.2S
+    __ fmul(v17, __ T4S, v18, v19);                    //       fmul    v17.4S, v18.4S, v19.4S
+    __ fmul(v13, __ T2D, v14, v15);                    //       fmul    v13.2D, v14.2D, v15.2D
+    __ mlav(v4, __ T4H, v5, v6);                       //       mla     v4.4H, v5.4H, v6.4H
+    __ mlav(v28, __ T8H, v29, v30);                    //       mla     v28.8H, v29.8H, v30.8H
+    __ mlav(v23, __ T2S, v24, v25);                    //       mla     v23.2S, v24.2S, v25.2S
+    __ mlav(v21, __ T4S, v22, v23);                    //       mla     v21.4S, v22.4S, v23.4S
+    __ fmla(v25, __ T2S, v26, v27);                    //       fmla    v25.2S, v26.2S, v27.2S
+    __ fmla(v24, __ T4S, v25, v26);                    //       fmla    v24.4S, v25.4S, v26.4S
+    __ fmla(v3, __ T2D, v4, v5);                       //       fmla    v3.2D, v4.2D, v5.2D
+    __ mlsv(v23, __ T4H, v24, v25);                    //       mls     v23.4H, v24.4H, v25.4H
+    __ mlsv(v26, __ T8H, v27, v28);                    //       mls     v26.8H, v27.8H, v28.8H
+    __ mlsv(v23, __ T2S, v24, v25);                    //       mls     v23.2S, v24.2S, v25.2S
+    __ mlsv(v14, __ T4S, v15, v16);                    //       mls     v14.4S, v15.4S, v16.4S
+    __ fmls(v21, __ T2S, v22, v23);                    //       fmls    v21.2S, v22.2S, v23.2S
+    __ fmls(v3, __ T4S, v4, v5);                       //       fmls    v3.4S, v4.4S, v5.4S
+    __ fmls(v23, __ T2D, v24, v25);                    //       fmls    v23.2D, v24.2D, v25.2D
+    __ fdiv(v8, __ T2S, v9, v10);                      //       fdiv    v8.2S, v9.2S, v10.2S
+    __ fdiv(v24, __ T4S, v25, v26);                    //       fdiv    v24.4S, v25.4S, v26.4S
+    __ fdiv(v19, __ T2D, v20, v21);                    //       fdiv    v19.2D, v20.2D, v21.2D
+    __ maxv(v15, __ T8B, v16, v17);                    //       smax    v15.8B, v16.8B, v17.8B
+    __ maxv(v16, __ T16B, v17, v18);                   //       smax    v16.16B, v17.16B, v18.16B
+    __ maxv(v2, __ T4H, v3, v4);                       //       smax    v2.4H, v3.4H, v4.4H
+    __ maxv(v1, __ T8H, v2, v3);                       //       smax    v1.8H, v2.8H, v3.8H
+    __ maxv(v0, __ T2S, v1, v2);                       //       smax    v0.2S, v1.2S, v2.2S
+    __ maxv(v24, __ T4S, v25, v26);                    //       smax    v24.4S, v25.4S, v26.4S
+    __ smaxp(v4, __ T8B, v5, v6);                      //       smaxp   v4.8B, v5.8B, v6.8B
+    __ smaxp(v3, __ T16B, v4, v5);                     //       smaxp   v3.16B, v4.16B, v5.16B
+    __ smaxp(v11, __ T4H, v12, v13);                   //       smaxp   v11.4H, v12.4H, v13.4H
+    __ smaxp(v30, __ T8H, v31, v0);                    //       smaxp   v30.8H, v31.8H, v0.8H
+    __ smaxp(v27, __ T2S, v28, v29);                   //       smaxp   v27.2S, v28.2S, v29.2S
+    __ smaxp(v9, __ T4S, v10, v11);                    //       smaxp   v9.4S, v10.4S, v11.4S
+    __ fmax(v25, __ T2S, v26, v27);                    //       fmax    v25.2S, v26.2S, v27.2S
+    __ fmax(v2, __ T4S, v3, v4);                       //       fmax    v2.4S, v3.4S, v4.4S
+    __ fmax(v12, __ T2D, v13, v14);                    //       fmax    v12.2D, v13.2D, v14.2D
+    __ minv(v17, __ T8B, v18, v19);                    //       smin    v17.8B, v18.8B, v19.8B
+    __ minv(v30, __ T16B, v31, v0);                    //       smin    v30.16B, v31.16B, v0.16B
+    __ minv(v1, __ T4H, v2, v3);                       //       smin    v1.4H, v2.4H, v3.4H
+    __ minv(v12, __ T8H, v13, v14);                    //       smin    v12.8H, v13.8H, v14.8H
+    __ minv(v28, __ T2S, v29, v30);                    //       smin    v28.2S, v29.2S, v30.2S
+    __ minv(v0, __ T4S, v1, v2);                       //       smin    v0.4S, v1.4S, v2.4S
+    __ sminp(v17, __ T8B, v18, v19);                   //       sminp   v17.8B, v18.8B, v19.8B
+    __ sminp(v12, __ T16B, v13, v14);                  //       sminp   v12.16B, v13.16B, v14.16B
+    __ sminp(v17, __ T4H, v18, v19);                   //       sminp   v17.4H, v18.4H, v19.4H
+    __ sminp(v21, __ T8H, v22, v23);                   //       sminp   v21.8H, v22.8H, v23.8H
     __ sminp(v12, __ T2S, v13, v14);                   //       sminp   v12.2S, v13.2S, v14.2S
-    __ sminp(v17, __ T4S, v18, v19);                   //       sminp   v17.4S, v18.4S, v19.4S
-    __ fmin(v21, __ T2S, v22, v23);                    //       fmin    v21.2S, v22.2S, v23.2S
-    __ fmin(v12, __ T4S, v13, v14);                    //       fmin    v12.4S, v13.4S, v14.4S
-    __ fmin(v27, __ T2D, v28, v29);                    //       fmin    v27.2D, v28.2D, v29.2D
-    __ cmeq(v29, __ T8B, v30, v31);                    //       cmeq    v29.8B, v30.8B, v31.8B
-    __ cmeq(v30, __ T16B, v31, v0);                    //       cmeq    v30.16B, v31.16B, v0.16B
-    __ cmeq(v1, __ T4H, v2, v3);                       //       cmeq    v1.4H, v2.4H, v3.4H
-    __ cmeq(v25, __ T8H, v26, v27);                    //       cmeq    v25.8H, v26.8H, v27.8H
-    __ cmeq(v27, __ T2S, v28, v29);                    //       cmeq    v27.2S, v28.2S, v29.2S
-    __ cmeq(v4, __ T4S, v5, v6);                       //       cmeq    v4.4S, v5.4S, v6.4S
+    __ sminp(v27, __ T4S, v28, v29);                   //       sminp   v27.4S, v28.4S, v29.4S
+    __ fmin(v29, __ T2S, v30, v31);                    //       fmin    v29.2S, v30.2S, v31.2S
+    __ fmin(v30, __ T4S, v31, v0);                     //       fmin    v30.4S, v31.4S, v0.4S
+    __ fmin(v1, __ T2D, v2, v3);                       //       fmin    v1.2D, v2.2D, v3.2D
+    __ cmeq(v25, __ T8B, v26, v27);                    //       cmeq    v25.8B, v26.8B, v27.8B
+    __ cmeq(v27, __ T16B, v28, v29);                   //       cmeq    v27.16B, v28.16B, v29.16B
+    __ cmeq(v4, __ T4H, v5, v6);                       //       cmeq    v4.4H, v5.4H, v6.4H
+    __ cmeq(v29, __ T8H, v30, v31);                    //       cmeq    v29.8H, v30.8H, v31.8H
+    __ cmeq(v3, __ T2S, v4, v5);                       //       cmeq    v3.2S, v4.2S, v5.2S
+    __ cmeq(v6, __ T4S, v7, v8);                       //       cmeq    v6.4S, v7.4S, v8.4S
     __ cmeq(v29, __ T2D, v30, v31);                    //       cmeq    v29.2D, v30.2D, v31.2D
-    __ fcmeq(v3, __ T2S, v4, v5);                      //       fcmeq   v3.2S, v4.2S, v5.2S
-    __ fcmeq(v6, __ T4S, v7, v8);                      //       fcmeq   v6.4S, v7.4S, v8.4S
-    __ fcmeq(v29, __ T2D, v30, v31);                   //       fcmeq   v29.2D, v30.2D, v31.2D
-    __ cmgt(v25, __ T8B, v26, v27);                    //       cmgt    v25.8B, v26.8B, v27.8B
-    __ cmgt(v17, __ T16B, v18, v19);                   //       cmgt    v17.16B, v18.16B, v19.16B
-    __ cmgt(v8, __ T4H, v9, v10);                      //       cmgt    v8.4H, v9.4H, v10.4H
-    __ cmgt(v7, __ T8H, v8, v9);                       //       cmgt    v7.8H, v8.8H, v9.8H
-    __ cmgt(v12, __ T2S, v13, v14);                    //       cmgt    v12.2S, v13.2S, v14.2S
-    __ cmgt(v0, __ T4S, v1, v2);                       //       cmgt    v0.4S, v1.4S, v2.4S
-    __ cmgt(v19, __ T2D, v20, v21);                    //       cmgt    v19.2D, v20.2D, v21.2D
-    __ cmhi(v1, __ T8B, v2, v3);                       //       cmhi    v1.8B, v2.8B, v3.8B
-    __ cmhi(v23, __ T16B, v24, v25);                   //       cmhi    v23.16B, v24.16B, v25.16B
-    __ cmhi(v2, __ T4H, v3, v4);                       //       cmhi    v2.4H, v3.4H, v4.4H
-    __ cmhi(v0, __ T8H, v1, v2);                       //       cmhi    v0.8H, v1.8H, v2.8H
-    __ cmhi(v8, __ T2S, v9, v10);                      //       cmhi    v8.2S, v9.2S, v10.2S
-    __ cmhi(v23, __ T4S, v24, v25);                    //       cmhi    v23.4S, v24.4S, v25.4S
-    __ cmhi(v25, __ T2D, v26, v27);                    //       cmhi    v25.2D, v26.2D, v27.2D
-    __ cmhs(v15, __ T8B, v16, v17);                    //       cmhs    v15.8B, v16.8B, v17.8B
-    __ cmhs(v29, __ T16B, v30, v31);                   //       cmhs    v29.16B, v30.16B, v31.16B
-    __ cmhs(v3, __ T4H, v4, v5);                       //       cmhs    v3.4H, v4.4H, v5.4H
-    __ cmhs(v10, __ T8H, v11, v12);                    //       cmhs    v10.8H, v11.8H, v12.8H
-    __ cmhs(v22, __ T2S, v23, v24);                    //       cmhs    v22.2S, v23.2S, v24.2S
-    __ cmhs(v10, __ T4S, v11, v12);                    //       cmhs    v10.4S, v11.4S, v12.4S
-    __ cmhs(v4, __ T2D, v5, v6);                       //       cmhs    v4.2D, v5.2D, v6.2D
-    __ fcmgt(v17, __ T2S, v18, v19);                   //       fcmgt   v17.2S, v18.2S, v19.2S
-    __ fcmgt(v1, __ T4S, v2, v3);                      //       fcmgt   v1.4S, v2.4S, v3.4S
-    __ fcmgt(v11, __ T2D, v12, v13);                   //       fcmgt   v11.2D, v12.2D, v13.2D
-    __ cmge(v7, __ T8B, v8, v9);                       //       cmge    v7.8B, v8.8B, v9.8B
-    __ cmge(v10, __ T16B, v11, v12);                   //       cmge    v10.16B, v11.16B, v12.16B
-    __ cmge(v15, __ T4H, v16, v17);                    //       cmge    v15.4H, v16.4H, v17.4H
-    __ cmge(v16, __ T8H, v17, v18);                    //       cmge    v16.8H, v17.8H, v18.8H
-    __ cmge(v2, __ T2S, v3, v4);                       //       cmge    v2.2S, v3.2S, v4.2S
-    __ cmge(v9, __ T4S, v10, v11);                     //       cmge    v9.4S, v10.4S, v11.4S
-    __ cmge(v11, __ T2D, v12, v13);                    //       cmge    v11.2D, v12.2D, v13.2D
-    __ fcmge(v12, __ T2S, v13, v14);                   //       fcmge   v12.2S, v13.2S, v14.2S
-    __ fcmge(v14, __ T4S, v15, v16);                   //       fcmge   v14.4S, v15.4S, v16.4S
-    __ fcmge(v13, __ T2D, v14, v15);                   //       fcmge   v13.2D, v14.2D, v15.2D
-    __ facgt(v2, __ T2S, v3, v4);                      //       facgt   v2.2S, v3.2S, v4.2S
-    __ facgt(v6, __ T4S, v7, v8);                      //       facgt   v6.4S, v7.4S, v8.4S
-    __ facgt(v19, __ T2D, v20, v21);                   //       facgt   v19.2D, v20.2D, v21.2D
+    __ fcmeq(v25, __ T2S, v26, v27);                   //       fcmeq   v25.2S, v26.2S, v27.2S
+    __ fcmeq(v17, __ T4S, v18, v19);                   //       fcmeq   v17.4S, v18.4S, v19.4S
+    __ fcmeq(v8, __ T2D, v9, v10);                     //       fcmeq   v8.2D, v9.2D, v10.2D
+    __ cmgt(v7, __ T8B, v8, v9);                       //       cmgt    v7.8B, v8.8B, v9.8B
+    __ cmgt(v12, __ T16B, v13, v14);                   //       cmgt    v12.16B, v13.16B, v14.16B
+    __ cmgt(v0, __ T4H, v1, v2);                       //       cmgt    v0.4H, v1.4H, v2.4H
+    __ cmgt(v19, __ T8H, v20, v21);                    //       cmgt    v19.8H, v20.8H, v21.8H
+    __ cmgt(v1, __ T2S, v2, v3);                       //       cmgt    v1.2S, v2.2S, v3.2S
+    __ cmgt(v23, __ T4S, v24, v25);                    //       cmgt    v23.4S, v24.4S, v25.4S
+    __ cmgt(v2, __ T2D, v3, v4);                       //       cmgt    v2.2D, v3.2D, v4.2D
+    __ cmhi(v0, __ T8B, v1, v2);                       //       cmhi    v0.8B, v1.8B, v2.8B
+    __ cmhi(v8, __ T16B, v9, v10);                     //       cmhi    v8.16B, v9.16B, v10.16B
+    __ cmhi(v23, __ T4H, v24, v25);                    //       cmhi    v23.4H, v24.4H, v25.4H
+    __ cmhi(v25, __ T8H, v26, v27);                    //       cmhi    v25.8H, v26.8H, v27.8H
+    __ cmhi(v15, __ T2S, v16, v17);                    //       cmhi    v15.2S, v16.2S, v17.2S
+    __ cmhi(v29, __ T4S, v30, v31);                    //       cmhi    v29.4S, v30.4S, v31.4S
+    __ cmhi(v3, __ T2D, v4, v5);                       //       cmhi    v3.2D, v4.2D, v5.2D
+    __ cmhs(v10, __ T8B, v11, v12);                    //       cmhs    v10.8B, v11.8B, v12.8B
+    __ cmhs(v22, __ T16B, v23, v24);                   //       cmhs    v22.16B, v23.16B, v24.16B
+    __ cmhs(v10, __ T4H, v11, v12);                    //       cmhs    v10.4H, v11.4H, v12.4H
+    __ cmhs(v4, __ T8H, v5, v6);                       //       cmhs    v4.8H, v5.8H, v6.8H
+    __ cmhs(v17, __ T2S, v18, v19);                    //       cmhs    v17.2S, v18.2S, v19.2S
+    __ cmhs(v1, __ T4S, v2, v3);                       //       cmhs    v1.4S, v2.4S, v3.4S
+    __ cmhs(v11, __ T2D, v12, v13);                    //       cmhs    v11.2D, v12.2D, v13.2D
+    __ fcmgt(v7, __ T2S, v8, v9);                      //       fcmgt   v7.2S, v8.2S, v9.2S
+    __ fcmgt(v10, __ T4S, v11, v12);                   //       fcmgt   v10.4S, v11.4S, v12.4S
+    __ fcmgt(v15, __ T2D, v16, v17);                   //       fcmgt   v15.2D, v16.2D, v17.2D
+    __ cmge(v16, __ T8B, v17, v18);                    //       cmge    v16.8B, v17.8B, v18.8B
+    __ cmge(v2, __ T16B, v3, v4);                      //       cmge    v2.16B, v3.16B, v4.16B
+    __ cmge(v9, __ T4H, v10, v11);                     //       cmge    v9.4H, v10.4H, v11.4H
+    __ cmge(v11, __ T8H, v12, v13);                    //       cmge    v11.8H, v12.8H, v13.8H
+    __ cmge(v12, __ T2S, v13, v14);                    //       cmge    v12.2S, v13.2S, v14.2S
+    __ cmge(v14, __ T4S, v15, v16);                    //       cmge    v14.4S, v15.4S, v16.4S
+    __ cmge(v13, __ T2D, v14, v15);                    //       cmge    v13.2D, v14.2D, v15.2D
+    __ fcmge(v2, __ T2S, v3, v4);                      //       fcmge   v2.2S, v3.2S, v4.2S
+    __ fcmge(v6, __ T4S, v7, v8);                      //       fcmge   v6.4S, v7.4S, v8.4S
+    __ fcmge(v19, __ T2D, v20, v21);                   //       fcmge   v19.2D, v20.2D, v21.2D
+    __ facgt(v25, __ T2S, v26, v27);                   //       facgt   v25.2S, v26.2S, v27.2S
+    __ facgt(v15, __ T4S, v16, v17);                   //       facgt   v15.4S, v16.4S, v17.4S
+    __ facgt(v4, __ T2D, v5, v6);                      //       facgt   v4.2D, v5.2D, v6.2D
 
 // SVEComparisonWithZero
-    __ sve_fcm(Assembler::EQ, p13, __ S, p0, z15, 0.0); //      fcmeq   p13.s, p0/z, z15.s, #0.0
-    __ sve_fcm(Assembler::GT, p2, __ D, p5, z11, 0.0); //       fcmgt   p2.d, p5/z, z11.d, #0.0
-    __ sve_fcm(Assembler::GE, p8, __ S, p5, z17, 0.0); //       fcmge   p8.s, p5/z, z17.s, #0.0
-    __ sve_fcm(Assembler::LT, p11, __ D, p5, z12, 0.0); //      fcmlt   p11.d, p5/z, z12.d, #0.0
-    __ sve_fcm(Assembler::LE, p14, __ S, p6, z14, 0.0); //      fcmle   p14.s, p6/z, z14.s, #0.0
-    __ sve_fcm(Assembler::NE, p0, __ D, p2, z11, 0.0); //       fcmne   p0.d, p2/z, z11.d, #0.0
+    __ sve_fcm(Assembler::EQ, p1, __ S, p4, z4, 0.0);  //       fcmeq   p1.s, p4/z, z4.s, #0.0
+    __ sve_fcm(Assembler::GT, p10, __ D, p2, z16, 0.0); //      fcmgt   p10.d, p2/z, z16.d, #0.0
+    __ sve_fcm(Assembler::GE, p10, __ S, p6, z22, 0.0); //      fcmge   p10.s, p6/z, z22.s, #0.0
+    __ sve_fcm(Assembler::LT, p11, __ S, p2, z28, 0.0); //      fcmlt   p11.s, p2/z, z28.s, #0.0
+    __ sve_fcm(Assembler::LE, p12, __ S, p7, z1, 0.0); //       fcmle   p12.s, p7/z, z1.s, #0.0
+    __ sve_fcm(Assembler::NE, p5, __ S, p0, z15, 0.0); //       fcmne   p5.s, p0/z, z15.s, #0.0
 
 // SpecialCases
     __ ccmn(zr, zr, 3u, Assembler::LE);                //       ccmn    xzr, xzr, #3, LE
@@ -1013,214 +1015,214 @@
     __ fmovd(v0, -1.0625);                             //       fmov d0, #-1.0625
 
 // LSEOp
-    __ swp(Assembler::xword, r16, r7, r2);             //       swp     x16, x7, [x2]
-    __ ldadd(Assembler::xword, r3, r13, r19);          //       ldadd   x3, x13, [x19]
-    __ ldbic(Assembler::xword, r17, r16, r3);          //       ldclr   x17, x16, [x3]
-    __ ldeor(Assembler::xword, r1, r11, r30);          //       ldeor   x1, x11, [x30]
-    __ ldorr(Assembler::xword, r5, r8, r15);           //       ldset   x5, x8, [x15]
-    __ ldsmin(Assembler::xword, r29, r30, r0);         //       ldsmin  x29, x30, [x0]
-    __ ldsmax(Assembler::xword, r20, r7, r20);         //       ldsmax  x20, x7, [x20]
-    __ ldumin(Assembler::xword, r23, r28, r21);        //       ldumin  x23, x28, [x21]
-    __ ldumax(Assembler::xword, r27, r25, r5);         //       ldumax  x27, x25, [x5]
+    __ swp(Assembler::xword, r3, r13, r19);            //       swp     x3, x13, [x19]
+    __ ldadd(Assembler::xword, r17, r16, r3);          //       ldadd   x17, x16, [x3]
+    __ ldbic(Assembler::xword, r1, r11, r30);          //       ldclr   x1, x11, [x30]
+    __ ldeor(Assembler::xword, r5, r8, r15);           //       ldeor   x5, x8, [x15]
+    __ ldorr(Assembler::xword, r29, r30, r0);          //       ldset   x29, x30, [x0]
+    __ ldsmin(Assembler::xword, r20, r7, r20);         //       ldsmin  x20, x7, [x20]
+    __ ldsmax(Assembler::xword, r23, r28, r21);        //       ldsmax  x23, x28, [x21]
+    __ ldumin(Assembler::xword, r27, r25, r5);         //       ldumin  x27, x25, [x5]
+    __ ldumax(Assembler::xword, r1, r23, r16);         //       ldumax  x1, x23, [x16]
 
 // LSEOp
-    __ swpa(Assembler::xword, r1, r23, r16);           //       swpa    x1, x23, [x16]
-    __ ldadda(Assembler::xword, zr, r5, r12);          //       ldadda  xzr, x5, [x12]
-    __ ldbica(Assembler::xword, r9, r28, r15);         //       ldclra  x9, x28, [x15]
-    __ ldeora(Assembler::xword, r29, r22, sp);         //       ldeora  x29, x22, [sp]
-    __ ldorra(Assembler::xword, r19, zr, r5);          //       ldseta  x19, xzr, [x5]
-    __ ldsmina(Assembler::xword, r14, r16, sp);        //       ldsmina x14, x16, [sp]
-    __ ldsmaxa(Assembler::xword, r16, r27, r20);       //       ldsmaxa x16, x27, [x20]
-    __ ldumina(Assembler::xword, r16, r12, r11);       //       ldumina x16, x12, [x11]
-    __ ldumaxa(Assembler::xword, r9, r6, r30);         //       ldumaxa x9, x6, [x30]
+    __ swpa(Assembler::xword, zr, r5, r12);            //       swpa    xzr, x5, [x12]
+    __ ldadda(Assembler::xword, r9, r28, r15);         //       ldadda  x9, x28, [x15]
+    __ ldbica(Assembler::xword, r29, r22, sp);         //       ldclra  x29, x22, [sp]
+    __ ldeora(Assembler::xword, r19, zr, r5);          //       ldeora  x19, xzr, [x5]
+    __ ldorra(Assembler::xword, r14, r16, sp);         //       ldseta  x14, x16, [sp]
+    __ ldsmina(Assembler::xword, r16, r27, r20);       //       ldsmina x16, x27, [x20]
+    __ ldsmaxa(Assembler::xword, r16, r12, r11);       //       ldsmaxa x16, x12, [x11]
+    __ ldumina(Assembler::xword, r9, r6, r30);         //       ldumina x9, x6, [x30]
+    __ ldumaxa(Assembler::xword, r17, r27, r28);       //       ldumaxa x17, x27, [x28]
 
 // LSEOp
-    __ swpal(Assembler::xword, r17, r27, r28);         //       swpal   x17, x27, [x28]
-    __ ldaddal(Assembler::xword, r30, r7, r10);        //       ldaddal x30, x7, [x10]
-    __ ldbical(Assembler::xword, r20, r10, r4);        //       ldclral x20, x10, [x4]
-    __ ldeoral(Assembler::xword, r24, r17, r17);       //       ldeoral x24, x17, [x17]
-    __ ldorral(Assembler::xword, r22, r3, r29);        //       ldsetal x22, x3, [x29]
-    __ ldsminal(Assembler::xword, r15, r22, r19);      //       ldsminal        x15, x22, [x19]
-    __ ldsmaxal(Assembler::xword, r19, r22, r2);       //       ldsmaxal        x19, x22, [x2]
-    __ lduminal(Assembler::xword, r15, r6, r12);       //       lduminal        x15, x6, [x12]
-    __ ldumaxal(Assembler::xword, r16, r11, r13);      //       ldumaxal        x16, x11, [x13]
+    __ swpal(Assembler::xword, r30, r7, r10);          //       swpal   x30, x7, [x10]
+    __ ldaddal(Assembler::xword, r20, r10, r4);        //       ldaddal x20, x10, [x4]
+    __ ldbical(Assembler::xword, r24, r17, r17);       //       ldclral x24, x17, [x17]
+    __ ldeoral(Assembler::xword, r22, r3, r29);        //       ldeoral x22, x3, [x29]
+    __ ldorral(Assembler::xword, r15, r22, r19);       //       ldsetal x15, x22, [x19]
+    __ ldsminal(Assembler::xword, r19, r22, r2);       //       ldsminal        x19, x22, [x2]
+    __ ldsmaxal(Assembler::xword, r15, r6, r12);       //       ldsmaxal        x15, x6, [x12]
+    __ lduminal(Assembler::xword, r16, r11, r13);      //       lduminal        x16, x11, [x13]
+    __ ldumaxal(Assembler::xword, r23, r1, r30);       //       ldumaxal        x23, x1, [x30]
 
 // LSEOp
-    __ swpl(Assembler::xword, r23, r1, r30);           //       swpl    x23, x1, [x30]
-    __ ldaddl(Assembler::xword, r19, r5, r17);         //       ldaddl  x19, x5, [x17]
-    __ ldbicl(Assembler::xword, r2, r16, r22);         //       ldclrl  x2, x16, [x22]
-    __ ldeorl(Assembler::xword, r13, r10, r21);        //       ldeorl  x13, x10, [x21]
-    __ ldorrl(Assembler::xword, r29, r27, r12);        //       ldsetl  x29, x27, [x12]
-    __ ldsminl(Assembler::xword, r27, r3, r1);         //       ldsminl x27, x3, [x1]
-    __ ldsmaxl(Assembler::xword, zr, r24, r19);        //       ldsmaxl xzr, x24, [x19]
-    __ lduminl(Assembler::xword, r17, r9, r28);        //       lduminl x17, x9, [x28]
-    __ ldumaxl(Assembler::xword, r27, r15, r7);        //       ldumaxl x27, x15, [x7]
+    __ swpl(Assembler::xword, r19, r5, r17);           //       swpl    x19, x5, [x17]
+    __ ldaddl(Assembler::xword, r2, r16, r22);         //       ldaddl  x2, x16, [x22]
+    __ ldbicl(Assembler::xword, r13, r10, r21);        //       ldclrl  x13, x10, [x21]
+    __ ldeorl(Assembler::xword, r29, r27, r12);        //       ldeorl  x29, x27, [x12]
+    __ ldorrl(Assembler::xword, r27, r3, r1);          //       ldsetl  x27, x3, [x1]
+    __ ldsminl(Assembler::xword, zr, r24, r19);        //       ldsminl xzr, x24, [x19]
+    __ ldsmaxl(Assembler::xword, r17, r9, r28);        //       ldsmaxl x17, x9, [x28]
+    __ lduminl(Assembler::xword, r27, r15, r7);        //       lduminl x27, x15, [x7]
+    __ ldumaxl(Assembler::xword, r21, r23, sp);        //       ldumaxl x21, x23, [sp]
 
 // LSEOp
-    __ swp(Assembler::word, r21, r23, sp);             //       swp     w21, w23, [sp]
-    __ ldadd(Assembler::word, r25, r2, sp);            //       ldadd   w25, w2, [sp]
-    __ ldbic(Assembler::word, r27, r16, r10);          //       ldclr   w27, w16, [x10]
-    __ ldeor(Assembler::word, r23, r19, r3);           //       ldeor   w23, w19, [x3]
-    __ ldorr(Assembler::word, r16, r0, r25);           //       ldset   w16, w0, [x25]
-    __ ldsmin(Assembler::word, r26, r23, r2);          //       ldsmin  w26, w23, [x2]
-    __ ldsmax(Assembler::word, r16, r12, r4);          //       ldsmax  w16, w12, [x4]
-    __ ldumin(Assembler::word, r28, r30, r29);         //       ldumin  w28, w30, [x29]
-    __ ldumax(Assembler::word, r16, r27, r6);          //       ldumax  w16, w27, [x6]
+    __ swp(Assembler::word, r25, r2, sp);              //       swp     w25, w2, [sp]
+    __ ldadd(Assembler::word, r27, r16, r10);          //       ldadd   w27, w16, [x10]
+    __ ldbic(Assembler::word, r23, r19, r3);           //       ldclr   w23, w19, [x3]
+    __ ldeor(Assembler::word, r16, r0, r25);           //       ldeor   w16, w0, [x25]
+    __ ldorr(Assembler::word, r26, r23, r2);           //       ldset   w26, w23, [x2]
+    __ ldsmin(Assembler::word, r16, r12, r4);          //       ldsmin  w16, w12, [x4]
+    __ ldsmax(Assembler::word, r28, r30, r29);         //       ldsmax  w28, w30, [x29]
+    __ ldumin(Assembler::word, r16, r27, r6);          //       ldumin  w16, w27, [x6]
+    __ ldumax(Assembler::word, r9, r29, r15);          //       ldumax  w9, w29, [x15]
 
 // LSEOp
-    __ swpa(Assembler::word, r9, r29, r15);            //       swpa    w9, w29, [x15]
-    __ ldadda(Assembler::word, r7, r4, r7);            //       ldadda  w7, w4, [x7]
-    __ ldbica(Assembler::word, r15, r9, r23);          //       ldclra  w15, w9, [x23]
-    __ ldeora(Assembler::word, r8, r2, r28);           //       ldeora  w8, w2, [x28]
-    __ ldorra(Assembler::word, r21, zr, r5);           //       ldseta  w21, wzr, [x5]
-    __ ldsmina(Assembler::word, r27, r0, r17);         //       ldsmina w27, w0, [x17]
-    __ ldsmaxa(Assembler::word, r15, r4, r26);         //       ldsmaxa w15, w4, [x26]
-    __ ldumina(Assembler::word, r8, r28, r22);         //       ldumina w8, w28, [x22]
-    __ ldumaxa(Assembler::word, r27, r27, r25);        //       ldumaxa w27, w27, [x25]
+    __ swpa(Assembler::word, r7, r4, r7);              //       swpa    w7, w4, [x7]
+    __ ldadda(Assembler::word, r15, r9, r23);          //       ldadda  w15, w9, [x23]
+    __ ldbica(Assembler::word, r8, r2, r28);           //       ldclra  w8, w2, [x28]
+    __ ldeora(Assembler::word, r21, zr, r5);           //       ldeora  w21, wzr, [x5]
+    __ ldorra(Assembler::word, r27, r0, r17);          //       ldseta  w27, w0, [x17]
+    __ ldsmina(Assembler::word, r15, r4, r26);         //       ldsmina w15, w4, [x26]
+    __ ldsmaxa(Assembler::word, r8, r28, r22);         //       ldsmaxa w8, w28, [x22]
+    __ ldumina(Assembler::word, r27, r27, r25);        //       ldumina w27, w27, [x25]
+    __ ldumaxa(Assembler::word, r23, r0, r4);          //       ldumaxa w23, w0, [x4]
 
 // LSEOp
-    __ swpal(Assembler::word, r23, r0, r4);            //       swpal   w23, w0, [x4]
-    __ ldaddal(Assembler::word, r6, r16, r0);          //       ldaddal w6, w16, [x0]
-    __ ldbical(Assembler::word, r4, r15, r1);          //       ldclral w4, w15, [x1]
-    __ ldeoral(Assembler::word, r10, r7, r5);          //       ldeoral w10, w7, [x5]
-    __ ldorral(Assembler::word, r10, r28, r7);         //       ldsetal w10, w28, [x7]
-    __ ldsminal(Assembler::word, r20, r23, r21);       //       ldsminal        w20, w23, [x21]
-    __ ldsmaxal(Assembler::word, r6, r11, r8);         //       ldsmaxal        w6, w11, [x8]
-    __ lduminal(Assembler::word, r17, zr, r6);         //       lduminal        w17, wzr, [x6]
-    __ ldumaxal(Assembler::word, r17, r2, r12);        //       ldumaxal        w17, w2, [x12]
+    __ swpal(Assembler::word, r6, r16, r0);            //       swpal   w6, w16, [x0]
+    __ ldaddal(Assembler::word, r4, r15, r1);          //       ldaddal w4, w15, [x1]
+    __ ldbical(Assembler::word, r10, r7, r5);          //       ldclral w10, w7, [x5]
+    __ ldeoral(Assembler::word, r10, r28, r7);         //       ldeoral w10, w28, [x7]
+    __ ldorral(Assembler::word, r20, r23, r21);        //       ldsetal w20, w23, [x21]
+    __ ldsminal(Assembler::word, r6, r11, r8);         //       ldsminal        w6, w11, [x8]
+    __ ldsmaxal(Assembler::word, r17, zr, r6);         //       ldsmaxal        w17, wzr, [x6]
+    __ lduminal(Assembler::word, r17, r2, r12);        //       lduminal        w17, w2, [x12]
+    __ ldumaxal(Assembler::word, r30, r29, r3);        //       ldumaxal        w30, w29, [x3]
 
 // LSEOp
-    __ swpl(Assembler::word, r30, r29, r3);            //       swpl    w30, w29, [x3]
-    __ ldaddl(Assembler::word, r27, r22, r29);         //       ldaddl  w27, w22, [x29]
-    __ ldbicl(Assembler::word, r14, r13, r28);         //       ldclrl  w14, w13, [x28]
-    __ ldeorl(Assembler::word, r17, r24, r5);          //       ldeorl  w17, w24, [x5]
-    __ ldorrl(Assembler::word, r2, r14, r10);          //       ldsetl  w2, w14, [x10]
-    __ ldsminl(Assembler::word, r16, r11, r27);        //       ldsminl w16, w11, [x27]
-    __ ldsmaxl(Assembler::word, r23, r12, r4);         //       ldsmaxl w23, w12, [x4]
-    __ lduminl(Assembler::word, r22, r17, r4);         //       lduminl w22, w17, [x4]
-    __ ldumaxl(Assembler::word, r1, r19, r16);         //       ldumaxl w1, w19, [x16]
+    __ swpl(Assembler::word, r27, r22, r29);           //       swpl    w27, w22, [x29]
+    __ ldaddl(Assembler::word, r14, r13, r28);         //       ldaddl  w14, w13, [x28]
+    __ ldbicl(Assembler::word, r17, r24, r5);          //       ldclrl  w17, w24, [x5]
+    __ ldeorl(Assembler::word, r2, r14, r10);          //       ldeorl  w2, w14, [x10]
+    __ ldorrl(Assembler::word, r16, r11, r27);         //       ldsetl  w16, w11, [x27]
+    __ ldsminl(Assembler::word, r23, r12, r4);         //       ldsminl w23, w12, [x4]
+    __ ldsmaxl(Assembler::word, r22, r17, r4);         //       ldsmaxl w22, w17, [x4]
+    __ lduminl(Assembler::word, r1, r19, r16);         //       lduminl w1, w19, [x16]
+    __ ldumaxl(Assembler::word, r16, r13, r14);        //       ldumaxl w16, w13, [x14]
 
 // SHA3SIMDOp
-    __ bcax(v17, __ T16B, v12, v14, v12);              //       bcax            v17.16B, v12.16B, v14.16B, v12.16B
-    __ eor3(v2, __ T16B, v16, v3, v20);                //       eor3            v2.16B, v16.16B, v3.16B, v20.16B
-    __ rax1(v23, __ T2D, v5, v6);                      //       rax1            v23.2D, v5.2D, v6.2D
-    __ xar(v7, __ T2D, v17, v12, 56);                  //       xar             v7.2D, v17.2D, v12.2D, #56
+    __ bcax(v12, __ T16B, v2, v16, v3);                //       bcax            v12.16B, v2.16B, v16.16B, v3.16B
+    __ eor3(v20, __ T16B, v23, v5, v6);                //       eor3            v20.16B, v23.16B, v5.16B, v6.16B
+    __ rax1(v7, __ T2D, v17, v12);                     //       rax1            v7.2D, v17.2D, v12.2D
+    __ xar(v27, __ T2D, v16, v16, 13);                 //       xar             v27.2D, v16.2D, v16.2D, #13
 
 // SHA512SIMDOp
-    __ sha512h(v16, __ T2D, v16, v6);                  //       sha512h         q16, q16, v6.2D
-    __ sha512h2(v2, __ T2D, v28, v3);                  //       sha512h2                q2, q28, v3.2D
-    __ sha512su0(v4, __ T2D, v6);                      //       sha512su0               v4.2D, v6.2D
-    __ sha512su1(v17, __ T2D, v19, v13);               //       sha512su1               v17.2D, v19.2D, v13.2D
+    __ sha512h(v2, __ T2D, v28, v3);                   //       sha512h         q2, q28, v3.2D
+    __ sha512h2(v4, __ T2D, v6, v17);                  //       sha512h2                q4, q6, v17.2D
+    __ sha512su0(v19, __ T2D, v13);                    //       sha512su0               v19.2D, v13.2D
+    __ sha512su1(v12, __ T2D, v19, v8);                //       sha512su1               v12.2D, v19.2D, v8.2D
 
 // SVEBinaryImmOp
-    __ sve_add(z12, __ S, 67u);                        //       add     z12.s, z12.s, #0x43
-    __ sve_sub(z24, __ S, 154u);                       //       sub     z24.s, z24.s, #0x9a
-    __ sve_and(z0, __ H, 511u);                        //       and     z0.h, z0.h, #0x1ff
-    __ sve_eor(z19, __ D, 9241386433220968447u);       //       eor     z19.d, z19.d, #0x803fffff803fffff
-    __ sve_orr(z6, __ B, 128u);                        //       orr     z6.b, z6.b, #0x80
+    __ sve_add(z24, __ S, 154u);                       //       add     z24.s, z24.s, #0x9a
+    __ sve_sub(z0, __ H, 196u);                        //       sub     z0.h, z0.h, #0xc4
+    __ sve_and(z6, __ S, 1073733632u);                 //       and     z6.s, z6.s, #0x3fffe000
+    __ sve_eor(z16, __ B, 62u);                        //       eor     z16.b, z16.b, #0x3e
+    __ sve_orr(z14, __ S, 62915520u);                  //       orr     z14.s, z14.s, #0x3c003c0
 
 // SVEBinaryImmOp
-    __ sve_add(z17, __ D, 74u);                        //       add     z17.d, z17.d, #0x4a
-    __ sve_sub(z10, __ S, 170u);                       //       sub     z10.s, z10.s, #0xaa
-    __ sve_and(z22, __ D, 17179852800u);               //       and     z22.d, z22.d, #0x3ffffc000
-    __ sve_eor(z15, __ S, 8388600u);                   //       eor     z15.s, z15.s, #0x7ffff8
-    __ sve_orr(z4, __ D, 8064u);                       //       orr     z4.d, z4.d, #0x1f80
+    __ sve_add(z10, __ S, 170u);                       //       add     z10.s, z10.s, #0xaa
+    __ sve_sub(z22, __ D, 22u);                        //       sub     z22.d, z22.d, #0x16
+    __ sve_and(z3, __ H, 51199u);                      //       and     z3.h, z3.h, #0xc7ff
+    __ sve_eor(z7, __ B, 62u);                         //       eor     z7.b, z7.b, #0x3e
+    __ sve_orr(z0, __ H, 51199u);                      //       orr     z0.h, z0.h, #0xc7ff
 
 // SVEBinaryImmOp
-    __ sve_add(z8, __ S, 162u);                        //       add     z8.s, z8.s, #0xa2
-    __ sve_sub(z22, __ B, 130u);                       //       sub     z22.b, z22.b, #0x82
-    __ sve_and(z9, __ S, 4292870159u);                 //       and     z9.s, z9.s, #0xffe0000f
-    __ sve_eor(z5, __ D, 1150687262887383032u);        //       eor     z5.d, z5.d, #0xff80ff80ff80ff8
-    __ sve_orr(z22, __ H, 32256u);                     //       orr     z22.h, z22.h, #0x7e00
+    __ sve_add(z22, __ B, 130u);                       //       add     z22.b, z22.b, #0x82
+    __ sve_sub(z9, __ S, 92u);                         //       sub     z9.s, z9.s, #0x5c
+    __ sve_and(z25, __ B, 131u);                       //       and     z25.b, z25.b, #0x83
+    __ sve_eor(z13, __ S, 496u);                       //       eor     z13.s, z13.s, #0x1f0
+    __ sve_orr(z13, __ H, 33279u);                     //       orr     z13.h, z13.h, #0x81ff
 
 // SVEBinaryImmOp
-    __ sve_add(z8, __ S, 134u);                        //       add     z8.s, z8.s, #0x86
-    __ sve_sub(z25, __ H, 39u);                        //       sub     z25.h, z25.h, #0x27
-    __ sve_and(z4, __ S, 4186112u);                    //       and     z4.s, z4.s, #0x3fe000
-    __ sve_eor(z29, __ B, 131u);                       //       eor     z29.b, z29.b, #0x83
-    __ sve_orr(z29, __ D, 4611685469745315712u);       //       orr     z29.d, z29.d, #0x3fffff803fffff80
+    __ sve_add(z25, __ H, 39u);                        //       add     z25.h, z25.h, #0x27
+    __ sve_sub(z4, __ S, 67u);                         //       sub     z4.s, z4.s, #0x43
+    __ sve_and(z6, __ D, 18446744069548802047u);       //       and     z6.d, z6.d, #0xffffffff07ffffff
+    __ sve_eor(z16, __ D, 4503599627354112u);          //       eor     z16.d, z16.d, #0xfffffffffc000
+    __ sve_orr(z14, __ B, 254u);                       //       orr     z14.b, z14.b, #0xfe
 
 // SVEBinaryImmOp
-    __ sve_add(z2, __ H, 237u);                        //       add     z2.h, z2.h, #0xed
-    __ sve_sub(z3, __ B, 10u);                         //       sub     z3.b, z3.b, #0xa
-    __ sve_and(z26, __ S, 1610637312u);                //       and     z26.s, z26.s, #0x60006000
-    __ sve_eor(z8, __ S, 4290777087u);                 //       eor     z8.s, z8.s, #0xffc00fff
-    __ sve_orr(z5, __ S, 3758096384u);                 //       orr     z5.s, z5.s, #0xe0000000
+    __ sve_add(z3, __ B, 10u);                         //       add     z3.b, z3.b, #0xa
+    __ sve_sub(z26, __ S, 150u);                       //       sub     z26.s, z26.s, #0x96
+    __ sve_and(z14, __ H, 57343u);                     //       and     z14.h, z14.h, #0xdfff
+    __ sve_eor(z24, __ B, 191u);                       //       eor     z24.b, z24.b, #0xbf
+    __ sve_orr(z17, __ S, 4294966791u);                //       orr     z17.s, z17.s, #0xfffffe07
 
 // SVEBinaryImmOp
-    __ sve_add(z22, __ S, 244u);                       //       add     z22.s, z22.s, #0xf4
-    __ sve_sub(z20, __ S, 3u);                         //       sub     z20.s, z20.s, #0x3
-    __ sve_and(z4, __ S, 491520u);                     //       and     z4.s, z4.s, #0x78000
-    __ sve_eor(z19, __ B, 239u);                       //       eor     z19.b, z19.b, #0xef
-    __ sve_orr(z19, __ B, 96u);                        //       orr     z19.b, z19.b, #0x60
+    __ sve_add(z20, __ S, 3u);                         //       add     z20.s, z20.s, #0x3
+    __ sve_sub(z4, __ S, 196u);                        //       sub     z4.s, z4.s, #0xc4
+    __ sve_and(z4, __ S, 4286578691u);                 //       and     z4.s, z4.s, #0xff800003
+    __ sve_eor(z25, __ S, 33553408u);                  //       eor     z25.s, z25.s, #0x1fffc00
+    __ sve_orr(z8, __ H, 49663u);                      //       orr     z8.h, z8.h, #0xc1ff
 
 // SVEVectorOp
-    __ sve_add(z14, __ D, z24, z17);                   //       add     z14.d, z24.d, z17.d
-    __ sve_sub(z21, __ B, z4, z30);                    //       sub     z21.b, z4.b, z30.b
-    __ sve_fadd(z10, __ S, z19, z12);                  //       fadd    z10.s, z19.s, z12.s
-    __ sve_fmul(z9, __ D, z7, z24);                    //       fmul    z9.d, z7.d, z24.d
-    __ sve_fsub(z4, __ S, z27, z6);                    //       fsub    z4.s, z27.s, z6.s
-    __ sve_abs(z27, __ S, p6, z13);                    //       abs     z27.s, p6/m, z13.s
-    __ sve_add(z30, __ S, p5, z22);                    //       add     z30.s, p5/m, z30.s, z22.s
-    __ sve_and(z30, __ H, p7, z9);                     //       and     z30.h, p7/m, z30.h, z9.h
-    __ sve_asr(z19, __ D, p1, z20);                    //       asr     z19.d, p1/m, z19.d, z20.d
-    __ sve_bic(z9, __ H, p2, z13);                     //       bic     z9.h, p2/m, z9.h, z13.h
-    __ sve_clz(z19, __ H, p0, z24);                    //       clz     z19.h, p0/m, z24.h
-    __ sve_cnt(z19, __ S, p3, z17);                    //       cnt     z19.s, p3/m, z17.s
-    __ sve_eor(z16, __ B, p1, z0);                     //       eor     z16.b, p1/m, z16.b, z0.b
-    __ sve_lsl(z11, __ H, p2, z15);                    //       lsl     z11.h, p2/m, z11.h, z15.h
-    __ sve_lsr(z15, __ D, p1, z15);                    //       lsr     z15.d, p1/m, z15.d, z15.d
-    __ sve_mul(z5, __ S, p0, z10);                     //       mul     z5.s, p0/m, z5.s, z10.s
-    __ sve_neg(z26, __ H, p0, z0);                     //       neg     z26.h, p0/m, z0.h
-    __ sve_not(z19, __ D, p7, z10);                    //       not     z19.d, p7/m, z10.d
-    __ sve_orr(z3, __ D, p5, z7);                      //       orr     z3.d, p5/m, z3.d, z7.d
-    __ sve_rbit(z28, __ H, p3, z21);                   //       rbit    z28.h, p3/m, z21.h
-    __ sve_revb(z26, __ D, p3, z17);                   //       revb    z26.d, p3/m, z17.d
-    __ sve_smax(z17, __ D, p3, z2);                    //       smax    z17.d, p3/m, z17.d, z2.d
-    __ sve_smin(z16, __ B, p5, z20);                   //       smin    z16.b, p5/m, z16.b, z20.b
-    __ sve_sub(z19, __ D, p0, z1);                     //       sub     z19.d, p0/m, z19.d, z1.d
-    __ sve_fabs(z17, __ D, p2, z16);                   //       fabs    z17.d, p2/m, z16.d
-    __ sve_fadd(z21, __ S, p0, z4);                    //       fadd    z21.s, p0/m, z21.s, z4.s
-    __ sve_fdiv(z23, __ S, p3, z6);                    //       fdiv    z23.s, p3/m, z23.s, z6.s
-    __ sve_fmax(z20, __ D, p3, z16);                   //       fmax    z20.d, p3/m, z20.d, z16.d
-    __ sve_fmin(z12, __ D, p0, z3);                    //       fmin    z12.d, p0/m, z12.d, z3.d
-    __ sve_fmul(z9, __ D, p0, z24);                    //       fmul    z9.d, p0/m, z9.d, z24.d
-    __ sve_fneg(z3, __ S, p4, z22);                    //       fneg    z3.s, p4/m, z22.s
-    __ sve_frintm(z25, __ S, p5, z13);                 //       frintm  z25.s, p5/m, z13.s
-    __ sve_frintn(z7, __ D, p6, z5);                   //       frintn  z7.d, p6/m, z5.d
-    __ sve_frintp(z17, __ S, p4, z0);                  //       frintp  z17.s, p4/m, z0.s
-    __ sve_fsqrt(z9, __ S, p5, z11);                   //       fsqrt   z9.s, p5/m, z11.s
-    __ sve_fsub(z11, __ D, p3, z17);                   //       fsub    z11.d, p3/m, z11.d, z17.d
-    __ sve_fmad(z11, __ D, p3, z24, z17);              //       fmad    z11.d, p3/m, z24.d, z17.d
-    __ sve_fmla(z17, __ D, p2, z15, z14);              //       fmla    z17.d, p2/m, z15.d, z14.d
-    __ sve_fmls(z22, __ S, p7, z22, z7);               //       fmls    z22.s, p7/m, z22.s, z7.s
-    __ sve_fmsb(z5, __ S, p7, z27, z10);               //       fmsb    z5.s, p7/m, z27.s, z10.s
-    __ sve_fnmad(z14, __ S, p6, z21, z20);             //       fnmad   z14.s, p6/m, z21.s, z20.s
-    __ sve_fnmsb(z3, __ D, p5, z25, z5);               //       fnmsb   z3.d, p5/m, z25.d, z5.d
-    __ sve_fnmla(z29, __ S, p4, z17, z1);              //       fnmla   z29.s, p4/m, z17.s, z1.s
-    __ sve_fnmls(z14, __ D, p7, z13, z0);              //       fnmls   z14.d, p7/m, z13.d, z0.d
-    __ sve_mla(z2, __ S, p7, z20, z22);                //       mla     z2.s, p7/m, z20.s, z22.s
-    __ sve_mls(z29, __ B, p3, z8, z2);                 //       mls     z29.b, p3/m, z8.b, z2.b
-    __ sve_and(z14, z23, z22);                         //       and     z14.d, z23.d, z22.d
-    __ sve_eor(z19, z25, z26);                         //       eor     z19.d, z25.d, z26.d
-    __ sve_orr(z12, z21, z21);                         //       orr     z12.d, z21.d, z21.d
-    __ sve_bic(z1, z10, z19);                          //       bic     z1.d, z10.d, z19.d
-    __ sve_uzp1(z19, __ H, z23, z23);                  //       uzp1    z19.h, z23.h, z23.h
-    __ sve_uzp2(z30, __ S, z17, z19);                  //       uzp2    z30.s, z17.s, z19.s
-    __ sve_fabd(z20, __ S, p1, z20);                   //       fabd    z20.s, p1/m, z20.s, z20.s
-    __ sve_bext(z30, __ D, z22, z30);                  //       bext    z30.d, z22.d, z30.d
-    __ sve_bdep(z25, __ H, z17, z17);                  //       bdep    z25.h, z17.h, z17.h
+    __ sve_add(z30, __ D, z21, z4);                    //       add     z30.d, z21.d, z4.d
+    __ sve_sub(z1, __ H, z10, z19);                    //       sub     z1.h, z10.h, z19.h
+    __ sve_fadd(z0, __ D, z9, z7);                     //       fadd    z0.d, z9.d, z7.d
+    __ sve_fmul(z17, __ S, z4, z27);                   //       fmul    z17.s, z4.s, z27.s
+    __ sve_fsub(z9, __ S, z27, z23);                   //       fsub    z9.s, z27.s, z23.s
+    __ sve_abs(z16, __ S, p7, z22);                    //       abs     z16.s, p7/m, z22.s
+    __ sve_add(z20, __ H, p7, z28);                    //       add     z20.h, p7/m, z20.h, z28.h
+    __ sve_and(z13, __ S, p5, z7);                     //       and     z13.s, p5/m, z13.s, z7.s
+    __ sve_asr(z28, __ H, p2, z11);                    //       asr     z28.h, p2/m, z28.h, z11.h
+    __ sve_bic(z11, __ D, p5, z1);                     //       bic     z11.d, p5/m, z11.d, z1.d
+    __ sve_clz(z8, __ S, p4, z13);                     //       clz     z8.s, p4/m, z13.s
+    __ sve_cnt(z17, __ B, p4, z4);                     //       cnt     z17.b, p4/m, z4.b
+    __ sve_eor(z3, __ H, p3, z7);                      //       eor     z3.h, p3/m, z3.h, z7.h
+    __ sve_lsl(z14, __ H, p4, z4);                     //       lsl     z14.h, p4/m, z14.h, z4.h
+    __ sve_lsr(z29, __ H, p1, z0);                     //       lsr     z29.h, p1/m, z29.h, z0.h
+    __ sve_mul(z21, __ B, p6, z3);                     //       mul     z21.b, p6/m, z21.b, z3.b
+    __ sve_neg(z9, __ H, p4, z28);                     //       neg     z9.h, p4/m, z28.h
+    __ sve_not(z24, __ B, p1, z19);                    //       not     z24.b, p1/m, z19.b
+    __ sve_orr(z23, __ S, p7, z13);                    //       orr     z23.s, p7/m, z23.s, z13.s
+    __ sve_rbit(z10, __ S, p6, z12);                   //       rbit    z10.s, p6/m, z12.s
+    __ sve_revb(z30, __ H, p4, z14);                   //       revb    z30.h, p4/m, z14.h
+    __ sve_smax(z29, __ S, p4, z21);                   //       smax    z29.s, p4/m, z29.s, z21.s
+    __ sve_smin(z7, __ B, p5, z2);                     //       smin    z7.b, p5/m, z7.b, z2.b
+    __ sve_sub(z26, __ S, p4, z9);                     //       sub     z26.s, p4/m, z26.s, z9.s
+    __ sve_fabs(z17, __ S, p5, z0);                    //       fabs    z17.s, p5/m, z0.s
+    __ sve_fadd(z2, __ S, p6, z14);                    //       fadd    z2.s, p6/m, z2.s, z14.s
+    __ sve_fdiv(z11, __ D, p5, z14);                   //       fdiv    z11.d, p5/m, z11.d, z14.d
+    __ sve_fmax(z29, __ S, p3, z3);                    //       fmax    z29.s, p3/m, z29.s, z3.s
+    __ sve_fmin(z22, __ D, p2, z3);                    //       fmin    z22.d, p2/m, z22.d, z3.d
+    __ sve_fmul(z27, __ D, p0, z19);                   //       fmul    z27.d, p0/m, z27.d, z19.d
+    __ sve_fneg(z7, __ S, p6, z21);                    //       fneg    z7.s, p6/m, z21.s
+    __ sve_frintm(z5, __ S, p2, z25);                  //       frintm  z5.s, p2/m, z25.s
+    __ sve_frintn(z21, __ S, p4, z17);                 //       frintn  z21.s, p4/m, z17.s
+    __ sve_frintp(z3, __ S, p2, z19);                  //       frintp  z3.s, p2/m, z19.s
+    __ sve_fsqrt(z7, __ D, p3, z14);                   //       fsqrt   z7.d, p3/m, z14.d
+    __ sve_fsub(z17, __ D, p2, z13);                   //       fsub    z17.d, p2/m, z17.d, z13.d
+    __ sve_fmad(z17, __ D, p7, z17, z8);               //       fmad    z17.d, p7/m, z17.d, z8.d
+    __ sve_fmla(z14, __ D, p6, z22, z27);              //       fmla    z14.d, p6/m, z22.d, z27.d
+    __ sve_fmls(z7, __ D, p2, z5, z27);                //       fmls    z7.d, p2/m, z5.d, z27.d
+    __ sve_fmsb(z10, __ D, p0, z14, z24);              //       fmsb    z10.d, p0/m, z14.d, z24.d
+    __ sve_fnmad(z20, __ D, p0, z3, z22);              //       fnmad   z20.d, p0/m, z3.d, z22.d
+    __ sve_fnmsb(z5, __ D, p6, z29, z17);              //       fnmsb   z5.d, p6/m, z29.d, z17.d
+    __ sve_fnmla(z1, __ S, p3, z14, z29);              //       fnmla   z1.s, p3/m, z14.s, z29.s
+    __ sve_fnmls(z0, __ D, p4, z2, z30);               //       fnmls   z0.d, p4/m, z2.d, z30.d
+    __ sve_mla(z22, __ H, p5, z29, z12);               //       mla     z22.h, p5/m, z29.h, z12.h
+    __ sve_mls(z2, __ S, p0, z14, z23);                //       mls     z2.s, p0/m, z14.s, z23.s
+    __ sve_and(z0, z19, z25);                          //       and     z0.d, z19.d, z25.d
+    __ sve_eor(z23, z12, z21);                         //       eor     z23.d, z12.d, z21.d
+    __ sve_orr(z1, z1, z10);                           //       orr     z1.d, z1.d, z10.d
+    __ sve_bic(z11, z19, z23);                         //       bic     z11.d, z19.d, z23.d
+    __ sve_uzp1(z8, __ S, z30, z17);                   //       uzp1    z8.s, z30.s, z17.s
+    __ sve_uzp2(z19, __ S, z20, z4);                   //       uzp2    z19.s, z20.s, z4.s
+    __ sve_fabd(z13, __ D, p7, z22);                   //       fabd    z13.d, p7/m, z13.d, z22.d
+    __ sve_bext(z30, __ S, z25, z17);                  //       bext    z30.s, z25.s, z17.s
+    __ sve_bdep(z14, __ D, z11, z12);                  //       bdep    z14.d, z11.d, z12.d
 
 // SVEReductionOp
-    __ sve_andv(v11, __ S, p3, z28);                   //       andv s11, p3, z28.s
-    __ sve_orv(v5, __ H, p0, z13);                     //       orv h5, p0, z13.h
-    __ sve_eorv(v2, __ H, p1, z10);                    //       eorv h2, p1, z10.h
-    __ sve_smaxv(v19, __ H, p1, z25);                  //       smaxv h19, p1, z25.h
-    __ sve_sminv(v2, __ B, p0, z29);                   //       sminv b2, p0, z29.b
-    __ sve_fminv(v20, __ D, p1, z20);                  //       fminv d20, p1, z20.d
-    __ sve_fmaxv(v28, __ S, p3, z13);                  //       fmaxv s28, p3, z13.s
-    __ sve_fadda(v13, __ S, p7, z1);                   //       fadda s13, p7, s13, z1.s
-    __ sve_uaddv(v27, __ D, p0, z3);                   //       uaddv d27, p0, z3.d
+    __ sve_andv(v20, __ H, p1, z1);                    //       andv h20, p1, z1.h
+    __ sve_orv(v13, __ H, p0, z7);                     //       orv h13, p0, z7.h
+    __ sve_eorv(v11, __ D, p4, z4);                    //       eorv d11, p4, z4.d
+    __ sve_smaxv(v15, __ D, p0, z3);                   //       smaxv d15, p0, z3.d
+    __ sve_sminv(v0, __ S, p5, z5);                    //       sminv s0, p5, z5.s
+    __ sve_fminv(v30, __ S, p7, z13);                  //       fminv s30, p7, z13.s
+    __ sve_fmaxv(v8, __ S, p3, z29);                   //       fmaxv s8, p3, z29.s
+    __ sve_fadda(v14, __ S, p7, z3);                   //       fadda s14, p7, s14, z3.s
+    __ sve_uaddv(v25, __ H, p2, z24);                  //       uaddv d25, p2, z24.h
 
     __ bind(forth);
 
@@ -1239,30 +1241,30 @@
     0x9101a1a0,     0xb10a5cc8,     0xd10810aa,     0xf10fd061,
     0x120cb166,     0x321764bc,     0x52174681,     0x720c0227,
     0x9241018e,     0xb25a2969,     0xd278b411,     0xf26aad01,
-    0x14000000,     0x17ffffd7,     0x140003ff,     0x94000000,
-    0x97ffffd4,     0x940003fc,     0x3400000a,     0x34fffa2a,
-    0x34007f2a,     0x35000008,     0x35fff9c8,     0x35007ec8,
-    0xb400000b,     0xb4fff96b,     0xb4007e6b,     0xb500001d,
-    0xb5fff91d,     0xb5007e1d,     0x10000013,     0x10fff8b3,
-    0x10007db3,     0x90000013,     0x36300016,     0x3637f836,
-    0x36307d36,     0x3758000c,     0x375ff7cc,     0x37587ccc,
+    0x14000000,     0x17ffffd7,     0x14000401,     0x94000000,
+    0x97ffffd4,     0x940003fe,     0x3400000a,     0x34fffa2a,
+    0x34007f6a,     0x35000008,     0x35fff9c8,     0x35007f08,
+    0xb400000b,     0xb4fff96b,     0xb4007eab,     0xb500001d,
+    0xb5fff91d,     0xb5007e5d,     0x10000013,     0x10fff8b3,
+    0x10007df3,     0x90000013,     0x36300016,     0x3637f836,
+    0x36307d76,     0x3758000c,     0x375ff7cc,     0x37587d0c,
     0x128313a0,     0x528a32c7,     0x7289173b,     0x92ab3acc,
     0xd2a0bf94,     0xf2c285e8,     0x9358722f,     0x330e652f,
     0x53067f3b,     0x93577c53,     0xb34a1aac,     0xd35a4016,
     0x13946c63,     0x93c3dbc8,     0x54000000,     0x54fff5a0,
-    0x54007aa0,     0x54000001,     0x54fff541,     0x54007a41,
-    0x54000002,     0x54fff4e2,     0x540079e2,     0x54000002,
-    0x54fff482,     0x54007982,     0x54000003,     0x54fff423,
-    0x54007923,     0x54000003,     0x54fff3c3,     0x540078c3,
-    0x54000004,     0x54fff364,     0x54007864,     0x54000005,
-    0x54fff305,     0x54007805,     0x54000006,     0x54fff2a6,
-    0x540077a6,     0x54000007,     0x54fff247,     0x54007747,
-    0x54000008,     0x54fff1e8,     0x540076e8,     0x54000009,
-    0x54fff189,     0x54007689,     0x5400000a,     0x54fff12a,
-    0x5400762a,     0x5400000b,     0x54fff0cb,     0x540075cb,
-    0x5400000c,     0x54fff06c,     0x5400756c,     0x5400000d,
-    0x54fff00d,     0x5400750d,     0x5400000e,     0x54ffefae,
-    0x540074ae,     0x5400000f,     0x54ffef4f,     0x5400744f,
+    0x54007ae0,     0x54000001,     0x54fff541,     0x54007a81,
+    0x54000002,     0x54fff4e2,     0x54007a22,     0x54000002,
+    0x54fff482,     0x540079c2,     0x54000003,     0x54fff423,
+    0x54007963,     0x54000003,     0x54fff3c3,     0x54007903,
+    0x54000004,     0x54fff364,     0x540078a4,     0x54000005,
+    0x54fff305,     0x54007845,     0x54000006,     0x54fff2a6,
+    0x540077e6,     0x54000007,     0x54fff247,     0x54007787,
+    0x54000008,     0x54fff1e8,     0x54007728,     0x54000009,
+    0x54fff189,     0x540076c9,     0x5400000a,     0x54fff12a,
+    0x5400766a,     0x5400000b,     0x54fff0cb,     0x5400760b,
+    0x5400000c,     0x54fff06c,     0x540075ac,     0x5400000d,
+    0x54fff00d,     0x5400754d,     0x5400000e,     0x54ffefae,
+    0x540074ee,     0x5400000f,     0x54ffef4f,     0x5400748f,
     0xd40658e1,     0xd4014d22,     0xd4046543,     0xd4273f60,
     0xd44cad80,     0xd503201f,     0xd503203f,     0xd503205f,
     0xd503209f,     0xd50320bf,     0xd503219f,     0xd50323bf,
@@ -1328,173 +1330,173 @@
     0x1e622831,     0x1e633946,     0x1f070578,     0x1f03c40b,
     0x1f3618dc,     0x1f3a0b60,     0x1f5c2ce5,     0x1f4bddb9,
     0x1f715513,     0x1f734699,     0x1e2043a2,     0x1e20c116,
-    0x1e214275,     0x1e21c174,     0x1e22c291,     0x1e6041e6,
-    0x1e60c063,     0x1e61407c,     0x1e61c1db,     0x1e62414e,
-    0x1e38016c,     0x9e380151,     0x1e7800f9,     0x9e7801c7,
-    0x1e22001c,     0x9e220016,     0x1e6202ec,     0x9e6201ad,
-    0x1e2401c7,     0x9e640107,     0x1e300234,     0x9e7003dc,
-    0x1e260050,     0x9e660209,     0x1e2703b4,     0x9e670024,
-    0x1e382340,     0x1e6e22e0,     0x1e2022a8,     0x1e602188,
-    0x2928630c,     0x29501616,     0x694e4db4,     0xa90619b1,
-    0xa9760625,     0x29a652cd,     0x29ca6d5e,     0x69c2534d,
-    0xa9bb5fa4,     0xa9f900d6,     0x288a6cb1,     0x28e02e0e,
-    0x68e25d2c,     0xa8821c17,     0xa8c52351,     0x282a3d4b,
-    0x28484093,     0xa831393e,     0xa8425e9d,     0x0c407365,
-    0x4cdfa32a,     0x0cd36fcf,     0x4cdf2611,     0x0d40c2fe,
-    0x4ddfc911,     0x0dc3cd2c,     0x4c408c53,     0x0cdf8515,
-    0x4d60c08d,     0x0dffc87c,     0x4de0cfbd,     0x4cd54827,
-    0x0c404811,     0x4d40e4ba,     0x4ddfe839,     0x0dddec56,
-    0x4cdf076d,     0x0cd7031d,     0x0d60e1ed,     0x0dffe5cf,
-    0x0df7ea9b,     0x0e31bb38,     0x4e31ba0f,     0x0e71bb59,
-    0x4e71b9ee,     0x4eb1b96a,     0x0e30a9cd,     0x4e30a9ee,
-    0x0e70aab4,     0x4e70a841,     0x4eb0aaf6,     0x6e30fbfe,
-    0x0e31a9ee,     0x2e31a862,     0x4e31a8e6,     0x6e31a883,
-    0x0e71a907,     0x2e71ab38,     0x4e71a820,     0x6e71ab9b,
-    0x4eb1abdd,     0x6eb1a8c5,     0x6eb0f8c5,     0x7e30fbdd,
-    0x7e70f98b,     0x7eb0fb59,     0x7ef0f820,     0x0e20bbfe,
-    0x4e20b820,     0x0e60ba51,     0x4e60bbbc,     0x0ea0bb59,
-    0x4ea0b949,     0x4ee0bb59,     0x0ea0f9ac,     0x4ea0fa0f,
-    0x4ee0f98b,     0x2ea0f96a,     0x6ea0fa51,     0x6ee0fb38,
-    0x2ea1fad5,     0x6ea1fb17,     0x6ee1f820,     0x2e205a30,
-    0x6e20596a,     0x0e281ce6,     0x4e3e1fbc,     0x0ea81ce6,
-    0x4ea71cc5,     0x2e271cc5,     0x6e361eb4,     0x0e338651,
-    0x4e31860f,     0x0e738651,     0x4e7f87dd,     0x0ebc877a,
-    0x4ebe87bc,     0x4ee38441,     0x0e3dd79b,     0x4e22d420,
-    0x4e76d6b4,     0x2e3e87bc,     0x6e31860f,     0x2e6e85ac,
-    0x6e6c856a,     0x2ebe87bc,     0x6ebe87bc,     0x6ef58693,
-    0x0eb8d6f6,     0x4eacd56a,     0x4ee6d4a4,     0x0e209ffe,
-    0x4e369eb4,     0x0e6a9d28,     0x4e609ffe,     0x0eb39e51,
-    0x4eac9d6a,     0x2ebdd79b,     0x6ea4d462,     0x6efad738,
-    0x2e26dca4,     0x6e25dc83,     0x6e6add28,     0x0e7896f6,
-    0x4e739651,     0x0eaf95cd,     0x4ea694a4,     0x0e3ecfbc,
-    0x4e39cf17,     0x4e77ced5,     0x2e7b9759,     0x6e7a9738,
-    0x2ea59483,     0x6eb99717,     0x0ebccf7a,     0x4eb9cf17,
-    0x4ef0cdee,     0x2e37fed5,     0x6e25fc83,     0x6e79ff17,
-    0x0e2a6528,     0x4e3a6738,     0x0e756693,     0x4e71660f,
-    0x0eb26630,     0x4ea46462,     0x0e23a441,     0x4e22a420,
-    0x0e7aa738,     0x4e66a4a4,     0x0ea5a483,     0x4eada58b,
-    0x0e20f7fe,     0x4e3df79b,     0x4e6bf549,     0x0e3b6f59,
-    0x4e246c62,     0x0e6e6dac,     0x4e736e51,     0x0ea06ffe,
-    0x4ea36c41,     0x0e2eadac,     0x4e3eafbc,     0x0e62ac20,
-    0x4e73ae51,     0x0eaeadac,     0x4eb3ae51,     0x0eb7f6d5,
-    0x4eaef5ac,     0x4efdf79b,     0x2e3f8fdd,     0x6e208ffe,
-    0x2e638c41,     0x6e7b8f59,     0x2ebd8f9b,     0x6ea68ca4,
-    0x6eff8fdd,     0x0e25e483,     0x4e28e4e6,     0x4e7fe7dd,
-    0x0e3b3759,     0x4e333651,     0x0e6a3528,     0x4e693507,
-    0x0eae35ac,     0x4ea23420,     0x4ef53693,     0x2e233441,
-    0x6e393717,     0x2e643462,     0x6e623420,     0x2eaa3528,
-    0x6eb93717,     0x6efb3759,     0x2e313e0f,     0x6e3f3fdd,
-    0x2e653c83,     0x6e6c3d6a,     0x2eb83ef6,     0x6eac3d6a,
-    0x6ee63ca4,     0x2eb3e651,     0x6ea3e441,     0x6eede58b,
-    0x0e293d07,     0x4e2c3d6a,     0x0e713e0f,     0x4e723e30,
-    0x0ea43c62,     0x4eab3d49,     0x4eed3d8b,     0x2e2ee5ac,
-    0x6e30e5ee,     0x6e6fe5cd,     0x2ea4ec62,     0x6ea8ece6,
-    0x6ef5ee93,     0x659221ed,     0x65d03572,     0x65903628,
-    0x65d1358b,     0x659139de,     0x65d32960,     0xba5fd3e3,
-    0x3a5f03e5,     0xfa411be4,     0x7a42cbe2,     0x93df03ff,
-    0xc820ffff,     0x8822fc7f,     0xc8247cbf,     0x88267fff,
-    0x4e010fe0,     0x5e040420,     0x4e081fe1,     0x4e0c1fe1,
-    0x4e0a1fe1,     0x4e071fe1,     0x4e042c20,     0x4e062c20,
-    0x4e052c20,     0x4e083c20,     0x0e0c3c20,     0x0e0a3c20,
-    0x0e073c20,     0x9eae0020,     0x0f03f409,     0x6f03f40e,
-    0x4cc0ac3f,     0x0ea1b820,     0x4e21c862,     0x4e61b8a4,
-    0x05a08020,     0x05104fe0,     0x05505001,     0x05906fe2,
-    0x05d03005,     0x05101fea,     0x05901feb,     0x04b0e3e0,
-    0x0470e7e1,     0x042f9c20,     0x043f9c35,     0x047f9c20,
-    0x04ff9c20,     0x04299420,     0x04319160,     0x0461943e,
-    0x04a19020,     0x04038100,     0x040381a0,     0x040387e1,
-    0x04438be2,     0x04c38fe3,     0x040181e0,     0x04018100,
-    0x04018621,     0x04418b22,     0x04418822,     0x04818c23,
-    0x040081e0,     0x04008120,     0x04008761,     0x04008621,
-    0x04408822,     0x04808c23,     0x042053ff,     0x047f5401,
-    0x25208028,     0x2538cfe0,     0x2578d001,     0x25b8efe2,
-    0x25f8f007,     0x2538dfea,     0x25b8dfeb,     0xa400a3e0,
-    0xa420a7e0,     0xa4484be0,     0xa467afe0,     0xa4a8a7ea,
-    0xa547a814,     0xa4084ffe,     0xa55c53e0,     0xa5e1540b,
-    0xe400fbf6,     0xe408ffff,     0xe420e7e0,     0xe4484be0,
-    0xe460efe0,     0xe547e400,     0xe4014be0,     0xe4a84fe0,
-    0xe5f15000,     0x858043e0,     0x85a043ff,     0xe59f5d08,
-    0x0420e3e9,     0x0460e3ea,     0x04a0e3eb,     0x04e0e3ec,
-    0x25104042,     0x25104871,     0x25904861,     0x25904c92,
-    0x05344020,     0x05744041,     0x05b44062,     0x05f44083,
-    0x252c8840,     0x253c1420,     0x25681572,     0x25a21ce3,
-    0x25ea1e34,     0x253c0421,     0x25680572,     0x25a20ce3,
-    0x25ea0e34,     0x0522c020,     0x05e6c0a4,     0x2401a001,
-    0x2443a051,     0x24858881,     0x24c78cd1,     0x24850891,
-    0x24c70cc1,     0x250f9001,     0x25508051,     0x25802491,
-    0x25df28c1,     0x25850c81,     0x251e10d1,     0x65816001,
-    0x65c36051,     0x65854891,     0x65c74cc1,     0x05733820,
-    0x05b238a4,     0x05f138e6,     0x0570396a,     0x65d0a001,
-    0x65d6a443,     0x65d4a826,     0x6594ac26,     0x6554ac26,
-    0x6556ac26,     0x6552ac26,     0x65cbac85,     0x65caac01,
-    0x65dea833,     0x659ca509,     0x65d8a801,     0x65dcac01,
-    0x655cb241,     0x0520a1e0,     0x0521a601,     0x052281e0,
-    0x05238601,     0x04a14026,     0x042244a6,     0x046344a6,
-    0x04a444a6,     0x04e544a7,     0x0568aca7,     0x05b23230,
-    0x853040af,     0xc5b040af,     0xe57080af,     0xe5b080af,
-    0x25034440,     0x254054c4,     0x25034640,     0x25415a05,
-    0x25834440,     0x25c54489,     0x250b5d3a,     0x2550dc20,
-    0x2518e3e1,     0x2518e021,     0x2518e0a1,     0x2518e121,
-    0x2518e1a1,     0x2558e3e2,     0x2558e042,     0x2558e0c2,
-    0x2558e142,     0x2598e3e3,     0x2598e063,     0x2598e0e3,
-    0x2598e163,     0x25d8e3e4,     0x25d8e084,     0x25d8e104,
-    0x25d8e184,     0x2518e407,     0x05214800,     0x05614800,
-    0x05a14800,     0x05e14800,     0x05214c00,     0x05614c00,
-    0x05a14c00,     0x05e14c00,     0x05304001,     0x05314001,
-    0x05a18610,     0x05e18610,     0x05271e11,     0x6545e891,
-    0x6585e891,     0x65c5e891,     0x6545c891,     0x6585c891,
-    0x65c5c891,     0x45b0c210,     0x45f1c231,     0x1e601000,
-    0x1e603000,     0x1e621000,     0x1e623000,     0x1e641000,
-    0x1e643000,     0x1e661000,     0x1e663000,     0x1e681000,
-    0x1e683000,     0x1e6a1000,     0x1e6a3000,     0x1e6c1000,
-    0x1e6c3000,     0x1e6e1000,     0x1e6e3000,     0x1e701000,
-    0x1e703000,     0x1e721000,     0x1e723000,     0x1e741000,
-    0x1e743000,     0x1e761000,     0x1e763000,     0x1e781000,
-    0x1e783000,     0x1e7a1000,     0x1e7a3000,     0x1e7c1000,
-    0x1e7c3000,     0x1e7e1000,     0x1e7e3000,     0xf8308047,
-    0xf823026d,     0xf8311070,     0xf82123cb,     0xf82531e8,
-    0xf83d501e,     0xf8344287,     0xf83772bc,     0xf83b60b9,
-    0xf8a18217,     0xf8bf0185,     0xf8a911fc,     0xf8bd23f6,
-    0xf8b330bf,     0xf8ae53f0,     0xf8b0429b,     0xf8b0716c,
-    0xf8a963c6,     0xf8f1839b,     0xf8fe0147,     0xf8f4108a,
-    0xf8f82231,     0xf8f633a3,     0xf8ef5276,     0xf8f34056,
-    0xf8ef7186,     0xf8f061ab,     0xf87783c1,     0xf8730225,
-    0xf86212d0,     0xf86d22aa,     0xf87d319b,     0xf87b5023,
-    0xf87f4278,     0xf8717389,     0xf87b60ef,     0xb83583f7,
-    0xb83903e2,     0xb83b1150,     0xb8372073,     0xb8303320,
-    0xb83a5057,     0xb830408c,     0xb83c73be,     0xb83060db,
-    0xb8a981fd,     0xb8a700e4,     0xb8af12e9,     0xb8a82382,
-    0xb8b530bf,     0xb8bb5220,     0xb8af4344,     0xb8a872dc,
-    0xb8bb633b,     0xb8f78080,     0xb8e60010,     0xb8e4102f,
-    0xb8ea20a7,     0xb8ea30fc,     0xb8f452b7,     0xb8e6410b,
-    0xb8f170df,     0xb8f16182,     0xb87e807d,     0xb87b03b6,
-    0xb86e138d,     0xb87120b8,     0xb862314e,     0xb870536b,
-    0xb877408c,     0xb8767091,     0xb8616213,     0xce2e3191,
-    0xce035202,     0xce668cb7,     0xce8ce227,     0xce668210,
-    0xce638782,     0xcec080c4,     0xce6d8a71,     0x25a0c86c,
-    0x25a1d358,     0x05800500,     0x05400ad3,     0x05000e06,
-    0x25e0c951,     0x25a1d54a,     0x05839276,     0x0540ea6f,
-    0x0503c8a4,     0x25a0d448,     0x2521d056,     0x058059c9,
-    0x05406d05,     0x05003cb6,     0x25a0d0c8,     0x2561c4f9,
-    0x05809904,     0x05400e5d,     0x0500cadd,     0x2560dda2,
-    0x2521c143,     0x05801c3a,     0x054052a8,     0x05001845,
-    0x25a0de96,     0x25a1c074,     0x05808864,     0x05401ed3,
-    0x05001e33,     0x04f1030e,     0x043e0495,     0x658c026a,
-    0x65d808e9,     0x65860764,     0x0496b9bb,     0x048016de,
-    0x045a1d3e,     0x04d08693,     0x045b09a9,     0x0459a313,
-    0x049aae33,     0x04190410,     0x045389eb,     0x04d185ef,
-    0x04900145,     0x0457a01a,     0x04debd53,     0x04d814e3,
-    0x05678ebc,     0x05e48e3a,     0x04c80c51,     0x040a1690,
-    0x04c10033,     0x04dcaa11,     0x65808095,     0x658d8cd7,
-    0x65c68e14,     0x65c7806c,     0x65c28309,     0x049db2c3,
-    0x6582b5b9,     0x65c0b8a7,     0x6581b011,     0x658db569,
-    0x65c18e2b,     0x65f18f0b,     0x65ee09f1,     0x65a73ed6,
-    0x65aabf65,     0x65b4daae,     0x65e5f723,     0x65a1523d,
-    0x65e07dae,     0x04965e82,     0x04026d1d,     0x043632ee,
-    0x04ba3333,     0x047532ac,     0x04f33141,     0x05776af3,
-    0x05b36e3e,     0x65888694,     0x45deb2de,     0x4551b639,
-    0x049a2f8b,     0x045821a5,     0x04592542,     0x04482733,
-    0x040a23a2,     0x65c72694,     0x65862dbc,     0x65983c2d,
-    0x04c1207b,
+    0x1e214275,     0x1e21c174,     0x1e22c291,     0x1e23c1e6,
+    0x1ee24063,     0x1e60407c,     0x1e60c1db,     0x1e61414e,
+    0x1e61c16c,     0x1e624151,     0x1e3800f9,     0x9e3801c7,
+    0x1e78001c,     0x9e780016,     0x1e2202ec,     0x9e2201ad,
+    0x1e6201c7,     0x9e620107,     0x1e240234,     0x9e6403dc,
+    0x1e300050,     0x9e700209,     0x1e2603b4,     0x9e660024,
+    0x1e27031a,     0x9e6701d7,     0x1e2c22a0,     0x1e6c20a0,
+    0x1e202308,     0x1e602308,     0x2910561b,     0x294436d1,
+    0x697e3626,     0xa9366a3c,     0xa97419b5,     0x29825e7a,
+    0x29d04144,     0x69f412ee,     0xa982321d,     0xa9c6477a,
+    0x28b40086,     0x28c079c2,     0x68e060f7,     0xa88868a0,
+    0xa8f62de6,     0x28302059,     0x2866383e,     0xa83701b6,
+    0xa8403363,     0x0c40700a,     0x4cdfa22c,     0x0cc26f0a,
+    0x4cdf2628,     0x0d40c3d7,     0x4ddfc856,     0x0dcfcfde,
+    0x4c408cb4,     0x0cdf8538,     0x4d60c190,     0x0dffc8f7,
+    0x4de3ce1a,     0x4cc74979,     0x0c40499e,     0x4d40e52f,
+    0x4ddfe8de,     0x0dcdeee7,     0x4cdf04c4,     0x0ccf0264,
+    0x0d60e1d9,     0x0dffe79a,     0x0de6e8b9,     0x0e31b9ee,
+    0x4e31b96a,     0x0e71b9cd,     0x4e71b9ee,     0x4eb1bab4,
+    0x0e30a841,     0x4e30aaf6,     0x0e70abfe,     0x4e70a9ee,
+    0x4eb0a862,     0x6e30f8e6,     0x0e31a883,     0x2e31a907,
+    0x4e31ab38,     0x6e31a820,     0x0e71ab9b,     0x2e71abdd,
+    0x4e71a8c5,     0x6e71a8c5,     0x4eb1abdd,     0x6eb1a98b,
+    0x6eb0fb59,     0x7e30f820,     0x7e70fbfe,     0x7eb0f820,
+    0x7ef0fa51,     0x0e20bbbc,     0x4e20bb59,     0x0e60b949,
+    0x4e60bb59,     0x0ea0b9ac,     0x4ea0ba0f,     0x4ee0b98b,
+    0x0ea0f96a,     0x4ea0fa51,     0x4ee0fb38,     0x2ea0fad5,
+    0x6ea0fb17,     0x6ee0f820,     0x2ea1fa30,     0x6ea1f96a,
+    0x6ee1f8e6,     0x2e205bbc,     0x6e2058e6,     0x0e271cc5,
+    0x4e271cc5,     0x0eb61eb4,     0x4eb31e51,     0x2e311e0f,
+    0x6e331e51,     0x0e3f87dd,     0x4e3c877a,     0x0e7e87bc,
+    0x4e638441,     0x0ebd879b,     0x4ea28420,     0x4ef686b4,
+    0x0e3ed7bc,     0x4e31d60f,     0x4e6ed5ac,     0x2e2c856a,
+    0x6e3e87bc,     0x2e7e87bc,     0x6e758693,     0x2eb886f6,
+    0x6eac856a,     0x6ee684a4,     0x0ea0d7fe,     0x4eb6d6b4,
+    0x4eead528,     0x0e209ffe,     0x4e339e51,     0x0e6c9d6a,
+    0x4e7d9f9b,     0x0ea49c62,     0x4eba9f38,     0x2ea6d4a4,
+    0x6ea5d483,     0x6eead528,     0x2e38def6,     0x6e33de51,
+    0x6e6fddcd,     0x0e6694a4,     0x4e7e97bc,     0x0eb99717,
+    0x4eb796d5,     0x0e3bcf59,     0x4e3acf38,     0x4e65cc83,
+    0x2e799717,     0x6e7c977a,     0x2eb99717,     0x6eb095ee,
+    0x0eb7ced5,     0x4ea5cc83,     0x4ef9cf17,     0x2e2afd28,
+    0x6e3aff38,     0x6e75fe93,     0x0e31660f,     0x4e326630,
+    0x0e646462,     0x4e636441,     0x0ea26420,     0x4eba6738,
+    0x0e26a4a4,     0x4e25a483,     0x0e6da58b,     0x4e60a7fe,
+    0x0ebda79b,     0x4eaba549,     0x0e3bf759,     0x4e24f462,
+    0x4e6ef5ac,     0x0e336e51,     0x4e206ffe,     0x0e636c41,
+    0x4e6e6dac,     0x0ebe6fbc,     0x4ea26c20,     0x0e33ae51,
+    0x4e2eadac,     0x0e73ae51,     0x4e77aed5,     0x0eaeadac,
+    0x4ebdaf9b,     0x0ebff7dd,     0x4ea0f7fe,     0x4ee3f441,
+    0x2e3b8f59,     0x6e3d8f9b,     0x2e668ca4,     0x6e7f8fdd,
+    0x2ea58c83,     0x6ea88ce6,     0x6eff8fdd,     0x0e3be759,
+    0x4e33e651,     0x4e6ae528,     0x0e293507,     0x4e2e35ac,
+    0x0e623420,     0x4e753693,     0x0ea33441,     0x4eb93717,
+    0x4ee43462,     0x2e223420,     0x6e2a3528,     0x2e793717,
+    0x6e7b3759,     0x2eb1360f,     0x6ebf37dd,     0x6ee53483,
+    0x2e2c3d6a,     0x6e383ef6,     0x2e6c3d6a,     0x6e663ca4,
+    0x2eb33e51,     0x6ea33c41,     0x6eed3d8b,     0x2ea9e507,
+    0x6eace56a,     0x6ef1e60f,     0x0e323e30,     0x4e243c62,
+    0x0e6b3d49,     0x4e6d3d8b,     0x0eae3dac,     0x4eb03dee,
+    0x4eef3dcd,     0x2e24e462,     0x6e28e4e6,     0x6e75e693,
+    0x2ebbef59,     0x6eb1ee0f,     0x6ee6eca4,     0x65923081,
+    0x65d02a1a,     0x65903aca,     0x65912b8b,     0x65913c3c,
+    0x659321e5,     0xba5fd3e3,     0x3a5f03e5,     0xfa411be4,
+    0x7a42cbe2,     0x93df03ff,     0xc820ffff,     0x8822fc7f,
+    0xc8247cbf,     0x88267fff,     0x4e010fe0,     0x5e040420,
+    0x4e081fe1,     0x4e0c1fe1,     0x4e0a1fe1,     0x4e071fe1,
+    0x4e042c20,     0x4e062c20,     0x4e052c20,     0x4e083c20,
+    0x0e0c3c20,     0x0e0a3c20,     0x0e073c20,     0x9eae0020,
+    0x0f03f409,     0x6f03f40e,     0x4cc0ac3f,     0x0ea1b820,
+    0x4e21c862,     0x4e61b8a4,     0x05a08020,     0x05104fe0,
+    0x05505001,     0x05906fe2,     0x05d03005,     0x05101fea,
+    0x05901feb,     0x04b0e3e0,     0x0470e7e1,     0x042f9c20,
+    0x043f9c35,     0x047f9c20,     0x04ff9c20,     0x04299420,
+    0x04319160,     0x0461943e,     0x04a19020,     0x04038100,
+    0x040381a0,     0x040387e1,     0x04438be2,     0x04c38fe3,
+    0x040181e0,     0x04018100,     0x04018621,     0x04418b22,
+    0x04418822,     0x04818c23,     0x040081e0,     0x04008120,
+    0x04008761,     0x04008621,     0x04408822,     0x04808c23,
+    0x042053ff,     0x047f5401,     0x25208028,     0x2538cfe0,
+    0x2578d001,     0x25b8efe2,     0x25f8f007,     0x2538dfea,
+    0x25b8dfeb,     0xa400a3e0,     0xa420a7e0,     0xa4484be0,
+    0xa467afe0,     0xa4a8a7ea,     0xa547a814,     0xa4084ffe,
+    0xa55c53e0,     0xa5e1540b,     0xe400fbf6,     0xe408ffff,
+    0xe420e7e0,     0xe4484be0,     0xe460efe0,     0xe547e400,
+    0xe4014be0,     0xe4a84fe0,     0xe5f15000,     0x858043e0,
+    0x85a043ff,     0xe59f5d08,     0x0420e3e9,     0x0460e3ea,
+    0x04a0e3eb,     0x04e0e3ec,     0x25104042,     0x25104871,
+    0x25904861,     0x25904c92,     0x05344020,     0x05744041,
+    0x05b44062,     0x05f44083,     0x252c8840,     0x253c1420,
+    0x25681572,     0x25a21ce3,     0x25ea1e34,     0x253c0421,
+    0x25680572,     0x25a20ce3,     0x25ea0e34,     0x0522c020,
+    0x05e6c0a4,     0x2401a001,     0x2443a051,     0x24858881,
+    0x24c78cd1,     0x24850891,     0x24c70cc1,     0x250f9001,
+    0x25508051,     0x25802491,     0x25df28c1,     0x25850c81,
+    0x251e10d1,     0x65816001,     0x65c36051,     0x65854891,
+    0x65c74cc1,     0x05733820,     0x05b238a4,     0x05f138e6,
+    0x0570396a,     0x65d0a001,     0x65d6a443,     0x65d4a826,
+    0x6594ac26,     0x6554ac26,     0x6556ac26,     0x6552ac26,
+    0x65cbac85,     0x65caac01,     0x65dea833,     0x659ca509,
+    0x65d8a801,     0x65dcac01,     0x655cb241,     0x0520a1e0,
+    0x0521a601,     0x052281e0,     0x05238601,     0x04a14026,
+    0x042244a6,     0x046344a6,     0x04a444a6,     0x04e544a7,
+    0x0568aca7,     0x05b23230,     0x853040af,     0xc5b040af,
+    0xe57080af,     0xe5b080af,     0x25034440,     0x254054c4,
+    0x25034640,     0x25415a05,     0x25834440,     0x25c54489,
+    0x250b5d3a,     0x2550dc20,     0x2518e3e1,     0x2518e021,
+    0x2518e0a1,     0x2518e121,     0x2518e1a1,     0x2558e3e2,
+    0x2558e042,     0x2558e0c2,     0x2558e142,     0x2598e3e3,
+    0x2598e063,     0x2598e0e3,     0x2598e163,     0x25d8e3e4,
+    0x25d8e084,     0x25d8e104,     0x25d8e184,     0x2518e407,
+    0x05214800,     0x05614800,     0x05a14800,     0x05e14800,
+    0x05214c00,     0x05614c00,     0x05a14c00,     0x05e14c00,
+    0x05304001,     0x05314001,     0x05a18610,     0x05e18610,
+    0x05271e11,     0x6545e891,     0x6585e891,     0x65c5e891,
+    0x6545c891,     0x6585c891,     0x65c5c891,     0x45b0c210,
+    0x45f1c231,     0x1e601000,     0x1e603000,     0x1e621000,
+    0x1e623000,     0x1e641000,     0x1e643000,     0x1e661000,
+    0x1e663000,     0x1e681000,     0x1e683000,     0x1e6a1000,
+    0x1e6a3000,     0x1e6c1000,     0x1e6c3000,     0x1e6e1000,
+    0x1e6e3000,     0x1e701000,     0x1e703000,     0x1e721000,
+    0x1e723000,     0x1e741000,     0x1e743000,     0x1e761000,
+    0x1e763000,     0x1e781000,     0x1e783000,     0x1e7a1000,
+    0x1e7a3000,     0x1e7c1000,     0x1e7c3000,     0x1e7e1000,
+    0x1e7e3000,     0xf823826d,     0xf8310070,     0xf82113cb,
+    0xf82521e8,     0xf83d301e,     0xf8345287,     0xf83742bc,
+    0xf83b70b9,     0xf8216217,     0xf8bf8185,     0xf8a901fc,
+    0xf8bd13f6,     0xf8b320bf,     0xf8ae33f0,     0xf8b0529b,
+    0xf8b0416c,     0xf8a973c6,     0xf8b1639b,     0xf8fe8147,
+    0xf8f4008a,     0xf8f81231,     0xf8f623a3,     0xf8ef3276,
+    0xf8f35056,     0xf8ef4186,     0xf8f071ab,     0xf8f763c1,
+    0xf8738225,     0xf86202d0,     0xf86d12aa,     0xf87d219b,
+    0xf87b3023,     0xf87f5278,     0xf8714389,     0xf87b70ef,
+    0xf87563f7,     0xb83983e2,     0xb83b0150,     0xb8371073,
+    0xb8302320,     0xb83a3057,     0xb830508c,     0xb83c43be,
+    0xb83070db,     0xb82961fd,     0xb8a780e4,     0xb8af02e9,
+    0xb8a81382,     0xb8b520bf,     0xb8bb3220,     0xb8af5344,
+    0xb8a842dc,     0xb8bb733b,     0xb8b76080,     0xb8e68010,
+    0xb8e4002f,     0xb8ea10a7,     0xb8ea20fc,     0xb8f432b7,
+    0xb8e6510b,     0xb8f140df,     0xb8f17182,     0xb8fe607d,
+    0xb87b83b6,     0xb86e038d,     0xb87110b8,     0xb862214e,
+    0xb870336b,     0xb877508c,     0xb8764091,     0xb8617213,
+    0xb87061cd,     0xce300c4c,     0xce051af4,     0xce6c8e27,
+    0xce90361b,     0xce638382,     0xce7184c4,     0xcec081b3,
+    0xce688a6c,     0x25a0d358,     0x2561d880,     0x05809a06,
+    0x05403e90,     0x0500546e,     0x25a0d54a,     0x25e1c2d6,
+    0x05801583,     0x05403e87,     0x05001580,     0x2520d056,
+    0x25a1cb89,     0x05800e59,     0x0540e08d,     0x05000d2d,
+    0x2560c4f9,     0x25a1c864,     0x05830746,     0x054394b0,
+    0x05003ece,     0x2520c143,     0x25a1d2da,     0x058015ce,
+    0x05400ed8,     0x0500bb31,     0x25a0c074,     0x25a1d884,
+    0x05804944,     0x0540b1d9,     0x05001548,     0x04e402be,
+    0x04730541,     0x65c70120,     0x659b0891,     0x65970769,
+    0x0496bed0,     0x04401f94,     0x049a14ed,     0x0450897c,
+    0x04db142b,     0x0499b1a8,     0x041ab091,     0x04590ce3,
+    0x0453908e,     0x0451841d,     0x04101875,     0x0457b389,
+    0x041ea678,     0x04981db7,     0x05a7998a,     0x056491de,
+    0x048812bd,     0x040a1447,     0x0481113a,     0x049cb411,
+    0x658099c2,     0x65cd95cb,     0x65868c7d,     0x65c78876,
+    0x65c2827b,     0x049dbaa7,     0x6582ab25,     0x6580b235,
+    0x6581aa63,     0x65cdadc7,     0x65c189b1,     0x65e89e31,
+    0x65fb1ace,     0x65fb28a7,     0x65f8a1ca,     0x65f6c074,
+    0x65f1fba5,     0x65bd4dc1,     0x65fe7040,     0x044c57b6,
+    0x049761c2,     0x04393260,     0x04b53197,     0x046a3021,
+    0x04f7326b,     0x05b16bc8,     0x05a46e93,     0x65c89ecd,
+    0x4591b33e,     0x45ccb56e,     0x045a2434,     0x045820ed,
+    0x04d9308b,     0x04c8206f,     0x048a34a0,     0x65873dbe,
+    0x65862fa8,     0x65983c6e,     0x04412b19,
   };
 // END  Generated code -- do not edit


### PR DESCRIPTION
This patch adds aarch64 backend support for library intrinsics that implement conversions between half-precision and single-precision floats.

Ran the following benchmarks to assess the performance with this patch -

org.openjdk.bench.java.math.Fp16ConversionBenchmark.floatToFloat16 org.openjdk.bench.java.math.Fp16ConversionBenchmark.float16ToFloat

The performance (ops/ms) gain with the patch on an ARM NEON machine is shown below -
```

  Benchmark                                      Gain
  Fp16ConversionBenchmark.float16ToFloat         3.42
  Fp16ConversionBenchmark.floatToFloat16         5.85
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295276](https://bugs.openjdk.org/browse/JDK-8295276): AArch64: Add backend support for half float conversion intrinsics


### Reviewers
 * [Nick Gasson](https://openjdk.org/census#ngasson) (@nick-arm - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Ningsheng Jian](https://openjdk.org/census#njian) (@nsjian - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10796/head:pull/10796` \
`$ git checkout pull/10796`

Update a local copy of the PR: \
`$ git checkout pull/10796` \
`$ git pull https://git.openjdk.org/jdk pull/10796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10796`

View PR using the GUI difftool: \
`$ git pr show -t 10796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10796.diff">https://git.openjdk.org/jdk/pull/10796.diff</a>

</details>
