### PR TITLE
8294845: Make globals accessed by G1 young gen revising atomic 

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1133,8 +1133,8 @@ void G1Policy::print_age_table() {
 uint G1Policy::calculate_young_max_length(uint target_young_length) const {
   uint expansion_region_num = 0;
   if (GCLockerEdenExpansionPercent > 0) {
-    double perc = (double) GCLockerEdenExpansionPercent / 100.0;
-    double expansion_region_num_d = perc * (double)young_list_target_length();
+    double perc = GCLockerEdenExpansionPercent / 100.0;
+    double expansion_region_num_d = perc * young_list_target_length();
     // We use ceiling so that if expansion_region_num_d is > 0.0 (but
     // less than 1.0) we'll get 1.
     expansion_region_num = (uint) ceil(expansion_region_num_d);

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -208,6 +208,13 @@ void G1Policy::update_young_length_bounds(size_t pending_cards, size_t rs_length
                             new_young_list_target_length,
                             new_young_list_max_length);
 
+  // Write back. This is not an attempt to control visibility order to other threads
+  // here; all the revising of the young gen length are best effort to keep pause time.
+  // E.g. we could be "too late" revising young gen upwards to avoid GC because
+  // there is some time left, or some threads could get different values for stopping
+  // allocation.
+  // That is "fine" - at most this will schedule a GC (hopefully only a little) too
+  // early or too late.
   Atomic::store(&_young_list_desired_length, new_young_list_desired_length);
   Atomic::store(&_young_list_target_length, new_young_list_target_length);
   Atomic::store(&_young_list_max_length, new_young_list_max_length);

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -35,6 +35,7 @@
 #include "gc/g1/g1Predictions.hpp"
 #include "gc/g1/g1YoungGenSizer.hpp"
 #include "gc/shared/gcCause.hpp"
+#include "runtime/atomic.hpp"
 #include "utilities/pair.hpp"
 #include "utilities/ticks.hpp"
 

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -77,12 +77,14 @@ class G1Policy: public CHeapObj<mtGC> {
 
   double _full_collection_start_sec;
 
-  uint _young_list_desired_length;
-  uint _young_list_target_length;
-
+  // Desired young gen length without taking actually available free regions into
+  // account.
+  volatile uint _young_list_desired_length;
+  // Actual target length given available free memory.
+  volatile uint _young_list_target_length;
   // The max number of regions we can extend the eden by while the GC
   // locker is active. This should be >= _young_list_target_length;
-  uint _young_list_max_length;
+  volatile uint _young_list_max_length;
 
   // The survivor rate groups below must be initialized after the predictor because they
   // indirectly use it through the "this" object passed to their constructor.
@@ -379,16 +381,13 @@ public:
   // This must be called at the very beginning of an evacuation pause.
   void decide_on_concurrent_start_pause();
 
-  uint young_list_desired_length() const { return _young_list_desired_length; }
-  uint young_list_target_length() const { return _young_list_target_length; }
+  uint young_list_desired_length() const { return Atomic::load(&_young_list_desired_length); }
+  uint young_list_target_length() const { return Atomic::load(&_young_list_target_length); }
+  uint young_list_max_length() const { return Atomic::load(&_young_list_max_length); }
 
   bool should_allocate_mutator_region() const;
 
   bool can_expand_young_list() const;
-
-  uint young_list_max_length() const {
-    return _young_list_max_length;
-  }
 
   bool use_adaptive_young_list_length() const;
 


### PR DESCRIPTION
Hi all,

  can I have reviews for this cleanup that makes a few globals accessed by `G1Policy::update_young_length_bounds` "atomic" as per style guide? Basically there are a few variables that are changed by young gen size revising that are read concurrently, and to indicate that, this change decorates them with the `Atomic` accessor functions.

This is no attempt to fix any visibility races that (already, pre-existing) occur when these values are written and read; I think all of these are benign and can at most lead to having garbage collections that are "too late" or "too early" due to that. However all the young gen length revising, particularly in presence of the gclocker, is and has always been a best effort approach as far as I could ever tell.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294845](https://bugs.openjdk.org/browse/JDK-8294845): Make globals accessed by G1 young gen revising atomic


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**) ⚠️ Review applies to [77af16da](https://git.openjdk.org/jdk/pull/10845/files/77af16da7838934317f117a15c6053bda643a753)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to [77af16da](https://git.openjdk.org/jdk/pull/10845/files/77af16da7838934317f117a15c6053bda643a753)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10845/head:pull/10845` \
`$ git checkout pull/10845`

Update a local copy of the PR: \
`$ git checkout pull/10845` \
`$ git pull https://git.openjdk.org/jdk pull/10845/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10845`

View PR using the GUI difftool: \
`$ git pr show -t 10845`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10845.diff">https://git.openjdk.org/jdk/pull/10845.diff</a>

</details>
