### PR TITLE
8295895: build error after JDK-8279366

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -895,7 +895,7 @@ bool FileMapInfo::check_paths(int shared_path_start_idx, int num_paths, Growable
     assert(strlen(shared_path(j)->name()) > (size_t)dumptime_prefix_len, "sanity");
     const char* dumptime_path = shared_path(j)->name() + dumptime_prefix_len;
     assert(strlen(rp_array->at(i)) > (size_t)runtime_prefix_len, "sanity");
-    const char* runtime_path = runtime_path = rp_array->at(i)  + runtime_prefix_len;
+    const char* runtime_path = rp_array->at(i)  + runtime_prefix_len;
     if (!os::same_files(dumptime_path, runtime_path)) {
       return true;
     }


### PR DESCRIPTION
Fixing a build error caused by JDK-8279366.

Ran some sanity tests locally on linux-x64.

Tier1 testing in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295895](https://bugs.openjdk.org/browse/JDK-8295895): build error after JDK-8279366


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10858/head:pull/10858` \
`$ git checkout pull/10858`

Update a local copy of the PR: \
`$ git checkout pull/10858` \
`$ git pull https://git.openjdk.org/jdk pull/10858/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10858`

View PR using the GUI difftool: \
`$ git pr show -t 10858`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10858.diff">https://git.openjdk.org/jdk/pull/10858.diff</a>

</details>
