### PR TITLE
8295673: Deprecate and disable legacy parallel class loading workaround for non-parallel-capable class loaders

### DIFF
--- a/src/hotspot/share/classfile/placeholders.cpp
+++ b/src/hotspot/share/classfile/placeholders.cpp
@@ -132,7 +132,7 @@ void PlaceholderEntry::add_seen_thread(JavaThread* thread, PlaceholderTable::cla
   SeenThread* threadEntry = new SeenThread(thread);
   SeenThread* seen = actionToQueue(action);
 
-  assert(action != PlaceholderTable::LOAD_INSTANCE || EnableWaitForParallelLoad || seen == NULL,
+  assert(action != PlaceholderTable::LOAD_INSTANCE || !EnableWaitForParallelLoad || seen == NULL,
          "Only one LOAD_INSTANCE allowed at a time");
 
   if (seen == NULL) {

--- a/src/hotspot/share/classfile/placeholders.cpp
+++ b/src/hotspot/share/classfile/placeholders.cpp
@@ -132,9 +132,6 @@ void PlaceholderEntry::add_seen_thread(JavaThread* thread, PlaceholderTable::cla
   SeenThread* threadEntry = new SeenThread(thread);
   SeenThread* seen = actionToQueue(action);
 
-  assert(action != PlaceholderTable::LOAD_INSTANCE || seen == NULL,
-         "Only one LOAD_INSTANCE allowed at a time");
-
   if (seen == NULL) {
     set_threadQ(threadEntry, action);
     return;

--- a/src/hotspot/share/classfile/placeholders.cpp
+++ b/src/hotspot/share/classfile/placeholders.cpp
@@ -132,6 +132,9 @@ void PlaceholderEntry::add_seen_thread(JavaThread* thread, PlaceholderTable::cla
   SeenThread* threadEntry = new SeenThread(thread);
   SeenThread* seen = actionToQueue(action);
 
+  assert(action != PlaceholderTable::LOAD_INSTANCE || EnableWaitForParallelLoad || seen == NULL,
+         "Only one LOAD_INSTANCE allowed at a time");
+
   if (seen == NULL) {
     set_threadQ(threadEntry, action);
     return;

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -538,6 +538,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "DynamicDumpSharedSpaces",      JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
   { "RequireSharedSpaces",          JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
   { "UseSharedSpaces",              JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
+  { "EnableWaitForParallelLoad",    JDK_Version::jdk(20), JDK_Version::jdk(21), JDK_Version::jdk(22) },
 
   // --- Deprecated alias flags (see also aliased_jvm_flags) - sorted by obsolete_in then expired_in:
   { "DefaultMaxRAMFraction",        JDK_Version::jdk(8),  JDK_Version::undefined(), JDK_Version::undefined() },

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -680,6 +680,10 @@ const int ObjectAlignmentInBytes = 8;
           "Allow parallel defineClass requests for class loaders "          \
           "registering as parallel capable")                                \
                                                                             \
+  product(bool, EnableWaitForParallelLoad, false,                           \
+          "(Deprecated) Enable legacy parallel classloading logic for "     \
+          "class loaders not registered as parallel capable")               \
+                                                                            \
   product_pd(bool, DontYieldALot,                                           \
           "Throw away obvious excess yield calls")                          \
                                                                             \

--- a/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
@@ -61,6 +61,7 @@ public class VMDeprecatedOptions {
             {"InitialRAMFraction",        "64"},
             {"TLABStats",                 "false"},
             {"AllowRedefinitionToAddDeleteMethods", "true"},
+            {"EnableWaitForParallelLoad", "false"},
 
             // deprecated alias flags (see also aliased_jvm_flags):
             {"DefaultMaxRAMFraction", "4"},

--- a/test/hotspot/jtreg/runtime/ParallelLoad/ParallelSuper/MyLoader.java
+++ b/test/hotspot/jtreg/runtime/ParallelLoad/ParallelSuper/MyLoader.java
@@ -81,7 +81,7 @@ class MyLoader extends ClassLoader {
          } else {
              try {
                 ThreadPrint.println("t1 waits non-parallelCapable loader");
-                wait();  // Give up lock before request to load B
+                wait(200);  // Give up lock before request to load B
               } catch (InterruptedException e) {}
          }
     }

--- a/test/hotspot/jtreg/runtime/ParallelLoad/ParallelSuper/ParallelSuperTest.java
+++ b/test/hotspot/jtreg/runtime/ParallelLoad/ParallelSuper/ParallelSuperTest.java
@@ -31,7 +31,7 @@
  * @compile -XDignore.symbol.file AsmClasses.java
  * @compile test-classes/ClassInLoader.java test-classes/A.java test-classes/B.java ../share/ThreadPrint.java
  * @run main/othervm ParallelSuperTest
- * @run main/othervm ParallelSuperTest -parallel
+ * @run main/othervm -XX:+EnableWaitForParallelLoad ParallelSuperTest -parallel
  * @run main/othervm ParallelSuperTest -parallel -parallelCapable
  */
 


### PR DESCRIPTION
This change adds an option **EnableWaitForParallelLoad** to enable the legacy behavior where the VM will manage synchronization for multiple threads loading the same class using a non-parallel capable class loader that have released the class loader lock.  The VM will break the class loader lock for parallel threads trying to load the class, and wait for the first thread that initiated loading the class to complete.  The subsequent threads will use the result of the first thread, rather than get a LinkageError: duplicate class definition for loading the class without synchronization.
Releasing the class loader lock was a common workaround for class loaders that used a non-hierarchical delegation scheme to avoid deadlock, before parallel capable class loading was added. 
https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/ClassLoader.html#registerAsParallelCapable()

Tested with tier1-6 and internal applications.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8295673](https://bugs.openjdk.org/browse/JDK-8295673): Deprecate and disable legacy parallel class loading workaround for non-parallel-capable class loaders
 * [JDK-8295848](https://bugs.openjdk.org/browse/JDK-8295848): Deprecate legacy parallel class loading workaround for non-parallel-capable class loaders (**CSR**)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to [3f5be0ac](https://git.openjdk.org/jdk/pull/10832/files/3f5be0acd8eb438ec15644007dfef7f6fde2235e)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [59c07651](https://git.openjdk.org/jdk/pull/10832/files/59c07651119a928cac3e400cc0b559bb309fe902)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10832/head:pull/10832` \
`$ git checkout pull/10832`

Update a local copy of the PR: \
`$ git checkout pull/10832` \
`$ git pull https://git.openjdk.org/jdk pull/10832/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10832`

View PR using the GUI difftool: \
`$ git pr show -t 10832`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10832.diff">https://git.openjdk.org/jdk/pull/10832.diff</a>

</details>
