### PR TITLE
6257207: JTable.getDefaultEditor throws NullPointerException

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -421,8 +421,8 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * in the <code>TableModel</code> interface.
      */
     protected transient Hashtable<Object, Object> defaultRenderersByColumnClass;
-    // Logically, the above is a Hashtable<Class<?>, TableCellRenderer>.
-    // It is declared otherwise to accommodate using UIDefaults.
+    // Logicaly, the above is a Hashtable<Class<?>, TableCellRenderer>.
+    // It is declared otherwise to accomodate using UIDefaults.
 
     /**
      * A table of objects that display and edit the contents of a cell,
@@ -430,8 +430,8 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * in the <code>TableModel</code> interface.
      */
     protected transient Hashtable<Object, Object> defaultEditorsByColumnClass;
-    // Logically, the above is a Hashtable<Class<?>, TableCellEditor>.
-    // It is declared otherwise to accommodate using UIDefaults.
+    // Logicaly, the above is a Hashtable<Class<?>, TableCellEditor>.
+    // It is declared otherwise to accomodate using UIDefaults.
 
     /** The foreground color of selected cells. */
     protected Color selectionForeground;
@@ -3180,7 +3180,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
             setWidthsFromPreferredWidths(false);
         }
         else {
-            // JTable behaves like a layout manager - but one in which the
+            // JTable behaves like a layout manger - but one in which the
             // user can come along and dictate how big one of the children
             // (columns) is supposed to be.
 
@@ -3191,7 +3191,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
             accommodateDelta(columnIndex, delta);
             delta = getWidth() - getColumnModel().getTotalColumnWidth();
 
-            // If the delta cannot be completely accommodated, then the
+            // If the delta cannot be completely accomodated, then the
             // resizing column will have to take any remainder. This means
             // that the column is not being allowed to take the requested
             // width. This happens under many circumstances: For example,
@@ -7307,7 +7307,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
 
                     // Situation:
                     //   We have a table, like the 6x3 table below,
-                    //   wherein three columns and one row selected
+                    //   wherein three colums and one row selected
                     //   (selected cells marked with "*", unselected "0"):
                     //
                     //            0 * 0 * * 0

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -421,8 +421,8 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * in the <code>TableModel</code> interface.
      */
     protected transient Hashtable<Object, Object> defaultRenderersByColumnClass;
-    // Logicaly, the above is a Hashtable<Class<?>, TableCellRenderer>.
-    // It is declared otherwise to accomodate using UIDefaults.
+    // Logically, the above is a Hashtable<Class<?>, TableCellRenderer>.
+    // It is declared otherwise to accommodate using UIDefaults.
 
     /**
      * A table of objects that display and edit the contents of a cell,
@@ -430,8 +430,8 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * in the <code>TableModel</code> interface.
      */
     protected transient Hashtable<Object, Object> defaultEditorsByColumnClass;
-    // Logicaly, the above is a Hashtable<Class<?>, TableCellEditor>.
-    // It is declared otherwise to accomodate using UIDefaults.
+    // Logically, the above is a Hashtable<Class<?>, TableCellEditor>.
+    // It is declared otherwise to accommodate using UIDefaults.
 
     /** The foreground color of selected cells. */
     protected Color selectionForeground;
@@ -684,7 +684,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
                            JComponent.getManagingFocusForwardTraversalKeys());
         setFocusTraversalKeys(KeyboardFocusManager.BACKWARD_TRAVERSAL_KEYS,
                            JComponent.getManagingFocusBackwardTraversalKeys());
-        initializeLocalVars();
+
         if (cm == null) {
             cm = createDefaultColumnModel();
             autoCreateColumnsFromModel = true;
@@ -703,7 +703,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
             dm = createDefaultDataModel();
         }
         setModel(dm);
-
+        initializeLocalVars();
         updateUI();
     }
 
