### PR TITLE
8295863 JFR: Use expected size for Maps and Sets

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/EventFactory.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/EventFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,7 +105,7 @@ public final class EventFactory {
 
         List<AnnotationElement> sanitizedAnnotation = Utils.sanitizeNullFreeList(annotationElements, AnnotationElement.class);
         List<ValueDescriptor> sanitizedFields = Utils.sanitizeNullFreeList(fields, ValueDescriptor.class);
-        Set<String> nameSet = new HashSet<>();
+        Set<String> nameSet = HashSet.newHashSet(sanitizedFields.size());
         for (ValueDescriptor v : sanitizedFields) {
             String name = v.getName();
             if (v.isArray()) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/EventType.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/EventType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,7 @@ public final class EventType {
         Objects.requireNonNull(name, "name");
         if (cache == null) {
             List<ValueDescriptor> fields = getFields();
-            Map<String, ValueDescriptor> newCache = new LinkedHashMap<>(fields.size());
+            Map<String, ValueDescriptor> newCache = LinkedHashMap.newLinkedHashMap(fields.size());
             for (ValueDescriptor v :fields) {
                 newCache.put(v.getName(), v);
             }

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/MetadataEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/MetadataEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,7 +102,7 @@ public final class MetadataEvent {
 
     private void calculateDelta() {
         List<EventType> added = new ArrayList<>();
-        Map<Long, EventType> previousSet = new HashMap<>(previous.size());
+        Map<Long, EventType> previousSet = HashMap.newHashMap(previous.size());
         for (EventType eventType : previous) {
             previousSet.put(eventType.getId(), eventType);
         }

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingFile.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingFile.java
@@ -163,8 +163,8 @@ public final class RecordingFile implements Closeable {
     List<Type> readTypes() throws IOException  {
         ensureOpen();
         MetadataDescriptor previous = null;
-        List<Type> types = new ArrayList<>();
-        HashSet<Long> foundIds = new HashSet<>();
+        List<Type> types = new ArrayList<>(200);
+        HashSet<Long> foundIds = HashSet.newHashSet(types.size());
         try (RecordingInput ri = new RecordingInput(file, FileAccess.UNPRIVILEGED)) {
             ChunkHeader ch = new ChunkHeader(ri);
             ch.awaitFinished();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataLoader.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataLoader.java
@@ -140,7 +140,7 @@ public final class MetadataLoader {
     }
 
     private final List<TypeElement> types;
-    private final Map<String, List<AnnotationElement>> anotationElements = new HashMap<>();
+    private final Map<String, List<AnnotationElement>> anotationElements = HashMap.newHashMap(16);
     private final Map<String, AnnotationElement> categories = new HashMap<>();
 
     MetadataLoader(DataInputStream dis) throws IOException {
@@ -273,7 +273,7 @@ public final class MetadataLoader {
 
     private Map<String, Type> buildTypeMap() {
         Map<String, Type> typeMap = HashMap.newHashMap(types.size());
-        Map<String, Type> knownTypeMap = new HashMap<>();
+        Map<String, Type> knownTypeMap = HashMap.newHashMap(16);
         for (Type kt : Type.getKnownTypes()) {
             typeMap.put(kt.getName(), kt);
             knownTypeMap.put(kt.getName(), kt);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataLoader.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -140,7 +140,7 @@ public final class MetadataLoader {
     }
 
     private final List<TypeElement> types;
-    private final Map<String, List<AnnotationElement>> anotationElements = new HashMap<>(20);
+    private final Map<String, List<AnnotationElement>> anotationElements = new HashMap<>();
     private final Map<String, AnnotationElement> categories = new HashMap<>();
 
     MetadataLoader(DataInputStream dis) throws IOException {
@@ -204,7 +204,7 @@ public final class MetadataLoader {
     }
 
     private Map<String, AnnotationElement> buildRelationMap(Map<String, Type> typeMap) {
-        Map<String, AnnotationElement> relationMap = new HashMap<>(20);
+        Map<String, AnnotationElement> relationMap = HashMap.newHashMap(10);
         for (TypeElement t : types) {
             if (t.isRelation) {
                 Type relationType = typeMap.get(t.name);
@@ -272,8 +272,8 @@ public final class MetadataLoader {
     }
 
     private Map<String, Type> buildTypeMap() {
-        Map<String, Type> typeMap = new HashMap<>(2 * types.size());
-        Map<String, Type> knownTypeMap = new HashMap<>(20);
+        Map<String, Type> typeMap = HashMap.newHashMap(types.size());
+        Map<String, Type> knownTypeMap = new HashMap<>();
         for (Type kt : Type.getKnownTypes()) {
             typeMap.put(kt.getName(), kt);
             knownTypeMap.put(kt.getName(), kt);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -57,8 +57,8 @@ public final class MetadataRepository {
     private static final JVM jvm = JVM.getJVM();
     private static final MetadataRepository instance = new MetadataRepository();
 
-    private final List<EventType> nativeEventTypes = new ArrayList<>(100);
-    private final List<EventControl> nativeControls = new ArrayList<EventControl>(100);
+    private final List<EventType> nativeEventTypes = new ArrayList<>(150);
+    private final List<EventControl> nativeControls = new ArrayList<EventControl>(nativeEventTypes.size());
     private final TypeLibrary typeLibrary = TypeLibrary.getInstance();
     private final SettingsManager settingsManager = new SettingsManager();
     private final Map<String, Class<? extends Event>> mirrors = new HashMap<>();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,11 +78,11 @@ final class MetadataWriter {
     }
 
     public void writeBinary(DataOutput output) throws IOException {
-        Set<String> stringPool = new HashSet<>(1000);
+        Set<String> stringPool = HashSet.newHashSet(2500);
         // Possible improvement, sort string by how often they occur.
         // and assign low number to the most frequently used.
         buildStringPool(root, stringPool);
-        HashMap<String, Integer> lookup = new LinkedHashMap<>(stringPool.size());
+        HashMap<String, Integer> lookup = LinkedHashMap.newLinkedHashMap(stringPool.size());
         int index = 0;
         int poolSize = stringPool.size();
         writeInt(output, poolSize);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/SettingsManager.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/SettingsManager.java
@@ -80,7 +80,7 @@ final class SettingsManager {
         private void addToMap(Map<String, Set<String>> map, String attribute, String value) {
             Set<String> values = map.get(attribute);
             if (values == null) {
-                values = new HashSet<String>(5);
+                values = HashSet.newHashSet(4);
                 map.put(attribute, values);
             }
             values.add(value);
@@ -173,7 +173,7 @@ final class SettingsManager {
     }
 
     private Map<String, InternalSetting> createSettingsMap(List<Map<String,String>> activeSettings) {
-        Map<String, InternalSetting> map = new LinkedHashMap<>(activeSettings.size());
+        Map<String, InternalSetting> map = LinkedHashMap.newLinkedHashMap(activeSettings.size());
         for (Map<String, String> rec : activeSettings) {
             for (InternalSetting internal : makeInternalSettings(rec)) {
                 InternalSetting is = map.get(internal.getSettingsId());
@@ -188,7 +188,7 @@ final class SettingsManager {
     }
 
     private Collection<InternalSetting> makeInternalSettings(Map<String, String> rec) {
-        Map<String, InternalSetting> internals = new LinkedHashMap<>();
+        Map<String, InternalSetting> internals = LinkedHashMap.newLinkedHashMap(rec.size());
         for (Map.Entry<String, String> entry : rec.entrySet()) {
             String key = entry.getKey();
             String value = entry.getValue();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/TypeLibrary.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/TypeLibrary.java
@@ -63,7 +63,7 @@ public final class TypeLibrary {
 
     private static TypeLibrary instance;
     private static boolean implicitFieldTypes;
-    private static final Map<Long, Type> types = new LinkedHashMap<>(100);
+    private static final Map<Long, Type> types = LinkedHashMap.newLinkedHashMap(350);
     static final ValueDescriptor DURATION_FIELD = createDurationField();
     static final ValueDescriptor THREAD_FIELD = createThreadField();
     static final ValueDescriptor STACK_TRACE_FIELD = createStackTraceField();
@@ -301,7 +301,7 @@ public final class TypeLibrary {
     }
 
     private static void addUserFields(Class<?> clazz, Type type, List<ValueDescriptor> dynamicFields) {
-        Map<String, ValueDescriptor> dynamicFieldSet = new HashMap<>();
+        Map<String, ValueDescriptor> dynamicFieldSet = HashMap.newHashMap(dynamicFields.size());
         for (ValueDescriptor dynamicField : dynamicFields) {
             dynamicFieldSet.put(dynamicField.getName(), dynamicField);
         }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
@@ -461,7 +461,7 @@ public final class Utils {
     }
 
     public static Map<String, String> sanitizeNullFreeStringMap(Map<String, String> settings) {
-        HashMap<String, String> map = new HashMap<>(settings.size());
+        HashMap<String, String> map = HashMap.newHashMap(settings.size());
         for (Map.Entry<String, String> e : settings.entrySet()) {
             String key = e.getKey();
             if (key == null) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventLog.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,7 +177,7 @@ public final class EventLog {
     // Therefore, create a lookup by event type ID to see if is a JDK/JVM event.
     private static void ensureSystemEventLookup() {
         if (systemEventLookup == null) {
-            systemEventLookup = new HashSet<>();
+            systemEventLookup = HashSet.newHashSet(200);
             for (EventType type : FlightRecorder.getFlightRecorder().getEventTypes()) {
                 PlatformEventType pe = PrivateAccess.getInstance().getPlatformEventType(type);
                 if (pe.isSystem()) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -232,7 +232,7 @@ final class DCmdStart extends AbstractDCmd {
     }
 
     private LinkedHashMap<String, String> configureStandard(String[] settings) throws DCmdException {
-        LinkedHashMap<String, String> s = new LinkedHashMap<>();
+        LinkedHashMap<String, String> s = LinkedHashMap.newLinkedHashMap(settings.length);
         for (String configName : settings) {
             try {
                 s.putAll(JFC.createKnown(configName).getSettings());

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/ConfigurationInfo.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/ConfigurationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,7 @@ public final class ConfigurationInfo {
         if (o instanceof TabularData) {
             TabularData td = (TabularData) o;
             Collection<?> values = td.values();
-            Map<String, String> map = new HashMap<>(values.size());
+            Map<String, String> map = HashMap.newHashMap(values.size());
             for (Object value : td.values()) {
                 if (value instanceof CompositeData) {
                     CompositeData cdRow = (CompositeData) value;

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/FlightRecorderMXBeanImpl.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/FlightRecorderMXBeanImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -316,7 +316,7 @@ final class FlightRecorderMXBeanImpl extends StandardEmitterMBean implements Fli
     public Map<String, String> getRecordingOptions(long recording) throws IllegalArgumentException {
         MBeanUtils.checkMonitor();
         Recording r = getExistingRecording(recording);
-        Map<String, String> options = new HashMap<>(10);
+        Map<String, String> options = HashMap.newHashMap(10);
         options.put(OPTION_DUMP_ON_EXIT, String.valueOf(r.getDumpOnExit()));
         options.put(OPTION_DISK, String.valueOf(r.isToDisk()));
         options.put(OPTION_NAME, String.valueOf(r.getName()));


### PR DESCRIPTION
Hi,

Could I have a review of PR that uses HashMap.newHashMap and HashSet.newHashSet to set the expected size. I also increased the size where the number of events have increased since JDK 9.

Testing: test/jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295863](https://bugs.openjdk.org/browse/JDK-8295863): JFR: Use expected size for Maps and Sets


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10844/head:pull/10844` \
`$ git checkout pull/10844`

Update a local copy of the PR: \
`$ git checkout pull/10844` \
`$ git pull https://git.openjdk.org/jdk pull/10844/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10844`

View PR using the GUI difftool: \
`$ git pr show -t 10844`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10844.diff">https://git.openjdk.org/jdk/pull/10844.diff</a>

</details>
