### PR TITLE
JDK-8265441: IGV: select block nodes by clicking on it

### DIFF
--- a/src/utils/IdealGraphVisualizer/Bytecodes/src/main/java/com/sun/hotspot/igv/bytecodes/SelectBytecodesAction.java
+++ b/src/utils/IdealGraphVisualizer/Bytecodes/src/main/java/com/sun/hotspot/igv/bytecodes/SelectBytecodesAction.java
@@ -41,7 +41,8 @@ public final class SelectBytecodesAction extends CookieAction {
         SelectBytecodesCookie c = activatedNodes[0].getCookie(SelectBytecodesCookie.class);
         InputGraphProvider p = LookupHistory.getLast(InputGraphProvider.class);
         if (p != null) {
-            p.setSelectedNodes(c.getNodes());
+            p.clearSelectedNodes();
+            p.addSelectedNodes(c.getNodes());
         }
     }
 

--- a/src/utils/IdealGraphVisualizer/ControlFlow/src/main/java/com/sun/hotspot/igv/controlflow/ControlFlowScene.java
+++ b/src/utils/IdealGraphVisualizer/ControlFlow/src/main/java/com/sun/hotspot/igv/controlflow/ControlFlowScene.java
@@ -133,7 +133,8 @@ public class ControlFlowScene extends GraphScene<InputBlock, InputBlockEdge> imp
             for (BlockWidget w : selection) {
                 inputNodes.addAll(w.getBlock().getNodes());
             }
-            p.setSelectedNodes(inputNodes);
+            p.clearSelectedNodes();
+            p.addSelectedNodes(inputNodes);
         }
     }
 

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/services/InputGraphProvider.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/services/InputGraphProvider.java
@@ -26,7 +26,7 @@ package com.sun.hotspot.igv.data.services;
 
 import com.sun.hotspot.igv.data.InputGraph;
 import com.sun.hotspot.igv.data.InputNode;
