### PR TITLE
8291781: assert(!is_visited) failed: visit only once with -XX:+SuperWordRTDepCheck

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -1113,10 +1113,11 @@ void SuperWord::dependence_graph() {
         int cmp = p1.cmp(p2);
         if (SuperWordRTDepCheck &&
             p1.base() != p2.base() && p1.valid() && p2.valid()) {
-          // Create a runtime check to disambiguate
+          // Trace disjoint pointers
           OrderedPair pp(p1.base(), p2.base());
           _disjoint_ptrs.append_if_missing(pp);
-        } else if (!SWPointer::not_equal(cmp)) {
+        }
+        if (!SWPointer::not_equal(cmp)) {
           // Possibly same address
           _dg.make_edge(s1, s2);
           sink_dependent = false;

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeTypeConversion.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeTypeConversion.java
@@ -51,7 +51,7 @@ public class TestVectorizeTypeConversion {
     private static float[] floatb = new float[SIZE];
 
     public static void main(String[] args) {
-        TestFramework.run();
+        TestFramework.runWithFlags("-XX:+SuperWordRTDepCheck");
     }
 
     @Test


### PR DESCRIPTION
`-XX:+SuperWordRTDepCheck` is a develop flag and misses proper implementation. But when enabled, it could change code path, resulting in the failures in [JDK-8291781](https://bugs.openjdk.org/browse/JDK-8291781) and [JDK-8291881](https://bugs.openjdk.org/browse/JDK-8291881). As @vnkozlov suggested in [JDK-8291781](https://bugs.openjdk.org/browse/JDK-8291781), the small patch converts the flag to pure debug code to avoid effect on code generation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291781](https://bugs.openjdk.org/browse/JDK-8291781): assert(!is_visited) failed: visit only once with -XX:+SuperWordRTDepCheck


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10868/head:pull/10868` \
`$ git checkout pull/10868`

Update a local copy of the PR: \
`$ git checkout pull/10868` \
`$ git pull https://git.openjdk.org/jdk pull/10868/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10868`

View PR using the GUI difftool: \
`$ git pr show -t 10868`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10868.diff">https://git.openjdk.org/jdk/pull/10868.diff</a>

</details>
