### PR TITLE
8295713: runtime/ParallelLoad/SuperWait/SuperWaitTest.java fails intermittently on Windows

### DIFF
--- a/test/hotspot/jtreg/runtime/ParallelLoad/SuperWait/ClassLoadingThread.java
+++ b/test/hotspot/jtreg/runtime/ParallelLoad/SuperWait/ClassLoadingThread.java
@@ -23,14 +23,12 @@
 
 class ClassLoadingThread extends Thread {
 
-    private ClassLoader ldr1;
-    private ClassLoader ldr2;
-    private int which;
+    private String className;
+    private ClassLoader ldr;
 
-    public ClassLoadingThread(ClassLoader loader1, ClassLoader loader2, int i) {
-        ldr1 = loader1;
-        ldr2 = loader2;
-        which = i;
+    public ClassLoadingThread(String name, ClassLoader loader) {
+        className = name;
+        ldr = loader;
     }
 
     private boolean success = true;
@@ -50,10 +48,6 @@ class ClassLoadingThread extends Thread {
     }
 
     public void run() {
-       if (which == 0) {
-           callForName("A",ldr1);
-       } else {
-           callForName("C", ldr2);
-       }
+       callForName(className, ldr);
     }
 }

--- a/test/hotspot/jtreg/runtime/ParallelLoad/SuperWait/SuperWaitTest.java
+++ b/test/hotspot/jtreg/runtime/ParallelLoad/SuperWait/SuperWaitTest.java
@@ -36,7 +36,6 @@ import java.util.concurrent.Semaphore;
 
 public class SuperWaitTest {
 
-    private static Semaphore threadSync = null;
     private static volatile boolean dIsLoading = false;
 
     // Loads classes A and D, delegates for A's super class B
@@ -60,8 +59,6 @@ public class SuperWaitTest {
             if (name.equals("A") || name.equals("D")) {
                 ThreadPrint.println("Loading " + name);
                 if (name.equals("A")) {
-                    threadSync.release();  // Let the other thread start
-
                     ThreadPrint.println("Waiting for " + name);
                     while (!dIsLoading) {  // guard against spurious wakeup
                         try {
@@ -129,7 +126,6 @@ public class SuperWaitTest {
 
     public static void main(java.lang.String[] unused) {
         // t1 loads (A,CL1) extends (B,CL2); t2 loads (C,CL2) extends (D,CL1)
-        threadSync = new Semaphore(0);
 
         ClassLoader appLoader = SuperWaitTest.class.getClassLoader();
         MyLoaderOne ldr1 = new MyLoaderOne(appLoader);
@@ -143,12 +139,6 @@ public class SuperWaitTest {
             threads[i].setName("Loading Thread #" + (i + 1));
             threads[i].start();
             System.out.println("Thread " + (i + 1) + " was started...");
-            if (i == 0) {
-                try {
-                    // Wait for the first thread to get to the wait, before starting second thread.
-                    threadSync.acquire();
-                } catch (InterruptedException ie) {}
-            }
         }
 
         if (report_success()) {

--- a/test/hotspot/jtreg/runtime/ParallelLoad/SuperWait/SuperWaitTest.java
+++ b/test/hotspot/jtreg/runtime/ParallelLoad/SuperWait/SuperWaitTest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.Semaphore;
 
 public class SuperWaitTest {
 
-    private static volatile boolean dIsLoading = false;
+    private static boolean dIsLoading = false;
 
     // Loads classes A and D, delegates for A's super class B
     private static class MyLoaderOne extends ClassLoader {

--- a/test/hotspot/jtreg/runtime/ParallelLoad/SuperWait/SuperWaitTest.java
+++ b/test/hotspot/jtreg/runtime/ParallelLoad/SuperWait/SuperWaitTest.java
@@ -36,10 +36,10 @@ import java.util.concurrent.Semaphore;
 
 public class SuperWaitTest {
 
-    private static boolean dIsLoading = false;
-
     // Loads classes A and D, delegates for A's super class B
     private static class MyLoaderOne extends ClassLoader {
+
+        private static boolean dIsLoading = false;
 
         ClassLoader parent;
         ClassLoader baseLoader;

--- a/test/hotspot/jtreg/runtime/ParallelLoad/SuperWait/SuperWaitTest.java
+++ b/test/hotspot/jtreg/runtime/ParallelLoad/SuperWait/SuperWaitTest.java
@@ -36,7 +36,6 @@ import java.util.concurrent.Semaphore;
 
 public class SuperWaitTest {
 
-    private static Semaphore mainSync = null;
     private static Semaphore threadSync = null;
 
     // Loads classes A and D, delegates for A's super class B
@@ -65,7 +64,6 @@ public class SuperWaitTest {
                     try {
                         ThreadPrint.println("Waiting for " + name);
                         threadSync.release();
-                        mainSync.acquire(); // wait until other thread gets here
                         wait(); // let the other thread have this lock.
                     } catch (InterruptedException ie) {}
                 } else {
@@ -109,7 +107,6 @@ public class SuperWaitTest {
                     try {
                         threadSync.acquire();
                     } catch (InterruptedException ie) {}
-                    mainSync.release();
                 }
                 byte[] classfile = ClassUnloadCommon.getClassData(name);
                 return defineClass(name, classfile, 0, classfile.length);
@@ -137,7 +134,6 @@ public class SuperWaitTest {
 
     public static void main(java.lang.String[] unused) {
         // t1 loads (A,CL1) extends (B,CL2); t2 loads (C,CL2) extends (D,CL1)
-        mainSync   = new Semaphore(0);
         threadSync = new Semaphore(0);
 
         ClassLoader appLoader = SuperWaitTest.class.getClassLoader();


### PR DESCRIPTION
I added another semaphore so the test will run in the order I want it to.  Alternate suggestions or corrections welcome.
Running with GHA, and our tier1 in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295713](https://bugs.openjdk.org/browse/JDK-8295713): runtime/ParallelLoad/SuperWait/SuperWaitTest.java fails intermittently on Windows


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**) ⚠️ Review applies to [6c4eced2](https://git.openjdk.org/jdk/pull/10822/files/6c4eced275a5705710eb7c5d9a05db8ca0d0cd5d)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [8278537a](https://git.openjdk.org/jdk/pull/10822/files/8278537a1c9d6202ff0669563693b5eba99b063e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10822/head:pull/10822` \
`$ git checkout pull/10822`

Update a local copy of the PR: \
`$ git checkout pull/10822` \
`$ git pull https://git.openjdk.org/jdk pull/10822/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10822`

View PR using the GUI difftool: \
`$ git pr show -t 10822`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10822.diff">https://git.openjdk.org/jdk/pull/10822.diff</a>

</details>
