### PR TITLE
8295844: jdk/test/whitebox/CPUInfoTest.java failed with "not all features are known: expected true, was false"

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -311,6 +311,11 @@ protected:
   static address   _cpuinfo_segv_addr; // address of instruction which causes SEGV
   static address   _cpuinfo_cont_addr; // address of instruction after the one which causes SEGV
 
+  /*
+   * Update next files when declaring new flags:
+   * test/lib-test/jdk/test/whitebox/CPUInfoTest.java
+   * src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.amd64/src/jdk/vm/ci/amd64/AMD64.java
+   */
   enum Feature_Flag : uint64_t {
 #define CPU_FEATURE_FLAGS(decl) \
     decl(CX8,               "cx8",               0)  /*  next bits are from cpuid 1 (EDX) */ \

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -312,7 +312,7 @@ protected:
   static address   _cpuinfo_cont_addr; // address of instruction after the one which causes SEGV
 
   /*
-   * Update next files when declaring new flags:
+   * Update following files when declaring new flags:
    * test/lib-test/jdk/test/whitebox/CPUInfoTest.java
    * src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.amd64/src/jdk/vm/ci/amd64/AMD64.java
    */

--- a/test/lib-test/jdk/test/whitebox/CPUInfoTest.java
+++ b/test/lib-test/jdk/test/whitebox/CPUInfoTest.java
@@ -64,7 +64,7 @@ public class CPUInfoTest {
                     "avx512_vnni",  "clflush",          "clflushopt",        "clwb",
                     "avx512_vbmi2", "avx512_vbmi",      "rdtscp",            "rdpid",
                     "hv",           "fsrm",             "avx512_bitalg",     "gfni",
-                    "f16c"
+                    "f16c", "pku", "ospke", "cet_ibt", "cet_ss"
                     );
             // @formatter:on
             // Checkstyle: resume

--- a/test/lib-test/jdk/test/whitebox/CPUInfoTest.java
+++ b/test/lib-test/jdk/test/whitebox/CPUInfoTest.java
@@ -64,7 +64,8 @@ public class CPUInfoTest {
                     "avx512_vnni",  "clflush",          "clflushopt",        "clwb",
                     "avx512_vbmi2", "avx512_vbmi",      "rdtscp",            "rdpid",
                     "hv",           "fsrm",             "avx512_bitalg",     "gfni",
-                    "f16c", "pku", "ospke", "cet_ibt", "cet_ss"
+                    "f16c",         "pku",              "ospke",             "cet_ibt",
+                    "cet_ss"
                     );
             // @formatter:on
             // Checkstyle: resume


### PR DESCRIPTION
[JDK-8295776](https://github.com/openjdk/jdk/commit/d50b6eb342e9ec96d1a01dafc317e00725dc84c0) added new x86 CPU flags checks but did not update  CPUInfoTest.java.
Add missing x86 CPU's flags to CPUInfoTest.java.

Tested with tier1 when CPUInfoTest.java is ran.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295844](https://bugs.openjdk.org/browse/JDK-8295844): jdk/test/whitebox/CPUInfoTest.java failed with "not all features are known: expected true, was false"


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [acd6b1f6](https://git.openjdk.org/jdk/pull/10837/files/acd6b1f649e67071025b161ee50113c1aa5b81df)
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - Committer) ⚠️ Review applies to [014e26ee](https://git.openjdk.org/jdk/pull/10837/files/014e26ee93ec20110091b8bae1296d16dfa63928)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10837/head:pull/10837` \
`$ git checkout pull/10837`

Update a local copy of the PR: \
`$ git checkout pull/10837` \
`$ git pull https://git.openjdk.org/jdk pull/10837/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10837`

View PR using the GUI difftool: \
`$ git pr show -t 10837`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10837.diff">https://git.openjdk.org/jdk/pull/10837.diff</a>

</details>