-import java.util.Set;
+import java.util.Collection;
 
 /**
  *
@@ -36,7 +36,10 @@ public interface InputGraphProvider {
 
     InputGraph getGraph();
 
-    void setSelectedNodes(Set<InputNode> nodes);
+    void addSelectedNodes(Collection<InputNode> nodes);
+
+    void clearSelectedNodes();
+
 
     /**
      * @return an iterator walking forward through the {@link InputGraph}s following the {@link #getGraph()}

--- a/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/SplitFilter.java
+++ b/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/SplitFilter.java
@@ -58,7 +58,6 @@ public class SplitFilter extends AbstractFilter {
                     OutputSlot os = c.getOutputSlot();
                     if (f.getInputNode() != null) {
                         os.getSource().addSourceNode(f.getInputNode());
-                        os.setAssociatedNode(f.getInputNode());
                         os.setColor(f.getColor());
                     }
 
@@ -75,7 +74,6 @@ public class SplitFilter extends AbstractFilter {
                     InputSlot is = c.getInputSlot();
                     if (f.getInputNode() != null) {
                         is.getSource().addSourceNode(f.getInputNode());
-                        is.setAssociatedNode(f.getInputNode());
                         is.setColor(f.getColor());
                     }
 

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/BlockQuickSearch.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/BlockQuickSearch.java
@@ -87,13 +87,14 @@ public class BlockQuickSearch implements SearchProvider {
             final InputGraph theGraph = p.getGraph() != matchGraph ? matchGraph : null;
             for (final InputBlock b : matches) {
                 if (!response.addResult(() -> {
-                            final EditorTopComponent comp = EditorTopComponent.getActive();
-                            assert(comp != null);
+                            final EditorTopComponent editor = EditorTopComponent.getActive();
+                            assert(editor != null);
                             if (theGraph != null) {
-                                comp.getModel().selectGraph(theGraph);
+                                editor.getModel().selectGraph(theGraph);
                             }
-                            comp.setSelectedNodes(b);
-                            comp.requestActive();
+                            editor.clearSelectedNodes();
+                            editor.addSelectedNodes(b.getNodes(), true);
+                            editor.requestActive();
                         },
                         "B" + b.getName() + (theGraph != null ? " in " + theGraph.getName() : ""))) {
                     return;

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
@@ -242,13 +242,12 @@ public class DiagramViewModel extends RangeSliderModel implements ChangedListene
     }
 
     public void showFigures(Collection<Figure> figures) {
-        HashSet<Integer> newHiddenNodes = new HashSet<>(getHiddenNodes());
+        HashSet<Integer> newHiddenNodes = new HashSet<>(hiddenNodes);
         for (Figure f : figures) {
             newHiddenNodes.remove(f.getInputNode().getId());
         }
         setHiddenNodes(newHiddenNodes);
     }
-
 
     public Set<Figure> getSelectedFigures() {
         Set<Figure> result = new HashSet<>();

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewer.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewer.java
@@ -31,7 +31,7 @@ import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.Collection;
-import java.util.List;
+import java.util.Set;
 import javax.swing.JComponent;
 import org.openide.awt.UndoRedo;
 import org.openide.util.Lookup;
@@ -77,9 +77,9 @@ public interface DiagramViewer {
 
     void componentShowing();
 
-    void setSelection(Collection<Figure> list);
+    void setFigureSelection(Set<Figure> list);
 
-    void centerFigures(List<Figure> list);
+    void centerFigures(Collection<Figure> list);
 
     void setInteractionMode(InteractionMode mode);
 

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorInputGraphProvider.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorInputGraphProvider.java
@@ -27,7 +27,7 @@ package com.sun.hotspot.igv.view;
 import com.sun.hotspot.igv.data.InputGraph;
 import com.sun.hotspot.igv.data.InputNode;
 import com.sun.hotspot.igv.data.services.InputGraphProvider;
-import java.util.Set;
+import java.util.Collection;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
@@ -57,9 +57,16 @@ public class EditorInputGraphProvider implements InputGraphProvider {
     }
 
     @Override
-    public void setSelectedNodes(Set<InputNode> nodes) {
+    public void addSelectedNodes(Collection<InputNode> nodes) {
         if (editor != null && EditorTopComponent.isOpen(editor)) {
-            editor.setSelectedNodes(nodes);
+            editor.addSelectedNodes(nodes, false);
+        }
+    }
+
+    @Override
+    public void clearSelectedNodes() {
+        if (editor != null && EditorTopComponent.isOpen(editor)) {
+            editor.clearSelectedNodes();
         }
     }
 

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorTopComponent.java
@@ -321,33 +321,25 @@ public final class EditorTopComponent extends TopComponent {
         }
     }
 
-    public void setSelectedFigures(List<Figure> list) {
-        scene.setSelection(list);
-        scene.centerFigures(list);
-    }
-
-    public void setSelectedNodes(Set<InputNode> nodes) {
-        List<Figure> list = new ArrayList<>();
-        Set<Integer> ids = new HashSet<>();
+    public void addSelectedNodes(Collection<InputNode> nodes, boolean centerSelection) {
+        Set<Integer> ids = new HashSet<>(getModel().getSelectedNodes());
         for (InputNode n : nodes) {
             ids.add(n.getId());
         }
+        Set<Figure> selectedFigures = new HashSet<>();
         for (Figure f : getDiagram().getFigures()) {
             if (ids.contains(f.getInputNode().getId())) {
-                list.add(f);
+                selectedFigures.add(f);
             }
         }
-        setSelectedFigures(list);
+        scene.setFigureSelection(selectedFigures);
+        if (centerSelection) {
+            scene.centerFigures(selectedFigures);
+        }
     }
 
-    public void setSelectedNodes(InputBlock b) {
-        List<Figure> list = new ArrayList<>();
-        for (Figure f : getDiagram().getFigures()) {
-            if (f.getBlock().getInputBlock() == b) {
-                list.add(f);
-            }
-        }
-        setSelectedFigures(list);
+    public void clearSelectedNodes() {
+        scene.setFigureSelection(Collections.emptySet());
     }
 
     public Rectangle getSceneBounds() {

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/NodeQuickSearch.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/NodeQuickSearch.java
@@ -108,24 +108,22 @@ public class NodeQuickSearch implements SearchProvider {
             }
 
             if (matches != null) {
-                final Set<InputNode> set = new HashSet<>(matches);
+                final Set<InputNode> nodeSet = new HashSet<>(matches);
                 final InputGraph theGraph = p.getGraph() != matchGraph ? matchGraph : null;
                 // Show "All N matching nodes" entry only if 1) there are
                 // multiple matches and 2) the query does not only contain
                 // digits (it is rare to select all nodes whose id contains a
                 // certain subsequence of digits).
                 if (matches.size() > 1 && !rawValue.matches("\\d+")) {
-                    if (!response.addResult(new Runnable() {
-                        @Override
-                        public void run() {
-                            final EditorTopComponent comp = EditorTopComponent.getActive();
-                            if (comp != null) {
-                                if (theGraph != null) {
-                                    comp.getModel().selectGraph(theGraph);
-                                }
-                                comp.setSelectedNodes(set);
-                                comp.requestActive();
+                    if (!response.addResult(() -> {
+                        final EditorTopComponent editor = EditorTopComponent.getActive();
+                        if (editor != null) {
+                            if (theGraph != null) {
+                                editor.getModel().selectGraph(theGraph);
                             }
+                            editor.clearSelectedNodes();
+                            editor.addSelectedNodes(nodeSet, true);
+                            editor.requestActive();
                         }
                     },
                             "All " + matches.size() + " matching nodes (" + name + "=" + value + ")" + (theGraph != null ? " in " + theGraph.getName() : "")
@@ -145,15 +143,16 @@ public class NodeQuickSearch implements SearchProvider {
                     if (!response.addResult(new Runnable() {
                         @Override
                         public void run() {
-                            final EditorTopComponent comp = EditorTopComponent.getActive();
-                            if (comp != null) {
+                            final EditorTopComponent editor = EditorTopComponent.getActive();
+                            if (editor != null) {
                                 final Set<InputNode> tmpSet = new HashSet<>();
                                 tmpSet.add(n);
                                 if (theGraph != null) {
-                                    comp.getModel().selectGraph(theGraph);
+                                    editor.getModel().selectGraph(theGraph);
                                 }
-                                comp.setSelectedNodes(tmpSet);
-                                comp.requestActive();
+                                editor.clearSelectedNodes();
+                                editor.addSelectedNodes(tmpSet, true);
+                                editor.requestActive();
                             }
                         }
                     },

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/actions/ExpandAdjacentAction.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/actions/ExpandAdjacentAction.java
@@ -38,27 +38,12 @@ abstract public class ExpandAdjacentAction extends CallableSystemAction {
     protected void expandFigures(Function<Figure, List<Figure>> getAdjacentFigures) {
         EditorTopComponent editor = EditorTopComponent.getActive();
         if (editor != null) {
-            Set<Figure> oldSelection = editor.getModel().getSelectedFigures();
-            Set<Figure> figures = new HashSet<>(oldSelection);
-            for (Figure f : editor.getModel().getDiagram().getFigures()) {
-                if (oldSelection.contains(f)) {
-                    continue;
-                }
-
-                boolean ok = false;
-                for (Figure adjFig : getAdjacentFigures.apply(f)) {
-                    if (oldSelection.contains(adjFig)) {
-                        ok = true;
-                        break;
-                    }
-                }
-
-                if (ok) {
-                    figures.add(f);
-                }
+            Set<Figure> selectedFigured = editor.getModel().getSelectedFigures();
+            Set<Figure> expandedFigures = new HashSet<>(selectedFigured);
+            for (Figure selectedFigure : selectedFigured) {
+                expandedFigures.addAll(getAdjacentFigures.apply(selectedFigure));
             }
-
-            editor.getModel().showFigures(figures);
+            editor.getModel().showFigures(expandedFigures);
         }
     }
 

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/actions/ExpandPredecessorsAction.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/actions/ExpandPredecessorsAction.java
@@ -33,7 +33,7 @@ public final class ExpandPredecessorsAction extends ExpandAdjacentAction {
 
     @Override
     public void performAction() {
-        expandFigures(Figure::getSuccessors);
+        expandFigures(Figure::getPredecessors);
     }
 
     @Override

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/actions/ExpandSuccessorsAction.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/actions/ExpandSuccessorsAction.java
@@ -33,7 +33,7 @@ public final class ExpandSuccessorsAction extends ExpandAdjacentAction {
 
     @Override
     public void performAction() {
-        expandFigures(Figure::getPredecessors);
+        expandFigures(Figure::getSuccessors);
     }
 
     @Override

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/widgets/BlockWidget.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/widgets/BlockWidget.java
@@ -24,24 +24,29 @@
 package com.sun.hotspot.igv.view.widgets;
 
 import com.sun.hotspot.igv.data.InputBlock;
-import com.sun.hotspot.igv.graph.Diagram;
+import com.sun.hotspot.igv.data.services.InputGraphProvider;
+import com.sun.hotspot.igv.util.DoubleClickHandler;
+import com.sun.hotspot.igv.util.LookupHistory;
 import java.awt.*;
+import java.awt.event.MouseEvent;
 import java.awt.geom.Rectangle2D;
+import org.netbeans.api.visual.action.WidgetAction;
 import org.netbeans.api.visual.widget.Scene;
 import org.netbeans.api.visual.widget.Widget;
+import org.openide.util.Utilities;
 
 /**
  *
  * @author Thomas Wuerthinger
  */
