### PR TITLE
8295839: G1: Single threaded phases (within parallel phases) report as using multiple threads in logs

### DIFF
--- a/src/hotspot/share/gc/g1/g1RootProcessor.cpp
+++ b/src/hotspot/share/gc/g1/g1RootProcessor.cpp
@@ -62,16 +62,14 @@ void G1RootProcessor::evacuate_roots(G1ParScanThreadState* pss, uint worker_id) 
 
   process_vm_roots(closures, phase_times, worker_id);
 
-  {
-    // Now the CM ref_processor roots.
+  // Now the CM ref_processor roots.
+  if (_process_strong_tasks.try_claim_task(G1RP_PS_refProcessor_oops_do)) {
     G1GCParPhaseTimesTracker x(phase_times, G1GCPhaseTimes::CMRefRoots, worker_id);
-    if (_process_strong_tasks.try_claim_task(G1RP_PS_refProcessor_oops_do)) {
-      // We need to treat the discovered reference lists of the
-      // concurrent mark ref processor as roots and keep entries
-      // (which are added by the marking threads) on them live
-      // until they can be processed at the end of marking.
-      _g1h->ref_processor_cm()->weak_oops_do(closures->strong_oops());
-    }
+    // We need to treat the discovered reference lists of the
+    // concurrent mark ref processor as roots and keep entries
+    // (which are added by the marking threads) on them live
+    // until they can be processed at the end of marking.
+    _g1h->ref_processor_cm()->weak_oops_do(closures->strong_oops());
   }
 
   // CodeCache is already processed in java roots
@@ -186,11 +184,9 @@ void G1RootProcessor::process_java_roots(G1RootClosures* closures,
                                        closures->strong_codeblobs());
   }
 
-  {
+  if (_process_strong_tasks.try_claim_task(G1RP_PS_ClassLoaderDataGraph_oops_do)) {
     G1GCParPhaseTimesTracker x(phase_times, G1GCPhaseTimes::CLDGRoots, worker_id);
-    if (_process_strong_tasks.try_claim_task(G1RP_PS_ClassLoaderDataGraph_oops_do)) {
-      ClassLoaderDataGraph::roots_cld_do(closures->strong_clds(), closures->weak_clds());
-    }
+    ClassLoaderDataGraph::roots_cld_do(closures->strong_clds(), closures->weak_clds());
   }
 }
 


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that changes log output to properly report single-threaded (sub-)phases  number of threads?

E.g.
```
 [87.104s][debug][gc,phases] GC(1412) Ext Root Scanning (ms): Min: 0.0, Avg: 0.0, Max: 0.0, Diff: 0.0, Sum: 0.1, Workers: 6
[...]
[87.104s][trace][gc,phases] GC(1412) CLDG Roots (ms): Min: 0.0, Avg: 0.0, Max: 0.0, Diff: 0.0, Sum: 0.0, Workers: 1
[87.104s][trace][gc,phases] GC(1412) CM RefProcessor Roots (ms): Min: 0.0, Avg: 0.0, Max: 0.0, Diff: 0.0, Sum: 0.0, Workers: 1
[...] 
```
instead of
```
 [87.104s][debug][gc,phases] GC(1412) Ext Root Scanning (ms): Min: 0.0, Avg: 0.0, Max: 0.0, Diff: 0.0, Sum: 0.1, Workers: 6
[...]
[87.104s][trace][gc,phases] GC(1412) CLDG Roots (ms): Min: 0.0, Avg: 0.0, Max: 0.0, Diff: 0.0, Sum: 0.0, Workers: 6
[87.104s][trace][gc,phases] GC(1412) CM RefProcessor Roots (ms): Min: 0.0, Avg: 0.0, Max: 0.0, Diff: 0.0, Sum: 0.0, Workers: 6
[...] 
```

Testing: local testing of some log files, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295839](https://bugs.openjdk.org/browse/JDK-8295839): G1: Single threaded phases (within parallel phases) report as using multiple threads in logs


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10833/head:pull/10833` \
`$ git checkout pull/10833`

Update a local copy of the PR: \
`$ git checkout pull/10833` \
`$ git pull https://git.openjdk.org/jdk pull/10833/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10833`

View PR using the GUI difftool: \
`$ git pr show -t 10833`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10833.diff">https://git.openjdk.org/jdk/pull/10833.diff</a>

</details>
