### PR TITLE
8293696: java/nio/channels/DatagramChannel/SelectWhenRefused.java fails with "Unexpected wakeup"

### DIFF
--- a/test/jdk/java/nio/channels/DatagramChannel/SelectWhenRefused.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/SelectWhenRefused.java
@@ -71,9 +71,9 @@ public class SelectWhenRefused {
                 if (n > 0) {
                     sel.selectedKeys().clear();
                     try {
-                        var buf = ByteBuffer.allocate(100);
+                        ByteBuffer buf = ByteBuffer.allocate(100);
                         n = dc.read(buf);
-                        var message = new String(buf.array());
+                        String message = new String(buf.array());
                         System.out.format("received %s at %s%n", message, dc.getLocalAddress());
                         throw new RuntimeException("Unexpected datagram received");
                     } catch (PortUnreachableException pue) {

--- a/test/jdk/java/nio/channels/DatagramChannel/SelectWhenRefused.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/SelectWhenRefused.java
@@ -163,6 +163,10 @@ public class SelectWhenRefused {
                 if (mayRetry) {
                     return false; // will retry
                 }
+
+                // BindException will be thrown if another service is using
+                // our expected refuser port, cannot run just exit.
+                DatagramChannel.open().bind(refuser).close();
                 throw new RuntimeException("PortUnreachableException not raised");
             } catch (PortUnreachableException pue) {
                 System.out.println("Got expected PortUnreachableException " + pue);

--- a/test/jdk/java/nio/channels/DatagramChannel/SelectWhenRefused.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/SelectWhenRefused.java
@@ -151,10 +151,9 @@ public class SelectWhenRefused {
                     }
                 }
 
-                // BindException will be thrown if another service is using
-                // our expected refuser port, cannot run just exit.
-                DatagramChannel.open().bind(refuser).close();
-                if (retryCount < MAX_TRIES - 1) return true;
+                if (retryCount < MAX_TRIES - 1) {
+                    return true;
+                }
                 throw new RuntimeException("PortUnreachableException not raised");
             } catch (PortUnreachableException pue) {
                 System.out.println("Got expected PortUnreachableException " + pue);

--- a/test/jdk/java/nio/channels/DatagramChannel/SelectWhenRefused.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/SelectWhenRefused.java
@@ -25,8 +25,7 @@
  * @bug 6935563 7044870
  * @summary Test that Selector does not select an unconnected DatagramChannel when
  *    ICMP port unreachable received
- * @library /test/lib
- * @run main/othervm SelectWhenRefused
+ * @run junit/othervm SelectWhenRefused
  */
 
 import java.nio.ByteBuffer;
@@ -35,13 +34,16 @@ import java.net.*;
 import java.io.IOException;
 import java.util.Set;
 
-import static jdk.test.lib.Asserts.assertNotEquals;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class SelectWhenRefused {
     static final int MAX_TRIES = 3;
     static final String GREETINGS_MESSAGE = "Greetings from SelectWhenRefused!";
 
-    public static void main(String[] args) throws IOException {
+    @Test
+    public void test() throws IOException {
         DatagramChannel dc1 = DatagramChannel.open().bind(new InetSocketAddress(0));
         int port = dc1.socket().getLocalPort();
 
@@ -86,6 +88,7 @@ public class SelectWhenRefused {
             }
         } catch (BindException e) {
             // Do nothing, some other test has used this port
+            System.out.println("Skipping test: refuser port has been reused: " + e);
         } finally {
             sel.close();
             dc.close();


### PR DESCRIPTION
Added logging to SelectWhenRefused for an intermittent failure caused by unexpected wakeups, this includes trying to receive data if there is any available to identify where it is coming from.

I also set the test to run in othervm mode which should reduce the chances of this failure happening in the first place.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293696](https://bugs.openjdk.org/browse/JDK-8293696): java/nio/channels/DatagramChannel/SelectWhenRefused.java fails with "Unexpected wakeup"


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Mark Sheppard](https://openjdk.org/census#msheppar) (@msheppar - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10851/head:pull/10851` \
`$ git checkout pull/10851`

Update a local copy of the PR: \
`$ git checkout pull/10851` \
`$ git pull https://git.openjdk.org/jdk pull/10851/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10851`

View PR using the GUI difftool: \
`$ git pr show -t 10851`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10851.diff">https://git.openjdk.org/jdk/pull/10851.diff</a>

</details>
