### PR TITLE
[PATCH] Use enhanced-for cycle instead of Enumeration in java.naming

### DIFF
--- a/src/java.naming/share/classes/javax/naming/directory/BasicAttribute.java
+++ b/src/java.naming/share/classes/javax/naming/directory/BasicAttribute.java
@@ -215,10 +215,10 @@ public class BasicAttribute implements Attribute {
             answer.append("No values");
         } else {
             boolean start = true;
-            for (Enumeration<Object> e = values.elements(); e.hasMoreElements(); ) {
+            for (Object value : values) {
                 if (!start)
                     answer.append(", ");
-                answer.append(e.nextElement());
+                answer.append(value);
                 start = false;
             }
         }

--- a/src/java.naming/share/classes/javax/naming/directory/BasicAttributes.java
+++ b/src/java.naming/share/classes/javax/naming/directory/BasicAttributes.java
@@ -294,9 +294,8 @@ public class BasicAttributes implements Attributes {
         // Overridden to avoid exposing implementation details
         s.defaultWriteObject(); // write out the ignoreCase flag
         s.writeInt(attrs.size());
-        Enumeration<Attribute> attrEnum = attrs.elements();
-        while (attrEnum.hasMoreElements()) {
-            s.writeObject(attrEnum.nextElement());
+        for (Attribute attribute : attrs.values()) {
+            s.writeObject(attribute);
         }
     }
 


### PR DESCRIPTION
`java.util.Enumeration` is a legacy interface from java 1.0.
There are couple of cycles which use it to iterate over collections. We can replace this manual cycle with enchanced-for, which is shorter and easier to read.