### PR TITLE
8295298: Automate javax/swing/JFileChooser/FileViewNPETest.java

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
@@ -59,9 +59,11 @@ public class FileViewNPETest {
 
             SwingUtilities.invokeAndWait(() -> {
                 jfc.setCurrentDirectory(path.getParentFile());
-                assert jfc.getCurrentDirectory() == null
-                       : "Expected to become null because the parent directory "
-                         + "is not traversable";
+                if (null != jfc.getCurrentDirectory()) {
+                    // The current directory to become null because
+                    // the parent directory is not traversable
+                    throw new RuntimeException("Current directory is not null");
+                }
             });
             robot.waitForIdle();
 
@@ -69,8 +71,9 @@ public class FileViewNPETest {
                 JComboBox<?> dirs = findDirectoryComboBox(jfc);
                 // No NPE is expected
                 dirs.setSelectedIndex(dirs.getSelectedIndex());
-                assert jfc.getCurrentDirectory().equals(path)
-                       : "The current directory should be restored";
+                if (!jfc.getCurrentDirectory().equals(path)) {
+                    throw new RuntimeException("The current directory is not restored");
+                }
             });
         } finally {
             SwingUtilities.invokeAndWait(() -> {

--- a/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileViewNPETest.java
@@ -22,80 +22,109 @@
  */
 
 import java.awt.BorderLayout;
-
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Robot;
 import java.io.File;
-import java.lang.reflect.InvocationTargetException;
+import java.util.function.Predicate;
 
-import javax.swing.JFrame;
+import javax.swing.JComboBox;
 import javax.swing.JFileChooser;
+import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.WindowConstants;
-
 import javax.swing.filechooser.FileView;
+import javax.swing.plaf.metal.MetalLookAndFeel;
 
 /*
  * @test
  * @bug 6616245
  * @key headful
- * @requires (os.family == "windows" | os.family == "linux")
- * @library /java/awt/regtesthelpers
- * @build PassFailJFrame
  * @summary Test to check if NPE occurs when using custom FileView.
- * @run main/manual FileViewNPETest
+ * @run main FileViewNPETest
  */
 public class FileViewNPETest {
-    static PassFailJFrame passFailJFrame;
+
+    private static JFrame frame;
+    private static JFileChooser jfc;
+    private static File path;
+
     public static void main(String[] args) throws Exception {
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                try {
-                    initialize();
-                } catch (InterruptedException | InvocationTargetException e) {
-                    throw new RuntimeException(e);
+        final Robot robot = new Robot();
+        try {
+            SwingUtilities.invokeAndWait(FileViewNPETest::initialize);
+            robot.waitForIdle();
+
+            SwingUtilities.invokeAndWait(() -> {
+                jfc.setCurrentDirectory(path.getParentFile());
+                assert jfc.getCurrentDirectory() == null
+                       : "Expected to become null because the parent directory "
+                         + "is not traversable";
+            });
+            robot.waitForIdle();
+
+            SwingUtilities.invokeAndWait(() -> {
+                JComboBox<?> dirs = findDirectoryComboBox(jfc);
+                // No NPE is expected
+                dirs.setSelectedIndex(dirs.getSelectedIndex());
+                assert jfc.getCurrentDirectory().equals(path)
+                       : "The current directory should be restored";
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
                 }
-            }
-        });
-        passFailJFrame.awaitAndCheck();
+            });
+        }
     }
 
-    static void initialize() throws InterruptedException, InvocationTargetException {
-        JFrame frame;
-        JFileChooser jfc;
-
-        //Initialize the components
-        final String INSTRUCTIONS = """
-                Instructions to Test:
-                1. The traversable folder is set to the Documents folder,
-                 if it exists, in the user's home folder, otherwise
-                 it's the user's home. Other folders are non-traversable.
-                2. When the file chooser appears on the screen, select any
-                 non-traversable folder from "Look-In" combo box,
-                 for example the user's folder or a folder above it.
-                 (The folder will not be opened since it's non-traversable).
-                3. Select the Documents folder again.
-                4. If NullPointerException does not occur in the step 3,
-                 click Pass, otherwise the test fails automatically.
-                """;
-        frame = new JFrame("JFileChooser File View NPE test");
-        passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS,
-                5L, 13, 40);
-        jfc = new JFileChooser();
+    private static void initialize() {
+        try {
+            UIManager.setLookAndFeel(new MetalLookAndFeel());
+        } catch (UnsupportedLookAndFeelException e) {
+            throw new RuntimeException(e);
+        }
 
         String userHome = System.getProperty("user.home");
         String docs = userHome + File.separator + "Documents";
-        String path = (new File(docs).exists()) ? docs : userHome;
+        path = new File((new File(docs).exists()) ? docs : userHome);
 
-        jfc.setCurrentDirectory(new File(path));
-        jfc.setFileView(new CustomFileView(path));
+        jfc = new JFileChooser();
+        jfc.setCurrentDirectory(path);
+        jfc.setFileView(new CustomFileView(path.getPath()));
         jfc.setControlButtonsAreShown(false);
 
-        PassFailJFrame.addTestWindow(frame);
-        PassFailJFrame.positionTestWindow(frame, PassFailJFrame.Position.HORIZONTAL);
+        frame = new JFrame("JFileChooser FileView NPE test");
         frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
-
         frame.add(jfc, BorderLayout.CENTER);
         frame.pack();
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
+    }
+
+    private static JComboBox<?> findDirectoryComboBox(final Container container) {
+        Component result = findComponent(container,
+                                         c -> c instanceof JComboBox<?>);
+        return (JComboBox<?>) result;
+    }
+
+    private static Component findComponent(final Container container,
+                                           final Predicate<Component> predicate) {
+        for (Component child : container.getComponents()) {
+            if (predicate.test(child)) {
+                return child;
+            }
+            if (child instanceof Container cont && cont.getComponentCount() > 0) {
+                Component result = findComponent(cont, predicate);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
     }
 }
 
@@ -106,6 +135,7 @@ class CustomFileView extends FileView {
         basePath = path;
     }
 
+    @Override
     public Boolean isTraversable(File filePath) {
         return ((filePath != null) && (filePath.isDirectory()))
                 && filePath.getAbsolutePath().startsWith(basePath);


### PR DESCRIPTION
The automated test follows the instructions of the manual test that was added in #10485.

Instead of selecting the parent folder from the **Look in** combo box, it calls `setCurrentDirectory` directly with the parent of the path which is not traversable. Thus, the current directory of the file chooser is set to `null`.

As the second step, the test finds the combo box and re-selects the currently selected element. Without the fix for [JDK-6616245](https://bugs.openjdk.org/browse/JDK-6616245), `NullPointerException` is thrown and the test fails; with the fix applied, the original folder is selected and the test passes.

@mrserb and @TejeshR13, please, take a look.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295298](https://bugs.openjdk.org/browse/JDK-8295298): Automate javax/swing/JFileChooser/FileViewNPETest.java


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Author) ⚠️ Review applies to [c878454b](https://git.openjdk.org/jdk/pull/10801/files/c878454b5d27cda710d8d17d79c25c73a5699f8b)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10801/head:pull/10801` \
`$ git checkout pull/10801`

Update a local copy of the PR: \
`$ git checkout pull/10801` \
`$ git pull https://git.openjdk.org/jdk pull/10801/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10801`

View PR using the GUI difftool: \
`$ git pr show -t 10801`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10801.diff">https://git.openjdk.org/jdk/pull/10801.diff</a>

</details>