@@ -1398,6 +1398,9 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
             return null;
         }
         else {
+            if (defaultRenderersByColumnClass == null) {
+                createDefaultRenderers();
+            }
             Object renderer = defaultRenderersByColumnClass.get(columnClass);
             if (renderer != null) {
                 return (TableCellRenderer)renderer;
@@ -1455,6 +1458,9 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
             return null;
         }
         else {
+            if (defaultEditorsByColumnClass == null) {
+                createDefaultEditors();
+            }
             Object editor = defaultEditorsByColumnClass.get(columnClass);
             if (editor != null) {
                 return (TableCellEditor)editor;
@@ -3174,7 +3180,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
             setWidthsFromPreferredWidths(false);
         }
         else {
-            // JTable behaves like a layout manger - but one in which the
+            // JTable behaves like a layout manager - but one in which the
             // user can come along and dictate how big one of the children
             // (columns) is supposed to be.
 
@@ -3185,7 +3191,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
             accommodateDelta(columnIndex, delta);
             delta = getWidth() - getColumnModel().getTotalColumnWidth();
 
-            // If the delta cannot be completely accomodated, then the
+            // If the delta cannot be completely accommodated, then the
             // resizing column will have to take any remainder. This means
             // that the column is not being allowed to take the requested
             // width. This happens under many circumstances: For example,
@@ -7301,7 +7307,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
 
                     // Situation:
                     //   We have a table, like the 6x3 table below,
-                    //   wherein three colums and one row selected
+                    //   wherein three columns and one row selected
                     //   (selected cells marked with "*", unselected "0"):
                     //
                     //            0 * 0 * * 0

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -684,6 +684,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
                            JComponent.getManagingFocusForwardTraversalKeys());
         setFocusTraversalKeys(KeyboardFocusManager.BACKWARD_TRAVERSAL_KEYS,
                            JComponent.getManagingFocusBackwardTraversalKeys());
+        initializeLocalVars();
         if (cm == null) {
             cm = createDefaultColumnModel();
             autoCreateColumnsFromModel = true;
@@ -703,7 +704,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
         }
         setModel(dm);
 
-        initializeLocalVars();
+
         updateUI();
     }
 

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -704,7 +704,6 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
         }
         setModel(dm);
 
-
         updateUI();
     }
 

--- a/test/jdk/javax/swing/JTable/JTableBugTest.java
+++ b/test/jdk/javax/swing/JTable/JTableBugTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 6257207
+   @summary Verifies if JTable.getDefaultEditor throws NullPointerException
+   @run main JTableBugTest
+ */
+import java.awt.Component;
+import javax.swing.JFrame;
+import javax.swing.JTable;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableModel;
+import javax.swing.table.TableCellEditor;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.event.TableModelEvent;
+import javax.swing.event.TableModelListener;
+
+public class JTableBugTest {
+    public static void main(String[] args)  {
+        JFrame frame = new JFrame();
+        frame.setSize(100, 100);
+
+        DefaultTableModel myModel = new DefaultTableModel();
+        myModel.addColumn("Col1");
+        myModel.addColumn("Col2");
+        myModel.addColumn("Col3");
+        myModel.addRow(new Object[]{"item1.1", "item1.2", "item1.3"});
+        myModel.addRow(new Object[]{"item2.1", "item2.2", "item2.3"});
+        MyTable tbl = new MyTable(myModel);
+        frame.getContentPane().add(tbl);
+        frame.setVisible(true);
+    }
+
+    static class MyTable extends JTable implements TableModelListener {
+        public MyTable(TableModel model)
+        {
+            super(model);
+        }
+
+        public void tableChanged(TableModelEvent event) {
+            super.tableChanged(event);
+
+            int column = event.getColumn();
+            if(column == TableModelEvent.ALL_COLUMNS)
+                resizeAll();
+            else
+                resize(column);
+        }
+
+        protected void resizeAll() {
+            for(int i=0; i<getModel().getColumnCount(); i++)
+                resize(i);
+        }
+
+        protected void resize(int column) {
+            TableCellEditor editor = null;
+            TableCellRenderer renderer = null;
+            Component comp;
+            int width=0;
+            for(int row=0; row<getModel().getRowCount(); row++) {
+                editor = this.getCellEditor(row, column);
+                if(editor != null)
+                {
+                    comp = editor.getTableCellEditorComponent(
+                            this, // table
+                            getModel().getValueAt(row,column), // value
+                            false, // isSelected
+                            row, // row
+                            column // column
+                    );
+                    if(comp != null)
+                        width = Math.max(width, comp.getPreferredSize().width);
+                }
+
+                renderer = this.getCellRenderer(row, column);
+                if(renderer != null) {
+                    comp = renderer.getTableCellRendererComponent(
+                            this, // table
+                            getModel().getValueAt(row,column), // value
+                            false, // isSelected
+                            false, // hasFocus
+                            row, // row
+                            column // column
+                    );
+                    if(comp != null)
+                        width = Math.max(width, comp.getPreferredSize().width);
+                }
+            }
+
+            getColumnModel().getColumn(column).setPreferredWidth(width);
+
+            this.revalidate();
+            this.repaint();
+        }
+    }
+}

