### PR TITLE
8294739: jdk/jshell/ToolShiftTabTest.java timed out

### DIFF
--- a/test/langtools/jdk/jshell/ToolShiftTabTest.java
+++ b/test/langtools/jdk/jshell/ToolShiftTabTest.java
@@ -108,12 +108,15 @@ public class ToolShiftTabTest extends UITesting {
 
     public void testFixImport() throws Exception {
         doRunTest((inputSink, out) -> {
-            do {
-                inputSink.write("Frame");
+            inputSink.write("Frame");
+            inputSink.write(FIX + "i");
+            while (!waitOutput(out, "java.awt.Frame", "Results may be incomplete")) {
+                Thread.sleep(1000);
                 inputSink.write(FIX + "i");
-                inputSink.write("1");
-                inputSink.write(".WIDTH\n");
-            } while (!waitOutput(out, "==> 1", "Results may be incomplete"));
+            }
+            inputSink.write("1");
+            inputSink.write(".WIDTH\n");
+            waitOutput(out, "==> 1");
             inputSink.write("/import\n");
             waitOutput(out, "|    import java.awt.Frame");
 


### PR DESCRIPTION
ToolShiftTabTest::testFixImport intermittently timeouts.
Reason is exhaustive busy waiting loop for completion  to be ready.
Proposed patch fixes the test loop.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294739](https://bugs.openjdk.org/browse/JDK-8294739): jdk/jshell/ToolShiftTabTest.java timed out


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10869/head:pull/10869` \
`$ git checkout pull/10869`

Update a local copy of the PR: \
`$ git checkout pull/10869` \
`$ git pull https://git.openjdk.org/jdk pull/10869/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10869`

View PR using the GUI difftool: \
`$ git pr show -t 10869`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10869.diff">https://git.openjdk.org/jdk/pull/10869.diff</a>

</details>
