### PR TITLE
8295476: Split G1 cost per byte predictor on gc phase 

### DIFF
--- a/src/hotspot/share/gc/g1/g1Analytics.cpp
+++ b/src/hotspot/share/gc/g1/g1Analytics.cpp
@@ -87,7 +87,6 @@ G1Analytics::G1Analytics(const G1Predictions* predictor) :
     _constant_other_time_ms_seq(TruncatedSeqLength),
     _young_other_cost_per_region_ms_seq(TruncatedSeqLength),
     _non_young_other_cost_per_region_ms_seq(TruncatedSeqLength),
-    _cost_per_byte_ms_during_cm_seq(TruncatedSeqLength),
     _recent_prev_end_times_for_all_gcs_sec(NumPrevPausesForHeuristics),
     _long_term_pause_time_ratio(0.0),
     _short_term_pause_time_ratio(0.0) {
@@ -107,8 +106,8 @@ G1Analytics::G1Analytics(const G1Predictions* predictor) :
   _cost_per_card_scan_ms_seq.set_initial(young_only_cost_per_card_scan_ms_defaults[index]);
   _rs_length_seq.set_initial(0);
   _rs_length_diff_seq.set_initial(0.0);
+  _copy_cost_per_byte_ms_seq.set_initial(cost_per_byte_ms_defaults[index]);
 
-  _copy_cost_per_byte_ms_seq.add(cost_per_byte_ms_defaults[index]);
   _constant_other_time_ms_seq.add(constant_other_time_ms_defaults[index]);
   _young_other_cost_per_region_ms_seq.add(young_other_cost_per_region_ms_defaults[index]);
   _non_young_other_cost_per_region_ms_seq.add(non_young_other_cost_per_region_ms_defaults[index]);
@@ -197,12 +196,8 @@ void G1Analytics::report_rs_length_diff(double rs_length_diff, bool for_young_on
   _rs_length_diff_seq.add(rs_length_diff, for_young_only_phase);
 }
 
-void G1Analytics::report_cost_per_byte_ms(double cost_per_byte_ms, bool mark_or_rebuild_in_progress) {
-  if (mark_or_rebuild_in_progress) {
-    _cost_per_byte_ms_during_cm_seq.add(cost_per_byte_ms);
-  } else {
-    _copy_cost_per_byte_ms_seq.add(cost_per_byte_ms);
-  }
+void G1Analytics::report_cost_per_byte_ms(double cost_per_byte_ms, bool for_young_only_phase) {
+  _copy_cost_per_byte_ms_seq.add(cost_per_byte_ms, for_young_only_phase);
 }
 
 void G1Analytics::report_young_other_cost_per_region_ms(double other_cost_per_region_ms) {
@@ -257,20 +252,8 @@ double G1Analytics::predict_card_scan_time_ms(size_t card_num, bool for_young_on
   return card_num * predict_zero_bounded(&_cost_per_card_scan_ms_seq, for_young_only_phase);
 }
 
-double G1Analytics::predict_object_copy_time_ms_during_cm(size_t bytes_to_copy) const {
-  if (!enough_samples_available(&_cost_per_byte_ms_during_cm_seq)) {
-    return (1.1 * bytes_to_copy) * predict_zero_bounded(&_copy_cost_per_byte_ms_seq);
-  } else {
-    return bytes_to_copy * predict_zero_bounded(&_cost_per_byte_ms_during_cm_seq);
-  }
-}
-
-double G1Analytics::predict_object_copy_time_ms(size_t bytes_to_copy, bool during_concurrent_mark) const {
-  if (during_concurrent_mark) {
-    return predict_object_copy_time_ms_during_cm(bytes_to_copy);
-  } else {
-    return bytes_to_copy * predict_zero_bounded(&_copy_cost_per_byte_ms_seq);
-  }
+double G1Analytics::predict_object_copy_time_ms(size_t bytes_to_copy, bool for_young_only_phase) const {
+  return bytes_to_copy * predict_zero_bounded(&_copy_cost_per_byte_ms_seq, for_young_only_phase);
 }
 
 double G1Analytics::predict_constant_other_time_ms() const {

--- a/src/hotspot/share/gc/g1/g1Analytics.cpp
+++ b/src/hotspot/share/gc/g1/g1Analytics.cpp
@@ -80,10 +80,10 @@ G1Analytics::G1Analytics(const G1Predictions* predictor) :
     _card_scan_to_merge_ratio_seq(TruncatedSeqLength),
     _cost_per_card_scan_ms_seq(TruncatedSeqLength),
     _cost_per_card_merge_ms_seq(TruncatedSeqLength),
+    _cost_per_byte_copied_ms_seq(TruncatedSeqLength),
     _pending_cards_seq(TruncatedSeqLength),
     _rs_length_seq(TruncatedSeqLength),
     _rs_length_diff_seq(TruncatedSeqLength),
-    _copy_cost_per_byte_ms_seq(TruncatedSeqLength),
     _constant_other_time_ms_seq(TruncatedSeqLength),
     _young_other_cost_per_region_ms_seq(TruncatedSeqLength),
     _non_young_other_cost_per_region_ms_seq(TruncatedSeqLength),
@@ -106,7 +106,7 @@ G1Analytics::G1Analytics(const G1Predictions* predictor) :
   _cost_per_card_scan_ms_seq.set_initial(young_only_cost_per_card_scan_ms_defaults[index]);
   _rs_length_seq.set_initial(0);
   _rs_length_diff_seq.set_initial(0.0);
-  _copy_cost_per_byte_ms_seq.set_initial(cost_per_byte_ms_defaults[index]);
+  _cost_per_byte_copied_ms_seq.set_initial(cost_per_byte_ms_defaults[index]);
 
   _constant_other_time_ms_seq.add(constant_other_time_ms_defaults[index]);
   _young_other_cost_per_region_ms_seq.add(young_other_cost_per_region_ms_defaults[index]);
@@ -197,7 +197,7 @@ void G1Analytics::report_rs_length_diff(double rs_length_diff, bool for_young_on
 }
 
 void G1Analytics::report_cost_per_byte_ms(double cost_per_byte_ms, bool for_young_only_phase) {
-  _copy_cost_per_byte_ms_seq.add(cost_per_byte_ms, for_young_only_phase);
+  _cost_per_byte_copied_ms_seq.add(cost_per_byte_ms, for_young_only_phase);
 }
 
 void G1Analytics::report_young_other_cost_per_region_ms(double other_cost_per_region_ms) {
@@ -253,7 +253,7 @@ double G1Analytics::predict_card_scan_time_ms(size_t card_num, bool for_young_on
 }
 
 double G1Analytics::predict_object_copy_time_ms(size_t bytes_to_copy, bool for_young_only_phase) const {
-  return bytes_to_copy * predict_zero_bounded(&_copy_cost_per_byte_ms_seq, for_young_only_phase);
+  return bytes_to_copy * predict_zero_bounded(&_cost_per_byte_copied_ms_seq, for_young_only_phase);
 }
 
 double G1Analytics::predict_constant_other_time_ms() const {

--- a/src/hotspot/share/gc/g1/g1Analytics.hpp
+++ b/src/hotspot/share/gc/g1/g1Analytics.hpp
@@ -55,15 +55,14 @@ class G1Analytics: public CHeapObj<mtGC> {
 
   // The cost to scan a card during young-only and mixed gcs in ms.
   G1PhaseDependentSeq _cost_per_card_scan_ms_seq;
-
   // The cost to merge a card during young-only and mixed gcs in ms.
   G1PhaseDependentSeq _cost_per_card_merge_ms_seq;
+  // The cost to copy a byte in ms.
+  G1PhaseDependentSeq _cost_per_byte_copied_ms_seq;
 
   G1PhaseDependentSeq _pending_cards_seq;
   G1PhaseDependentSeq _rs_length_seq;
   G1PhaseDependentSeq _rs_length_diff_seq;
-  // The cost to copy a byte in ms.
-  G1PhaseDependentSeq _copy_cost_per_byte_ms_seq;
 
   TruncatedSeq _constant_other_time_ms_seq;
   TruncatedSeq _young_other_cost_per_region_ms_seq;

--- a/src/hotspot/share/gc/g1/g1Analytics.hpp
+++ b/src/hotspot/share/gc/g1/g1Analytics.hpp
@@ -62,9 +62,9 @@ class G1Analytics: public CHeapObj<mtGC> {
   G1PhaseDependentSeq _pending_cards_seq;
   G1PhaseDependentSeq _rs_length_seq;
   G1PhaseDependentSeq _rs_length_diff_seq;
-
   // The cost to copy a byte in ms.
-  TruncatedSeq _copy_cost_per_byte_ms_seq;
+  G1PhaseDependentSeq _copy_cost_per_byte_ms_seq;
+
   TruncatedSeq _constant_other_time_ms_seq;
   TruncatedSeq _young_other_cost_per_region_ms_seq;
   TruncatedSeq _non_young_other_cost_per_region_ms_seq;
@@ -131,7 +131,7 @@ public:
   void report_cost_per_card_merge_ms(double cost_per_card_ms, bool for_young_only_phase);
   void report_card_scan_to_merge_ratio(double cards_per_entry_ratio, bool for_young_only_phase);
   void report_rs_length_diff(double rs_length_diff, bool for_young_only_phase);
-  void report_cost_per_byte_ms(double cost_per_byte_ms, bool mark_or_rebuild_in_progress);
+  void report_cost_per_byte_ms(double cost_per_byte_ms, bool for_young_only_phase);
   void report_young_other_cost_per_region_ms(double other_cost_per_region_ms);
   void report_non_young_other_cost_per_region_ms(double other_cost_per_region_ms);
   void report_constant_other_time_ms(double constant_other_time_ms);
@@ -152,9 +152,7 @@ public:
   double predict_card_merge_time_ms(size_t card_num, bool for_young_only_phase) const;
   double predict_card_scan_time_ms(size_t card_num, bool for_young_only_phase) const;
 
-  double predict_object_copy_time_ms_during_cm(size_t bytes_to_copy) const;
-
-  double predict_object_copy_time_ms(size_t bytes_to_copy, bool during_concurrent_mark) const;
+  double predict_object_copy_time_ms(size_t bytes_to_copy, bool for_young_only_phase) const;
 
   double predict_constant_other_time_ms() const;
 

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -851,7 +851,7 @@ void G1Policy::record_young_collection_end(bool concurrent_operation_is_full_mar
 
     if (copied_bytes > 0) {
       double cost_per_byte_ms = (average_time_ms(G1GCPhaseTimes::ObjCopy) + average_time_ms(G1GCPhaseTimes::OptObjCopy)) / copied_bytes;
-      _analytics->report_cost_per_byte_ms(cost_per_byte_ms, collector_state()->mark_or_rebuild_in_progress());
+      _analytics->report_cost_per_byte_ms(cost_per_byte_ms, is_young_only_pause);
     }
 
     if (_collection_set->young_region_length() > 0) {
@@ -1055,12 +1055,12 @@ double G1Policy::predict_eden_copy_time_ms(uint count, size_t* bytes_to_copy) co
   if (bytes_to_copy != NULL) {
     *bytes_to_copy = expected_bytes;
   }
-  return _analytics->predict_object_copy_time_ms(expected_bytes, collector_state()->mark_or_rebuild_in_progress());
+  return _analytics->predict_object_copy_time_ms(expected_bytes, collector_state()->in_young_only_phase());
 }
 
 double G1Policy::predict_region_copy_time_ms(HeapRegion* hr) const {
   size_t const bytes_to_copy = predict_bytes_to_copy(hr);
-  return _analytics->predict_object_copy_time_ms(bytes_to_copy, collector_state()->mark_or_rebuild_in_progress());
+  return _analytics->predict_object_copy_time_ms(bytes_to_copy, collector_state()->in_young_only_phase());
 }
 
 double G1Policy::predict_region_non_copy_time_ms(HeapRegion* hr,


### PR DESCRIPTION
Hi,

  please review this change to the cost-per-byte predictor to be split on gc phase (young-only/mixed) instead of during marking/outside of marking.

The reason is that the distinction between young-only/mixed of these values is higher than marking/outside of marking, although the latter degrades somewhat to the former in case of continuous concurrent marking where both are almost equivalent anyway. I believe that has been the original reason to do the marking/not-marking distinction.

I also removed the implied 10% extra cost for copies during marking (i.e. during the young-only phase). I could not find any particular reason why copying would be more expensive then with the current code base.

The distinction in general makes sense as the data copied during young-only and mixed is different (only short-lived data vs. short+long-lived data).

Testing: gha, examining predictions with some benchmarks

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295476](https://bugs.openjdk.org/browse/JDK-8295476): Split G1 cost per byte predictor on gc phase


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10862/head:pull/10862` \
`$ git checkout pull/10862`

Update a local copy of the PR: \
`$ git checkout pull/10862` \
`$ git pull https://git.openjdk.org/jdk pull/10862/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10862`

View PR using the GUI difftool: \
`$ git pr show -t 10862`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10862.diff">https://git.openjdk.org/jdk/pull/10862.diff</a>

</details>
