### PR TITLE
8295868: 32-bit Windows build failures after JDK-8294466

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -768,7 +768,7 @@ ifeq ($(ENABLE_HEADLESS_ONLY), false)
       DISABLED_WARNINGS_clang_splashscreen_png.c := incompatible-pointer-types, \
       DISABLED_WARNINGS_clang_splashscreen_sys.m := deprecated-declarations, \
       DISABLED_WARNINGS_microsoft_dgif_lib.c := 4018 4267, \
-      DISABLED_WARNINGS_microsoft_splashscreen_impl.c := 4267 4244, \
+      DISABLED_WARNINGS_microsoft_splashscreen_impl.c := 4018 4267 4244, \
       DISABLED_WARNINGS_microsoft_splashscreen_png.c := 4267, \
       DISABLED_WARNINGS_microsoft_splashscreen_sys.c := 4267 4244, \
       LDFLAGS := $(LDFLAGS_JDKLIB) \


### PR DESCRIPTION
Fails like this:

```
* For target support_native_java.desktop_libsplashscreen_splashscreen_impl.obj:
splashscreen_impl.c
c:\buildbot\worker\build-jdkx-windows\build\src\java.desktop\share\native\libsplashscreen\splashscreen_impl.c(443): error C2220: the following warning is treated as an error
c:\buildbot\worker\build-jdkx-windows\build\src\java.desktop\share\native\libsplashscreen\splashscreen_impl.c(443): warning C4018: '>': signed/unsigned mismatch
c:\buildbot\worker\build-jdkx-windows\build\src\java.desktop\share\native\libsplashscreen\splashscreen_impl.c(444): warning C4018: '>': signed/unsigned mismatch
c:\buildbot\worker\build-jdkx-windows\build\src\java.desktop\share\native\libsplashscreen\splashscreen_impl.c(466): warning C4018: '>': signed/unsigned mismatch
c:\buildbot\worker\build-jdkx-windows\build\src\java.desktop\share\native\libsplashscreen\splashscreen_impl.c(467): warning C4018: '>': signed/unsigned mismatch
``` 

I just added the disabled warning for that file. 

Additional testing:
 - [x] Windows x86_32 release (now builds)
 - [x] Windows x86_32 fastdebug (now builds)
 - [x] Windows x86_32 slowdebug (now builds)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295868](https://bugs.openjdk.org/browse/JDK-8295868): 32-bit Windows build failures after JDK-8294466


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10848/head:pull/10848` \
`$ git checkout pull/10848`

Update a local copy of the PR: \
`$ git checkout pull/10848` \
`$ git pull https://git.openjdk.org/jdk pull/10848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10848`

View PR using the GUI difftool: \
`$ git pr show -t 10848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10848.diff">https://git.openjdk.org/jdk/pull/10848.diff</a>

</details>
