### PR TITLE
8295798: (ch) Test java/nio/channels/Channels/ReadXBytes.java is very slow on Windows

### DIFF
--- a/test/jdk/java/nio/channels/Channels/ReadXBytes.java
+++ b/test/jdk/java/nio/channels/Channels/ReadXBytes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/channels/Channels/ReadXBytes.java
+++ b/test/jdk/java/nio/channels/Channels/ReadXBytes.java
@@ -100,24 +100,29 @@ public class ReadXBytes {
     // Creates a temporary file of a specified length with random content
     static Path createFileWithRandomContent(long length) throws IOException {
         Path file = createFile(length);
-        try (FileChannel fc = FileChannel.open(file, WRITE);) {
-            long pos = 0L;
-            // if the length exceeds 2 GB, skip the first 2 GB - 1 MB bytes
-            if (length >= 2L*1024*1024*1024) {
-                // write the last (length - 2GB - 1MB) bytes
-                pos = 2047L*1024*1024;
-            } else if (length > 0) {
-                // write either the first or last bytes only
-                long p = Math.min(Math.abs(RAND.nextLong()), length - 1);
-                pos = RAND.nextBoolean() ? p : length - 1 - p;
-            }
-            fc.position(pos);
-            int bufLength = Math.min(32768, (int)Math.min(length - pos, BIG_LENGTH));
-            byte[] buf = new byte[bufLength];
-            while (pos < length) {
+        try (FileChannel fc = FileChannel.open(file, WRITE)) {
+            if (length < 65536) {
+                // if the length is less than 64k, write the entire file
+                byte[] buf = new byte[(int)length];
                 RAND.nextBytes(buf);
-                int len = (int)Math.min(bufLength, length - pos);
-                pos += fc.write(ByteBuffer.wrap(buf, 0, len));
+                ByteBuffer bb = ByteBuffer.wrap(buf);
+                while (bb.hasRemaining()) {
+                    fc.write(bb);
+                }
+            } else {
+                // write the first and the last 32k only
+                byte[] buf = new byte[32768];
+                RAND.nextBytes(buf);
+                ByteBuffer bb = ByteBuffer.wrap(buf);
+                while (bb.hasRemaining()) {
+                    fc.write(bb);
+                }
+                bb.clear();
+                fc.position(length - buf.length);
+                RAND.nextBytes(buf);
+                while (bb.hasRemaining()) {
+                    fc.write(bb);
+                }
             }
         }
         return file;


### PR DESCRIPTION
Please review this PR that reduces the number of bytes written by ReadXBytes test on machines supporting sparse files.

Before this change the `createFileWithRandomContent` function would usually write either the last byte only, or the entire file (`long p` was usually set to length - 1). Now the function only writes the first and the last 32kB, and the remaining bytes are initialized in platform-defined manner.

Before this change the test took between 1-10 minutes to complete on our Windows CI machines.
After this change the test finishes in less than 1 minute.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295798](https://bugs.openjdk.org/browse/JDK-8295798): (ch) Test java/nio/channels/Channels/ReadXBytes.java is very slow on Windows


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [70f4b4bf](https://git.openjdk.org/jdk/pull/10834/files/70f4b4bfe7546f1bbe80efd069bfa29a4e8145a9)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10834/head:pull/10834` \
`$ git checkout pull/10834`

Update a local copy of the PR: \
`$ git checkout pull/10834` \
`$ git pull https://git.openjdk.org/jdk pull/10834/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10834`

View PR using the GUI difftool: \
`$ git pr show -t 10834`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10834.diff">https://git.openjdk.org/jdk/pull/10834.diff</a>

</details>
