### PR TITLE
8295795: hsdis does not build with binutils 2.39+

### DIFF
--- a/src/utils/hsdis/binutils/hsdis-binutils.c
+++ b/src/utils/hsdis/binutils/hsdis-binutils.c
@@ -59,6 +59,7 @@
 
 #include <libiberty.h>
 #include <bfd.h>
+#include <bfdver.h>
 #include <dis-asm.h>
 
 #include "hsdis.h"
@@ -561,7 +562,13 @@ static void init_disassemble_info_from_bfd(struct disassemble_info* dinfo,
                                            fprintf_ftype fprintf_func,
                                            bfd* abfd,
                                            char* disassembler_options) {
+#if BFD_VERSION >= 239000000
+  // binutils 2.39+ changed the API in incompatible manner,
+  // by adding the additional "styled printf" parameter
+  init_disassemble_info(dinfo, stream, fprintf_func, NULL);
+#else
   init_disassemble_info(dinfo, stream, fprintf_func);
+#endif
 
   dinfo->flavour = bfd_get_flavour(abfd);
   dinfo->arch = bfd_get_arch(abfd);


### PR DESCRIPTION
Fails like this:

```
$ sh ./configure --with-boot-jdk=jdk19u-ea --with-hsdis=binutils --with-binutils-src=binutils-2.39
$ make clean build-hsdis

=== Output from failing command(s) repeated here ===
* For target support_hsdis_hsdis-binutils.o:
/home/shade/trunks/jdk/src/utils/hsdis/binutils/hsdis-binutils.c: In function 'init_disassemble_info_from_bfd':
/home/shade/trunks/jdk/src/utils/hsdis/binutils/hsdis-binutils.c:564:3: error: too few arguments to function 'init_disassemble_info'
  564 | init_disassemble_info(dinfo, stream, fprintf_func);
      | ^~~~~~~~~~~~~~~~~~~~~
In file included from /home/shade/trunks/jdk/src/utils/hsdis/binutils/hsdis-binutils.c:62:
/home/shade/trunks/jdk/binutils-2.39/include/dis-asm.h:472:13: note: declared here
  472 | extern void init_disassemble_info (struct disassemble_info *dinfo, void *stream,
      | ^~~~~~~~~~~~~~~~~~~~~
```

Additional testing:
 - [x] Linux x86_64 build with binutils 2.38 (still works)
 - [x] Linux x86_64 build with binutils 2.39 (now works)
 - [ ] JMH -prof perfasm with binutils-2.39-built hsdis

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295795](https://bugs.openjdk.org/browse/JDK-8295795): hsdis does not build with binutils 2.39+


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/10817/head:pull/10817` \
`$ git checkout pull/10817`

Update a local copy of the PR: \
`$ git checkout pull/10817` \
`$ git pull https://git.openjdk.org/jdk.git pull/10817/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10817`

View PR using the GUI difftool: \
`$ git pr show -t 10817`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10817.diff">https://git.openjdk.org/jdk/pull/10817.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/10817#issuecomment-1287128647)