-public class BlockWidget extends Widget {
+public class BlockWidget extends Widget implements DoubleClickHandler {
 
     public static final Color BACKGROUND_COLOR = new Color(235, 235, 255);
     private static final Font TITLE_FONT = new Font("Arial", Font.BOLD, 14);
     public static final Color TITLE_COLOR = new Color(42, 42, 171);
-    private InputBlock blockNode;
+    private final InputBlock blockNode;
 
-    public BlockWidget(Scene scene, Diagram d, InputBlock blockNode) {
+    public BlockWidget(Scene scene, InputBlock blockNode) {
         super(scene);
         this.blockNode = blockNode;
         this.setBackground(BACKGROUND_COLOR);
@@ -70,5 +75,27 @@ public class BlockWidget extends Widget {
         Rectangle2D r1 = g.getFontMetrics().getStringBounds(s, g);
         g.drawString(s, r.x + 5, r.y + (int) r1.getHeight());
         g.setStroke(old);
+    }
+
+    private void addToSelection(BlockWidget blockWidget, boolean additiveSelection) {
+        InputGraphProvider graphProvider = LookupHistory.getLast(InputGraphProvider.class);
+        if (graphProvider != null) {
+            if (!additiveSelection) {
+                graphProvider.clearSelectedNodes();
+            }
+            graphProvider.addSelectedNodes(blockWidget.blockNode.getNodes());
+        }
+    }
+
+    private int getModifierMask () {
+        return Utilities.isMac() ? MouseEvent.META_DOWN_MASK : MouseEvent.CTRL_DOWN_MASK;
+    }
+
+    @Override
+    public void handleDoubleClick(Widget widget, WidgetAction.WidgetMouseEvent event) {
+        assert widget instanceof BlockWidget;
+        BlockWidget blockWidget = (BlockWidget) widget;
+        boolean additiveSelection = (event.getModifiersEx() & getModifierMask()) != 0;
+        addToSelection(blockWidget, additiveSelection);
     }
 }

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/widgets/FigureWidget.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/widgets/FigureWidget.java
@@ -84,7 +84,7 @@ public class FigureWidget extends Widget implements Properties.Provider, PopupMe
         return middleWidget.isHitAt(localLocation);
     }
 
-    public FigureWidget(final Figure f, WidgetAction hoverAction, WidgetAction selectAction, DiagramScene scene, Widget parent) {
+    public FigureWidget(final Figure f, DiagramScene scene, Widget parent) {
         super(scene);
 
         assert this.getScene() != null;


### PR DESCRIPTION
In "Cluster nodes into blocks" mode, it is now possible to select all nodes in a block by simply double-clicking in the block. The attached images illustrate the new behavior, after double-clicking on block B10. Similarly, the current node selection can be extended with all nodes of a block when holding the Ctrl/Cmd-key and double-clicking on a block.

![select_block](https://user-images.githubusercontent.com/71546117/197827820-4edf3333-f0e8-4e77-849e-b8e09eaf67ef.png)


# Overview selection
new selection modes in **bold**. We refer to B4/B10 as _blocks_, and 86, 87, 88, ... as _nodes_

## no key pressed
+ `click on single node` : select single node, unselect all other nodes
+ `click on edge` : select src/dest nodes, unselect all other nodes
+ **`double-click on block` : select all nodes in block, unselect all other nodes**
+ **`double-click outside of node/block` : unselect all nodes**
## holding down Ctrl/Cmd
+ `click on single node` : add node to current selection
+ `click on edge` : invert the selection of src/dest nodes
+ **`double-click on block` : add all nodes in block to current selection**
+ `draw selection rectangle` : **invert** the selection of all nodes in rectangle
    - select unselected nodes, **unselect selected nodes**
    
    
# Implementation
The main functionality was implemented by extending `BlockWidget` with `DoubleClickHandler` and adding methods `handleDoubleClick` / `addToSelection`. We also needed to replace `setSelectedNodes` with `clearSelectedNodes` and `addSelectedNodes` in `InputGraphProvider` and the corresponding methods in `EditorTopComponent`. All code that used `setSelectedNodes` needed to be adjusted accordingly. 

In order for the `DoubleClickHandler` in `BlockWidget` to work, we needed to extend `selectAction` in `DiagramScene` to _invert_ the selection of the nodes in the rectangle (the `symmetricDiff` set).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8265441](https://bugs.openjdk.org/browse/JDK-8265441): IGV: select block nodes by clicking on it


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10854/head:pull/10854` \
`$ git checkout pull/10854`

Update a local copy of the PR: \
`$ git checkout pull/10854` \
`$ git pull https://git.openjdk.org/jdk pull/10854/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10854`

View PR using the GUI difftool: \
`$ git pr show -t 10854`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10854.diff">https://git.openjdk.org/jdk/pull/10854.diff</a>

</details>
