### PR TITLE
6244831: JFileChooser does not have tooltip for Desktop, Recent etc ToggleButton on Windows Look and feel

### DIFF
--- a/src/java.desktop/share/classes/sun/swing/WindowsPlacesBar.java
+++ b/src/java.desktop/share/classes/sun/swing/WindowsPlacesBar.java
@@ -145,6 +145,7 @@ public class WindowsPlacesBar extends JToolBar
             buttons[i].setPreferredSize(buttonSize);
             buttons[i].setMaximumSize(buttonSize);
             buttons[i].addActionListener(this);
+            buttons[i].setToolTipText(folderName);
             add(buttons[i]);
             if (i < files.length-1 && isXPStyle) {
                 add(Box.createRigidArea(new Dimension(1, 1)));

--- a/test/jdk/javax/swing/JFileChooser/FileChooserToolTipTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileChooserToolTipTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Robot;
+
+import javax.swing.JFrame;
+import javax.swing.JFileChooser;
+import javax.swing.JToolTip;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.WindowConstants;
+
+/*
+ * @test
+ * @bug 6616245
+ * @key headful
+ * @requires (os.family == "windows")
+ * @library ../regtesthelpers
+ * @build Util
+ * @summary Test to check if ToolTip is shown for shell folders
+ * @run main FileChooserToolTipTest
+ */
+public class FileChooserToolTipTest {
+    static Robot robot;
+    static JFrame frame;
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+        robot = new Robot();
+        SwingUtilities.invokeAndWait(new Runnable() {
+            public void run() {
+                initialize();
+            }
+        });
+        robot.delay(1000);
+        robot.waitForIdle();
+        Point movePoint = getFramePoint(frame);
+        robot.mouseMove(movePoint.x, movePoint.y);
+        robot.delay(2000);
+        robot.waitForIdle();
+        handleToolTip();
+        System.out.println("Test Pass");
+    }
+
+    static void initialize() {
+        JFileChooser jfc;
+        frame = new JFrame("JFileChooser ToolTip test");
+        jfc = new JFileChooser();
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        frame.add(jfc, BorderLayout.CENTER);
+        frame.pack();
+        frame.setVisible(true);
+    }
+
+    static Point getFramePoint(JFrame frame) throws Exception {
+        final Point[] result = new Point[1];
+
+        SwingUtilities.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                Point p = frame.getLocationOnScreen();
+                Dimension size = frame.getSize();
+                result[0] = new Point(p.x + size.width / 10, p.y + size.height / 2);
+            }
+        });
+        return result[0];
+    }
+
+    static void handleToolTip() throws Exception {
+        SwingUtilities.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    JToolTip tooltip = (JToolTip) Util.findSubComponent(
+                            JFrame.getFrames()[0], "JToolTip");
+
+                    if (tooltip == null) {
+                        throw new RuntimeException("Basic Tooltip not been found");
+                    }
+                    System.out.println("ToolTp :"+tooltip.getTipText());
+
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    frame.dispose();
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
Tooltip is not shown for the buttons placed in left side of JFileChooser(In Windows Look And Feel), namely the shellFolder like (Recent Items, Desktop, Documents). Hence the tooltip is added for those shell folders/WindowBar when they are constructed. The Automatic test is added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6244831](https://bugs.openjdk.org/browse/JDK-6244831): JFileChooser does not have tooltip for Desktop, Recent etc ToggleButton on Windows Look and feel


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * @kumarabhi006 (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10819/head:pull/10819` \
`$ git checkout pull/10819`

Update a local copy of the PR: \
`$ git checkout pull/10819` \
`$ git pull https://git.openjdk.org/jdk pull/10819/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10819`

View PR using the GUI difftool: \
`$ git pr show -t 10819`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10819.diff">https://git.openjdk.org/jdk/pull/10819.diff</a>

</details>
