### PR TITLE
8295776: [JVMCI] Add x86 CPU flags for MPK and CET

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -2991,6 +2991,22 @@ uint64_t VM_Version::feature_flags() {
     }
   }
 
+  // Protection key features.
+  if (_cpuid_info.sef_cpuid7_ecx.bits.pku != 0) {
+    result |= CPU_PKU;
+  }
+  if (_cpuid_info.sef_cpuid7_ecx.bits.ospke != 0) {
+    result |= CPU_OSPKE;
+  }
+
+  // Control flow enforcement (CET) features.
+  if (_cpuid_info.sef_cpuid7_ecx.bits.cet_ss != 0) {
+    result |= CPU_CET_SS;
+  }
+  if (_cpuid_info.sef_cpuid7_edx.bits.cet_ibt != 0) {
+    result |= CPU_CET_IBT;
+  }
+
   // Composite features.
   if (supports_tscinv_bit() &&
       ((is_amd_family() && !is_amd_Barcelona()) ||

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -246,7 +246,7 @@ class VM_Version : public Abstract_VM_Version {
                      ospke : 1,
                            : 1,
               avx512_vbmi2 : 1,
-                           : 1,
+                    cet_ss : 1,
                       gfni : 1,
                       vaes : 1,
          avx512_vpclmulqdq : 1,
@@ -271,7 +271,9 @@ class VM_Version : public Abstract_VM_Version {
         fast_short_rep_mov : 1,
                            : 9,
                  serialize : 1,
-                           : 17;
+                           : 5,
+                   cet_ibt : 1,
+                           : 11;
     } bits;
   };
 
@@ -376,7 +378,11 @@ protected:
     decl(FSRM,              "fsrm",              50) /* Fast Short REP MOV */ \
     decl(GFNI,              "gfni",              51) /* Vector GFNI instructions */ \
     decl(AVX512_BITALG,     "avx512_bitalg",     52) /* Vector sub-word popcount and bit gather instructions */\
-    decl(F16C,              "f16c",              53) /* Half-precision and single precision FP conversion instructions*/
+    decl(F16C,              "f16c",              53) /* Half-precision and single precision FP conversion instructions*/ \
+    decl(PKU,               "pku",               54) /* Protection keys for user-mode pages */ \
+    decl(OSPKE,             "ospke",             55) /* OS enables protection keys */ \
+    decl(CET_IBT,           "cet_ibt",           56) /* Control Flow Enforcement - Indirect Branch Tracking */ \
+    decl(CET_SS,            "cet_ss",            57) /* Control Flow Enforcement - Shadow Stack */
 
 #define DECLARE_CPU_FEATURE_FLAG(id, name, bit) CPU_##id = (1ULL << bit),
     CPU_FEATURE_FLAGS(DECLARE_CPU_FEATURE_FLAG)
@@ -684,6 +690,10 @@ public:
   static bool supports_hv()           { return (_features & CPU_HV) != 0; }
   static bool supports_serialize()    { return (_features & CPU_SERIALIZE) != 0; }
   static bool supports_f16c()         { return (_features & CPU_F16C) != 0; }
+  static bool supports_pku()          { return (_features & CPU_PKU) != 0; }
+  static bool supports_ospke()        { return (_features & CPU_OSPKE) != 0; }
+  static bool supports_cet_ss()       { return (_features & CPU_CET_SS) != 0; }
+  static bool supports_cet_ibt()      { return (_features & CPU_CET_IBT) != 0; }
 
   // Intel features
   static bool is_intel_family_core() { return is_intel() &&

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.amd64/src/jdk/vm/ci/amd64/AMD64.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.amd64/src/jdk/vm/ci/amd64/AMD64.java
@@ -227,6 +227,10 @@ public class AMD64 extends Architecture {
         GFNI,
         AVX512_BITALG,
         F16C,
+        PKU,
+        OSPKE,
+        CET_IBT,
+        CET_SS,
     }
 
     private final EnumSet<CPUFeature> features;

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.amd64/src/jdk/vm/ci/hotspot/amd64/AMD64HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.amd64/src/jdk/vm/ci/hotspot/amd64/AMD64HotSpotVMConfig.java
@@ -83,4 +83,8 @@ class AMD64HotSpotVMConfig extends HotSpotVMConfigAccess {
     final long amd64AVX512VL = getConstant("VM_Version::CPU_AVX512VL", Long.class);
     final long amd64SHA = getConstant("VM_Version::CPU_SHA", Long.class);
     final long amd64FMA = getConstant("VM_Version::CPU_FMA", Long.class);
+    final long amd64PKU = getConstant("VM_Version::CPU_PKU", Long.class);
+    final long amd64OSPKE = getConstant("VM_Version::CPU_OSPKE", Long.class);
+    final long amd64CET_IBT = getConstant("VM_Version::CPU_CET_IBT", Long.class);
+    final long amd64CET_SS = getConstant("VM_Version::CPU_CET_SS", Long.class);
 }


### PR DESCRIPTION
Add the CPU flags for memory protection keys (MPK) and control flow enforcement technology (CET) to JVMCI such that Graal can make use of these technologies.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295776](https://bugs.openjdk.org/browse/JDK-8295776): [JVMCI] Add x86 CPU flags for MPK and CET


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10810/head:pull/10810` \
`$ git checkout pull/10810`

Update a local copy of the PR: \
`$ git checkout pull/10810` \
`$ git pull https://git.openjdk.org/jdk pull/10810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10810`

View PR using the GUI difftool: \
`$ git pr show -t 10810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10810.diff">https://git.openjdk.org/jdk/pull/10810.diff</a>

</details>