--- a/test/jdk/javax/swing/JTable/JTableBugTest.java
+++ b/test/jdk/javax/swing/JTable/JTableBugTest.java
@@ -22,9 +22,10 @@
  */
 
 /* @test
-   @bug 6257207
-   @summary Verifies if JTable.getDefaultEditor throws NullPointerException
-   @run main JTableBugTest
+ * @bug 6257207
+ * @key headful
+ * @summary Verifies if JTable.getDefaultEditor throws NullPointerException
+ * @run main JTableBugTest
  */
 import java.awt.Component;
 import javax.swing.JFrame;
@@ -35,26 +36,40 @@ import javax.swing.table.TableCellEditor;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.event.TableModelEvent;
 import javax.swing.event.TableModelListener;
+import javax.swing.SwingUtilities;
 
 public class JTableBugTest {
-    public static void main(String[] args)  {
-        JFrame frame = new JFrame();
-        frame.setSize(100, 100);
+    private static JFrame frame;
 
-        DefaultTableModel myModel = new DefaultTableModel();
-        myModel.addColumn("Col1");
-        myModel.addColumn("Col2");
-        myModel.addColumn("Col3");
-        myModel.addRow(new Object[]{"item1.1", "item1.2", "item1.3"});
-        myModel.addRow(new Object[]{"item2.1", "item2.2", "item2.3"});
-        MyTable tbl = new MyTable(myModel);
-        frame.getContentPane().add(tbl);
-        frame.setVisible(true);
+    public static void main(String[] args) throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame();
+                frame.setSize(100, 100);
+
+                DefaultTableModel myModel = new DefaultTableModel();
+                myModel.addColumn("Col1");
+                myModel.addColumn("Col2");
+                myModel.addColumn("Col3");
+                myModel.addRow(new Object[]{"item1.1", "item1.2", "item1.3"});
+                myModel.addRow(new Object[]{"item2.1", "item2.2", "item2.3"});
+                MyTable tbl = new MyTable(myModel);
+                frame.getContentPane().add(tbl);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+	    });
+        } finally {
+            Thread.sleep(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
     }
 
     static class MyTable extends JTable implements TableModelListener {
-        public MyTable(TableModel model)
-        {
+        public MyTable(TableModel model) {
             super(model);
         }
 

--- a/test/jdk/javax/swing/JTable/JTableBugTest.java
+++ b/test/jdk/javax/swing/JTable/JTableBugTest.java
@@ -57,7 +57,7 @@ public class JTableBugTest {
                 frame.getContentPane().add(tbl);
                 frame.setLocationRelativeTo(null);
                 frame.setVisible(true);
-	    });
+            });
         } finally {
             Thread.sleep(1000);
             SwingUtilities.invokeAndWait(() -> {

--- a/test/jdk/javax/swing/JTable/JTableEditorNPE.java
+++ b/test/jdk/javax/swing/JTable/JTableEditorNPE.java
@@ -25,7 +25,7 @@
  * @bug 6257207
  * @key headful
  * @summary Verifies if JTable.getDefaultEditor throws NullPointerException
- * @run main JTableBugTest
+ * @run main JTableEditorNPE
  */
 import java.awt.Component;
 import javax.swing.JFrame;
@@ -38,7 +38,7 @@ import javax.swing.event.TableModelEvent;
 import javax.swing.event.TableModelListener;
 import javax.swing.SwingUtilities;
 
-public class JTableBugTest {
+public class JTableEditorNPE {
     private static JFrame frame;
 
     public static void main(String[] args) throws Exception {
@@ -77,15 +77,18 @@ public class JTableBugTest {
             super.tableChanged(event);
 
             int column = event.getColumn();
-            if(column == TableModelEvent.ALL_COLUMNS)
+            if (column == TableModelEvent.ALL_COLUMNS) {
                 resizeAll();
-            else
+            }
+            else {
                 resize(column);
+            }
         }
 
         protected void resizeAll() {
-            for(int i=0; i<getModel().getColumnCount(); i++)
+            for (int i = 0; i < getModel().getColumnCount(); i++) {
                 resize(i);
+            }
         }
 
         protected void resize(int column) {
@@ -93,10 +96,9 @@ public class JTableBugTest {
             TableCellRenderer renderer = null;
             Component comp;
             int width=0;
-            for(int row=0; row<getModel().getRowCount(); row++) {
+            for (int row = 0; row < getModel().getRowCount(); row++) {
                 editor = this.getCellEditor(row, column);
-                if(editor != null)
-                {
+                if (editor != null) {
                     comp = editor.getTableCellEditorComponent(
                             this, // table
                             getModel().getValueAt(row,column), // value
@@ -104,12 +106,13 @@ public class JTableBugTest {
                             row, // row
                             column // column
                     );
-                    if(comp != null)
+                    if (comp != null) {
                         width = Math.max(width, comp.getPreferredSize().width);
+                    }
                 }
 
                 renderer = this.getCellRenderer(row, column);
-                if(renderer != null) {
+                if (renderer != null) {
                     comp = renderer.getTableCellRendererComponent(
                             this, // table
                             getModel().getValueAt(row,column), // value
@@ -118,8 +121,9 @@ public class JTableBugTest {
                             row, // row
                             column // column
                     );
-                    if(comp != null)
+                    if (comp != null) {
                         width = Math.max(width, comp.getPreferredSize().width);
+                    }
                 }
             }
 

--- a/test/jdk/javax/swing/JTable/JTableEditorNPE.java
+++ b/test/jdk/javax/swing/JTable/JTableEditorNPE.java
@@ -55,11 +55,9 @@ public class JTableEditorNPE {
                 myModel.addRow(new Object[]{"item2.1", "item2.2", "item2.3"});
                 MyTable tbl = new MyTable(myModel);
                 frame.getContentPane().add(tbl);
-                frame.setLocationRelativeTo(null);
-                frame.setVisible(true);
+                frame.validate();
             });
         } finally {
-            Thread.sleep(1000);
             SwingUtilities.invokeAndWait(() -> {
                 if (frame != null) {
                     frame.dispose();
@@ -79,8 +77,7 @@ public class JTableEditorNPE {
             int column = event.getColumn();
             if (column == TableModelEvent.ALL_COLUMNS) {
                 resizeAll();
-            }
-            else {
+            } else {
                 resize(column);
             }
         }
@@ -115,7 +112,7 @@ public class JTableEditorNPE {
                 if (renderer != null) {
                     comp = renderer.getTableCellRendererComponent(
                             this, // table
-                            getModel().getValueAt(row,column), // value
+                            getModel().getValueAt(row, column), // value
                             false, // isSelected
                             false, // hasFocus
                             row, // row
@@ -134,3 +131,4 @@ public class JTableEditorNPE {
         }
     }
 }
+


### PR DESCRIPTION
If getDefaultEditor() is called before the JTable model is setup, it results in NPE.

This is because when JTable sets its model, which ends up firing a table changed event. The testcase is listening for tableChanged events and querying the editor. But the editor isn't installed until after the model is set which results in NPE.
Fix is to ensure initializeLocalVars() which initializes default editor is setup before JTable sets its model.

No regression is observed in jtreg/jck testsuite with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6257207](https://bugs.openjdk.org/browse/JDK-6257207): JTable.getDefaultEditor throws NullPointerException


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer) ⚠️ Review applies to [e2e5c38d](https://git.openjdk.org/jdk/pull/10871/files/e2e5c38d95d95c3850adfce132f28b16c6a7b5d0)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Author) ⚠️ Review applies to [e2e5c38d](https://git.openjdk.org/jdk/pull/10871/files/e2e5c38d95d95c3850adfce132f28b16c6a7b5d0)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**) ⚠️ Review applies to [a2c499fb](https://git.openjdk.org/jdk/pull/10871/files/a2c499fb995383f2dd16628f293aa0940e7dd305)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10871/head:pull/10871` \
`$ git checkout pull/10871`

Update a local copy of the PR: \
`$ git checkout pull/10871` \
`$ git pull https://git.openjdk.org/jdk pull/10871/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10871`

View PR using the GUI difftool: \
`$ git pr show -t 10871`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10871.diff">https://git.openjdk.org/jdk/pull/10871.diff</a>

</details>
