### PR TITLE
JDK-8295889: NMT preinit code does not handle allocation errors

### DIFF
--- a/src/hotspot/share/services/nmtPreInit.cpp
+++ b/src/hotspot/share/services/nmtPreInit.cpp
@@ -52,9 +52,7 @@ static void fail_oom(size_t size) {
 
 NMTPreInitAllocation* NMTPreInitAllocation::do_alloc(size_t payload_size) {
   const size_t outer_size = sizeof(NMTPreInitAllocation) + payload_size;
-  if (outer_size < payload_size) {
-    fail_oom(payload_size);
-  }
+  guarantee(outer_size > payload_size, "Overflow");
   void* p = raw_malloc(outer_size);
   if (p == nullptr) {
     fail_oom(outer_size);
@@ -67,9 +65,7 @@ NMTPreInitAllocation* NMTPreInitAllocation::do_reallocate(NMTPreInitAllocation* 
   assert(old->next == NULL, "unhang from map first");
   // We just reallocate the old block, header and all.
   const size_t new_outer_size = sizeof(NMTPreInitAllocation) + new_payload_size;
-  if (new_outer_size < new_payload_size) {
-    fail_oom(new_payload_size);
-  }
+  guarantee(new_outer_size > new_payload_size, "Overflow");
   void* p = raw_realloc(old, new_outer_size);
   if (p == nullptr) {
     fail_oom(new_outer_size);

--- a/test/hotspot/gtest/nmt/test_nmtpreinit.cpp
+++ b/test/hotspot/gtest/nmt/test_nmtpreinit.cpp
@@ -90,6 +90,25 @@ public:
     os::free(NULL);                      // free(null)
     DEBUG_ONLY(NMTPreInit::verify();)
 
+    // This should result in a fatal native oom error from NMT preinit with a clear error message.
+    // It should not result in a SEGV or anything similar. Unfortunately difficult to test
+    // automatically.
+    // Uncomment to test manually.
+
+    // case 1: overflow
+    // os_malloc(SIZE_MAX);
+
+    // case 2: failing malloc
+    // os_malloc(SIZE_MAX - M);
+
+    // case 3: overflow in realloc
+    // void* p = os_malloc(10);
+    // p = os_realloc(p, SIZE_MAX);
+
+    // case 4: failing realloc
+    // void* p = os_malloc(10);
+    // p = os_realloc(p, SIZE_MAX - M);
+
     log_state();
   }
   void test_post() {


### PR DESCRIPTION
The NMT preinit allocator (used for os::malloc and friends before the VM is initialized) does not handle malloc errors, nor does it handle overflows due to large sizes (it uses malloc headers too). Both cases need to be handled.

However, we can keep matters very simple. No need to propagate errors up to the caller; we can just fatal out on errors here since, in this phase, there is no alternative for failed allocations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295889](https://bugs.openjdk.org/browse/JDK-8295889): NMT preinit code does not handle allocation errors


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10855/head:pull/10855` \
`$ git checkout pull/10855`

Update a local copy of the PR: \
`$ git checkout pull/10855` \
`$ git pull https://git.openjdk.org/jdk pull/10855/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10855`

View PR using the GUI difftool: \
`$ git pr show -t 10855`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10855.diff">https://git.openjdk.org/jdk/pull/10855.diff</a>

</details>
