### PR TITLE
8295376: Improve debug agent virtual thread performance when no debugger is attached

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c
@@ -1028,6 +1028,7 @@ parseOptions(char *options)
     /* Set vthread debugging level. */
     gdata->vthreadsSupported = JNI_TRUE;
     gdata->includeVThreads = JNI_FALSE;
+    gdata->rememberVThreadsWhenDisconnected = JNI_FALSE;
 
     /* Options being NULL will end up being an error. */
     if (options == NULL) {
@@ -1142,6 +1143,8 @@ parseOptions(char *options)
             } else {
                 goto syntax_error;
             }
+            // These two flags always set the same for now.
+            gdata->rememberVThreadsWhenDisconnected = gdata->includeVThreads;
             current += strlen(current) + 1;
         } else if (strcmp(buf, "launch") == 0) {
             /*LINTED*/

--- a/src/jdk.jdwp.agent/share/native/libjdwp/debugLoop.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/debugLoop.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,6 +97,7 @@ debugLoop_run(void)
 
     standardHandlers_onConnect();
     threadControl_onConnect();
+    eventHandler_onConnect();
 
     /* Okay, start reading cmds! */
     while (shouldListen) {

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
@@ -133,8 +133,8 @@ static jrawMonitorID callbackBlock;
                 debugMonitorEnter(callbackBlock);                       \
                 debugMonitorExit(callbackBlock);                        \
             } else {                                                    \
-                /* Notify anyone waiting for callbacks to exit during reset */ \
-                if (waiting_for_active_callbacks && active_callbacks == 0) {        \
+                /* Notify anyone waiting for callbacks to exit */       \
+                if (waiting_for_active_callbacks && active_callbacks == 0) { \
                     debugMonitorNotifyAll(callbackLock);                \
                 }                                                       \
                 debugMonitorExit(callbackLock);                         \
@@ -1514,8 +1514,10 @@ eventHandler_initialize(jbyte sessionID)
     if (error != JVMTI_ERROR_NONE) {
         EXIT_ERROR(error,"Can't enable garbage collection finish events");
     }
-    /* Only enable vthread START and END events if we want to remember
-       vthreads when no debugger is connected. */
+    /*
+     * Only enable vthread START and END events if we want to remember
+     * vthreads when no debugger is connected.
+     */
     if (gdata->vthreadsSupported && gdata->rememberVThreadsWhenDisconnected) {
         error = threadControl_setEventMode(JVMTI_ENABLE,
                                            EI_VIRTUAL_THREAD_START, NULL);
@@ -1592,10 +1594,11 @@ void
 eventHandler_onConnect() {
     debugMonitorEnter(handlerLock);
 
-    /* Enable vthread START and END events if they are not already always enabled.
+    /*
+     * Enable vthread START and END events if they are not already always enabled.
      * They are always enabled if we are remembering vthreads when no debugger is
-     * connected. Otherwise they are only enabled when connected because they can be very
-     * noisy and hurt performance a lot.
+     * connected. Otherwise they are only enabled when connected because they can
+     * be very noisy and hurt performance a lot.
      */
     if (gdata->vthreadsSupported && !gdata->rememberVThreadsWhenDisconnected) {
         jvmtiError error;

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
@@ -1675,13 +1675,13 @@ eventHandler_waitForActiveCallbacks()
      * callback. The only callbacks enabled at this point are the permanent ones,
      * and they never involve vthreads.
      */
-    waiting_for_active_callbacks = JNI_TRUE;
     debugMonitorEnter(callbackLock);
+    waiting_for_active_callbacks = JNI_TRUE;
     while (active_callbacks > 0) {
         debugMonitorWait(callbackLock);
     }
-    debugMonitorExit(callbackLock);
     waiting_for_active_callbacks = JNI_FALSE;
+    debugMonitorExit(callbackLock);
 }
 
 void

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
@@ -74,7 +74,6 @@ static jbyte currentSessionID;
 
 /* Counter of active callbacks and flag for vm_death */
 static int      active_callbacks   = 0;
-static volatile jboolean waiting_for_active_callbacks = JNI_FALSE;
 static jboolean vm_death_callback_active = JNI_FALSE;
 static jrawMonitorID callbackLock;
 static jrawMonitorID callbackBlock;
@@ -134,7 +133,7 @@ static jrawMonitorID callbackBlock;
                 debugMonitorExit(callbackBlock);                        \
             } else {                                                    \
                 /* Notify anyone waiting for callbacks to exit */       \
-                if (waiting_for_active_callbacks && active_callbacks == 0) { \
+                if (active_callbacks == 0) {                            \
                     debugMonitorNotifyAll(callbackLock);                \
                 }                                                       \
                 debugMonitorExit(callbackLock);                         \
@@ -1676,11 +1675,9 @@ eventHandler_waitForActiveCallbacks()
      * and they never involve vthreads.
      */
     debugMonitorEnter(callbackLock);
-    waiting_for_active_callbacks = JNI_TRUE;
     while (active_callbacks > 0) {
         debugMonitorWait(callbackLock);
     }
-    waiting_for_active_callbacks = JNI_FALSE;
     debugMonitorExit(callbackLock);
 }
 

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
@@ -74,6 +74,7 @@ static jbyte currentSessionID;
 
 /* Counter of active callbacks and flag for vm_death */
 static int      active_callbacks   = 0;
+static volatile jboolean waiting_for_active_callbacks = JNI_FALSE;
 static jboolean vm_death_callback_active = JNI_FALSE;
 static jrawMonitorID callbackLock;
 static jrawMonitorID callbackBlock;
@@ -132,6 +133,10 @@ static jrawMonitorID callbackBlock;
                 debugMonitorEnter(callbackBlock);                       \
                 debugMonitorExit(callbackBlock);                        \
             } else {                                                    \
+                /* Notify anyone waiting for callbacks to exit during reset */ \
+                if (waiting_for_active_callbacks && active_callbacks == 0) {        \
+                    debugMonitorNotifyAll(callbackLock);                \
+                }                                                       \
                 debugMonitorExit(callbackLock);                         \
             }                                                           \
         }                                                               \
@@ -1509,8 +1514,9 @@ eventHandler_initialize(jbyte sessionID)
     if (error != JVMTI_ERROR_NONE) {
         EXIT_ERROR(error,"Can't enable garbage collection finish events");
     }
-    /* Only enable vthread events if vthread support is enabled. */
-    if (gdata->vthreadsSupported) {
+    /* Only enable vthread START and END events if we want to remember
+       vthreads when no debugger is connected. */
+    if (gdata->vthreadsSupported && gdata->rememberVThreadsWhenDisconnected) {
         error = threadControl_setEventMode(JVMTI_ENABLE,
                                            EI_VIRTUAL_THREAD_START, NULL);
         if (error != JVMTI_ERROR_NONE) {
@@ -1583,6 +1589,32 @@ eventHandler_initialize(jbyte sessionID)
 }
 
 void
+eventHandler_onConnect() {
+    debugMonitorEnter(handlerLock);
+
+    /* Enable vthread START and END events if they are not already always enabled.
+     * They are always enabled if we are remembering vthreads when no debugger is
+     * connected. Otherwise they are only enabled when connected because they can be very
+     * noisy and hurt performance a lot.
+     */
+    if (gdata->vthreadsSupported && !gdata->rememberVThreadsWhenDisconnected) {
+        jvmtiError error;
+        error = threadControl_setEventMode(JVMTI_ENABLE,
+                                           EI_VIRTUAL_THREAD_START, NULL);
+        if (error != JVMTI_ERROR_NONE) {
+            EXIT_ERROR(error,"Can't disable vthread start events");
+        }
+        error = threadControl_setEventMode(JVMTI_ENABLE,
+                                           EI_VIRTUAL_THREAD_END, NULL);
+        if (error != JVMTI_ERROR_NONE) {
+            EXIT_ERROR(error,"Can't disable vthread end events");
+        }
+    }
+
+    debugMonitorExit(handlerLock);
+}
+
+void
 eventHandler_reset(jbyte sessionID)
 {
     int i;
@@ -1595,6 +1627,24 @@ eventHandler_reset(jbyte sessionID)
      * the invoke completions can sneak through.
      */
     threadControl_detachInvokes();
+
+    /* Disable vthread START and END events unless we are remembering vthreads
+     * when no debugger is connected. We do this because these events can
+     * be very noisy and hurt performance a lot.
+     */
+    if (gdata->vthreadsSupported && !gdata->rememberVThreadsWhenDisconnected) {
+        jvmtiError error;
+        error = threadControl_setEventMode(JVMTI_DISABLE,
+                                           EI_VIRTUAL_THREAD_START, NULL);
+        if (error != JVMTI_ERROR_NONE) {
+            EXIT_ERROR(error,"Can't disable vthread start events");
+        }
+        error = threadControl_setEventMode(JVMTI_DISABLE,
+                                           EI_VIRTUAL_THREAD_END, NULL);
+        if (error != JVMTI_ERROR_NONE) {
+            EXIT_ERROR(error,"Can't disable vthread end events");
+        }
+    }
 
     /* Reset the event helper thread, purging all queued and
      * in-process commands.
@@ -1610,6 +1660,25 @@ eventHandler_reset(jbyte sessionID)
     currentSessionID = sessionID;
 
     debugMonitorExit(handlerLock);
+}
+
+void
+eventHandler_waitForActiveCallbacks()
+{
+    /*
+     * Wait for active callbacks to complete. It is ok if more callbacks come in
+     * after this point. This is being done so threadControl_reset() can safely
+     * remove all vthreads without worry that they might be referenced in an active
+     * callback. The only callbacks enabled at this point are the permanent ones,
+     * and they never involve vthreads.
+     */
+    waiting_for_active_callbacks = JNI_TRUE;
+    debugMonitorEnter(callbackLock);
+    while (active_callbacks > 0) {
+        debugMonitorWait(callbackLock);
+    }
+    debugMonitorExit(callbackLock);
+    waiting_for_active_callbacks = JNI_FALSE;
 }
 
 void

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
@@ -1604,12 +1604,12 @@ eventHandler_onConnect() {
         error = threadControl_setEventMode(JVMTI_ENABLE,
                                            EI_VIRTUAL_THREAD_START, NULL);
         if (error != JVMTI_ERROR_NONE) {
-            EXIT_ERROR(error,"Can't disable vthread start events");
+            EXIT_ERROR(error,"Can't enable vthread start events");
         }
         error = threadControl_setEventMode(JVMTI_ENABLE,
                                            EI_VIRTUAL_THREAD_END, NULL);
         if (error != JVMTI_ERROR_NONE) {
-            EXIT_ERROR(error,"Can't disable vthread end events");
+            EXIT_ERROR(error,"Can't enable vthread end events");
         }
     }
 

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,9 @@ void eventHandler_freeClassBreakpoints(jclass clazz);
 /***** HandlerNode manipulation *****/
 
 void eventHandler_initialize(jbyte sessionID);
+void eventHandler_onConnect();
 void eventHandler_reset(jbyte sessionID);
+void eventHandler_waitForActiveCallbacks();
 
 void eventHandler_lock(void);
 void eventHandler_unlock(void);

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -511,6 +511,19 @@ removeResumed(JNIEnv *env, ThreadList *list)
 }
 
 static void
+removeVThreads(JNIEnv *env)
+{
+    ThreadList *list = &runningVThreads;
+    ThreadNode *node = list->first;
+    while (node != NULL) {
+        ThreadNode *temp = node->next;
+        removeNode(list, node);
+        clearThread(env, node);
+        node = temp;
+    }
+}
+
+static void
 moveNode(ThreadList *source, ThreadList *dest, ThreadNode *node)
 {
     removeNode(source, node);
@@ -2754,6 +2767,29 @@ threadControl_reset(void)
     debugMonitorNotifyAll(threadLock);
     debugMonitorExit(threadLock);
     eventHandler_unlock();
+
+    /*
+     * Unless we are remembering all vthreads when the debugger is not connected,
+     * we free them all up here.
+     */
+    if (!gdata->rememberVThreadsWhenDisconnected) {
+        /*
+         * First we need to wait for all active callbacks to complete. They were resumed
+         * above by the resetHelper. We can't remove the vthreads until after they complete,
+         * because the vthread ThreadNodes might be referenced as the callbacks unwind.
+         * We do this outside of any locking, because the callbacks may need to acquire locks
+         * in order to complete. It's ok if there are more callbacks after this point because
+         * the only callbacks enabled are the permanent ones, and they never involve vthreads.
+         */
+        eventHandler_waitForActiveCallbacks();
+        /* Now that event callbacks have exited, we can reacquire the threadLock, which
+         * is needed before before calling removeVThreads().
+         */
+        debugMonitorEnter(threadLock);
+        removeVThreads(env);
+        debugMonitorExit(threadLock);
+    }
+
 }
 
 jvmtiEventMode

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -2782,7 +2782,8 @@ threadControl_reset(void)
          * the only callbacks enabled are the permanent ones, and they never involve vthreads.
          */
         eventHandler_waitForActiveCallbacks();
-        /* Now that event callbacks have exited, we can reacquire the threadLock, which
+        /*
+         * Now that event callbacks have exited, we can reacquire the threadLock, which
          * is needed before before calling removeVThreads().
          */
         debugMonitorEnter(threadLock);

--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.h
@@ -86,6 +86,7 @@ typedef struct {
     jboolean assertFatal;
     jboolean vthreadsSupported; /* If true, debugging support for vthreads is enabled. */
     jboolean includeVThreads;   /* If true, VM.AllThreads includes vthreads. */
+    jboolean rememberVThreadsWhenDisconnected;
     jboolean doerrorexit;
     jboolean modifiedUtf8;
     jboolean quiet;


### PR DESCRIPTION
This PR disables VIRTUAL_THREAD_START/END events when no debugger is attached. Some customers like to launch (in production mode) the JVM with the debug agent enabled, but with no debugger attached. This usually has a very minimal performance impact as long as the debugger remains unattached. Launching the JVM in this manner allows a debugger to later be attached if there are issues.

In the past the debug agent has always kept THREAD_START/END events enabled, even when no debugger is attached. It does so to keep track of all existing threads, and this generally has minimal performance impact. However, with virtual threads there can be a very large number of virtual threads constantly being created and destroyed. With SkyNet, this results in as much as a 250x performance regression when the debug agent is enabled. A large part of this is due to all the VIRTUAL_THREAD_START/END events the debug agent has to deal with. When these events are disabled, the performance slowdown is more like 10x. This remaining 10x comes from JVMTI and is not addressed in this CR.

The fix for this performance issue is to disable VIRTUAL_THREAD_START/END events when the debugger is not attached. This also requires forgetting about all known virtual threads when the debugger detaches since there will be no VIRTUAL_THREAD_END event to notify the debug agent when the virtual thread has died.

I decided it was appropriate to not introduce this behavior change if the debug agent is launched with `includevirtualthreads=y` (the default is 'n'). `includevirtualthreads=y` is meant to help legacy debuggers, and indicates that the debug agent should try to track (remember) all vthreads that are running, and return them when `VirtualMachine.GetAllThreads` is called. `includevirtualthreads=y` sets `gdata->includeVThreads` true, so initially I had these changes conditional on `gdata->includeVThreads`. However, most of our testing is done with `includevirtualthreads=y` (an unfortunate necessity because of how most of the test are written). This made it hard to test these changes. So I introduced `gdata->rememberVThreadsWhenDisconnected`, and made the changes conditional on it instead. It defaults to be the same as `gdata->includeVThreads`. However, I did some testing with it manually set it to always be false to get better testing coverage. This could be made a debug agent flag settable on the command line, but I opted not to since it's not really of interest to the typical debug agent user. I suppose it could be an undocumented flag just to use in testing. I can make this change if others agree.

A couple notes on code flow that might help with understanding the changes:
- When the connection is initiated, `debugLoop_run()` is called, and it calls `eventHandler_onConnect()` to enable the START/END callbacks.
- When the connection is dropped, `debugLoop_run()` calls `debugInit_reset()`, which calls `eventHandler_reset()` to disable the START/END callbacks. A bit later `debugInit_reset()` calls `threadControl_reset()` to free up the vthread ThreadNodes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295376](https://bugs.openjdk.org/browse/JDK-8295376): Improve debug agent virtual thread performance when no debugger is attached


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [a2061e64](https://git.openjdk.org/jdk/pull/10865/files/a2061e644a5058af9457408837ae1a85b897492c)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to [a2061e64](https://git.openjdk.org/jdk/pull/10865/files/a2061e644a5058af9457408837ae1a85b897492c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10865/head:pull/10865` \
`$ git checkout pull/10865`

Update a local copy of the PR: \
`$ git checkout pull/10865` \
`$ git pull https://git.openjdk.org/jdk pull/10865/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10865`

View PR using the GUI difftool: \
`$ git pr show -t 10865`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10865.diff">https://git.openjdk.org/jdk/pull/10865.diff</a>

</details>
