### PR TITLE
8297275: WatchService delay with PollingWatchService causes test failures

### DIFF
--- a/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
+++ b/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
@@ -150,7 +150,15 @@ class PollingWatchService
                 new PrivilegedExceptionAction<PollingWatchKey>() {
                     @Override
                     public PollingWatchKey run() throws IOException {
-                        return doPrivilegedRegister(path, eventSet, value);
+                        PollingWatchKey newKey = doPrivilegedRegister(path, eventSet, value);
+
+                        try {
+                            // To ensure the key is watching for changes when this method returns, sleep
+                            // for the initial delay period before returning.
+                            Thread.sleep(1000 * POLLING_INIT_DELAY);
+                        } catch (InterruptedException e) {}
+
+                        return newKey;
                     }
                 });
         } catch (PrivilegedActionException pae) {


### PR DESCRIPTION
This minor change fixes a compliance test failure which was partially addressed by https://github.com/openjdk/jdk/commit/1bb4de2e2868a539846ec48dd43fd623c2ba69a5. However the failure was still observed on select machines. This change addresses the remaining failures by ensuring that any new WatchKey is held until the polling thread becomes active.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297275](https://bugs.openjdk.org/browse/JDK-8297275): WatchService delay with PollingWatchService causes test failures


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10824/head:pull/10824` \
`$ git checkout pull/10824`

Update a local copy of the PR: \
`$ git checkout pull/10824` \
`$ git pull https://git.openjdk.org/jdk pull/10824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10824`

View PR using the GUI difftool: \
`$ git pr show -t 10824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10824.diff">https://git.openjdk.org/jdk/pull/10824.diff</a>

</details>
