### PR TITLE
8295885: GHA: Bump gcc versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,7 +130,7 @@ jobs:
     with:
       platform: linux-x64
       gcc-major-version: '10'
-      apt-gcc-version: '10.3.0-15ubuntu1'
+      apt-gcc-version: '10.4.0-4ubuntu1~22.04'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     # The linux-x64 jdk bundle is used as buildjdk for the cross-compile job
@@ -144,7 +144,7 @@ jobs:
       platform: linux-x86
       gcc-major-version: '10'
       gcc-package-suffix: '-multilib'
-      apt-gcc-version: '10.3.0-15ubuntu1'
+      apt-gcc-version: '10.4.0-4ubuntu1~22.04'
       apt-architecture: 'i386'
       # Some multilib libraries do not have proper inter-dependencies, so we have to
       # install their dependencies manually.
@@ -163,7 +163,7 @@ jobs:
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
       gcc-major-version: '10'
-      apt-gcc-version: '10.3.0-15ubuntu1'
+      apt-gcc-version: '10.4.0-4ubuntu1~22.04'
       extra-conf-options: '--disable-precompiled-headers'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -178,7 +178,7 @@ jobs:
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
       gcc-major-version: '10'
-      apt-gcc-version: '10.3.0-15ubuntu1'
+      apt-gcc-version: '10.4.0-4ubuntu1~22.04'
       extra-conf-options: '--with-jvm-variants=zero --disable-precompiled-headers'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -193,7 +193,7 @@ jobs:
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
       gcc-major-version: '10'
-      apt-gcc-version: '10.3.0-15ubuntu1'
+      apt-gcc-version: '10.4.0-4ubuntu1~22.04'
       extra-conf-options: '--with-jvm-variants=minimal --disable-precompiled-headers'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -209,7 +209,7 @@ jobs:
       # Technically this is not the "debug" level, but we can't inject a new matrix state for just this job
       debug-levels: '[ "debug" ]'
       gcc-major-version: '10'
-      apt-gcc-version: '10.3.0-15ubuntu1'
+      apt-gcc-version: '10.4.0-4ubuntu1~22.04'
       extra-conf-options: '--with-debug-level=optimized --disable-precompiled-headers'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -223,8 +223,8 @@ jobs:
     uses: ./.github/workflows/build-cross-compile.yml
     with:
       gcc-major-version: '10'
-      apt-gcc-version: '10.3.0-15ubuntu1'
-      apt-gcc-cross-version: '10.3.0-8ubuntu1cross1'
+      apt-gcc-version: '10.4.0-4ubuntu1~22.04'
+      apt-gcc-cross-version: '10.4.0-4ubuntu1~22.04cross1'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-cross-compile == 'true'


### PR DESCRIPTION
Recent PRs have to start to fail due to failed gcc installations. For example, #10850 has [linux-x86 / build (release)](https://github.com/tschatzl/jdk/actions/runs/3319164391/jobs/5483988905) and [linux-cross-compile / build (riscv64)](https://github.com/tschatzl/jdk/actions/runs/3319164391/jobs/5484657183) failing.

Ubuntu 22.04 has bumped gcc to `10.4.0-4ubuntu1~22.04` for amd64. See https://packages.ubuntu.com/jammy/gcc-10

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295885](https://bugs.openjdk.org/browse/JDK-8295885): GHA: Bump gcc versions


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10852/head:pull/10852` \
`$ git checkout pull/10852`

Update a local copy of the PR: \
`$ git checkout pull/10852` \
`$ git pull https://git.openjdk.org/jdk pull/10852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10852`

View PR using the GUI difftool: \
`$ git pr show -t 10852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10852.diff">https://git.openjdk.org/jdk/pull/10852.diff</a>

</details>
