### PR TITLE
8295855: ProblemList jdk/jshell/CommandCompletionTest.java on linux-all

### DIFF
--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -35,6 +35,7 @@ jdk/jshell/UserJdiUserRemoteTest.java                                           
 jdk/jshell/UserInputTest.java                                                   8169536    generic-all
 jdk/jshell/ToolBasicTest.java                                                   8265357    macosx-aarch64
 jdk/jshell/HighlightUITest.java                                                 8284144    generic-all
+jdk/jshell/CommandCompletionTest.java                                           8295814    linux-all
 
 ###########################################################################
 #


### PR DESCRIPTION
A trivial fix to ProblemList jdk/jshell/CommandCompletionTest.java on linux-all.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295855](https://bugs.openjdk.org/browse/JDK-8295855): ProblemList jdk/jshell/CommandCompletionTest.java on linux-all


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10841/head:pull/10841` \
`$ git checkout pull/10841`

Update a local copy of the PR: \
`$ git checkout pull/10841` \
`$ git pull https://git.openjdk.org/jdk pull/10841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10841`

View PR using the GUI difftool: \
`$ git pr show -t 10841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10841.diff">https://git.openjdk.org/jdk/pull/10841.diff</a>

</details>
