### PR TITLE
8295872: [PPC64] JfrGetCallTrace: Need pc == nullptr check before frame constructor

### DIFF
--- a/src/hotspot/os_cpu/aix_ppc/javaThread_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/javaThread_aix_ppc.cpp
@@ -32,7 +32,9 @@
 frame JavaThread::pd_last_frame() {
   assert(has_last_Java_frame(), "must have last_Java_sp() when suspended");
 
-  intptr_t* sp = Atomic::load_acquire(&_anchor._last_Java_sp);
+  // Only called by current thread or when the thread is suspended.
+  // No memory barrier needed, here. Only writer must write sp last (for use by profiler).
+  intptr_t* sp = last_Java_sp();
   address pc = _anchor.last_Java_pc();
 
   return frame(sp, pc);
@@ -43,10 +45,10 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   if (has_last_Java_frame() && frame_anchor()->walkable()) {
-    intptr_t* sp = Atomic::load_acquire(&_anchor._last_Java_sp);
+    intptr_t* sp = last_Java_sp();
     address pc = _anchor.last_Java_pc();
     // pc can be seen as null because not all writers use store pc + release store sp.
-    // Simply discard the sample in this rare case.
+    // Simply discard the sample in this very rare case.
     if (pc == nullptr) return false;
     *fr_addr = frame(sp, pc);
     return true;

--- a/src/hotspot/os_cpu/aix_ppc/javaThread_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/javaThread_aix_ppc.cpp
@@ -43,9 +43,12 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   if (has_last_Java_frame() && frame_anchor()->walkable()) {
-    frame last_frame = pd_last_frame();
-    if (last_frame.pc() == nullptr) return false;
-    *fr_addr = last_frame;
+    intptr_t* sp = Atomic::load_acquire(&_anchor._last_Java_sp);
+    address pc = _anchor.last_Java_pc();
+    // pc can be seen as null because not all writers use store pc + release store sp.
+    // Simply discard the sample in this rare case.
+    if (pc == nullptr) return false;
+    *fr_addr = frame(sp, pc);
     return true;
   }
 

--- a/src/hotspot/os_cpu/linux_ppc/javaThread_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/javaThread_linux_ppc.cpp
@@ -31,7 +31,9 @@
 frame JavaThread::pd_last_frame() {
   assert(has_last_Java_frame(), "must have last_Java_sp() when suspended");
 
-  intptr_t* sp = Atomic::load_acquire(&_anchor._last_Java_sp);
+  // Only called by current thread or when the thread is suspended.
+  // No memory barrier needed, here. Only writer must write sp last (for use by profiler).
+  intptr_t* sp = last_Java_sp();
   address pc = _anchor.last_Java_pc();
 
   return frame(sp, pc);
@@ -42,10 +44,10 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   if (has_last_Java_frame() && frame_anchor()->walkable()) {
-    intptr_t* sp = Atomic::load_acquire(&_anchor._last_Java_sp);
+    intptr_t* sp = last_Java_sp();
     address pc = _anchor.last_Java_pc();
     // pc can be seen as null because not all writers use store pc + release store sp.
-    // Simply discard the sample in this rare case.
+    // Simply discard the sample in this very rare case.
     if (pc == nullptr) return false;
     *fr_addr = frame(sp, pc);
     return true;

--- a/src/hotspot/os_cpu/linux_ppc/javaThread_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/javaThread_linux_ppc.cpp
@@ -42,9 +42,12 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   if (has_last_Java_frame() && frame_anchor()->walkable()) {
-    frame last_frame = pd_last_frame();
-    if (last_frame.pc() == nullptr) return false;
-    *fr_addr = last_frame;
+    intptr_t* sp = Atomic::load_acquire(&_anchor._last_Java_sp);
+    address pc = _anchor.last_Java_pc();
+    // pc can be seen as null because not all writers use store pc + release store sp.
+    // Simply discard the sample in this rare case.
+    if (pc == nullptr) return false;
+    *fr_addr = frame(sp, pc);
     return true;
   }
 


### PR DESCRIPTION
The check pc == nullptr is needed before the frame constructor.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295872](https://bugs.openjdk.org/browse/JDK-8295872): [PPC64] JfrGetCallTrace: Need pc == nullptr check before frame constructor


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [fe0bfd32](https://git.openjdk.org/jdk/pull/10846/files/fe0bfd327ccf438a61b6c49b174290917e8fa8fa)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10846/head:pull/10846` \
`$ git checkout pull/10846`

Update a local copy of the PR: \
`$ git checkout pull/10846` \
`$ git pull https://git.openjdk.org/jdk pull/10846/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10846`

View PR using the GUI difftool: \
`$ git pr show -t 10846`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10846.diff">https://git.openjdk.org/jdk/pull/10846.diff</a>

</details>
