### PR TITLE
JDK-8295461: IGV: Wrong src/dest nodes highlighted for edge

### DIFF
--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/widgets/LineWidget.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/widgets/LineWidget.java
@@ -239,27 +239,6 @@ public class LineWidget extends Widget implements PopupMenuProvider {
         g.setStroke(oldStroke);
     }
 
-    private void setHighlighted(boolean b) {
-        this.highlighted = b;
-        Set<Object> highlightedObjects = new HashSet<>(scene.getHighlightedObjects());
-        Set<Object> highlightedObjectsChange = new HashSet<>();
-        for (Connection c : connections) {
-            if (c.hasSlots()) {
-                highlightedObjectsChange.add(c.getTo());
-                highlightedObjectsChange.add(c.getTo().getVertex());
-                highlightedObjectsChange.add(c.getFrom());
-                highlightedObjectsChange.add(c.getFrom().getVertex());
-            }
-        }
-        if(b) {
-            highlightedObjects.addAll(highlightedObjectsChange);
-        } else {
-            highlightedObjects.removeAll(highlightedObjectsChange);
-        }
-        scene.setHighlightedObjects(highlightedObjects);
-        this.revalidate(true);
-    }
-
     private void setPopupVisible(boolean b) {
         this.popupVisible = b;
         this.revalidate(true);
@@ -273,26 +252,51 @@ public class LineWidget extends Widget implements PopupMenuProvider {
     @Override
     protected void notifyStateChanged(ObjectState previousState, ObjectState state) {
         if (previousState.isHovered() != state.isHovered()) {
-            setRecursiveHighlighted(state.isHovered());
+            boolean enableHighlighting = state.isHovered();
+            highlightPredecessors(enableHighlighting);
+            setHighlighted(enableHighlighting);
+            recursiveHighlightSuccessors(enableHighlighting);
+            highlightVertices(enableHighlighting);
         }
     }
 
-    private void setRecursiveHighlighted(boolean b) {
-        LineWidget cur = predecessor;
-        while (cur != null) {
-            cur.setHighlighted(b);
-            cur = cur.predecessor;
+    private void highlightPredecessors(boolean enable) {
+        LineWidget predecessorLineWidget = predecessor;
+        while (predecessorLineWidget != null) {
+            predecessorLineWidget.setHighlighted(enable);
+            predecessorLineWidget = predecessorLineWidget.predecessor;
         }
-
-        highlightSuccessors(b);
-        this.setHighlighted(b);
     }
 
-    private void highlightSuccessors(boolean b) {
-        for (LineWidget s : successors) {
-            s.setHighlighted(b);
-            s.highlightSuccessors(b);
+    private void recursiveHighlightSuccessors(boolean enable) {
+        for (LineWidget successorLineWidget : successors) {
+            successorLineWidget.setHighlighted(enable);
+            successorLineWidget.recursiveHighlightSuccessors(enable);
         }
+    }
+
+    private void highlightVertices(boolean enable) {
+        Set<Object> highlightedObjects = new HashSet<>(scene.getHighlightedObjects());
+        Set<Object> highlightedObjectsChange = new HashSet<>();
+        for (Connection c : connections) {
+            if (c.hasSlots()) {
+                highlightedObjectsChange.add(c.getTo());
+                highlightedObjectsChange.add(c.getTo().getVertex());
+                highlightedObjectsChange.add(c.getFrom());
+                highlightedObjectsChange.add(c.getFrom().getVertex());
+            }
+        }
+        if(enable) {
+            highlightedObjects.addAll(highlightedObjectsChange);
+        } else {
+            highlightedObjects.removeAll(highlightedObjectsChange);
+        }
+        scene.setHighlightedObjects(highlightedObjects);
+    }
+
+    private void setHighlighted(boolean enable) {
+        highlighted = enable;
+        revalidate(true);
     }
 
     private void setRecursivePopupVisible(boolean b) {

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/widgets/LineWidget.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/widgets/LineWidget.java
@@ -286,7 +286,7 @@ public class LineWidget extends Widget implements PopupMenuProvider {
                 highlightedObjectsChange.add(c.getFrom().getVertex());
             }
         }
-        if(enable) {
+        if (enable) {
             highlightedObjects.addAll(highlightedObjectsChange);
         } else {
             highlightedObjects.removeAll(highlightedObjectsChange);


### PR DESCRIPTION
Outgoing edges in IGV are organized like trees. When hovering with the mouse over a segment of an edge, the edge is highlighted all the way up the the source node, as well as all the way down to the leave nodes. This works as expected. The nodes at the source and leaves of the highlighted segments are highlighted as well. There is a bug that instead of only highlighting the leave nodes in the subtree, IGV highlights all leave nodes:
![before](https://user-images.githubusercontent.com/71546117/197223077-962a5d97-c1c8-4720-9983-295e07468be9.png)

# Solution
The segments in the edge tree are `LineWidget` objects. Each `LineWidget` has a single `LineWidget` `predecessor` and list of `LineWidget` `successors`. When hovering over a line segment the `notifyStateChanged` function is called in the corresponding `LineWidget` : `predecessor` and `successors` `LineWidget` are recursively visited and highlighted here. The nodes (of super type `Vertex`) are new highlighted with a new `highlightVertices` function instead of using recursion. 
`highlightVertices(boolean enable)` uses the list of `connections` which already contains all the one-to-one connections between src/dest nodes that go through a single `LineWidget` segment. This gives as the `Vertex` nodes of the root as well as the leaves in the subtree of the hovered `LineWidget` segment.

Now the highlighting of the leave nodes works as expected: 
![ex1](https://user-images.githubusercontent.com/71546117/197225776-eb7cba50-6f6a-4f47-a91f-3b793021fdae.png)
![ex2](https://user-images.githubusercontent.com/71546117/197225789-d9510f36-d89a-44cd-ab69-1341edcafdfb.png)

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295461](https://bugs.openjdk.org/browse/JDK-8295461): IGV: Wrong src/dest nodes highlighted for edge


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10815/head:pull/10815` \
`$ git checkout pull/10815`

Update a local copy of the PR: \
`$ git checkout pull/10815` \
`$ git pull https://git.openjdk.org/jdk pull/10815/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10815`

View PR using the GUI difftool: \
`$ git pr show -t 10815`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10815.diff">https://git.openjdk.org/jdk/pull/10815.diff</a>

</details>
