### PR TITLE
8295838: Document why we do not print Code Cache Roots phase in G1 logging

### DIFF
--- a/src/hotspot/share/gc/g1/g1RootProcessor.cpp
+++ b/src/hotspot/share/gc/g1/g1RootProcessor.cpp
@@ -209,6 +209,9 @@ void G1RootProcessor::process_vm_roots(G1RootClosures* closures,
 void G1RootProcessor::process_code_cache_roots(CodeBlobClosure* code_closure,
                                                G1GCPhaseTimes* phase_times,
                                                uint worker_id) {
+  // We do not track timing of this phase. It is only required with class unloading
+  // disabled, which is an extremely uncommon use case and would otherwise only ever
+  // show up as "skipped" in the logs.
   if (_process_strong_tasks.try_claim_task(G1RP_PS_CodeCache_oops_do)) {
     CodeCache::blobs_do(code_closure);
   }


### PR DESCRIPTION
Hi all,

  can I get reviews for this trivial addition of some comment why we do not measure the `Code Cache Roots` phase in G1 logging?

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295838](https://bugs.openjdk.org/browse/JDK-8295838): Document why we do not print Code Cache Roots phase in G1 logging


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10835/head:pull/10835` \
`$ git checkout pull/10835`

Update a local copy of the PR: \
`$ git checkout pull/10835` \
`$ git pull https://git.openjdk.org/jdk pull/10835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10835`

View PR using the GUI difftool: \
`$ git pr show -t 10835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10835.diff">https://git.openjdk.org/jdk/pull/10835.diff</a>

</details>
