### PR TITLE
8295811: serviceability/sa/TestObjectAlignment.java fails on x86_32

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestObjectAlignment.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestObjectAlignment.java
@@ -38,7 +38,7 @@ import jdk.test.lib.Utils;
 /**
  * @test
  * @library /test/lib
- * @requires vm.hasSA
+ * @requires vm.hasSA & vm.bits == "64"
  * @modules jdk.hotspot.agent/sun.jvm.hotspot
  *          jdk.hotspot.agent/sun.jvm.hotspot.runtime
  * @run driver TestObjectAlignment


### PR DESCRIPTION
It fails on x86_32 due to `Unrecognized VM option ObjectAlignmentInBytes=8`.
So let's only run the test on 64-bit platforms.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295811](https://bugs.openjdk.org/browse/JDK-8295811): serviceability/sa/TestObjectAlignment.java fails on x86_32


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10829/head:pull/10829` \
`$ git checkout pull/10829`

Update a local copy of the PR: \
`$ git checkout pull/10829` \
`$ git pull https://git.openjdk.org/jdk pull/10829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10829`

View PR using the GUI difftool: \
`$ git pr show -t 10829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10829.diff">https://git.openjdk.org/jdk/pull/10829.diff</a>

</details>
